### PR TITLE
Address Coverity warnings

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/deviceType/DeviceTypeMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/deviceType/DeviceTypeMutationResolver.java
@@ -24,7 +24,7 @@ public class DeviceTypeMutationResolver implements GraphQLMutationResolver {
         String model,
         String loincCode
     ) throws IllegalGraphqlArgumentException {
-        return _dts.createDeviceType(name, manufacturer, model, loincCode);
+        return _dts.createDeviceType(name, model, manufacturer, loincCode);
     }
 
     public DeviceType updateDeviceType(
@@ -34,6 +34,6 @@ public class DeviceTypeMutationResolver implements GraphQLMutationResolver {
         String model,
         String loincCode
     ) throws IllegalGraphqlArgumentException {
-        return _dts.updateDeviceType(id, name, manufacturer, model, loincCode);
+        return _dts.updateDeviceType(id, name, model, manufacturer, loincCode);
     }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -66,6 +66,10 @@ public abstract class BaseTestInfo extends AuditedEntity
 		return facility;
 	}
 
+	public void setFacility(Facility facility) {
+		this.facility = facility;
+	}
+
 	public DeviceType getDeviceType() {
 		return deviceType;
 	}


### PR DESCRIPTION
## Related Issue or Background Info

Now that we have Coverity running as a daily job, we should start attempting to address the warnings it generates.
This PR fixes the first batch reported, which are fairly small, but worth a quick once over.

## Changes Proposed

- TestDevice resolver passes parameters to the DB in the wrong order. One of the downfalls of a stringly typed API.
- Add missing setter to the `BaseTestInfo` class to correctly set the Facility when created via Hibernate.

## Additional Information

- There is still an outstanding warning due to missing CORS protection. @benwarfield-usds not sure if this is a real issue or not; meaning, not sure if it's a false positive in Coverity or if the config is actually missing.
