### PR TITLE
add dummy value for client-id

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ graphql:
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default
-    client-id: ${OKTA_OAUTH2_CLIENT_ID}
+    client-id: ${OKTA_OAUTH2_CLIENT_ID:MISSING}
     client-secret: ${OKTA_OAUTH2_CLIENT_SECRET:MISSING}
     groups-claim: ${simple-report.authorization.role-claim}
   client:


### PR DESCRIPTION
## Related Issue or Background Info

our demo env is currently down because `OKTA_OAUTH2_CLIENT_ID` is not defined. This also effects running the test locally because by default no value for `OKTA_OAUTH2_CLIENT_ID` is provided and `client-id` is not overwritten

demo is failing to start and throwing the following exception
```
org.springframework.boot.context.properties.bind.BindException: Failed to bind properties under 'spring.security.oauth2.resourceserver.opaquetoken.client-id' to java.lang.String
```

