### PR TITLE
Bulk code-smell removal: public "test" declarations.

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 public class SimpleReportApplicationTests {
 
     @Test
-    public void contextLoads() {
+    void contextLoads() {
         // no-op
     }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiSmokeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiSmokeTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class ApiSmokeTest extends BaseApiTest {
+class ApiSmokeTest extends BaseApiTest {
 
     @Test
-    public void smoketestPatientList() throws IOException {
+    void smoketestPatientList() throws IOException {
         JsonNode jsonResponse = runQuery("person-query");
         assertTrue(jsonResponse.get("patients").isEmpty());
         executeAddPersonMutation("Baz", "Jesek", "2403-12-03", null, "BAZ");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiUserManagementTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class ApiUserManagementTest extends BaseApiTest {
+class ApiUserManagementTest extends BaseApiTest {
 
     private static final List<String> USERNAMES = List.of("rjj@gmail.com", 
                                                           "rjjones@gmail.com");
@@ -34,7 +34,7 @@ public class ApiUserManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void whoami_standardUser_okResponses() {
+    void whoami_standardUser_okResponses() {
         ObjectNode who = (ObjectNode) runQuery("current-user-query").get("whoami");
         assertEquals("Bobbity", who.get("firstName").asText());
         assertEquals("Standard user", who.get("roleDescription").asText());
@@ -83,7 +83,7 @@ public class ApiUserManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void createUser() {
+    void createUser() {
         useSuperUser();
         when(_oktaService.getOrganizationExternalIdForUser(USERNAMES.get(0)))
             .thenReturn(_initService.getDefaultOrganizationId());
@@ -104,7 +104,7 @@ public class ApiUserManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void createUser_orgUser_failure() {
+    void createUser_orgUser_failure() {
         ObjectNode variables = JsonNodeFactory.instance.objectNode()
             .put("firstName", "Rhonda")
             .put("middleName", "Janet")
@@ -116,7 +116,7 @@ public class ApiUserManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void updateUser() {
+    void updateUser() {
         useSuperUser();
         when(_oktaService.getOrganizationExternalIdForUser(USERNAMES.get(0)))
             .thenReturn(_initService.getDefaultOrganizationId());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceManagementTest.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class DeviceManagementTest extends BaseApiTest {
+class DeviceManagementTest extends BaseApiTest {
 
     @Test
     void listDeviceTypes_orgUser_expectedDevices() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
 
-public class OrganizationFacilityTest extends BaseApiTest {
+class OrganizationFacilityTest extends BaseApiTest {
 
     @Autowired
     private DeviceTypeService _deviceService;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/PatientManagementTest.java
@@ -22,7 +22,7 @@ import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 /**
  * Tests for adding and fetching patients through the API
  */
-public class PatientManagementTest extends BaseApiTest {
+class PatientManagementTest extends BaseApiTest {
 
     @Autowired
     private TestDataFactory _dataFactory;
@@ -30,7 +30,7 @@ public class PatientManagementTest extends BaseApiTest {
     private OrganizationService _orgService;
 
     @Test
-    public void queryPatientWithFacility() throws Exception {
+    void queryPatientWithFacility() throws Exception {
         Organization org = _orgService.getCurrentOrganization();
         Facility place = _orgService.getFacilities(org).get(0);
         _dataFactory.createMinimalPerson(org, place, "Cassandra", null, "Thom", null);
@@ -41,7 +41,7 @@ public class PatientManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void createAndFetchOnePatientUsDate() throws Exception {
+    void createAndFetchOnePatientUsDate() throws Exception {
         String firstName = "Jon";
         JsonNode patients = doCreateAndFetch(firstName, "Snow", "05/18/1066", "(202) 867-5309", "youknownothing");
         assertTrue(patients.has(0), "At least one patient found");
@@ -52,7 +52,7 @@ public class PatientManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void createAndFetchOnePatientIsoDate() throws Exception {
+    void createAndFetchOnePatientIsoDate() throws Exception {
         String firstName = "Sansa";
         JsonNode patients = doCreateAndFetch(firstName, "Stark", "12/25/1100", "1-800-BIZ-NAME", "notbitter");
         assertTrue(patients.has(0), "At least one patient found");
@@ -63,14 +63,14 @@ public class PatientManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void createPatient_adminUser_ok() throws Exception {
+    void createPatient_adminUser_ok() throws Exception {
         useOrgAdmin();
         String firstName = "Sansa";
         doCreateAndFetch(firstName, "Stark", "12/25/1100", "1-800-BIZ-NAME", "notbitter");
     }
 
     @Test
-    public void createPatient_entryUser_fail() throws Exception {
+    void createPatient_entryUser_fail() throws Exception {
         useOrgEntryOnly();
         String firstName = "Sansa";
         GraphQLResponse mutandem = executeAddPersonMutation(firstName, "Stark", "12/25/1100", "1-800-BIZ-NAME",
@@ -79,7 +79,7 @@ public class PatientManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void failsOnInvalidPhoneNumber() throws Exception {
+    void failsOnInvalidPhoneNumber() throws Exception {
         GraphQLResponse resp = executeAddPersonMutation("a", "b", "12/29/2020", "d", "e");
         JsonNode errors = resp.readTree().get("errors");
         assertNotNull(errors);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/QueueManagementTest.java
@@ -25,7 +25,7 @@ import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
-public class QueueManagementTest extends BaseApiTest {
+class QueueManagementTest extends BaseApiTest {
 
     private static final String QUERY = "queue-dates-query";
 
@@ -46,7 +46,7 @@ public class QueueManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void enqueueOnePatient() throws Exception {
+    void enqueueOnePatient() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         String personId = p.getInternalId().toString();
         ObjectNode variables = getFacilityScopedArguments().put("id", personId).put("previousTestDate", "05/15/2020")
@@ -65,7 +65,7 @@ public class QueueManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void updateViaPatientLink() throws Exception {
+    void updateViaPatientLink() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         String personId = p.getInternalId().toString();
         ObjectNode variables = getFacilityScopedArguments().put("id", personId);
@@ -97,7 +97,7 @@ public class QueueManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void updateItemInQueue() throws Exception {
+    void updateItemInQueue() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         TestOrder o = _dataFactory.createTestOrder(p, _site);
         String orderId = o.getInternalId().toString();
@@ -122,7 +122,7 @@ public class QueueManagementTest extends BaseApiTest {
     }
 
     @Test
-    public void enqueueOnePatientIsoDate() throws Exception {
+    void enqueueOnePatientIsoDate() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         String personId = p.getInternalId().toString();
         ObjectNode variables = getFacilityScopedArguments().put("id", personId).put("previousTestDate", "2020-05-15")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TestResultTest.java
@@ -22,7 +22,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class TestResultTest extends BaseApiTest {
+class TestResultTest extends BaseApiTest {
 
     @Autowired
     private TestDataFactory _dataFactory;
@@ -39,7 +39,7 @@ public class TestResultTest extends BaseApiTest {
     }
 
     @Test
-    public void fetchTestResults() throws Exception {
+    void fetchTestResults() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         _dataFactory.createTestEvent(p, _site);
         _dataFactory.createTestEvent(p, _site);
@@ -61,7 +61,7 @@ public class TestResultTest extends BaseApiTest {
     }
     
     @Test
-    public void submitTestResult() throws Exception {
+    void submitTestResult() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         DeviceType d = _dataFactory.getGenericDevice();
         TestOrder to = _dataFactory.createTestOrder(p, _site);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 
-@SuppressWarnings("checkstyle:MagicNumber")
 class TranslatorTest {
     @Test
     void testEmptyShortDate() {
@@ -53,6 +52,7 @@ class TranslatorTest {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseUserShortDate("fooexample.com");
         });
+        assertEquals("[fooexample.com] is not a valid date.", caught.getMessage());
     }
 
     @Test
@@ -82,6 +82,7 @@ class TranslatorTest {
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vestibulum lacus vitae condimentum ultricies. Phasellus sed velit a urna aliquam tempus. Nulla nunc ex, porta eget tristique vel, cursus eu enim. Sed malesuada turpis at rhoncus aliquam. Nullam blandit turpis ac pharetra lobortis. Ut bibendum ligula ex. Curabitur fermentum condimentum erat, in tristique justo maximus eu. Fusce posuere cursus enim, a ullamcorper augue bibendum eget. In eu nunc vitae est molestie mollis. Sed mollis fermentum ante vel bibendum. Fusce vel elit risus."
             );
         });
+        assertEquals("Value received exceeds field length limit of 500 characters", caught.getMessage());
     }
 
     @Test
@@ -104,7 +105,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidParseUUID() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseUUID("abc 123");
         });
     }
@@ -126,7 +127,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidParseRace() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseRace("xyz");
         });
     }
@@ -170,7 +171,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidParseEthnicity() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseEthnicity("xyz");
         });
     }
@@ -192,7 +193,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidParseGender() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseGender("asd");
         });
     }
@@ -217,7 +218,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidParseYesNo() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseYesNo("positive");
         });
     }
@@ -239,7 +240,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidState() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseState("New York");
         });
     }
@@ -261,7 +262,7 @@ class TranslatorTest {
 
     @Test
     void testInvalidEmail() {
-        IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseEmail("fooexample.com");
         });
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
@@ -20,19 +20,19 @@ import org.junit.jupiter.api.Test;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class TranslatorTest {
+class TranslatorTest {
     @Test
-    public void testEmptyShortDate() {
+    void testEmptyShortDate() {
         assertEquals(null, parseUserShortDate(""));
     }
 
     @Test
-    public void testNullShortDate() {
+    void testNullShortDate() {
         assertEquals(null, parseUserShortDate(null));
     }
 
     @Test
-    public void testValidShortDate() {
+    void testValidShortDate() {
         LocalDate result = parseUserShortDate("2/1/2021");
         assertEquals(2, result.getMonthValue());
         assertEquals(1, result.getDayOfMonth());
@@ -40,7 +40,7 @@ public class TranslatorTest {
     }
 
     @Test
-    public void testValidDateWithLeadingZeros() {
+    void testValidDateWithLeadingZeros() {
         LocalDate result = parseUserShortDate("02/01/2021");
         assertEquals(2, result.getMonthValue());
         assertEquals(1, result.getDayOfMonth());
@@ -48,34 +48,34 @@ public class TranslatorTest {
     }
 
     @Test
-    public void testInvalidShortDate() {
+    void testInvalidShortDate() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseUserShortDate("fooexample.com");
         });
     }
 
     @Test
-    public void testEmptyParseString() {
+    void testEmptyParseString() {
         assertEquals(null, parseString(""));
     }
 
     @Test
-    public void testNullParseString() {
+    void testNullParseString() {
         assertEquals(null, parseString(null));
     }
 
     @Test
-    public void testValidParseString() {
+    void testValidParseString() {
         assertEquals("abc 123", parseString("abc 123"));
     }
 
     @Test
-    public void testValidParseStringWithSurroundingSpaces() {
+    void testValidParseStringWithSurroundingSpaces() {
         assertEquals("abc 123", parseString("   abc 123   "));
     }
 
     @Test
-    public void testParseStringWithLongString() {
+    void testParseStringWithLongString() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseString(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vestibulum lacus vitae condimentum ultricies. Phasellus sed velit a urna aliquam tempus. Nulla nunc ex, porta eget tristique vel, cursus eu enim. Sed malesuada turpis at rhoncus aliquam. Nullam blandit turpis ac pharetra lobortis. Ut bibendum ligula ex. Curabitur fermentum condimentum erat, in tristique justo maximus eu. Fusce posuere cursus enim, a ullamcorper augue bibendum eget. In eu nunc vitae est molestie mollis. Sed mollis fermentum ante vel bibendum. Fusce vel elit risus."
@@ -84,17 +84,17 @@ public class TranslatorTest {
     }
 
     @Test
-    public void testEmptyUUID() {
+    void testEmptyUUID() {
         assertEquals(null, parseUUID(""));
     }
 
     @Test
-    public void testNullParseUUID() {
+    void testNullParseUUID() {
         assertEquals(null, parseUUID(null));
     }
 
     @Test
-    public void testValidParseUUID() {
+    void testValidParseUUID() {
         assertEquals(
             "8ae1a210-fe20-44ab-80c6-214289acead7",
             parseUUID("8ae1a210-fe20-44ab-80c6-214289acead7").toString()
@@ -102,90 +102,90 @@ public class TranslatorTest {
     }
 
     @Test
-    public void testInvalidParseUUID() {
+    void testInvalidParseUUID() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseUUID("abc 123");
         });
     }
 
     @Test
-    public void testEmptyParseRace() {
+    void testEmptyParseRace() {
         assertEquals(null, parseRace(""));
     }
 
     @Test
-    public void testNullParseRace() {
+    void testNullParseRace() {
         assertEquals(null, parseRace(null));
     }
 
     @Test
-    public void testValidParseRace() {
+    void testValidParseRace() {
         assertEquals("native", parseRace("native"));
     }
 
     @Test
-    public void testInvalidParseRace() {
+    void testInvalidParseRace() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseRace("xyz");
         });
     }
 
     @Test
-    public void testEmptyParseEthnicity() {
+    void testEmptyParseEthnicity() {
         assertEquals(null, parseEthnicity(""));
     }
 
     @Test
-    public void testNullParseEthnicity() {
+    void testNullParseEthnicity() {
         assertEquals(null, parseEthnicity(null));
     }
 
     @Test
-    public void testValidParseEthnicity() {
+    void testValidParseEthnicity() {
         assertEquals("hispanic", parseEthnicity("hispanic"));
     }
 
     @Test
-    public void testInvalidParseEthnicity() {
+    void testInvalidParseEthnicity() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseEthnicity("xyz");
         });
     }
 
     @Test
-    public void testEmptyParseGender() {
+    void testEmptyParseGender() {
         assertEquals(null, parseGender(""));
     }
 
     @Test
-    public void testNullParseGender() {
+    void testNullParseGender() {
         assertEquals(null, parseGender(null));
     }
 
     @Test
-    public void testValidParseGender() {
+    void testValidParseGender() {
         assertEquals("other", parseGender("other"));
     }
 
     @Test
-    public void testInvalidParseGender() {
+    void testInvalidParseGender() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseGender("asd");
         });
     }
 
     @Test
-    public void testEmptyParseYesNo() {
+    void testEmptyParseYesNo() {
         assertEquals(null, parseYesNo(""));
     }
 
     @Test
-    public void testNullParseYesNo() {
+    void testNullParseYesNo() {
         assertEquals(null, parseYesNo(null));
     }
 
     @Test
-    public void testValidParseYesNo() {
+    void testValidParseYesNo() {
         assertEquals(true, parseYesNo("y"));
         assertEquals(true, parseYesNo("yEs"));
         assertEquals(false, parseYesNo("n"));
@@ -193,51 +193,51 @@ public class TranslatorTest {
     }
 
     @Test
-    public void testInvalidParseYesNo() {
+    void testInvalidParseYesNo() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseYesNo("positive");
         });
     }
 
     @Test
-    public void testEmptyState() {
+    void testEmptyState() {
         assertEquals(null, parseState(""));
     }
 
     @Test
-    public void testNullState() {
+    void testNullState() {
         assertEquals(null, parseState(null));
     }
 
     @Test
-    public void testValidState() {
+    void testValidState() {
         assertEquals("NY", parseState("ny"));
     }
 
     @Test
-    public void testInvalidState() {
+    void testInvalidState() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseState("New York");
         });
     }
 
     @Test
-    public void testEmptyEmail() {
+    void testEmptyEmail() {
         assertEquals(null, parseEmail(""));
     }
 
     @Test
-    public void testNullEmail() {
+    void testNullEmail() {
         assertEquals(null, parseEmail(null));
     }
 
     @Test
-    public void testValidEmail() {
+    void testValidEmail() {
         assertEquals("foo@example.com", parseEmail("foo@example.com"));
     }
 
     @Test
-    public void testInvalidEmail() {
+    void testInvalidEmail() {
         IllegalGraphqlArgumentException caught = assertThrows(IllegalGraphqlArgumentException.class, () -> {
             parseEmail("fooexample.com");
         });

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -20,31 +20,31 @@ import org.springframework.boot.test.json.ObjectContent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
 @JsonTest
-public class PersonSerializationTest {
+class PersonSerializationTest {
 
     @Autowired
     private JacksonTester<Person> _tester;
 
     @Test
-    public void deserialize_stringRace_raceFound() throws IOException {
+    void deserialize_stringRace_raceFound() throws IOException {
         ObjectContent<Person> ob = _tester.read("/deserialization/race-scalar.json");
         assertAlexanderHamilton(ob);
     }
 
     @Test
-    public void deserialize_arrayRace_raceFound() throws IOException {
+    void deserialize_arrayRace_raceFound() throws IOException {
         ObjectContent<Person> ob = _tester.read("/deserialization/race-array.json");
         assertAlexanderHamilton(ob);
     }
 
     @Test
-    public void deserialize_withFacility_raceFoundNoFacility() throws IOException {
+    void deserialize_withFacility_raceFoundNoFacility() throws IOException {
         ObjectContent<Person> ob = _tester.read("/deserialization/with-facility.json");
         assertAlexanderHamilton(ob);
     }
 
     @Test
-    public void serialize_withOrgAndFacility_noOrgOrFacility() throws IOException {
+    void serialize_withOrgAndFacility_noOrgOrFacility() throws IOException {
         // consts are to keep style check happy othewise it complains about
         // "magic numbers"
         final int BIRTH_YEAR = 2000;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -18,7 +18,7 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
-public class FacilityRepositoryTest extends BaseRepositoryTest {
+class FacilityRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private DeviceTypeRepository _devices;
@@ -30,7 +30,7 @@ public class FacilityRepositoryTest extends BaseRepositoryTest {
     private FacilityRepository _repo;
 
     @Test
-    public void smokeTestDeviceOperations() {
+    void smokeTestDeviceOperations() {
         List<DeviceType> configuredDevices = new ArrayList<>();
         DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E");
         Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepositoryTest.java
@@ -11,13 +11,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
 
-public class OrganizationRepositoryTest extends BaseRepositoryTest {
+class OrganizationRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private OrganizationRepository _repo;
 
     @Test
-    public void createAndFindSomething() {
+    void createAndFindSomething() {
         Organization saved = _repo.save(new Organization("My House", "12345"));
         assertNotNull(saved);
         assertNotNull(saved.getInternalId());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
@@ -13,7 +13,7 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
-public class PersonRepositoryTest extends BaseRepositoryTest {
+class PersonRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private PersonRepository _repo;
@@ -21,7 +21,7 @@ public class PersonRepositoryTest extends BaseRepositoryTest {
     private OrganizationRepository _orgRepo;
 
     @Test
-    public void doPersonOperations() {
+    void doPersonOperations() {
         Organization org = _orgRepo.save(new Organization("Here", "there"));
         Organization other = _orgRepo.save(new Organization("There", "where?"));
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestEventRepositoryTest extends BaseRepositoryTest {
+class TestEventRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private TestEventRepository _repo;
@@ -34,7 +34,7 @@ public class TestEventRepositoryTest extends BaseRepositoryTest {
     private TestDataFactory _dataFactory;
 
     @Test
-    public void testFindByPatient() {
+    void testFindByPatient() {
         Organization org = _dataFactory.createValidOrg();
         Facility place = _dataFactory.createValidFacility(org);
         Person patient = _dataFactory.createMinimalPerson(org);
@@ -47,7 +47,7 @@ public class TestEventRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void testLatestTestEventForPerson() {
+    void testLatestTestEventForPerson() {
         Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
         final Date DATE_1MIN_FUTURE = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
         List<TestEvent> foundTestReports1 = _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE,
@@ -70,7 +70,7 @@ public class TestEventRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void fetchResults_multipleEntries_sortedLifo() throws InterruptedException {
+    void fetchResults_multipleEntries_sortedLifo() throws InterruptedException {
         Organization org = _dataFactory.createValidOrg();
         Person adam = _dataFactory.createMinimalPerson(org, null, "Adam", "A.", "Astaire", "Jr.");
         Person brad = _dataFactory.createMinimalPerson(org, null, "Bradley", "B.", "Bones", null);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -26,7 +26,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class TestOrderRepositoryTest extends BaseRepositoryTest {
+class TestOrderRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private TestOrderRepository _repo;
@@ -40,7 +40,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
     private TestDataFactory _dataFactory;
 
     @Test
-    public void runChanges() {
+    void runChanges() {
         Organization gwu = _orgRepo.save(new Organization("George Washington", "gwu"));
         Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt"));
         Facility site = _dataFactory.createValidFacility(gtown);
@@ -62,7 +62,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void testLifeCycle() {
+    void testLifeCycle() {
         DeviceType device = _dataFactory.getGenericDevice();
         Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt"));
         Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", null, LocalDate.now(), null,
@@ -89,7 +89,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void createOrder_duplicatesFound_error() {
+    void createOrder_duplicatesFound_error() {
         Organization org = _dataFactory.createValidOrg();
         Person patient0 = _dataFactory.createMinimalPerson(org);
         Facility site = _dataFactory.createValidFacility(org);
@@ -105,7 +105,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void createOrder_duplicateCanceled_ok() {
+    void createOrder_duplicateCanceled_ok() {
         Organization org = _dataFactory.createValidOrg();
         Person patient0 = _dataFactory.createMinimalPerson(org);
         Facility site = _dataFactory.createValidFacility(org);
@@ -127,7 +127,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void createOrder_duplicateSubmitted_ok() {
+    void createOrder_duplicateSubmitted_ok() {
         Organization org = _dataFactory.createValidOrg();
         Person patient0 = _dataFactory.createMinimalPerson(org);
         Facility site = _dataFactory.createValidFacility(org);
@@ -152,7 +152,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
     }
 
     @Test
-    public void fetchQueue_multipleEntries_sortedFifo() {
+    void fetchQueue_multipleEntries_sortedFifo() {
         Organization org = _dataFactory.createValidOrg();
         Person adam = _dataFactory.createMinimalPerson(org, null, "Adam", "A.", "Astaire", "Jr.");
         Person brad = _dataFactory.createMinimalPerson(org, null, "Bradley", "B.", "Bones", null);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -51,7 +51,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
     @Test
     @WithSimpleReportSiteAdminUser
-    public void createAndDeleteDeviceTypes_adminUser_success() {
+    void createAndDeleteDeviceTypes_adminUser_success() {
         DeviceType devA = _service.createDeviceType("A", "B", "C", "D", "E");
         DeviceType devB = _service.createDeviceType("F", "G", "H", "I", "J");
         assertNotNull(devA);
@@ -66,7 +66,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
     @Test
     @WithSimpleReportSiteAdminUser
-    public void updateDeviceTypeName_adminUser_success() {
+    void updateDeviceTypeName_adminUser_success() {
         DeviceType device = _service.createDeviceType("A", "B", "C", "D", "E");
 
         DeviceType updatedDevice = _service.updateDeviceType(device.getInternalId(), "Tim", null, null, null, null);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -13,13 +13,13 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 
-public class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
+class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
     @Autowired
     private DeviceTypeRepository _deviceTypeRepo;
 
     @Test
-    public void fetchDeviceTypes() {
+    void fetchDeviceTypes() {
         _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
 
         DeviceType deviceType = _service.fetchDeviceTypes().get(0);
@@ -32,19 +32,19 @@ public class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     }
 
     @Test
-    public void createDeviceType_baseUser_error() {
+    void createDeviceType_baseUser_error() {
         assertSecurityError(() -> _service.createDeviceType("A", "B", "C", "D", "E"));
     }
 
     @Test
-    public void updateDeviceType_baseUser_error() {
+    void updateDeviceType_baseUser_error() {
         DeviceType deviceType = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
         assertSecurityError(() -> _service.updateDeviceType(deviceType.getInternalId(), "1", "2", "3", "4", "5"));
     }
 
 
     @Test
-    public void removeDeviceType_baseUser_eror() {
+    void removeDeviceType_baseUser_eror() {
         DeviceType deviceType = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
         assertSecurityError(() -> _service.removeDeviceType(deviceType));
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OktaServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OktaServiceTest.java
@@ -17,7 +17,7 @@ import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 
-public class OktaServiceTest extends BaseServiceTest<OktaService> {
+class OktaServiceTest extends BaseServiceTest<OktaService> {
 
     private static final IdentityAttributes AMOS = new IdentityAttributes("aquint@gmail.com", "Amos", null, "Quint", null);
     private static final IdentityAttributes BRAD = new IdentityAttributes("bzj@msn.com", "Bradley", "Z.", "Jones", "Jr.");
@@ -50,7 +50,7 @@ public class OktaServiceTest extends BaseServiceTest<OktaService> {
 
     @Disabled
     @Test
-    public void createOrganizationAndUser() {
+    void createOrganizationAndUser() {
 
         _service.createOrganization(ABC.getOrganizationName(), ABC.getExternalId());
         _service.createUser(AMOS, ABC.getExternalId());
@@ -84,7 +84,7 @@ public class OktaServiceTest extends BaseServiceTest<OktaService> {
 
     @Disabled
     @Test
-    public void updateUser() {
+    void updateUser() {
 
         _service.createOrganization(DEF.getOrganizationName(), DEF.getExternalId());
         _service.createUser(AMOS, DEF.getExternalId());
@@ -121,7 +121,7 @@ public class OktaServiceTest extends BaseServiceTest<OktaService> {
 
     @Disabled
     @Test
-    public void getOrganizationExternalIdForUser() {
+    void getOrganizationExternalIdForUser() {
         _service.createOrganization(GHI.getOrganizationName(), GHI.getExternalId());
         _service.createUser(CHARLES, GHI.getExternalId());
 
@@ -130,7 +130,7 @@ public class OktaServiceTest extends BaseServiceTest<OktaService> {
 
     @Disabled
     @Test
-    public void createUser_duplicateUsernames() {
+    void createUser_duplicateUsernames() {
         _service.createOrganization(ABC.getOrganizationName(), ABC.getExternalId());
         _service.createUser(FRANK, ABC.getExternalId());
 
@@ -153,7 +153,7 @@ public class OktaServiceTest extends BaseServiceTest<OktaService> {
 
     @Disabled
     @Test
-    public void createOrganization_duplicateExternalIds() {
+    void createOrganization_duplicateExternalIds() {
         _service.createOrganization(GHI.getOrganizationName(), GHI.getExternalId());
         assertThrows(ResourceException.class, () -> {
             _service.createOrganization(GHI_DUP.getOrganizationName(), GHI_DUP.getExternalId());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -17,10 +17,10 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.service.model.DeviceTypeHolder;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 
-public class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
+class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
     @Test
-    public void findit() {
+    void findit() {
         initSampleData();
         Organization org = _service.getCurrentOrganization();
         assertNotNull(org);
@@ -28,7 +28,7 @@ public class OrganizationServiceTest extends BaseServiceTest<OrganizationService
     }
 
     @Test
-    public void createOrganization_standardUser_error() {
+    void createOrganization_standardUser_error() {
         assertSecurityError(() -> {
             List<DeviceType> configuredDevices = new ArrayList<>();
             DeviceType device = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -44,7 +44,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
     @Test
     @WithSimpleReportSiteAdminUser
-    public void createOrganization_adminUser_success() {
+    void createOrganization_adminUser_success() {
         List<DeviceType> configuredDevices = new ArrayList<>();
         DeviceType device = _dataFactory.createDeviceType("Bill", "Weasleys", "1", "12345-6", "E");
         configuredDevices.add(device);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
@@ -19,7 +19,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
+class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
         @Autowired
         private OrganizationService _organizationService;
         @Autowired
@@ -33,7 +33,7 @@ public class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> 
         }
 
         @Test
-        public void getPatientLinkCurrent() throws Exception {
+        void getPatientLinkCurrent() throws Exception {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.", LocalDate.of(1865, 12, 25),
@@ -50,7 +50,7 @@ public class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> 
         }
 
         @Test
-        public void getPatientLinkVerify() throws Exception {
+        void getPatientLinkVerify() throws Exception {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.", LocalDate.of(1865, 12, 25),
@@ -67,7 +67,7 @@ public class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> 
         }
 
         @Test
-        public void refreshPatientLink() throws Exception {
+        void refreshPatientLink() throws Exception {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.", LocalDate.of(1865, 12, 25),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -45,7 +45,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     @Test
     @WithSimpleReportStandardUser
-    public void roundTrip() {
+    void roundTrip() {
         _service.addPatient(null, "FOO", "Fred", null, "Fosbury", "Sr.", LocalDate.of(1865, 12, 25), "123 Main",
                 "Apartment 3", "Hicksville", "NY",
                 "11801", "5555555555", PersonRole.STAFF, null, "Nassau", null, null, null, false, false);
@@ -58,7 +58,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     @Test
     @WithSimpleReportStandardUser
-    public void deletePatient_standardUser_error() {
+    void deletePatient_standardUser_error() {
         Person p = _service.addPatient(null, "FOO", "Fred", null, "Fosbury", "Sr.", LocalDate.of(1865, 12, 25), "123 Main",
                 "Apartment 3", "Hicksville", "NY",
                 "11801", "5555555555", PersonRole.STAFF, null, "Nassau", null, null, null, false, false);
@@ -69,7 +69,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     @Test
     @WithSimpleReportSiteAdminUser
-    public void deletePatient_adminUser_success() {
+    void deletePatient_adminUser_success() {
         Person p = _service.addPatient(null, "FOO", "Fred", null, "Fosbury", "Sr.", LocalDate.of(1865, 12, 25),
                 "123 Main",
                 "Apartment 3", "Hicksville", "NY",
@@ -83,7 +83,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     @Test
     @WithSimpleReportSiteAdminUser
-    public void getPatients_noFacility_allFetchedAndSorted() {
+    void getPatients_noFacility_allFetchedAndSorted() {
         makedata();
         List<Person> patients = _service.getPatients(null);
         assertPatientList(patients, CHARLES, FRANK, BRAD, DEXTER, ELIZABETH, AMOS);
@@ -91,7 +91,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     @Test
     @WithSimpleReportSiteAdminUser
-    public void getPatients_facilitySpecific_nullsAndSpecifiedFetchedAndSorted() {
+    void getPatients_facilitySpecific_nullsAndSpecifiedFetchedAndSorted() {
         makedata();
         List<Person> patients = _service.getPatients(_site1.getInternalId());
         assertPatientList(patients, CHARLES, BRAD, ELIZABETH, AMOS);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -21,7 +21,7 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class PersonServiceTest extends BaseServiceTest<PersonService> {
+class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     // I'll have you know that I didn't actually mean to do this...
     private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ScheduledTasksServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ScheduledTasksServiceTest.java
@@ -20,7 +20,7 @@ import org.springframework.scheduling.support.CronTrigger;
 import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
 
 
-public class ScheduledTasksServiceTest {
+class ScheduledTasksServiceTest {
 
     @Test
     void scheduleUploads_oneSchedule_scheduled() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -29,7 +29,7 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
+class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
         @Autowired
         private DeviceTypeRepository _deviceTypeRepo;
@@ -48,7 +48,7 @@ public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         }
 
         @Test
-        public void addPatientToQueue() {
+        void addPatientToQueue() {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.", LocalDate.of(1865, 12, 25),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -65,7 +65,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
         @Test
         @WithSimpleReportStandardUser
-        public void addTestResult() {
+        void addTestResult() {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.", LocalDate.of(1865, 12, 25),
@@ -85,7 +85,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
         @Test
         @WithSimpleReportStandardUser
-        public void editTestResult_standardUser_ok() {
+        void editTestResult_standardUser_ok() {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.", LocalDate.of(1865, 12, 25),
@@ -107,7 +107,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
         @Test
         @WithSimpleReportEntryOnlyUser
-        public void editTestResult_entryOnlyUser_ok() {
+        void editTestResult_entryOnlyUser_ok() {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _dataFactory.createFullPerson(org);
@@ -127,7 +127,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
         @Test
         @WithSimpleReportStandardUser
-        public void fetchTestEventsResults_standardUser_ok() {
+        void fetchTestEventsResults_standardUser_ok() {
                 Organization org = _organizationService.getCurrentOrganization();
                 Facility facility = _organizationService.getFacilities(org).get(0);
                 Person p = _dataFactory.createFullPerson(org);


### PR DESCRIPTION
Both test classes and test methods are now allowed to be package-friendly, rather that public. Sonar thinks that it is a good idea to make them as low-visibility as possible, so this commit does that.

If we disagree with Sonar, we should disable this check so it quits flagging this as a code smell.