### PR TITLE
Fix state propagation so that queue refresh updates AoE tags

### DIFF
--- a/frontend/src/app/testQueue/AskOnEntryTag.jsx
+++ b/frontend/src/app/testQueue/AskOnEntryTag.jsx
@@ -26,7 +26,9 @@ export const areAnswersComplete = (answers) => {
 
 const AskOnEntryTag = ({ aoeAnswers }) => {
   const [answers, setAnswers] = useState(aoeAnswers);
-  useEffect(() => { setAnswers(aoeAnswers) }, [aoeAnswers]);
+  useEffect(() => {
+    setAnswers(aoeAnswers);
+  }, [aoeAnswers]);
   if (areAnswersComplete(answers)) {
     return <span className="usa-tag bg-green">COMPLETED</span>;
   } else {

--- a/frontend/src/app/testQueue/AskOnEntryTag.jsx
+++ b/frontend/src/app/testQueue/AskOnEntryTag.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 export const areAnswersComplete = (answers) => {
   if (!answers.noSymptoms) {
@@ -25,7 +25,9 @@ export const areAnswersComplete = (answers) => {
 };
 
 const AskOnEntryTag = ({ aoeAnswers }) => {
-  if (areAnswersComplete(aoeAnswers)) {
+  const [answers, setAnswers] = useState(aoeAnswers);
+  useEffect(() => { setAnswers(aoeAnswers) }, [aoeAnswers]);
+  if (areAnswersComplete(answers)) {
     return <span className="usa-tag bg-green">COMPLETED</span>;
   } else {
     return <span className="usa-tag">PENDING</span>;

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { toast } from "react-toastify";
@@ -250,6 +250,9 @@ const QueueItem: any = ({
 
   const [isAoeModalOpen, updateIsAoeModalOpen] = useState(false);
   const [aoeAnswers, setAoeAnswers] = useState(askOnEntry);
+  useEffect(() => {
+    setAoeAnswers(askOnEntry);
+  }, [askOnEntry]);
 
   const [deviceId, updateDeviceId] = useState(
     selectedDeviceId || defaultDevice.internalId


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #863

## Changes Proposed

- Adds `useEffect` callbacks in QueueItem and AskOnEntryTag to propagate changes to props through to component state

## Additional Information

- This change also exists in #813 