### PR TITLE
Fix `undefined` plid bug for pre-existing test orders

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -14,11 +14,11 @@ const AoEModalForm = ({
   patient,
   loadState = {},
   saveCallback,
-  qrCodeValue = `${getUrl()}pxp`,
+  qrCodeValue = "",
   canAddToTestQueue,
 }) => {
   const [modalView, setModalView] = useState(null);
-  const [patientLink, setPatientLink] = useState(qrCodeValue);
+  const [patientLink, setPatientLink] = useState("");
   const modalViewValues = [
     { label: "Complete on smartphone", value: "smartphone" },
     { label: "Complete questionnaire verbally", value: "verbal" },
@@ -51,8 +51,11 @@ const AoEModalForm = ({
 
   const chooseModalView = async (view) => {
     if (view === "smartphone") {
-      const patientLinkId = await saveCallback(patientResponse);
-      setPatientLink(`${getUrl()}pxp?plid=${patientLinkId}`);
+       // if we already have a truthy qrCodeValue, we do not need to save the test order to generate a PLID
+       setPatientLink(
+        qrCodeValue ||
+          `${getUrl()}pxp?plid=${await saveCallback(patientResponse)}`
+      );
     }
     setModalView(view);
   };

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -51,8 +51,8 @@ const AoEModalForm = ({
 
   const chooseModalView = async (view) => {
     if (view === "smartphone") {
-       // if we already have a truthy qrCodeValue, we do not need to save the test order to generate a PLID
-       setPatientLink(
+      // if we already have a truthy qrCodeValue, we do not need to save the test order to generate a PLID
+      setPatientLink(
         qrCodeValue ||
           `${getUrl()}pxp?plid=${await saveCallback(patientResponse)}`
       );


### PR DESCRIPTION
## Related Issue or Background Info

#849 

## Changes Proposed

- Use the existing patient link id when possible

## Additional Information

- The `saveCallback` called internally is different for test orders that exist vs. ones that don't. The one for test orders that already exist doesn't return a `plid`, hence the `undefined`. This change makes it so that orders that already have a Patient Link ID just use that, instead of trying to generate a new one.

## Screenshots / Demos
