### PR TITLE
Extend feature flag to cover QR code display

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -98,11 +98,11 @@ const AoEModalForm = ({
         {buttonGroup}
       </div>
       <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
-      <h2 className="font-heading-lg margin-top-205 margin-bottom-0">
-        Test questionnaire
-      </h2>
       {process.env.REACT_APP_PATIENT_EXPERIENCE_ENABLED === "true" ? (
         <>
+          <h2 className="font-heading-lg margin-top-205 margin-bottom-0">
+            Test questionnaire
+          </h2>
           <RadioGroup
             legend="How would you like to complete the questionnaire?"
             name="qr-code"

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -1,15 +1,15 @@
-import { React, useState } from "react";
-import QRCode from "react-qr-code";
-import Modal from "react-modal";
-import AoEForm from "./AoEForm";
-import Button from "../../commonComponents/Button";
-import RadioGroup from "../../commonComponents/RadioGroup";
-import { displayFullName } from "../../utils";
-import { getSymptomList } from "../../../patientApp/timeOfTest/constants";
-import { getUrl } from "../../utils/url";
+import { React, useState } from 'react';
+import QRCode from 'react-qr-code';
+import Modal from 'react-modal';
+import AoEForm from './AoEForm';
+import Button from '../../commonComponents/Button';
+import RadioGroup from '../../commonComponents/RadioGroup';
+import { displayFullName } from '../../utils';
+import { getSymptomList } from '../../../patientApp/timeOfTest/constants';
+import { getUrl } from '../../utils/url';
 
 const AoEModalForm = ({
-  saveButtonText = "Save",
+  saveButtonText = 'Save',
   onClose,
   patient,
   facilityId,
@@ -21,8 +21,8 @@ const AoEModalForm = ({
   const [modalView, setModalView] = useState(null);
   const [patientLink, setPatientLink] = useState(qrCodeValue);
   const modalViewValues = [
-    { label: "Complete on smartphone", value: "smartphone" },
-    { label: "Complete questionnaire verbally", value: "verbal" },
+    { label: 'Complete on smartphone', value: 'smartphone' },
+    { label: 'Complete questionnaire verbally', value: 'verbal' },
   ];
 
   const symptomsResponse = {};
@@ -51,7 +51,7 @@ const AoEModalForm = ({
   };
 
   const chooseModalView = async (view) => {
-    if (view === "smartphone") {
+    if (view === 'smartphone') {
       const patientLinkId = await saveCallback(patientResponse);
       setPatientLink(`${getUrl()}pxp?plid=${patientLinkId}`);
     }
@@ -64,7 +64,7 @@ const AoEModalForm = ({
       <Button
         className="margin-right-0"
         label={saveButtonText}
-        type={"button"}
+        type={'button'}
         onClick={() => continueModal()}
       />
     </div>
@@ -75,13 +75,13 @@ const AoEModalForm = ({
       isOpen={true}
       style={{
         content: {
-          inset: "3em auto auto auto",
-          overflow: "auto",
-          maxHeight: "90vh",
-          width: "50%",
-          minWidth: "20em",
-          marginRight: "50%",
-          transform: "translate(50%, 0)",
+          inset: '3em auto auto auto',
+          overflow: 'auto',
+          maxHeight: '90vh',
+          width: '50%',
+          minWidth: '20em',
+          marginRight: '50%',
+          transform: 'translate(50%, 0)',
         },
       }}
       overlayClassName="prime-modal-overlay"
@@ -101,39 +101,54 @@ const AoEModalForm = ({
       <h2 className="font-heading-lg margin-top-205 margin-bottom-0">
         Test questionnaire
       </h2>
-      <RadioGroup
-        legend="How would you like to complete the questionnaire?"
-        name="qr-code"
-        type="radio"
-        onChange={(evt) => chooseModalView(evt.currentTarget.value)}
-        buttons={modalViewValues}
-        selectedRadio={modalView}
-        className="margin-top-205"
-      />
-      {modalView === "smartphone" && (
+      {process.env.REACT_APP_PATIENT_EXPERIENCE_ENABLED === 'true' ? (
         <>
-          <section className="display-flex flex-justify-center margin-top-4 padding-top-5 border-top border-base-lighter">
-            <div className="text-center">
-              <p className="font-body-lg margin-y-0">
-                Point your camera at the QR code <br />
-                to access the questionnaire
-              </p>
-              <div className="margin-top-205">
-                <QRCode value={patientLink} size="190" />
+          <RadioGroup
+            legend="How would you like to complete the questionnaire?"
+            name="qr-code"
+            type="radio"
+            onChange={(evt) => chooseModalView(evt.currentTarget.value)}
+            buttons={modalViewValues}
+            selectedRadio={modalView}
+            className="margin-top-205"
+          />
+          {modalView === 'smartphone' && (
+            <>
+              <section className="display-flex flex-justify-center margin-top-4 padding-top-5 border-top border-base-lighter">
+                <div className="text-center">
+                  <p className="font-body-lg margin-y-0">
+                    Point your camera at the QR code <br />
+                    to access the questionnaire
+                  </p>
+                  <div className="margin-top-205">
+                    <QRCode value={patientLink} size="190" />
+                  </div>
+                </div>
+              </section>
+              <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
+                <Button
+                  className="margin-right-205"
+                  label={saveButtonText}
+                  type={'button'}
+                  onClick={() => continueModal()}
+                />
               </div>
-            </div>
-          </section>
-          <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
-            <Button
-              className="margin-right-205"
-              label={saveButtonText}
-              type={"button"}
-              onClick={() => continueModal()}
+            </>
+          )}
+          {modalView === 'verbal' && (
+            <AoEForm
+              saveButtonText="Continue"
+              onClose={onClose}
+              patient={patient}
+              facilityId={facilityId}
+              loadState={loadState}
+              saveCallback={saveCallback}
+              isModal={true}
+              noValidation={true}
             />
-          </div>
+          )}
         </>
-      )}
-      {modalView === "verbal" && (
+      ) : (
         <AoEForm
           saveButtonText="Continue"
           onClose={onClose}

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -1,15 +1,15 @@
-import { React, useState } from 'react';
-import QRCode from 'react-qr-code';
-import Modal from 'react-modal';
-import AoEForm from './AoEForm';
-import Button from '../../commonComponents/Button';
-import RadioGroup from '../../commonComponents/RadioGroup';
-import { displayFullName } from '../../utils';
-import { getSymptomList } from '../../../patientApp/timeOfTest/constants';
-import { getUrl } from '../../utils/url';
+import { React, useState } from "react";
+import QRCode from "react-qr-code";
+import Modal from "react-modal";
+import AoEForm from "./AoEForm";
+import Button from "../../commonComponents/Button";
+import RadioGroup from "../../commonComponents/RadioGroup";
+import { displayFullName } from "../../utils";
+import { getSymptomList } from "../../../patientApp/timeOfTest/constants";
+import { getUrl } from "../../utils/url";
 
 const AoEModalForm = ({
-  saveButtonText = 'Save',
+  saveButtonText = "Save",
   onClose,
   patient,
   facilityId,
@@ -21,8 +21,8 @@ const AoEModalForm = ({
   const [modalView, setModalView] = useState(null);
   const [patientLink, setPatientLink] = useState(qrCodeValue);
   const modalViewValues = [
-    { label: 'Complete on smartphone', value: 'smartphone' },
-    { label: 'Complete questionnaire verbally', value: 'verbal' },
+    { label: "Complete on smartphone", value: "smartphone" },
+    { label: "Complete questionnaire verbally", value: "verbal" },
   ];
 
   const symptomsResponse = {};
@@ -51,7 +51,7 @@ const AoEModalForm = ({
   };
 
   const chooseModalView = async (view) => {
-    if (view === 'smartphone') {
+    if (view === "smartphone") {
       const patientLinkId = await saveCallback(patientResponse);
       setPatientLink(`${getUrl()}pxp?plid=${patientLinkId}`);
     }
@@ -64,7 +64,7 @@ const AoEModalForm = ({
       <Button
         className="margin-right-0"
         label={saveButtonText}
-        type={'button'}
+        type={"button"}
         onClick={() => continueModal()}
       />
     </div>
@@ -75,13 +75,13 @@ const AoEModalForm = ({
       isOpen={true}
       style={{
         content: {
-          inset: '3em auto auto auto',
-          overflow: 'auto',
-          maxHeight: '90vh',
-          width: '50%',
-          minWidth: '20em',
-          marginRight: '50%',
-          transform: 'translate(50%, 0)',
+          inset: "3em auto auto auto",
+          overflow: "auto",
+          maxHeight: "90vh",
+          width: "50%",
+          minWidth: "20em",
+          marginRight: "50%",
+          transform: "translate(50%, 0)",
         },
       }}
       overlayClassName="prime-modal-overlay"
@@ -101,7 +101,7 @@ const AoEModalForm = ({
       <h2 className="font-heading-lg margin-top-205 margin-bottom-0">
         Test questionnaire
       </h2>
-      {process.env.REACT_APP_PATIENT_EXPERIENCE_ENABLED === 'true' ? (
+      {process.env.REACT_APP_PATIENT_EXPERIENCE_ENABLED === "true" ? (
         <>
           <RadioGroup
             legend="How would you like to complete the questionnaire?"
@@ -112,7 +112,7 @@ const AoEModalForm = ({
             selectedRadio={modalView}
             className="margin-top-205"
           />
-          {modalView === 'smartphone' && (
+          {modalView === "smartphone" && (
             <>
               <section className="display-flex flex-justify-center margin-top-4 padding-top-5 border-top border-base-lighter">
                 <div className="text-center">
@@ -129,13 +129,13 @@ const AoEModalForm = ({
                 <Button
                   className="margin-right-205"
                   label={saveButtonText}
-                  type={'button'}
+                  type={"button"}
                   onClick={() => continueModal()}
                 />
               </div>
             </>
           )}
-          {modalView === 'verbal' && (
+          {modalView === "verbal" && (
             <AoEForm
               saveButtonText="Continue"
               onClose={onClose}


### PR DESCRIPTION
This extends the feature flag implemented in #641 to cover the frontend display of QR codes.