### PR TITLE
Fix no-security profile

### DIFF
--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -22,6 +22,3 @@ simple-report:
   data-hub:
     upload-enabled: ${DATAHUB_UPLOAD_ENABLE:false}
     upload-url: "https://prime-data-hub-test.azurefd.net/api/reports?option=SkipSend"  # ValidatePayload, SkipSend, SkipInvalidItems
-okta:
-  oauth2:
-    client-id: 0oa61vdmqd56921Ka4h6

--- a/backend/src/main/resources/application-no-security.yaml
+++ b/backend/src/main/resources/application-no-security.yaml
@@ -4,6 +4,7 @@ spring:
       - com.okta.spring.boot.oauth.OktaOAuth2AutoConfig
       - com.okta.spring.boot.oauth.OktaOAuth2ResourceServerAutoConfig
       - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
 simple-report:
   admin-emails:
     - ruby@example.com


### PR DESCRIPTION
## Related Issue or Background Info

Demo is broken because autoconfiguration is running that requires an Okta client ID.

Oddly, local dev builds which use the same bean profiles are _not_ broken.

## Changes Proposed

- delete the setting in the `dev` profile properties that was allowing it to not be broken, so that this does not slip by again
- exclude the guilty autoconfiguration class explicitly from the `no-security` bean profile, so that nobody tries to configure OAuth2 in our no-security environments

## Additional Information

The way I did this originally, and the way I updated it, was basically just to find what class was blowing up in the stack trace, then go look at the other classes in that package or adjacent packages in that JAR until I found an autoconfiguration class, then add that autoconfiguration class to the `exclude` list and see if it worked.