### PR TITLE
update get test event permissions

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -60,8 +60,7 @@ public class TestOrderService {
   }
 
     @Transactional(readOnly = true)
-    @AuthorizationConfiguration.RequirePermissionStartTest // Intentionally incorrect permission:
-                                                           // https://github.com/CDCgov/prime-simplereport/issues/677
+    @AuthorizationConfiguration.RequirePermissionReadResultList
     public List<TestEvent> getTestEventsResults(UUID facilityId, Date newerThanDate) {
         Facility fac = _os.getFacilityInCurrentOrg(facilityId);  // org access is checked here
         return _terepo.getTestEventResults(fac.getInternalId(), (newerThanDate != null) ? newerThanDate: new Date(0));


### PR DESCRIPTION
## Related Issue or Background Info

Related issue https://github.com/CDCgov/prime-simplereport/issues/677
Issue of getting all records was fixed with https://github.com/CDCgov/prime-simplereport/pull/762

## Changes Proposed

- remove permissions for entry only users to access `getTestEventsResults()`
