### PR TITLE
Let SchemaSpy run on other ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ http://schemaspy.org/
 cd backend
 docker-compose up db
 docker-compose up --build schemaspy
+# to run on a different port than 8081
+SR_SCHEMASPY_PORT=8082 docker-compose up --build schemaspy
 ```
 
 visit http://localhost:8081

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       dockerfile: Dockerfile.schemaspy
       network: dev-net
     ports:
-      - "8081:80"
+      - "${SR_SCHEMASPY_PORT:-8081}:80"
     environment:
       HOST: dev-net
     networks:


### PR DESCRIPTION
This USCIS laptop has a UI for McAfee Agent running on 8081 and I can't change that. Looking forward to getting the CDC Mac.