### PR TITLE
add facility id to edit links

### DIFF
--- a/frontend/src/app/Settings/Facility/ManageFacilities.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilities.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import { NavLink } from "react-router-dom";
 
 import Nav from "../Nav";
@@ -8,6 +9,9 @@ interface Props {
 }
 
 const ManageFacilities: React.FC<Props> = ({ facilities }) => {
+  const activeFacilityId = useSelector(
+    (state) => (state as any).facility.id as string
+  );
   return (
     <main className="prime-home">
       <div className="grid-container">
@@ -35,7 +39,9 @@ const ManageFacilities: React.FC<Props> = ({ facilities }) => {
                   {facilities.map((facility) => (
                     <tr key={facility.id}>
                       <td>
-                        <NavLink to={`/settings/facility/${facility.id}`}>
+                        <NavLink
+                          to={`/settings/facility/${facility.id}?facility=${activeFacilityId}`}
+                        >
                           {facility.name}
                         </NavLink>
                       </td>

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -60,7 +60,9 @@ const ManagePatients = ({ activeFacilityId }: Props) => {
     return patients.map((patient: Patient) => (
       <tr key={patient.internalId}>
         <th scope="row">
-          <NavLink to={`/patient/${patient.internalId}`}>
+          <NavLink
+            to={`/patient/${patient.internalId}?facility=${activeFacilityId}`}
+          >
             {displayFullName(
               patient.firstName,
               patient.middleName,


### PR DESCRIPTION
## Related Issue or Background Info

- These links worked before because we were auto selecting a default facility. Now with the select we need to persist the params as it is currently required on all pages with the `Header`

## Changes Proposed

- add `facilityId` to facility and patient edit
