### PR TITLE
RequirePermissionReadPatientList -> RequirePermissionSearchPatients

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -50,7 +50,7 @@ public class PersonService {
     person.setFacility(facility);
   }
 
-  @AuthorizationConfiguration.RequirePermissionReadPatientList
+  @AuthorizationConfiguration.RequirePermissionSearchPatients
   public List<Person> getPatients(UUID facilityId, int pageOffset, int pageSize) {
     return _repo
         .findByFacilityAndOrganization(
@@ -61,13 +61,13 @@ public class PersonService {
         .toList();
   }
 
-  @AuthorizationConfiguration.RequirePermissionReadPatientList
+  @AuthorizationConfiguration.RequirePermissionSearchPatients
   public long getPatientsCount(UUID facilityId) {
     return _repo.countAllByFacilityAndOrganization(
         _os.getFacilityInCurrentOrg(facilityId), _os.getCurrentOrganization(), false);
   }
 
-  @AuthorizationConfiguration.RequirePermissionReadPatientList
+  @AuthorizationConfiguration.RequirePermissionSearchPatients
   public List<Person> getAllPatients(int pageOffset, int pageSize) {
     return _repo
         .findAllByOrganization(
@@ -75,7 +75,7 @@ public class PersonService {
         .toList();
   }
 
-  @AuthorizationConfiguration.RequirePermissionReadPatientList
+  @AuthorizationConfiguration.RequirePermissionSearchPatients
   public long getAllPatientsCount() {
     return _repo.countAllByOrganization(_os.getCurrentOrganization(), false);
   }


### PR DESCRIPTION
## Related Issue or Background Info

- Users with limited permissions can't use the Search Patients box in the Add to Queue tab.

## Changes Proposed

- change RequirePermissionReadPatientList permissions check to RequirePermissionSearchPatients
