### PR TITLE
Dewonkify the time-of-test question logic

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -94,11 +94,17 @@ const PriorTestInputs = ({
   setPriorTestType,
   mostRecentTest,
 }) => {
+  const recentDate = (mostRecentTest?.dateTested || "").split("T")[0];
   const filledPriorTest =
-    (mostRecentTest ? mostRecentTest.dateTested : "").split("T")[0] ===
-      priorTestDate && mostRecentTest.result === priorTestResult;
+    priorTestDate &&
+    recentDate === priorTestDate &&
+    mostRecentTest.result === priorTestResult;
   const [mostRecentTestAnswer, setMostRecentTestAnswer] = useState(
-    isFirstTest === undefined ? undefined : filledPriorTest ? "yes" : "no"
+    !priorTestDate || isFirstTest === undefined
+      ? undefined
+      : filledPriorTest
+      ? "yes"
+      : "no"
   );
   const previousTestEntry = (
     <>
@@ -181,6 +187,10 @@ const PriorTestInputs = ({
               setPriorTestType("2");
               setPriorTestDate((mostRecentTest.dateTested || "").split("T")[0]);
               setPriorTestResult(mostRecentTest?.result);
+            } else {
+              setPriorTestType(null);
+              setPriorTestDate(null);
+              setPriorTestResult(null);
             }
           }}
           legend="Was this your most recent COVID-19 test?"

--- a/frontend/src/app/testQueue/AskOnEntryTag.jsx
+++ b/frontend/src/app/testQueue/AskOnEntryTag.jsx
@@ -3,7 +3,8 @@ import React from "react";
 export const areAnswersComplete = (answers) => {
   if (!answers.noSymptoms) {
     const symptoms = JSON.parse(answers.symptoms);
-    const filled = Object.values(symptoms).some((v) => v === true);
+    //TODO: real booleans rather than Pinocchio boolean strings
+    const filled = Object.values(symptoms).some((v) => String(v) === "true");
     if (!filled || !answers.symptomOnset) {
       return false;
     }

--- a/frontend/src/app/testQueue/AskOnEntryTag.jsx
+++ b/frontend/src/app/testQueue/AskOnEntryTag.jsx
@@ -1,39 +1,23 @@
 import React from "react";
 
-export const areAnswersComplete = (answerDict) => {
-  if (!answerDict.noSymptoms) {
-    let symptomFound = false;
-
-    try {
-      const symptoms = JSON.parse(answerDict.symptoms);
-      Object.values(symptoms).forEach((val) => {
-        if (val) {
-          symptomFound = true;
-        }
-      });
-    } catch (e) {
-      console.error("expected json response. found:", e);
-    }
-
-    if (!symptomFound) {
-      return false;
-    }
-    if (answerDict.symptomOnset) {
-      const onsetDate = answerDict.symptomOnset;
-      if (!onsetDate) {
-        return false;
-      }
-    }
-  }
-  if (!answerDict.firstTest) {
-    if (!answerDict.priorTestDate) {
-      return false;
-    }
-    if (!answerDict.priorTestType || !answerDict.priorTestResult) {
+export const areAnswersComplete = (answers) => {
+  if (!answers.noSymptoms) {
+    const symptoms = JSON.parse(answers.symptoms);
+    const filled = Object.values(symptoms).some((v) => v === true);
+    if (!filled || !answers.symptomOnset) {
       return false;
     }
   }
-  if (!answerDict.pregnancy) {
+  if (!answers.firstTest) {
+    if (
+      !answers.priorTestDate ||
+      !answers.priorTestType ||
+      !answers.priorTestResult
+    ) {
+      return false;
+    }
+  }
+  if (!answers.pregnancy) {
     return false;
   }
   return true;

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -260,22 +260,17 @@ const QueueItem: any = ({
         deviceId,
         result,
       },
-    }).then(
-      (response) => {
-        if (!response.data) {
-          throw Error("null response from update queue");
-        }
+    })
+      .then((response) => {
+        if (!response.data) throw Error("updateQueueItem null response");
         updateDeviceId(response.data.editQueueItem.deviceType.internalId);
         updateTestResultValue(response.data.editQueueItem.result);
-      },
-      (error) => {
-        updateMutationError(error);
-      }
-    );
+      })
+      .catch(updateMutationError);
   };
 
   const onDeviceChange = (e: React.FormEvent<HTMLSelectElement>) => {
-    const deviceId = (e.target as HTMLSelectElement).value;
+    const deviceId = e.currentTarget.value;
     updateQueueItem({ deviceId });
   };
 
@@ -316,24 +311,12 @@ const QueueItem: any = ({
     trackUpdateAoEResponse({});
     updateAoe({
       variables: {
+        ...answers,
         patientId: patient.internalId,
-        noSymptoms: answers.noSymptoms,
-        symptoms: answers.symptoms,
-        symptomOnset: answers.symptomOnset,
-        pregnancy: answers.pregnancy,
-        firstTest: answers.firstTest,
-        priorTestDate: answers.priorTestDate,
-        priorTestType: answers.priorTestType,
-        priorTestResult: answers.priorTestResult,
       },
-    }).then(
-      (_response) => {
-        refetchQueue();
-      },
-      (error) => {
-        updateMutationError(error);
-      }
-    );
+    })
+      .then(refetchQueue)
+      .catch(updateMutationError);
   };
 
   let options = devices.map((device) => ({


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #279 

Well most of it. Below I will try to rationalize the rest away. 😁 

## Changes Proposed

- On return to ToT questions, don't assume No answer for most recent test. (#279 Bug 1)
- Accept strings as booleans so symptom questions are interpreted correctly. (#279 Bug 2)
- If switching from Yes to No, clear out last-test fields that would otherwise have most recent one.
- Ensure errors thrown are reported back.
- A few minor cosmetic cleanups.

## Additional Information

There is (currently) no persisted answer for the "is this your most recent test" question. It is inferred from two existing pieces of information: 

1) Patient has a test history in SimpleReport, thus a most recent test, thus  `isFirstTest === false` by definition;
2) Prior test fields either are _not filled in at all_, or _match_ / _do not match_ those of the most recent test.

When the user answers "Yes" to the most recent test question, the code fills the prior test fields with the most recent test info so that it can be sent along with the current test result. If they later return to the form, we can tell they answered "Yes" because the answers match the most recent test.

When the user answers "No" to the most recent test question, the code shows the prior test fields. If the user does nothing at all to those fields, it's not possible to determine whether they answered the "Is this the most recent test" question because the persisted state matches the not-filled-at-all initial state.

Have I missed a simple way to infer they answered that question but left the other stuff incomplete?

With all that in mind, Bug 0 from #279 just works that way if they don't answer the most-recent-test question. I don't think this is a big issue, since their questions are incomplete regardless. The original design ticket didn't specify what should happen for these cases.

I fixed Bug 1 to leave the question unanswered, it was related to the logic used to decide whether things were filled out.

I fixed Bug 2, it seems like the time-of-test questions are retrieved from the backend as string `"true"` and `"false"` rather than boolean. I've added some more logic to accept either when deciding if the form is complete, since we actually send the backend bona-fide booleans and it has never complained.

## Screenshots / Demos
