### PR TITLE
Produce test name for printing

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestDescription.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestDescription.java
@@ -2,6 +2,8 @@ package gov.cdc.usds.simplereport.api.model;
 
 import java.util.Map;
 
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+
 public class TestDescription {
 
     private static TestDescription DEFAULT_TEST = new TestDescription("Unknown", "Unknown", "Unknown", "Unknown",
@@ -47,8 +49,19 @@ public class TestDescription {
         return loincCode;
     }
 
-    public String getName() {
-        return shortName;
+    public String getName(String nameType) {
+        switch(nameType) {
+            case "short":
+                return shortName;
+            case "long":
+                return longName;
+            case "display":
+                return displayName;
+            case "consumer":
+                return consumerName;
+            default:
+                throw new IllegalGraphqlArgumentException("Name type not recognized");
+        }
     }
 
     public String getLongName() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestDescription.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestDescription.java
@@ -1,0 +1,73 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import java.util.Map;
+
+public class TestDescription {
+
+    private static TestDescription DEFAULT_TEST = new TestDescription("Unknown", "Unknown", "Unknown", "Unknown",
+            "Unknown");
+
+    private static Map<String, TestDescription> KNOWN_TESTS = Map.of(
+            "94534-5", new TestDescription(
+                    "94534-5",
+                    "SARS-CoV-2 (COVID-19) RdRp gene [Presence] in Respiratory specimen by NAA with probe detection",
+                    "SARS-CoV-2 RdRp Resp Ql NAA+probe",
+                    "SARS-CoV-2 (COVID-19) RdRp gene NAA+probe Ql (Resp)",
+                    "SARS-CoV-2 (COVID-19) RdRp gene, Respiratory"),
+            "95209-3", new TestDescription(
+                    "95209-3",
+                    "SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay",
+                    "SARS-CoV+SARS-CoV-2 Ag Resp Ql IA.rapid",
+                    "SARS-CoV+SARS-CoV-2 (COVID-19) Ag IA.rapid Ql (Resp)",
+                    "SARS-CoV+SARS-CoV-2 (COVID-19) antigen, Respiratory"),
+            "94558-4", new TestDescription(
+                    "94558-4",
+                    "SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay",
+                    "SARS-CoV-2 Ag Resp Ql IA.rapid",
+                    "SARS-CoV-2 (COVID-19) Ag IA.rapid Ql (Resp)",
+                    "SARS-CoV-2 (COVID-19) antigen, Respiratory"));
+
+    private String loincCode;
+    private String longName;
+    private String shortName;
+    private String displayName;
+    private String consumerName;
+
+    protected TestDescription(String loincCode, String longName, String shortName, String displayName,
+            String consumerName) {
+        super();
+        this.loincCode = loincCode;
+        this.longName = longName;
+        this.shortName = shortName;
+        this.displayName = displayName;
+        this.consumerName = consumerName;
+    }
+
+    public String getLoincCode() {
+        return loincCode;
+    }
+
+    public String getName() {
+        return shortName;
+    }
+
+    public String getLongName() {
+        return longName;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getConsumerName() {
+        return consumerName;
+    }
+
+    public static TestDescription findTestDescription(String loincCode) {
+        return KNOWN_TESTS.getOrDefault(loincCode, DEFAULT_TEST);
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
@@ -14,6 +14,7 @@ import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
+import gov.cdc.usds.simplereport.api.model.TestDescription;
 
 @Component
 public class TestResultDataResolver implements GraphQLResolver<TestEvent> {
@@ -73,6 +74,10 @@ public class TestResultDataResolver implements GraphQLResolver<TestEvent> {
 
     public Date getDateTested(TestEvent testEvent) {
         return testEvent.getDateTested();
+    }
+
+    public TestDescription getTestPerformed(TestEvent event) {
+        return TestDescription.findTestDescription(event.getDeviceType().getLoincCode());
     }
 
     public String getCorrectionStatus(TestEvent testEvent) { return testEvent.getCorrectionStatus().toString(); }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
@@ -7,24 +7,16 @@ import java.time.LocalDate;
 
 import graphql.kickstart.tools.GraphQLResolver;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
-import gov.cdc.usds.simplereport.service.TestOrderService;
-import gov.cdc.usds.simplereport.service.TestEventService;
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 
 @Component
 public class TestResultDataResolver implements GraphQLResolver<TestEvent> {
-
-    @Autowired
-    private TestEventService _testEventService;
-    @Autowired
-    public TestOrderService _svc;
 
     private AskOnEntrySurvey getSurvey(TestEvent testEvent) {
         return testEvent.getSurveyData();

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -30,7 +30,7 @@ enum TestCorrectionStatus {
 }
 
 type TestDescription {
-  name: String!
+  name(nameType: String = "long"): String!
   loincCode: String!
 }
 

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -29,6 +29,11 @@ enum TestCorrectionStatus {
   REMOVED
 }
 
+type TestDescription {
+  name: String!
+  loincCode: String!
+}
+
 type DeviceType {
   internalId: ID
   name: String
@@ -142,6 +147,7 @@ type TestResult {
   deviceType: DeviceType
   result: String
   dateTested: DateTime
+  testPerformed: TestDescription!
   correctionStatus: String
   reasonForCorrection: String
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TestResultTest.java
@@ -45,10 +45,15 @@ class TestResultTest extends BaseApiTest {
   
         ObjectNode variables = getFacilityScopedArguments();
         ArrayNode testResults = fetchTestResults(variables);
+        assertEquals(3, testResults.size());
+        assertEquals("SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay",
+                testResults.get(0).get("testPerformed").get("name").asText());
 
+        variables.put("nameType", "short");
+        testResults = fetchTestResults(variables);
         assertEquals(3, testResults.size());
         assertEquals("SARS-CoV+SARS-CoV-2 Ag Resp Ql IA.rapid",
-                testResults.get(0).get("testPerformed").get("name"));
+                testResults.get(0).get("testPerformed").get("name").asText());
     }
 
     private ObjectNode getFacilityScopedArguments() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TestResultTest.java
@@ -14,14 +14,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
-@SuppressWarnings("checkstyle:MagicNumber")
 class TestResultTest extends BaseApiTest {
 
     @Autowired
@@ -49,6 +47,8 @@ class TestResultTest extends BaseApiTest {
         ArrayNode testResults = fetchTestResults(variables);
 
         assertEquals(3, testResults.size());
+        assertEquals("SARS-CoV+SARS-CoV-2 Ag Resp Ql IA.rapid",
+                testResults.get(0).get("testPerformed").get("name"));
     }
 
     private ObjectNode getFacilityScopedArguments() {
@@ -64,7 +64,7 @@ class TestResultTest extends BaseApiTest {
     void submitTestResult() throws Exception {
         Person p = _dataFactory.createFullPerson(_org);
         DeviceType d = _dataFactory.getGenericDevice();
-        TestOrder to = _dataFactory.createTestOrder(p, _site);
+        _dataFactory.createTestOrder(p, _site);
         String dateTested = "2020-12-31T14:30:30.001Z";
 
         ObjectNode variables = JsonNodeFactory.instance.objectNode()

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestDescriptionTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestDescriptionTest.java
@@ -1,0 +1,35 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class TestDescriptionTest {
+
+    @Test
+    void construction_validInputs_expectedOutputs() {
+        TestDescription desc = new TestDescription("CODE", "LONG", "SHORT", "DISPLAY", "CONSUMER");
+        assertEquals("CODE", desc.getLoincCode());
+        assertEquals("LONG", desc.getLongName());
+        assertEquals("SHORT", desc.getShortName());
+        assertEquals("DISPLAY", desc.getDisplayName());
+        assertEquals("CONSUMER", desc.getConsumerName());
+    }
+
+    @Test
+    void findTestDescription_invalid_defaultFound() {
+        TestDescription desc = TestDescription.findTestDescription("nope");
+        assertNotNull(desc);
+        assertEquals("Unknown", desc.getLoincCode());
+        assertEquals("Unknown", desc.getShortName());
+    }
+
+    @Test
+    void findTestDescription_knownTest_correctResultFound() {
+        TestDescription rnaTest = TestDescription.findTestDescription("94534-5");
+        assertNotNull(rnaTest);
+        assertEquals("SARS-CoV-2 (COVID-19) RdRp gene [Presence] in Respiratory specimen by NAA with probe detection",
+                rnaTest.getLongName());
+    }
+}

--- a/backend/src/test/resources/test-result-query
+++ b/backend/src/test/resources/test-result-query
@@ -14,5 +14,8 @@ query GetFacilityResults($facilityId: String!) {
       lastName
       lookupId
     }
+    testPerformed {
+      name
+    }
   }
 }

--- a/backend/src/test/resources/test-result-query
+++ b/backend/src/test/resources/test-result-query
@@ -1,4 +1,4 @@
-query GetFacilityResults($facilityId: String!) {
+query GetFacilityResults($facilityId: String!, $nameType: String = "long") {
   testResults(facilityId: $facilityId) {
     internalId
     dateTested
@@ -15,7 +15,7 @@ query GetFacilityResults($facilityId: String!) {
       lookupId
     }
     testPerformed {
-      name
+      name(nameType: $nameType)
     }
   }
 }


### PR DESCRIPTION
## Related Issue or Background Info

- for #426 we need the name of the test that was performend
- this led to #631 which got a little confused and didn't get prioritized, so now we're in a hurry

## Changes Proposed

- introduce new API graph node for test description, to allow the test name to be retrieved whenever a test result is retrieved
- implement a very, very crude shim at the API layer to provide this information based on the LOINC "test performed" code, which is stored on the device type in the database

## Additional Information

- the LIVD spreadsheet also includes a "test ordered" code, which is not always the same
- antibody tests will probably complicate this, since there exist tests (which we might support?) in which IgM and IgG are included in one order code (e.g. [94503-0](https://loinc.org/94503-0/)) but reported as two different tests performed ([94507-1](https://loinc.org/94507-1/) and [94508-9](https://loinc.org/94508-9))

