### PR TITLE
Add TLS enforcement to lower environment API infra

### DIFF
--- a/ops/demo/api.tf
+++ b/ops/demo/api.tf
@@ -9,6 +9,7 @@ module "simple_report_api" {
   docker_image_uri = "DOCKER|simplereportacr.azurecr.io/api/simple-report-api-build:${var.acr_image_tag}"
   key_vault_id     = data.azurerm_key_vault.global.id
   tenant_id        = data.azurerm_client_config.current.tenant_id
+  https_only       = true
 
   app_settings = {
     SPRING_PROFILES_ACTIVE                         = "azure-demo,no-security,no-okta-mgmt"

--- a/ops/dev/api.tf
+++ b/ops/dev/api.tf
@@ -11,6 +11,7 @@ module "simple_report_api" {
   docker_image_uri = "DOCKER|simplereportacr.azurecr.io/api/simple-report-api-build:${var.acr_image_tag}"
   key_vault_id     = data.azurerm_key_vault.sr_global.id
   tenant_id        = data.azurerm_client_config.current.tenant_id
+  https_only       = true
 
   app_settings = {
     SPRING_PROFILES_ACTIVE                         = "azure-dev"

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -24,6 +24,7 @@ resource "azurerm_app_service" "service" {
   site_config {
     linux_fx_version = var.docker_image_uri
     always_on        = "true"
+    min_tls_version  = "1.2"
   }
 
   app_settings = merge(var.app_settings, {

--- a/ops/test/api.tf
+++ b/ops/test/api.tf
@@ -9,6 +9,7 @@ module "simple_report_api" {
   docker_image_uri = "DOCKER|simplereportacr.azurecr.io/api/simple-report-api-build:${var.acr_image_tag}"
   key_vault_id     = data.azurerm_key_vault.sr_global.id
   tenant_id        = data.azurerm_client_config.current.tenant_id
+  https_only       = true
 
   app_settings = {
     SPRING_PROFILES_ACTIVE                         = "azure-test"


### PR DESCRIPTION
## Related Issue or Background Info

- We're not requiring HTTPS in demo, dev, or test, but we should be.

## Changes Proposed

- Require HTTPS in demo, dev, and test
- Explicitly require TLS 1.2 (this is already the default, but defaults can change)
