### PR TITLE
Update Okta settings to point to the simplereport.gov sub-domains.

### DIFF
--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -21,7 +21,7 @@ module "monitoring" {
   rg_location   = data.azurerm_resource_group.prod.location
   rg_name       = data.azurerm_resource_group.prod.name
 
-  app_url = "${local.env}.simeplreport.gov"
+  app_url = "simplereport.gov"
 
   tags = local.management_tags
 }

--- a/ops/services/all-persistent/main.tf
+++ b/ops/services/all-persistent/main.tf
@@ -5,7 +5,7 @@ locals {
   }
   management_rg = "prime-simple-report-management"
   is_prod       = var.env == "prod"
-  app_url       = local.is_prod ? "https://simplereport.cdc.gov/app" : "https://${var.env}.simplereport.org/app"
+  app_url       = local.is_prod ? "https://simplereport.gov/app" : "https://${var.env}.simplereport.gov/app"
 }
 
 data "azurerm_resource_group" "rg" {
@@ -20,10 +20,11 @@ data "azurerm_key_vault" "kv" {
 // Okta application
 
 module "okta" {
-  source        = "../../services/okta-app"
-  env           = var.env
-  app_url       = local.app_url
-  redirect_urls = []
+  source               = "../../services/okta-app"
+  env                  = var.env
+  app_url              = local.app_url
+  redirect_urls        = []
+  logout_redirect_uris = local.is_prod ? "https://simplereport.gov" : "https://${var.env}.simplereport.gov"
 }
 
 // Create the Okta secrets

--- a/ops/services/monitoring/_var.tf
+++ b/ops/services/monitoring/_var.tf
@@ -1,4 +1,4 @@
 variable "app_url" {
   description = "test that the app_url is running."
-  default     = "simplereport.cdc.gov"
+  default     = "simplereport.gov"
 }

--- a/ops/services/monitoring/main.tf
+++ b/ops/services/monitoring/main.tf
@@ -1,7 +1,6 @@
 locals {
   is_prod = var.env == "prod"
-  // This is commented out until we actually have production deployments. Right now, it's just set to test that simplereport.cdc.gov is running.
-  //  app_url = local.is_prod ? "simplereport.cdc.gov" : "${var.env}.simplereport.cdc.gov"
+  app_url = local.is_prod ? "simplereport.gov" : "${var.env}.simplereport.gov"
 }
 
 data "azurerm_log_analytics_workspace" "law" {

--- a/ops/services/okta-app/_var.tf
+++ b/ops/services/okta-app/_var.tf
@@ -23,8 +23,7 @@ variable "redirect_urls" {
     "http://localhost:3000",
     "https://simple-report-qa.app.cloud.gov/",
     "https://simple-report-qa-api.app.cloud.gov/",
-    "https://staging.simplereport.org/app",
-    "https://simplereport.cdc.gov/app"
+    "https://simplereport.gov/app"
   ]
 }
 
@@ -33,5 +32,6 @@ variable "app_url" {
 }
 
 variable "logout_redirect_uris" {
-  default = "https://simplereport.cdc.gov"
+  description = "Where to redirect users on logout"
+  type        = string
 }

--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -11,8 +11,7 @@ resource "okta_app_oauth" "app" {
     "implicit"
   ]
   redirect_uris = concat(var.redirect_urls, [
-    "https://${var.env}.simplereport.org/app",
-    "https://${var.env}.simplereport.gov/app",
+    var.app_url
   ])
   response_types = [
     "code",


### PR DESCRIPTION
## Related Issue or Background Info

Okta settings in TF need to be synced with the manual changes done as part of the prod deployment.
Also fixes #600 

## Changes Proposed

- Removes references to *.cdc.gov subdomains
- Updates the redirect URIs to redirect to the appropriate environment (e.g. dev -> dev) rather than redirecting to prod (e.g. dev -> prod) which is what we're currently doing.
- Update the uptime monitor checks to point to simplereport.gov.

## Screenshots / Demos

TF plan for prod:

```
  # module.db.azurerm_monitor_diagnostic_setting.postgres will be updated in-place
  ~ resource "azurerm_monitor_diagnostic_setting" "postgres" {
        id                         = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-prod/providers/Microsoft.DBforPostgreSQL/servers/simple-report-prod-db|simple-report-prod-db-diag"
        name                       = "simple-report-prod-db-diag"
        # (2 unchanged attributes hidden)

      - log {
          - category = "PostgreSQLLogs" -> null
          - enabled  = true -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = false -> null
            }
        }
      + log {
          + category = "PostgreSQLLogs"
          + enabled  = true

          + retention_policy {
              + enabled = false
            }
        }
      - log {
          - category = "QueryStoreRuntimeStatistics" -> null
          - enabled  = false -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = false -> null
            }
        }
      - log {
          - category = "QueryStoreWaitStatistics" -> null
          - enabled  = false -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = false -> null
            }
        }

      + metric {
          + category = "AllMetrics"
          + enabled  = true

          + retention_policy {
              + enabled = false
            }
        }
      - metric {
          - category = "Errors" -> null
          - enabled  = true -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = true -> null
            }
        }
      - metric {
          - category = "Latency" -> null
          - enabled  = true -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = true -> null
            }
        }
      - metric {
          - category = "Saturation" -> null
          - enabled  = true -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = true -> null
            }
        }
      - metric {
          - category = "Traffic" -> null
          - enabled  = true -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = true -> null
            }
        }
    }

  # module.monitoring.azurerm_application_insights_web_test.web_test will be updated in-place
  ~ resource "azurerm_application_insights_web_test" "web_test" {
      ~ configuration           = <<-EOT
            <WebTest Name="WebTest1" Id="ABD48585-0831-40CB-9069-682EA6BB3583" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="0" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
              <Items>
          -     <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="https://prod.simeplreport.gov" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
          +     <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="https://simplereport.gov" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
              </Items>
            </WebTest>
        EOT
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-prod/providers/microsoft.insights/webtests/prime-simple-report-prod-web-test"
        name                    = "prime-simple-report-prod-web-test"
        tags                    = {
            "environment"                                                                                                                                                                       = "prod"
            "hidden-link:/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-prod/providers/microsoft.insights/components/prime-simple-report-prod-insights" = "Resource"
            "prime-app"                                                                                                                                                                         = "simplereport"
            "resource_group"                                                                                                                                                                    = "prime-simple-report-prod"
        }
        # (11 unchanged attributes hidden)
    }

  # module.all.module.okta.okta_app_oauth.app will be updated in-place
  ~ resource "okta_app_oauth" "app" {
        id                         = "0oa5ahrdfSpxmNZO74h6"
        name                       = "oidc_client"
      ~ redirect_uris              = [
          - "http://localhost:3000",
          - "http://localhost:8080",
          - "http://localhost:9090",
          - "https://prod.simplereport.gov/app",
          - "https://prod.simplereport.org/app",
          - "https://simple-report-qa-api.app.cloud.gov/",
          - "https://simple-report-qa.app.cloud.gov/",
          - "https://simplereport.cdc.gov/app",
          - "https://staging.simplereport.org/app",
            # (1 unchanged element hidden)
        ]
        # (19 unchanged attributes hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```
