### PR TITLE
Initial SonarCloud integration for Java

### DIFF
--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube --info
+        run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.GITHUB_WORKSPACE }} --info
   build-jar:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -59,7 +59,7 @@ jobs:
           chmod 0600 $PGPASSFILE
           db-setup/create-db.sh
       - name: Run Java Tests
-        run: ./gradlew test
+        run: ./gradlew jacocoTestReport
       - name: Archive Test Results
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -37,6 +37,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
       - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -4,7 +4,8 @@ name: Smoke Test Back-end API
 on:
   workflow_dispatch: # because sometimes you just want to force a branch to have tests run
   push:
-    branches: "**"
+    branches:
+      - "**"
     paths:
       - "backend/**"
       - .github/workflows/smoketestBackend.yml
@@ -65,6 +66,11 @@ jobs:
           name: test-report
           path: backend/build/reports/tests/test
           retention-days: 7
+      - name: Sonar analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube --info
   build-jar:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -13,7 +13,7 @@ on:
 env:
   NODE_VERSION: 14
   JAVA_VERSION: 11
-  PROJECT_ROOT: ${{ env.GITHUB_WORKSPACE }} # Stashing this value here, as it gets overriden by one of the steps
+  PROJECT_ROOT: /home/runner/work/prime-simplereport/prime-simplereport # Hardcoding this here because env.WORKSPACE_ROOT gets overridden by one of the steps downstream. We only need this for Sonar.
 
 defaults:
   run:

--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -13,6 +13,7 @@ on:
 env:
   NODE_VERSION: 14
   JAVA_VERSION: 11
+  PROJECT_ROOT: ${{ env.GITHUB_WORKSPACE }} # Stashing this value here, as it gets overriden by one of the steps
 
 defaults:
   run:
@@ -70,7 +71,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.GITHUB_WORKSPACE }} --info
+        run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.PROJECT_ROOT }} --info
   build-jar:
     runs-on: ubuntu-latest
     steps:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,6 +64,7 @@ jacocoTestReport {
 	reports {
 		xml.enabled = true
 	}
+	dependsOn test // tests are required to run before generating the report
 }
 
 sonarqube {
@@ -71,6 +72,6 @@ sonarqube {
 		property "sonar.projectKey", "CDCgov_prime-data-input-client"
 		property "sonar.organization", "cdcgov"
 		property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.sources", "src/main/java,../frontend/src"
+		property "sonar.sources", "backend/src/main/java,frontend/src"
 	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -60,10 +60,17 @@ configurations {
 	}
 }
 
+jacocoTestReport {
+	reports {
+		xml.enabled = true
+	}
+}
+
 sonarqube {
 	properties {
 		property "sonar.projectKey", "CDCgov_prime-data-input-client"
 		property "sonar.organization", "cdcgov"
 		property "sonar.host.url", "https://sonarcloud.io"
+		property "sonar.sources", "src/main/java,../frontend/src"
 	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -65,5 +65,6 @@ sonarqube {
 		property "sonar.projectKey", "CDCgov_prime-data-input-client"
 		property "sonar.organization", "cdcgov"
 		property "sonar.host.url", "https://sonarcloud.io"
+		property "sonar.sources", "src/main/java,../frontend/src"
 	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -65,6 +65,5 @@ sonarqube {
 		property "sonar.projectKey", "CDCgov_prime-data-input-client"
 		property "sonar.organization", "cdcgov"
 		property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.sources", "src/main/java,../frontend/src"
 	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'java'
 	id 'checkstyle'
 	id 'jacoco'
-	id 'org.sonarqube'  version '2.7.1'
+	id 'org.sonarqube'  version '3.0'
 }
 
 group = 'gov.cdc.usds'
@@ -57,5 +57,13 @@ configurations {
 	}
 	runtimeClasspath {
 		resolutionStrategy.activateDependencyLocking()
+	}
+}
+
+sonarqube {
+	properties {
+		property "sonar.projectKey", "CDCgov_prime-data-input-client"
+		property "sonar.organization", "cdcgov"
+		property "sonar.host.url", "https://sonarcloud.io"
 	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -72,6 +72,7 @@ sonarqube {
 		property "sonar.projectKey", "CDCgov_prime-data-input-client"
 		property "sonar.organization", "cdcgov"
 		property "sonar.host.url", "https://sonarcloud.io"
+		// In order to get both the frontend and backend code to report, we need to set the sonar project to the root directory.
 		property "sonar.sources", "backend/src/main/java,frontend/src"
 	}
 }


### PR DESCRIPTION
## Related Issue or Background Info

We'd like to make use of Sonar Cloud for software quality and lifecycle monitoring.
CDC has enabled the application, this PR adds the integration.

## Changes Proposed

- Adds an additional Sonar step to the `test` action.
This enables use to get some code coverage numbers from the Java tests.
- Run jacoco task in CI and generate XML files

## Additional Information

- Currently, this will only run when the backend code changes, we may want to split this out into is own separate job in order to run everything.
- We don't collect code coverage numbers for the frontend
- We still need to configure our quality gates, especially since code coverage is going to always be really low.
## Screenshots / Demos
