### PR TITLE
Add missing Switch statement for settings nav

### DIFF
--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { Route, RouteComponentProps } from "react-router-dom";
+import { Route, RouteComponentProps, Switch } from "react-router-dom";
 import ManageOrganizationContainer from "./ManageOrganizationContainer";
 import ManageFacilitiesContainer from "./Facility/ManageFacilitiesContainer";
 import FacilityFormContainer from "./Facility/FacilityFormContainer";
@@ -14,24 +14,26 @@ const Settings: React.FC<RouteComponentProps<{}>> = ({ match }) => {
     <main className="prime-home">
       <div className="grid-container">
         <SettingsNav />
-        <Route
-          path={match.url + "/facilities"}
-          component={ManageFacilitiesContainer}
-        />
-        <Route
-          path={match.url + "/facility/:facilityId"}
-          render={({ match }: RouteComponentProps<Params>) => (
-            <FacilityFormContainer facilityId={match.params.facilityId} />
-          )}
-        />
-        <Route
-          path={match.url + "/add-facility/"}
-          render={({ match }: RouteComponentProps<Params>) => (
-            <FacilityFormContainer facilityId={match.params.facilityId} />
-          )}
-        />
-        <Route path={match.url + "/users"} component={ManageUsersContainer} />
-        <Route component={ManageOrganizationContainer} />
+        <Switch>
+          <Route
+            path={match.url + "/facilities"}
+            component={ManageFacilitiesContainer}
+          />
+          <Route
+            path={match.url + "/facility/:facilityId"}
+            render={({ match }: RouteComponentProps<Params>) => (
+              <FacilityFormContainer facilityId={match.params.facilityId} />
+            )}
+          />
+          <Route
+            path={match.url + "/add-facility/"}
+            render={({ match }: RouteComponentProps<Params>) => (
+              <FacilityFormContainer facilityId={match.params.facilityId} />
+            )}
+          />
+          <Route path={match.url + "/users"} component={ManageUsersContainer} />
+          <Route component={ManageOrganizationContainer} />
+        </Switch>
       </div>
     </main>
   );


### PR DESCRIPTION
## Related Issue or Background Info

I introduced a bug when fixing the settings nav because I forgot to surround the routes in a `Switch` component, which would render the _first_ child route that matched. Since I didn't have a `Switch`, _all_ matching child routes were returned (meaning the matching route + the default route for any settings page).

<img width="960" alt="multiple routes showing" src="https://user-images.githubusercontent.com/49658917/108889392-52f46200-75da-11eb-8df4-c9d7866d9720.png">


## Changes Proposed

- Surround settings routes with `Switch`