### PR TITLE
Update GraphQL loggers to play nicely with App Insights

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 //	Okta dependencies
 	implementation 'com.okta.spring:okta-spring-boot-starter:1.4.0'
 
+// App insights instrumentation
+	implementation 'com.microsoft.azure:applicationinsights-core:2.6.2'
+
 
 	// test/check dependencies
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -26,6 +26,7 @@ com.graphql-java-kickstart:graphql-spring-boot-autoconfigure:8.0.0
 com.graphql-java-kickstart:graphql-spring-boot-starter:8.0.0
 com.graphql-java:graphql-java:15.0
 com.graphql-java:java-dataloader:2.2.3
+com.microsoft.azure:applicationinsights-core:2.6.2
 com.nimbusds:content-type:2.0
 com.nimbusds:lang-tag:1.4.4
 com.nimbusds:nimbus-jose-jwt:8.19

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -27,6 +27,7 @@ com.graphql-java-kickstart:graphql-spring-boot-autoconfigure:8.0.0
 com.graphql-java-kickstart:graphql-spring-boot-starter:8.0.0
 com.graphql-java:graphql-java:15.0
 com.graphql-java:java-dataloader:2.2.3
+com.microsoft.azure:applicationinsights-core:2.6.2
 com.nimbusds:content-type:2.0
 com.nimbusds:lang-tag:1.4.4
 com.nimbusds:nimbus-jose-jwt:8.19

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTelemetryConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTelemetryConfiguration.java
@@ -1,0 +1,19 @@
+package gov.cdc.usds.simplereport.config;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+/**
+ * Created by nickrobison on 12/16/20
+ */
+@Configuration
+public class AzureTelemetryConfiguration {
+
+    @Bean
+    @Scope("singleton")
+    TelemetryClient getTelemetryClient() {
+        return new TelemetryClient();
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQLInstrumentationConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQLInstrumentationConfiguration.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.config;
 
+import com.microsoft.applicationinsights.TelemetryClient;
 import gov.cdc.usds.simplereport.logging.QueryLoggingInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 import org.springframework.context.annotation.Bean;
@@ -19,8 +20,8 @@ public class GraphQLInstrumentationConfiguration {
     }
 
     @Bean
-    List<Instrumentation> instrumentations() {
+    List<Instrumentation> instrumentations(TelemetryClient client) {
         // The upstream users of this method expect a modifiable list, so we need to re-wrap away from List.of, which defaults to immutable
-        return new ArrayList<>(List.of(new QueryLoggingInstrumentation()));
+        return new ArrayList<>(List.of(new QueryLoggingInstrumentation(client)));
     }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
@@ -61,6 +61,8 @@ public class GraphQLLoggingHelpers {
      * Handles logging the exeuction time, query success/fail and any associated errors
      *
      * @param queryStart - {@link Long} timestamp of when query started
+     * @param client - {@link TelemetryClient} for submitting GraphQL requests to Azure
+     * @param request - {@link RequestTelemetry} for tracking success/failure and duration
      * @return - {@link InstrumentationContext} to handle query completion
      */
     public static InstrumentationContext<ExecutionResult> createInstrumentationContext(long queryStart, TelemetryClient client, RequestTelemetry request) {
@@ -75,6 +77,7 @@ public class GraphQLLoggingHelpers {
                     LOG.error("GraphQL execution failed: {}", t.getMessage(), t);
                     LOG.info("GraphQL execution FAILED in {}ms", queryDuration.getMilliseconds());
                     request.setSuccess(false);
+                    client.trackException((Exception) t);
                 } else if (!result.getErrors().isEmpty()) {
                     result.getErrors().forEach(error -> LOG.error("Query failed with error {}", error));
                     LOG.info("GraphQL execution FAILED in {}ms", queryDuration.getMilliseconds());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
@@ -1,5 +1,8 @@
 package gov.cdc.usds.simplereport.logging;
 
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import graphql.ExecutionResult;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.SimpleInstrumentationContext;
@@ -10,8 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
 /**
@@ -62,24 +63,29 @@ public class GraphQLLoggingHelpers {
      * @param queryStart - {@link Long} timestamp of when query started
      * @return - {@link InstrumentationContext} to handle query completion
      */
-    public static InstrumentationContext<ExecutionResult> createInstrumentationContext(long queryStart) {
+    public static InstrumentationContext<ExecutionResult> createInstrumentationContext(long queryStart, TelemetryClient client, RequestTelemetry request) {
         return new SimpleInstrumentationContext<>() {
             @Override
             public void onCompleted(ExecutionResult result, Throwable t) {
                 final long queryEnd = System.currentTimeMillis();
-                final Duration queryDuration = Duration.of(queryEnd - queryStart, ChronoUnit.MILLIS);
+                final Duration queryDuration = new Duration(queryEnd - queryStart);
+                request.setDuration(queryDuration);
 
                 if (t != null) {
                     LOG.error("GraphQL execution failed: {}", t.getMessage(), t);
-                    LOG.info("GraphQL execution FAILED in {}ms", queryDuration.toMillis());
+                    LOG.info("GraphQL execution FAILED in {}ms", queryDuration.getMilliseconds());
+                    request.setSuccess(false);
                 } else if (!result.getErrors().isEmpty()) {
                     result.getErrors().forEach(error -> LOG.error("Query failed with error {}", error));
-                    LOG.info("GraphQL execution FAILED in {}ms", queryDuration.toMillis());
+                    LOG.info("GraphQL execution FAILED in {}ms", queryDuration.getMilliseconds());
+                    request.setSuccess(false);
                 } else {
-                    LOG.info("GraphQL execution COMPLETED in {}ms", queryDuration.toMillis());
+                    LOG.info("GraphQL execution COMPLETED in {}ms", queryDuration.getMilliseconds());
+                    request.setSuccess(true);
                 }
                 // Clear the MDC context
                 MDC.remove(GRAPHQL_QUERY_MDC_KEY);
+                client.trackRequest(request);
             }
         };
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -62,7 +62,7 @@ public class QueryLoggingInstrumentation extends SimpleInstrumentation {
 
         // Try to get the operation name, if one exists
         final String name = parameters.getExecutionInput().getOperationName();
-        if ("".equals(name)) {
+        if (name == null || "".equals(name)) {
             LOG.warn("Anonymous GraphQL operation submitted, we'll be missing interesting data");
         } else {
             requestTelemetry.setName(name);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -62,10 +62,10 @@ public class QueryLoggingInstrumentation extends SimpleInstrumentation {
 
         // Try to get the operation name, if one exists
         final String name = parameters.getExecutionInput().getOperationName();
-        if (!name.isBlank()) {
-            requestTelemetry.setName(name);
-        } else {
+        if ("".equals(name)) {
             LOG.warn("Anonymous GraphQL operation submitted, we'll be missing interesting data");
+        } else {
+            requestTelemetry.setName(name);
         }
 
         return GraphQLLoggingHelpers.createInstrumentationContext(queryStart, client, requestTelemetry);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -60,6 +60,14 @@ public class QueryLoggingInstrumentation extends SimpleInstrumentation {
         final RequestTelemetry requestTelemetry = new RequestTelemetry();
         requestTelemetry.setId(executionId.toString());
 
+        // Try to get the operation name, if one exists
+        final String name = parameters.getExecutionInput().getOperationName();
+        if (!name.isBlank()) {
+            requestTelemetry.setName(name);
+        } else {
+            LOG.warn("Anonymous GraphQL operation submitted, we'll be missing interesting data");
+        }
+
         return GraphQLLoggingHelpers.createInstrumentationContext(queryStart, client, requestTelemetry);
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,8 @@
         {
           "env": "apollo"
         }
-      ]
+      ],
+      "graphql/named-operations": ["error"]
     }
   },
   "browserslist": {

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -11,7 +11,7 @@ import { showNotification } from "../../utils";
 import FacilityForm from "./FacilityForm";
 
 const GET_FACILITY_QUERY = gql`
-  {
+  query GetFacilities {
     organization {
       internalId
       testingFacility {
@@ -55,7 +55,7 @@ const GET_FACILITY_QUERY = gql`
 `;
 
 const UPDATE_FACILITY_MUTATION = gql`
-  mutation(
+  mutation UpdateFacility(
     $facilityId: String!
     $testingFacilityName: String!
     $cliaNumber: String
@@ -111,7 +111,7 @@ const UPDATE_FACILITY_MUTATION = gql`
 `;
 
 const ADD_FACILITY_MUTATION = gql`
-  mutation(
+  mutation AddFacility(
     $testingFacilityName: String!
     $cliaNumber: String
     $street: String

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
@@ -3,7 +3,7 @@ import { gql, useQuery } from "@apollo/client";
 import ManageFacilities from "./ManageFacilities";
 
 const GET_FACILITIES = gql`
-  {
+  query GetFacilities {
     organization {
       testingFacility {
         id

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -19,7 +19,7 @@ interface Data {
 }
 
 const GET_ORGANIZATION = gql`
-  {
+  query GetOrganization {
     organization {
       name
     }
@@ -27,7 +27,7 @@ const GET_ORGANIZATION = gql`
 `;
 
 const SET_ORGANIZATION = gql`
-  mutation($name: String!) {
+  mutation SetOrganization($name: String!) {
     updateOrganization(name: $name)
   }
 `;

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -22,7 +22,7 @@ import ManageFacilitiesContainer from "./Settings/Facility/ManageFacilitiesConta
 import FacilityFormContainer from "./Settings/Facility/FacilityFormContainer";
 
 const WHOAMI_QUERY = gql`
-  query WhoAmI{
+  query WhoAmI {
     whoami {
       id
       firstName

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -22,7 +22,7 @@ import ManageFacilitiesContainer from "./Settings/Facility/ManageFacilitiesConta
 import FacilityFormContainer from "./Settings/Facility/FacilityFormContainer";
 
 const WHOAMI_QUERY = gql`
-  {
+  query WhoAmI{
     whoami {
       id
       firstName

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -4,7 +4,7 @@ import { gql, useQuery } from "@apollo/client";
 import PatientForm from "./PatientForm";
 
 const GET_PATIENT = gql`
-  query Patient($id: String!) {
+  query GetPatientDetails($id: String!) {
     patient(id: $id) {
       lookupId
       firstName

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -13,7 +13,7 @@ import {
 import { daysSince } from "../utils/date";
 
 const patientQuery = gql`
-  query Patient($facilityId: String!) {
+  query GetPatientsByFacility($facilityId: String!) {
     patients(facilityId: $facilityId) {
       internalId
       lookupId

--- a/frontend/src/app/patients/PatientForm.jsx
+++ b/frontend/src/app/patients/PatientForm.jsx
@@ -24,7 +24,7 @@ import "./EditPatient.scss";
 import Alert from "../commonComponents/Alert";
 
 const ADD_PATIENT = gql`
-  mutation(
+  mutation AddPatient(
     $facilityId: String
     $lookupId: String
     $firstName: String!
@@ -72,7 +72,7 @@ const ADD_PATIENT = gql`
 `;
 
 const UPDATE_PATIENT = gql`
-  mutation(
+  mutation UpdatePatient(
     $facilityId: String
     $patientId: String!
     $lookupId: String

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -56,7 +56,11 @@ interface EditQueueItemResponse {
 }
 
 const SUBMIT_TEST_RESULT = gql`
-  mutation SubmitTestResult($patientId: String!, $deviceId: String!, $result: String!) {
+  mutation SubmitTestResult(
+    $patientId: String!
+    $deviceId: String!
+    $result: String!
+  ) {
     addTestResult(patientId: $patientId, deviceId: $deviceId, result: $result)
   }
 `;

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -26,13 +26,13 @@ import moment from "moment";
 import Button from "../commonComponents/Button";
 
 const REMOVE_PATIENT_FROM_QUEUE = gql`
-  mutation($patientId: String!) {
+  mutation RemovePatientFromQueue($patientId: String!) {
     removePatientFromQueue(patientId: $patientId)
   }
 `;
 
 const EDIT_QUEUE_ITEM = gql`
-  mutation($id: String!, $deviceId: String, $result: String) {
+  mutation EditQueueItem($id: String!, $deviceId: String, $result: String) {
     editQueueItem(id: $id, deviceId: $deviceId, result: $result) {
       result
       deviceType {
@@ -56,13 +56,13 @@ interface EditQueueItemResponse {
 }
 
 const SUBMIT_TEST_RESULT = gql`
-  mutation($patientId: String!, $deviceId: String!, $result: String!) {
+  mutation SubmitTestResult($patientId: String!, $deviceId: String!, $result: String!) {
     addTestResult(patientId: $patientId, deviceId: $deviceId, result: $result)
   }
 `;
 
 const UPDATE_AOE = gql`
-  mutation(
+  mutation UpdateAOE(
     $patientId: String!
     $symptoms: String
     $symptomOnset: String

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -17,48 +17,48 @@ const emptyQueueMessage = (
 );
 
 const queueQuery = gql`
-  query Queue($facilityId: String!) {
-    queue(facilityId: $facilityId) {
-      internalId
-      pregnancy
-      dateAdded
-      symptoms
-      symptomOnset
-      noSymptoms
-      firstTest
-      priorTestDate
-      priorTestType
-      priorTestResult
-      deviceType {
-        internalId
-        name
-      }
-      patient {
-        internalId
-        telephone
-        birthDate
-        lookupId
-        firstName
-        middleName
-        lastName
-        gender
-      }
-      result
-    }
-    organization {
-      testingFacility {
-        id
-        deviceTypes {
-          internalId
-          name
+    query GetFacilityQueue($facilityId: String!) {
+        queue(facilityId: $facilityId) {
+            internalId
+            pregnancy
+            dateAdded
+            symptoms
+            symptomOnset
+            noSymptoms
+            firstTest
+            priorTestDate
+            priorTestType
+            priorTestResult
+            deviceType {
+                internalId
+                name
+            }
+            patient {
+                internalId
+                telephone
+                birthDate
+                lookupId
+                firstName
+                middleName
+                lastName
+                gender
+            }
+            result
         }
-        defaultDeviceType {
-          internalId
-          name
+        organization {
+            testingFacility {
+                id
+                deviceTypes {
+                    internalId
+                    name
+                }
+                defaultDeviceType {
+                    internalId
+                    name
+                }
+            }
         }
-      }
     }
-  }
 `;
 
 interface Props {

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -17,48 +17,48 @@ const emptyQueueMessage = (
 );
 
 const queueQuery = gql`
-    query GetFacilityQueue($facilityId: String!) {
-        queue(facilityId: $facilityId) {
-            internalId
-            pregnancy
-            dateAdded
-            symptoms
-            symptomOnset
-            noSymptoms
-            firstTest
-            priorTestDate
-            priorTestType
-            priorTestResult
-            deviceType {
-                internalId
-                name
-            }
-            patient {
-                internalId
-                telephone
-                birthDate
-                lookupId
-                firstName
-                middleName
-                lastName
-                gender
-            }
-            result
-        }
-        organization {
-            testingFacility {
-                id
-                deviceTypes {
-                    internalId
-                    name
-                }
-                defaultDeviceType {
-                    internalId
-                    name
-                }
-            }
-        }
+  query GetFacilityQueue($facilityId: String!) {
+    queue(facilityId: $facilityId) {
+      internalId
+      pregnancy
+      dateAdded
+      symptoms
+      symptomOnset
+      noSymptoms
+      firstTest
+      priorTestDate
+      priorTestType
+      priorTestResult
+      deviceType {
+        internalId
+        name
+      }
+      patient {
+        internalId
+        telephone
+        birthDate
+        lookupId
+        firstName
+        middleName
+        lastName
+        gender
+      }
+      result
     }
+    organization {
+      testingFacility {
+        id
+        deviceTypes {
+          internalId
+          name
+        }
+        defaultDeviceType {
+          internalId
+          name
+        }
+      }
+    }
+  }
 `;
 
 interface Props {

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.jsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.jsx
@@ -16,7 +16,7 @@ import { displayFullName } from "../../utils";
 const MIN_SEARCH_CHARACTER_COUNT = 3;
 
 const QUERY_PATIENT = gql`
-  query Patient($facilityId: String!) {
+  query GetPatientsByFacility($facilityId: String!) {
     patients(facilityId: $facilityId) {
       internalId
       lookupId
@@ -30,7 +30,7 @@ const QUERY_PATIENT = gql`
 `;
 
 const ADD_PATIENT_TO_QUEUE = gql`
-  mutation(
+  mutation AddPatientToQueue(
     $facilityId: String!
     $patientId: String!
     $symptoms: String

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -10,7 +10,7 @@ import { PATIENT_TERM_CAP } from "../../config/constants";
 import { displayFullName } from "../utils";
 
 export const testResultQuery = gql`
-  query Results($facilityId: String!) {
+  query GetFacilityResults($facilityId: String!) {
     testResults(facilityId: $facilityId) {
       internalId
       dateTested


### PR DESCRIPTION
## Related Issue or Background Info

Now that we have App Insights working, we should try to improve our logging state so that we get more request information than just `/graphql`.
This involves updating our GraphQL logging handlers to also send data along to App Insights

## Changes Proposed

- Add App Insights SDK to Java application
- Wire in the Telemetry Collector to create a Request event on each invocation with the duration, name, and success measures.
- Update frontend to add an operation name to each GraphQL query.

## Additional Information

- In order for the logging to work correctly, we need to make sure we avoid anonymous GraphQL queries as much as possible. @benwarfield-usds is there a way to apply this constraint in the GraphQL linter?

## Screenshot

![Screen Shot 2020-12-16 at 12 59 53 PM](https://user-images.githubusercontent.com/44269964/102387788-cfe1da80-3f9e-11eb-927a-8447b66ed430.png)

