### PR TITLE
Fix AoE modal continue button

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
@@ -72,6 +72,7 @@ interface Props {
   }) => void;
   isModal: boolean;
   noValidation: boolean;
+  formRef?: React.Ref<HTMLFormElement>;
 }
 
 const AoEForm: React.FC<Props> = ({
@@ -82,6 +83,7 @@ const AoEForm: React.FC<Props> = ({
   saveCallback,
   isModal,
   noValidation,
+  formRef,
 }) => {
   // this seems like it will do a bunch of wasted work on re-renders and non-renders,
   // but it's all small-ball stuff for now
@@ -233,7 +235,7 @@ const AoEForm: React.FC<Props> = ({
 
   return (
     <>
-      <form onSubmit={saveAnswers}>
+      <form onSubmit={saveAnswers} ref={formRef}>
         {isModal && (
           <div className="margin-top-4 border-top border-base-lighter" />
         )}

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -15,7 +15,6 @@ const AoEModalForm = ({
   loadState = {},
   saveCallback,
   qrCodeValue = "",
-  canAddToTestQueue,
 }) => {
   const [modalView, setModalView] = useState(null);
   const [patientLink, setPatientLink] = useState("");

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -1,4 +1,4 @@
-import { React, useState } from "react";
+import { React, useRef, useState } from "react";
 import QRCode from "react-qr-code";
 import Modal from "react-modal";
 import AoEForm from "./AoEForm";
@@ -15,10 +15,10 @@ const AoEModalForm = ({
   loadState = {},
   saveCallback,
   qrCodeValue = "",
-  canAddToTestQueue,
 }) => {
   const [modalView, setModalView] = useState(null);
   const [patientLink, setPatientLink] = useState("");
+  const formRef = useRef(null);
   const modalViewValues = [
     { label: "Complete on smartphone", value: "smartphone" },
     { label: "Complete questionnaire verbally", value: "verbal" },
@@ -41,12 +41,12 @@ const AoEModalForm = ({
   };
 
   const continueModal = () => {
-    if (canAddToTestQueue) {
+    if (modalView === "smartphone") {
       saveCallback(patientResponse);
-      onClose();
-    } else {
-      onClose();
+    } else if (formRef?.current) {
+      formRef.current.dispatchEvent(new Event("submit"));
     }
+    onClose();
   };
 
   const chooseModalView = async (view) => {
@@ -63,12 +63,12 @@ const AoEModalForm = ({
   const buttonGroup = (
     <div className="sr-time-of-test-buttons">
       <Button variant="unstyled" label="Cancel" onClick={onClose} />
-      {/* <Button
+      <Button
         className="margin-right-0"
         label={saveButtonText}
         type={"button"}
         onClick={() => continueModal()}
-      /> */}
+      />
     </div>
   );
 
@@ -146,6 +146,7 @@ const AoEModalForm = ({
               saveCallback={saveCallback}
               isModal={true}
               noValidation={true}
+              formRef={formRef}
             />
           )}
         </>
@@ -158,6 +159,7 @@ const AoEModalForm = ({
           saveCallback={saveCallback}
           isModal={true}
           noValidation={true}
+          formRef={formRef}
         />
       )}
     </Modal>

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -15,6 +15,7 @@ const AoEModalForm = ({
   loadState = {},
   saveCallback,
   qrCodeValue = "",
+  canAddToTestQueue,
 }) => {
   const [modalView, setModalView] = useState(null);
   const [patientLink, setPatientLink] = useState("");
@@ -40,10 +41,11 @@ const AoEModalForm = ({
     symptoms: JSON.stringify(symptomsResponse),
   };
 
+  // Save default values if in "smartphone mode" or verbal form not displayed
   const continueModal = () => {
-    if (modalView === "smartphone") {
+    if (modalView === "smartphone" || !formRef?.current) {
       saveCallback(patientResponse);
-    } else if (formRef?.current) {
+    } else {
       formRef.current.dispatchEvent(new Event("submit"));
     }
     onClose();

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -40,9 +40,13 @@ const AoEModalForm = ({
     symptoms: JSON.stringify(symptomsResponse),
   };
 
-  // Save default values if in "smartphone mode" or verbal form not displayed
   const continueModal = () => {
-    if (modalView === "smartphone" || !formRef?.current) {
+    // No need to save form if in "smartphone" mode
+    if (modalView === "smartphone") {
+      return onClose();
+    }
+    // Save default if form doesn't exist, otherwise submit form
+    if (!formRef?.current) {
       saveCallback(patientResponse);
     } else {
       formRef.current.dispatchEvent(new Event("submit"));

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -529,7 +529,6 @@ const QueueItem: any = ({
                           patient={patient}
                           loadState={aoeAnswers}
                           saveCallback={saveAoeCallback}
-                          canAddToTestQueue={false}
                           qrCodeValue={`${getUrl()}pxp?plid=${patientLinkId}`}
                         />
                       )}

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -82,7 +82,6 @@ const SearchResults = ({
           saveCallback={(a: any) =>
             onAddToQueue(dialogPatient, a, canAddToQueue ? "create" : "update")
           }
-          canAddToTestQueue={canAddToQueue}
         />
       )}
       {shouldShowSuggestions && results}


### PR DESCRIPTION
## Related Issue or Background Info

- Issue #784

## Changes Proposed

The "buggy" button at the top of the AoE modal was submitting a default/empty `patientResponse` object _no matter what_. This makes sense if the user hasn't made an initial selection (QR code vs. verbal completion). However, if the user has made a selection, it should either (a) For QR code: close the form without submitting responses, or (b) For verbal: submit the form responses and not an empty/default object.

The form lives in a child component and the data submittal is accomplished using the form `onSubmit` handler. The easiest way to hook into that process with the parent's "Continue" button was to use a `ref` and pass it from the child to the parent, triggering a submit event when the "Continue" button is clicked.

## Additional Information

- We already have tests of the AoE Form component, but nothing of this modal. I'd like to do a full RTL test of adding a user and verbal test, but not sure if it's worth the time right now. (I usually regret it when I decide testing is not worth the time)