### PR TITLE
Extended uploading hours from 5PM ET to 9PM.

### DIFF
--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -10,7 +10,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems"
-    upload-schedule: "0 0 5-17/2 * * *"
+    upload-schedule: "0 0 5-21/2 * * *"
   admin-emails:
     - bwarfield@cdc.gov
     - tim.best@usds.dhs.gov


### PR DESCRIPTION
We've been told that if we upload until 9:00 ET, we will potentially catch EOD work in California, and Data Hub still won't have a problem with maintenance windows.