### PR TITLE
Annoyance-reducing change to gradle tests.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,7 +62,9 @@ springBoot {
 }
 
 test {
-	useJUnitPlatform()
+    // people sometimes export this to run local dev more easily: don't let it break the tests
+    environment "SPRING_PROFILES_ACTIVE", ""
+    useJUnitPlatform()
 }
 
 configurations {


### PR DESCRIPTION
Made tests run with the SPRING_PROFILES_ACTIVE environment variable hard-set to be empty, since we almost never want to change the way tests run by setting an environment variable, and frequently set that variable without wanting to change the way tests run.
