### PR TITLE
Cancel alarm if test is removed from queue

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -218,9 +218,6 @@ const QueueItem: any = ({
     };
     let alert = <Alert type={type} title={title} body={body} />;
     showNotification(toast, alert);
-    refetchQueue();
-    // Stop/remove any running timer
-    removeTimer(internalId);
   };
 
   const onTestResultSubmit = (e?: any) => {
@@ -233,12 +230,11 @@ const QueueItem: any = ({
           deviceId: deviceId,
           result: testResultValue,
         },
-      }).then(
-        (_response) => testResultsSubmitted(),
-        (error) => {
-          updateMutationError(error);
-        }
-      );
+      })
+        .then(testResultsSubmitted)
+        .then(refetchQueue)
+        .then(() => removeTimer(internalId))
+        .catch((error) => updateMutationError(error));
     } else {
       updateIsConfirmationModalOpen(true);
     }
@@ -280,12 +276,10 @@ const QueueItem: any = ({
       variables: {
         patientId,
       },
-    }).then(
-      (_response) => refetchQueue(),
-      (error) => {
-        updateMutationError(error);
-      }
-    );
+    })
+      .then(refetchQueue)
+      .then(() => removeTimer(internalId))
+      .catch((error) => updateMutationError(error));
   };
 
   const openAoeModal = () => {


### PR DESCRIPTION
## Related Issue or Background Info

No associated issue

## Changes Proposed

I found this bug while rehearsing the demo for today. If you start a timer on a card and then remove the card from the queue, the timer continues to run and alarms after 15 minutes. This is because there are two paths out of the component that have similar logic. 

A TODO at some point would be to merge the two paths into a single common tail that both could call, but offhand I couldn't figure out how to do that and preserve the final `.catch()` at the end in a way that would catch errors from the original Promise.

## Additional Information


