### PR TITLE
API support for specimen types

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
 	// data layer dependencies
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.vladmihalcea:hibernate-types-52:2.10.0'
 	implementation 'org.liquibase:liquibase-core'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/backend/db-setup/reset-db.sql
+++ b/backend/db-setup/reset-db.sql
@@ -11,4 +11,6 @@ GRANT SELECT, INSERT, DELETE, UPDATE, TRUNCATE ON TABLES TO simple_report_app;
 ALTER DEFAULT PRIVILEGES FOR USER simple_report_migrations IN SCHEMA simple_report
 GRANT SELECT, UPDATE ON SEQUENCES TO simple_report_app;
 GRANT USAGE ON LANGUAGE plpgsql to simple_report_app;
+DROP EXTENSION IF EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA simple_report;
 

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -51,6 +51,7 @@ jakarta.activation:jakarta.activation-api:1.2.2
 jakarta.annotation:jakarta.annotation-api:1.3.5
 jakarta.persistence:jakarta.persistence-api:2.2.3
 jakarta.transaction:jakarta.transaction-api:1.3.3
+jakarta.validation:jakarta.validation-api:2.0.2
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
 javax.activation:javax.activation-api:1.2.0
 javax.servlet:javax.servlet-api:4.0.1
@@ -72,6 +73,7 @@ org.glassfish.jaxb:txw2:2.3.3
 org.glassfish:jakarta.el:3.0.3
 org.hdrhistogram:HdrHistogram:2.1.12
 org.hibernate.common:hibernate-commons-annotations:5.1.2.Final
+org.hibernate.validator:hibernate-validator:6.1.6.Final
 org.hibernate:hibernate-core:5.4.25.Final
 org.javassist:javassist:3.27.0-GA
 org.jboss.logging:jboss-logging:3.4.1.Final
@@ -101,6 +103,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.1
 org.springframework.boot:spring-boot-starter-logging:2.4.1
 org.springframework.boot:spring-boot-starter-security:2.4.1
 org.springframework.boot:spring-boot-starter-tomcat:2.4.1
+org.springframework.boot:spring-boot-starter-validation:2.4.1
 org.springframework.boot:spring-boot-starter-web:2.4.1
 org.springframework.boot:spring-boot-starter-websocket:2.4.1
 org.springframework.boot:spring-boot-starter:2.4.1

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -60,6 +60,7 @@ jakarta.activation:jakarta.activation-api:1.2.2
 jakarta.annotation:jakarta.annotation-api:1.3.5
 jakarta.persistence:jakarta.persistence-api:2.2.3
 jakarta.transaction:jakarta.transaction-api:1.3.3
+jakarta.validation:jakarta.validation-api:2.0.2
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
 javax.activation:javax.activation-api:1.2.0
 javax.servlet:javax.servlet-api:4.0.1
@@ -87,6 +88,7 @@ org.glassfish.jaxb:txw2:2.3.3
 org.glassfish:jakarta.el:3.0.3
 org.hdrhistogram:HdrHistogram:2.1.12
 org.hibernate.common:hibernate-commons-annotations:5.1.2.Final
+org.hibernate.validator:hibernate-validator:6.1.6.Final
 org.hibernate:hibernate-core:5.4.25.Final
 org.javassist:javassist:3.27.0-GA
 org.jboss.logging:jboss-logging:3.4.1.Final
@@ -119,6 +121,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.1
 org.springframework.boot:spring-boot-starter-logging:2.4.1
 org.springframework.boot:spring-boot-starter-security:2.4.1
 org.springframework.boot:spring-boot-starter-tomcat:2.4.1
+org.springframework.boot:spring-boot-starter-validation:2.4.1
 org.springframework.boot:spring-boot-starter-web:2.4.1
 org.springframework.boot:spring-boot-starter-websocket:2.4.1
 org.springframework.boot:spring-boot-starter:2.4.1

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -50,7 +50,8 @@ public class TestEventExport {
 	private String genderUnknown = "U";
 	private String ethnicityUnknown = "U";
 	private String raceUnknown = "UNK";
-	private String nasopharyngealStructureCode = "71836000";
+    private static final String DEFAULT_LOCATION_CODE = "53342003"; // http://snomed.info/id/53342003
+                                                                    // "Internal nose structure"
 	// values pulled from https://github.com/CDCgov/prime-data-hub/blob/master/prime-router/metadata/valuesets/common.valuesets
 	private Map<String, String> genderMap = Map.of(
 		"male", "M",
@@ -434,7 +435,7 @@ public class TestEventExport {
 	@JsonProperty("Specimen_source_site_code")
 	public String getSpecimenSourceSiteCode() {
         return Optional.ofNullable(specimenType.getCollectionLocationCode())
-                .orElse(nasopharyngealStructureCode);
+                .orElse(DEFAULT_LOCATION_CODE);
 	}
 
 	@JsonProperty("Specimen_type_code")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -5,6 +5,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -12,6 +13,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
@@ -31,6 +33,7 @@ public class TestEventExport {
 	private AskOnEntrySurvey survey;
 	private Provider provider;
 	private Facility facility;
+    private SpecimenType specimenType;
 	private DeviceType device;
 
 	public TestEventExport(TestEvent testEvent) {
@@ -40,7 +43,8 @@ public class TestEventExport {
 		this.survey = testEvent.getSurveyData();
 		this.provider = testEvent.getProviderData();
 		this.facility = testEvent.getFacility();
-		this.device = testEvent.getDeviceType();
+        this.specimenType = testEvent.getDeviceSpecimen().getSpecimenType();
+		this.device = testEvent.getDeviceSpecimen().getDeviceType();
 	}
 
 	private String genderUnknown = "U";
@@ -429,12 +433,13 @@ public class TestEventExport {
 
 	@JsonProperty("Specimen_source_site_code")
 	public String getSpecimenSourceSiteCode() {
-		return nasopharyngealStructureCode;
+        return Optional.ofNullable(specimenType.getCollectionLocationCode())
+                .orElse(nasopharyngealStructureCode);
 	}
 
 	@JsonProperty("Specimen_type_code")
 	public String getSpecimenTypeCode() {
-		return device.getSwabType();
+        return specimenType.getTypeCode();
 	}
 
 	@JsonProperty("Instrument_ID")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -117,8 +117,7 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
           Translators.parseState(orderingProviderState),
           orderingProviderZipCode,
           Translators.parsePhoneNumber(orderingProviderTelephone),
-          deviceTypes.getConfiguredDeviceTypes(),
-          deviceTypes.getDefaultDeviceType()
+                deviceTypes
         );
         return new ApiFacility(facility);
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -60,8 +60,8 @@ public class InitialSetupProperties {
 
     public List<SpecimenType> getSpecimenTypes() {
         return specimenTypes.stream()
-                .map(d -> new SpecimenType(d.getName(), d.getTypeCode(), d.getCollectionLocationName(),
-                        d.getCollectionLocationCode()))
+                .map(s -> new SpecimenType(s.getName(), s.getTypeCode(), s.getCollectionLocationName(),
+                        s.getCollectionLocationCode()))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -89,8 +89,8 @@ public class InitialSetupProperties {
             this.email = email;
         }
 
-        public Facility makeRealFacility(Organization org, Provider p, DeviceSpecimen defaultDeviceSpec,
-                List<DeviceSpecimen> configured) {
+        public Facility makeRealFacility(Organization org, Provider p, DeviceSpecimenType defaultDeviceSpec,
+                List<DeviceSpecimenType> configured) {
             return new Facility(org, name, cliaNumber, address, telephone, email, p, defaultDeviceSpec, configured);
         }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -6,10 +6,12 @@ import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
@@ -19,6 +21,7 @@ public class InitialSetupProperties {
 
     private Organization organization;
     private Provider provider;
+    private List<SpecimenType> specimenTypes;
     private List<? extends DeviceType> deviceTypes;
     private List<String> configuredDeviceTypes;
     private ConfigFacility facility;
@@ -26,10 +29,12 @@ public class InitialSetupProperties {
     public InitialSetupProperties(Organization organization,
             ConfigFacility facility,
             Provider provider,
+            List<SpecimenType> specimenTypes,
             List<DeviceType> deviceTypes,
             List<String> configuredDeviceTypes) {
         this.organization = organization;
         this.provider = provider;
+        this.specimenTypes = specimenTypes;
         this.deviceTypes = deviceTypes;
         this.configuredDeviceTypes = configuredDeviceTypes;
         this.facility = facility;
@@ -53,7 +58,14 @@ public class InitialSetupProperties {
                 provider.getProviderId(), provider.getAddress(), provider.getTelephone());
     }
 
-    public List<? extends DeviceType> getDeviceTypes() {
+    public List<SpecimenType> getSpecimenTypes() {
+        return specimenTypes.stream()
+                .map(d -> new SpecimenType(d.getName(), d.getTypeCode(), d.getCollectionLocationName(),
+                        d.getCollectionLocationCode()))
+                .collect(Collectors.toList());
+    }
+
+    public List<DeviceType> getDeviceTypes() {
         return deviceTypes.stream()
             .map(d->new DeviceType(d.getName(), d.getManufacturer(), d.getModel(), d.getLoincCode(), d.getSwabType()))
             .collect(Collectors.toList())
@@ -77,9 +89,9 @@ public class InitialSetupProperties {
             this.email = email;
         }
 
-        public Facility makeRealFacility(Organization org, Provider p, DeviceType defaultDeviceType,
-                List<DeviceType> configured) {
-            Facility f = new Facility(org, name, cliaNumber, address, telephone, email, p, defaultDeviceType,
+        public Facility makeRealFacility(Organization org, Provider p, DeviceSpecimen defaultDeviceSpec,
+                List<DeviceSpecimen> configured) {
+            Facility f = new Facility(org, name, cliaNumber, address, telephone, email, p, defaultDeviceSpec,
                     configured);
             return f;
         }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -91,9 +91,7 @@ public class InitialSetupProperties {
 
         public Facility makeRealFacility(Organization org, Provider p, DeviceSpecimen defaultDeviceSpec,
                 List<DeviceSpecimen> configured) {
-            Facility f = new Facility(org, name, cliaNumber, address, telephone, email, p, defaultDeviceSpec,
-                    configured);
-            return f;
+            return new Facility(org, name, cliaNumber, address, telephone, email, p, defaultDeviceSpec, configured);
         }
 
         public String getName() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -33,7 +33,7 @@ public abstract class BaseTestInfo extends AuditedEntity
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "device_specimen_id")
-    private DeviceSpecimen deviceSpecimen;
+    private DeviceSpecimenType deviceSpecimen;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "device_type_id")
@@ -63,7 +63,7 @@ public abstract class BaseTestInfo extends AuditedEntity
         this(orig.getPatient(), orig.getFacility(), orig.getDeviceSpecimen(), orig.getResult());
     }
 
-    protected BaseTestInfo(Person patient, Facility facility, DeviceSpecimen deviceSpecimen, TestResult result) {
+    protected BaseTestInfo(Person patient, Facility facility, DeviceSpecimenType deviceSpecimen, TestResult result) {
         super();
         this.patient = patient;
         this.facility = facility;
@@ -101,7 +101,7 @@ public abstract class BaseTestInfo extends AuditedEntity
         return deviceType;
     }
 
-    public DeviceSpecimen getDeviceSpecimen() {
+    public DeviceSpecimenType getDeviceSpecimen() {
         return deviceSpecimen;
     }
 
@@ -125,7 +125,7 @@ public abstract class BaseTestInfo extends AuditedEntity
         result = newResult;
     }
 
-    protected void setDeviceSpecimen(DeviceSpecimen deviceSpecimen) {
+    protected void setDeviceSpecimen(DeviceSpecimenType deviceSpecimen) {
         this.deviceSpecimen = deviceSpecimen;
         this.deviceType = deviceSpecimen.getDeviceType();
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -32,6 +32,10 @@ public abstract class BaseTestInfo extends AuditedEntity
     private Facility facility;
 
     @ManyToOne(optional = false)
+    @JoinColumn(name = "device_specimen_id")
+    private DeviceSpecimen deviceSpecimen;
+
+    @ManyToOne(optional = false)
     @JoinColumn(name = "device_type_id")
     private DeviceType deviceType;
 
@@ -55,22 +59,27 @@ public abstract class BaseTestInfo extends AuditedEntity
         super();
     }
 
-    public BaseTestInfo(Person patient, Facility facility, DeviceType deviceType, TestResult result) {
+    protected BaseTestInfo(BaseTestInfo orig) {
+        this(orig.getPatient(), orig.getFacility(), orig.getDeviceSpecimen(), orig.getResult());
+    }
+
+    protected BaseTestInfo(Person patient, Facility facility, DeviceSpecimen deviceSpecimen, TestResult result) {
         super();
         this.patient = patient;
         this.facility = facility;
         this.organization = facility.getOrganization();
-        this.deviceType = deviceType;
+        this.deviceSpecimen = deviceSpecimen;
+        this.deviceType = deviceSpecimen.getDeviceType();
         this.result = result;
         this.correctionStatus = TestCorrectionStatus.ORIGINAL;
     }
 
     protected BaseTestInfo(Person patient, Facility facility) {
-        this(patient, facility, facility.getDefaultDeviceType(), null);
+        this(patient, facility, facility.getDefaultDeviceSpecimen(), null);
     }
 
     protected BaseTestInfo(BaseTestInfo cloneInfo, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
-        this(cloneInfo.patient, cloneInfo.facility, cloneInfo.deviceType, cloneInfo.result);
+        this(cloneInfo);
         this.reasonForCorrection = reasonForCorrection;
         this.correctionStatus = correctionStatus;
     }
@@ -90,6 +99,10 @@ public abstract class BaseTestInfo extends AuditedEntity
 
     public DeviceType getDeviceType() {
         return deviceType;
+    }
+
+    public DeviceSpecimen getDeviceSpecimen() {
+        return deviceSpecimen;
     }
 
     public TestResult getResult() {
@@ -112,8 +125,9 @@ public abstract class BaseTestInfo extends AuditedEntity
         result = newResult;
     }
 
-    protected void setDeviceType(DeviceType deviceType) {
-        this.deviceType = deviceType;
+    protected void setDeviceSpecimen(DeviceSpecimen deviceSpecimen) {
+        this.deviceSpecimen = deviceSpecimen;
+        this.deviceType = deviceSpecimen.getDeviceType();
     }
 
     public TestCorrectionStatus getCorrectionStatus() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -32,7 +32,7 @@ public abstract class BaseTestInfo extends AuditedEntity
     private Facility facility;
 
     @ManyToOne(optional = false)
-    @JoinColumn(name = "device_specimen_id")
+    @JoinColumn(name = "device_specimen_type_id")
     private DeviceSpecimenType deviceSpecimen;
 
     @ManyToOne(optional = false)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimen.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimen.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
@@ -9,17 +10,21 @@ import org.hibernate.annotations.NaturalId;
  * A valid combination of device and specimen types. Can be soft-deleted, but
  * cannot be otherwise modified.
  */
+@Entity
 public class DeviceSpecimen extends EternalEntity {
 
     @NaturalId
     @ManyToOne(optional = false)
-    @JoinColumn(name = "device_type_id", nullable = false)
+    @JoinColumn(name = "device_type_id", nullable = false, updatable = false)
     private DeviceType deviceType;
 
     @NaturalId
     @ManyToOne(optional = false)
-    @JoinColumn(name = "specimen_type_id", nullable = false)
+    @JoinColumn(name = "specimen_type_id", nullable = false, updatable = false)
     private SpecimenType specimenType;
+
+    protected DeviceSpecimen() {
+    } // for hibernate
 
     public DeviceSpecimen(DeviceType deviceType, SpecimenType specimenType) {
         this.deviceType = deviceType;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimen.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimen.java
@@ -1,0 +1,36 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.NaturalId;
+
+/**
+ * A valid combination of device and specimen types. Can be soft-deleted, but
+ * cannot be otherwise modified.
+ */
+public class DeviceSpecimen extends EternalEntity {
+
+    @NaturalId
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "device_type_id", nullable = false)
+    private DeviceType deviceType;
+
+    @NaturalId
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "specimen_type_id", nullable = false)
+    private SpecimenType specimenType;
+
+    public DeviceSpecimen(DeviceType deviceType, SpecimenType specimenType) {
+        this.deviceType = deviceType;
+        this.specimenType = specimenType;
+    }
+
+    public DeviceType getDeviceType() {
+        return deviceType;
+    }
+
+    public SpecimenType getSpecimenType() {
+        return specimenType;
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimenType.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.db.model;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 import org.hibernate.annotations.NaturalId;
 
@@ -12,7 +11,6 @@ import org.hibernate.annotations.NaturalId;
  * cannot be otherwise modified.
  */
 @Entity
-@Table(name = "device_specimen")
 public class DeviceSpecimenType extends EternalAuditedEntity {
 
     @NaturalId

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimenType.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.db.model;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 import org.hibernate.annotations.NaturalId;
 
@@ -11,7 +12,8 @@ import org.hibernate.annotations.NaturalId;
  * cannot be otherwise modified.
  */
 @Entity
-public class DeviceSpecimen extends EternalEntity {
+@Table(name = "device_specimen")
+public class DeviceSpecimenType extends EternalAuditedEntity {
 
     @NaturalId
     @ManyToOne(optional = false)
@@ -23,10 +25,10 @@ public class DeviceSpecimen extends EternalEntity {
     @JoinColumn(name = "specimen_type_id", nullable = false, updatable = false)
     private SpecimenType specimenType;
 
-    protected DeviceSpecimen() {
+    protected DeviceSpecimenType() {
     } // for hibernate
 
-    public DeviceSpecimen(DeviceType deviceType, SpecimenType specimenType) {
+    public DeviceSpecimenType(DeviceType deviceType, SpecimenType specimenType) {
         this.deviceType = deviceType;
         this.specimenType = specimenType;
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -119,14 +119,14 @@ public class Facility extends OrganizationScopedEternalEntity {
     public void removeDeviceType(DeviceType existingDevice) {
         Iterator<DeviceSpecimen> i = configuredDeviceSpecimens.iterator();
         UUID removedId = existingDevice.getInternalId();
+        if (defaultDeviceSpecimen != null
+                && defaultDeviceSpecimen.getDeviceType().getInternalId().equals(removedId)) {
+            defaultDeviceSpecimen = null;
+        }
         while (i != null && i.hasNext()) {
             DeviceType d = i.next().getDeviceType();
             if (d.getInternalId().equals(removedId)) {
                 i.remove();
-                if (defaultDeviceSpecimen != null
-                        && defaultDeviceSpecimen.getDeviceType().getInternalId().equals(removedId)) {
-                    defaultDeviceSpecimen = null;
-                }
                 break;
             }
         }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -43,7 +43,7 @@ public class Facility extends OrganizationScopedEternalEntity {
 
     @ManyToOne(optional = true)
     @JoinColumn(name = "default_device_specimen_id")
-    private DeviceSpecimen defaultDeviceSpecimen;
+    private DeviceSpecimenType defaultDeviceSpecimen;
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
@@ -51,13 +51,13 @@ public class Facility extends OrganizationScopedEternalEntity {
             joinColumns = @JoinColumn(name = "facility_id"),
             inverseJoinColumns = @JoinColumn(name = "device_specimen_id")
     )
-    private Set<DeviceSpecimen> configuredDeviceSpecimens = new HashSet<>();
+    private Set<DeviceSpecimenType> configuredDeviceSpecimenTypes = new HashSet<>();
 
     protected Facility() {/* for hibernate */}
 
 	public Facility(Organization org, String facilityName, String cliaNumber, StreetAddress facilityAddress,
-			String phone, String email, Provider orderingProvider, DeviceSpecimen defaultDeviceSpecimen,
-			List<DeviceSpecimen> configuredDeviceSpecimens) {
+			String phone, String email, Provider orderingProvider, DeviceSpecimenType defaultDeviceSpecimen,
+			List<DeviceSpecimenType> configuredDeviceSpecimens) {
 		super(org);
 		this.facilityName = facilityName;
 		this.cliaNumber = cliaNumber;
@@ -67,9 +67,9 @@ public class Facility extends OrganizationScopedEternalEntity {
 		this.orderingProvider = orderingProvider;
         this.defaultDeviceSpecimen = defaultDeviceSpecimen;
 		if (defaultDeviceSpecimen != null) {
-            this.configuredDeviceSpecimens.add(defaultDeviceSpecimen);
+            this.configuredDeviceSpecimenTypes.add(defaultDeviceSpecimen);
 		}
-        this.configuredDeviceSpecimens.addAll(configuredDeviceSpecimens);
+        this.configuredDeviceSpecimenTypes.addAll(configuredDeviceSpecimens);
 	}
 
 	public void setFacilityName(String facilityName) {
@@ -80,7 +80,7 @@ public class Facility extends OrganizationScopedEternalEntity {
 		return facilityName;
 	}
 
-    public DeviceSpecimen getDefaultDeviceSpecimen() {
+    public DeviceSpecimenType getDefaultDeviceSpecimen() {
         return defaultDeviceSpecimen;
     }
 
@@ -90,34 +90,34 @@ public class Facility extends OrganizationScopedEternalEntity {
 
 	public List<DeviceType> getDeviceTypes() {
 		// this might be better done on the DB side, but that seems like a recipe for weird behaviors
-        return configuredDeviceSpecimens.stream()
+        return configuredDeviceSpecimenTypes.stream()
 			.filter(e -> !e.isDeleted())
-                .map(DeviceSpecimen::getDeviceType)
+                .map(DeviceSpecimenType::getDeviceType)
                 .filter(e -> !e.isDeleted())
 			.collect(Collectors.toList());
 	}
 
-    public List<DeviceSpecimen> getDeviceSpecimens() {
-        return configuredDeviceSpecimens.stream()
+    public List<DeviceSpecimenType> getDeviceSpecimenTypes() {
+        return configuredDeviceSpecimenTypes.stream()
                 .filter(e -> !(e.isDeleted() || e.getSpecimenType().isDeleted() || e.getDeviceType().isDeleted()))
                 .collect(Collectors.toList());
     }
 
-    public void addDeviceSpecimen(DeviceSpecimen ds) {
-        configuredDeviceSpecimens.add(ds);
+    public void addDeviceSpecimenType(DeviceSpecimenType ds) {
+        configuredDeviceSpecimenTypes.add(ds);
     }
 
-    public void addDefaultDeviceSpecimen(DeviceSpecimen newDefault) {
-        addDeviceSpecimen(newDefault);
+    public void addDefaultDeviceSpecimen(DeviceSpecimenType newDefault) {
+        addDeviceSpecimenType(newDefault);
         defaultDeviceSpecimen = newDefault;
     }
 
-    public void removeDeviceSpecimen(DeviceSpecimen existing) {
-        configuredDeviceSpecimens.remove(existing); // count on this being in one hibernate session
+    public void removeDeviceSpecimenType(DeviceSpecimenType existing) {
+        configuredDeviceSpecimenTypes.remove(existing); // count on this being in one hibernate session
     }
 
     public void removeDeviceType(DeviceType existingDevice) {
-        Iterator<DeviceSpecimen> i = configuredDeviceSpecimens.iterator();
+        Iterator<DeviceSpecimenType> i = configuredDeviceSpecimenTypes.iterator();
         UUID removedId = existingDevice.getInternalId();
         if (defaultDeviceSpecimen != null
                 && defaultDeviceSpecimen.getDeviceType().getInternalId().equals(removedId)) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -42,14 +42,14 @@ public class Facility extends OrganizationScopedEternalEntity {
 	private Provider orderingProvider;
 
     @ManyToOne(optional = true)
-    @JoinColumn(name = "default_device_specimen_id")
+    @JoinColumn(name = "default_device_specimen_type_id")
     private DeviceSpecimenType defaultDeviceSpecimen;
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
-            name = "facility_device_specimen",
+            name = "facility_device_specimen_type",
             joinColumns = @JoinColumn(name = "facility_id"),
-            inverseJoinColumns = @JoinColumn(name = "device_specimen_id")
+            inverseJoinColumns = @JoinColumn(name = "device_specimen_type_id")
     )
     private Set<DeviceSpecimenType> configuredDeviceSpecimenTypes = new HashSet<>();
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -51,7 +51,19 @@ public class Facility extends OrganizationScopedEternalEntity {
 	)
 	private Set<DeviceType> configuredDevices = new HashSet<>();
 
-	protected Facility() {/* for hibernate */}
+    @ManyToOne(optional = true)
+    @JoinColumn(name = "default_device_specimen_id")
+    private DeviceSpecimen defaultDeviceSpecimen;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "facility_device_specimen",
+            joinColumns = @JoinColumn(name = "facility_id"),
+            inverseJoinColumns = @JoinColumn(name = "device_specimen_id")
+    )
+    private Set<DeviceSpecimen> configuredDeviceSpecimens = new HashSet<>();
+
+    protected Facility() {/* for hibernate */}
 
 	public Facility(Organization org, String facilityName, String cliaNumber, StreetAddress facilityAddress,
 			String phone, String email, Provider orderingProvider, DeviceType defaultDeviceType,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -88,10 +88,6 @@ public class Facility extends OrganizationScopedEternalEntity {
         return defaultDeviceSpecimen == null ? null : defaultDeviceSpecimen.getDeviceType();
 	}
 
-	public void setDefaultDeviceType(DeviceType defaultDeviceType) {
-        throw new IllegalArgumentException();
-	}
-
 	public List<DeviceType> getDeviceTypes() {
 		// this might be better done on the DB side, but that seems like a recipe for weird behaviors
         return configuredDeviceSpecimens.stream()

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
@@ -14,7 +14,7 @@ import gov.cdc.usds.simplereport.validators.RequiredNumericCode;
  * {@link DeviceType}s.
  */
 @Entity
-public class SpecimenType extends EternalEntity {
+public class SpecimenType extends EternalAuditedEntity {
 
     @Column(nullable = false)
     private String name;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
@@ -1,8 +1,10 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import javax.persistence.Column;
+import javax.persistence.Entity;
 
 import org.hibernate.annotations.NaturalId;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 import gov.cdc.usds.simplereport.validators.NumericCode;
 import gov.cdc.usds.simplereport.validators.RequiredNumericCode;
@@ -11,6 +13,7 @@ import gov.cdc.usds.simplereport.validators.RequiredNumericCode;
  * A SNOMED-registered specimen type that can be used by one or more
  * {@link DeviceType}s.
  */
+@Entity
 public class SpecimenType extends EternalEntity {
 
     @Column(nullable = false)
@@ -30,6 +33,7 @@ public class SpecimenType extends EternalEntity {
 
     protected SpecimenType() {} // for hibernate
 
+    @ConstructorBinding
     public SpecimenType(String name, String typeCode, String collectionLocationName, String collectionLocationCode) {
         this(name, typeCode);
         this.collectionLocationName = collectionLocationName;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
@@ -1,0 +1,81 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.Column;
+
+import org.hibernate.annotations.NaturalId;
+
+import gov.cdc.usds.simplereport.validators.NumericCode;
+import gov.cdc.usds.simplereport.validators.RequiredNumericCode;
+
+/**
+ * A SNOMED-registered specimen type that can be used by one or more
+ * {@link DeviceType}s.
+ */
+public class SpecimenType extends EternalEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, updatable = false)
+    @RequiredNumericCode
+    @NaturalId
+    private String typeCode;
+
+    @Column
+    private String collectionLocationName;
+
+    @Column
+    @NumericCode
+    private String collectionLocationCode;
+
+    protected SpecimenType() {} // for hibernate
+
+    public SpecimenType(String name, String typeCode, String collectionLocationName, String collectionLocationCode) {
+        this(name, typeCode);
+        this.collectionLocationName = collectionLocationName;
+        this.collectionLocationCode = collectionLocationCode;
+    }
+
+    public SpecimenType(String name, String typeCode) {
+        this.name = name;
+        this.typeCode = typeCode;
+    }
+
+    /**
+     * The human readable name for this specimen type (e.g. "swab of interior nose")
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /** The SNOMED code for this specimen type */
+    public String getTypeCode() {
+        return typeCode;
+    }
+
+    /**
+     * The human-readable name for the specimen collection location (e.g. "nasal
+     * structure", which is probably redundant)
+     */
+    public String getCollectionLocationName() {
+        return collectionLocationName;
+    }
+
+    public void setCollectionLocationName(String collectionLocation) {
+        this.collectionLocationName = collectionLocation;
+    }
+
+    /** The SNOMED code for this specimen type */
+    public String getCollectionLocationCode() {
+        return collectionLocationCode;
+    }
+
+    public void setCollectionLocationCode(String collectionLocationCode) {
+        this.collectionLocationCode = collectionLocationCode;
+    }
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -46,37 +46,35 @@ public class TestEvent extends BaseTestInfo {
 
 	public TestEvent() {}
 
-	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Facility facility, TestOrder order) {
-		super(patient, facility, deviceType, result);
-		// store a link, and *also* store the object as JSON
-		this.patientData = getPatient();
-		this.providerData = getFacility().getOrderingProvider();
-		this.order = order;
-		super.setDateTestedBackdate(order.getDateTestedBackdate());
-		PatientAnswers answers = order.getAskOnEntrySurvey();
-		if (answers != null) {
-			this.surveyData = order.getAskOnEntrySurvey().getSurvey();
-		} else {
-			// this can happen during unit tests, but never in prod.
-			LOG.error("Order {} missing PatientAnswers", order.getInternalId());
-		}
-	}
+    public TestEvent(TestResult result, DeviceSpecimen deviceType, Person patient, Facility facility, TestOrder order) {
+        super(patient, facility, deviceType, result);
+        // store a link, and *also* store the object as JSON
+        this.patientData = getPatient();
+        this.providerData = getFacility().getOrderingProvider();
+        this.order = order;
+        super.setDateTestedBackdate(order.getDateTestedBackdate());
+        PatientAnswers answers = order.getAskOnEntrySurvey();
+        if (answers != null) {
+            this.surveyData = order.getAskOnEntrySurvey().getSurvey();
+        } else {
+            // this can happen during unit tests, but never in prod.
+            LOG.error("Order {} missing PatientAnswers", order.getInternalId());
+        }
+    }
 
-	public TestEvent(TestOrder order) {
-		this(order.getResult(), order.getDeviceType(), order.getPatient(), order.getFacility(), order);
+    public TestEvent(TestOrder order) {
+        this(order.getResult(), order.getDeviceSpecimen(), order.getPatient(), order.getFacility(), order);
 	}
 
 	// Constructor for creating corrections. Copy the original event
 	public TestEvent(TestEvent event, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
 		super(event, correctionStatus, reasonForCorrection);
 
-		this.order = event.getTestOrder();
 		this.patientData = event.getPatientData();
 		this.providerData = event.getProviderData();
 		this.order = event.getTestOrder();
-		// this.patient_answers_data =
 		this.surveyData = event.getSurveyData();
-		super.setDateTestedBackdate(order.getDateTestedBackdate());
+        setDateTestedBackdate(order.getDateTestedBackdate());
 		this.priorCorrectedTestEventId = event.getInternalId();
 	}
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -46,7 +46,7 @@ public class TestEvent extends BaseTestInfo {
 
 	public TestEvent() {}
 
-    public TestEvent(TestResult result, DeviceSpecimen deviceType, Person patient, Facility facility, TestOrder order) {
+    public TestEvent(TestResult result, DeviceSpecimenType deviceType, Person patient, Facility facility, TestOrder order) {
         super(patient, facility, deviceType, result);
         // store a link, and *also* store the object as JSON
         this.patientData = getPatient();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -52,7 +52,7 @@ public class TestEvent extends BaseTestInfo {
         this.patientData = getPatient();
         this.providerData = getFacility().getOrderingProvider();
         this.order = order;
-        super.setDateTestedBackdate(order.getDateTestedBackdate());
+        setDateTestedBackdate(order.getDateTestedBackdate());
         PatientAnswers answers = order.getAskOnEntrySurvey();
         if (answers != null) {
             this.surveyData = order.getAskOnEntrySurvey().getSurvey();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -64,7 +64,7 @@ public class TestOrder extends BaseTestInfo {
 	}
 
     @Override
-    public void setDeviceSpecimen(DeviceSpecimen ds) {
+    public void setDeviceSpecimen(DeviceSpecimenType ds) {
         super.setDeviceSpecimen(ds);
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -63,6 +63,11 @@ public class TestOrder extends BaseTestInfo {
 		return askOnEntrySurvey;
 	}
 
+    @Override
+    public void setDeviceSpecimen(DeviceSpecimen ds) {
+        super.setDeviceSpecimen(ds);
+    }
+
 	@Override
 	public void setDateTestedBackdate(Date date) {
 		super.setDateTestedBackdate(date);
@@ -128,11 +133,6 @@ public class TestOrder extends BaseTestInfo {
 
 	public Boolean getNoSymptoms() {
 		return askOnEntrySurvey.getSurvey().getNoSymptoms();
-	}
-
-	@Override
-	public void setDeviceType(DeviceType deviceType) {
-		super.setDeviceType(deviceType);
 	}
 
 	// this will eventually be used when corrections are put back into the queue to

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
@@ -24,6 +24,7 @@ public interface DeviceSpecimenRepository extends EternalEntityRepository<Device
 
     // INSTA-DEPRECATION: this should only be used until we fix the API to not need
     // it
+    @Deprecated
     @EntityGraph(attributePaths = { "deviceType", "specimenType" })
     public Optional<DeviceSpecimen> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId); // IGNORES
                                                                                                         // DELETION

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
@@ -1,0 +1,17 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
+
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+
+public interface DeviceSpecimenRepository extends EternalEntityRepository<DeviceSpecimen> {
+
+    @Override
+    @EntityGraph(attributePaths = { "deviceType", "specimenType" })
+    @Query(BASE_QUERY + " and e.deviceType.isDeleted = false and e.specimenType.isDeleted = false")
+    public List<DeviceSpecimen> findAll();
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenRepository.java
@@ -1,11 +1,15 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 
 public interface DeviceSpecimenRepository extends EternalEntityRepository<DeviceSpecimen> {
 
@@ -13,5 +17,15 @@ public interface DeviceSpecimenRepository extends EternalEntityRepository<Device
     @EntityGraph(attributePaths = { "deviceType", "specimenType" })
     @Query(BASE_QUERY + " and e.deviceType.isDeleted = false and e.specimenType.isDeleted = false")
     public List<DeviceSpecimen> findAll();
+
+    @EntityGraph(attributePaths = { "deviceType", "specimenType" })
+    @Query(BASE_QUERY + " and e.deviceType = :deviceType and e.specimenType = :specimenType")
+    public Optional<DeviceSpecimen> find(DeviceType deviceType, SpecimenType specimenType);
+
+    // INSTA-DEPRECATION: this should only be used until we fix the API to not need
+    // it
+    @EntityGraph(attributePaths = { "deviceType", "specimenType" })
+    public Optional<DeviceSpecimen> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId); // IGNORES
+                                                                                                        // DELETION
 
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
@@ -7,26 +7,26 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 
-public interface DeviceSpecimenRepository extends EternalEntityRepository<DeviceSpecimen> {
+public interface DeviceSpecimenTypeRepository extends EternalAuditedEntityRepository<DeviceSpecimenType> {
 
     @Override
     @EntityGraph(attributePaths = { "deviceType", "specimenType" })
     @Query(BASE_QUERY + " and e.deviceType.isDeleted = false and e.specimenType.isDeleted = false")
-    public List<DeviceSpecimen> findAll();
+    public List<DeviceSpecimenType> findAll();
 
     @EntityGraph(attributePaths = { "deviceType", "specimenType" })
     @Query(BASE_QUERY + " and e.deviceType = :deviceType and e.specimenType = :specimenType")
-    public Optional<DeviceSpecimen> find(DeviceType deviceType, SpecimenType specimenType);
+    public Optional<DeviceSpecimenType> find(DeviceType deviceType, SpecimenType specimenType);
 
     // INSTA-DEPRECATION: this should only be used until we fix the API to not need
     // it
     @Deprecated
     @EntityGraph(attributePaths = { "deviceType", "specimenType" })
-    public Optional<DeviceSpecimen> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId); // IGNORES
+    public Optional<DeviceSpecimenType> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId); // IGNORES
                                                                                                         // DELETION
 
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
@@ -6,6 +6,8 @@ import gov.cdc.usds.simplereport.db.model.SpecimenType;
 
 public interface SpecimenTypeRepository extends EternalEntityRepository<SpecimenType> {
 
+    @Deprecated // this doesn't check for soft-deletion! But we need that behavior for the
+                // backward-compatibility shim code.
     Optional<SpecimenType> findByTypeCode(String swabType);
 
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
@@ -1,7 +1,11 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import java.util.Optional;
+
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 
 public interface SpecimenTypeRepository extends EternalEntityRepository<SpecimenType> {
+
+    Optional<SpecimenType> findByTypeCode(String swabType);
 
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 
-public interface SpecimenTypeRepository extends EternalEntityRepository<SpecimenType> {
+public interface SpecimenTypeRepository extends EternalAuditedEntityRepository<SpecimenType> {
 
     @Deprecated // this doesn't check for soft-deletion! But we need that behavior for the
                 // backward-compatibility shim code.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
@@ -1,0 +1,7 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
+
+public interface SpecimenTypeRepository extends EternalEntityRepository<SpecimenType> {
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -51,6 +51,12 @@ public class DeviceTypeService {
         return _repo.findById(actualId).orElseThrow(()->new IllegalGraphqlArgumentException("invalid device type ID"));
     }
 
+    /**
+     * Find the original device/specimen type combination created for this
+     * DeviceType, since that will be the one that is assumed by callers who aren't
+     * aware that you can have multiple specimen types for a given device type.
+     */
+    @Deprecated // this is a backward-compatibility shim!
     public DeviceSpecimen getDefaultForDeviceId(String deviceId) {
         UUID actualDeviceId = UUID.fromString(deviceId);
         return _deviceSpecimenRepo.findFirstByDeviceTypeInternalIdOrderByCreatedAt(actualDeviceId).orElseThrow(
@@ -95,6 +101,7 @@ public class DeviceTypeService {
         String loincCode,
         String swabType
     ) {
+        @SuppressWarnings("deprecation") // this is a shim
         SpecimenType st = _specimenTypeRepo.findByTypeCode(swabType).orElseGet(
                 () -> _specimenTypeRepo.save(new SpecimenType("Auto-generated " + swabType, swabType)));
         if (st.isDeleted()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -15,14 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
@@ -50,7 +50,7 @@ public class OrganizationInitializingService {
 	@Autowired
     private SpecimenTypeRepository _specimenTypeRepo;
     @Autowired
-    private DeviceSpecimenRepository _deviceSpecimenRepo;
+    private DeviceSpecimenTypeRepository _deviceSpecimenRepo;
     @Autowired
 	private FacilityRepository _facilityRepo;
 	@Autowired
@@ -87,7 +87,7 @@ public class OrganizationInitializingService {
             specimenTypesByCode.put(specimenType.getTypeCode(), specimenType);
         }
 
-        Map<String, DeviceSpecimen> dsForDeviceName = new HashMap<>();
+        Map<String, DeviceSpecimenType> dsForDeviceName = new HashMap<>();
         for (DeviceType d : _props.getDeviceTypes()) {
 			DeviceType deviceType = byName.get(d.getName());
 			if (null == deviceType) {
@@ -99,19 +99,19 @@ public class OrganizationInitializingService {
             if (defaultTypeForDevice == null) {
                 throw new RuntimeException("specimen type " + deviceType.getSwabType() + " was not initialized");
             }
-            Optional<DeviceSpecimen> deviceSpecimen = _deviceSpecimenRepo.find(deviceType, defaultTypeForDevice);
+            Optional<DeviceSpecimenType> deviceSpecimen = _deviceSpecimenRepo.find(deviceType, defaultTypeForDevice);
             if (deviceSpecimen.isEmpty()) {
                 dsForDeviceName.put(deviceType.getName(),
-                        _deviceSpecimenRepo.save(new DeviceSpecimen(deviceType, defaultTypeForDevice)));
+                        _deviceSpecimenRepo.save(new DeviceSpecimenType(deviceType, defaultTypeForDevice)));
             } else {
                 dsForDeviceName.put(deviceType.getName(), deviceSpecimen.get());
             }
 		}
 
-        List<DeviceSpecimen> configured = _props.getConfiguredDeviceTypeNames().stream()
+        List<DeviceSpecimenType> configured = _props.getConfiguredDeviceTypeNames().stream()
                 .map(dsForDeviceName::get)
 				.collect(Collectors.toList());
-        DeviceSpecimen defaultDeviceSpecimen = configured.get(0);
+        DeviceSpecimenType defaultDeviceSpecimen = configured.get(0);
 
 		LOG.info("Creating organization {}", emptyOrg.getOrganizationName());
 		Organization realOrg = _orgRepo.save(emptyOrg);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -84,7 +84,6 @@ public class OrganizationInitializingService {
                 specimenTypesByName.put(specimenType.getName(), specimenType);
             }
         }
-        SpecimenType defaultSpecimenType = specimenTypesByName.get(_props.getSpecimenTypes().get(0).getName());
 		for (DeviceType d : _props.getDeviceTypes()) {
 			DeviceType deviceType = byName.get(d.getName());
 			if (null == deviceType) {
@@ -92,10 +91,11 @@ public class OrganizationInitializingService {
 				deviceType = _deviceTypeRepo.save(d);
 				byName.put(deviceType.getName(), deviceType);
 			}
-            Optional<DeviceSpecimen> deviceSpecimens = _deviceSpecimenRepo
-                    .findFirstByDeviceTypeInternalIdOrderByCreatedAt(deviceType.getInternalId());
+            SpecimenType defaultTypeForDevice = _specimenTypeRepo.findByTypeCode(d.getSwabType())
+                    .orElseThrow(() -> new IllegalArgumentException("No specimen type with code " + d.getSwabType()));
+            Optional<DeviceSpecimen> deviceSpecimens = _deviceSpecimenRepo.find(d, defaultTypeForDevice);
             if (deviceSpecimens.isEmpty()) {
-                _deviceSpecimenRepo.save(new DeviceSpecimen(deviceType, defaultSpecimenType));
+                _deviceSpecimenRepo.save(new DeviceSpecimen(deviceType, defaultTypeForDevice));
             }
 		}
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -15,7 +15,7 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
@@ -173,13 +173,13 @@ public class OrganizationService {
         a.setPostalCode(orderingProviderZipCode);
         p.setAddress(a);
 
-        for (DeviceSpecimen ds : deviceHolder.getConfiguredDeviceTypes()) {
-            facility.addDeviceSpecimen(ds);
+        for (DeviceSpecimenType ds : deviceHolder.getConfiguredDeviceTypes()) {
+            facility.addDeviceSpecimenType(ds);
         }
         // remove all existing devices
-        for (DeviceSpecimen ds : facility.getDeviceSpecimens()) {
+        for (DeviceSpecimenType ds : facility.getDeviceSpecimenTypes()) {
             if (!deviceHolder.getConfiguredDeviceTypes().contains(ds)) {
-                facility.removeDeviceSpecimen(ds);
+                facility.removeDeviceSpecimenType(ds);
             }
         }
         facility.addDefaultDeviceSpecimen(deviceHolder.getDefaultDeviceType());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
@@ -104,7 +104,7 @@ public class TestOrderService {
   @AuthorizationConfiguration.RequirePermissionSubmitTest
   @Deprecated // switch to using device specimen ID, using methods that ... don't exist yet!
   public void addTestResult(String deviceID, TestResult result, String patientId, Date dateTested) {
-      DeviceSpecimen deviceSpecimen = _dts.getDefaultForDeviceId(deviceID);
+      DeviceSpecimenType deviceSpecimen = _dts.getDefaultForDeviceId(deviceID);
     Organization org = _os.getCurrentOrganization();
     Person person = _ps.getPatient(patientId, org);
     TestOrder order = _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
@@ -90,8 +90,7 @@ public class TestOrderService {
     TestOrder order = this.getTestOrder(id);
 
     if (deviceId != null) {
-      DeviceType deviceType = _dts.getDeviceType(deviceId);
-      order.setDeviceType(deviceType);
+        order.setDeviceSpecimen(_dts.getDefaultForDeviceId(deviceId));
     }
 
     order.setResult(result == null ? null : TestResult.valueOf(result));
@@ -103,11 +102,11 @@ public class TestOrderService {
 
   @AuthorizationConfiguration.RequirePermissionSubmitTest
   public void addTestResult(String deviceID, TestResult result, String patientId, Date dateTested) {
-    DeviceType deviceType = _dts.getDeviceType(deviceID);
+      DeviceSpecimen deviceType = _dts.getDefaultForDeviceId(deviceID);
     Organization org = _os.getCurrentOrganization();
     Person person = _ps.getPatient(patientId, org);
     TestOrder order = _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
-    order.setDeviceType(deviceType);
+    order.setDeviceSpecimen(deviceType);
     order.setResult(result);
     order.setDateTestedBackdate(dateTested);
     order.markComplete();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -86,6 +86,7 @@ public class TestOrderService {
   }
 
   @AuthorizationConfiguration.RequirePermissionUpdateTest
+  @Deprecated // switch to specifying device-specimen combo
   public TestOrder editQueueItem(String id, String deviceId, String result, Date dateTested) {
     TestOrder order = this.getTestOrder(id);
 
@@ -101,12 +102,13 @@ public class TestOrderService {
   }
 
   @AuthorizationConfiguration.RequirePermissionSubmitTest
+  @Deprecated // switch to using device specimen ID, using methods that ... don't exist yet!
   public void addTestResult(String deviceID, TestResult result, String patientId, Date dateTested) {
-      DeviceSpecimen deviceType = _dts.getDefaultForDeviceId(deviceID);
+      DeviceSpecimen deviceSpecimen = _dts.getDefaultForDeviceId(deviceID);
     Organization org = _os.getCurrentOrganization();
     Person person = _ps.getPatient(patientId, org);
     TestOrder order = _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
-    order.setDeviceSpecimen(deviceType);
+    order.setDeviceSpecimen(deviceSpecimen);
     order.setResult(result);
     order.setDateTestedBackdate(dateTested);
     order.markComplete();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/DeviceTypeHolder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/DeviceTypeHolder.java
@@ -3,24 +3,24 @@ package gov.cdc.usds.simplereport.service.model;
 import java.util.Collections;
 import java.util.List;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 
 public class DeviceTypeHolder {
 
-    private DeviceSpecimen _defaultDeviceType;
-    private List<DeviceSpecimen> _allDeviceTypes;
+    private DeviceSpecimenType _defaultDeviceType;
+    private List<DeviceSpecimenType> _allDeviceTypes;
 
-    public DeviceTypeHolder(DeviceSpecimen defaultType, List<DeviceSpecimen> configuredTypes) {
+    public DeviceTypeHolder(DeviceSpecimenType defaultType, List<DeviceSpecimenType> configuredTypes) {
 		super();
 		this._defaultDeviceType = defaultType;
 		this._allDeviceTypes = Collections.unmodifiableList(configuredTypes);
 	}
 
-    public DeviceSpecimen getDefaultDeviceType() {
+    public DeviceSpecimenType getDefaultDeviceType() {
 		return _defaultDeviceType;
 	}
 
-    public List<DeviceSpecimen> getConfiguredDeviceTypes() {
+    public List<DeviceSpecimenType> getConfiguredDeviceTypes() {
 		return _allDeviceTypes;
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/DeviceTypeHolder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/DeviceTypeHolder.java
@@ -3,23 +3,24 @@ package gov.cdc.usds.simplereport.service.model;
 import java.util.Collections;
 import java.util.List;
 
-import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
 
 public class DeviceTypeHolder {
 
-	private DeviceType _defaultDeviceType;
-	private List<DeviceType> _allDeviceTypes;
-	public DeviceTypeHolder(DeviceType defaultType, List<DeviceType> configuredTypes) {
+    private DeviceSpecimen _defaultDeviceType;
+    private List<DeviceSpecimen> _allDeviceTypes;
+
+    public DeviceTypeHolder(DeviceSpecimen defaultType, List<DeviceSpecimen> configuredTypes) {
 		super();
 		this._defaultDeviceType = defaultType;
 		this._allDeviceTypes = Collections.unmodifiableList(configuredTypes);
 	}
 
-	public DeviceType getDefaultDeviceType() {
+    public DeviceSpecimen getDefaultDeviceType() {
 		return _defaultDeviceType;
 	}
 
-	public List<DeviceType> getConfiguredDeviceTypes() {
+    public List<DeviceSpecimen> getConfiguredDeviceTypes() {
 		return _allDeviceTypes;
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/NumericCode.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/NumericCode.java
@@ -12,7 +12,6 @@ import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
@@ -23,7 +22,6 @@ import javax.validation.constraints.Size;
  */
 
 @Constraint(validatedBy = {})
-@NotNull
 @Pattern(regexp = "\\d+")
 @Size(min = NumericCode.MIN_DIGITS)
 @Documented

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/NumericCode.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/NumericCode.java
@@ -17,19 +17,28 @@ import javax.validation.constraints.Size;
 
 /**
  * A constraint to force a value to be a nullable numeric string of length at
- * least 8 (adjust this value up or down if it turns out that is not the minimum
- * length for valid CLIA numbers and SNOMED codes).
+ * between 6 and 32 (adjust these values up or down if it turns out that is not
+ * the minimum length for valid CLIA numbers and SNOMED codes).
  */
 
 @Constraint(validatedBy = {})
 @Pattern(regexp = "\\d+")
-@Size(min = NumericCode.MIN_DIGITS)
+@Size(min = NumericCode.MIN_DIGITS, max = NumericCode.MAX_DIGITS)
 @Documented
 @Retention(RUNTIME)
 @Target({ FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE })
 public @interface NumericCode {
 
-    public static final int MIN_DIGITS = 8;
+    /**
+     * The minimum length of a numeric code string. Set to what we believe is the
+     * minimum value for a SNOMED code.
+     */
+    public static final int MIN_DIGITS = 6;
+    /**
+     * The maximum length of a numeric code string. We believe this to be wildly
+     * generous, since as far as we know SNOMED codes top out at 18 characters.
+     */
+    public static final int MAX_DIGITS = 32;
 
     Class<?>[] groups() default {};
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/NumericCode.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/NumericCode.java
@@ -1,0 +1,42 @@
+package gov.cdc.usds.simplereport.validators;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+/**
+ * A constraint to force a value to be a nullable numeric string of length at
+ * least 8 (adjust this value up or down if it turns out that is not the minimum
+ * length for valid CLIA numbers and SNOMED codes).
+ */
+
+@Constraint(validatedBy = {})
+@NotNull
+@Pattern(regexp = "\\d+")
+@Size(min = NumericCode.MIN_DIGITS)
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE })
+public @interface NumericCode {
+
+    public static final int MIN_DIGITS = 8;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String message() default "Parameter must be a numeric code string";
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/RequiredNumericCode.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/RequiredNumericCode.java
@@ -1,0 +1,32 @@
+package gov.cdc.usds.simplereport.validators;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+
+/**
+ * A constraint to force a value to be a non-null numeric string of length at
+ * least 8 (adjust this value up or down if it turns out that is not the minimum
+ * length for valid CLIA numbers and SNOMED codes).
+ */
+@Constraint(validatedBy = { })
+@NotNull
+@NumericCode
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, LOCAL_VARIABLE })
+public @interface RequiredNumericCode {
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String message() default "Parameter must be a non-null numeric code string";
+}

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,43 +1,8 @@
 {"properties": [
   {
-    "name": "simple-report-initialization.organization.org-name",
-    "type": "java.lang.String",
-    "description": "The human-readable name for the organization"
-  },
-  {
-    "name": "simple-report-initialization.organization.external-id",
-    "type": "java.lang.String",
-    "description": "Durable external ID (for authorization management) of the organization"
-  },
-  {
-    "name": "simple-report-initialization.configured-device-types",
-    "type": "java.util.List<java.lang.String>",
-    "description": "The devices to be configured at the default facility"
-  },
-  {
-    "name": "simple-report-initialization.provider",
-    "type": "gov.cdc.usds.simplereport.db.model.Provider",
-    "description": "The ordering provider'"
-  },
-  {
-    "name": "simple-report-initialization.facility.address",
-    "type": "gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress",
-    "description": "facility address'"
-  },
-  {
-    "name": "simple-report-initialization.provider.address",
-    "type": "gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress",
-    "description": "The street address of the ordering provider"
-  },
-  {
-    "name": "simple-report-initialization.device-types",
-    "type": "java.util.List<gov.cdc.usds.simplereport.db.model.DeviceType>",
-    "description": "A description for 'simple-report-initialization.device-types'"
-  },
-  {
-    "name": "simple-report.authorization.role-claim",
-    "type": "java.lang.String",
-    "description": "A description for 'simple-report.authorization.role-claim'"
+    "name": "simple-report-initialization",
+    "type": "gov.cdc.usds.simplereport.config.InitialSetupProperties",
+    "description": "The full configuration for initial setup on a blank database."
   },
   {
     "name": "simple-report.data-hub",
@@ -46,8 +11,8 @@
   },
   {
     "name": "simple-report.authorization",
-    "type": "gov.cdc.usds.simplereport.config.AuthorizationConfiguration",
-    "description": "A description for 'simple-report.authorization.superuser-claim'"
+    "type": "gov.cdc.usds.simplereport.config.AuthorizationProperties",
+    "description": "Properties for configuring authorization claims mapping from the IDP"
   },
   {
     "name": "graphql.datetime.scalars",

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -26,7 +26,7 @@ simple-report-initialization:
       type-code: "445297001"
       collection-location-name: Internal nose structure
     - name: Nasopharyngeal swab
-      type-code: 258500001
+      type-code: "258500001"
       collection-location-name: Nasopharyngeal structure
       collection-location-code: "71836000"
   device-types:

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -21,6 +21,11 @@ simple-report-initialization:
   configured-device-types:
     - LumiraDX
     - Quidel Sofia 2
+  specimen-types:
+    - name: Swab of the Nose
+      type-code: "445297001"
+      collection-location-name: "NOSE"
+      collection-location-code: "71836000"
   device-types:
     - name: Abbott IDNow
       manufacturer: Abbott

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -24,7 +24,7 @@ simple-report-initialization:
   specimen-types:
     - name: Swab of internal nose
       type-code: "445297001"
-      collection-location-name: Nasal structure
+      collection-location-name: Internal nose structure
     - name: Nasopharyngeal swab
       type-code: 258500001
       collection-location-name: Nasopharyngeal structure

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -22,9 +22,12 @@ simple-report-initialization:
     - LumiraDX
     - Quidel Sofia 2
   specimen-types:
-    - name: Swab of the Nose
+    - name: Swab of internal nose
       type-code: "445297001"
-      collection-location-name: "NOSE"
+      collection-location-name: Nasal structure
+    - name: Nasopharyngeal swab
+      type-code: 258500001
+      collection-location-name: Nasopharyngeal structure
       collection-location-code: "71836000"
   device-types:
     - name: Abbott IDNow

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1253,7 +1253,7 @@ databaseChangeLog:
                   remarks: The SNOMED code for the collection location of this specimen type.
                   type: *string
         - createTable:
-            tableName: device_specimen
+            tableName: device_specimen_type
             remarks: A usable combination of device type and specimen type.
             columns:
               - column: *pk_column
@@ -1268,7 +1268,7 @@ databaseChangeLog:
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__device_specimen__device_type
+                    foreignKeyName: fk__device_specimen_type__device_type
                     references: device_type
               - column:
                   name: specimen_type_id
@@ -1276,14 +1276,14 @@ databaseChangeLog:
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__device_specimen__specimen_type
+                    foreignKeyName: fk__device_specimen_type__specimen_type
                     references: specimen_type
         - addUniqueConstraint:
-            tableName: device_specimen
-            constraintName: uk__device_specimen
+            tableName: device_specimen_type
+            constraintName: uk__device_specimen_type
             columnNames: device_type_id, specimen_type_id
         - createTable:
-            tableName: facility_device_specimen
+            tableName: facility_device_specimen_type
             remarks: Many-to-many table for device/specimen configuration at a facility.
             columns:
               - column:
@@ -1292,50 +1292,50 @@ databaseChangeLog:
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__facility_device_specimen__facility
+                    foreignKeyName: fk__facility_device_specimen_type__facility
                     references: facility
               - column:
-                  name: device_specimen_id
+                  name: device_specimen_type_id
                   remarks: A device/specimen combination that is allowed to be used at the facility.
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__facility_device_specimen__device_specimen
-                    references: device_specimen
+                    foreignKeyName: fk__facility_device_specimen_type__device_specimen_type
+                    references: device_specimen_type
         - addUniqueConstraint:
-            tableName: facility_device_specimen
-            constraintName: uk__facility_device_specimen
-            columnNames: facility_id, device_specimen_id
+            tableName: facility_device_specimen_type
+            constraintName: uk__facility_device_specimen_type
+            columnNames: facility_id, device_specimen_type_id
         - addColumn:
             tableName: facility
             columns:
               - column:
-                  name: default_device_specimen_id
+                  name: default_device_specimen_type_id
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__facility__default_device_specimen
-                    referencedTableName: device_specimen
+                    foreignKeyName: fk__facility__default_device_specimen_type
+                    referencedTableName: device_specimen_type
         - addColumn:
             tableName: test_order
             columns:
               - column:
-                  name: device_specimen_id
+                  name: device_specimen_type_id
                   remarks: The device/specimen combination used to record the test result.
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__test_order__device_specimen
-                    referencedTableName: device_specimen
+                    foreignKeyName: fk__test_order__device_specimen_type
+                    referencedTableName: device_specimen_type
                     # will be made non-null in a subsequent migration
         - addColumn:
             tableName: test_event
             columns:
               - column:
-                  name: device_specimen_id
+                  name: device_specimen_type_id
                   remarks: The device/specimen combination used to record the test result.
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__test_event__device_specimen
-                    referencedTableName: device_specimen
+                    foreignKeyName: fk__test_event__device_specimen_type
+                    referencedTableName: device_specimen_type
                     # will be made non-null in a subsequent migration
   - changeSet:
       id: create-migrations-user
@@ -1386,7 +1386,7 @@ databaseChangeLog:
                 false
               FROM swab_types_historical cross join migration_user
         - sql:
-            remarks: Add device_specimen entries based on current device-type data.
+            remarks: Add device_specimen_type entries based on current device-type data.
             sql: |
               WITH device_swab_historical as (
                 SELECT dt.internal_id device_type_id, swt.internal_id specimen_type_id
@@ -1398,7 +1398,7 @@ databaseChangeLog:
                 FROM ${database.defaultSchemaName}.api_user
                 WHERE login_email = '${migrations_user_email}'
               )
-              INSERT INTO ${database.defaultSchemaName}.device_specimen
+              INSERT INTO ${database.defaultSchemaName}.device_specimen_type
               ( internal_id,
                 created_at, created_by, updated_at, updated_by, is_deleted,
                 device_type_id, specimen_type_id
@@ -1409,36 +1409,36 @@ databaseChangeLog:
                 device_type_id, specimen_type_id
               FROM device_swab_historical cross join migration_user;
         - sql:
-            remarks: Populate facility_device_specimen table and (default) device_specimen_id columns in facility, test_type and test_order.
+            remarks: Populate facility_device_specimen_type table and (default) device_specimen_type_id columns in facility, test_type and test_order.
             sql: |
-              INSERT INTO ${database.defaultSchemaName}.facility_device_specimen
-              (facility_id, device_specimen_id)
+              INSERT INTO ${database.defaultSchemaName}.facility_device_specimen_type
+              (facility_id, device_specimen_type_id)
               SELECT facility_id, ds.internal_id
               FROM ${database.defaultSchemaName}.facility_device_type
-                JOIN ${database.defaultSchemaName}.device_specimen ds using(device_type_id);
+                JOIN ${database.defaultSchemaName}.device_specimen_type ds using(device_type_id);
 
               UPDATE ${database.defaultSchemaName}.facility f
-              SET default_device_specimen_id = ds.internal_id
-              FROM ${database.defaultSchemaName}.device_specimen ds
+              SET default_device_specimen_type_id = ds.internal_id
+              FROM ${database.defaultSchemaName}.device_specimen_type ds
               WHERE ds.device_type_id = f.default_device_type_id;
 
               UPDATE ${database.defaultSchemaName}.test_order t
-              SET device_specimen_id = ds.internal_id
-              FROM ${database.defaultSchemaName}.device_specimen ds
+              SET device_specimen_type_id = ds.internal_id
+              FROM ${database.defaultSchemaName}.device_specimen_type ds
               WHERE ds.device_type_id = t.device_type_id;
 
               UPDATE ${database.defaultSchemaName}.test_event t
-              SET device_specimen_id = ds.internal_id
-              FROM ${database.defaultSchemaName}.device_specimen ds
+              SET device_specimen_type_id = ds.internal_id
+              FROM ${database.defaultSchemaName}.device_specimen_type ds
               WHERE ds.device_type_id = t.device_type_id;
   - changeSet:
       id: complete-specimen-column-additions
       author: bwarfield@cdc.gov
-      comment: Update constraints for newly-added columns referencing device_specimen.
+      comment: Update constraints for newly-added columns referencing device_specimen_type.
       changes:
         - addNotNullConstraint:
             tableName: test_event
-            columnName: device_specimen_id
+            columnName: device_specimen_type_id
         - addNotNullConstraint:
             tableName: test_order
-            columnName: device_specimen_id
+            columnName: device_specimen_type_id

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1356,6 +1356,7 @@ databaseChangeLog:
       author: bwarfield@cdc.gov
       comment: Populate specimen tables and relations based on existing data.
       preConditions:
+        # run this migration only if there is at least one row in device_type. If there is not, mark it as already run.
         - onSqlOutput: FAIL
         - onFail: MARK_RAN
         - sqlCheck:

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -45,6 +45,9 @@ x-ref-data:
         constraints:
           nullable: false
 databaseChangeLog:
+  - property:
+      name: migrations_user_email
+      value: usds@cdc.gov
   - changeSet:
       id: define-enum-types
       author: bwarfield@cdc.gov
@@ -1210,3 +1213,191 @@ databaseChangeLog:
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
+  - changeSet:
+      id: add-swab-tables
+      description: Introduce the tables necessary for tracking swab types.
+      changes:
+        - createTable:
+            tableName: swab_type
+            remarks: A type of swab/specimen collection location.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *soft_delete_column
+              - column:
+                  name: name
+                  type: *string
+                  remarks: The name of the swab type, as displayed in isolation
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk__swab_type__name
+              - column:
+                  name: type_code
+                  remarks: The SNOMED specimen type code for this swab type.
+                  type: *string
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk__swab_type__type_code
+        - createTable:
+            tableName: device_swab
+            remarks: A usable combination of device type and swab type.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *soft_delete_column
+              - column:
+                  name: device_type_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_swab__device_type
+                    references: device_type
+              - column:
+                  name: swab_type_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_swab__swab_type
+                    references: swab_type
+        - addUniqueConstraint:
+            tableName: device_swab
+            constraintName: uk__device_swab
+            columnNames: device_type_id, swab_type_id
+        - createTable:
+            tableName: facility_device_swab
+            remarks: Many-to-many table for device/swab configuration at a facility.
+            columns:
+              - column:
+                  name: facility_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_swab__facility
+                    references: facility
+              - column:
+                  name: device_swab_id
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_swab__device_swab
+                    references: device_swab
+        - addUniqueConstraint:
+            tableName: facility_device_swab
+            constraintName: uk__facility_device_swab
+            columnNames: facility_id, device_swab_id
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_device_swab_id
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__facility__default_device_swab
+                    referencedTableName: device_swab
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: device_swab_id
+                  remarks: The device/swab combination used to record the test result.
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__test_order__device_swab
+                    referencedTableName: device_swab
+                    # will be made non-null in a subsequent migration
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: device_swab_id
+                  remarks: The device/swab combination used to record the test result.
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__test_event__device_swab
+                    referencedTableName: device_swab
+                    # will be made non-null in a subsequent migration
+  - changeSet:
+      id: populate-specimen-tables
+      author: bwarfield@cdc.gov
+      comment: Populate specimen tables and relations based on existing data.
+      preConditions:
+        - onSqlOutput: FAIL
+        - onFail: MARK_RAN
+        - sqlCheck:
+            sql:  SELECT case when count(1) > 0 then 1 else 0 end FROM ${database.defaultSchemaName}.device_type;
+            expectedResult: 1
+      changes:
+        - sql:
+          remarks: Create migrations user to indicate records created by migration rather than by a human.
+          sql: |
+            INSERT INTO ${database.defaultSchemaName}.api_user
+            (internal_id, created_at, updated_at, last_seen, login_email, last_name)
+            VALUES (
+              gen_random_uuid(), now(), now(), null,
+              '${migration_user_email}', 'Database Migration Process'
+            )
+        - sql:
+          remarks: Create default specimen type for known devices at the time of this migration.
+          sql: |
+            WITH specimen_types_historical as (
+              select distinct swab_type as type_code from ${database.defaultSchemaName}.device_type
+            ),
+            migration_user as (
+              SELECT internal_id as migrations_user_id
+              FROM ${database.defaultSchemaName}.api_user 
+              WHERE login_email = '${migrations_user_email}'
+            )
+            INSERT INTO ${database.defaultSchemaName}.specimen_type (name, type_code,
+              internal_id, created_at, created_by, updated_at, updated_by, is_deleted)
+            SELECT (
+              'Auto-generated specimen type ' || type_code,
+              type_code,
+              gen_random_uuid(),
+              migrations_user_id,
+              now(),
+              migrations_user_id,
+              now(),
+              false             
+            )
+            FROM specimen_types_historical cross join migration_user
+        - sql:
+          remarks: Add device_specimen and facility_device_specimen entries based on existing data, and populate facility.default_device_specimen_id.
+          sql: |
+            WITH device_swab_historical as (
+              SELECT dt.internal_id device_type_id, swt.internal_id specimen_type_id
+              FROM ${database.defaultSchemaName}.device_type dt
+               JOIN ${database.defaultSchemaName}.specimen_type swt ON dt.swab_type = swt.type_code 
+            ),
+            migration_user as (
+              SELECT internal_id as migrations_user_id
+              FROM ${database.defaultSchemaName}.api_user 
+              WHERE login_email = '${migrations_user_email}'
+            )
+            
+            INSERT INTO ${database.defaultSchemaName}.device_specimen
+            ( internal_id,               
+              created_at, created_by, updated_at, updated_by, is_deleted,
+            )
+            SELECT
+              gen_random_uuid(),
+              now(), migration_user_id, now(), migration_user_id, false
+            FROM device_swab_historical cross join migration_user 
+  - changeSet:
+      id: complete-specimen-column-additions
+      author: bwarfield@cdc.gov
+      comment: Update constraints for newly-added columns referencing device_specimen.
+      changes:
+        - addNotNullConstraint:
+            tableName: test_event
+            columnName: device_specimen_id
+        - addNotNullConstraint:
+            tableName: test_order
+            columnName: device_specimen_id

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1214,12 +1214,13 @@ databaseChangeLog:
                   constraints:
                     nullable: false
   - changeSet:
-      id: add-swab-tables
-      description: Introduce the tables necessary for tracking swab types.
+      id: add-specimen-tables
+      author: bwarfield@cdc.gov
+      description: Introduce the tables necessary for tracking specimen types.
       changes:
         - createTable:
-            tableName: swab_type
-            remarks: A type of swab/specimen collection location.
+            tableName: specimen_type
+            remarks: A type of specimen collection from a patient.
             columns:
               - column: *pk_column
               - column: *created_at_column
@@ -1230,22 +1231,30 @@ databaseChangeLog:
               - column:
                   name: name
                   type: *string
-                  remarks: The name of the swab type, as displayed in isolation
+                  remarks: The name of the specimen type, as displayed in isolation
                   constraints:
                     nullable: false
                     unique: true
-                    uniqueConstraintName: uk__swab_type__name
+                    uniqueConstraintName: uk__specimen_type__name
               - column:
                   name: type_code
-                  remarks: The SNOMED specimen type code for this swab type.
+                  remarks: The SNOMED type code for this specimen type.
                   type: *string
                   constraints:
                     nullable: false
                     unique: true
-                    uniqueConstraintName: uk__swab_type__type_code
+                    uniqueConstraintName: uk__specimen_type__type_code
+              - column:
+                  name: collection_location_name
+                  remarks: The collection location of this specimen type.
+                  type: *string
+              - column:
+                  name: collection_location_code
+                  remarks: The SNOMED code for the collection location of this specimen type.
+                  type: *string
         - createTable:
-            tableName: device_swab
-            remarks: A usable combination of device type and swab type.
+            tableName: device_specimen
+            remarks: A usable combination of device type and specimen type.
             columns:
               - column: *pk_column
               - column: *created_at_column
@@ -1255,75 +1264,93 @@ databaseChangeLog:
               - column: *soft_delete_column
               - column:
                   name: device_type_id
+                  remarks: The device type for this combination.
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__device_swab__device_type
+                    foreignKeyName: fk__device_specimen__device_type
                     references: device_type
               - column:
-                  name: swab_type_id
+                  name: specimen_type_id
+                  remarks: The specimen type for this combination.
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__device_swab__swab_type
-                    references: swab_type
+                    foreignKeyName: fk__device_specimen__specimen_type
+                    references: specimen_type
         - addUniqueConstraint:
-            tableName: device_swab
-            constraintName: uk__device_swab
-            columnNames: device_type_id, swab_type_id
+            tableName: device_specimen
+            constraintName: uk__device_specimen
+            columnNames: device_type_id, specimen_type_id
         - createTable:
-            tableName: facility_device_swab
-            remarks: Many-to-many table for device/swab configuration at a facility.
+            tableName: facility_device_specimen
+            remarks: Many-to-many table for device/specimen configuration at a facility.
             columns:
               - column:
                   name: facility_id
+                  remarks: A facility at which this device/specimen combination is used.
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__facility_device_swab__facility
+                    foreignKeyName: fk__facility_device_specimen__facility
                     references: facility
               - column:
-                  name: device_swab_id
+                  name: device_specimen_id
+                  remarks: A device/specimen combination that is allowed to be used at the facility.
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__facility_device_swab__device_swab
-                    references: device_swab
+                    foreignKeyName: fk__facility_device_specimen__device_specimen
+                    references: device_specimen
         - addUniqueConstraint:
-            tableName: facility_device_swab
-            constraintName: uk__facility_device_swab
-            columnNames: facility_id, device_swab_id
+            tableName: facility_device_specimen
+            constraintName: uk__facility_device_specimen
+            columnNames: facility_id, device_specimen_id
         - addColumn:
             tableName: facility
             columns:
               - column:
-                  name: default_device_swab_id
+                  name: default_device_specimen_id
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__facility__default_device_swab
-                    referencedTableName: device_swab
+                    foreignKeyName: fk__facility__default_device_specimen
+                    referencedTableName: device_specimen
         - addColumn:
             tableName: test_order
             columns:
               - column:
-                  name: device_swab_id
-                  remarks: The device/swab combination used to record the test result.
+                  name: device_specimen_id
+                  remarks: The device/specimen combination used to record the test result.
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__test_order__device_swab
-                    referencedTableName: device_swab
+                    foreignKeyName: fk__test_order__device_specimen
+                    referencedTableName: device_specimen
                     # will be made non-null in a subsequent migration
         - addColumn:
             tableName: test_event
             columns:
               - column:
-                  name: device_swab_id
-                  remarks: The device/swab combination used to record the test result.
+                  name: device_specimen_id
+                  remarks: The device/specimen combination used to record the test result.
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__test_event__device_swab
-                    referencedTableName: device_swab
+                    foreignKeyName: fk__test_event__device_specimen
+                    referencedTableName: device_specimen
                     # will be made non-null in a subsequent migration
+  - changeSet:
+      id: create-migrations-user
+      author: bwarfield@cdc.gov
+      comment: Create a system-level user to attribute migration insert/updates to.
+      changes:
+        - sql:
+            remarks: Create migrations user to indicate records created by migration rather than by a human.
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.api_user
+              (internal_id, created_at, updated_at, last_seen, login_email, last_name)
+              VALUES (
+                gen_random_uuid(), now(), now(), null,
+                '${migrations_user_email}', 'Database Migration Process'
+              )
   - changeSet:
       id: populate-specimen-tables
       author: bwarfield@cdc.gov
@@ -1336,60 +1363,74 @@ databaseChangeLog:
             expectedResult: 1
       changes:
         - sql:
-          remarks: Create migrations user to indicate records created by migration rather than by a human.
-          sql: |
-            INSERT INTO ${database.defaultSchemaName}.api_user
-            (internal_id, created_at, updated_at, last_seen, login_email, last_name)
-            VALUES (
-              gen_random_uuid(), now(), now(), null,
-              '${migration_user_email}', 'Database Migration Process'
-            )
+            remarks: Create in-use specimen types based on current device-type data.
+            sql: |
+              WITH swab_types_historical as (
+                select distinct swab_type as type_code from ${database.defaultSchemaName}.device_type
+              ),
+              migration_user as (
+                SELECT internal_id as migrations_user_id
+                FROM ${database.defaultSchemaName}.api_user
+                WHERE login_email = '${migrations_user_email}'
+              )
+              INSERT INTO ${database.defaultSchemaName}.specimen_type (name, type_code,
+                internal_id, created_by, created_at, updated_by, updated_at, is_deleted)
+              SELECT
+                'Auto-generated specimen type ' || type_code,
+                type_code,
+                gen_random_uuid(),
+                migrations_user_id,
+                now(),
+                migrations_user_id,
+                now(),
+                false
+              FROM swab_types_historical cross join migration_user
         - sql:
-          remarks: Create default specimen type for known devices at the time of this migration.
-          sql: |
-            WITH specimen_types_historical as (
-              select distinct swab_type as type_code from ${database.defaultSchemaName}.device_type
-            ),
-            migration_user as (
-              SELECT internal_id as migrations_user_id
-              FROM ${database.defaultSchemaName}.api_user 
-              WHERE login_email = '${migrations_user_email}'
-            )
-            INSERT INTO ${database.defaultSchemaName}.specimen_type (name, type_code,
-              internal_id, created_at, created_by, updated_at, updated_by, is_deleted)
-            SELECT (
-              'Auto-generated specimen type ' || type_code,
-              type_code,
-              gen_random_uuid(),
-              migrations_user_id,
-              now(),
-              migrations_user_id,
-              now(),
-              false             
-            )
-            FROM specimen_types_historical cross join migration_user
+            remarks: Add device_specimen entries based on current device-type data.
+            sql: |
+              WITH device_swab_historical as (
+                SELECT dt.internal_id device_type_id, swt.internal_id specimen_type_id
+                FROM ${database.defaultSchemaName}.device_type dt
+                 JOIN ${database.defaultSchemaName}.specimen_type swt ON dt.swab_type = swt.type_code
+              ),
+              migration_user as (
+                SELECT internal_id as migrations_user_id
+                FROM ${database.defaultSchemaName}.api_user
+                WHERE login_email = '${migrations_user_email}'
+              )
+              INSERT INTO ${database.defaultSchemaName}.device_specimen
+              ( internal_id,
+                created_at, created_by, updated_at, updated_by, is_deleted,
+                device_type_id, specimen_type_id
+              )
+              SELECT
+                gen_random_uuid(),
+                now(), migrations_user_id, now(), migrations_user_id, false,
+                device_type_id, specimen_type_id
+              FROM device_swab_historical cross join migration_user;
         - sql:
-          remarks: Add device_specimen and facility_device_specimen entries based on existing data, and populate facility.default_device_specimen_id.
-          sql: |
-            WITH device_swab_historical as (
-              SELECT dt.internal_id device_type_id, swt.internal_id specimen_type_id
-              FROM ${database.defaultSchemaName}.device_type dt
-               JOIN ${database.defaultSchemaName}.specimen_type swt ON dt.swab_type = swt.type_code 
-            ),
-            migration_user as (
-              SELECT internal_id as migrations_user_id
-              FROM ${database.defaultSchemaName}.api_user 
-              WHERE login_email = '${migrations_user_email}'
-            )
-            
-            INSERT INTO ${database.defaultSchemaName}.device_specimen
-            ( internal_id,               
-              created_at, created_by, updated_at, updated_by, is_deleted,
-            )
-            SELECT
-              gen_random_uuid(),
-              now(), migration_user_id, now(), migration_user_id, false
-            FROM device_swab_historical cross join migration_user 
+            remarks: Populate facility_device_specimen table and (default) device_specimen_id columns in facility, test_type and test_order.
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.facility_device_specimen
+              (facility_id, device_specimen_id)
+              SELECT facility_id, ds.internal_id
+              FROM ${database.defaultSchemaName}.facility_device_type
+                JOIN ${database.defaultSchemaName}.device_specimen ds using(device_type_id);
+
+              UPDATE ${database.defaultSchemaName}.facility f
+              SET default_device_specimen_id = ds.internal_id
+              FROM ${database.defaultSchemaName}.device_specimen ds
+              WHERE ds.device_type_id = f.default_device_type_id;
+
+              UPDATE ${database.defaultSchemaName}.test_order t
+              SET device_specimen_id = ds.internal_id
+              FROM ${database.defaultSchemaName}.device_specimen ds
+              WHERE ds.device_type_id = t.device_type_id;
+
+              UPDATE ${database.defaultSchemaName}.test_event t
+              SET device_specimen_id = ds.internal_id
+              FROM ${database.defaultSchemaName}.device_specimen ds
+              WHERE ds.device_type_id = t.device_type_id;
   - changeSet:
       id: complete-specimen-column-additions
       author: bwarfield@cdc.gov

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,7 +47,7 @@ x-ref-data:
 databaseChangeLog:
   - property:
       name: migrations_user_email
-      value: usds@cdc.gov
+      value: db-migrations@simplereport.gov
   - changeSet:
       id: define-enum-types
       author: bwarfield@cdc.gov
@@ -1231,7 +1231,7 @@ databaseChangeLog:
               - column:
                   name: name
                   type: *string
-                  remarks: The name of the specimen type, as displayed in isolation
+                  remarks: The name of this specimen type.
                   constraints:
                     nullable: false
                     unique: true
@@ -1346,9 +1346,9 @@ databaseChangeLog:
             remarks: Create migrations user to indicate records created by migration rather than by a human.
             sql: |
               INSERT INTO ${database.defaultSchemaName}.api_user
-              (internal_id, created_at, updated_at, last_seen, login_email, last_name)
+              (internal_id, created_at, updated_at, is_deleted, last_seen, login_email, last_name)
               VALUES (
-                gen_random_uuid(), now(), now(), null,
+                gen_random_uuid(), now(), now(), false, null,
                 '${migrations_user_email}', 'Database Migration Process'
               )
   - changeSet:

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceManagementTest.java
@@ -48,8 +48,18 @@ class DeviceManagementTest extends BaseApiTest {
         useSuperUser();
         ObjectNode someDeviceType = (ObjectNode) fetchSorted().get(0);
         ObjectNode variables = sillyDeviceArgs()
-                .put("id", someDeviceType.get("internalId").asText());
+                .put("id", someDeviceType.get("internalId").asText())
+                .set("swabType", null);
         runQuery("device-type-update", variables);
+    }
+
+    @Test
+    void updateDeviceType_adminUserUpdatingSwabType_failure() {
+        useSuperUser();
+        ObjectNode someDeviceType = (ObjectNode) fetchSorted().get(0);
+        ObjectNode variables = sillyDeviceArgs()
+                .put("id", someDeviceType.get("internalId").asText());
+        runQuery("device-type-update", variables, "swab type");
     }
 
     private List<JsonNode> fetchSorted() {
@@ -66,7 +76,7 @@ class DeviceManagementTest extends BaseApiTest {
                 .put("manufacturer", "Acme")
                 .put("model", "Test-A-Lot")
                 .put("loincCode", "123456")
-                .put("swabType", "abcdef");
+                .put("swabType", "0987654321");
         return variables;
     }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -1,7 +1,7 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -14,12 +14,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonContent;
 import org.springframework.boot.test.json.ObjectContent;
 
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
 @JsonTest
 class PersonSerializationTest {
+
+    private static final int BIRTH_YEAR = 2000;
+    private static final int BIRTH_MONTH = 3;
+    private static final int BIRTH_DAY = 31;
 
     @Autowired
     private JacksonTester<Person> _tester;
@@ -43,16 +48,33 @@ class PersonSerializationTest {
     }
 
     @Test
-    void serialize_withOrgAndFacility_noOrgOrFacility() throws IOException {
-        // consts are to keep style check happy othewise it complains about
-        // "magic numbers"
-        final int BIRTH_YEAR = 2000;
-        final int BIRTH_MONTH = 3;
-        final int BIRTH_DAY = 31;
+    void serialize_withoutFacility_valuesStored() throws IOException {
         Organization fakeOrg = new Organization("ABC", "123");
-        Person p = new Person(fakeOrg, null, "John", "Jacob", "Jingleheimer-Jones", "Jr.",
-                LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY), null, "1234556", null, "a@b.c", "marathon", "generic",
-                "Male-ish", true, false);
+        Person p = makeSerializablePerson(fakeOrg);
+        JsonContent<Person> serialized = _tester.write(p);
+        assertThat(serialized).extractingJsonPathStringValue("firstName")
+                .isEqualTo("John");
+        assertThat(serialized).extractingJsonPathStringValue("lastName")
+                .isEqualTo("Jingleheimer-Jones");
+        assertThat(serialized).extractingJsonPathStringValue("middleName")
+                .isEqualTo("Jacob");
+        assertThat(serialized).extractingJsonPathStringValue("suffix")
+                .isEqualTo("Jr.");
+        assertThat(serialized).extractingJsonPathStringValue("birthDate")
+                .isEqualTo(String.format("%4d-%02d-%02d", BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY));
+        assertThat(serialized).extractingJsonPathArrayValue("address.street")
+                .hasSize(3)
+                .isEqualTo(List.of("1600 Pennsylvania Avenue", "Right Side Door", "Down the Steps"));
+        assertThat(serialized).extractingJsonPathMapValue("facility")
+                .isNull();
+        assertThat(serialized).extractingJsonPathMapValue("organization")
+                .isNull();
+    }
+
+    @Test
+    void serialize_withFacility_noOrgOrFacility() throws IOException {
+        Organization fakeOrg = new Organization("ABC", "123");
+        Person p = makeSerializablePerson(fakeOrg);
         Provider mccoy = new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222");
         DeviceSpecimen ds = new DeviceSpecimen(
                 new DeviceType("Bill", "Weasleys", "1", "12345-6", "E"),
@@ -60,9 +82,22 @@ class PersonSerializationTest {
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
         p.setFacility(new Facility(fakeOrg, "Nice Place", "YOUGOTHERE", addy, "555-867-5309", "facility@test.com",
                 mccoy, ds, List.of(ds)));
-        String json = _tester.write(p).getJson();
-        assertFalse(json.contains("organization"));
-        assertFalse(json.contains("facility"));
+        JsonContent<Person> serialized = _tester.write(p);
+        assertThat(serialized).extractingJsonPathStringValue("lastName")
+                .isEqualTo("Jingleheimer-Jones");
+        assertThat(serialized).extractingJsonPathMapValue("facility")
+                .isNull();
+        assertThat(serialized).extractingJsonPathMapValue("organization")
+                .isNull();
+    }
+
+    private Person makeSerializablePerson(Organization fakeOrg) {
+        StreetAddress addy = new StreetAddress(List.of("1600 Pennsylvania Avenue", "Right Side Door", "Down the Steps"),
+                "Washington", "DC", "20001", "DC");
+        Person p = new Person(fakeOrg, null, "John", "Jacob", "Jingleheimer-Jones", "Jr.",
+                LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY), addy, "1234556", null, "a@b.c", "marathon", "generic",
+                "Male-ish", true, false);
+        return p;
     }
 
     private void assertAlexanderHamilton(ObjectContent<Person> ob) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -76,7 +76,7 @@ class PersonSerializationTest {
         Organization fakeOrg = new Organization("ABC", "123");
         Person p = makeSerializablePerson(fakeOrg);
         Provider mccoy = new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222");
-        DeviceSpecimen ds = new DeviceSpecimen(
+        DeviceSpecimenType ds = new DeviceSpecimenType(
                 new DeviceType("Bill", "Weasleys", "1", "12345-6", "E"),
                 new SpecimenType("Troll Bogies", "000111222"));
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,12 +54,12 @@ class PersonSerializationTest {
                 LocalDate.of(BIRTH_YEAR, BIRTH_MONTH, BIRTH_DAY), null, "1234556", null, "a@b.c", "marathon", "generic",
                 "Male-ish", true, false);
         Provider mccoy = new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222");
-        List<DeviceType> configuredDevices = new ArrayList<>();
-        DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E");
-        configuredDevices.add(bill);
+        DeviceSpecimen ds = new DeviceSpecimen(
+                new DeviceType("Bill", "Weasleys", "1", "12345-6", "E"),
+                new SpecimenType("Troll Bogies", "000111222"));
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
         p.setFacility(new Facility(fakeOrg, "Nice Place", "YOUGOTHERE", addy, "555-867-5309", "facility@test.com",
-                mccoy, bill, configuredDevices));
+                mccoy, ds, List.of(ds)));
         String json = _tester.write(p).getJson();
         assertFalse(json.contains("organization"));
         assertFalse(json.contains("facility"));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -25,7 +25,7 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
     @Autowired
     private DeviceTypeRepository _devices;
     @Autowired
-    private DeviceSpecimenRepository _deviceSpecimens;
+    private DeviceSpecimenTypeRepository _deviceSpecimens;
     @Autowired
     private SpecimenTypeRepository _specimens;
     @Autowired
@@ -37,14 +37,14 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
 
     @Test
     void smokeTestDeviceOperations() {
-        List<DeviceSpecimen> configuredDevices = new ArrayList<>();
+        List<DeviceSpecimenType> configuredDevices = new ArrayList<>();
         DeviceType bill = _devices.save(new DeviceType("Bill", "Weasleys", "1", "12345-6", "E"));
         DeviceType percy = _devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", "E"));
         SpecimenType spec = _specimens.save(new SpecimenType("Troll Bogies", "0001111234"));
-        DeviceSpecimen billbogies = _deviceSpecimens.save(new DeviceSpecimen(bill, spec));
+        DeviceSpecimenType billbogies = _deviceSpecimens.save(new DeviceSpecimenType(bill, spec));
         Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
         configuredDevices.add(billbogies);
-        configuredDevices.add(_deviceSpecimens.save(new DeviceSpecimen(percy, spec)));
+        configuredDevices.add(_deviceSpecimens.save(new DeviceSpecimenType(percy, spec)));
         Organization org = _orgs.save(new Organization("My Office", "650Mass"));
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
         Facility saved = _repo.save(new Facility(org, "Third Floor", "123456", addy, "555-867-5309",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -12,16 +12,22 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
 class FacilityRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     private DeviceTypeRepository _devices;
+    @Autowired
+    private DeviceSpecimenRepository _deviceSpecimens;
+    @Autowired
+    private SpecimenTypeRepository _specimens;
     @Autowired
     private ProviderRepository _providers;
     @Autowired
@@ -31,20 +37,23 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
 
     @Test
     void smokeTestDeviceOperations() {
-        List<DeviceType> configuredDevices = new ArrayList<>();
-        DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E");
+        List<DeviceSpecimen> configuredDevices = new ArrayList<>();
+        DeviceType bill = _devices.save(new DeviceType("Bill", "Weasleys", "1", "12345-6", "E"));
+        DeviceType percy = _devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", "E"));
+        SpecimenType spec = _specimens.save(new SpecimenType("Troll Bogies", "0001111234"));
+        DeviceSpecimen billbogies = _deviceSpecimens.save(new DeviceSpecimen(bill, spec));
         Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
-        configuredDevices.add(_devices.save(bill));
-        configuredDevices.add(_devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", "E")));
+        configuredDevices.add(billbogies);
+        configuredDevices.add(_deviceSpecimens.save(new DeviceSpecimen(percy, spec)));
         Organization org = _orgs.save(new Organization("My Office", "650Mass"));
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
         Facility saved = _repo.save(new Facility(org, "Third Floor", "123456", addy, "555-867-5309",
-                "facility@test.com", mccoy, bill, configuredDevices));
+                "facility@test.com", mccoy, billbogies, configuredDevices));
         Optional<Facility> maybe = _repo.findByOrganizationAndFacilityName(org, "Third Floor");
         assertTrue(maybe.isPresent(), "should find the facility");
         Facility found = maybe.get();
         assertEquals(2, found.getDeviceTypes().size());
-        found.addDefaultDeviceType(bill);
+        found.addDefaultDeviceSpecimen(billbogies);
         _repo.save(found);
         found = _repo.findById(saved.getInternalId()).get();
         found.removeDeviceType(bill);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -39,8 +39,8 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
         Facility place = _dataFactory.createValidFacility(org);
         Person patient = _dataFactory.createMinimalPerson(org);
         TestOrder order = _dataFactory.createTestOrder(patient, place);
-        _repo.save(new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceType(), patient, place, order));
-        _repo.save(new TestEvent(TestResult.UNDETERMINED, place.getDefaultDeviceType(), patient, place, order));
+        _repo.save(new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceSpecimen(), patient, place, order));
+        _repo.save(new TestEvent(TestResult.UNDETERMINED, place.getDefaultDeviceSpecimen(), patient, place, order));
         flush();
         List<TestEvent> found = _repo.findAllByPatient(patient);
         assertEquals(2, found.size());
@@ -56,8 +56,9 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
         Facility place = _dataFactory.createValidFacility(org);
         Person patient = _dataFactory.createMinimalPerson(org);
         TestOrder order = _dataFactory.createTestOrder(patient, place);
-        TestEvent first = new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceType(), patient, place, order);
-        TestEvent second = new TestEvent(TestResult.UNDETERMINED, place.getDefaultDeviceType(), patient, place, order);
+        TestEvent first = new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceSpecimen(), patient, place, order);
+        TestEvent second = new TestEvent(TestResult.UNDETERMINED, place.getDefaultDeviceSpecimen(), patient, place,
+                order);
         _repo.save(first);
         _repo.save(second);
         flush();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -71,7 +71,8 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
         TestOrder order = _repo.save(new TestOrder(hoya, site));
         assertNotNull(order);
         flush();
-        TestEvent ev = _events.save(new TestEvent(TestResult.POSITIVE, device, hoya, site, order));
+        TestEvent ev = _events
+                .save(new TestEvent(TestResult.POSITIVE, site.getDefaultDeviceSpecimen(), hoya, site, order));
         assertNotNull(ev);
         order.setTestEventRef(ev);
         _repo.save(order);
@@ -134,7 +135,8 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
         TestOrder order1 = new TestOrder(patient0, site);
         _repo.save(order1);
         flush();
-        TestEvent didit = _events.save(new TestEvent(TestResult.NEGATIVE, site.getDefaultDeviceType(), patient0, site, order1));
+        TestEvent didit = _events
+                .save(new TestEvent(TestResult.NEGATIVE, site.getDefaultDeviceSpecimen(), patient0, site, order1));
         order1.setTestEventRef(didit);
         order1.setResult(didit.getResult());
         order1.markComplete();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -16,6 +16,7 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 
 class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
+    private static final String FAKE_SWAB_TYPE = "012345678";
     @Autowired
     private DeviceTypeRepository _deviceTypeRepo;
 
@@ -26,7 +27,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
     @Test
     void fetchDeviceTypes() {
-        _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
+        _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE));
 
         DeviceType deviceType = _service.fetchDeviceTypes().get(0);
     
@@ -34,32 +35,32 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
         assertEquals(deviceType.getManufacturer(), "B");
         assertEquals(deviceType.getModel(), "C");
         assertEquals(deviceType.getLoincCode(), "D");
-        assertEquals(deviceType.getSwabType(), "E");
+        assertEquals(deviceType.getSwabType(), FAKE_SWAB_TYPE);
     }
 
     @Test
     void createDeviceType_baseUser_error() {
-        assertSecurityError(() -> _service.createDeviceType("A", "B", "C", "D", "E"));
+        assertSecurityError(() -> _service.createDeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE));
     }
 
     @Test
     void updateDeviceType_baseUser_error() {
-        DeviceType deviceType = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
+        DeviceType deviceType = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE));
         assertSecurityError(() -> _service.updateDeviceType(deviceType.getInternalId(), "1", "2", "3", "4", "5"));
     }
 
 
     @Test
     void removeDeviceType_baseUser_eror() {
-        DeviceType deviceType = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
+        DeviceType deviceType = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE));
         assertSecurityError(() -> _service.removeDeviceType(deviceType));
     }
 
     @Test
     @WithSimpleReportSiteAdminUser
     void createAndDeleteDeviceTypes_adminUser_success() {
-        DeviceType devA = _service.createDeviceType("A", "B", "C", "D", "E");
-        DeviceType devB = _service.createDeviceType("F", "G", "H", "I", "J");
+        DeviceType devA = _service.createDeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE);
+        DeviceType devB = _service.createDeviceType("F", "G", "H", "I", "91234567");
         assertNotNull(devA);
         assertNotNull(devB);
         assertNotEquals(devA.getInternalId(), devB.getInternalId());
@@ -73,7 +74,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     @Test
     @WithSimpleReportSiteAdminUser
     void updateDeviceTypeName_adminUser_success() {
-        DeviceType device = _service.createDeviceType("A", "B", "C", "D", "E");
+        DeviceType device = _service.createDeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE);
 
         DeviceType updatedDevice = _service.updateDeviceType(device.getInternalId(), "Tim", null, null, null, null);
 
@@ -82,6 +83,6 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
         assertEquals(updatedDevice.getModel(), "B");
         assertEquals(updatedDevice.getManufacturer(), "C");
         assertEquals(updatedDevice.getLoincCode(), "D");
-        assertEquals(updatedDevice.getSwabType(), "E");
+        assertEquals(updatedDevice.getSwabType(), FAKE_SWAB_TYPE);
     }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -48,7 +48,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     private DeviceTypeHolder getDeviceConfig() {
         DeviceType device = _dataFactory.createDeviceType("Bill", "Weasleys", "1", "12345-6", "E");
         SpecimenType specimen = _dataFactory.getGenericSpecimen();
-        DeviceSpecimen dst = _dataFactory.createDeviceSpecimen(device, specimen);
+        DeviceSpecimenType dst = _dataFactory.createDeviceSpecimen(device, specimen);
         DeviceTypeHolder holder = new DeviceTypeHolder(dst, List.of(dst));
         return holder;
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,6 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -34,11 +35,8 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
     @Test
     void createOrganization_standardUser_error() {
+        DeviceTypeHolder holder = getDeviceConfig();
         assertSecurityError(() -> {
-            List<DeviceType> configuredDevices = new ArrayList<>();
-            DeviceType device = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E");
-            configuredDevices.add(device);
-            DeviceTypeHolder holder = new DeviceTypeHolder(device, configuredDevices);
             StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "",
                     "");
             PersonName bill = new PersonName("Bill", "Foo", "Nye", "");
@@ -47,13 +45,18 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
         });
     }
 
+    private DeviceTypeHolder getDeviceConfig() {
+        DeviceType device = _dataFactory.createDeviceType("Bill", "Weasleys", "1", "12345-6", "E");
+        SpecimenType specimen = _dataFactory.getGenericSpecimen();
+        DeviceSpecimen dst = _dataFactory.createDeviceSpecimen(device, specimen);
+        DeviceTypeHolder holder = new DeviceTypeHolder(dst, List.of(dst));
+        return holder;
+    }
+
     @Test
     @WithSimpleReportSiteAdminUser
     void createOrganization_adminUser_success() {
-        List<DeviceType> configuredDevices = new ArrayList<>();
-        DeviceType device = _dataFactory.createDeviceType("Bill", "Weasleys", "1", "12345-6", "E");
-        configuredDevices.add(device);
-        DeviceTypeHolder holder = new DeviceTypeHolder(device, configuredDevices);
+        DeviceTypeHolder holder = getDeviceConfig();
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
         PersonName bill = new PersonName("Bill", "Foo", "Nye", "");
         Organization org = _service.createOrganization("Tim's org", "d6b3951b-6698-4ee7-9d63-aaadee85bac0",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.LocalDate;
@@ -23,8 +24,6 @@ import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
-import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
-import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 
@@ -32,15 +31,11 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
         @Autowired
-        private DeviceTypeRepository _deviceTypeRepo;
-        @Autowired
         private OrganizationService _organizationService;
         @Autowired
         private PersonService _personService;
         @Autowired
         private HibernateQueryInterceptor hibernateQueryInterceptor;
-        @Autowired
-        private TestDataFactory _dataFactory;
 
         @BeforeEach
         void setupData() {
@@ -74,7 +69,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                 _service.addPatientToQueue(facility.getInternalId(), p, "", Collections.<String, Boolean>emptyMap(),
                                 false, LocalDate.of(1865, 12, 25), "", TestResult.POSITIVE, LocalDate.of(1865, 12, 25),
                                 false);
-                DeviceType devA = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
+                DeviceType devA = _dataFactory.getGenericDevice();
 
                 _service.addTestResult(devA.getInternalId().toString(), TestResult.POSITIVE,
                                 p.getInternalId().toString(), null);
@@ -94,7 +89,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                 TestOrder o = _service.addPatientToQueue(facility.getInternalId(), p, "",
                                 Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
                                 TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
-                DeviceType devA = _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", "E"));
+                DeviceType devA = _dataFactory.getGenericDevice();
+                assertNotEquals(o.getDeviceType().getName(), devA.getName());
 
                 _service.editQueueItem(o.getInternalId().toString(), devA.getInternalId().toString(),
                                 TestResult.POSITIVE.toString(), null);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimen;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -23,7 +23,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
@@ -59,7 +59,7 @@ public class TestDataFactory {
     @Autowired
     private SpecimenTypeRepository _specimenRepo;
     @Autowired
-    private DeviceSpecimenRepository _deviceSpecimenRepo;
+    private DeviceSpecimenTypeRepository _deviceSpecimenRepo;
 
     public Organization createValidOrg() {
         return _orgRepo.save(new Organization("The Mall", "MALLRAT"));
@@ -70,8 +70,8 @@ public class TestDataFactory {
     }
 
     public Facility createValidFacility(Organization org, String facilityName) {
-        DeviceSpecimen dev = getGenericDeviceSpecimen();
-        List<DeviceSpecimen> configuredDevices = new ArrayList<>();
+        DeviceSpecimenType dev = getGenericDeviceSpecimen();
+        List<DeviceSpecimenType> configuredDevices = new ArrayList<>();
         configuredDevices.add(dev);
         StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
         Provider doc = _providerRepo.save(new Provider("Doctor", "", "Doom", "", "DOOOOOOM", addy, "800-555-1212"));
@@ -157,7 +157,7 @@ public class TestDataFactory {
         return getGenericDeviceSpecimen().getSpecimenType();
     }
 
-    public DeviceSpecimen getGenericDeviceSpecimen() {
+    public DeviceSpecimenType getGenericDeviceSpecimen() {
         DeviceType dev = _deviceRepo.findAll().stream().filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE)).findFirst()
                 .orElseGet(() -> createDeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E"));
         SpecimenType specType = _specimenRepo.findAll().stream().filter(d -> d.getName().equals(DEFAULT_SPECIMEN_TYPE))
@@ -167,8 +167,8 @@ public class TestDataFactory {
                 .orElseGet(() -> createDeviceSpecimen(dev, specType));
     }
 
-    public DeviceSpecimen createDeviceSpecimen(DeviceType device, SpecimenType specimen) {
-        return _deviceSpecimenRepo.save(new DeviceSpecimen(device, specimen));
+    public DeviceSpecimenType createDeviceSpecimen(DeviceType device, SpecimenType specimen) {
+        return _deviceSpecimenRepo.save(new DeviceSpecimenType(device, specimen));
     }
 
 }

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -48,6 +48,11 @@ simple-report-initialization:
   configured-device-types:
     - LumiraDX
     - Quidel Sofia 2
+  specimen-types:
+    - name: Swab of the Nose
+      type-code: "445297001"
+      collection-location-name: "NOSE"
+      collection-location-code: "71836000"
   device-types:
     - name: Abbott IDNow
       manufacturer: Abbott

--- a/backend/src/test/resources/device-type-update
+++ b/backend/src/test/resources/device-type-update
@@ -4,7 +4,7 @@ mutation updateDevice(
     $manufacturer: String!
     $model: String!
     $loincCode: String!
-    $swabType: String!
+    $swabType: String
 ) {
     updateDeviceType(
       id: $id


### PR DESCRIPTION
## Related Issue or Background Info

Beginning of API work to support #384 / #358 
Most but not all of #325 

## Changes Proposed

- add javax.validation support so we can be more confident about CLIA and SNOMED values being what we expect
- add database tables to support this approach:
  - the specimen type is a free-standing soft-deletable entity
  - the combination device and specimen is a soft-deletable entity
  - facilities choose one or more of those combinations to use
- update facility, test event and test order to point in the direction of the new structure (without deleting any old columns yet)
- update services to assume that in the absence of specific information about specimen type, we will be using the oldest DeviceSpecimen record that exists for a given DeviceType (this, frankly, needs some testing that it doesn't have yet, and may not get much of before we strip this shim code out)


## Additional Information
* This PR will disable Java support for the previous relationship between Facility and DeviceType, but leave the database structure for that relationship to be removed in a future changeset, since dropping tables and columns cannot be rolled back
* Similarly, the device_type_id and swab_type columns on test_* and facility are left untouched (for now)
* This PR allows creating new device types with new swab types (by transparently creating new specimen-type records if needed), but disallows changing the swab type of an existing device type (too complicated for a temporary shim)
