### PR TITLE
Fix override date being clobbered on server return

### DIFF
--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -14,7 +14,7 @@ interface Props {
   options: Option[];
   label?: string;
   name?: string;
-  onChange: (e: React.FormEvent<HTMLSelectElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   selectedValue: string;
   disabled?: boolean;
   defaultOption?: string;


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #439.

I discovered this while refactoring the forms stuff but wanted to fix it sooner without having to rush through that big set of changes.

## Changes Proposed

- Save the override date locally
- Only save to the server when the date is valid
- Incomplete dates won't be saved, if the user navigates away it will return to the old value

Ultimately I think we'll need to re-plumb the app something like described in #304 but this fixes the problem, mostly, for now. There are still situations where the user's typing might be clobbered but I think they'll be much less likely. 