### PR TITLE
Scale down staging to 1 instance.

### DIFF
--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -5,7 +5,7 @@ module "simple_report_api" {
 
   instance_tier  = "PremiumV2"
   instance_size  = "P1v2"
-  instance_count = 2
+  instance_count = 1
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
We are not actually ready for horizontal scaling on the API: scaling down staging first to make sure it works the way we think.

## Related Issue or Background Info

When we moved to our Azure infrastructure, we set up two instances in staging and production. Unfortunately we do not have any form of serialization on our upload to the data hub, so each instance thought that it was responsible for uploading at 11:00 AM ET. Pending resolution of the underlying problem, we will scale back to one instance to prevent downstream issues.

- #606 (bandaid)
- #608 (underlying issue)

## Changes Proposed

- change the instance count for `stg` from 2 to 1
