### PR TITLE
More lazy fetching to avoid N+1 problems

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -43,12 +44,12 @@ public abstract class AuditedEntity {
 
     @CreatedBy
     @Immutable // not sure this is needed. Not sure it works if it is. :-(
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by", updatable = false)
     private ApiUser createdBy;
 
     @LastModifiedBy
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "updated_by")
     private ApiUser updatedBy;
 


### PR DESCRIPTION
## Related Issue or Background Info

We've had some performance issues with N+1 querying. Trying to get ahead of those by a little.

## Changes Proposed

- lazy-fetch audit users for all the entities that have them

