### PR TITLE
Fix ORDER_CREATION_ORDER for test queue ordering

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -22,7 +22,7 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
     public static final String FACILITY_QUERY = BASE_ORG_QUERY + " and q.facility = :facility ";
     public static final String IS_PENDING = " and q.orderStatus = 'PENDING' ";
     public static final String IS_COMPLETED = " and q.orderStatus = 'COMPLETED' ";
-    public static final String ORDER_CREATION_ORDER = " order by q.updatedAt ";
+    public static final String ORDER_CREATION_ORDER = " order by q.createdAt ";
     public static final String RESULT_RECENT_ORDER = " order by updatedAt desc ";
 
     @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)


### PR DESCRIPTION
## Related Issue or Background Info

- Issue #942

## Changes Proposed

- ORDER_CREATION_ORDER is currently set to order by `updatedAt` but should be `createdAt`. Ordering by `updatedAt` is what's causing the test queue to reorder when changes are made to individual records.