### PR TITLE
Try to protect against overlapping run of the Datahub uploader

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -270,6 +270,7 @@ public class DataHubUploaderService {
         }
     }
 
+    @Transactional
     public void dataHubUploaderTask() {
         // sanity check everything is configured correctly (dev likely will not be)
         if (!_config.getUploadEnabled()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ScheduledTasksService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ScheduledTasksService.java
@@ -4,16 +4,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.annotation.ApplicationScope;
 
 import javax.management.timer.Timer;
 
 
+// ApplicationScope makes it a singleton
 @Service
+@ApplicationScope
 public class ScheduledTasksService {
     private static final Logger LOG = LoggerFactory.getLogger(ScheduledTasksService.class);
     private final DataHubUploaderService _dataHubUploaderService;
 
     ScheduledTasksService(DataHubUploaderService dataHubUploaderService) {
+        LOG.info("Scheduler initialized. Should ONLY HAPPEN ONCE.");
         _dataHubUploaderService = dataHubUploaderService;
     }
 


### PR DESCRIPTION
 - Add a `@Transactional` to `dataHubUploaderTask()` (the Class has this spring keyword as well)
 - Add a `@ApplicationScope` to the `ScheduledTasksService` to make sure it's a singleton.