### PR TITLE
Update DTD URLs for checkstyle to a valid address.

### DIFF
--- a/backend/config/checkstyle/checkstyle.xml
+++ b/backend/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-     "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <module name="SuppressionFilter">
     <property name="file" value="${config_loc}/suppressions.xml"/>

--- a/backend/config/checkstyle/checkstyleTest.xml
+++ b/backend/config/checkstyle/checkstyleTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-     "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <module name="SuppressWarningsFilter" />
   <module name="FileTabCharacter"/>


### PR DESCRIPTION
The DTD was previously stored on puppycrawl.com but appears not to be there any more.