### PR TITLE
Restore valid behavior of superuser User objects.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
@@ -26,6 +26,13 @@ public class User {
             permissions.addAll(orgwrapper.get().getGrantedPermissions());
             roleDescription = orgwrapper.get().getEffectiveRole().get().getDescription();
         }
+        if (isAdmin) {
+            if (roleDescription == null) {
+                roleDescription = "Super Admin";
+            } else {
+                roleDescription = roleDescription + " (SU)";
+            }
+        }
     }
 
     public User(ApiUser user, Optional<Organization> org, Boolean isAdmin, List<UserPermission> permissions) {


### PR DESCRIPTION
When a site admin has no organization role, they need a valid role description
or graphql will (correctly) complain that the object is invalid.

## Related Issue or Background Info

A snap fix last night caused a test to fail, and the test is actually testing a valid use case: super-user who has no role in an organization.

## Changes Proposed

- Return "Super Admin" if a super admin is logged in with no other role
- return a badged version of the organization role (e.g. "Standard user (SU)") if a user is both a site admin and an organization user