### PR TITLE
Only poll queue when tab is active

### DIFF
--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -116,7 +116,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
     queueQuery,
     {
-      fetchPolicy: "cache-and-network",
+      fetchPolicy: "no-cache",
       variables: {
         facilityId: activeFacilityId,
       },

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -124,9 +124,10 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   );
 
   useEffect(() => {
+    // Start polling on creation, stop on componenent teardown
     startPolling(pollInterval);
     return stopPolling;
-  });
+  }, [startPolling, stopPolling]);
 
   if (error) {
     throw error;

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
 import { toast } from "react-toastify";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
@@ -113,12 +113,19 @@ interface QueueItemData {
 }
 
 const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
-  const { data, loading, error, refetch: refetchQueue } = useQuery(queueQuery, {
-    fetchPolicy: "no-cache",
-    variables: {
-      facilityId: activeFacilityId,
-    },
-    pollInterval,
+  const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
+    queueQuery,
+    {
+      fetchPolicy: "cache-and-network",
+      variables: {
+        facilityId: activeFacilityId,
+      },
+    }
+  );
+
+  useEffect(() => {
+    startPolling(pollInterval);
+    return stopPolling;
   });
 
   if (error) {
@@ -170,7 +177,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
                 selectedTestResult={result}
                 devices={facility.deviceTypes}
                 defaultDevice={facility.defaultDeviceType}
-                refetchQueue={refetchQueue}
+                refetchQueue={refetch}
                 facilityId={activeFacilityId}
                 dateTestedProp={dateTested}
                 patientLinkId={patientLink?.internalId || null}
@@ -210,7 +217,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
       <div className="grid-container">
         <div className="grid-row position-relative">
           <AddToQueueSearch
-            refetchQueue={refetchQueue}
+            refetchQueue={refetch}
             facilityId={activeFacilityId}
             patientsInQueue={patientsInQueue}
           />


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #713

## Changes Proposed

Use `startPolling` and `stopPolling` to poll only when the queue is the active page, rather than starting a new poll each time the queue is rendered.

## Additional Information

To see the effect of this you'll need to open the Network tab in devtools and note that switching back and forth between the queue and other pages doesn't cancel the earlier 10-second polls.
