### PR TITLE
Set USWDS global link styles to true

### DIFF
--- a/frontend/src/scss/_uswds-theme-typography.scss
+++ b/frontend/src/scss/_uswds-theme-typography.scss
@@ -66,7 +66,7 @@ unclassed elements:
 */
 
 $theme-global-paragraph-styles: false;
-$theme-global-link-styles: false;
+$theme-global-link-styles: true;
 $theme-global-content-styles: false;
 
 /*


### PR DESCRIPTION
## Related Issue or Background Info

**Problem**
Various links on the site are displaying the user agent link styles. 

**Solution**
Sets global link styles to true in USWDS typography settings. B/c the anchor link is so low in specificity, it shouldn't effect anything we don't want it to.
 
## Screenshots / Demos
### Before
<img width="937" alt="Screen Shot 2021-02-23 at 1 11 41 PM" src="https://user-images.githubusercontent.com/5249443/108908911-baa9ad80-75d8-11eb-9c1f-c6502e60fd6c.png">

### After
<img width="929" alt="Screen Shot 2021-02-23 at 1 11 00 PM" src="https://user-images.githubusercontent.com/5249443/108908909-ba111700-75d8-11eb-8276-05b40d76ec28.png">
