### PR TITLE
Tim best/fix test db

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -131,7 +131,6 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             String orderingProviderCity, String orderingProviderCounty, String orderingProviderState,
             String orderingProviderZipCode, String orderingProviderTelephone, List<String> deviceIds,
             String defaultDeviceId) {
-        _os.assertFacilityNameAvailable(testingFacilityName);
         DeviceTypeHolder deviceTypes = _dts.getTypesForFacility(defaultDeviceId, deviceIds);
         StreetAddress facilityAddress = new StreetAddress(street, streetTwo, city, Translators.parseState(state), zipCode, county);
         StreetAddress providerAddress = new StreetAddress(orderingProviderStreet, orderingProviderStreetTwo,

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -114,7 +114,12 @@ const App = () => {
                   path="/"
                   exact
                   render={({ location }) => (
-                    <Redirect to={{ ...location, pathname: "/queue" }} />
+                    <Redirect
+                      to={{
+                        ...location,
+                        pathname: data.whoami.isAdmin ? "/admin" : "/queue",
+                      }}
+                    />
                   )}
                 />
                 <ProtectedRoute

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -59,9 +59,9 @@ const App = () => {
     dispatch(
       setInitialState({
         organization: {
-          name: data.whoami.organization.name,
+          name: data.whoami.organization?.name,
         },
-        facilities: data.whoami.organization.testingFacility,
+        facilities: data.whoami.organization?.testingFacility,
         facility: null,
         user: {
           id: data.whoami.id,

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -18,9 +18,11 @@ const Header: React.FC<{}> = () => {
     (state) => (state as any).organization as Organization
   );
   const facilities = useSelector(
-    (state) => (state as any).facilities as Facility[]
+    (state) => ((state as any).facilities as Facility[]) || []
   );
-  const facility = useSelector((state) => (state as any).facility as Facility);
+  const facility = useSelector(
+    (state) => ((state as any).facility as Facility) || { id: "", name: "" }
+  );
   const user = useSelector((state) => (state as any).user as User);
   const [menuVisible, setMenuVisible] = useState(false);
   const {

--- a/frontend/src/app/facilitySelect/WithFacility.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.tsx
@@ -24,7 +24,7 @@ const WithFacility: React.FC<Props> = ({ children }) => {
   const facilityInStore = useSelector(
     (state) => (state as any).facility as Facility
   );
-  const facilityFromUrl = facilities.find(
+  const facilityFromUrl = facilities?.find(
     (f) => f.id === getFacilityIdFromUrl()
   );
 
@@ -36,6 +36,10 @@ const WithFacility: React.FC<Props> = ({ children }) => {
     dispatch(updateFacility(facility));
     setFacilityProp(facility.id);
   };
+
+  if (facilities === undefined) {
+    return <>{children}</>;
+  }
 
   if (facilities.length === 0) {
     return <Loading />;

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,13 +1,24 @@
 # Deploying SimpleReport
 
-## Operations that only need to be performed once
+## Table of Contents
+- [Deploying SimpleReport](#deploying-simplereport)
+  - [Table of Contents](#table-of-contents)
+  - [Setup](#setup)
+      - [Azure](#azure)
+      - [Okta](#okta)
+      - [Terraform](#terraform)
+  - [Reset a database](#reset-a-database)
+  - [General steps](#general-steps)
+  - [Operations performed once per environment](#operations-performed-once-per-environment)
 
-### Authentication
+## Setup
 
 #### Azure
 
-Azure auth is really simple and only requires installing Azure CLI and logging in.
+You will need to get a cdc.gov email address and access to our azure resources. Then install the Azure
+CLI: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
+On Mac with homebrew
 ```bash
 brew install azure-cli
 az login
@@ -15,16 +26,61 @@ az login
 
 #### Okta
 
-[Okta API tokens](https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/) are assigned at the environment level, and not on a per user basis.
-You can create one for yourself [here](https://prime-eval-admin.okta.com/admin/access/api/tokens).
+You need to be invited to okta and be made an okta admin. Then you can create an Okta API token via
+the [Okta Admin Portal](https://hhs-prime-admin.okta.com/admin/access/api/tokens).
 
+[Okta API token docs](https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/) 
+
+Add the following line to your `~/.bash_profile`
 ```bash
-export OKTA_ORG_NAME=<okta_org>
-export OKTA_BASE_URL="okta.com"
 export OKTA_API_TOKEN={Okta API token}
 ```
+then run `source ~/.bash_profile`
 
-### General steps
+#### Terraform
+Install instructions: https://learn.hashicorp.com/tutorials/terraform/install-cli
+
+On Mac with homebrew
+```bash
+$ brew tap hashicorp/tap
+$ brew install hashicorp/tap/terraform
+```
+Verify that the installation worked by opening a new terminal session and listing Terraform's available subcommands.
+
+```bash
+$ terraform help
+Usage: terraform [global options] <subcommand> [args]
+
+The available commands for execution are listed below.
+The primary workflow commands are given first, followed by
+less common or more advanced commands.
+
+...
+```
+
+## Reset a database
+
+**DO NOT DO THIS IN THE PRODUCTION ENVIRONMENT!**
+
+The following instructions walk through the steps to reset the database in the test environment to a
+clean state. If you are doing this in different environment then replace `test` with your pre-prod
+environment of choice.
+
+1. Stop the `simple-report-api-test` app service so there are no running connections on the database. For test I also had to stop `prime-simple-report-test-metabase`
+![Screen Shot 2021-02-18 at 7 11 02 PM](https://user-images.githubusercontent.com/53869143/108438453-4a3c0e80-721d-11eb-9319-e1d4b66a563c.png)
+2. Run the following commands
+```bash
+cd ops/test/persistent
+terraform init
+terraform plan
+# taint will mark a resource for creation by terraform and the apply step will start that action
+terraform taint module.db.azurerm_postgresql_database.simple_report
+terraform apply
+```
+Terraform works by managing the state of azure resources, so we are able to select the specific resources state we want to recreate by running `terraform state list` and get the name we want. in this case `module.db.azurerm_postgresql_database.simple_report`
+3. Start the simple-report-api-test
+
+## General steps
 
 The initial Terraform and environment bootstrap creates a couple of resource which are shared across the various resource groups and environments.
 


### PR DESCRIPTION
## Related Issue or Background Info

Changes that came about from fixing the api in the test environment. The API schemas and tables got clobbered when testing out the MetaBase integration. 

UI changes are so I can setup organizations in `test` via the admin port instead of the DB

## Changes Proposed

- Updated the terraform setups instructions in the ops README
- Added steps I took to take down and rebuild the database in the test env
- Allow the admin portal to be accessed when a user is not part of an org
- Redirects site admins to the site admin page (resolves #661)
- Removes check for facility name uniqueness on first facility 


