### PR TITLE
Scaling-friendly upload job

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -15,6 +16,7 @@ import gov.cdc.usds.simplereport.config.simplereport.AdminEmailList;
 import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
+import gov.cdc.usds.simplereport.service.ScheduledTasksService;
 
 @SpringBootApplication
 // Adding any configuration here should probably be added to SliceTestConfiguration &/or SliceTestConfigurationAdmin
@@ -36,5 +38,11 @@ public class SimpleReportApplication {
     @Profile(BeanProfiles.CREATE_SAMPLE_DATA)
     public CommandLineRunner initDataOnStartup(OrganizationInitializingService initService) {
         return args -> initService.initAll();
+    }
+
+    @Bean
+    @ConditionalOnProperty("simple-report.data-hub.upload-enabled")
+    public CommandLineRunner scheduleUploads(DataHubConfig config, ScheduledTasksService scheduler) {
+        return args -> scheduler.scheduleUploads(config);
     }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/simplereport/DataHubConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/simplereport/DataHubConfig.java
@@ -1,25 +1,44 @@
 package gov.cdc.usds.simplereport.config.simplereport;
 
+import java.util.List;
+import java.util.TimeZone;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "simple-report.data-hub")
 public final class DataHubConfig {
 
+    /** whether or not the uploader is enabled. */
     private final boolean uploadEnabled;
+    /** the POST endpoint to which we will upload data */
     private final String uploadUrl;
+    /** the maximum number of records to upload at once */
     private final int maxCsvRows;
+    /** the data hub API key */
     private final String apiKey;
+    /** the slack webhook URL for sending notifications about the upload */
     private final String secretSlackNotifyWebhookUrl;
+    /**
+     * A list of <a href=
+     * "https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html">cron
+     * expressions</a> to use to schedule the uploader job (most likely a
+     * single-element list in all cases, but flexibility available if we want it).
+     */
+    private List<String> uploadSchedule;
+    /** The time zone for the cron expressions in the schedule (default: GMT) */
+    private TimeZone uploadTimezone;
 
     @ConstructorBinding
     public DataHubConfig(boolean uploadEnabled, String uploadUrl, int maxCsvRows, String apiKey,
-                         String secretSlackNotifyWebhookUrl) {
+            String secretSlackNotifyWebhookUrl, List<String> uploadSchedule, String uploadTimezone) {
         this.uploadEnabled = uploadEnabled;
         this.uploadUrl = uploadUrl;
         this.maxCsvRows = maxCsvRows;
         this.apiKey = apiKey;
         this.secretSlackNotifyWebhookUrl = secretSlackNotifyWebhookUrl;
+        this.uploadSchedule = uploadSchedule;
+        this.uploadTimezone = TimeZone.getTimeZone(null != uploadTimezone ? uploadTimezone : "GMT");
     }
 
     // to change go into application-dev.yaml and/or application-test.yaml and change uploadEnabled
@@ -39,5 +58,13 @@ public final class DataHubConfig {
 
     public String getSlackNotifyWebhookUrl() {
         return secretSlackNotifyWebhookUrl;
+    }
+
+    public List<String> getUploadSchedule() {
+        return uploadSchedule;
+    }
+
+    public TimeZone getUploadTimezone() {
+        return uploadTimezone;
     }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -1,15 +1,10 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import java.util.Date;
-import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
@@ -27,20 +22,8 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
  */
 @Entity
 @DynamicUpdate
-public class ApiUser {
+public class ApiUser extends SystemManagedEntity {
 
-	@Column(updatable = false, nullable = false)
-	@Id
-	@GeneratedValue(generator = "UUID4")
-	private UUID internalId;
-	@Column(updatable = false)
-	@Temporal(TemporalType.TIMESTAMP)
-	@CreationTimestamp
-	private Date createdAt;
-	@Column
-	@Temporal(TemporalType.TIMESTAMP)
-	@UpdateTimestamp
-	private Date updatedAt;
 	@Column(nullable = false, updatable = true, unique = true)
 	@NaturalId(mutable = true)
 	private String loginEmail;
@@ -55,18 +38,6 @@ public class ApiUser {
 		loginEmail = email;
 		nameInfo = name;
 		lastSeen = null;
-	}
-
-	public UUID getInternalId() {
-		return internalId;
-	}
-
-	public Date getCreatedAt() {
-		return createdAt;
-	}
-
-	public Date getUpdatedAt() {
-		return updatedAt;
 	}
 
 	public String getLoginEmail() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DataHubUpload.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DataHubUpload.java
@@ -1,26 +1,21 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import java.util.Date;
-import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 
 import gov.cdc.usds.simplereport.db.model.auxiliary.DataHubUploadStatus;
 
-import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.Type;
-import org.hibernate.annotations.UpdateTimestamp;
 
 
 @Entity
 @DynamicUpdate
-public class DataHubUpload {
+public class DataHubUpload extends SystemManagedEntity {
 
     // We have to pass config into the constructor because Configuration doesn't work in constructors
     public DataHubUpload() {
@@ -30,24 +25,11 @@ public class DataHubUpload {
         errorMessage = "";
     }
 
-    @Column(updatable = false, nullable = false)
-    @Id
-    @GeneratedValue(generator = "UUID4")
-    private UUID internalId;
-
     // set to "SUCCESS" when done.
     @Column(nullable = false)
     @Type(type = "pg_enum")
     @Enumerated(EnumType.STRING)
     private DataHubUploadStatus jobStatus;
-
-    @Column(updatable = false)
-    @CreationTimestamp
-    private Date createdAt;
-
-    @Column
-    @UpdateTimestamp
-    private Date updatedAt;
 
     @Column
     private int recordsProcessed;
@@ -65,10 +47,6 @@ public class DataHubUpload {
     @Type(type = "jsonb")
     private String responseData;
 
-    public UUID getInternalId() {
-        return internalId;
-    }
-
     public DataHubUploadStatus getJobStatus() {
         return jobStatus;
     }
@@ -76,14 +54,6 @@ public class DataHubUpload {
     public DataHubUpload setJobStatus(DataHubUploadStatus jobStatus) {
         this.jobStatus = jobStatus;
         return this;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
     }
 
     public int getRecordsProcessed() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SystemManagedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SystemManagedEntity.java
@@ -1,0 +1,54 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Base class for entities that have no user creating or modifying them, but
+ * still have creation and modification times and a UUID primary key.
+ */
+@MappedSuperclass
+public abstract class SystemManagedEntity {
+
+    @Column(updatable = false, nullable = false)
+    @Id
+    @GeneratedValue(generator = "UUID4")
+    private UUID internalId;
+
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    @CreationTimestamp
+    private Date createdAt;
+
+    @Column
+    @Temporal(TemporalType.TIMESTAMP)
+    @UpdateTimestamp
+    private Date updatedAt;
+
+    protected SystemManagedEntity() {
+        super();
+    }
+
+    public UUID getInternalId() {
+        return internalId;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/AdvisoryLockManager.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/AdvisoryLockManager.java
@@ -9,13 +9,23 @@ import org.springframework.data.jpa.repository.query.Procedure;
  */
 public interface AdvisoryLockManager {
 
+    /**
+     * The "scope" constant that defines the category of all postgresql advisory
+     * locks this application should obtain. To be used as the first argument to
+     * postgresql two-argument lock functions.
+     */
     int CORE_API_LOCK_SCOPE = 110506458; // some arbitrary 32-bit number that defines "our" locks
+
     /**
      * Take the advisory lock defined by the two arguments, waiting until the lock
      * is available and releasing it at the end of the current transaction.
      *
-     * @param lockCategory
-     * @param lock
+     * @param lockCategory the high-level group of locks that contains the lock we
+     *                     are trying to obtain (in this case, almost always
+     *                     {{@link #CORE_API_LOCK_SCOPE}).
+     * @param lock         the specific lock we are trying to obtain (usually a
+     *                     constant in the implementing repository or the service
+     *                     that calls it).
      */
     @Query(nativeQuery = true,
             // can't tell hibernate that Types.OTHER is a "void" result in this case:
@@ -29,8 +39,12 @@ public interface AdvisoryLockManager {
      * current transaction. If the lock is not available, return {@code false}
      * immediately.
      *
-     * @param lockCategory
-     * @param lock
+     * @param lockCategory the high-level group of locks that contains the lock we
+     *                     are trying to obtain (in this case, almost always
+     *                     {{@link #CORE_API_LOCK_SCOPE}).
+     * @param lock         the specific lock we are trying to obtain (usually a
+     *                     constant in the implementing repository or the service
+     *                     that calls it).
      * @return true if the lock was obtained, false otherwise
      */
     @Procedure("pg_try_advisory_xact_lock")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/AdvisoryLockManager.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/AdvisoryLockManager.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.query.Procedure;
  * advisory locks.
  */
 public interface AdvisoryLockManager {
+
+    int CORE_API_LOCK_SCOPE = 110506458; // some arbitrary 32-bit number that defines "our" locks
     /**
      * Take the advisory lock defined by the two arguments, waiting until the lock
      * is available and releasing it at the end of the current transaction.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.Repository;
 import java.util.List;
 import java.util.UUID;
 
-public interface DataHubUploadRespository extends Repository<DataHubUpload, UUID> {
+public interface DataHubUploadRespository extends Repository<DataHubUpload, UUID>, AdvisoryLockManager {
 
     public DataHubUpload save(DataHubUpload entity);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
@@ -9,6 +9,10 @@ import java.util.UUID;
 
 public interface DataHubUploadRespository extends Repository<DataHubUpload, UUID>, AdvisoryLockManager {
 
+    /**
+     * The lock identifier for the advisory lock for the scheduled upload task. (Use
+     * as the second argument to the postgresql two-argument locking functions.)
+     */
     int SCHEDULED_UPLOAD_LOCK = 66037627; // arbitrary 32-bit integer for our lock
 
     public DataHubUpload save(DataHubUpload entity);
@@ -19,6 +23,12 @@ public interface DataHubUploadRespository extends Repository<DataHubUpload, UUID
     // used by unit tests
     public List<DataHubUpload> findAll();
 
+    /**
+     * Try to obtain the lock for the scheduled upload task. (It will be released
+     * automatically when the current transaction closes.)
+     * 
+     * @return true if the lock was obtained, false otherwise.
+     */
     default boolean tryUploadLock() {
         return tryLock(CORE_API_LOCK_SCOPE, SCHEDULED_UPLOAD_LOCK);
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 public interface DataHubUploadRespository extends Repository<DataHubUpload, UUID>, AdvisoryLockManager {
 
+    int SCHEDULED_UPLOAD_LOCK = 66037627; // arbitrary 32-bit integer for our lock
+
     public DataHubUpload save(DataHubUpload entity);
 
     // @Query("FROM #{#entityName} e WHERE e.job_status=?1 ORDER BY latest_recorded_timestamp DESC LIMIT 1")
@@ -16,4 +18,8 @@ public interface DataHubUploadRespository extends Repository<DataHubUpload, UUID
 
     // used by unit tests
     public List<DataHubUpload> findAll();
+
+    default boolean tryUploadLock() {
+        return tryLock(CORE_API_LOCK_SCOPE, SCHEDULED_UPLOAD_LOCK);
+    }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -26,7 +26,7 @@ public interface TestEventRepository extends AuditedEntityRepository<TestEvent> 
 
 	// Need to control how this query is built. "between" is too vague.
 	// This is across all Orgs/facilities because datahub uploader users
-    @Query("FROM #{#entityName} q WHERE q.createdAt > :before AND q.createdAt <= :after ORDER BY q.createdAt DESC")
+    @Query("FROM #{#entityName} q WHERE q.createdAt > :before AND q.createdAt <= :after ORDER BY q.createdAt")
     public List<TestEvent> queryMatchAllBetweenDates(Date before, Date after, Pageable p);
 
 	@Query( value = "SELECT DISTINCT ON (test_order_id) * " +

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -4,6 +4,8 @@ import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Date;
@@ -24,8 +26,8 @@ public interface TestEventRepository extends AuditedEntityRepository<TestEvent> 
 
 	// Need to control how this query is built. "between" is too vague.
 	// This is across all Orgs/facilities because datahub uploader users
-	@Query("FROM #{#entityName} q WHERE q.createdAt > :before AND q.createdAt <= :after ORDER BY q.createdAt DESC ")
-	public List<TestEvent> queryMatchAllBetweenDates(Date before, Date after);
+    @Query("FROM #{#entityName} q WHERE q.createdAt > :before AND q.createdAt <= :after ORDER BY q.createdAt DESC")
+    public List<TestEvent> queryMatchAllBetweenDates(Date before, Date after, Pageable p);
 
 	@Query( value = "SELECT DISTINCT ON (test_order_id) * " +
 					" FROM {h-schema}test_event te " +

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -293,6 +293,10 @@ public class DataHubUploaderService {
             return;
         }
 
+        if (!_dataHubUploadRepo.tryUploadLock()) { // take the advisory lock for this process
+            LOG.info("Data hub upload locked out by mutex: aborting");
+            return;
+        }
         DataHubUpload newUpload = new DataHubUpload();
         try {
             // The start date is the last end date. Can be null for empty database.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -255,7 +255,7 @@ public class DataHubUploaderService {
                         this.uploadCSVDocument(apiKey);
                         _trackingService.markSucceeded(upload, _resultJson, _warnMessage);
                     } catch (RestClientException e) {
-                        _trackingService.markFailed(upload, this._resultJson, e.toString());
+                        _trackingService.markFailed(upload, this._resultJson, e);
                     }
                 }
             } else {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -144,7 +144,7 @@ public class DataHubUploaderService {
             HttpEntity<String> entity = new HttpEntity<>(requestJson, headers);
             restTemplate.put(_config.getSlackNotifyWebhookUrl(), entity);
         } catch (RestClientException | JSONException err) {
-            LOG.error("sendSlackChannelMessage failed ", err.toString());
+            LOG.error("sendSlackChannelMessage failed {}", err.toString());
         }
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -306,17 +306,16 @@ public class DataHubUploaderService {
             return;
         }
         
-        DataHubUpload newUpload = new DataHubUpload();
-        try {
-            // The start date is the last end date. Can be null for empty database.
-            Date lastTimestamp = getLatestRecordedTimestamp();
-            if (lastTimestamp == null) {
-                // this happens if EVERYTHING in the db would be matched.
-                LOG.error("No earliest_recorded_timestamp found. EVERYTHING would be matched and sent");
-                return;
-            }
-            _trackingService.startUpload(lastTimestamp);
+        // The start date is the last end date. Can be null for empty database.
+        Date lastTimestamp = getLatestRecordedTimestamp();
+        if (lastTimestamp == null) {
+            // this happens if EVERYTHING in the db would be matched.
+            LOG.error("No earliest_recorded_timestamp found. EVERYTHING would be matched and sent");
+            return;
+        }
 
+        DataHubUpload newUpload = _trackingService.startUpload(lastTimestamp);
+        try {
             // end range is back 1 minute, to avoid complications involving open
             // transactions
             Timestamp dateOneMinAgo = Timestamp.from(Instant.now().minus(1, ChronoUnit.MINUTES));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -188,9 +188,9 @@ public class DataHubUploaderService {
             this._warnMessage += "More rows were found than can be uploaded in a single batch.";
         }
 
-        // timestamp of highest matched entry, used for the next query.
-        this._nextTimestamp = events.get(0).getCreatedAt();
         this._rowCount = events.size();
+        // timestamp of last matched entry, used for the next query.
+        this._nextTimestamp = events.get(_rowCount - 1).getCreatedAt();
 
         List<TestEventExport> eventsToExport = new ArrayList<>();
         events.forEach(e -> eventsToExport.add(new TestEventExport(e)));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -285,7 +285,9 @@ public class DataHubUploaderService {
             return;
         }
 
-        if (!_dataHubUploadRepo.tryUploadLock()) {   // take the advisory lock for this process. auto released after transaction
+        if (_dataHubUploadRepo.tryUploadLock()) { // take the advisory lock for this process. auto released after transaction
+            LOG.info("Data hub upload lock obtained: commencing upload processing.");
+        } else {
             LOG.info("Data hub upload locked out by mutex: aborting");
             return;
         }
@@ -324,6 +326,8 @@ public class DataHubUploaderService {
 
             if (_rowCount > 0) {
                 this.uploadCSVDocument(_config.getApiKey());
+            } else {
+                LOG.info("No new tests found since previous successful data hub upload.");
             }
 
             // todo: parse json run sanity checks like total records processed matches what we sent.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ScheduledTasksService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ScheduledTasksService.java
@@ -27,10 +27,10 @@ public class ScheduledTasksService {
     }
 
     // see https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html
-    // Try to pick times where most of the US is on the same calendar date.
-    @Scheduled(cron = "0 0 11 * * *", zone="America/New_York")
-    public void runDaily() {
-        LOG.info("Daily Cron: Start");
+    // @Scheduled(cron = "0 0 5-17/2 * * *", zone="America/New_York")  // ever 2hrs between 5am-5pm EST
+    @Scheduled(cron = "0 0/15 * * * *", zone="America/New_York")    // every 15min on the clock 1:00, 1:15, 1:30, etc
+    public void runCron() {
+        LOG.info("Cron: Start");
         _dataHubUploaderService.dataHubUploaderTask();
     }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadTrackingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadTrackingService.java
@@ -1,0 +1,61 @@
+package gov.cdc.usds.simplereport.service;
+
+import java.util.Date;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import gov.cdc.usds.simplereport.db.model.DataHubUpload;
+import gov.cdc.usds.simplereport.db.model.auxiliary.DataHubUploadStatus;
+import gov.cdc.usds.simplereport.db.repository.DataHubUploadRespository;
+
+@Service
+@Transactional
+public class UploadTrackingService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UploadTrackingService.class);
+
+    @Autowired
+    private DataHubUploadRespository _repo;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public DataHubUpload startUpload(Date earliestRecordedTimestamp) {
+        return _repo.save(new DataHubUpload().setEarliestRecordedTimestamp(earliestRecordedTimestamp));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markRowCount(DataHubUpload dhu, int rowsFound, Date nextTimestamp) {
+        dhu
+                .setRecordsProcessed(rowsFound)
+                .setLatestRecordedTimestamp(nextTimestamp);
+        _repo.save(dhu);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(DataHubUpload dhu, String responseString, String errorMessage) {
+        dhu.setJobStatus(DataHubUploadStatus.FAIL)
+                .setResponseData(responseString)
+                .setErrorMessage(errorMessage);
+        _repo.save(dhu);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markSucceeded(DataHubUpload newUpload, String resultJson, String warnMessage) {
+        newUpload.setJobStatus(DataHubUploadStatus.SUCCESS)
+                .setResponseData(resultJson)
+                .setErrorMessage(warnMessage);
+        _repo.save(newUpload);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(DataHubUpload newUpload, String resultJson, Exception err) {
+        LOG.error("Data hub upload failed", err);
+        markFailed(newUpload, resultJson, err.toString());
+
+    }
+
+}

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -19,3 +19,6 @@ simple-report:
     - qrk8@cdc.gov # Sparkle
     - David.w.methvin@omb.eop.gov
     - thomas.a.nielsen@omb.eop.gov
+  data-hub:
+      upload-enabled: true
+      upload-url: "https://prime-data-hub-test.azurefd.net/api/reports?option=SkipInvalidItems"

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -22,3 +22,6 @@ simple-report:
   data-hub:
       upload-enabled: true
       upload-url: "https://prime-data-hub-test.azurefd.net/api/reports?option=SkipInvalidItems"
+      upload-schedule: "0 0/15 * * * *" # every 15min on the clock 1:00, 1:15, 1:30, etc
+      max-csv-rows: 25
+

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -10,6 +10,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems"
+    upload-schedule: "0 0 5-17/2 * * *"
   admin-emails:
     - bwarfield@cdc.gov
     - tim.best@usds.dhs.gov

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -48,6 +48,8 @@ simple-report:
     max-csv-rows: 999
     api-key: ${DATAHUB_API_KEY:MISSING}
     secret-slack-notify-webhook-url: ${SECRET_SLACK_NOTIFY_WEBHOOK_URL:MISSING}
+    upload-schedule: "0 0 11 * * *" # Daily at 11:00 AM Eastern Time
+    upload-timezone: America/New_York
   authorization:    
     # these are overridden by application-dev, -prod, -test, etc
     role-claim: dev_roles

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadEntityRespositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadEntityRespositoryTest.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.db.repository;
 
-import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
 import gov.cdc.usds.simplereport.db.model.DataHubUpload;
 import gov.cdc.usds.simplereport.db.model.auxiliary.DataHubUploadStatus;
 import org.junit.jupiter.api.Test;
@@ -19,8 +18,6 @@ class DataHubUploadEntityRespositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private DataHubUploadRespository _repoDH;
-    @Autowired
-    private DataHubConfig _config;
 
     @Test
     void testBasicSavingQueryDataHubUpload() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -11,6 +11,8 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -48,7 +50,8 @@ public class TestEventRepositoryTest extends BaseRepositoryTest {
     public void testLatestTestEventForPerson() {
         Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
         final Date DATE_1MIN_FUTURE = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-        List<TestEvent> foundTestReports1 = _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE);
+        List<TestEvent> foundTestReports1 = _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE,
+                PageRequest.of(0, 100));
         Organization org = _dataFactory.createValidOrg();
         Facility place = _dataFactory.createValidFacility(org);
         Person patient = _dataFactory.createMinimalPerson(org);
@@ -60,7 +63,7 @@ public class TestEventRepositoryTest extends BaseRepositoryTest {
         flush();
         TestEvent found = _repo.findFirst1ByPatientOrderByCreatedAtDesc(patient);
         assertEquals(second.getResult(), TestResult.UNDETERMINED);
-        List<TestEvent> foundTestReports2 = _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE);
+        List<TestEvent> foundTestReports2 = _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE, Pageable.unpaged());
         assertEquals(2, foundTestReports2.size() - foundTestReports1.size());
 
         testTestEventUnitTests(order, first);  // just leverage existing order, event to test on newer columns

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ScheduledTasksServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ScheduledTasksServiceTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
+
+
+public class ScheduledTasksServiceTest {
+
+    @Test
+    void scheduleUploads_oneSchedule_scheduled() {
+        String cronExpression = "0 0 0 * * *";
+        List<String> uploadSchedule = List.of(cronExpression);
+        DataHubConfig config = new DataHubConfig(true, "http://mock.com", 20, "NOPE", "", uploadSchedule,
+                null);
+
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        ArgumentCaptor<CronTrigger> captureTrigger = ArgumentCaptor.forClass(CronTrigger.class);
+        ArgumentCaptor<Runnable> captureMethod = ArgumentCaptor.forClass(Runnable.class);
+
+        DataHubUploaderService uploader = mock(DataHubUploaderService.class);
+
+        Map<String, ScheduledFuture<?>> scheduledUploads = new ScheduledTasksService(uploader, scheduler)
+                .scheduleUploads(config);
+        assertEquals(Set.of(cronExpression), scheduledUploads.keySet());
+
+        verify(scheduler, only()).schedule(captureMethod.capture(), captureTrigger.capture());
+        CronTrigger trigger = captureTrigger.getValue();
+        assertEquals(cronExpression, trigger.getExpression());
+        verify(uploader, never()).dataHubUploaderTask();
+        captureMethod.getValue().run();
+        verify(uploader, only()).dataHubUploaderTask();
+    }
+
+    @Test
+    void scheduleUploads_noSchedule_nothingScheduled() {
+        DataHubConfig config = new DataHubConfig(true, "http://mock.com", 20, "NOPE", "", Collections.emptyList(),
+                null);
+
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        ArgumentCaptor<CronTrigger> captureTrigger = ArgumentCaptor.forClass(CronTrigger.class);
+        ArgumentCaptor<Runnable> captureMethod = ArgumentCaptor.forClass(Runnable.class);
+
+        DataHubUploaderService uploader = mock(DataHubUploaderService.class);
+
+        Map<String, ScheduledFuture<?>> scheduledUploads = new ScheduledTasksService(uploader, scheduler)
+                .scheduleUploads(config);
+        assertEquals(Collections.emptyMap(), scheduledUploads);
+
+        verify(scheduler, never()).schedule(captureMethod.capture(), captureTrigger.capture());
+        verify(uploader, never()).dataHubUploaderTask();
+    }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadTrackingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadTrackingServiceTest.java
@@ -1,0 +1,99 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.cdc.usds.simplereport.db.model.DataHubUpload;
+import gov.cdc.usds.simplereport.db.model.auxiliary.DataHubUploadStatus;
+import gov.cdc.usds.simplereport.db.repository.DataHubUploadRespository;
+
+class UploadTrackingServiceTest extends BaseServiceTest<UploadTrackingService> {
+
+    @Autowired
+    private DataHubUploadRespository _repo;
+
+    @Test
+    void startUpload_validDate_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.IN_PROGRESS, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals("", upload.getErrorMessage());
+        assertNull(upload.getLatestRecordedTimestamp());
+        assertEquals(0, upload.getRecordsProcessed());
+    }
+
+    @Test
+    void markRowCount_validInputs_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        Date endDate = Date.valueOf("2020-10-31");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+        _service.markRowCount(upload, 12345, endDate);
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.IN_PROGRESS, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals(endDate, upload.getLatestRecordedTimestamp());
+        assertEquals(12345, upload.getRecordsProcessed());
+        assertEquals("", upload.getErrorMessage());
+    }
+
+    @Test
+    void markSuccess_validInputs_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+        String warning = "Nope nope nope";
+        String responseJson = "{\"woot\": true}";
+        _service.markSucceeded(upload, responseJson, warning);
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.SUCCESS, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals(0, upload.getRecordsProcessed());
+        assertEquals(warning, upload.getErrorMessage());
+        assertEquals(responseJson, upload.getResponseData());
+    }
+
+    @Test
+    void markFailed_validInputs_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+        String responseJson = "{\"nope\": false}";
+        String errorMessage = "You lose!";
+        _service.markFailed(upload, responseJson, new RuntimeException(errorMessage));
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.FAIL, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals(0, upload.getRecordsProcessed());
+        assertEquals("java.lang.RuntimeException: " + errorMessage, upload.getErrorMessage());
+        assertEquals(responseJson, upload.getResponseData());
+    }
+}

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -11,13 +11,16 @@ spring:
         default_schema: simple_report
 logging:
   level:
-    # NOTE: un-comment any of the below to turn on something interesting
-    # Hibernate SQL query logging: basically the same as hibernate.show_sql but through slf4j
-    # org.hibernate.SQL: DEBUG
-    # Hibernate input and output value logging: SUPER VERBOSE
-    # org.hibernate.type: TRACE
     # Always have our own debug logging turned on in tests:
     gov.cdc.usds: DEBUG
+    # Hibernate SQL query logging: basically the same as hibernate.show_sql but through slf4j
+    org.hibernate.SQL: DEBUG
+    # NOTE: un-comment any of the below to turn on something potentially interesting
+    # Hibernate input and output value logging: SUPER VERBOSE
+    # org.hibernate.type: TRACE
+    # Other possibilities:
+    # com.okta: DEBUG
+    # org.springframework.security: DEBUG
 simple-report:
   authorization:
     role-prefix: "SR-UNITTEST-TENANT:"

--- a/ops/dev/api.tf
+++ b/ops/dev/api.tf
@@ -3,6 +3,8 @@ module "simple_report_api" {
   name   = "${local.name}-api"
   env    = local.env
 
+  instance_count = 2
+
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name
 

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -3,7 +3,7 @@ module "simple_report_api" {
   name   = "${local.name}-api"
   env    = local.env
 
-  instance_count = 1
+  instance_count = 2
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -3,7 +3,7 @@ module "simple_report_api" {
   name   = "${local.name}-api"
   env    = local.env
 
-  instance_count = 1
+  instance_count = 2
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
## Related Issue or Background Info

As step 0 of #667, make it possible to run our existing upload code on multiple machines without producing duplicate uploads to the hub.

## Changes Proposed

- add a postgresql advisory lock to the function that performs the export
- change 0 rows found from a failure to a success
- make the upload schedule property-driven instead of hard-coded
- enable the upload to catch up on the following scheduled run if too many rows were found to upload all at once
- do some other random refactoring that seemed easy and had been bugging me 
