### PR TITLE
Fix docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,7 @@ COPY --chown=gradle:gradle ./*.gradle ./
 # COPY --chown=gradle:gradle ./.git ./.git
 COPY --chown=gradle:gradle ./config ./config
 COPY --chown=gradle:gradle ./src ./src
+COPY --chown=gradle:gradle gradle.properties gradle.properties
 
 RUN gradle --no-daemon classes testClasses assemble
 


### PR DESCRIPTION
## Related Issue or Background Info

- `gradle.properties` was added in a recent change and running the app in docker was breaking because it wasn't being copied over

## Changes Proposed

- copy `gradle.properties` over to the docker container

