### PR TITLE
Sort lists

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -105,7 +105,14 @@ public class Person extends OrganizationScopedEternalEntity {
 		this.employedInHealthcare = employedInHealthcare;
 	}
 
-	public void updatePatient(
+    public Person(PersonName names, Organization org, Facility fac) {
+        super(org);
+        this.facility = fac;
+        this.nameInfo = names;
+        this.role = PersonRole.STAFF;
+    }
+
+    public void updatePatient(
 		String lookupId,
 		String firstName,
 		String middleName,
@@ -151,7 +158,11 @@ public class Person extends OrganizationScopedEternalEntity {
 		return lookupId;
 	}
 
-	public String getFirstName() {
+    public PersonName getNameInfo() {
+        return nameInfo;
+    }
+
+    public String getFirstName() {
 		return nameInfo.getFirstName();
 	}
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/PersonName.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/PersonName.java
@@ -74,4 +74,31 @@ public class PersonName {
 	public int hashCode() {
 		return Objects.hash(firstName, middleName, lastName, suffix);
 	}
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+        if (firstName != null) {
+            b.append(firstName);
+        }
+        if (middleName != null) {
+            if (b.length() > 0) {
+                b.append(' ');
+            }
+            b.append(middleName);
+        }
+        if (lastName != null) {
+            if (b.length() > 0) {
+                b.append(' ');
+            }
+            b.append(lastName);
+        }
+        if (suffix != null) {
+            if (b.length() > 0) {
+                b.append(", ");
+            }
+            b.append(suffix);
+        }
+        return b.toString();
+    }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PersonRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PersonRepository.java
@@ -3,6 +3,8 @@ package gov.cdc.usds.simplereport.db.repository;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
+
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -15,11 +17,11 @@ import java.util.UUID;
 public interface PersonRepository extends EternalEntityRepository<Person> {
 
     @Query(BASE_QUERY + " and organization = :org")
-    public List<Person> findAllByOrganization(Organization org);
+    public List<Person> findAllByOrganization(Organization org, Sort sortBy);
 
     @Query(BASE_QUERY + " and internalId = :id and organization = :org")
     public Optional<Person> findByIDAndOrganization(UUID id, Organization org);
 
     @Query(BASE_QUERY + " AND e.organization = :org AND (e.facility IS NULL OR e.facility = :fac)")
-    public List<Person> findByFacilityAndOrganization(Facility fac, Organization org);
+    public List<Person> findByFacilityAndOrganization(Facility fac, Organization org, Sort sortBy);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -25,10 +25,6 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
     public static final String ORDER_CREATION_ORDER = " order by q.createdAt ";
     public static final String RESULT_RECENT_ORDER = " order by q.testEvent.createdAt desc ";
 
-	@Query(BASE_ORG_QUERY + IS_PENDING)
-	@EntityGraph(attributePaths = "patient")
-	public List<TestOrder> fetchQueueForOrganization(Organization org);
-
     @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)
 	@EntityGraph(attributePaths = "patient")
 	public List<TestOrder> fetchQueue(Organization org, Facility facility);
@@ -39,10 +35,6 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
 
 	@Query(BASE_ORG_QUERY + IS_PENDING + " and q.id = :id")
 	public Optional<TestOrder> fetchQueueItemById(Organization org, UUID id);
-
-	@Query(BASE_ORG_QUERY + IS_COMPLETED)
-	@EntityGraph(attributePaths = "patient")
-	public List<TestOrder> fetchPastResultsForOrganization(Organization org);
 
     @Query(FACILITY_QUERY + IS_COMPLETED + RESULT_RECENT_ORDER)
 	@EntityGraph(attributePaths = "patient")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -22,12 +22,14 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
 	public static final String FACILITY_QUERY = BASE_ORG_QUERY + " and q.facility = :facility ";
 	public static final String IS_PENDING = " and q.orderStatus = 'PENDING' "; 
 	public static final String IS_COMPLETED = " and q.orderStatus = 'COMPLETED' ";
+    public static final String ORDER_CREATION_ORDER = " order by q.createdAt ";
+    public static final String RESULT_RECENT_ORDER = " order by q.testEvent.createdAt desc ";
 
 	@Query(BASE_ORG_QUERY + IS_PENDING)
 	@EntityGraph(attributePaths = "patient")
 	public List<TestOrder> fetchQueueForOrganization(Organization org);
 
-	@Query(FACILITY_QUERY + IS_PENDING)
+    @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)
 	@EntityGraph(attributePaths = "patient")
 	public List<TestOrder> fetchQueue(Organization org, Facility facility);
 
@@ -42,7 +44,7 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
 	@EntityGraph(attributePaths = "patient")
 	public List<TestOrder> fetchPastResultsForOrganization(Organization org);
 
-	@Query(FACILITY_QUERY + IS_COMPLETED)
+    @Query(FACILITY_QUERY + IS_COMPLETED + RESULT_RECENT_ORDER)
 	@EntityGraph(attributePaths = "patient")
 	public List<TestOrder> fetchPastResults(Organization org, Facility facility);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +15,6 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 
 
@@ -24,27 +24,28 @@ import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 @Service
 @Transactional(readOnly = false)
 public class PersonService {
-		private OrganizationService _os;
+
+    private OrganizationService _os;
 		private PersonRepository _repo;
-		private FacilityRepository _facilityRepo;
+
+        private static final Sort NAME_SORT = Sort.by("nameInfo.lastName", "nameInfo.firstName", "nameInfo.middleName",
+                "nameInfo.suffix");
 
 		public PersonService(
 			OrganizationService os,
-			PersonRepository repo,
-			FacilityRepository facilityRepo
+                PersonRepository repo
 		) {
 			_os = os;
 				_repo = repo;
-				_facilityRepo = facilityRepo;
 		}
 
 		public List<Person> getPatients(UUID facilityId) {
 			Organization org = _os.getCurrentOrganization();
 			if (facilityId == null) {
-				return _repo.findAllByOrganization(org);
+                return _repo.findAllByOrganization(org, NAME_SORT);
 			}
 			Facility facility = _os.getFacilityInCurrentOrg(facilityId);
-			return _repo.findByFacilityAndOrganization(facility, _os.getCurrentOrganization());
+            return _repo.findByFacilityAndOrganization(facility, _os.getCurrentOrganization(), NAME_SORT);
 		}
 
 	public Person getPatient(String id) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -76,7 +76,6 @@ public class TestOrderService {
     }
 
     public TestOrder editQueueItem(String id, String deviceId, String result) {
-        Organization org = _os.getCurrentOrganization();
         TestOrder order = this.getTestOrder(id);
 
         if (deviceId != null) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
@@ -27,10 +27,10 @@ public class PersonRepositoryTest extends BaseRepositoryTest {
 
 		StreetAddress addy = new StreetAddress("123 4th Street", null, "Washington", "DC", "20001", null);
 		_repo.save(new Person(org, "lookupid", "Joe", null, "Schmoe", null, LocalDate.now(),  addy, "(123) 456-7890", PersonRole.VISITOR, "", null, "", "", false, false));
-		List<Person> found = _repo.findAllByOrganization(org);
+		List<Person> found = _repo.findAllByOrganization(org, null);
 		assertEquals(1, found.size());
 		assertEquals("Joe", found.get(0).getFirstName());
-		found = _repo.findAllByOrganization(other);
+		found = _repo.findAllByOrganization(other, null);
 		assertEquals(0, found.size());
 	}
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -130,4 +130,67 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		assertEquals(order2.getInternalId(), queue.get(0).getInternalId());
 	}
 
+    @Test
+    public void fetchQueue_multipleEntries_sortedFifo() {
+        Organization org = _dataFactory.createValidOrg();
+        Person adam = _dataFactory.createMinimalPerson(org, "Adam", "A.", "Astaire", "Jr.");
+        Person brad = _dataFactory.createMinimalPerson(org, "Bradley", "B.", "Bones", null);
+        Person charlie = _dataFactory.createMinimalPerson(org, "Charles", "C.", "Crankypants", "3rd");
+        Facility facility = _dataFactory.createValidFacility(org);
+        _repo.save(new TestOrder(charlie, facility));
+        pause();
+        _repo.save(new TestOrder(adam, facility));
+        pause();
+        _repo.save(new TestOrder(brad, facility));
+        List<TestOrder> orders = _repo.fetchQueue(org, facility);
+        assertEquals("Charles", orders.get(0).getPatient().getFirstName());
+        assertEquals("Adam", orders.get(1).getPatient().getFirstName());
+        assertEquals("Bradley", orders.get(2).getPatient().getFirstName());
+    }
+
+    @Test
+    public void fetchResults_multipleEntries_sortedLifo() throws InterruptedException {
+        Organization org = _dataFactory.createValidOrg();
+        Person adam = _dataFactory.createMinimalPerson(org, "Adam", "A.", "Astaire", "Jr.");
+        Person brad = _dataFactory.createMinimalPerson(org, "Bradley", "B.", "Bones", null);
+        Person charlie = _dataFactory.createMinimalPerson(org, "Charles", "C.", "Crankypants", "3rd");
+        Facility facility = _dataFactory.createValidFacility(org);
+
+        TestOrder charlieOrder = _repo.save(new TestOrder(charlie, facility));
+        pause();
+        TestOrder adamOrder = _repo.save(new TestOrder(adam, facility));
+        pause();
+        TestOrder bradleyOrder = _repo.save(new TestOrder(brad, facility));
+
+        List<TestOrder> results = _repo.fetchPastResults(org, facility);
+        assertEquals(0, results.size());
+
+        doTest(bradleyOrder, TestResult.NEGATIVE);
+        pause();
+        doTest(charlieOrder, TestResult.POSITIVE);
+        pause();
+        doTest(adamOrder, TestResult.UNDETERMINED);
+
+        results = _repo.fetchPastResults(org, facility);
+        assertEquals(3, results.size());
+        assertEquals("Adam", results.get(0).getPatient().getFirstName());
+        assertEquals("Charles", results.get(1).getPatient().getFirstName());
+        assertEquals("Bradley", results.get(2).getPatient().getFirstName());
+    }
+
+    private void doTest(TestOrder order, TestResult result) {
+        order.setResult(result);
+        TestEvent event = _events.save(new TestEvent(order));
+        order.setTestEvent(event);
+        order.markComplete();
+        _repo.save(order);
+    }
+
+    private static void pause() {
+        try {
+            Thread.sleep(2);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -43,17 +43,16 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		Organization gwu = _orgRepo.save(new Organization("George Washington", "gwu"));
 		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt"));
 		Facility site = _dataFactory.createValidFacility(gtown);
+        Facility otherSite = _dataFactory.createValidFacility(gwu);
 		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", null, LocalDate.now(), null, "(123) 456-7890", PersonRole.RESIDENT, "", null, "", "", false, false));
 		TestOrder order = _repo.save(new TestOrder(hoya, site));
-		List<TestOrder> queue = _repo.fetchQueueForOrganization(gwu);
+        List<TestOrder> queue = _repo.fetchQueue(gwu, otherSite);
 		assertEquals(0, queue.size());
-		queue = _repo.fetchQueueForOrganization(gtown);
+        queue = _repo.fetchQueue(gtown, site);
 		assertEquals(1, queue.size());
-		order.setResult(TestResult.NEGATIVE);
-		order.markComplete();
-		_repo.save(order);
-		assertEquals(0, _repo.fetchQueueForOrganization(gtown).size());
-		assertEquals(1, _repo.fetchPastResultsForOrganization(gtown).size());
+        doTest(order, TestResult.NEGATIVE);
+        assertEquals(0, _repo.fetchQueue(gtown, site).size());
+        assertEquals(1, _repo.fetchPastResults(gtown, site).size());
 	}
 
 	@Test
@@ -100,7 +99,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		assertNotNull(order2.getInternalId());
 		assertNotNull(order1.getInternalId());
 		assertNotEquals(order1.getInternalId(), order2.getInternalId());
-		List<TestOrder> queue = _repo.fetchQueueForOrganization(org);
+        List<TestOrder> queue = _repo.fetchQueue(org, site);
 		assertEquals(1, queue.size());
 		assertEquals(order2.getInternalId(), queue.get(0).getInternalId());
 	}
@@ -125,7 +124,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		assertNotNull(order2.getInternalId());
 		assertNotNull(order1.getInternalId());
 		assertNotEquals(order1.getInternalId(), order2.getInternalId());
-		List<TestOrder> queue = _repo.fetchQueueForOrganization(org);
+        List<TestOrder> queue = _repo.fetchQueue(org, site);
 		assertEquals(1, queue.size());
 		assertEquals(order2.getInternalId(), queue.get(0).getInternalId());
 	}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import gov.cdc.usds.simplereport.test_util.DbTruncator;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
 /**
  * Base class for service-level integration. Avoids setting up servlet
@@ -25,6 +26,8 @@ public class BaseServiceTest<T> {
 
 	@Autowired
 	private DbTruncator _truncator;
+    @Autowired
+    protected TestDataFactory _dataFactory;
 	@Autowired
 	protected T _service;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -1,18 +1,38 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 
 @SuppressWarnings("checkstyle:MagicNumber")
 public class PersonServiceTest extends BaseServiceTest<PersonService> {
 
-	@Test
+    // I'll have you know that I didn't actually mean to do this...
+    private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
+    private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
+    private static final PersonName CHARLES = new PersonName("Charles", null, "Albemarle", "Sr.");
+    private static final PersonName DEXTER = new PersonName("Dexter", null, "Jones", null);
+    private static final PersonName ELIZABETH = new PersonName("Elizabeth", null, "Merriwether", null);
+    private static final PersonName FRANK = new PersonName("Frank", null, "Bones", "3");
+
+    @Autowired
+    private OrganizationService _orgService;
+
+    private Organization _org;
+    private Facility _site1;
+    private Facility _site2;
+
+    @Test
 	public void roundTrip() {
 		_service.addPatient(null, "FOO", "Fred", null, "Fosbury", "Sr.", LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Hicksville", "NY",
 			"11801", "(888) GET-BENT", "STAFF", null, "Nassau", null, null, null, false, false);
@@ -22,4 +42,43 @@ public class PersonServiceTest extends BaseServiceTest<PersonService> {
 		assertEquals(2, all.size());
 	}
 
+    @Test
+    public void getPatients_noFacility_allFetchedAndSorted() {
+        makedata();
+        List<Person> patients = _service.getPatients(null);
+        assertPatientList(patients, CHARLES, FRANK, BRAD, DEXTER, ELIZABETH, AMOS);
+    }
+
+    @Test
+    public void getPatients_facilitySpecific_nullsAndSpecifiedFetchedAndSorted() {
+        makedata();
+        List<Person> patients = _service.getPatients(_site1.getInternalId());
+        assertPatientList(patients, CHARLES, BRAD, ELIZABETH, AMOS);
+        patients = _service.getPatients(_site2.getInternalId());
+        assertPatientList(patients, FRANK, BRAD, DEXTER, AMOS);
+    }
+
+    private void makedata() {
+        _org = _orgService.getCurrentOrganization();
+        _site1 = _dataFactory.createValidFacility(_org, "First One");
+        _site2 = _dataFactory.createValidFacility(_org, "Second One");
+
+        _dataFactory.createMinimalPerson(_org, null, AMOS);
+        _dataFactory.createMinimalPerson(_org, null, BRAD);
+        _dataFactory.createMinimalPerson(_org, _site1, ELIZABETH);
+        _dataFactory.createMinimalPerson(_org, _site1, CHARLES);
+        _dataFactory.createMinimalPerson(_org, _site2, DEXTER);
+        _dataFactory.createMinimalPerson(_org, _site2, FRANK);
+    }
+
+    private static void assertPatientList(List<Person> found, PersonName... expected) {
+        // check common elements first
+        for (int i = 0; i < expected.length && i < found.size(); i++) {
+            assertEquals(expected[i], found.get(i).getNameInfo());
+        }
+        // *then* check if there are extras
+        if (expected.length != found.size()) {
+            fail("Expected" + expected.length + " items but found " + found.size());
+        }
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.test_util;
 import java.time.LocalDate;
 import java.util.Collections;
 
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +14,7 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
@@ -49,14 +49,17 @@ public class TestDataFactory {
 	}
 
 	public Facility createValidFacility(Organization org) {
+        return createValidFacility(org, "Injection Site");
+    }
+
+    public Facility createValidFacility(Organization org, String facilityName) {
 		DeviceType dev = getGenericDevice();
 		StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
 		Provider doc = _providerRepo.save(new Provider("Doctor", "", "Doom", "", "DOOOOOOM", addy, "1-900-CALL-FOR-DOC")); 
-		Facility facility = new Facility(org, "Injection Site", "123456", doc);
+        Facility facility = new Facility(org, facilityName, "123456", doc);
 		facility.setAddress(addy);
 		facility.setDefaultDeviceType(dev);
 		Facility save = _facilityRepo.save(facility);
-		LoggerFactory.getLogger("DERPDERPDERP").warn("Facility looks like {}", save);
 		return save;
 	}
 
@@ -66,10 +69,16 @@ public class TestDataFactory {
 
     public Person createMinimalPerson(Organization org, String firstName, String middleName, String lastName,
             String suffix) {
-        return _personRepo.save(new Person(firstName, middleName, lastName, suffix, org));
+        PersonName names = new PersonName(firstName, middleName, lastName, suffix);
+        return createMinimalPerson(org, null, names);
     }
 
-	public Person createFullPerson(Organization org) {
+    public Person createMinimalPerson(Organization org, Facility fac, PersonName names) {
+        Person p = new Person(names, org, fac);
+        return _personRepo.save(p);
+    }
+
+    public Person createFullPerson(Organization org) {
 		Person p = new Person(
 			org, "HELLOTHERE", "Fred", null, "Astaire", null, LocalDate.of(1899, 5, 10),
 			new StreetAddress("1 Central Park West", null, "New York", "NY", "11000", "New Yawk"), "202-123-4567",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -61,8 +61,13 @@ public class TestDataFactory {
 	}
 
 	public Person createMinimalPerson(Organization org) {
-		return _personRepo.save(new Person("John", "Brown", "Boddie", "Jr.", org));
+        return createMinimalPerson(org, "John", "Brown", "Boddie", "Jr.");
 	}
+
+    public Person createMinimalPerson(Organization org, String firstName, String middleName, String lastName,
+            String suffix) {
+        return _personRepo.save(new Person(firstName, middleName, lastName, suffix, org));
+    }
 
 	public Person createFullPerson(Organization org) {
 		Person p = new Person(


### PR DESCRIPTION
## Related Issue or Background Info

Per user feedback captured in #312, we should be returning lists of patients, results and test orders to the client in
sorted order. This was taken care of in redux selectors originally, but those are no longer part of the client display logic, so the sort needs to be implemented on the server.

## Changes Proposed

- modify TestOrder queries to include explicit sorts in the correct direction for the queue and for past results
- modify Person queries to take a Sort object at runtime, and modify PersonService to pass in the correct one.
- clean up dead code

There are two reasons for doing it differently in the two classes:
1. the TestOrder fetches have fairly specific roles in the UI that are unlikely to change materially in the future, while the Person list is likely to end up being sorted and filtered by user request.
2. it's annoying to hard-code a four-part sort, which is what sorting by a four-part name requires.

## Additional Information

As soon as this is done I'm going to reformat the entire src/test tree to use 4-space indent instead of the mix of tabs and spaces we've currently arrived at. Shoulda stuck with my original plan of making everybody use tabs....

Resolves #312.