### PR TITLE
Made demo user configuration separate from sample data.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -13,6 +13,7 @@ import gov.cdc.usds.simplereport.config.BeanProfiles;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.config.simplereport.AdminEmailList;
 import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
+import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 
 @SpringBootApplication
@@ -22,6 +23,7 @@ import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
         AdminEmailList.class,
         AuthorizationProperties.class,
         DataHubConfig.class,
+        DemoUserConfiguration.class,
 })
 @EnableScheduling
 public class SimpleReportApplication {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 
 /**
@@ -23,7 +24,7 @@ public class DevSecurityConfiguration extends WebSecurityConfigurerAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(DevSecurityConfiguration.class);
 
     @Autowired
-    private InitialSetupProperties _setupProps;
+    private DemoUserConfiguration _demoUsers;
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
@@ -33,8 +34,8 @@ public class DevSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 ;
     }
 
-	@Bean
-	public IdentitySupplier getDummyIdentity() {
-		return _setupProps::getDefaultUser;
-	}
+    @Bean
+    public IdentitySupplier getDemoIdentitySupplier() {
+        return () -> _demoUsers.getDefaultUser().getIdentity();
+    }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -12,7 +12,6 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
-import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 
 @ConfigurationProperties(prefix = "simple-report-initialization")
 @ConstructorBinding
@@ -22,21 +21,17 @@ public class InitialSetupProperties {
     private Provider provider;
     private List<? extends DeviceType> deviceTypes;
     private List<String> configuredDeviceTypes;
-    private IdentityAttributes defaultUser;
     private ConfigFacility facility;
 
     public InitialSetupProperties(Organization organization,
             ConfigFacility facility,
             Provider provider,
             List<DeviceType> deviceTypes,
-            List<String> configuredDeviceTypes,
-            IdentityAttributes defaultUser,
-            IdentityAttributes adminUser) {
+            List<String> configuredDeviceTypes) {
         this.organization = organization;
         this.provider = provider;
         this.deviceTypes = deviceTypes;
         this.configuredDeviceTypes = configuredDeviceTypes;
-        this.defaultUser = defaultUser;
         this.facility = facility;
     }
 
@@ -63,10 +58,6 @@ public class InitialSetupProperties {
             .map(d->new DeviceType(d.getName(), d.getManufacturer(), d.getModel(), d.getLoincCode(), d.getSwabType()))
             .collect(Collectors.toList())
             ;
-    }
-
-    public IdentityAttributes getDefaultUser() {
-        return defaultUser;
     }
 
     public static final class ConfigFacility {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/AuthorizationServiceConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/AuthorizationServiceConfig.java
@@ -7,10 +7,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 import gov.cdc.usds.simplereport.config.BeanProfiles;
-import gov.cdc.usds.simplereport.config.InitialSetupProperties;
+import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.service.AuthorizationService;
 import gov.cdc.usds.simplereport.service.LoggedInAuthorizationService;
-import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 
 @Configuration
 public class AuthorizationServiceConfig {
@@ -23,11 +22,8 @@ public class AuthorizationServiceConfig {
 
     @Bean
     @Profile(BeanProfiles.SINGLE_TENANT)
-    public AuthorizationService getDummyAuthorizer(InitialSetupProperties setupProps,
-            OrganizationInitializingService initService) {
-        final OrganizationRoles defaultOrg = new OrganizationRoles(
-                setupProps.getOrganization().getExternalId(),
-                Collections.singleton(OrganizationRole.USER));
+    public AuthorizationService getDemoAuthorizer(DemoUserConfiguration configProps) {
+        final OrganizationRoles defaultOrg = configProps.getDefaultUser().getAuthorization();
         return () -> Collections.singletonList(defaultOrg);
     }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/simplereport/DemoUserConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/simplereport/DemoUserConfiguration.java
@@ -1,0 +1,47 @@
+package gov.cdc.usds.simplereport.config.simplereport;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRoles;
+import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
+
+/**
+ * Bound configuration for the default demo user, and possibly more demo users
+ * in the future if we make demo login more useful.
+ */
+@ConfigurationProperties(prefix = "simple-report.demo-users")
+@ConstructorBinding
+public class DemoUserConfiguration {
+
+    private DemoUser defaultUser;
+
+    public DemoUserConfiguration(DemoUser defaultUser) {
+        super();
+        this.defaultUser = defaultUser;
+    }
+
+    public DemoUser getDefaultUser() {
+        return defaultUser;
+    }
+
+    @ConstructorBinding
+    public static class DemoUser {
+        private OrganizationRoles authorization;
+        private IdentityAttributes identity;
+
+        public DemoUser(OrganizationRoles authorization, IdentityAttributes identity) {
+            super();
+            this.authorization = authorization;
+            this.identity = identity;
+        }
+
+        public OrganizationRoles getAuthorization() {
+            return authorization;
+        }
+
+        public IdentityAttributes getIdentity() {
+            return identity;
+        }
+    }
+}

--- a/backend/src/main/resources/application-azure-demo.yaml
+++ b/backend/src/main/resources/application-azure-demo.yaml
@@ -1,6 +1,4 @@
 spring:
-  # create-sample-data is currently subtly supporting single-tenant, because single-tenant assumes
-  # that simple-report-initialization.organization.external-id is set
   profiles.include: no-security, single-tenant, create-sample-data
 graphql.servlet.cors:
   allowed-origins:

--- a/backend/src/main/resources/application-no-security.yaml
+++ b/backend/src/main/resources/application-no-security.yaml
@@ -4,11 +4,15 @@ spring:
       - com.okta.spring.boot.oauth.OktaOAuth2AutoConfig
       - com.okta.spring.boot.oauth.OktaOAuth2ResourceServerAutoConfig
       - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
-simple-report-initialization.default-user:
-  username: bob@example.com
-  first-name: Bobbity
-  middle-name: Bob
-  last-name: Bobberoo
 simple-report:
   admin-emails:
     - ruby@example.com
+  demo-users:
+    default-user:
+      identity:
+        username: bob@bobby.bob
+        first-name: Bob
+        last-name: Bobberoo
+      authorization:
+        organization-external-id: ${SR_DEMO_USER_ORG:DIS_ORG}
+        granted-roles: ${SR_DEMO_USER_ROLE:ADMIN}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -5,6 +5,7 @@ import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
 import gov.cdc.usds.simplereport.config.simplereport.AdminEmailList;
 import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
+import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.OktaServiceImpl;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
@@ -36,7 +37,14 @@ import org.springframework.security.test.context.support.WithMockUser;
  * stereotype because we very much do not want it to be picked up automatically!
  */
 @Import({ TestDataFactory.class, AuditingConfig.class, OktaServiceImpl.class, ApiUserService.class, OrganizationInitializingService.class })
-@EnableConfigurationProperties({InitialSetupProperties.class, OktaClientProperties.class, AuthorizationProperties.class, AdminEmailList.class, DataHubConfig.class})
+@EnableConfigurationProperties({
+        InitialSetupProperties.class,
+        OktaClientProperties.class,
+        AuthorizationProperties.class,
+        AdminEmailList.class,
+        DataHubConfig.class,
+        DemoUserConfiguration.class,
+})
 public class SliceTestConfiguration {
 
     @Bean


### PR DESCRIPTION
Separated out default user (for demo and local dev) from initialization properties that actually belong to a different bean profile, and added an easy way to change the role or the organization of the default user for local development.

## Related Issue or Background Info

- now that we have multiple roles available, local development needs to support them
- demo environment needs a different role than it has right now

## Changes Proposed

- make ADMIN the default demo role
- make it configurable via environment variable
- rewire a bunch of stuff under the hood to make space for having more complicated demo authentication in the future.

