### PR TITLE
hack to fix docker-compose up

### DIFF
--- a/backend/Dockerfile.schemaspy
+++ b/backend/Dockerfile.schemaspy
@@ -5,8 +5,7 @@ RUN apt update && apt install -y graphviz
 RUN curl -H "Accept: application/zip" -L https://github.com/schemaspy/schemaspy/releases/download/v6.1.0/schemaspy-6.1.0.jar > schemaspy.jar
 RUN curl -H "Accept: application/zip" https://jdbc.postgresql.org/download/postgresql-42.2.18.jar > postgresql.jar
 
-RUN java -jar schemaspy.jar -debug -t pgsql -db simple_report -u postgres -p admin_password_for_local_dev_is_not_very_secure -host db:5432 -o output -s "simple_report" -dp postgresql.jar
-
+RUN java -jar schemaspy.jar -debug -t pgsql -db simple_report -u postgres -p admin_password_for_local_dev_is_not_very_secure -host db:5432 -o output -s "simple_report" -dp postgresql.jar || true
 FROM nginx:latest
 EXPOSE 80
 COPY --from=build /home/schemaspy/output /output


### PR DESCRIPTION
## Related Issue or Background Info

- `docker-compose build` breaks currently due to schemaspy expecting a db. this is a quick change to allow the build command to pass
