### PR TITLE
API swab type support

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
 	// data layer dependencies
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.vladmihalcea:hibernate-types-52:2.10.0'
 	implementation 'org.liquibase:liquibase-core'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -51,6 +51,7 @@ jakarta.activation:jakarta.activation-api:1.2.2
 jakarta.annotation:jakarta.annotation-api:1.3.5
 jakarta.persistence:jakarta.persistence-api:2.2.3
 jakarta.transaction:jakarta.transaction-api:1.3.3
+jakarta.validation:jakarta.validation-api:2.0.2
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
 javax.activation:javax.activation-api:1.2.0
 javax.servlet:javax.servlet-api:4.0.1
@@ -72,6 +73,7 @@ org.glassfish.jaxb:txw2:2.3.3
 org.glassfish:jakarta.el:3.0.3
 org.hdrhistogram:HdrHistogram:2.1.12
 org.hibernate.common:hibernate-commons-annotations:5.1.2.Final
+org.hibernate.validator:hibernate-validator:6.1.6.Final
 org.hibernate:hibernate-core:5.4.25.Final
 org.javassist:javassist:3.27.0-GA
 org.jboss.logging:jboss-logging:3.4.1.Final
@@ -101,6 +103,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.1
 org.springframework.boot:spring-boot-starter-logging:2.4.1
 org.springframework.boot:spring-boot-starter-security:2.4.1
 org.springframework.boot:spring-boot-starter-tomcat:2.4.1
+org.springframework.boot:spring-boot-starter-validation:2.4.1
 org.springframework.boot:spring-boot-starter-web:2.4.1
 org.springframework.boot:spring-boot-starter-websocket:2.4.1
 org.springframework.boot:spring-boot-starter:2.4.1

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -60,6 +60,7 @@ jakarta.activation:jakarta.activation-api:1.2.2
 jakarta.annotation:jakarta.annotation-api:1.3.5
 jakarta.persistence:jakarta.persistence-api:2.2.3
 jakarta.transaction:jakarta.transaction-api:1.3.3
+jakarta.validation:jakarta.validation-api:2.0.2
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
 javax.activation:javax.activation-api:1.2.0
 javax.servlet:javax.servlet-api:4.0.1
@@ -87,6 +88,7 @@ org.glassfish.jaxb:txw2:2.3.3
 org.glassfish:jakarta.el:3.0.3
 org.hdrhistogram:HdrHistogram:2.1.12
 org.hibernate.common:hibernate-commons-annotations:5.1.2.Final
+org.hibernate.validator:hibernate-validator:6.1.6.Final
 org.hibernate:hibernate-core:5.4.25.Final
 org.javassist:javassist:3.27.0-GA
 org.jboss.logging:jboss-logging:3.4.1.Final
@@ -119,6 +121,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.1
 org.springframework.boot:spring-boot-starter-logging:2.4.1
 org.springframework.boot:spring-boot-starter-security:2.4.1
 org.springframework.boot:spring-boot-starter-tomcat:2.4.1
+org.springframework.boot:spring-boot-starter-validation:2.4.1
 org.springframework.boot:spring-boot-starter-web:2.4.1
 org.springframework.boot:spring-boot-starter-websocket:2.4.1
 org.springframework.boot:spring-boot-starter:2.4.1

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimen.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimen.java
@@ -1,0 +1,36 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.NaturalId;
+
+/**
+ * A valid combination of device and specimen types. Can be soft-deleted, but
+ * cannot be otherwise modified.
+ */
+public class DeviceSpecimen extends EternalEntity {
+
+    @NaturalId
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "device_type_id", nullable = false)
+    private DeviceType deviceType;
+
+    @NaturalId
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "specimen_type_id", nullable = false)
+    private SpecimenType specimenType;
+
+    public DeviceSpecimen(DeviceType deviceType, SpecimenType specimenType) {
+        this.deviceType = deviceType;
+        this.specimenType = specimenType;
+    }
+
+    public DeviceType getDeviceType() {
+        return deviceType;
+    }
+
+    public SpecimenType getSpecimenType() {
+        return specimenType;
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -51,7 +51,19 @@ public class Facility extends OrganizationScopedEternalEntity {
 	)
 	private Set<DeviceType> configuredDevices = new HashSet<>();
 
-	protected Facility() {/* for hibernate */}
+    @ManyToOne(optional = true)
+    @JoinColumn(name = "default_device_specimen_id")
+    private DeviceSpecimen defaultDeviceSpecimen;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "facility_device_specimen",
+            joinColumns = @JoinColumn(name = "facility_id"),
+            inverseJoinColumns = @JoinColumn(name = "device_specimen_id")
+    )
+    private Set<DeviceSpecimen> configuredDeviceSpecimens = new HashSet<>();
+
+    protected Facility() {/* for hibernate */}
 
 	public Facility(Organization org, String facilityName, String cliaNumber, StreetAddress facilityAddress,
 			String phone, String email, Provider orderingProvider, DeviceType defaultDeviceType,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
@@ -1,0 +1,43 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.Column;
+
+import org.hibernate.annotations.NaturalId;
+
+import gov.cdc.usds.simplereport.validators.RequiredNumericCode;
+
+/**
+ * A SNOMED-registered specimen type that can be used by one or more
+ * {@link DeviceType}s.
+ */
+public class SpecimenType extends EternalEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, updatable = false)
+    @RequiredNumericCode
+    @NaturalId
+    private String typeCode;
+
+    public SpecimenType(String name, String typeCode) {
+        this.name = name;
+        this.typeCode = typeCode;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getTypeCode() {
+        return typeCode;
+    }
+
+    public void setTypeCode(String typeCode) {
+        this.typeCode = typeCode;
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
@@ -1,0 +1,17 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
+
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+
+public interface DeviceSpecimenRepository extends EternalEntityRepository<DeviceSpecimen> {
+
+    @Override
+    @EntityGraph(attributePaths = { "deviceType", "specimenType" })
+    @Query(BASE_QUERY + " and e.deviceType.isDeleted = false and e.specimenType.isDeleted = false")
+    public List<DeviceSpecimen> findAll();
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/RequiredNumericCode.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/RequiredNumericCode.java
@@ -1,0 +1,37 @@
+package gov.cdc.usds.simplereport.validators;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+/**
+ * A constraint to force a value to be a non-null numeric string of length at
+ * least 8 (adjust this value up or down if it turns out that is not the minimum
+ * length for valid CLIA numbers and SNOMED codes).
+ */
+@Constraint(validatedBy = { })
+@NotNull
+@Pattern(regexp = "\\d+")
+@Size(min = RequiredNumericCode.MIN_DIGITS)
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, LOCAL_VARIABLE })
+public @interface RequiredNumericCode {
+
+    public static final int MIN_DIGITS = 8;
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String message() default "Parameter must be a non-null numeric code string";
+}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -45,6 +45,9 @@ x-ref-data:
         constraints:
           nullable: false
 databaseChangeLog:
+  - property:
+      name: migrations_user_email
+      value: usds@cdc.gov
   - changeSet:
       id: define-enum-types
       author: bwarfield@cdc.gov
@@ -1192,3 +1195,191 @@ databaseChangeLog:
                   name: refreshed_at
                   type: DATETIME
                   remarks: The timestamp for the most recent refresh of this entity.
+  - changeSet:
+      id: add-swab-tables
+      description: Introduce the tables necessary for tracking swab types.
+      changes:
+        - createTable:
+            tableName: swab_type
+            remarks: A type of swab/specimen collection location.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *soft_delete_column
+              - column:
+                  name: name
+                  type: *string
+                  remarks: The name of the swab type, as displayed in isolation
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk__swab_type__name
+              - column:
+                  name: type_code
+                  remarks: The SNOMED specimen type code for this swab type.
+                  type: *string
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk__swab_type__type_code
+        - createTable:
+            tableName: device_swab
+            remarks: A usable combination of device type and swab type.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *soft_delete_column
+              - column:
+                  name: device_type_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_swab__device_type
+                    references: device_type
+              - column:
+                  name: swab_type_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_swab__swab_type
+                    references: swab_type
+        - addUniqueConstraint:
+            tableName: device_swab
+            constraintName: uk__device_swab
+            columnNames: device_type_id, swab_type_id
+        - createTable:
+            tableName: facility_device_swab
+            remarks: Many-to-many table for device/swab configuration at a facility.
+            columns:
+              - column:
+                  name: facility_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_swab__facility
+                    references: facility
+              - column:
+                  name: device_swab_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_swab__device_swab
+                    references: device_swab
+        - addUniqueConstraint:
+            tableName: facility_device_swab
+            constraintName: uk__facility_device_swab
+            columnNames: facility_id, device_swab_id
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_device_swab_id
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__facility__default_device_swab
+                    referencedTableName: device_swab
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: device_swab_id
+                  remarks: The device/swab combination used to record the test result.
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__test_order__device_swab
+                    referencedTableName: device_swab
+                    # will be made non-null in a subsequent migration
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: device_swab_id
+                  remarks: The device/swab combination used to record the test result.
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__test_event__device_swab
+                    referencedTableName: device_swab
+                    # will be made non-null in a subsequent migration
+  - changeSet:
+      id: populate-specimen-tables
+      author: bwarfield@cdc.gov
+      comment: Populate specimen tables and relations based on existing data.
+      preConditions:
+        - onSqlOutput: FAIL
+        - onFail: MARK_RAN
+        - sqlCheck:
+            sql:  SELECT case when count(1) > 0 then 1 else 0 end FROM ${database.defaultSchemaName}.device_type;
+            expectedResult: 1
+      changes:
+        - sql:
+          remarks: Create migrations user to indicate records created by migration rather than by a human.
+          sql: |
+            INSERT INTO ${database.defaultSchemaName}.api_user
+            (internal_id, created_at, updated_at, last_seen, login_email, last_name)
+            VALUES (
+              gen_random_uuid(), now(), now(), null,
+              '${migration_user_email}', 'Database Migration Process'
+            )
+        - sql:
+          remarks: Create default specimen type for known devices at the time of this migration.
+          sql: |
+            WITH specimen_types_historical as (
+              select distinct swab_type as type_code from ${database.defaultSchemaName}.device_type
+            ),
+            migration_user as (
+              SELECT internal_id as migrations_user_id
+              FROM ${database.defaultSchemaName}.api_user 
+              WHERE login_email = '${migrations_user_email}'
+            )
+            INSERT INTO ${database.defaultSchemaName}.specimen_type (name, type_code,
+              internal_id, created_at, created_by, updated_at, updated_by, is_deleted)
+            SELECT (
+              'Auto-generated specimen type ' || type_code,
+              type_code,
+              gen_random_uuid(),
+              migrations_user_id,
+              now(),
+              migrations_user_id,
+              now(),
+              false             
+            )
+            FROM specimen_types_historical cross join migration_user
+        - sql:
+          remarks: Add device_specimen and facility_device_specimen entries based on existing data, and populate facility.default_device_specimen_id.
+          sql: |
+            WITH device_swab_historical as (
+              SELECT dt.internal_id device_type_id, swt.internal_id specimen_type_id
+              FROM ${database.defaultSchemaName}.device_type dt
+               JOIN ${database.defaultSchemaName}.specimen_type swt ON dt.swab_type = swt.type_code 
+            ),
+            migration_user as (
+              SELECT internal_id as migrations_user_id
+              FROM ${database.defaultSchemaName}.api_user 
+              WHERE login_email = '${migrations_user_email}'
+            )
+            
+            INSERT INTO ${database.defaultSchemaName}.device_specimen
+            ( internal_id,               
+              created_at, created_by, updated_at, updated_by, is_deleted,
+            )
+            SELECT
+              gen_random_uuid(),
+              now(), migration_user_id, now(), migration_user_id, false
+            FROM device_swab_historical cross join migration_user 
+  - changeSet:
+      id: complete-specimen-column-additions
+      author: bwarfield@cdc.gov
+      comment: Update constraints for newly-added columns referencing device_specimen.
+      changes:
+        - addNotNullConstraint:
+            tableName: test_event
+            columnName: device_specimen_id
+        - addNotNullConstraint:
+            tableName: test_order
+            columnName: device_specimen_id


### PR DESCRIPTION
## Related Issue or Background Info

Beginning of API work to support #384 / #358 
Resolves #325 
(or it will eventually, anyway).

## Changes Proposed

- add javax.validation support so we can be more confident about CLIA and SNOMED values being what we expect
- add database tables to support this approach:
  - the swab type is a free-standing soft-deletable entity
  - the combination device and swab is a soft-deletable entity
  - facilities choose one or more of those combinations to use
- add or update entities to support this database structure (so far, only skeletally—this will probably cause all manner of tests to fail, and that's totally fine)

TODO:
- make the new models fully functional (currently they contain only column definitions)
- support both devices and device/swab combinations transparently in API layer
- enforce in the API layer the business rule that a facility may only use one swab type per device type

## Additional Information

* This PR is initially against an active feature branch, in anticipation that that feature branch will be merged before this work is completed.
* This PR will disable Java support for the previous relationship between Facility and DeviceType, but leave the database structure for that relationship to be removed in a future changeset, since dropping tables and columns cannot be rolled back

## Screenshots / Demos
