### PR TITLE
Better upload tracking

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -255,7 +255,7 @@ public class DataHubUploaderService {
                         this.uploadCSVDocument(apiKey);
                         _trackingService.markSucceeded(upload, _resultJson, _warnMessage);
                     } catch (RestClientException e) {
-                        _trackingService.markFailed(upload, this._resultJson, e.toString());
+                        _trackingService.markFailed(upload, this._resultJson, e);
                     }
                 }
             } else {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadTrackingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadTrackingService.java
@@ -1,0 +1,61 @@
+package gov.cdc.usds.simplereport.service;
+
+import java.util.Date;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import gov.cdc.usds.simplereport.db.model.DataHubUpload;
+import gov.cdc.usds.simplereport.db.model.auxiliary.DataHubUploadStatus;
+import gov.cdc.usds.simplereport.db.repository.DataHubUploadRespository;
+
+@Service
+@Transactional
+public class UploadTrackingService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UploadTrackingService.class);
+
+    @Autowired
+    private DataHubUploadRespository _repo;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public DataHubUpload startUpload(Date earliestRecordedTimestamp) {
+        return _repo.save(new DataHubUpload().setEarliestRecordedTimestamp(earliestRecordedTimestamp));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markRowCount(DataHubUpload dhu, int rowsFound, Date nextTimestamp) {
+        dhu
+                .setRecordsProcessed(rowsFound)
+                .setLatestRecordedTimestamp(nextTimestamp);
+        _repo.save(dhu);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(DataHubUpload dhu, String responseString, String errorMessage) {
+        dhu.setJobStatus(DataHubUploadStatus.FAIL)
+                .setResponseData(responseString)
+                .setErrorMessage(errorMessage);
+        _repo.save(dhu);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markSucceeded(DataHubUpload newUpload, String resultJson, String warnMessage) {
+        newUpload.setJobStatus(DataHubUploadStatus.SUCCESS)
+                .setResponseData(resultJson)
+                .setErrorMessage(warnMessage);
+        _repo.save(newUpload);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(DataHubUpload newUpload, String resultJson, Exception err) {
+        LOG.error("Data hub upload failed", err);
+        markFailed(newUpload, resultJson, err.toString());
+
+    }
+
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ScheduledTasksServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ScheduledTasksServiceTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
+
+
+public class ScheduledTasksServiceTest {
+
+    @Test
+    void scheduleUploads_oneSchedule_scheduled() {
+        String cronExpression = "0 0 0 * * *";
+        List<String> uploadSchedule = List.of(cronExpression);
+        DataHubConfig config = new DataHubConfig(true, "http://mock.com", 20, "NOPE", "", uploadSchedule,
+                null);
+
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        ArgumentCaptor<CronTrigger> captureTrigger = ArgumentCaptor.forClass(CronTrigger.class);
+        ArgumentCaptor<Runnable> captureMethod = ArgumentCaptor.forClass(Runnable.class);
+
+        DataHubUploaderService uploader = mock(DataHubUploaderService.class);
+
+        Map<String, ScheduledFuture<?>> scheduledUploads = new ScheduledTasksService(uploader, scheduler)
+                .scheduleUploads(config);
+        assertEquals(Set.of(cronExpression), scheduledUploads.keySet());
+
+        verify(scheduler, only()).schedule(captureMethod.capture(), captureTrigger.capture());
+        CronTrigger trigger = captureTrigger.getValue();
+        assertEquals(cronExpression, trigger.getExpression());
+        verify(uploader, never()).dataHubUploaderTask();
+        captureMethod.getValue().run();
+        verify(uploader, only()).dataHubUploaderTask();
+    }
+
+    @Test
+    void scheduleUploads_noSchedule_nothingScheduled() {
+        DataHubConfig config = new DataHubConfig(true, "http://mock.com", 20, "NOPE", "", Collections.emptyList(),
+                null);
+
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        ArgumentCaptor<CronTrigger> captureTrigger = ArgumentCaptor.forClass(CronTrigger.class);
+        ArgumentCaptor<Runnable> captureMethod = ArgumentCaptor.forClass(Runnable.class);
+
+        DataHubUploaderService uploader = mock(DataHubUploaderService.class);
+
+        Map<String, ScheduledFuture<?>> scheduledUploads = new ScheduledTasksService(uploader, scheduler)
+                .scheduleUploads(config);
+        assertEquals(Collections.emptyMap(), scheduledUploads);
+
+        verify(scheduler, never()).schedule(captureMethod.capture(), captureTrigger.capture());
+        verify(uploader, never()).dataHubUploaderTask();
+    }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadTrackingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadTrackingServiceTest.java
@@ -1,0 +1,99 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.cdc.usds.simplereport.db.model.DataHubUpload;
+import gov.cdc.usds.simplereport.db.model.auxiliary.DataHubUploadStatus;
+import gov.cdc.usds.simplereport.db.repository.DataHubUploadRespository;
+
+class UploadTrackingServiceTest extends BaseServiceTest<UploadTrackingService> {
+
+    @Autowired
+    private DataHubUploadRespository _repo;
+
+    @Test
+    void startUpload_validDate_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.IN_PROGRESS, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals("", upload.getErrorMessage());
+        assertNull(upload.getLatestRecordedTimestamp());
+        assertEquals(0, upload.getRecordsProcessed());
+    }
+
+    @Test
+    void markRowCount_validInputs_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        Date endDate = Date.valueOf("2020-10-31");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+        _service.markRowCount(upload, 12345, endDate);
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.IN_PROGRESS, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals(endDate, upload.getLatestRecordedTimestamp());
+        assertEquals(12345, upload.getRecordsProcessed());
+        assertEquals("", upload.getErrorMessage());
+    }
+
+    @Test
+    void markSuccess_validInputs_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+        String warning = "Nope nope nope";
+        String responseJson = "{\"woot\": true}";
+        _service.markSucceeded(upload, responseJson, warning);
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.SUCCESS, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals(0, upload.getRecordsProcessed());
+        assertEquals(warning, upload.getErrorMessage());
+        assertEquals(responseJson, upload.getResponseData());
+    }
+
+    @Test
+    void markFailed_validInputs_fieldsCorrect() {
+        Date startDate = Date.valueOf("2019-09-21");
+        DataHubUpload upload = _service.startUpload(startDate);
+        assertNotNull(upload.getInternalId());
+        String responseJson = "{\"nope\": false}";
+        String errorMessage = "You lose!";
+        _service.markFailed(upload, responseJson, new RuntimeException(errorMessage));
+
+        List<DataHubUpload> saved = _repo.findAll();
+        assertEquals(1, saved.size());
+        assertEquals(upload.getInternalId(), saved.get(0).getInternalId());
+        upload = saved.get(0); // check database state
+
+        assertEquals(DataHubUploadStatus.FAIL, upload.getJobStatus());
+        assertEquals(startDate, upload.getEarliestRecordedTimestamp());
+        assertEquals(0, upload.getRecordsProcessed());
+        assertEquals("java.lang.RuntimeException: " + errorMessage, upload.getErrorMessage());
+        assertEquals(responseJson, upload.getResponseData());
+    }
+}


### PR DESCRIPTION
## Related Issue or Background Info

We track what happened with each upload in the database, but we don't actually save that information until the upload is complete, which means that certain forms of error will be hard to spot.

## Changes Proposed

- Create a new service that manages the DataHubUpload object state transitions in separate read-write transactions
- Mark the main data hub upload transaction as read-only, which should make it consume fewer resources
