### PR TITLE
More hacky `facilityID` fixes, also a bug

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -69,7 +69,9 @@ const Header = (props: Props) => {
         <div className="usa-navbar">
           <div className="usa-logo" id="basic-logo">
             <em className="usa-logo__text">
-              <Link to="/">{process.env.REACT_APP_TITLE}</Link>
+              <Link to={`/queue/?facility=${facility.id}`}>
+                {process.env.REACT_APP_TITLE}
+              </Link>
               <div className="prime-organization-name">{organization.name}</div>
             </em>
           </div>

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -61,7 +61,7 @@ const ManagePatients = ({ activeFacilityId }: Props) => {
     return patients.map((patient: Patient) => (
       <tr key={patient.internalId}>
         <th scope="row">
-          <NavLink to={`patient/${patient.internalId}`}>
+          <NavLink to={`/patient/${patient.internalId}`}>
             {displayFullName(
               patient.firstName,
               patient.middleName,
@@ -87,7 +87,7 @@ const ManagePatients = ({ activeFacilityId }: Props) => {
           <div className="prime-container usa-card__container">
             <div className="usa-card__header">
               <h2> All {PATIENT_TERM_PLURAL_CAP}</h2>
-              <NavLink to={"add-patient"}>
+              <NavLink to={`/add-patient/?facility=${activeFacilityId}`}>
                 <Button
                   outline
                   icon={"plus"}

--- a/frontend/src/app/patients/PatientForm.jsx
+++ b/frontend/src/app/patients/PatientForm.jsx
@@ -237,7 +237,7 @@ const PatientForm = (props) => {
   };
   // after the submit was success, redirect back to the List page
   if (submitted) {
-    return <Redirect to="/patients" />;
+    return <Redirect to={`/patients/?facility=${props.activeFacilityId}`} />;
   }
   //TODO: when to save initial data? What if name isn't filled? required fields?
   return (
@@ -250,7 +250,10 @@ const PatientForm = (props) => {
       />
       <Breadcrumbs
         crumbs={[
-          { link: "../patients", text: PATIENT_TERM_PLURAL_CAP },
+          {
+            link: `/patients/?facility=${props.activeFacilityId}`,
+            text: PATIENT_TERM_PLURAL_CAP,
+          },
           {
             text: !props.patientId
               ? `Create New ${PATIENT_TERM_CAP}`


### PR DESCRIPTION
## Related Issue or Background Info

This fixes a few broken routes as part of the short-term `facility id` hack, which was recently merged: https://github.com/CDCgov/prime-simplereport/pull/342

## Changes Proposed

- fixed the logo link to direct to the queue, preserving the facilityId in the url
- same with the addPatient, editPatient, savePatient, and breadcrumbs link

## Additional Information

- The hacky way of changing facilities while preserving what page the user is on introduces a bug. The user can be a patient on FacilityA, change to facilityB, and still see the patient. Editing that patient *DELETES* that patient from the app somehow. 

![bug](https://user-images.githubusercontent.com/35268641/102440942-10107f80-3fd6-11eb-825a-06603fc9913d.gif)



- A simple alternative to that would be to always redirect the user to the queue if they change devices. Because of the additional `app/` in the pathname in the demo app, it isn't obvious how to do this without brittle string parsing or conditional logic using app environmental varibales

## Screenshots / Demos
