### PR TITLE
Remove redundent network error handling

### DIFF
--- a/frontend/src/app/patients/ArchivePersonModal.tsx
+++ b/frontend/src/app/patients/ArchivePersonModal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
 import Button from "../commonComponents/Button";
-import { displayFullName, showNotification, showError } from "../utils";
+import { displayFullName, showNotification } from "../utils";
 import "./ArchivePersonModal.scss";
 import { Patient } from "./ManagePatients";
 import Alert from "../commonComponents/Alert";
@@ -42,9 +42,6 @@ const ArchivePersonModal = ({ person, closeModal }: Props) => {
       .then(() => {
         const alert = <Alert type="success" title="Record archived" body="" />;
         showNotification(toast, alert);
-      })
-      .catch((e) => {
-        showError(toast, String(e));
       })
       .finally(() => {
         closeModal();

--- a/frontend/src/app/patients/PatientForm.tsx
+++ b/frontend/src/app/patients/PatientForm.tsx
@@ -361,41 +361,31 @@ const PatientForm = (props: Props) => {
           county,
           zipCode,
         },
-      }).then(
-        (updatedPatientFromApi: any) => {
-          showNotification(
-            toast,
-            <Alert
-              type="success"
-              title={`Your profile changes have been saved`}
-            />
-          );
+      }).then((updatedPatientFromApi: any) => {
+        showNotification(
+          toast,
+          <Alert
+            type="success"
+            title={`Your profile changes have been saved`}
+          />
+        );
 
-          const residentCongregateSetting = updatedPatientFromApi.residentCongregateSetting
-            ? "YES"
-            : "NO";
-          const employedInHealthcare = updatedPatientFromApi.employedInHealthcare
-            ? "YES"
-            : "NO";
+        const residentCongregateSetting = updatedPatientFromApi.residentCongregateSetting
+          ? "YES"
+          : "NO";
+        const employedInHealthcare = updatedPatientFromApi.employedInHealthcare
+          ? "YES"
+          : "NO";
 
-          dispatch(
-            reduxSetPatient({
-              ...updatedPatientFromApi,
-              residentCongregateSetting,
-              employedInHealthcare,
-            })
-          );
-          setSubmitted(true);
-        },
-        (error: any) => {
-          appInsights.trackException(error);
-          showError(
-            toast,
-            `${PATIENT_TERM_CAP} Data Error`,
-            "Please check for missing data or typos."
-          );
-        }
-      );
+        dispatch(
+          reduxSetPatient({
+            ...updatedPatientFromApi,
+            residentCongregateSetting,
+            employedInHealthcare,
+          })
+        );
+        setSubmitted(true);
+      });
     } else if (props.patientId) {
       trackUpdatePatient({});
       updatePatient({
@@ -403,50 +393,30 @@ const PatientForm = (props: Props) => {
           patientId: props.patientId,
           ...variables,
         },
-      }).then(
-        () => {
-          showNotification(
-            toast,
-            <Alert
-              type="success"
-              title={`${PATIENT_TERM_CAP} Record Saved`}
-              body="Information record has been updated."
-            />
-          );
-          setSubmitted(true);
-        },
-        (error) => {
-          appInsights.trackException(error);
-          showError(
-            toast,
-            `${PATIENT_TERM_CAP} Data Error`,
-            "Please check for missing data or typos."
-          );
-        }
-      );
+      }).then(() => {
+        showNotification(
+          toast,
+          <Alert
+            type="success"
+            title={`${PATIENT_TERM_CAP} Record Saved`}
+            body="Information record has been updated."
+          />
+        );
+        setSubmitted(true);
+      });
     } else {
       trackAddPatient({});
-      addPatient({ variables }).then(
-        () => {
-          showNotification(
-            toast,
-            <Alert
-              type="success"
-              title={`${PATIENT_TERM_CAP} Record Created`}
-              body="New information record has been created."
-            />
-          );
-          setSubmitted(true);
-        },
-        (error) => {
-          appInsights.trackException(error);
-          showError(
-            toast,
-            `${PATIENT_TERM_CAP} Data Error`,
-            "Please check for missing data or typos."
-          );
-        }
-      );
+      addPatient({ variables }).then(() => {
+        showNotification(
+          toast,
+          <Alert
+            type="success"
+            title={`${PATIENT_TERM_CAP} Record Created`}
+            body="New information record has been created."
+          />
+        );
+        setSubmitted(true);
+      });
     }
   };
   // after the submit was success, redirect back to the List page


### PR DESCRIPTION
## Related Issue or Background Info

- Graphql network errors are handled globally at https://github.com/CDCgov/prime-simplereport/blob/main/frontend/src/index.tsx#L64

## Changes Proposed
- remove duplicate network error handling

## Screenshots / Demos
Current behavior: The app shows the server error in a toast and a second toast saying there is an error
![Screen Shot 2021-03-02 at 10 24 45 AM](https://user-images.githubusercontent.com/53869143/109670859-89356280-7b41-11eb-85dc-6aad9173aac2.png)

With this change we only show the server error toast
![Screen Shot 2021-03-02 at 10 25 17 AM](https://user-images.githubusercontent.com/53869143/109670928-9e11f600-7b41-11eb-80b9-4332a449cc98.png)

