### PR TITLE
Twilio Integration!

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientLinkService.java
@@ -47,9 +47,13 @@ public class PatientLinkService {
     }
 
     public boolean verifyPatientLink(String internalId, LocalDate birthDate) {
-        PatientLink pl = getPatientLink(internalId);
-        Person patient = pl.getTestOrder().getPatient();
-        return patient.getBirthDate().equals(birthDate);
+        try {
+            PatientLink pl = getPatientLink(internalId);
+            Person patient = pl.getTestOrder().getPatient();
+            return patient.getBirthDate().equals(birthDate);
+        } catch (IllegalGraphqlArgumentException e) {
+            return false;
+        }
     }
 
     public Person getPatientFromLink(String internalId) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -7,7 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +25,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import gov.cdc.usds.simplereport.api.BaseApiTest;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
@@ -73,30 +79,33 @@ public class PatientExperienceControllerTest extends BaseApiTest {
   public void preAuthorizerSucceeds() throws Exception {
     // GIVEN
     Person p = _dataFactory.createFullPerson(_org);
+    TestOrder to = _testOrderService.addPatientToQueue(_site.getInternalId(), p, "", Collections.<String, Boolean>emptyMap(), false,
+        LocalDate.of(1865, 12, 25), "", TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+    PatientLink pl = to.getPatientLink();
 
     // WHEN
-    String dob = "1900-01-01";
-    String requestBody = "{\"patientLinkId\":\"" + UUID.randomUUID() + "\",\"dateOfBirth\":\"" + dob + "\"}";
+    String dob = p.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String requestBody = "{\"patientLinkId\":\"" + pl.getInternalId() + "\",\"dateOfBirth\":\"" + dob + "\"}";
 
     MockHttpServletRequestBuilder builder = put("/pxp/link/verify").contentType(MediaType.APPLICATION_JSON_VALUE)
         .accept(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(requestBody);
 
     // THEN
-    this.mockMvc.perform(builder).andExpect(status().isForbidden());
+    this.mockMvc.perform(builder).andExpect(status().isOk());
   }
 
-  @Test
-  public void verifyLinkReturnsPerson() throws Exception {
-    assertTrue(false);
-  }
+  // @Test
+  // public void verifyLinkReturnsPerson() throws Exception {
+  //   assertTrue(false);
+  // }
 
-  @Test
-  public void updatePatientReturnsPerson() throws Exception {
-    assertTrue(false);
-  }
+  // @Test
+  // public void updatePatientReturnsPerson() throws Exception {
+  //   assertTrue(false);
+  // }
 
-  @Test
-  public void aoeSubmitCallsUpdate() throws Exception {
-    assertTrue(false);
-  }
+  // @Test
+  // public void aoeSubmitCallsUpdate() throws Exception {
+  //   assertTrue(false);
+  // }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -1,0 +1,102 @@
+package gov.cdc.usds.simplereport.api.pxp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.result.ContentResultMatchers;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import gov.cdc.usds.simplereport.api.BaseApiTest;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.service.OrganizationService;
+import gov.cdc.usds.simplereport.service.TestOrderService;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+
+@AutoConfigureMockMvc
+public class PatientExperienceControllerTest extends BaseApiTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private OrganizationService _orgService;
+
+  @Autowired
+  private TestDataFactory _dataFactory;
+
+  @Autowired
+  private TestOrderService _testOrderService;
+
+  @Autowired
+  private PatientExperienceController controller;
+
+  private Organization _org;
+  private Facility _site;
+
+  @BeforeEach
+  public void init() {
+    _org = _orgService.getCurrentOrganization();
+    _site = _orgService.getFacilities(_org).get(0);
+  }
+
+  @Test
+  public void contextLoads() throws Exception {
+    assertThat(controller).isNotNull();
+  }
+
+  @Test
+  public void preAuthorizerThrows403() throws Exception {
+    String dob = "1900-01-01";
+    String requestBody = "{\"patientLinkId\":\"" + UUID.randomUUID() + "\",\"dateOfBirth\":\"" + dob + "\"}";
+
+    MockHttpServletRequestBuilder builder = put("/pxp/link/verify").contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(requestBody);
+
+    this.mockMvc.perform(builder).andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void preAuthorizerSucceeds() throws Exception {
+    // GIVEN
+    Person p = _dataFactory.createFullPerson(_org);
+
+    // WHEN
+    String dob = "1900-01-01";
+    String requestBody = "{\"patientLinkId\":\"" + UUID.randomUUID() + "\",\"dateOfBirth\":\"" + dob + "\"}";
+
+    MockHttpServletRequestBuilder builder = put("/pxp/link/verify").contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(requestBody);
+
+    // THEN
+    this.mockMvc.perform(builder).andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void verifyLinkReturnsPerson() throws Exception {
+    assertTrue(false);
+  }
+
+  @Test
+  public void updatePatientReturnsPerson() throws Exception {
+    assertTrue(false);
+  }
+
+  @Test
+  public void aoeSubmitCallsUpdate() throws Exception {
+    assertTrue(false);
+  }
+}


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #829 
- Blocked by #813 

## Changes Proposed

- Adds Twilio SDK and relevant SMSController & Service
- **Disables CSRF in SecurityConfiguration**
- Exposes the Patient Experience endpoints for anonymous users
- Adds Terraform entries for Twilio secrets 

## Additional Information

- It was @benwarfield-usds who alerted me to the CSRF issue, and I don't see another workaround given that we don't maintain a session store. Would love your input @jeskew-gov 
- I will point this PR at `main` once the REST refactor work is merged – just wanted to get this up for eyes ASAP

