### PR TITLE
Include Java build info in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,6 @@ build
 .dockerignore
 Dockerfile
 Dockerfile.prod
+/frontend
+/ops
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,14 @@
 FROM gradle:6.7.1-jdk11-hotspot
 
 WORKDIR /home/gradle/graphql-api
-COPY --chown=gradle:gradle gradle ./gradle
-COPY --chown=gradle:gradle ./*.gradle ./
+COPY --chown=gradle:gradle ./.git ./.git
 
-# nice optimization opportunity: get the dependencies cached in an intermediate
-# docker layer (have to tickle gradle, may not be worth it)
-
-# This is only useful if we have the git-info actuator, in which case we have 
-# to rearrange some files because we're in a subdirectory
-# COPY --chown=gradle:gradle ./.git ./.git
-COPY --chown=gradle:gradle ./config ./config
-COPY --chown=gradle:gradle ./src ./src
-COPY --chown=gradle:gradle gradle.properties gradle.properties
+WORKDIR /home/gradle/graphql-api/backend
+COPY --chown=gradle:gradle ./backend/gradle ./gradle
+COPY --chown=gradle:gradle ./backend/*.gradle ./
+COPY --chown=gradle:gradle ./backend/config ./config
+COPY --chown=gradle:gradle ./backend/src ./src
+COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
 
 RUN gradle --no-daemon classes testClasses assemble
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,7 +1,9 @@
 FROM gradle:6.7.1-jdk11-hotspot AS build
 WORKDIR /home/gradle/graphql-api
-COPY --chown=gradle:gradle gradle ./gradle
-COPY --chown=gradle:gradle ./*.gradle ./
+COPY --chown=gradle:gradle ./.git ./.git
+WORKDIR /home/gradle/graphql-api/backend
+COPY --chown=gradle:gradle backend/gradle ./gradle
+COPY --chown=gradle:gradle backend/*.gradle ./
 
 # Download the application insights JAR
 RUN wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.0.0/applicationinsights-agent-3.0.0.jar -O insights.jar
@@ -12,14 +14,14 @@ RUN wget https://github.com/microsoft/ApplicationInsights-Java/releases/download
 # This is only useful if we have the git-info actuator, in which case we have
 # to rearrange some files because we're in a subdirectory
 # COPY --chown=gradle:gradle ./.git ./.git
-COPY --chown=gradle:gradle ./config ./config
-COPY --chown=gradle:gradle ./src ./src
-COPY --chown=gradle:gradle gradle.properties gradle.properties
+COPY --chown=gradle:gradle ./backend/config ./config
+COPY --chown=gradle:gradle ./backend/src ./src
+COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
 
-RUN gradle --no-daemon classes assemble
+RUN gradle --no-daemon assemble
 
 FROM openjdk:11-jre-slim
 EXPOSE 8080
-COPY --from=build /home/gradle/graphql-api/build/libs/*.jar app.jar
-COPY --from=build  /home/gradle/graphql-api/insights.jar insights.jar
+COPY --from=build /home/gradle/graphql-api/backend/build/libs/*.jar app.jar
+COPY --from=build  /home/gradle/graphql-api/backend/insights.jar insights.jar
 ENTRYPOINT ["java", "-javaagent:insights.jar", "-jar", "app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,6 +5,7 @@ plugins {
 	id 'checkstyle'
 	id 'jacoco'
 	id 'org.sonarqube'  version '3.0'
+	id 'com.gorylenko.gradle-git-properties' version '2.2.0'
 }
 
 group = 'gov.cdc.usds'
@@ -53,6 +54,10 @@ dependencies {
 	testImplementation "com.graphql-java-kickstart:graphql-spring-boot-starter-test:${kickstartVersion}"
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.yannbriancon:spring-hibernate-query-utils:1.0.3'
+}
+
+springBoot {
+    buildInfo()
 }
 
 test {

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -2,8 +2,8 @@ version: "3.2"
 services:
   api:
     build:
-      context: .
-      dockerfile: Dockerfile.prod
+      context: ..
+      dockerfile: backend/Dockerfile.prod
     image: simple-report-api-build
     ports:
       - "8080:8080"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,7 +23,8 @@ services:
       - dev-net
   api:
     build:
-      context: .
+      context: ..
+      dockerfile: backend/Dockerfile
     image: simple-report-api-build
     command: bootRun
     environment:

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -53,6 +54,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, WebConfiguration.HEALTH_CHECK).permitAll()
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 				.requestMatchers(EndpointRequest.to(HealthEndpoint.class)).permitAll()
+                .requestMatchers(EndpointRequest.to(InfoEndpoint.class)).permitAll()
                 .anyRequest()
                 .authenticated();
         Okta.configureResourceServer401ResponseBody(http);


### PR DESCRIPTION
Add build time and git hash information to /actuators/info.

## Related Issue or Background Info

- Resolves #447

## Changes Proposed

- use build info plugin in Spring Boot
- update Docker builds so that git repository is visible when building jar

## Sample Output
```json
{
  "git": {
    "branch": "benwarfield-usds/include-java-build-info",
    "commit": {
      "id": "f319d7b",
      "time": "2021-02-02T02:36:04Z"
    }
  },
  "build": {
    "artifact": "simple-report",
    "name": "simple-report",
    "time": "2021-02-02T02:43:47.142Z",
    "version": "0.0.1-SNAPSHOT",
    "group": "gov.cdc.usds"
  }
}
```