### PR TITLE
Refactor patient profile display logic to utils

### DIFF
--- a/frontend/src/app/utils/address.test.ts
+++ b/frontend/src/app/utils/address.test.ts
@@ -1,0 +1,208 @@
+import { formatAddress } from "./address";
+
+describe("formatAddress", () => {
+  test("empty address", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "",
+      state: "",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("");
+  });
+  test("with only street", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "",
+      city: "",
+      state: "",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("123 Green Street");
+  });
+  test("with street and streetTwo", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "APT 1",
+      city: "",
+      state: "",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("123 Green Street\nAPT 1");
+  });
+  test("with street, streetTwo, and city", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "APT 1",
+      city: "New City",
+      state: "",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("123 Green Street\nAPT 1\nNew City");
+  });
+  test("with street, streetTwo, city, and state", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "APT 1",
+      city: "New City",
+      state: "NC",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe(
+      "123 Green Street\nAPT 1\nNew City, NC"
+    );
+  });
+  test("with complete address", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "APT 1",
+      city: "New City",
+      state: "NC",
+      county: "County",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe(
+      "123 Green Street\nAPT 1\nNew City, NC 00700"
+    );
+  });
+  test("with no state", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "APT 1",
+      city: "New City",
+      state: "",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe(
+      "123 Green Street\nAPT 1\nNew City 00700"
+    );
+  });
+  test("with no city", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "APT 1",
+      city: "",
+      state: "NC",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("123 Green Street\nAPT 1\nNC 00700");
+  });
+  test("with no streetTwo", () => {
+    const address = {
+      street: "123 Green Street",
+      streetTwo: "",
+      city: "New City",
+      state: "NC",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("123 Green Street\nNew City, NC 00700");
+  });
+  test("with no street", () => {
+    const address = {
+      street: "",
+      streetTwo: "APT 1",
+      city: "New City",
+      state: "NC",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("APT 1\nNew City, NC 00700");
+  });
+  test("with only city, state, zipCode", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "New City",
+      state: "NC",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("New City, NC 00700");
+  });
+  test("with only city and state", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "New City",
+      state: "NC",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("New City, NC");
+  });
+  test("with only city and zipCode", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "New City",
+      state: "",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("New City 00700");
+  });
+  test("with only state and zipCode", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "",
+      state: "NC",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("NC 00700");
+  });
+  test("with only streetTwo", () => {
+    const address = {
+      street: "",
+      streetTwo: "APT 1",
+      city: "",
+      state: "",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("APT 1");
+  });
+  test("with only city", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "New City",
+      state: "",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("New City");
+  });
+  test("with only state", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "",
+      state: "NC",
+      county: "",
+      zipCode: "",
+    };
+    expect(formatAddress(address)).toBe("NC");
+  });
+  test("with only zipCode", () => {
+    const address = {
+      street: "",
+      streetTwo: "",
+      city: "",
+      state: "",
+      county: "",
+      zipCode: "00700",
+    };
+    expect(formatAddress(address)).toBe("00700");
+  });
+});

--- a/frontend/src/app/utils/address.ts
+++ b/frontend/src/app/utils/address.ts
@@ -1,0 +1,21 @@
+export function formatAddress(address: Address) {
+  // format address with correct punctuation and separated by `\n`s
+  const lastAddressLine = `${address.city}${
+    address.state && address.city ? ", " : ""
+  }${address.city && address.zipCode && !address.state ? " " : ""}${
+    address.state
+  }${address.state && address.zipCode ? " " : ""}${address.zipCode}`;
+
+  let result = address.street;
+  result += `${
+    result.length > 0 && address.streetTwo
+      ? "\n" + address.streetTwo
+      : address.streetTwo
+  }`;
+  result += `${
+    result.length > 0 && lastAddressLine
+      ? "\n" + lastAddressLine
+      : lastAddressLine
+  }`;
+  return result;
+}

--- a/frontend/src/app/utils/text.test.ts
+++ b/frontend/src/app/utils/text.test.ts
@@ -1,0 +1,20 @@
+import { capitalizeText } from "./text";
+
+describe("capitalizeText", () => {
+  test("empty text", () => {
+    const text = "";
+    expect(capitalizeText(text)).toBe("");
+  });
+  test("all capitalized text", () => {
+    const text = "FOOBAR";
+    expect(capitalizeText(text)).toBe("Foobar");
+  });
+  test("all capitalized except first letter", () => {
+    const text = "fOOBAR";
+    expect(capitalizeText(text)).toBe("Foobar");
+  });
+  test("two words", () => {
+    const text = "foo bar";
+    expect(capitalizeText(text)).toBe("Foo bar");
+  });
+});

--- a/frontend/src/app/utils/text.ts
+++ b/frontend/src/app/utils/text.ts
@@ -1,0 +1,5 @@
+export function capitalizeText(text = ""): string {
+  // capitalizes first letter
+  let result = text.toLowerCase();
+  return result.charAt(0).toUpperCase() + result.slice(1);
+}

--- a/frontend/src/patientApp/timeOfTest/PatientProfileContainer.tsx
+++ b/frontend/src/patientApp/timeOfTest/PatientProfileContainer.tsx
@@ -1,18 +1,25 @@
 import moment from "moment";
 
-import { formatFullName } from "../../utils/user";
-import { formatAddress } from "../../utils/address";
-import { capitalizeText } from "../../utils/text";
+import { formatFullName } from "../../app/utils/user";
+import PatientForm from "../../app/patients/PatientForm";
 
-import { RACE_VALUES, ETHNICITY_VALUES, GENDER_VALUES } from "../../constants";
+import {
+  RACE_VALUES,
+  ETHNICITY_VALUES,
+  GENDER_VALUES,
+} from "../../app/constants";
 
-import Button from "../../commonComponents/Button";
+import Button from "../../app/commonComponents/Button";
+import React, { useState } from "react";
+import { Redirect } from "react-router";
 
 interface Props {
   patient: any;
 }
 
-const PatientProfile = (props: Props) => {
+const PatientProfileContainer = (props: Props) => {
+  const [nextPage, setNextPage] = useState(false);
+
   const fullName = formatFullName(props.patient);
   const race = RACE_VALUES.find((val) => val.value === props.patient.race)
     ?.label;
@@ -22,34 +29,68 @@ const PatientProfile = (props: Props) => {
   const gender = GENDER_VALUES.find((val) => val.value === props.patient.gender)
     ?.label;
 
+  const formattedAddress = () => {
+    const lastAddressLine = `${props.patient.city}${
+      props.patient.state && props.patient.city ? "," : ""
+    }${props.patient.city ? " " : ""}${props.patient.state}${
+      props.patient.state ? " " : ""
+    }${props.patient.zipCode}`;
+
+    let result = props.patient.street;
+    result += `${
+      result.length > 0
+        ? "\n" + props.patient.streetTwo
+        : props.patient.streetTwo
+    }`;
+    result += `${result.length > 0 ? "\n" + lastAddressLine : lastAddressLine}`;
+    return result;
+  };
+
   const newLineSpan = ({ text = "" }) => {
     return text
       .split("\n")
       .map((str) => <span className="display-block">{str}</span>);
   };
 
-  const address = formatAddress({
-    street: props.patient.street,
-    streetTwo: props.patient.streetTwo,
-    city: props.patient.city,
-    county: props.patient.county,
-    state: props.patient.state,
-    zipCode: props.patient.zipCode,
-  });
+  const capitalize = ({ text = "" }) => {
+    const answer = text.toLowerCase();
+    return answer.charAt(0).toUpperCase() + answer.slice(1);
+  };
+
+  const address = formattedAddress();
   const notProvided = "Not provided";
 
   const savePatientAnswers = () => {
-    console.log("saved");
+    setNextPage(true);
   };
 
   const buttonGroup = (
-    <div className="margin-top-3">
-      <Button label="Confirm and continue" onClick={savePatientAnswers} />
-    </div>
+    <>
+      <div className="margin-top-3">
+        <Button label="Confirm and continue" onClick={savePatientAnswers} />
+      </div>
+      <div className="margin-top-3">
+        <Button label="Edit information" onClick={savePatientAnswers} />
+      </div>
+    </>
   );
+
+  if (nextPage) {
+    return (
+      <Redirect
+        push
+        to={{
+          pathname: "/patient-info-confirmation",
+          state: { page: "symptoms" },
+        }}
+      />
+    );
+  }
 
   return (
     <>
+      {/* <PatientForm
+      activeFacilityId={loadSta}/> */}
       <div className="usa-alert usa-alert--info margin-bottom-3">
         <div className="usa-alert__body">
           <p className="usa-alert__text">
@@ -95,13 +136,13 @@ const PatientProfile = (props: Props) => {
         </h3>
         <p>
           {props.patient.residentCongregateSetting
-            ? capitalizeText(props.patient.residentCongregateSetting)
+            ? capitalize({ text: props.patient.residentCongregateSetting })
             : notProvided}
         </p>
         <h3 className="font-heading-sm">Employed in healthcare</h3>
         <p>
           {props.patient.employedInHealthcare
-            ? capitalizeText(props.patient.employedInHealthcare)
+            ? capitalize({ text: props.patient.employedInHealthcare })
             : notProvided}
         </p>
       </div>
@@ -110,4 +151,4 @@ const PatientProfile = (props: Props) => {
   );
 };
 
-export default PatientProfile;
+export default PatientProfileContainer;


### PR DESCRIPTION
## Related Issue or Background Info
This PR refactors display logic for the patient profile introduced in #622.

## Changes Proposed

- move display logic to `utils`
- write unit tests

## Additional Information

- N/A

## Screenshots / Demos

- N/A
