### PR TITLE
Disable Twilio in demo and training envs

### DIFF
--- a/backend/src/main/resources/application-azure-demo.yaml
+++ b/backend/src/main/resources/application-azure-demo.yaml
@@ -10,4 +10,4 @@ simple-report:
   feature-flags:
     patient-links: true
 twilio:
-  enabled: true
+  enabled: false

--- a/backend/src/main/resources/application-azure-training.yaml
+++ b/backend/src/main/resources/application-azure-training.yaml
@@ -10,4 +10,4 @@ simple-report:
   feature-flags:
     patient-links: true
 twilio:
-  enabled: true
+  enabled: false

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.tsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.tsx
@@ -74,11 +74,14 @@ const SmsModalContents = ({
   saveCallback,
   continueModal,
 }: SmsModalProps) => {
+  const [patientLink, setPatientLink] = useState("");
+
   const sendSms = async () => {
     const internalId = patientLinkId || (await saveCallback(patientResponse));
     try {
       await sendSmsMutation({ variables: { internalId } });
       setSmsSuccess(true);
+      setPatientLink(`${getUrl()}pxp?plid=${internalId}`);
     } catch (e) {
       showError(toast, "SMS error", e);
     }
@@ -86,7 +89,10 @@ const SmsModalContents = ({
   return (
     <>
       {smsSuccess && (
-        <div className="usa-alert usa-alert--success outline-0">
+        <div
+          className="usa-alert usa-alert--success outline-0"
+          data-patient-link={patientLink}
+        >
           <div className="usa-alert__body">
             <h3 className="usa-alert__heading">Text message sent</h3>
             <p className="usa-alert__text">The link was sent to {telephone}</p>


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #1003 

## Changes Proposed

- Disables Twilio in demo and training
- Adds the patient link into a `data-patient-link` property in the mocked SMS success message, so that we can still get to the patient link in those envs if needed
