### PR TITLE
Workaround for #677 and fixes for other bug-bash incidents.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 
+import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.service.PersonService;
 
@@ -23,6 +24,7 @@ public class PatientResolver implements GraphQLQueryResolver {
         return ps.getPatients(facilityId);
     }
 
+    @AuthorizationConfiguration.RequirePermissionEditPatient
     public Person getPatient(String id) {
         return ps.getPatient(id);
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -57,7 +57,7 @@ public class PersonService {
         return _repo.findByFacilityAndOrganization(facility, _os.getCurrentOrganization(), NAME_SORT);
     }
 
-    @AuthorizationConfiguration.RequirePermissionEditPatient
+    // NO PERMISSION CHECK (make sure the caller has one!)
     public Person getPatient(String id) {
         return getPatient(id, _os.getCurrentOrganization());
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -62,7 +62,8 @@ public class TestOrderService {
   }
 
   @Transactional(readOnly = true)
-  @AuthorizationConfiguration.RequirePermissionReadResultList
+  @AuthorizationConfiguration.RequirePermissionStartTest // Incorrect permission:
+                                                         // https://github.com/CDCgov/prime-simplereport/issues/677
   public List<TestOrder> getTestResults(String facilityId) {
     Facility fac = _os.getFacilityInCurrentOrg(UUID.fromString(facilityId));
     return _repo.getTestResults(fac.getOrganization(), fac);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -148,7 +148,9 @@ public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Person p = _dataFactory.createFullPerson(org);
         _dataFactory.createTestEvent(p, facility);
 
-        assertSecurityError(() -> _service.getTestResults(facility.getInternalId().toString()));
+        // https://github.com/CDCgov/prime-simplereport/issues/677
+        // assertSecurityError(() ->
+        // _service.getTestResults(facility.getInternalId().toString()));
         assertSecurityError(() -> _service.getTestResults(p));
     }
 }


### PR DESCRIPTION
Temporarily (!!) made full facility results list available to entry-only user, to work around #677.

Also tweaked restriction on `getPatient` so that enqueueing is permitted but fetching a single patient is not.