### PR TITLE
Remove Okta redirect URL overrides

### DIFF
--- a/ops/dev/persistent/okta.tf
+++ b/ops/dev/persistent/okta.tf
@@ -1,7 +1,6 @@
 module "okta" {
   source               = "../../services/okta-app"
   env                  = local.env
-  redirect_urls        = []
   logout_redirect_uris = "https://${local.env}.simplereport.gov"
   app_url              = "https://${local.env}.simplereport.gov/app"
 }

--- a/ops/services/all-persistent/main.tf
+++ b/ops/services/all-persistent/main.tf
@@ -20,9 +20,10 @@ data "azurerm_key_vault" "kv" {
 // Okta application
 
 module "okta" {
-  source  = "../../services/okta-app"
-  env     = var.env
-  app_url = local.app_url
+  source        = "../../services/okta-app"
+  env           = var.env
+  app_url       = local.app_url
+  redirect_urls = []
 }
 
 // Create the Okta secrets

--- a/ops/services/okta-app/_var.tf
+++ b/ops/services/okta-app/_var.tf
@@ -16,6 +16,7 @@ variable "admin_groups" {
 }
 
 variable "redirect_urls" {
+  description = "Additional redirect URLs for Okta applications (defaults to dev URLs)"
   default = [
     "http://localhost:8080",
     "http://localhost:9090",

--- a/ops/stg/persistent/okta.tf
+++ b/ops/stg/persistent/okta.tf
@@ -3,6 +3,7 @@ module "okta" {
   env                  = local.env
   logout_redirect_uris = "https://${local.env}.simplereport.gov"
   app_url              = "https://${local.env}.simplereport.gov/app"
+  redirect_urls        = []
 }
 
 // Create the Okta secrets

--- a/ops/stg/persistent/okta.tf
+++ b/ops/stg/persistent/okta.tf
@@ -1,7 +1,6 @@
 module "okta" {
   source               = "../../services/okta-app"
   env                  = local.env
-  redirect_urls        = []
   logout_redirect_uris = "https://${local.env}.simplereport.gov"
   app_url              = "https://${local.env}.simplereport.gov/app"
 }


### PR DESCRIPTION
## Related Issue or Background Info

Non-prod Okta environments were rejecting dev URLs (http://localhost:3000).
This was due to the dev/stg environments having an empty array overriding the default variable.
Moved the empty array to prod in order to reject dev environment logins.

Adresses #507 

## Changes Proposed

- Remove overrides from dev/stg environments, which were causing the Okta apps to reject development URLs.
- Reset the redirect URL in prod to remove dev environments.
