### PR TITLE
Java development quality-of-life improvements

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -68,6 +68,10 @@ configurations {
 	}
 }
 
+checkstyleTest {
+   configFile = file("config/checkstyle/checkstyleTest.xml")
+}
+
 jacocoTestReport {
 	reports {
 		xml.enabled = true

--- a/backend/config/checkstyle/checkstyleTest.xml
+++ b/backend/config/checkstyle/checkstyleTest.xml
@@ -3,9 +3,6 @@
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
      "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-  <module name="SuppressionFilter">
-    <property name="file" value="${config_loc}/suppressions.xml"/>
-  </module>
   <module name="SuppressWarningsFilter" />
   <module name="FileTabCharacter"/>
   <module name="TreeWalker">
@@ -30,9 +27,6 @@
       <property name="severity" value="error"/>
     </module>
     <module name="IllegalCatch">
-      <property name="severity" value="error"/>
-    </module>
-    <module name="MagicNumber">
       <property name="severity" value="error"/>
     </module>
   </module>

--- a/backend/config/checkstyle/suppressions.xml
+++ b/backend/config/checkstyle/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!--  REMOVE ENTRIES FROM THIS AS POSSIBLE -->
+    <!--  NEVER ADD NEW ENTRIES UNLESS A NEW CHECK IS BEING ADDED THAT NOT ALL FILES PASS -->
+    <suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/AuthTestController.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/Translators.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/apiuser/ApiUserResolver.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/model/ApiProvider.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/model/User.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/model/errors/IllegalGraphqlArgumentException.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationDataResolver.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/api/queue/QueueResolver.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/config/AuditingConfig.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScoped.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScopedEternalEntity.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/PatientAnswers.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/Person.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/Provider.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/AskOnEntrySurvey.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/OptionalBoolean.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/OrderStatus.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/PersonName.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/RaceArrayConverter.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/TestResult.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/model/package-info.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/repository/EternalEntityRepository.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/UploadService.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/model/DeviceTypeHolder.java" />
+	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/model/IdentityAttributes.java" />
+	<!-- IF AND WHEN THIS COMMENT LINE MEETS THE COMMENTS AT THE TOP, PLEASE DELETE THIS FILE -->
+</suppressions>

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.5"
 services:
   db:
     image: postgres:12-alpine

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/simplereport/DataHubConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/simplereport/DataHubConfig.java
@@ -4,7 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "simple-report.data-hub")
-@ConstructorBinding
 public final class DataHubConfig {
 
     private final boolean uploadEnabled;
@@ -13,6 +12,7 @@ public final class DataHubConfig {
     private final String apiKey;
     private final String secretSlackNotifyWebhookUrl;
 
+    @ConstructorBinding
     public DataHubConfig(boolean uploadEnabled, String uploadUrl, int maxCsvRows, String apiKey,
                          String secretSlackNotifyWebhookUrl) {
         this.uploadEnabled = uploadEnabled;

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,72 @@
+{"properties": [
+  {
+    "name": "simple-report-initialization.organization.org-name",
+    "type": "java.lang.String",
+    "description": "The human-readable name for the organization"
+  },
+  {
+    "name": "simple-report-initialization.organization.external-id",
+    "type": "java.lang.String",
+    "description": "Durable external ID (for authorization management) of the organization"
+  },
+  {
+    "name": "simple-report-initialization.configured-device-types",
+    "type": "java.util.List<java.lang.String>",
+    "description": "The devices to be configured at the default facility"
+  },
+  {
+    "name": "simple-report-initialization.provider",
+    "type": "gov.cdc.usds.simplereport.db.model.Provider",
+    "description": "The ordering provider'"
+  },
+  {
+    "name": "simple-report-initialization.facility.address",
+    "type": "gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress",
+    "description": "facility address'"
+  },
+  {
+    "name": "simple-report-initialization.provider.address",
+    "type": "gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress",
+    "description": "The street address of the ordering provider"
+  },
+  {
+    "name": "simple-report-initialization.device-types",
+    "type": "java.util.List<gov.cdc.usds.simplereport.db.model.DeviceType>",
+    "description": "A description for 'simple-report-initialization.device-types'"
+  },
+  {
+    "name": "simple-report.authorization.role-claim",
+    "type": "java.lang.String",
+    "description": "A description for 'simple-report.authorization.role-claim'"
+  },
+  {
+    "name": "simple-report.data-hub",
+    "type": "gov.cdc.usds.simplereport.config.simplereport.DataHubConfig",
+    "description": "Configuration for data hub communications"
+  },
+  {
+    "name": "simple-report.authorization",
+    "type": "gov.cdc.usds.simplereport.config.AuthorizationConfiguration",
+    "description": "A description for 'simple-report.authorization.superuser-claim'"
+  },
+  {
+    "name": "graphql.datetime.scalars",
+    "type": "java.util.Map<java.lang.String, java.util.Map<java.lang.String,java.lang.String>>",
+    "description": "Definitions of graphql scalar types implemented by graphql-datetime"
+  },
+  {
+    "name": "simple-report.admin-emails",
+    "type": "java.util.List<java.lang.String>",
+    "description": "The e-mails of admin users for the application."
+  },
+  {
+    "name": "simple-report.data-hub",
+    "type": "gov.cdc.usds.simplereport.config.simplereport.DataHubConfig",
+    "description": "A description for 'simple-report.data-hub.upload-enabled'"
+  },
+  {
+    "name": "simple-report.demo-users",
+    "type": "gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration",
+    "description": "A description for 'simple-report.demo-users.default-user.authorization.granted-roles'"
+  }
+]}


### PR DESCRIPTION
## Changes Proposed

- split checkstyle configuration for test and main source files, so different rules can be enabled as appropriate (&lt;cough&gt;MagicNumber&lt;/cought&gt;)
- added a check for tab characters, and suppressed the error that it raised from each of the 42 files in src/main that still has tabs. As we reformat files, we should remove them from that suppression.
- added a metadata file to allow smart IDE's to auto-complete field names in application*.yaml (or .properties) files
- updated docker-compose.yml version key to the correct value for the syntax used in the file (fortunately, without breaking it for macOS Sierra users!)