### PR TITLE
Made logout URL use appropriate build environment variable.

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -2,5 +2,5 @@ REACT_APP_TITLE=SimpleReport
 REACT_APP_DESCRIPTION=SimpleReport Test Management Application
 REACT_APP_ICON=usds-32x32.png
 REACT_APP_BACKEND_URL=https://simple-report-qa-api.app.cloud.gov/graphql
-REACT_APP_OKTA_URL=https://simplereport.cdc.gov/
+REACT_APP_OKTA_URL=https://simplereport.gov/
 REACT_APP_APPINSIGHTS_KEY=ec65665e-358e-4f07-9292-3d80f23bcc3b

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -41,7 +41,7 @@ const Header: React.FC<{}> = () => {
     localStorage.removeItem("access_token");
     localStorage.removeItem("id_token");
     window.location.replace(
-      `https://hhs-prime.okta.com/oauth2/default/v1/logout?id_token_hint=${id_token}&post_logout_redirect_uri=https://simplereport.cdc.gov&state=${state}`
+      `https://hhs-prime.okta.com/oauth2/default/v1/logout?id_token_hint=${id_token}&post_logout_redirect_uri=${process.env.REACT_APP_OKTA_URL}&state=${state}`
     );
   };
 


### PR DESCRIPTION
Updated the default home-page redirect to simplereport.gov, and made Header.tsx use it instead of a hard-coded value.

## Related Issue or Background Info

- This purports to fix #600 

## Changes Proposed

- update .env file with correct logout redirect URL
- update Header.tsx to refer to the .env value when logging out
