### PR TITLE
Remove per-patient test results from People page

### DIFF
--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -25,11 +25,6 @@ const GET_PATIENT = gql`
       gender
       residentCongregateSetting
       employedInHealthcare
-      testResults {
-        internalId
-        dateTested
-        result
-      }
       facility {
         id
       }

--- a/frontend/src/app/patients/PatientForm.tsx
+++ b/frontend/src/app/patients/PatientForm.tsx
@@ -484,26 +484,28 @@ const PatientForm = (props: Props) => {
           required
         />
       </FormGroup>
-      <FormGroup title="Test History">
-        {patient.testResults && patient.testResults.length !== 0 && (
-          <table className="usa-table usa-table--borderless">
-            <thead>
-              <tr>
-                <th scope="col">Date of Test</th>
-                <th scope="col">Result</th>
-              </tr>
-            </thead>
-            <tbody>
-              {patient.testResults.map((r: any, i: number) => (
-                <tr key={i}>
-                  <td>{moment(r.dateTested).format("lll")}</td>
-                  <td>{r.result}</td>
+      {patient.testResults && (
+        <FormGroup title="Test History">
+          {patient.testResults.length !== 0 && (
+            <table className="usa-table usa-table--borderless">
+              <thead>
+                <tr>
+                  <th scope="col">Date of Test</th>
+                  <th scope="col">Result</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </FormGroup>
+              </thead>
+              <tbody>
+                {patient.testResults.map((r: any, i: number) => (
+                  <tr key={i}>
+                    <td>{moment(r.dateTested).format("lll")}</td>
+                    <td>{r.result}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </FormGroup>
+      )}
       <div className="prime-edit-patient-heading">
         <div></div>
         <button


### PR DESCRIPTION
## Related Issue or Background Info

Temporary change preceding #738 

Discussed in Slack:

```
From Alicia:

Instead, can you comment out the code that displays the test results in the patient profile?
Here's my thinking:
* We should really let you see test results for a person in the Results page by adding filters
* This is going to continue to be an extra place we have to update anytime we change the results page
* I have not heard anything form our users about liking it or using it, and if they get upset we can always uncomment out the code and fix the corrections issue.
* We should also probably remind ourselves to check in on this in month and see if anyone noticed.
```

## Changes Proposed

Remove the patient results from the patient page