### PR TITLE
Normalize the formatting of java tests

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -9,8 +9,8 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("dev") // :-(
 public class SimpleReportApplicationTests {
 
-	@Test
-	public void contextLoads() {
-		// no-op
-	}
+    @Test
+    public void contextLoads() {
+        // no-op
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiSmokeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiSmokeTest.java
@@ -15,21 +15,21 @@ import gov.cdc.usds.simplereport.service.PersonService;
 @SuppressWarnings("checkstyle:MagicNumber")
 public class ApiSmokeTest extends BaseApiTest {
 
-	@Autowired
-	private PersonService _personService;
-	
-	@Test
-	public void smoketestPatientList() throws IOException {
-		truncateDb();
-		JsonNode jsonResponse = runQuery("person-query");
-		assertTrue(jsonResponse.get("patients").isEmpty());
-		// should do this as a mutator call, but not today
-		_personService.addPatient(null, "BAZ", "Baz", null, "Jesek", null, 
-				LocalDate.of(2403, 12, 3),
-				"Someplace", "Nice", "Capitol", "Escobar", "12345-6678",
-				"(12) 2345", "STAFF", "baz@dendarii.net", "Vorkosigan", null, null, "M", false, false);
-		jsonResponse = runQuery("person-query");
-		assertTrue(jsonResponse.get("patients").has(0));
-		truncateDb();
-	}
+    @Autowired
+    private PersonService _personService;
+
+    @Test
+    public void smoketestPatientList() throws IOException {
+        truncateDb();
+        JsonNode jsonResponse = runQuery("person-query");
+        assertTrue(jsonResponse.get("patients").isEmpty());
+        // should do this as a mutator call, but not today
+        _personService.addPatient(null, "BAZ", "Baz", null, "Jesek", null,
+                LocalDate.of(2403, 12, 3),
+                "Someplace", "Nice", "Capitol", "Escobar", "12345-6678",
+                "(12) 2345", "STAFF", "baz@dendarii.net", "Vorkosigan", null, null, "M", false, false);
+        jsonResponse = runQuery("person-query");
+        assertTrue(jsonResponse.get("patients").has(0));
+        truncateDb();
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseApiTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseApiTest.java
@@ -22,73 +22,74 @@ import gov.cdc.usds.simplereport.test_util.DbTruncator;
 @ActiveProfiles("dev")
 public abstract class BaseApiTest {
 
-	@Autowired
-	private DbTruncator _truncator;
+    @Autowired
+    private DbTruncator _truncator;
 
-	@Autowired
-	protected GraphQLTestTemplate _template; // screw delegation
+    @Autowired
+    protected GraphQLTestTemplate _template; // screw delegation
 
-	protected void truncateDb() {
-		_truncator.truncateAll();
-	}
+    protected void truncateDb() {
+        _truncator.truncateAll();
+    }
 
-	@AfterEach
-	public void cleanup() {
-		truncateDb();
-	}
+    @AfterEach
+    public void cleanup() {
+        truncateDb();
+    }
 
-	/** 
-	 * Run the query in the given resource file, check if the response has errors, and
-	 * return the {@code data} section of the response if not.
-	 * @param queryFileName
-	 * @return the "data" key from the server response.
-	 * @throws AssertionFailedError if the response has errors
-	 * @throws RuntimeException for unexpected errors
-	 */
-	protected ObjectNode runQuery(String queryFileName) {
-		try {
-			GraphQLResponse response = _template.postForResource(queryFileName);
-			assertTrue(response.isOk(), "Servlet response should be OK");
-			JsonNode responseBody = response.readTree();
-			assertGraphQLSuccess(responseBody);
-			return (ObjectNode) responseBody.get("data");
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    /**
+     * Run the query in the given resource file, check if the response has
+     * errors, and return the {@code data} section of the response if not.
+     * 
+     * @param queryFileName
+     * @return the "data" key from the server response.
+     * @throws AssertionFailedError if the response has errors
+     * @throws RuntimeException     for unexpected errors
+     */
+    protected ObjectNode runQuery(String queryFileName) {
+        try {
+            GraphQLResponse response = _template.postForResource(queryFileName);
+            assertTrue(response.isOk(), "Servlet response should be OK");
+            JsonNode responseBody = response.readTree();
+            assertGraphQLSuccess(responseBody);
+            return (ObjectNode) responseBody.get("data");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	protected ObjectNode runQuery(String queryFileName, ObjectNode variables) {
-		try {
-			GraphQLResponse response = _template.perform(queryFileName, variables);
-			assertTrue(response.isOk(), "Servlet response should be OK");
-			JsonNode responseBody = response.readTree();
-			assertGraphQLSuccess(responseBody);
-			return (ObjectNode) responseBody.get("data");
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    protected ObjectNode runQuery(String queryFileName, ObjectNode variables) {
+        try {
+            GraphQLResponse response = _template.perform(queryFileName, variables);
+            assertTrue(response.isOk(), "Servlet response should be OK");
+            JsonNode responseBody = response.readTree();
+            assertGraphQLSuccess(responseBody);
+            return (ObjectNode) responseBody.get("data");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	/**
-	 * Check if the given response has an {@code errors} section, and if so, fail
-	 * the test using the errors section as a failure message. 
-	 */
-	protected static void assertGraphQLSuccess(GraphQLResponse resp) {
-		try {
-			assertGraphQLSuccess(resp.readTree());
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    /**
+     * Check if the given response has an {@code errors} section, and if so,
+     * fail the test using the errors section as a failure message.
+     */
+    protected static void assertGraphQLSuccess(GraphQLResponse resp) {
+        try {
+            assertGraphQLSuccess(resp.readTree());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	/**
-	 * Check if the given response body has an {@code errors} section, and if so, fail
-	 * the test using the errors section as a failure message. 
-	 */
-	protected static void assertGraphQLSuccess(JsonNode responseBody) {
-		JsonNode errorNode = responseBody.path("errors");
-		if(!errorNode.isMissingNode()) {
-			fail(errorNode.toString());
-		}
-	}
+    /**
+     * Check if the given response body has an {@code errors} section, and if
+     * so, fail the test using the errors section as a failure message.
+     */
+    protected static void assertGraphQLSuccess(JsonNode responseBody) {
+        JsonNode errorNode = responseBody.path("errors");
+        if (!errorNode.isMissingNode()) {
+            fail(errorNode.toString());
+        }
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
@@ -9,16 +9,16 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class OrganizationFacilityTest extends BaseApiTest {
 
-	@BeforeEach
-	public void setup() {
-		truncateDb();
-	}
+    @BeforeEach
+    public void setup() {
+        truncateDb();
+    }
 
-	@Test
-	public void fetchFakeUserData() {
-		ObjectNode resp = runQuery("current-user-query");
-		ObjectNode who = (ObjectNode) resp.get("whoami");
-		assertEquals("Bobbity", who.get("firstName").asText());
-	}
+    @Test
+    public void fetchFakeUserData() {
+        ObjectNode resp = runQuery("current-user-query");
+        ObjectNode who = (ObjectNode) resp.get("whoami");
+        assertEquals("Bobbity", who.get("firstName").asText());
+    }
 
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/PatientManagementTest.java
@@ -18,42 +18,41 @@ import com.graphql.spring.boot.test.GraphQLResponse;
  */
 public class PatientManagementTest extends BaseApiTest {
 
-	@BeforeEach
-	public void setup() {
-		truncateDb();
-	}
+    @BeforeEach
+    public void setup() {
+        truncateDb();
+    }
 
-	@Test
-	public void createAndFetchOnePatientUsDate() throws Exception {
-		String firstName = "Jon";
-		JsonNode patients = doCreateAndFetch(firstName, "Snow", "05/18/1066", "youknownothing");
-		assertTrue(patients.has(0), "At least one patient found");
-		JsonNode jon = patients.get(0);
-		assertEquals(firstName, jon.get("firstName").asText());
-		assertEquals("1066-05-18", jon.get("birthDate").asText());
-	}
+    @Test
+    public void createAndFetchOnePatientUsDate() throws Exception {
+        String firstName = "Jon";
+        JsonNode patients = doCreateAndFetch(firstName, "Snow", "05/18/1066", "youknownothing");
+        assertTrue(patients.has(0), "At least one patient found");
+        JsonNode jon = patients.get(0);
+        assertEquals(firstName, jon.get("firstName").asText());
+        assertEquals("1066-05-18", jon.get("birthDate").asText());
+    }
 
-	@Test
-	public void createAndFetchOnePatientIsoDate() throws Exception {
-		String firstName = "Sansa";
-		JsonNode patients = doCreateAndFetch(firstName, "Stark", "12/25/1100", "notbitter");
-		assertTrue(patients.has(0), "At least one patient found");
-		JsonNode sansa = patients.get(0);
-		assertEquals(firstName, sansa.get("firstName").asText());
-		assertEquals("1100-12-25", sansa.get("birthDate").asText());
-	}
+    @Test
+    public void createAndFetchOnePatientIsoDate() throws Exception {
+        String firstName = "Sansa";
+        JsonNode patients = doCreateAndFetch(firstName, "Stark", "12/25/1100", "notbitter");
+        assertTrue(patients.has(0), "At least one patient found");
+        JsonNode sansa = patients.get(0);
+        assertEquals(firstName, sansa.get("firstName").asText());
+        assertEquals("1100-12-25", sansa.get("birthDate").asText());
+    }
 
-	private JsonNode doCreateAndFetch(String firstName, String lastName, String birthDate, String lookupId)
-			throws IOException {
-		ObjectNode variables = JsonNodeFactory.instance.objectNode()
-			.put("firstName", firstName)
-			.put("lastName", lastName)
-			.put("birthDate", birthDate)
-			.put("lookupId", lookupId)
-			;
-		GraphQLResponse resp = _template.perform("add-person", variables);
-		assertGraphQLSuccess(resp);
-		JsonNode patients = runQuery("person-query").get("patients");
-		return patients;
-	}
+    private JsonNode doCreateAndFetch(String firstName, String lastName, String birthDate, String lookupId)
+            throws IOException {
+        ObjectNode variables = JsonNodeFactory.instance.objectNode()
+                .put("firstName", firstName)
+                .put("lastName", lastName)
+                .put("birthDate", birthDate)
+                .put("lookupId", lookupId);
+        GraphQLResponse resp = _template.perform("add-person", variables);
+        assertGraphQLSuccess(resp);
+        JsonNode patients = runQuery("person-query").get("patients");
+        return patients;
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/QueueManagementTest.java
@@ -26,51 +26,50 @@ import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
 public class QueueManagementTest extends BaseApiTest {
 
-	private static final String QUERY = "queue-dates-query";
+    private static final String QUERY = "queue-dates-query";
 
-	@Autowired
-	private TestDataFactory _dataFactory;
-	@Autowired
-	private OrganizationService _orgService;
+    @Autowired
+    private TestDataFactory _dataFactory;
+    @Autowired
+    private OrganizationService _orgService;
     @Autowired
     private TestOrderService _testOrderService;
 
-	private Organization _org;
-	private Facility _site;
+    private Organization _org;
+    private Facility _site;
 
-	@BeforeEach
-	public void init() {
-		truncateDb();
-		_org = _orgService.getCurrentOrganization();
-		_site = _orgService.getFacilities(_org).get(0);
-	}
+    @BeforeEach
+    public void init() {
+        truncateDb();
+        _org = _orgService.getCurrentOrganization();
+        _site = _orgService.getFacilities(_org).get(0);
+    }
 
-	@Test
-	public void enqueueOnePatient() throws Exception {
-		Person p = _dataFactory.createFullPerson(_org);
-		String personId = p.getInternalId().toString();
-		ObjectNode variables = getFacilityScopedArguments()
-				.put("id", personId)
-				.put("previousTestDate", "05/15/2020")
-				.put("symptomOnsetDate", "11/30/2020")
-				;
-		performEnqueueMutation(variables);
-		ArrayNode queueData = fetchQueue();
-		assertEquals(1, queueData.size());
-		JsonNode queueEntry = queueData.get(0);
-		String symptomOnset = queueEntry.get("symptomOnset").asText();
-		String priorTest = queueEntry.get("priorTestDate").asText();
-		assertEquals("2020-11-30", symptomOnset);
-		assertEquals("2020-05-15", priorTest);
-		// this assertion is kind of extra, should be on a patient management test instead
-		assertEquals("1899-05-10", queueEntry.get("patient").get("birthDate").asText());
-	}
-
+    @Test
+    public void enqueueOnePatient() throws Exception {
+        Person p = _dataFactory.createFullPerson(_org);
+        String personId = p.getInternalId().toString();
+        ObjectNode variables = getFacilityScopedArguments()
+                .put("id", personId)
+                .put("previousTestDate", "05/15/2020")
+                .put("symptomOnsetDate", "11/30/2020");
+        performEnqueueMutation(variables);
+        ArrayNode queueData = fetchQueue();
+        assertEquals(1, queueData.size());
+        JsonNode queueEntry = queueData.get(0);
+        String symptomOnset = queueEntry.get("symptomOnset").asText();
+        String priorTest = queueEntry.get("priorTestDate").asText();
+        assertEquals("2020-11-30", symptomOnset);
+        assertEquals("2020-05-15", priorTest);
+        // this assertion is kind of extra, should be on a patient management
+        // test instead
+        assertEquals("1899-05-10", queueEntry.get("patient").get("birthDate").asText());
+    }
 
     @Test
     public void updateItemInQueue() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
-		TestOrder o = _dataFactory.createTestOrder(p, _site);
+        TestOrder o = _dataFactory.createTestOrder(p, _site);
         String orderId = o.getInternalId().toString();
         DeviceType d = _dataFactory.getGenericDevice();
         String deviceId = d.getInternalId().toString();
@@ -87,37 +86,36 @@ public class QueueManagementTest extends BaseApiTest {
         assertEquals(updatedTestOrder.getTestEvent(), null);
     }
 
-	@Test
-	public void enqueueOnePatientIsoDate() throws Exception {
-		Person p = _dataFactory.createFullPerson(_org);
-		String personId = p.getInternalId().toString();
-		ObjectNode variables = getFacilityScopedArguments()
-				.put("id", personId)
-				.put("previousTestDate", "2020-05-15")
-				.put("symptomOnsetDate", "2020-11-30")
-				;
-		performEnqueueMutation(variables);
-		ArrayNode queueData = fetchQueue();
-		assertEquals(1, queueData.size());
-		JsonNode queueEntry = queueData.get(0);
-		String symptomOnset = queueEntry.get("symptomOnset").asText();
-		String priorTest = queueEntry.get("priorTestDate").asText();
-		assertEquals("2020-11-30", symptomOnset);
-		assertEquals("2020-05-15", priorTest);
-	}
+    @Test
+    public void enqueueOnePatientIsoDate() throws Exception {
+        Person p = _dataFactory.createFullPerson(_org);
+        String personId = p.getInternalId().toString();
+        ObjectNode variables = getFacilityScopedArguments()
+                .put("id", personId)
+                .put("previousTestDate", "2020-05-15")
+                .put("symptomOnsetDate", "2020-11-30");
+        performEnqueueMutation(variables);
+        ArrayNode queueData = fetchQueue();
+        assertEquals(1, queueData.size());
+        JsonNode queueEntry = queueData.get(0);
+        String symptomOnset = queueEntry.get("symptomOnset").asText();
+        String priorTest = queueEntry.get("priorTestDate").asText();
+        assertEquals("2020-11-30", symptomOnset);
+        assertEquals("2020-05-15", priorTest);
+    }
 
-	private ObjectNode getFacilityScopedArguments() {
-		return JsonNodeFactory.instance.objectNode()
-			.put("facilityId", _site.getInternalId().toString());
-	}
+    private ObjectNode getFacilityScopedArguments() {
+        return JsonNodeFactory.instance.objectNode()
+                .put("facilityId", _site.getInternalId().toString());
+    }
 
-	private ArrayNode fetchQueue() {
-		return (ArrayNode) runQuery(QUERY, getFacilityScopedArguments()).get("queue");
-	}
+    private ArrayNode fetchQueue() {
+        return (ArrayNode) runQuery(QUERY, getFacilityScopedArguments()).get("queue");
+    }
 
-	private void performEnqueueMutation(ObjectNode variables) throws IOException {
-		assertGraphQLSuccess(_template.perform("add-to-queue", variables));
-	}
+    private void performEnqueueMutation(ObjectNode variables) throws IOException {
+        assertGraphQLSuccess(_template.perform("add-to-queue", variables));
+    }
 
     private void performQueueUpdateMutation(ObjectNode variables) throws IOException {
         assertGraphQLSuccess(_template.perform("edit-queue-item", variables));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -17,49 +17,51 @@ import org.springframework.boot.test.json.ObjectContent;
 @JsonTest
 public class PersonSerializationTest {
 
-	@Autowired
-	private JacksonTester<Person> _tester;
+    @Autowired
+    private JacksonTester<Person> _tester;
 
-	@Test
-	public void deserialize_stringRace_raceFound() throws IOException {
-		ObjectContent<Person> ob = _tester.read("/deserialization/race-scalar.json");
-		assertAlexanderHamilton(ob);
-	}
+    @Test
+    public void deserialize_stringRace_raceFound() throws IOException {
+        ObjectContent<Person> ob = _tester.read("/deserialization/race-scalar.json");
+        assertAlexanderHamilton(ob);
+    }
 
-	@Test
-	public void deserialize_arrayRace_raceFound() throws IOException {
-		ObjectContent<Person> ob = _tester.read("/deserialization/race-array.json");
-		assertAlexanderHamilton(ob);
-	}
+    @Test
+    public void deserialize_arrayRace_raceFound() throws IOException {
+        ObjectContent<Person> ob = _tester.read("/deserialization/race-array.json");
+        assertAlexanderHamilton(ob);
+    }
 
-	@Test
-	public void deserialize_withFacility_raceFoundNoFacility() throws IOException {
-		ObjectContent<Person> ob = _tester.read("/deserialization/with-facility.json");
-		assertAlexanderHamilton(ob);
-	}
+    @Test
+    public void deserialize_withFacility_raceFoundNoFacility() throws IOException {
+        ObjectContent<Person> ob = _tester.read("/deserialization/with-facility.json");
+        assertAlexanderHamilton(ob);
+    }
 
-	@Test
-	public void serialize_withOrgAndFacility_noOrgOrFacility() throws IOException {
-		// consts are to keep style check happy othewise it complains about "magic numbers"
-		final int BIRTH_YEAR = 2000;
-		final int BIRTH_MONTH = 3;
-		final int BIRTH_DAY = 31;
-		Organization fakeOrg = new Organization("ABC", "123");
-		Person p = new Person(fakeOrg,
-				null, "John", "Jacob", "Jingleheimer-Jones", "Jr.", LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY), null, "1234556",
-				null, "a@b.c", "marathon", "generic", "Male-ish", true, false);
-		p.setFacility(new Facility(fakeOrg, "Nice Place", "YOUGOTHERE", null));
-		String json = _tester.write(p).getJson();
-		assertFalse(json.contains("organization"));
-		assertFalse(json.contains("facility"));
-	}
+    @Test
+    public void serialize_withOrgAndFacility_noOrgOrFacility() throws IOException {
+        // consts are to keep style check happy othewise it complains about
+        // "magic numbers"
+        final int BIRTH_YEAR = 2000;
+        final int BIRTH_MONTH = 3;
+        final int BIRTH_DAY = 31;
+        Organization fakeOrg = new Organization("ABC", "123");
+        Person p = new Person(fakeOrg,
+                null, "John", "Jacob", "Jingleheimer-Jones", "Jr.", LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY),
+                null, "1234556",
+                null, "a@b.c", "marathon", "generic", "Male-ish", true, false);
+        p.setFacility(new Facility(fakeOrg, "Nice Place", "YOUGOTHERE", null));
+        String json = _tester.write(p).getJson();
+        assertFalse(json.contains("organization"));
+        assertFalse(json.contains("facility"));
+    }
 
-	private void assertAlexanderHamilton(ObjectContent<Person> ob) {
-		Person p = ob.getObject();
-		assertNotNull(p);
-		assertEquals("Alexander", p.getFirstName());
-		assertEquals("Hamilton", p.getLastName());
-		assertEquals("white", p.getRace());
-		assertNull(p.getFacility());
-	}
+    private void assertAlexanderHamilton(ObjectContent<Person> ob) {
+        Person p = ob.getObject();
+        assertNotNull(p);
+        assertEquals("Alexander", p.getFirstName());
+        assertEquals("Hamilton", p.getLastName());
+        assertEquals("white", p.getRace());
+        assertNull(p.getFacility());
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -16,10 +16,10 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
 @Import(SliceTestConfiguration.class)
 public abstract class BaseRepositoryTest {
 
-	@Autowired
-	private TestEntityManager _manager;
+    @Autowired
+    private TestEntityManager _manager;
 
-	protected void flush() {
-		_manager.flush();
-	}
+    protected void flush() {
+        _manager.flush();
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -18,35 +18,35 @@ import gov.cdc.usds.simplereport.db.model.Provider;
 
 public class FacilityRepositoryTest extends BaseRepositoryTest {
 
-	@Autowired
-	private DeviceTypeRepository _devices;
-	@Autowired
-	private ProviderRepository _providers;
-	@Autowired
-	private OrganizationRepository _orgs;
-	@Autowired
-	private FacilityRepository _repo;
+    @Autowired
+    private DeviceTypeRepository _devices;
+    @Autowired
+    private ProviderRepository _providers;
+    @Autowired
+    private OrganizationRepository _orgs;
+    @Autowired
+    private FacilityRepository _repo;
 
-	@Test
-	public void smokeTestDeviceOperations() {
-		Set<DeviceType> configuredDevices = new HashSet<>();
-		DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6");
-		Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
-		configuredDevices.add(_devices.save(bill));
-		configuredDevices.add(_devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7")));
-		Organization org = _orgs.save(new Organization("My Office", "650Mass"));
-		Facility saved = _repo.save(new Facility(org, "Third Floor", "123456", mccoy, bill, configuredDevices));
-		Optional<Facility> maybe = _repo.findByOrganizationAndFacilityName(org, "Third Floor");
-		assertTrue(maybe.isPresent(), "should find the facility");
-		Facility found = maybe.get();
-		assertEquals(2, found.getDeviceTypes().size());
-		found.addDefaultDeviceType(bill);
-		_repo.save(found);
-		found = _repo.findById(saved.getInternalId()).get();
-		found.removeDeviceType(bill);
-		_repo.save(found);
-		found = _repo.findById(saved.getInternalId()).get();
-		assertNull(found.getDefaultDeviceType());
-		assertEquals(1, found.getDeviceTypes().size());
-	}
+    @Test
+    public void smokeTestDeviceOperations() {
+        Set<DeviceType> configuredDevices = new HashSet<>();
+        DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6");
+        Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
+        configuredDevices.add(_devices.save(bill));
+        configuredDevices.add(_devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7")));
+        Organization org = _orgs.save(new Organization("My Office", "650Mass"));
+        Facility saved = _repo.save(new Facility(org, "Third Floor", "123456", mccoy, bill, configuredDevices));
+        Optional<Facility> maybe = _repo.findByOrganizationAndFacilityName(org, "Third Floor");
+        assertTrue(maybe.isPresent(), "should find the facility");
+        Facility found = maybe.get();
+        assertEquals(2, found.getDeviceTypes().size());
+        found.addDefaultDeviceType(bill);
+        _repo.save(found);
+        found = _repo.findById(saved.getInternalId()).get();
+        found.removeDeviceType(bill);
+        _repo.save(found);
+        found = _repo.findById(saved.getInternalId()).get();
+        assertNull(found.getDefaultDeviceType());
+        assertEquals(1, found.getDeviceTypes().size());
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepositoryTest.java
@@ -13,17 +13,17 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 
 public class OrganizationRepositoryTest extends BaseRepositoryTest {
 
-	@Autowired
-	private OrganizationRepository _repo;
+    @Autowired
+    private OrganizationRepository _repo;
 
-	@Test
-	public void createAndFindSomething() {
-		Organization saved = _repo.save(new Organization("My House", "12345"));
-		assertNotNull(saved);
-		assertNotNull(saved.getInternalId());
-		Optional<Organization> sameOrg = _repo.findByExternalId("12345");
-		assertTrue(sameOrg.isPresent());
-		assertEquals(sameOrg.get().getInternalId(), saved.getInternalId());
-	}
+    @Test
+    public void createAndFindSomething() {
+        Organization saved = _repo.save(new Organization("My House", "12345"));
+        assertNotNull(saved);
+        assertNotNull(saved.getInternalId());
+        Optional<Organization> sameOrg = _repo.findByExternalId("12345");
+        assertTrue(sameOrg.isPresent());
+        assertEquals(sameOrg.get().getInternalId(), saved.getInternalId());
+    }
 
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
@@ -15,22 +15,23 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
 public class PersonRepositoryTest extends BaseRepositoryTest {
 
-	@Autowired
-	private PersonRepository _repo;
-	@Autowired
-	private OrganizationRepository _orgRepo;
+    @Autowired
+    private PersonRepository _repo;
+    @Autowired
+    private OrganizationRepository _orgRepo;
 
-	@Test
-	public void doPersonOperations() {
-		Organization org = _orgRepo.save(new Organization("Here", "there"));
-		Organization other = _orgRepo.save(new Organization("There", "where?"));
+    @Test
+    public void doPersonOperations() {
+        Organization org = _orgRepo.save(new Organization("Here", "there"));
+        Organization other = _orgRepo.save(new Organization("There", "where?"));
 
-		StreetAddress addy = new StreetAddress("123 4th Street", null, "Washington", "DC", "20001", null);
-		_repo.save(new Person(org, "lookupid", "Joe", null, "Schmoe", null, LocalDate.now(),  addy, "(123) 456-7890", PersonRole.VISITOR, "", null, "", "", false, false));
-		List<Person> found = _repo.findAllByOrganization(org, null);
-		assertEquals(1, found.size());
-		assertEquals("Joe", found.get(0).getFirstName());
-		found = _repo.findAllByOrganization(other, null);
-		assertEquals(0, found.size());
-	}
+        StreetAddress addy = new StreetAddress("123 4th Street", null, "Washington", "DC", "20001", null);
+        _repo.save(new Person(org, "lookupid", "Joe", null, "Schmoe", null, LocalDate.now(), addy, "(123) 456-7890",
+                PersonRole.VISITOR, "", null, "", "", false, false));
+        List<Person> found = _repo.findAllByOrganization(org, null);
+        assertEquals(1, found.size());
+        assertEquals("Joe", found.get(0).getFirstName());
+        found = _repo.findAllByOrganization(other, null);
+        assertEquals(0, found.size());
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -11,32 +11,32 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
 /**
- * Base class for service-level integration. Avoids setting up servlet
- * and web security, but sets up service and persistence layer.
+ * Base class for service-level integration. Avoids setting up servlet and web
+ * security, but sets up service and persistence layer.
  *
- * Note that when service-layer security is configured, it will mysteriously
- * not work in tests because security configuration is attached to a web
- * security configuration module. (That module is also on the wrong profile,
- * so there's a significant rearrangement required regardless.)
+ * Note that when service-layer security is configured, it will mysteriously not
+ * work in tests because security configuration is attached to a web security
+ * configuration module. (That module is also on the wrong profile, so there's a
+ * significant rearrangement required regardless.)
  */
 @SpringBootTest(properties = "spring.main.web-application-type=NONE")
 @ActiveProfiles("dev")
 @Import(SliceTestConfiguration.class)
 public class BaseServiceTest<T> {
 
-	@Autowired
-	private DbTruncator _truncator;
+    @Autowired
+    private DbTruncator _truncator;
     @Autowired
     protected TestDataFactory _dataFactory;
-	@Autowired
-	protected T _service;
+    @Autowired
+    protected T _service;
 
-	@BeforeEach
-	public void clearDb() {
-		_truncator.truncateAll();
-	}
+    @BeforeEach
+    public void clearDb() {
+        _truncator.truncateAll();
+    }
 
-	protected void reset() {
-		_truncator.truncateAll();
-	}
+    protected void reset() {
+        _truncator.truncateAll();
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -12,17 +12,17 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 
 public class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
-	@Test
-	public void insertAndFindAndDeleteAndSoForth() {
-		DeviceType devA = _service.createDeviceType("A", "B", "C", "DUMMY");
-		DeviceType devB = _service.createDeviceType("D", "E", "F", "DUMMY");
-		assertNotNull(devA);
-		assertNotNull(devB);
-		assertNotEquals(devA.getInternalId(), devB.getInternalId());
-		List<DeviceType> found = _service.fetchDeviceTypes();
-		assertEquals(2, found.size());
-		_service.removeDeviceType(devB);
-		found = _service.fetchDeviceTypes();
-		assertEquals(1, found.size());
-	}
+    @Test
+    public void insertAndFindAndDeleteAndSoForth() {
+        DeviceType devA = _service.createDeviceType("A", "B", "C", "DUMMY");
+        DeviceType devB = _service.createDeviceType("D", "E", "F", "DUMMY");
+        assertNotNull(devA);
+        assertNotNull(devB);
+        assertNotEquals(devA.getInternalId(), devB.getInternalId());
+        List<DeviceType> found = _service.fetchDeviceTypes();
+        assertEquals(2, found.size());
+        _service.removeDeviceType(devB);
+        found = _service.fetchDeviceTypes();
+        assertEquals(1, found.size());
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test;
 import gov.cdc.usds.simplereport.db.model.Organization;
 
 public class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
-	
-	@Test
-	public void findit() {
-		Organization org = _service.getCurrentOrganization();
-		assertNotNull(org);
-		assertEquals("DIS_ORG", org.getExternalId());
-	}
+
+    @Test
+    public void findit() {
+        Organization org = _service.getCurrentOrganization();
+        assertNotNull(org);
+        assertEquals("DIS_ORG", org.getExternalId());
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -33,14 +33,16 @@ public class PersonServiceTest extends BaseServiceTest<PersonService> {
     private Facility _site2;
 
     @Test
-	public void roundTrip() {
-		_service.addPatient(null, "FOO", "Fred", null, "Fosbury", "Sr.", LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Hicksville", "NY",
-			"11801", "(888) GET-BENT", "STAFF", null, "Nassau", null, null, null, false, false);
-		_service.addPatient(null, "BAR", "Basil", null, "Barnacle", "4th", LocalDate.of(1865, 12, 25), "13 Main",null, "Hicksville", "NY",
-				"11801", "(888) GET-BENT", "STAFF", null, "Nassau", null, null, null, false, false);
-		List<Person> all = _service.getPatients(null);
-		assertEquals(2, all.size());
-	}
+    public void roundTrip() {
+        _service.addPatient(null, "FOO", "Fred", null, "Fosbury", "Sr.", LocalDate.of(1865, 12, 25), "123 Main",
+                "Apartment 3", "Hicksville", "NY",
+                "11801", "(888) GET-BENT", "STAFF", null, "Nassau", null, null, null, false, false);
+        _service.addPatient(null, "BAR", "Basil", null, "Barnacle", "4th", LocalDate.of(1865, 12, 25), "13 Main", null,
+                "Hicksville", "NY",
+                "11801", "(888) GET-BENT", "STAFF", null, "Nassau", null, null, null, false, false);
+        List<Person> all = _service.getPatients(null);
+        assertEquals(2, all.size());
+    }
 
     @Test
     public void getPatients_noFacility_allFetchedAndSorted() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -32,12 +32,12 @@ public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Organization org = _organizationService.getCurrentOrganization();
         Facility facility = _organizationService.getFacilities(org).get(0);
         Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.",
-            LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
-            "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
-        
+                LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
+                "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
+
         _service.addPatientToQueue(facility.getInternalId(), p, "",
-            Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
-            TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+                Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
+                TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
 
         List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
         assertEquals(1, queue.size());
@@ -48,15 +48,15 @@ public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Organization org = _organizationService.getCurrentOrganization();
         Facility facility = _organizationService.getFacilities(org).get(0);
         Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.",
-            LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
-            "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
+                LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
+                "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
         _service.addPatientToQueue(facility.getInternalId(), p, "",
-            Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
-            TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+                Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
+                TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
         DeviceType devA = _deviceTypeService.createDeviceType("A", "B", "C", "DUMMY");
 
         _service.addTestResult(devA.getInternalId().toString(), TestResult.POSITIVE,
-            p.getInternalId().toString());
+                p.getInternalId().toString());
 
         List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
         assertEquals(0, queue.size());
@@ -67,15 +67,15 @@ public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Organization org = _organizationService.getCurrentOrganization();
         Facility facility = _organizationService.getFacilities(org).get(0);
         Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.",
-            LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
-            "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
+                LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
+                "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
         TestOrder o = _service.addPatientToQueue(facility.getInternalId(), p, "",
-            Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
-            TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+                Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
+                TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
         DeviceType devA = _deviceTypeService.createDeviceType("A", "B", "C", "DUMMY");
 
         _service.editQueueItem(o.getInternalId().toString(), devA.getInternalId().toString(),
-            TestResult.POSITIVE.toString());
+                TestResult.POSITIVE.toString());
 
         List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
         assertEquals(1, queue.size());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -27,7 +27,8 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
     @Test
     void testInsert() throws IOException {
         // Read the test CSV file
-        try (InputStream inputStream = UploadServiceTest.class.getClassLoader().getResourceAsStream("test-upload.csv")) {
+        try (InputStream inputStream = UploadServiceTest.class.getClassLoader()
+                .getResourceAsStream("test-upload.csv")) {
             this._service.processPersonCSV(inputStream);
         }
 
@@ -40,8 +41,10 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
 
     @Test
     void testNotCSV() throws IOException {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream("this is not a CSV".getBytes(StandardCharsets.UTF_8))) {
-            final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> this._service.processPersonCSV(bis), "Should fail to parse");
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(
+                "this is not a CSV".getBytes(StandardCharsets.UTF_8))) {
+            final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                    () -> this._service.processPersonCSV(bis), "Should fail to parse");
             assertTrue(e.getMessage().contains("Empty or invalid CSV submitted"), "Should have correct error message");
             assertEquals(0, this._ps.getPatients(null).size(), "Should not have any patients");
         }
@@ -49,9 +52,12 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
 
     @Test
     void testMalformedCSV() throws IOException {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream("patientID\n'123445'\n".getBytes(StandardCharsets.UTF_8))) {
-            final RuntimeJsonMappingException e = assertThrows(RuntimeJsonMappingException.class, () -> this._service.processPersonCSV(bis), "CSV parsing should fail");
-            assertTrue(e.getMessage().contains("Not enough column values: expected 21, found 1"), "Should have correct error message");
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(
+                "patientID\n'123445'\n".getBytes(StandardCharsets.UTF_8))) {
+            final RuntimeJsonMappingException e = assertThrows(RuntimeJsonMappingException.class,
+                    () -> this._service.processPersonCSV(bis), "CSV parsing should fail");
+            assertTrue(e.getMessage().contains("Not enough column values: expected 21, found 1"),
+                    "Should have correct error message");
         }
     }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/DbTruncator.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/DbTruncator.java
@@ -8,38 +8,41 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
- * Shamelessly stolen from a past life: a function executor that truncates
- * all the business tables in our schema, all at once so no foreign keys get upset.
+ * Shamelessly stolen from a past life: a function executor that truncates all
+ * the business tables in our schema, all at once so no foreign keys get upset.
  */
 @Component
 public class DbTruncator {
 
-	@Value("${spring.jpa.properties.hibernate.default_schema:public}")
-	private String hibernateSchema;
+    @Value("${spring.jpa.properties.hibernate.default_schema:public}")
+    private String hibernateSchema;
 
-	/** Credit: https://stackoverflow.com/questions/2829158/truncating-all-tables-in-a-postgres-database */
-	private static final String TRUNCATE_FUNCTION_TEMPLATE = "DO " +
-			"$func$ " +
-			"BEGIN " +
-			"   EXECUTE " +
-			"   (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE' " +
-			"    FROM   pg_class " +
-			"    WHERE  relkind = 'r' " + // only tables
-			"    AND relname not like 'databasechangelog%%' " + // no liquibase tables!
-			"    AND    relnamespace = '%1$s'::regnamespace " +
-			"   ); " +
-			"END " +
-			"$func$;";
+    /**
+     * Credit:
+     * https://stackoverflow.com/questions/2829158/truncating-all-tables-in-a-postgres-database
+     */
+    private static final String TRUNCATE_FUNCTION_TEMPLATE = "DO " +
+            "$func$ " +
+            "BEGIN " +
+            "   EXECUTE " +
+            "   (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE' " +
+            "    FROM   pg_class " +
+            "    WHERE  relkind = 'r' " + // only tables
+            "    AND relname not like 'databasechangelog%%' " + // no liquibase
+                                                                // tables!
+            "    AND    relnamespace = '%1$s'::regnamespace " +
+            "   ); " +
+            "END " +
+            "$func$;";
 
-	@Autowired
-	private JdbcTemplate jdbc;
+    @Autowired
+    private JdbcTemplate jdbc;
 
-	/* (non-Javadoc)
-	 * @see gov.usds.case_issues.test_util.DbTruncator#truncateAll()
-	 */
-	@Transactional
-	public void truncateAll() {
-		jdbc.execute(String.format(TRUNCATE_FUNCTION_TEMPLATE, hibernateSchema));
-	}
+    /* (non-Javadoc)
+     * 
+     * @see gov.usds.case_issues.test_util.DbTruncator#truncateAll() */
+    @Transactional
+    public void truncateAll() {
+        jdbc.execute(String.format(TRUNCATE_FUNCTION_TEMPLATE, hibernateSchema));
+    }
 }
-

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -11,16 +11,16 @@ import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 
 /**
- * Bean creation and wiring required to get slice tests to run without a full application
- * context being created. This is not annotated with a Spring stereotype because we very much
- * do not want it to be picked up automatically!
+ * Bean creation and wiring required to get slice tests to run without a full
+ * application context being created. This is not annotated with a Spring
+ * stereotype because we very much do not want it to be picked up automatically!
  */
-@Import({TestDataFactory.class, AuditingConfig.class, ApiUserService.class, OrganizationInitializingService.class})
+@Import({ TestDataFactory.class, AuditingConfig.class, ApiUserService.class, OrganizationInitializingService.class })
 @EnableConfigurationProperties(InitialSetupProperties.class)
 public class SliceTestConfiguration {
 
-	@Bean
-	public IdentitySupplier dummyIdentityProvider(InitialSetupProperties props) {
-		return props::getDefaultUser;
-	}
+    @Bean
+    public IdentitySupplier dummyIdentityProvider(InitialSetupProperties props) {
+        return props::getDefaultUser;
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -28,44 +28,45 @@ import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 @Component
 public class TestDataFactory {
 
-	private static final String DEFAULT_DEVICE_TYPE = "Acme SuperFine";
-	@Autowired
-	private OrganizationRepository _orgRepo;
-	@Autowired
-	private FacilityRepository _facilityRepo;
-	@Autowired
-	private PersonRepository _personRepo;
-	@Autowired
-	private ProviderRepository _providerRepo;
-	@Autowired
-	private DeviceTypeRepository _deviceRepo;
+    private static final String DEFAULT_DEVICE_TYPE = "Acme SuperFine";
+    @Autowired
+    private OrganizationRepository _orgRepo;
+    @Autowired
+    private FacilityRepository _facilityRepo;
+    @Autowired
+    private PersonRepository _personRepo;
+    @Autowired
+    private ProviderRepository _providerRepo;
+    @Autowired
+    private DeviceTypeRepository _deviceRepo;
     @Autowired
     private TestOrderRepository _testOrderRepo;
     @Autowired
     private PatientAnswersRepository _patientAnswerRepo;
 
-	public Organization createValidOrg() {
-		return _orgRepo.save(new Organization("The Mall", "MALLRAT"));
-	}
+    public Organization createValidOrg() {
+        return _orgRepo.save(new Organization("The Mall", "MALLRAT"));
+    }
 
-	public Facility createValidFacility(Organization org) {
+    public Facility createValidFacility(Organization org) {
         return createValidFacility(org, "Injection Site");
     }
 
     public Facility createValidFacility(Organization org, String facilityName) {
-		DeviceType dev = getGenericDevice();
-		StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
-		Provider doc = _providerRepo.save(new Provider("Doctor", "", "Doom", "", "DOOOOOOM", addy, "1-900-CALL-FOR-DOC")); 
+        DeviceType dev = getGenericDevice();
+        StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
+        Provider doc = _providerRepo
+                .save(new Provider("Doctor", "", "Doom", "", "DOOOOOOM", addy, "1-900-CALL-FOR-DOC"));
         Facility facility = new Facility(org, facilityName, "123456", doc);
-		facility.setAddress(addy);
-		facility.setDefaultDeviceType(dev);
-		Facility save = _facilityRepo.save(facility);
-		return save;
-	}
+        facility.setAddress(addy);
+        facility.setDefaultDeviceType(dev);
+        Facility save = _facilityRepo.save(facility);
+        return save;
+    }
 
-	public Person createMinimalPerson(Organization org) {
+    public Person createMinimalPerson(Organization org) {
         return createMinimalPerson(org, "John", "Brown", "Boddie", "Jr.");
-	}
+    }
 
     public Person createMinimalPerson(Organization org, String firstName, String middleName, String lastName,
             String suffix) {
@@ -79,21 +80,22 @@ public class TestDataFactory {
     }
 
     public Person createFullPerson(Organization org) {
-		// consts are to keep style check happy othewise it complains about "magic numbers"
-		final int BIRTH_YEAR = 1899;
-		final int BIRTH_MONTH = 5;
-		final int BIRTH_DAY = 10;
-		Person p = new Person(
-			org, "HELLOTHERE", "Fred", null, "Astaire", null, LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY),
-			new StreetAddress("1 Central Park West", null, "New York", "NY", "11000", "New Yawk"), "202-123-4567",
-			PersonRole.RESIDENT, null,
-			"W", null, "M", false, false
-		);
-		return _personRepo.save(p);
-	}
+        // consts are to keep style check happy othewise it complains about
+        // "magic numbers"
+        final int BIRTH_YEAR = 1899;
+        final int BIRTH_MONTH = 5;
+        final int BIRTH_DAY = 10;
+        Person p = new Person(
+                org, "HELLOTHERE", "Fred", null, "Astaire", null, LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY),
+                new StreetAddress("1 Central Park West", null, "New York", "NY", "11000", "New Yawk"), "202-123-4567",
+                PersonRole.RESIDENT, null,
+                "W", null, "M", false, false);
+        return _personRepo.save(p);
+    }
 
     public TestOrder createTestOrder(Person p, Facility f) {
-        AskOnEntrySurvey survey = new AskOnEntrySurvey(null,Collections.emptyMap(),null,null,null,null,null,null);
+        AskOnEntrySurvey survey = new AskOnEntrySurvey(null, Collections.emptyMap(), null, null, null, null, null,
+                null);
         PatientAnswers answers = new PatientAnswers(survey);
         _patientAnswerRepo.save(answers);
         TestOrder o = new TestOrder(p, f);
@@ -101,8 +103,8 @@ public class TestDataFactory {
         return _testOrderRepo.save(o);
     }
 
-	public DeviceType getGenericDevice() {
-		return _deviceRepo.findAll().stream().filter(d->d.getName().equals(DEFAULT_DEVICE_TYPE)).findFirst()
-			.orElseGet(()->_deviceRepo.save(new DeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM")));
-	}
+    public DeviceType getGenericDevice() {
+        return _deviceRepo.findAll().stream().filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE)).findFirst()
+                .orElseGet(() -> _deviceRepo.save(new DeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM")));
+    }
 }


### PR DESCRIPTION
Ran Eclipse formatter on the entire backend/src/test tree.

This is clearly excessively aggressive, but it takes care of all our whitespace issues in one go.

