### PR TITLE
Implement a few Fortify recommendations

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/CsvProcessingException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/CsvProcessingException.java
@@ -1,0 +1,26 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import java.util.List;
+
+/**
+ * An error thrown when CSV uploads fail for reasons other than validation
+ */
+public class CsvProcessingException extends RuntimeException implements GraphQLError {
+    public CsvProcessingException(String message) {
+        super(message);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorType.ExecutionAborted;
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/CsvProcessingException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/CsvProcessingException.java
@@ -16,7 +16,7 @@ public class CsvProcessingException extends RuntimeException implements GraphQLE
 
     @Override
     public List<SourceLocation> getLocations() {
-        return null;
+        return List.of();
     }
 
     @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -91,7 +91,7 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
                                    String orderingProviderZipCode,
                                    String orderingProviderTelephone,
                                    List<String> deviceIds,
-                                   String defaultDeviceId) throws Exception {
+                                   String defaultDeviceId) {
         DeviceSpecimenTypeHolder deviceSpecimenTypes = _dts.getTypesForFacility(defaultDeviceId, deviceIds);
         Facility facility = _os.updateFacility(
           facilityId,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 import javax.servlet.http.Part;
 
+import liquibase.pro.packaged.E;
 import org.springframework.stereotype.Component;
 
 import gov.cdc.usds.simplereport.db.model.Person;
@@ -36,8 +37,11 @@ public class PatientMutationResolver implements GraphQLMutationResolver  {
     }
 
     public String uploadPatients(Part part) throws Exception {
-        InputStream people = part.getInputStream();
-        return _us.processPersonCSV(people);
+        try (InputStream people = part.getInputStream()) {
+            return _us.processPersonCSV(people);
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     public void addPatient(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
@@ -9,6 +9,7 @@ import static gov.cdc.usds.simplereport.api.Translators.parseRace;
 import static gov.cdc.usds.simplereport.api.Translators.parseState;
 import static gov.cdc.usds.simplereport.api.Translators.parseString;
 
+import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import java.io.InputStream;
 import java.time.LocalDate;
@@ -45,9 +46,9 @@ public class PatientMutationResolver implements GraphQLMutationResolver  {
             return _us.processPersonCSV(people);
         } catch (IllegalGraphqlArgumentException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOG.error("Patient CSV upload failed", e);
-            throw new IllegalGraphqlArgumentException("Unable to complete patient CSV upload");
+            throw new CsvProcessingException("Unable to complete patient CSV upload");
         }
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolver.java
@@ -11,6 +11,7 @@ import static gov.cdc.usds.simplereport.api.Translators.parseString;
 
 import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -46,7 +47,7 @@ public class PatientMutationResolver implements GraphQLMutationResolver  {
             return _us.processPersonCSV(people);
         } catch (IllegalGraphqlArgumentException e) {
             throw e;
-        } catch (Throwable e) {
+        } catch (IOException e) {
             LOG.error("Patient CSV upload failed", e);
             throw new CsvProcessingException("Unable to complete patient CSV upload");
         }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -1,8 +1,5 @@
 package gov.cdc.usds.simplereport.config;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
@@ -18,9 +15,6 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
-import org.springframework.security.web.savedrequest.RequestCache;
-import org.springframework.security.web.savedrequest.SimpleSavedRequest;
 
 import com.okta.spring.boot.oauth.Okta;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -70,19 +70,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	}
 
 	@Bean
-	public RequestCache refererRequestCache() {
-		return new HttpSessionRequestCache() {
-			@Override
-			public void saveRequest(HttpServletRequest request, HttpServletResponse response) {
-				final String referrer = request.getHeader("referer");
-				if (referrer != null) {
-					request.getSession().setAttribute(SAVED_REQUEST_HEADER, new SimpleSavedRequest(referrer));
-				}
-			}
-		};
-	}
-
-	@Bean
 	public IdentitySupplier getRealIdentity() {
 		return () -> {
 			Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static gov.cdc.usds.simplereport.api.Translators.parseEmail;
@@ -23,12 +24,12 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 class TranslatorTest {
     @Test
     void testEmptyShortDate() {
-        assertEquals(null, parseUserShortDate(""));
+        assertNull(parseUserShortDate(""));
     }
 
     @Test
     void testNullShortDate() {
-        assertEquals(null, parseUserShortDate(null));
+        assertNull(parseUserShortDate(null));
     }
 
     @Test
@@ -57,12 +58,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyParseString() {
-        assertEquals(null, parseString(""));
+        assertNull(parseString(""));
     }
 
     @Test
     void testNullParseString() {
-        assertEquals(null, parseString(null));
+        assertNull(parseString(null));
     }
 
     @Test
@@ -87,12 +88,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyUUID() {
-        assertEquals(null, parseUUID(""));
+        assertNull(parseUUID(""));
     }
 
     @Test
     void testNullParseUUID() {
-        assertEquals(null, parseUUID(null));
+        assertNull(parseUUID(null));
     }
 
     @Test
@@ -112,12 +113,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyParseRace() {
-        assertEquals(null, parseRace(""));
+        assertNull(parseRace(""));
     }
 
     @Test
     void testNullParseRace() {
-        assertEquals(null, parseRace(null));
+        assertNull(parseRace(null));
     }
 
     @Test
@@ -134,12 +135,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyParseRaceDisplayValue() {
-        assertEquals(null, parseRaceDisplayValue(""));
+        assertNull(parseRaceDisplayValue(""));
     }
 
     @Test
     void testNullParseRaceDisplayValue() {
-        assertEquals(null, parseRaceDisplayValue(null));
+        assertNull(parseRaceDisplayValue(null));
     }
 
     @Test
@@ -156,12 +157,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyParseEthnicity() {
-        assertEquals(null, parseEthnicity(""));
+        assertNull(parseEthnicity(""));
     }
 
     @Test
     void testNullParseEthnicity() {
-        assertEquals(null, parseEthnicity(null));
+        assertNull(parseEthnicity(null));
     }
 
     @Test
@@ -178,12 +179,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyParseGender() {
-        assertEquals(null, parseGender(""));
+        assertNull(parseGender(""));
     }
 
     @Test
     void testNullParseGender() {
-        assertEquals(null, parseGender(null));
+        assertNull(parseGender(null));
     }
 
     @Test
@@ -200,12 +201,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyParseYesNo() {
-        assertEquals(null, parseYesNo(""));
+        assertNull(parseYesNo(""));
     }
 
     @Test
     void testNullParseYesNo() {
-        assertEquals(null, parseYesNo(null));
+        assertNull(parseYesNo(null));
     }
 
     @Test
@@ -225,12 +226,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyState() {
-        assertEquals(null, parseState(""));
+        assertNull(parseState(""));
     }
 
     @Test
     void testNullState() {
-        assertEquals(null, parseState(null));
+        assertNull(parseState(null));
     }
 
     @Test
@@ -247,12 +248,12 @@ class TranslatorTest {
 
     @Test
     void testEmptyEmail() {
-        assertEquals(null, parseEmail(""));
+        assertNull(parseEmail(""));
     }
 
     @Test
     void testNullEmail() {
-        assertEquals(null, parseEmail(null));
+        assertNull(parseEmail(null));
     }
 
     @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolverTest.java
@@ -1,13 +1,20 @@
 package gov.cdc.usds.simplereport.api.patient;
 
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.service.UploadService;
+import graphql.ErrorType;
 import graphql.GraphQLError;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.servlet.http.Part;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +33,27 @@ class PatientMutationResolverTest {
             sut.uploadPatients(input);
             throw new IllegalStateException("Shouldn't reach this line!");
         } catch (Throwable t) {
-            assertTrue(t instanceof GraphQLError);
+            if (t instanceof GraphQLError) {
+                var gqe = (GraphQLError) t;
+                assertEquals(ErrorType.ExecutionAborted, gqe.getErrorType());
+            } else {
+                fail();
+            }
         }
+    }
+
+    @Test
+    void validation_exceptions_are_propagated_without_change() throws IOException {
+        var personService = mock(PersonService.class);
+        var uploadService = mock(UploadService.class);
+        when(uploadService.processPersonCSV(any(InputStream.class)))
+                .thenThrow(new IllegalGraphqlArgumentException("PANIC"));
+
+        var input = mock(Part.class);
+        when(input.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+
+        var sut = new PatientMutationResolver(personService, uploadService);
+
+        assertThrows(IllegalGraphqlArgumentException.class, () -> sut.uploadPatients(input));
     }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolverTest.java
@@ -1,0 +1,26 @@
+package gov.cdc.usds.simplereport.api.patient;
+
+import gov.cdc.usds.simplereport.service.PersonService;
+import gov.cdc.usds.simplereport.service.UploadService;
+import graphql.GraphQLError;
+import java.io.IOException;
+import javax.servlet.http.Part;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PatientMutationResolverTest {
+    @Test
+    void io_exceptions_are_surfaced_as_graphql_errors() throws IOException {
+        var personService = mock(PersonService.class);
+        var uploadService = mock(UploadService.class);
+        var input = mock(Part.class);
+        when(input.getInputStream()).thenThrow(new IOException("Some TCP error, probably."));
+
+        var sut = new PatientMutationResolver(personService, uploadService);
+
+        assertThrows(GraphQLError.class, () -> sut.uploadPatients(input));
+    }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientMutationResolverTest.java
@@ -7,12 +7,13 @@ import java.io.IOException;
 import javax.servlet.http.Part;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class PatientMutationResolverTest {
     @Test
+    @SuppressWarnings("checkstyle:IllegalCatch")
     void io_exceptions_are_surfaced_as_graphql_errors() throws IOException {
         var personService = mock(PersonService.class);
         var uploadService = mock(UploadService.class);
@@ -21,6 +22,11 @@ class PatientMutationResolverTest {
 
         var sut = new PatientMutationResolver(personService, uploadService);
 
-        assertThrows(GraphQLError.class, () -> sut.uploadPatients(input));
+        try {
+            sut.uploadPatients(input);
+            throw new IllegalStateException("Shouldn't reach this line!");
+        } catch (Throwable t) {
+            assertTrue(t instanceof GraphQLError);
+        }
     }
 }

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -33,7 +33,9 @@ const Header: React.FC<{}> = () => {
 
   const onFacilitySelect = (e: React.FormEvent<HTMLSelectElement>) => {
     const id = (e.target as HTMLSelectElement).value;
-    window.location.href = `${window.location.pathname}?facility=${encodeURIComponent(id)}`;
+    window.location.href = `${
+      window.location.pathname
+    }?facility=${encodeURIComponent(id)}`;
   };
 
   const canViewSettings = hasPermission(
@@ -64,10 +66,12 @@ const Header: React.FC<{}> = () => {
     localStorage.removeItem("access_token");
     localStorage.removeItem("id_token");
     window.location.replace(
-      "https://hhs-prime.okta.com/oauth2/default/v1/logout"
-        + `?id_token_hint=${encodeURIComponent(id_token || "")}`
-        + `&post_logout_redirect_uri=${encodeURIComponent(process.env.REACT_APP_OKTA_URL || "")}`
-        + `&state=${state}`
+      "https://hhs-prime.okta.com/oauth2/default/v1/logout" +
+        `?id_token_hint=${encodeURIComponent(id_token || "")}` +
+        `&post_logout_redirect_uri=${encodeURIComponent(
+          process.env.REACT_APP_OKTA_URL || ""
+        )}` +
+        `&state=${state}`
     );
   };
 

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -33,7 +33,7 @@ const Header: React.FC<{}> = () => {
 
   const onFacilitySelect = (e: React.FormEvent<HTMLSelectElement>) => {
     const id = (e.target as HTMLSelectElement).value;
-    window.location.href = `${window.location.pathname}?facility=${id}`;
+    window.location.href = `${window.location.pathname}?facility=${encodeURIComponent(id)}`;
   };
 
   const canViewSettings = hasPermission(
@@ -64,7 +64,10 @@ const Header: React.FC<{}> = () => {
     localStorage.removeItem("access_token");
     localStorage.removeItem("id_token");
     window.location.replace(
-      `https://hhs-prime.okta.com/oauth2/default/v1/logout?id_token_hint=${id_token}&post_logout_redirect_uri=${process.env.REACT_APP_OKTA_URL}&state=${state}`
+      "https://hhs-prime.okta.com/oauth2/default/v1/logout"
+        + `?id_token_hint=${encodeURIComponent(id_token || "")}`
+        + `&post_logout_redirect_uri=${encodeURIComponent(process.env.REACT_APP_OKTA_URL || "")}`
+        + `&state=${state}`
     );
   };
 


### PR DESCRIPTION
## Related Issue or Background Info

- This PR is a bit of a grab bag, as Fortify has different focus areas than our normal scanner. The hope is that none of the changes have an impact on application functionality. Each change type is in a separate commit.

## Changes Proposed

- Use a try-with-resources block to access the request input stream in the CSV upload mutation resolver to ensure the input stream is always closed.
- Be more circumspect in declaring the exceptions that may be thrown by methods.
- URL-encode a few strings that *should* only contain URL-safe characters in `Header.tsx`.
- Use `assertNull` instead of `assertEquals` with a first parameter of `null`.
- Remove the request referrer cache.

## Additional Information

- Fortify is super worried about `Header.tsx` and stylistic regularity in backend code.
-  No one knows why we have the request referrer cache (the app doesn't use sessions!), so no one can be sure removing it won't break anything.
  - This change will need to be tested in `test` to make sure it is safe.
