### PR TITLE
Configure sonarcloud to ignore testfiles

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -91,6 +91,7 @@ sonarqube {
 		property "sonar.host.url", "https://sonarcloud.io"
 		// In order to get both the frontend and backend code to report, we need to set the sonar project to the root directory.
 		property "sonar.sources", "backend/src/main/java,frontend/src"
+		property "sonar.exclusions", "frontend/src/**/*.test.*"
 		property "sonar.javascript.lcov.reportPaths", "frontend/coverage/lcov.info"
 	}
 }


### PR DESCRIPTION
## Related Issue or Background Info

Currently, sonarcloud is complaining about coverage on test files themselves. For example: https://sonarcloud.io/component_measures?id=CDCgov_prime-data-input-client&pullRequest=821&metric=new_coverage&view=list

Where `TestQueue.test.tsx` is a test and doesn't itself need to be covered.

## Changes Proposed

Add an exclusion to the sonarcloud config to ignore any `frontend/src/**/*.test.*` files in analysis