### PR TITLE
Fix

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -212,6 +212,11 @@ public class TestOrderService {
             throw new IllegalGraphqlArgumentException("TestEvent: could not load the parent order");
         }
 
+        // sanity check that two different users can't deleting the same event and delete it twice.
+        if (!testEventId.equals(order.getTestEventId())) {
+            throw new IllegalGraphqlArgumentException("TestEvent: already deleted?");
+        }
+
         // generate a duplicate test_event that just has a status of REMOVED and the reason
         TestEvent newRemoveEvent = new TestEvent(event, TestCorrectionStatus.REMOVED, reasonForCorrection);
         _terepo.save(newRemoveEvent);


### PR DESCRIPTION
Sanity check that the Order's TestEventId matches the TestEventId being deleted. If they are not the same, this could indicate that two users are trying to delete the same event on different machines.

This change also means we cannot remove the TestEventId field from TestOrder.