### PR TITLE
Route to new user after adding and some refactoring

### DIFF
--- a/frontend/src/app/Settings/Users/CreateUserForm.tsx
+++ b/frontend/src/app/Settings/Users/CreateUserForm.tsx
@@ -11,6 +11,7 @@ import "./ManageUsers.scss";
 interface Props {
   onClose: () => void;
   onSubmit: (newUserInvite: NewUserInvite) => void;
+  isUpdating: boolean;
 }
 
 const initialFormState: NewUserInvite = {
@@ -36,7 +37,7 @@ const ROLE_OPTIONS = [
   },
 ];
 
-const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit }) => {
+const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit, isUpdating }) => {
   const [newUser, updateNewUser] = useState(initialFormState);
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
@@ -85,6 +86,7 @@ const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit }) => {
           value={newUser.firstName}
           required
           onChange={onChange}
+          disabled={isUpdating}
         />
         <TextInput
           name="lastName"
@@ -93,6 +95,7 @@ const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit }) => {
           value={newUser.lastName}
           required
           onChange={onChange}
+          disabled={isUpdating}
         />
       </div>
       <div className="grid-row">
@@ -104,6 +107,7 @@ const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit }) => {
           value={newUser.email}
           required
           onChange={onChange}
+          disabled={isUpdating}
         />
         <div className="grid-row">{setUserRole}</div>
       </div>
@@ -118,7 +122,8 @@ const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit }) => {
           <Button
             className="margin-right-205"
             onClick={() => onSubmit(newUser)}
-            label="Send invite"
+            label={isUpdating ? "Sending" : "Send invite"}
+            disabled={isUpdating}
           />
         </div>
       </div>

--- a/frontend/src/app/Settings/Users/CreateUserModal.tsx
+++ b/frontend/src/app/Settings/Users/CreateUserModal.tsx
@@ -9,9 +9,14 @@ import "./ManageUsers.scss";
 interface Props {
   onClose: () => void;
   onSubmit: (newUserInvite: NewUserInvite) => void;
+  isUpdating: boolean;
 }
 
-const CreateUserModal: React.FC<Props> = ({ onClose, onSubmit }) => {
+const CreateUserModal: React.FC<Props> = ({
+  onClose,
+  onSubmit,
+  isUpdating,
+}) => {
   return (
     <Modal
       isOpen={true}
@@ -26,7 +31,11 @@ const CreateUserModal: React.FC<Props> = ({ onClose, onSubmit }) => {
       contentLabel="Unsaved changes to current user"
       ariaHideApp={process.env.NODE_ENV !== "test"}
     >
-      <CreateUserForm onClose={onClose} onSubmit={onSubmit} />
+      <CreateUserForm
+        onClose={onClose}
+        onSubmit={onSubmit}
+        isUpdating={isUpdating}
+      />
     </Modal>
   );
 };

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -36,18 +36,22 @@ const users: SettingsUsers[keyof SettingsUsers][] = [
 let updateUserRole: () => Promise<any>;
 let addUserToOrg: () => Promise<any>;
 let deleteUser: (obj: any) => Promise<any>;
-let getUsers: () => void;
+let getUsers: () => Promise<any>;
 
 let inputValue = (value: string) => ({ target: { value } });
 
 describe("ManageUsers", () => {
   beforeEach(() => {
     updateUserRole = jest.fn(() => Promise.resolve());
-    addUserToOrg = jest.fn(() => Promise.resolve());
+    addUserToOrg = jest.fn(() =>
+      Promise.resolve({
+        data: { data: { addUserToCurrentOrg: { id: "added-user-id" } } },
+      })
+    );
     deleteUser = jest.fn((obj) =>
       Promise.resolve({ data: { setUserIsDeleted: { id: obj.variables.id } } })
     );
-    getUsers = jest.fn();
+    getUsers = jest.fn(() => Promise.resolve());
   });
   it("displays the list of users and defaults to the first user", () => {
     const { container } = render(

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -157,4 +157,19 @@ describe("ManageUsers", () => {
       variables: { id: users[0].id, role: "ADMIN" },
     });
   });
+  it("fails gracefully when there are no users", async () => {
+    const { findByText } = render(
+      <ManageUsers
+        users={[]}
+        loggedInUser={loggedInUser}
+        allFacilities={allFacilities}
+        updateUserRole={updateUserRole}
+        addUserToOrg={addUserToOrg}
+        deleteUser={deleteUser}
+        getUsers={getUsers}
+      />
+    );
+    const noUsers = await findByText("no users", { exact: false });
+    expect(noUsers).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -254,7 +254,7 @@ const ManageUsers: React.FC<Props> = ({
           {!localUsers.length ? (
             <p>There are no users in this organization</p>
           ) : (
-            <p>Loading data</p>
+            <p>Loading user data</p>
           )}
         </div>
       ) : (
@@ -268,13 +268,11 @@ const ManageUsers: React.FC<Props> = ({
             <div className="tablet:grid-col padding-left-2">
               <div className="user-header grid-row flex-row flex-align-center">
                 <h2 className="display-inline-block margin-y-1">
-                  {activeUser
-                    ? displayFullNameInOrder(
-                        activeUser.firstName,
-                        activeUser.middleName,
-                        activeUser.lastName
-                      )
-                    : "Loading..."}
+                  {displayFullNameInOrder(
+                    activeUser.firstName,
+                    activeUser.middleName,
+                    activeUser.lastName
+                  )}
                 </h2>
                 {activeUser?.id === loggedInUser.id ? (
                   <span className="usa-tag margin-left-1 bg-base-lighter text-ink">
@@ -287,16 +285,15 @@ const ManageUsers: React.FC<Props> = ({
                   Admins have full access to conduct tests, manage results and
                   profiles, and manage settings and users
                 </p>
-                {activeUser && (
+                {
                   <UserRoleSettingsForm
                     activeUser={activeUser}
                     loggedInUser={loggedInUser}
                     onUpdateUser={updateUser}
                   />
-                )}
+                }
 
-                {process.env.REACT_APP_VIEW_USER_FACILITIES === "true" &&
-                activeUser ? (
+                {process.env.REACT_APP_VIEW_USER_FACILITIES === "true" ? (
                   <UserFacilitiesSettingsForm
                     activeUser={activeUser}
                     allFacilities={allFacilities}
@@ -330,12 +327,12 @@ const ManageUsers: React.FC<Props> = ({
                 />
               </div>
 
-              {showInProgressModal && activeUser ? (
+              {showInProgressModal && (
                 <InProgressModal
                   onClose={() => updateShowInProgressModal(false)}
                   onContinue={() => onContinueChangeActiveUser()}
                 />
-              ) : null}
+              )}
               {isUserEdited ? (
                 <Prompt
                   when={isUserEdited}

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Prompt } from "react-router-dom";
 import { toast } from "react-toastify";
 
@@ -37,7 +37,7 @@ interface Props {
   updateUserRole: (variables: any) => Promise<any>;
   addUserToOrg: (variables: any) => Promise<any>;
   deleteUser: (variables: any) => Promise<any>;
-  getUsers: () => void;
+  getUsers: () => Promise<any>;
 }
 
 export type SettingsUsers = { [id: string]: SettingsUser };
@@ -50,6 +50,12 @@ const sortUsers = (users: SettingsUsers) =>
     return nameA > nameB ? 1 : -1;
   });
 
+const getSettingsUser = (users: SettingsUser[]) =>
+  users.reduce((acc: SettingsUsers, user: SettingsUser) => {
+    acc[user.id] = user;
+    return acc;
+  }, {});
+
 const ManageUsers: React.FC<Props> = ({
   users,
   loggedInUser,
@@ -59,21 +65,7 @@ const ManageUsers: React.FC<Props> = ({
   deleteUser,
   getUsers,
 }) => {
-  let settingsUsers: SettingsUsers = users.reduce(
-    (acc: SettingsUsers, user: SettingsUser) => {
-      acc[user.id] = user;
-      return acc;
-    },
-    {}
-  );
-
-  const [usersState, updateUsersState] = useState<SettingsUsers>(settingsUsers);
-
-  const sortedUsers = sortUsers(usersState);
-
-  const [activeUserId, updateActiveUserId] = useState<string>(
-    sortedUsers[0].id
-  );
+  const [activeUser, updateActiveUser] = useState<SettingsUser>();
   const [nextActiveUserId, updateNextActiveUserId] = useState<string | null>(
     null
   );
@@ -81,11 +73,24 @@ const ManageUsers: React.FC<Props> = ({
   const [showAddUserModal, updateShowAddUserModal] = useState(false);
   const [showDeleteUserModal, updateShowDeleteUserModal] = useState(false);
   const [isUserEdited, updateIsUserEdited] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState<Error>();
+  // Maintain deleted user ID on client while request is in flight
+  const [deletedUserId, setDeletedUserId] = useState<string>();
+  // Maintain added user on client while request is in flight
+  const [addedUserId, setAddedUserId] = useState<string>();
 
   if (error) {
     throw error;
   }
+
+  // Local users will be more up-to-date than users, which only gets updated after server requests complete
+  let localUsers = [...users];
+  if (deletedUserId) {
+    localUsers = localUsers.filter(({ id }) => id !== deletedUserId);
+  }
+  const usersState: SettingsUsers = getSettingsUser(localUsers);
+  const sortedUsers = sortUsers(usersState);
 
   // only updates the local state
   function updateUser<T>(
@@ -93,12 +98,9 @@ const ManageUsers: React.FC<Props> = ({
     key: string, // the field to update
     value: T // value of the field to update
   ) {
-    updateUsersState({
-      ...usersState,
-      [userId]: {
-        ...usersState[userId],
-        [key]: value,
-      },
+    updateActiveUser({
+      ...usersState[userId],
+      [key]: value,
     });
     updateIsUserEdited(true);
   }
@@ -109,44 +111,38 @@ const ManageUsers: React.FC<Props> = ({
       updateNextActiveUserId(nextActiveUserId);
       updateShowInProgressModal(true);
     } else {
-      updateActiveUserId(nextActiveUserId);
+      updateActiveUser(usersState[nextActiveUserId]);
     }
   };
 
   // proceed with changing the active user
-  const onContinueChangeActiveUser = (currentActiveUserId: string) => {
-    updateShowInProgressModal(false);
-
-    updateActiveUserId(nextActiveUserId as string);
-    resetUser(currentActiveUserId);
-  };
-
-  // throw away unsaved edits
-  const resetUser = (userId: string) => {
-    updateUsersState({
-      ...usersState,
-      [userId]: settingsUsers[userId],
-    });
+  const onContinueChangeActiveUser = () => {
     updateIsUserEdited(false);
+    updateShowInProgressModal(false);
+    if (nextActiveUserId) {
+      updateActiveUser(usersState[nextActiveUserId]);
+    }
   };
 
-  const handleUpdateUser = (userId: string) => {
-    const selectedRoleDescription = usersState[userId]
-      .roleDescription as RoleDescription;
+  const handleUpdateUser = () => {
+    if (!activeUser) {
+      return;
+    }
+    setIsUpdating(true);
+    const selectedRoleDescription = activeUser.roleDescription as RoleDescription;
     const selectedOrganizationRole = RoleDescriptionToOrgRole[
       selectedRoleDescription
     ] as OrganizationRole;
     updateUserRole({
       variables: {
-        id: userId,
+        id: activeUser.id,
         role: selectedOrganizationRole,
       },
     })
       .then(() => {
+        getUsers();
         updateIsUserEdited(false);
-
-        const user = usersState[userId];
-
+        const user = usersState[activeUser.id];
         const fullName = displayFullNameInOrder(
           user.firstName,
           user.middleName,
@@ -162,88 +158,87 @@ const ManageUsers: React.FC<Props> = ({
           />
         );
       })
-      .catch(setError);
+      .catch(setError)
+      .finally(() => {
+        setIsUpdating(false);
+      });
   };
 
-  const handleAddUserToOrg = (newUserInvite: NewUserInvite) => {
+  const handleAddUserToOrg = async (newUserInvite: NewUserInvite) => {
     // TODO: validate form
-    const { firstName, lastName, email } = { ...newUserInvite };
-    addUserToOrg({
-      variables: {
-        firstName: firstName,
-        lastName: lastName,
-        email: email,
-      },
-    })
-      .then(() => {
-        const fullName = displayFullNameInOrder(firstName, "", lastName);
-        showNotification(
-          toast,
-          <Alert
-            type="success"
-            title={`Invitation sent to ${fullName}`}
-            body={`They will receive an invitation to create an account at the email address provided`}
-          />
-        );
-        updateShowAddUserModal(false);
-        getUsers();
-      })
-      .catch(setError);
+    try {
+      setIsUpdating(true);
+      const { firstName, lastName, email } = { ...newUserInvite };
+      const { data } = await addUserToOrg({
+        variables: {
+          firstName: firstName,
+          lastName: lastName,
+          email: email,
+        },
+      });
+      await getUsers();
+      const fullName = displayFullNameInOrder(firstName, "", lastName);
+      showNotification(
+        toast,
+        <Alert
+          type="success"
+          title={`Invitation sent to ${fullName}`}
+          body={`They will receive an invitation to create an account at the email address provided`}
+        />
+      );
+      updateShowAddUserModal(false);
+      setAddedUserId(data?.addUserToCurrentOrg?.id);
+    } catch (e) {
+      setError(e);
+    } finally {
+      setIsUpdating(false);
+    }
   };
 
-  const handleDeleteUser = (userId: string) => {
-    deleteUser({
-      variables: {
-        id: userId,
-        deleted: true,
-      },
-    })
-      .then((data) => {
-        const deletedUserId = data.data.setUserIsDeleted.id;
-        const user = usersState[deletedUserId];
+  const handleDeleteUser = async (userId: string) => {
+    try {
+      const data = await deleteUser({
+        variables: {
+          id: userId,
+          deleted: true,
+        },
+      });
+      const deletedUserId = data.data.setUserIsDeleted.id;
+      const user = usersState[deletedUserId];
 
-        const fullName = displayFullNameInOrder(
-          user.firstName,
-          user.middleName,
-          user.lastName
-        );
-
-        showNotification(
-          toast,
-          <Alert
-            type="success"
-            title={`User account removed for ${fullName}`}
-          />
-        );
-
-        // remove the deleted user from the UI
-        const { [deletedUserId]: value, ...usersMinusDeleted } = usersState;
-        updateUsersState(usersMinusDeleted);
-        const firstUserId =
-          sortedUsers[0].id === deletedUserId
-            ? sortedUsers[1].id
-            : sortedUsers[0].id;
-        updateActiveUserId(firstUserId); // arbitrarily pick the first user as the next active.
-      })
-      .catch(setError);
-
-    const user = usersState[userId];
-
-    const fullName = displayFullNameInOrder(
-      user.firstName,
-      user.middleName,
-      user.lastName
-    );
-
-    let successAlert = (
-      <Alert type="success" title={`User account removed for ${fullName}`} />
-    );
-
-    showNotification(toast, successAlert);
-    updateShowDeleteUserModal(false);
+      const fullName = displayFullNameInOrder(
+        user.firstName,
+        user.middleName,
+        user.lastName
+      );
+      updateShowDeleteUserModal(false);
+      setDeletedUserId(userId);
+      showNotification(
+        toast,
+        <Alert type="success" title={`User account removed for ${fullName}`} />
+      );
+      await getUsers();
+      updateActiveUser(sortedUsers[0]); // arbitrarily pick the first user as the next active.
+      setDeletedUserId(undefined);
+    } catch (e) {
+      setError(e);
+    }
   };
 
-  const activeUser: SettingsUser = usersState[activeUserId];
+  // Default to first user
+  useEffect(() => {
+    if (!activeUser && sortedUsers.length) {
+      updateActiveUser(sortedUsers[0]);
+    }
+  }, [activeUser, sortedUsers]);
+
+  // Navigate to addeed user, if applicable
+  useEffect(() => {
+    if (addedUserId && usersState[addedUserId]) {
+      updateActiveUser(usersState[addedUserId]);
+      setAddedUserId(undefined);
+    }
+  }, [addedUserId, usersState]);
 
   return (
     <div className="prime-container usa-card__container">
@@ -257,28 +252,34 @@ const ManageUsers: React.FC<Props> = ({
           />
         ) : null}
       </div>
-      {!activeUser ? (
+      {!activeUser || !localUsers.length ? (
         <div className="usa-card__body">
-          <p> There are no users in this organization </p>
+          {!localUsers.length ? (
+            <p>There are no users in this organization</p>
+          ) : (
+            <p>Loading data</p>
+          )}
         </div>
       ) : (
         <div className="usa-card__body">
           <div className="grid-row">
             <UsersSideNav
-              activeUserId={activeUserId}
+              activeUserId={activeUser.id || ""}
               users={sortedUsers}
               onChangeActiveUser={onChangeActiveUser}
             />
             <div className="tablet:grid-col padding-left-2">
               <div className="user-header grid-row flex-row flex-align-center">
                 <h2 className="display-inline-block margin-y-1">
-                  {displayFullNameInOrder(
-                    activeUser.firstName,
-                    activeUser.middleName,
-                    activeUser.lastName
-                  )}
+                  {activeUser
+                    ? displayFullNameInOrder(
+                        activeUser.firstName,
+                        activeUser.middleName,
+                        activeUser.lastName
+                      )
+                    : "Loading..."}
                 </h2>
-                {activeUser.id === loggedInUser.id ? (
+                {activeUser?.id === loggedInUser.id ? (
                   <span className="usa-tag margin-left-1 bg-base-lighter text-ink">
                     YOU
                   </span>
@@ -289,13 +290,16 @@ const ManageUsers: React.FC<Props> = ({
                   Admins have full access to conduct tests, manage results and
                   profiles, and manage settings and users
                 </p>
-                <UserRoleSettingsForm
-                  activeUser={activeUser}
-                  loggedInUser={loggedInUser}
-                  onUpdateUser={updateUser}
-                />
+                {activeUser && (
+                  <UserRoleSettingsForm
+                    activeUser={activeUser}
+                    loggedInUser={loggedInUser}
+                    onUpdateUser={updateUser}
+                  />
+                )}
 
-                {process.env.REACT_APP_VIEW_USER_FACILITIES === "true" ? (
+                {process.env.REACT_APP_VIEW_USER_FACILITIES === "true" &&
+                activeUser ? (
                   <UserFacilitiesSettingsForm
                     activeUser={activeUser}
                     allFacilities={allFacilities}
@@ -311,27 +315,28 @@ const ManageUsers: React.FC<Props> = ({
                     className="flex-align-self-start display-inline-block"
                     onClick={() => updateShowDeleteUserModal(true)}
                     label="Remove user"
-                    disabled={loggedInUser.id === activeUser.id}
+                    disabled={loggedInUser.id === activeUser.id || isUpdating}
                   />
                 ) : null}
                 <Button
                   type="button"
-                  onClick={() => handleUpdateUser(activeUserId)}
-                  label="Save changes"
+                  onClick={() => handleUpdateUser()}
+                  label={isUpdating ? "Saving..." : "Save changes"}
                   disabled={
                     // enabled only if the user has been edited AND the loggedInUser is an org admin or super admin
                     !isUserEdited ||
                     !["Admin user", "Admin user (SU)"].includes(
                       loggedInUser.roleDescription
-                    )
+                    ) ||
+                    isUpdating
                   }
                 />
               </div>
 
-              {showInProgressModal ? (
+              {showInProgressModal && activeUser ? (
                 <InProgressModal
                   onClose={() => updateShowInProgressModal(false)}
-                  onContinue={() => onContinueChangeActiveUser(activeUserId)}
+                  onContinue={() => onContinueChangeActiveUser()}
                 />
               ) : null}
               {isUserEdited ? (
@@ -343,6 +348,7 @@ const ManageUsers: React.FC<Props> = ({
               {showAddUserModal &&
               process.env.REACT_APP_ADD_NEW_USER_ENABLED === "true" ? (
                 <CreateUserModal
+                  isUpdating={isUpdating}
                   onClose={() => updateShowAddUserModal(false)}
                   onSubmit={handleAddUserToOrg}
                 />

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -149,6 +149,7 @@ const ManageUsers: React.FC<Props> = ({
           user.lastName
         );
 
+        setIsUpdating(false);
         showNotification(
           toast,
           <Alert
@@ -158,10 +159,7 @@ const ManageUsers: React.FC<Props> = ({
           />
         );
       })
-      .catch(setError)
-      .finally(() => {
-        setIsUpdating(false);
-      });
+      .catch(setError);
   };
 
   const handleAddUserToOrg = async (newUserInvite: NewUserInvite) => {
@@ -188,10 +186,9 @@ const ManageUsers: React.FC<Props> = ({
       );
       updateShowAddUserModal(false);
       setAddedUserId(data?.addUserToCurrentOrg?.id);
+      setIsUpdating(false);
     } catch (e) {
       setError(e);
-    } finally {
-      setIsUpdating(false);
     }
   };
 

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react";
-import { gql, useQuery, useMutation, useLazyQuery } from "@apollo/client";
+import React, { useState } from "react";
+import { gql, useQuery, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 
 import ManageUsers from "./ManageUsers";
@@ -108,7 +108,7 @@ const ManageUsersContainer: any = () => {
   const [deleteUser] = useMutation(DELETE_USER);
   const [addUserToOrg] = useMutation(ADD_USER_TO_ORG);
 
-  const [getUsers, { data, loading, error }] = useLazyQuery<UserData, {}>(
+  const { data, loading, error, refetch: getUsers } = useQuery<UserData, {}>(
     GET_USERS,
     { fetchPolicy: "no-cache" }
   );
@@ -120,8 +120,6 @@ const ManageUsersContainer: any = () => {
   } = useQuery<FacilityData, {}>(GET_FACILITIES, {
     fetchPolicy: "no-cache",
   });
-
-  useEffect(getUsers, [getUsers]);
 
   if (loading || loadingFacilities) {
     return <p> Loading... </p>;


### PR DESCRIPTION
## Related Issue or Background Info

- Issue: #924

## Changes Proposed

- Uses `refetch` from `useQuery` rather than using `useLazyQuery` since `refetch` returns a promise whereas `useLazyQuery` doesn't return anything.
- Waits for new call to `getUsers` to resolve and then sets `activeUser` to that person
- Even thought the change set looks a bit large, a lot of it was refactoring from promises to async await since it's a nicer interface for awaiting multiple promises (e.g., await submitting a new user and then await getting all users)
- Adds `isUpdating` logic in to disable buttons and show "submitting" indicators for feedback to the user