### PR TITLE
Use empty/null facilityid rather than bogus one

### DIFF
--- a/backend/src/test/resources/test-upload-invalid-phone.csv
+++ b/backend/src/test/resources/test-upload-invalid-phone.csv
@@ -1,2 +1,2 @@
 LastName,FirstName,MiddleName,Suffix,Race,DOB,Gender,Ethnicity,Street,Street2,City ,County,State,ZipCode,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId, Location
-Best,Tim,,,White,5/11/1933,Male,Not Hispanic,123 Main Street,,Washington,,DC,20008,not a phone number,Yes,No,Staff,foo@example.com,25ba3159-d3f8-4d1f-8ea6-c4466a190ab5,
+Best,Tim,,,White,5/11/1933,Male,Not Hispanic,123 Main Street,,Washington,,DC,20008,not a phone number,Yes,No,Staff,foo@example.com,,

--- a/backend/src/test/resources/test-upload.csv
+++ b/backend/src/test/resources/test-upload.csv
@@ -1,2 +1,2 @@
 LastName,FirstName,MiddleName,Suffix,Race,DOB,Gender,Ethnicity,Street,Street2,City ,County,State,ZipCode,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId, Location
-Best,Tim,,,White,5/11/1933,Male,Not Hispanic,123 Main Street,,Washington,,DC,20008,5656667777,Yes,No,Staff,foo@example.com,25ba3159-d3f8-4d1f-8ea6-c4466a190ab5,
+Best,Tim,,,White,5/11/1933,Male,Not Hispanic,123 Main Street,,Washington,,DC,20008,5656667777,Yes,No,Staff,foo@example.com,,


### PR DESCRIPTION
## Related Issue or Background Info

- link to issue, or a few sentences describing why this PR exists

## Changes Proposed

Use an empty `facilityId` in the CSV data because that facility doesn't exist. The test was passing before because STAFF roles never had their facility checked and were always considered to be `null`.

## Additional Information

## Screenshots / Demos
