### PR TITLE
Add a translator for phone numbers to ensure a standard format is used

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'com.vladmihalcea:hibernate-types-52:2.10.0'
 	implementation 'org.liquibase:liquibase-core'
 	runtimeOnly 'org.postgresql:postgresql'
+	implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.15'
 
 	// UI layer dependencies
 	implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:${kickstartVersion}"

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -15,6 +15,7 @@ com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
+com.googlecode.libphonenumber:libphonenumber:8.12.15
 com.graphql-java-kickstart:graphiql-spring-boot-starter:8.0.0
 com.graphql-java-kickstart:graphql-java-kickstart:10.0.0
 com.graphql-java-kickstart:graphql-java-servlet:10.0.0

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -15,6 +15,7 @@ com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
+com.googlecode.libphonenumber:libphonenumber:8.12.15
 com.graphql-java-kickstart:graphiql-spring-boot-autoconfigure:8.0.0
 com.graphql-java-kickstart:graphiql-spring-boot-starter:8.0.0
 com.graphql-java-kickstart:graphql-java-kickstart:10.0.0

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -1,5 +1,8 @@
 package gov.cdc.usds.simplereport.api;
 
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -18,6 +21,20 @@ public class Translators {
 			return LocalDate.parse(userSuppliedDateString, US_SLASHDATE_FORMATTER);
 		} else {
 			return LocalDate.parse(userSuppliedDateString); // ISO_LOCAL_DATE is the default
+		}
+	}
+
+	public static String parsePhoneNumber(String userSuppliedPhoneNumber) {
+		if (userSuppliedPhoneNumber == null) {
+			return null;
+		}
+
+		try {
+			var phoneUtil = PhoneNumberUtil.getInstance();
+			return phoneUtil.format(phoneUtil.parse(userSuppliedPhoneNumber, "US"),
+					PhoneNumberUtil.PhoneNumberFormat.NATIONAL);
+		} catch (NumberParseException parseException) {
+			throw new IllegalGraphqlArgumentException("[" + userSuppliedPhoneNumber + "] is not a valid phone number.");
 		}
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.organization;
 
+import gov.cdc.usds.simplereport.api.Translators;
 import java.util.List;
 import java.util.UUID;
 
@@ -60,7 +61,7 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
         StreetAddress providerAddress = new StreetAddress(orderingProviderStreet, orderingProviderStreetTwo,
             orderingProviderCity, orderingProviderState, orderingProviderZipCode, orderingProviderCounty);
         PersonName providerName = new PersonName(orderingProviderFirstName, orderingProviderMiddleName, orderingProviderLastName, orderingProviderSuffix);
-        Facility created = _os.createFacility(testingFacilityName, cliaNumber, facilityAddress, phone, deviceTypes,
+        Facility created = _os.createFacility(testingFacilityName, cliaNumber, facilityAddress, Translators.parsePhoneNumber(phone), deviceTypes,
             providerName, providerAddress, orderingProviderTelephone, orderingProviderNPI);
         return new ApiFacility(created);
     }
@@ -100,7 +101,7 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
           county,
           state,
           zipCode,
-          phone,
+          Translators.parsePhoneNumber(phone),
           orderingProviderFirstName,
           orderingProviderMiddleName,
           orderingProviderLastName,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.patient;
 
+import static gov.cdc.usds.simplereport.api.Translators.parsePhoneNumber;
 import static gov.cdc.usds.simplereport.api.Translators.parseUserDate;
 
 import java.time.LocalDate;
@@ -60,7 +61,7 @@ public class PatientMutationResolver implements GraphQLMutationResolver  {
             city,
             state,
             zipCode,
-            telephone,
+            parsePhoneNumber(telephone),
             role,
             email,
             county,
@@ -111,7 +112,7 @@ public class PatientMutationResolver implements GraphQLMutationResolver  {
           city,
           state,
           zipCode,
-          telephone,
+          parsePhoneNumber(telephone),
           role,
           email,
           county,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/PatientManagementTest.java
@@ -26,29 +26,32 @@ public class PatientManagementTest extends BaseApiTest {
     @Test
     public void createAndFetchOnePatientUsDate() throws Exception {
         String firstName = "Jon";
-        JsonNode patients = doCreateAndFetch(firstName, "Snow", "05/18/1066", "youknownothing");
+        JsonNode patients = doCreateAndFetch(firstName, "Snow", "05/18/1066", "(202) 867-5309", "youknownothing");
         assertTrue(patients.has(0), "At least one patient found");
         JsonNode jon = patients.get(0);
         assertEquals(firstName, jon.get("firstName").asText());
         assertEquals("1066-05-18", jon.get("birthDate").asText());
+        assertEquals("(202) 867-5309", jon.get("telephone").asText());
     }
 
     @Test
     public void createAndFetchOnePatientIsoDate() throws Exception {
         String firstName = "Sansa";
-        JsonNode patients = doCreateAndFetch(firstName, "Stark", "12/25/1100", "notbitter");
+        JsonNode patients = doCreateAndFetch(firstName, "Stark", "12/25/1100", "1-800-BIZ-NAME", "notbitter");
         assertTrue(patients.has(0), "At least one patient found");
         JsonNode sansa = patients.get(0);
         assertEquals(firstName, sansa.get("firstName").asText());
         assertEquals("1100-12-25", sansa.get("birthDate").asText());
+        assertEquals("(800) 249-6263", sansa.get("telephone").asText());
     }
 
-    private JsonNode doCreateAndFetch(String firstName, String lastName, String birthDate, String lookupId)
+    private JsonNode doCreateAndFetch(String firstName, String lastName, String birthDate, String phone, String lookupId)
             throws IOException {
         ObjectNode variables = JsonNodeFactory.instance.objectNode()
                 .put("firstName", firstName)
                 .put("lastName", lastName)
                 .put("birthDate", birthDate)
+                .put("telephone", phone)
                 .put("lookupId", lookupId);
         GraphQLResponse resp = _template.perform("add-person", variables);
         assertGraphQLSuccess(resp);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -60,4 +60,12 @@ class UploadServiceTest extends BaseServiceTestOrgUser<UploadService> {
                     "Should have correct error message");
         }
     }
+
+    @Test
+    void testInvalidPhoneNumber() throws Exception {
+        try (InputStream inputStream = UploadServiceTest.class.getClassLoader()
+                .getResourceAsStream("test-upload-invalid-phone.csv")) {
+            assertThrows(IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
+        }
+    }
 }

--- a/backend/src/test/resources/person-query
+++ b/backend/src/test/resources/person-query
@@ -1,4 +1,8 @@
 { 
-patients {
-  firstName lastName birthDate
-}}
+  patients {
+    firstName
+    lastName
+    birthDate
+    telephone
+  }
+}

--- a/backend/src/test/resources/test-upload-invalid-phone.csv
+++ b/backend/src/test/resources/test-upload-invalid-phone.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,Gender,Ethnicity,Street,Street2,City ,County,State,ZipCode,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId, Location
+Best,Tim,,,White,5/11/1933,Male,Not Hispanic,123 Main Street,,Washington,,DC,20008,not a phone number,Yes,No,Staff,foo@example.com,25ba3159-d3f8-4d1f-8ea6-c4466a190ab5,


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #340.

## Changes Proposed

- Validate/normalize phone numbers included in incoming mutations.
- Validate/normalize phone numbers included in incoming CSV uploads. 

## Additional Information

- There is some code repeated in the CSV vs mutation resolver validation application. Both code paths currently rely on exception throwing for validation but I believe expect different exceptions (e.g., CSV upload probably shouldn't fail with a generic `IllegalGraphqlArgumentException`).
- This change pulls in `libphonenumber`, which is the same dependency PRIME data hub is using for phone number validation and normalization.