### PR TITLE
Fix "Showing N of N" message when total count < page size

### DIFF
--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -164,7 +164,8 @@ export const DetachedManagePatients = ({
               <h2>
                 {PATIENT_TERM_PLURAL_CAP}
                 <span className="sr-showing-patients-on-page">
-                  Showing {entriesPerPage} of {totalEntries}
+                  Showing {Math.min(entriesPerPage, totalEntries)} of{" "}
+                  {totalEntries}
                 </span>
               </h2>
               {canEditUser ? (
@@ -224,6 +225,7 @@ const ManagePatients = (
     refetch: refetchCount,
   } = useQuery(patientsCountQuery, {
     variables: { facilityId: activeFacilityId, showDeleted: false },
+    fetchPolicy: "no-cache",
   });
 
   if (activeFacilityId.length < 1) {


### PR DESCRIPTION
Bug was that it was saying "Showing 20 of 6" when there were fewer patients than the page size.
Also noticed the message wasn't being refreshed after adding a new patient, so added "no-cache" parameter to query.