### PR TITLE
Updated specimen-type migration to run in all environments.

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1355,7 +1355,9 @@ databaseChangeLog:
       id: populate-specimen-tables
       author: bwarfield@cdc.gov
       comment: Populate specimen tables and relations based on existing data.
-      validCheckSum: "8:ab7979e21fd696979931d82120bcbfab"
+      validCheckSum: # yes there are two of them because liquibase checksums are not platform-independent LOLsob.
+        - "8:824e942da27e8b5c9d965bf00d067d91" # Linux
+        - "8:ab7979e21fd696979931d82120bcbfab" # MacOS
       preConditions:
         # run this migration only if there is at least one row in device_type. If there is not, mark it as already run.
         - onSqlOutput: FAIL

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1355,6 +1355,7 @@ databaseChangeLog:
       id: populate-specimen-tables
       author: bwarfield@cdc.gov
       comment: Populate specimen tables and relations based on existing data.
+      validCheckSum: "8:ab7979e21fd696979931d82120bcbfab"
       preConditions:
         # run this migration only if there is at least one row in device_type. If there is not, mark it as already run.
         - onSqlOutput: FAIL
@@ -1414,7 +1415,7 @@ databaseChangeLog:
             sql: |
               INSERT INTO ${database.defaultSchemaName}.facility_device_specimen_type
               (facility_id, device_specimen_type_id)
-              SELECT facility_id, ds.internal_id
+              SELECT DISTINCT facility_id, ds.internal_id
               FROM ${database.defaultSchemaName}.facility_device_type
                 JOIN ${database.defaultSchemaName}.device_specimen_type ds using(device_type_id);
 

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1434,6 +1434,27 @@ databaseChangeLog:
               FROM ${database.defaultSchemaName}.device_specimen_type ds
               WHERE ds.device_type_id = t.device_type_id;
   - changeSet:
+      id: test-order-fixup
+      author: bwarfield@cdc.gov
+      comment: Populate test_order.device_type_id and device_specimen_type_id with a default when it was previously left empty.
+      preConditions:
+        # run this migration only if there is at least one row in test_order with no device_type_id.
+        - onSqlOutput: FAIL
+        - onFail: MARK_RAN
+        - sqlCheck:
+            sql:  SELECT case when count(1) > 0 then 1 else 0 end FROM ${database.defaultSchemaName}.test_order WHERE device_type_id is null;
+            expectedResult: 1
+      changes:
+        - sql:
+            remarks: Populate the device_type_id and device_specimen_type_id for test orders with the default_device_type_id from their facility.
+            sql: |
+              UPDATE ${database.defaultSchemaName}.test_order t
+              SET device_type_id = f.default_device_type_id,
+                device_specimen_type_id = f.default_device_specimen_type_id
+              FROM ${database.defaultSchemaName}.facility f
+              WHERE f.internal_id = t.facility_id
+              AND t.device_type_id is null
+  - changeSet:
       id: complete-specimen-column-additions
       author: bwarfield@cdc.gov
       comment: Update constraints for newly-added columns referencing device_specimen_type.


### PR DESCRIPTION
Since there is no uniqueness constraint on facility_device_type, it has acquired duplicate rows in production, which caused the migration to fail when we copied the rows of that table one-for-one into a new table that does have a uniqueness
constraint. Changed the migration to filter out duplicates, and updated the changelog to allow both migrations to be considered valid.

ALSO

We have a small number of TestOrder entities from November and December that have no device type associated with them, so we need to back-populate those in order to have a non-null device_specimen_type_id column.

## Related Issue or Background Info

- production release failed this afternoon

## Changes Proposed

- adjust the migration so that it can run even in the presence of duplicate rows
- kick liquibase until it accepts the new migration
- fill in the (7) rows in `test_order` that have no device_type_id before we try to impose the not-null constraints

## Additional Information

Write-up on root cause will be in Slack.