### PR TITLE
Refactored and ironed out API deployment properties.

### DIFF
--- a/backend/src/main/resources/application-azure-demo.yaml
+++ b/backend/src/main/resources/application-azure-demo.yaml
@@ -1,3 +1,5 @@
+spring:
+  profiles.active: no-security, single-tenant
 graphql.servlet.cors:
   allowed-origins:
     - https://simple-report-api-demo.azurewebsites.net

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -1,3 +1,5 @@
+spring:
+  profiles.include: okta-dev, single-tenant
 graphql.servlet.cors:
   allowed-origins:
     - https://simplereportdevapp.z13.web.core.windows.net
@@ -10,12 +12,6 @@ graphql.servlet.cors:
     - https://dev.simplereport.gov
     - https://demo.simplereport.gov
     - https://test.simplereport.gov
-
-okta:
-  oauth2:
-    issuer: https://hhs-prime.okta.com/oauth2/default
-    client-id: ${OKTA_OAUTH2_CLIENT_ID}
-    client-secret: ${OKTA_OAUTH2_CLIENT_SECRET}
 
 simple-report-initialization:
   organization:

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -1,3 +1,5 @@
+spring:
+  profiles.include: okta-prod, single-tenant
 graphql.servlet.cors:
   allowed-origins:
     - https://simple-report-api-prod.azurewebsites.net
@@ -7,12 +9,6 @@ graphql.servlet.cors:
 simple-report:
   data-hub:
     uploadurl: "https://prime-data-hub-prod.azurefd.net/api/reports"
-
-okta:
-  oauth2:
-    issuer: https://hhs-prime.okta.com/oauth2/default
-    client-id: ${OKTA_OAUTH2_CLIENT_ID}
-    client-secret: ${OKTA_OAUTH2_CLIENT_SECRET}
 
 simple-report-initialization:
   organization:

--- a/backend/src/main/resources/application-azure-stg.yaml
+++ b/backend/src/main/resources/application-azure-stg.yaml
@@ -1,15 +1,10 @@
+spring:
+  profiles.include: okta-stg, single-tenant
 graphql.servlet.cors:
   allowed-origins:
     - https://simple-report-api-stg.azurewebsites.net
     - https://simple-report-stg.azureedge.net
     - https://stg.simplereport.gov
-
-okta:
-  oauth2:
-    issuer: https://hhs-prime.okta.com/oauth2/default
-    client-id: ${OKTA_OAUTH2_CLIENT_ID}
-    client-secret: ${OKTA_OAUTH2_CLIENT_SECRET}
-
 simple-report-initialization:
   organization:
     facility-name: ${ORG_FACILITY_NAME}

--- a/backend/src/main/resources/application-cloud.yaml
+++ b/backend/src/main/resources/application-cloud.yaml
@@ -1,5 +1,5 @@
 spring:
-  profiles.include: no-security
+  profiles.include: okta-dev
   jpa:
     properties:
       hibernate:

--- a/backend/src/main/resources/application-okta-dev.yaml
+++ b/backend/src/main/resources/application-okta-dev.yaml
@@ -1,0 +1,8 @@
+# Bean profile to be included in deployment-specific profiles
+# for DEV/TEST deployments.
+okta:
+  oauth2:
+    client-id: 0oa61vdmqd56921Ka4h6
+simple-report.authorization:
+    role-claim: dev_roles
+    role-prefix: "SR-DEV-TENANT:"

--- a/backend/src/main/resources/application-okta-prod.yaml
+++ b/backend/src/main/resources/application-okta-prod.yaml
@@ -1,0 +1,8 @@
+# Bean profile to be included in deployment-specific profiles
+# for PRODUCTION ONLY.
+okta:
+  oauth2:
+    client-id: 0oa5ahrdfSpxmNZO74h6
+simple-report.authorization:
+    role-claim: prod_roles
+    role-prefix: "SR-PROD-TENANT:"

--- a/backend/src/main/resources/application-okta-stg.yaml
+++ b/backend/src/main/resources/application-okta-stg.yaml
@@ -1,0 +1,8 @@
+# Bean profile to be included in deployment-specific profiles
+# for STAGING deployments.
+okta:
+  oauth2:
+    client-id: 0oa62qncijWSeQMuc4h6
+simple-report.authorization:
+    role-claim: stg_roles
+    role-prefix: "SR-STG-TENANT:"

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,5 +1,5 @@
 spring:
-  profiles.include: single-tenant
+  profiles.include: okta-prod, single-tenant
 graphql.servlet.cors:
   allowed-origins:
     - https://simplereport.cdc.gov

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -30,8 +30,10 @@ graphql:
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default
+    # DEPRECATION: the FAKE fallback here is to enable behavior that
+    # we would be better off not enabling. Removal planned before 1/15/2021
     client-id: ${clientID:FAKE}
-    client-secret: ${clientSecret:FAKE}
+    client-secret: ${OKTA_OAUTH2_CLIENT_ID:FAKE}
     groups-claim: ${simple-report.authorization.role-claim}
 simple-report-initialization:
   device-types:


### PR DESCRIPTION
Created new properties files for our three Okta environments, and included those profiles as appropriate in deployment-specific profile YAML files so that each environment will have the expected behavior.

Key points:
* eliminated duplication of Okta properties that are set in the main application.yaml file
* changed the application.yaml file to inject the okta client secret using the same variable name we use in Azure
* added the environment-specific client IDs to property files so they do not need to be managed on the Azure side