### PR TITLE
Fix deprecation warning in build.gradle.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,8 +39,8 @@ dependencies {
 //	Okta dependencies
 	implementation 'com.okta.spring:okta-spring-boot-starter:2.0.0'
 	implementation 'com.okta.sdk:okta-sdk-api:3.0.1'
-	runtime 'com.okta.sdk:okta-sdk-impl:3.0.1'
-	runtime 'com.okta.sdk:okta-sdk-httpclient:3.0.1'
+	runtimeOnly 'com.okta.sdk:okta-sdk-impl:3.0.1'
+	runtimeOnly 'com.okta.sdk:okta-sdk-httpclient:3.0.1'
 
 // App insights instrumentation
 	implementation 'com.microsoft.azure:applicationinsights-core:2.6.2'


### PR DESCRIPTION
Two dependency entries were using a deprecated configuration: changed them to be non-deprecated, and consistent with the rest of the file.