### PR TITLE
add swabtypes to test

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceManagementTest.java
@@ -70,7 +70,8 @@ public class DeviceManagementTest extends BaseApiTest {
                 .put("name", "Funny")
                 .put("manufacturer", "Acme")
                 .put("model", "Test-A-Lot")
-                .put("loincCode", "123456");
+                .put("loincCode", "123456")
+                .put("swabType", "abcdef");
         return variables;
     }
 

--- a/backend/src/test/resources/device-type-add
+++ b/backend/src/test/resources/device-type-add
@@ -3,17 +3,20 @@ mutation addDevice(
     $manufacturer: String!
     $model: String!
     $loincCode: String!
+    $swabType: String!
 ) {
     createDeviceType(
       name: $name
       manufacturer: $manufacturer
       model: $model
       loincCode: $loincCode
+      swabType: $swabType
     ) {
       internalId
       name
       model
-     manufacturer
-     loincCode
+      manufacturer
+      loincCode
+      swabType
     }
 }

--- a/backend/src/test/resources/device-type-query
+++ b/backend/src/test/resources/device-type-query
@@ -5,5 +5,6 @@ query listDevices {
         manufacturer
         model
         loincCode
+        swabType
     }
 }

--- a/backend/src/test/resources/device-type-update
+++ b/backend/src/test/resources/device-type-update
@@ -4,6 +4,7 @@ mutation updateDevice(
     $manufacturer: String!
     $model: String!
     $loincCode: String!
+    $swabType: String!
 ) {
     updateDeviceType(
       id: $id
@@ -11,11 +12,14 @@ mutation updateDevice(
       manufacturer: $manufacturer
       model: $model
       loincCode: $loincCode
+      swabType: $swabType
+
     ) {
       internalId
       name
       model
       manufacturer
       loincCode
+      swabType
     }
 }


### PR DESCRIPTION
## Related Issue or Background Info

- merged adding swabtype without rebasing on the latest version of `main`. This updates the `deviceType` test to include `swabType`
