### PR TITLE
Enable Advanced Threat Protection in Azure DB

### DIFF
--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -19,6 +19,11 @@ resource "azurerm_postgresql_server" "db" {
 
   tags = var.tags
 
+  threat_detection_policy {
+    enabled = true
+    email_account_admins = true
+  }
+
   lifecycle {
     ignore_changes = [
       identity

--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_postgresql_server" "db" {
   tags = var.tags
 
   threat_detection_policy {
-    enabled = true
+    enabled              = true
     email_account_admins = true
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

CDC needs us to turn on Advanced Threat Protection for Azure Database for PostgreSQL, which is a very fancy and long brand name for some automated log monitoring on the DB.

## Changes Proposed

- Flip on the `threat_detection_policy` feature in the terraform module that stands up DBs.

## Additional Information

- This feature has already been enabled (via the console) in all SR environments.
