### PR TITLE
Enable multi-tenant mode in Azure dev.

### DIFF
--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -1,5 +1,5 @@
 spring:
-  profiles.include: okta-dev, single-tenant, auth-dev
+  profiles.include: okta-dev, auth-dev
 graphql.servlet.cors:
   allowed-origins:
     - https://simplereportdevapp.z13.web.core.windows.net

--- a/backend/src/main/resources/application-okta-dev.yaml
+++ b/backend/src/main/resources/application-okta-dev.yaml
@@ -3,6 +3,11 @@
 okta:
   oauth2:
     client-id: 0oa61vdmqd56921Ka4h6
-simple-report.authorization:
+simple-report:
+  authorization:
     role-claim: dev_roles
     role-prefix: "SR-DEV-TENANT:"
+  admin-emails:
+    - bwarfield@cdc.gov
+    - tim.best@usds.dhs.gov
+    - qom2@cdc.gov

--- a/backend/src/main/resources/application-okta-dev.yaml
+++ b/backend/src/main/resources/application-okta-dev.yaml
@@ -10,4 +10,4 @@ simple-report:
   admin-emails:
     - bwarfield@cdc.gov
     - tim.best@usds.dhs.gov
-    - qom2@cdc.gov
+    - qom2@cdc.gov # a.k.a. abeckett@cdc.gov


### PR DESCRIPTION
Removed the single-tenant profile, and added a short list of admins to create new organizations in dev instances.

## Related Issue or Background Info

- Advances the checklist for #405 by another step or so.

## Changes Proposed

- add admin users to the dev Okta configuration
- add multiple tenants to the Azure dev deployment
