### PR TITLE
Add isSubmitting state to disallow multi-submit in queue

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -250,6 +250,8 @@ const QueueItem: any = ({
     setAoeAnswers(askOnEntry);
   }, [askOnEntry]);
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const [deviceId, updateDeviceId] = useState(
     selectedDeviceId || defaultDevice.internalId
   );
@@ -313,6 +315,7 @@ const QueueItem: any = ({
   };
 
   const onTestResultSubmit = (e?: React.MouseEvent<HTMLButtonElement>) => {
+    setIsSubmitting(true);
     if (e) e.preventDefault();
     if (forceSubmit || areAnswersComplete(aoeAnswers)) {
       if (e) e.currentTarget.disabled = true;
@@ -332,6 +335,7 @@ const QueueItem: any = ({
         .catch((error) => {
           updateMutationError(error);
           // Re-enable Submit in the hopes it will work
+          setIsSubmitting(false);
           if (e) e.currentTarget.disabled = false;
         });
     } else {
@@ -629,8 +633,9 @@ const QueueItem: any = ({
                 queueItemId={internalId}
                 testResultValue={testResultValue}
                 isSubmitDisabled={
-                  !shouldUseCurrentDateTime() &&
-                  !isValidCustomDateTested(dateTested)
+                  isSubmitting ||
+                  (!shouldUseCurrentDateTime() &&
+                    !isValidCustomDateTested(dateTested))
                 }
                 onSubmit={onTestResultSubmit}
                 onChange={onTestResultChange}

--- a/frontend/src/app/testResults/TestResultInputForm.tsx
+++ b/frontend/src/app/testResults/TestResultInputForm.tsx
@@ -32,9 +32,13 @@ const TestResultInputForm: React.FC<Props> = ({
     }
   };
 
+  const allowSubmit = testResultValue && !isSubmitDisabled;
+
   const onResultSubmit = (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    onSubmit();
+    if (allowSubmit) {
+      onSubmit();
+    }
   };
 
   return (
@@ -67,7 +71,7 @@ const TestResultInputForm: React.FC<Props> = ({
           <Button
             onClick={onResultSubmit}
             type="submit"
-            disabled={!testResultValue || !!isSubmitDisabled}
+            disabled={!allowSubmit}
             variant="outline"
             label="Submit"
           />


### PR DESCRIPTION
## Related Issue or Background Info

- Issue #449

## Changes Proposed

- Adds `isSubmitting` boolean state for each queue item to disable submit button when submitting
- Only sets `isSubmitting` back to `false` if the request fails