### PR TITLE
Remove standing bastion hosts from azure environments

### DIFF
--- a/ops/demo/persistent/_data.tf
+++ b/ops/demo/persistent/_data.tf
@@ -34,8 +34,3 @@ data "azurerm_key_vault_key" "db_encryption_key" {
   name         = local.env
   key_vault_id = data.azurerm_key_vault.db_keys.id
 }
-
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}

--- a/ops/demo/persistent/main.tf
+++ b/ops/demo/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.demo.location
-  resource_group_name     = data.azurerm_resource_group.demo.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 module "db" {
   source      = "../../services/postgres_db"
   env         = local.env

--- a/ops/dev/persistent/_data.tf
+++ b/ops/dev/persistent/_data.tf
@@ -35,11 +35,6 @@ data "azurerm_key_vault" "global" {
   resource_group_name = data.azurerm_resource_group.global.name
 }
 
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}
-
 data "azurerm_key_vault" "db_keys" {
   name                = "simple-report-db-keys"
   resource_group_name = data.azurerm_resource_group.global.name

--- a/ops/dev/persistent/main.tf
+++ b/ops/dev/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.dev.location
-  resource_group_name     = data.azurerm_resource_group.dev.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 module "db" {
   source      = "../../services/postgres_db"
   env         = local.env

--- a/ops/pentest/persistent/_data.tf
+++ b/ops/pentest/persistent/_data.tf
@@ -34,8 +34,3 @@ data "azurerm_key_vault_key" "db_encryption_key" {
   name         = local.env
   key_vault_id = data.azurerm_key_vault.db_keys.id
 }
-
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}

--- a/ops/pentest/persistent/main.tf
+++ b/ops/pentest/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.pentest.location
-  resource_group_name     = data.azurerm_resource_group.pentest.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 module "db" {
   source      = "../../services/postgres_db"
   env         = local.env

--- a/ops/prod/persistent/_data.tf
+++ b/ops/prod/persistent/_data.tf
@@ -40,8 +40,3 @@ data "azurerm_key_vault_key" "db_encryption_key" {
   name         = local.env
   key_vault_id = data.azurerm_key_vault.db_keys.id
 }
-
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}

--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.prod.location
-  resource_group_name     = data.azurerm_resource_group.prod.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 
 module "db" {
   source      = "../../services/postgres_db"

--- a/ops/stg/persistent/_data.tf
+++ b/ops/stg/persistent/_data.tf
@@ -34,8 +34,3 @@ data "azurerm_key_vault_key" "db_encryption_key" {
   name         = local.env
   key_vault_id = data.azurerm_key_vault.db_keys.id
 }
-
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}

--- a/ops/stg/persistent/main.tf
+++ b/ops/stg/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.stg.location
-  resource_group_name     = data.azurerm_resource_group.stg.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 module "db" {
   source      = "../../services/postgres_db"
   env         = local.env

--- a/ops/test/persistent/_data.tf
+++ b/ops/test/persistent/_data.tf
@@ -34,8 +34,3 @@ data "azurerm_key_vault_key" "db_encryption_key" {
   name         = local.env
   key_vault_id = data.azurerm_key_vault.db_keys.id
 }
-
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}

--- a/ops/test/persistent/main.tf
+++ b/ops/test/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.test.location
-  resource_group_name     = data.azurerm_resource_group.test.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 module "db" {
   source      = "../../services/postgres_db"
   env         = local.env

--- a/ops/training/persistent/_data.tf
+++ b/ops/training/persistent/_data.tf
@@ -34,8 +34,3 @@ data "azurerm_key_vault_key" "db_encryption_key" {
   name         = local.env
   key_vault_id = data.azurerm_key_vault.db_keys.id
 }
-
-data "azurerm_key_vault_secret" "psql_connect_password" {
-  name         = "psql-connect-password-${local.env}"
-  key_vault_id = data.azurerm_key_vault.global.id
-}

--- a/ops/training/persistent/main.tf
+++ b/ops/training/persistent/main.tf
@@ -34,19 +34,6 @@ module "bastion" {
   tags = local.management_tags
 }
 
-module "psql_connect" {
-  source                  = "../../services/basic_vm"
-  name                    = "psql-connect"
-  env                     = local.env
-  resource_group_location = data.azurerm_resource_group.training.location
-  resource_group_name     = data.azurerm_resource_group.training.name
-
-  subnet_id                = azurerm_subnet.vms.id
-  bastion_connect_password = data.azurerm_key_vault_secret.psql_connect_password.value
-
-  tags = local.management_tags
-}
-
 module "db" {
   source      = "../../services/postgres_db"
   env         = local.env


### PR DESCRIPTION
## Related Issue or Background Info

https://github.com/usds/prime-simplereport-docs/pull/7

## Changes Proposed

Updates the terraform scripts for all regions in Azure to:
- remove standing bastion hosts.
- remove data resources of stable bastion host login passwords.
