### PR TITLE
Search by patient last name in e2e

### DIFF
--- a/frontend/e2e/pages/home.js
+++ b/frontend/e2e/pages/home.js
@@ -5,7 +5,7 @@ function conductTest(patientName) {
   this.section.navbar.expect.element("@conductTestLink").to.be.visible;
   this.section.navbar.click("@conductTestLink");
   this.section.app.expect.element("@searchBar").to.be.visible;
-  this.section.app.setValue("@searchBar", patientName);
+  this.section.app.setValue("@searchBar", patientName.split(",")[0]);
   this.expect.section("@searchResults").to.be.visible;
   this.section.searchResults.expect.element("@beginTest").to.be.visible;
   this.section.searchResults.expect
@@ -56,7 +56,7 @@ function getPatientLink(patientName) {
   this.section.navbar.expect.element("@conductTestLink").to.be.visible;
   this.section.navbar.click("@conductTestLink");
   this.section.app.expect.element("@searchBar").to.be.visible;
-  this.section.app.setValue("@searchBar", patientName);
+  this.section.app.setValue("@searchBar", patientName.split(",")[0]);
   this.expect.section("@searchResults").to.be.visible;
   this.section.searchResults.expect.element("@beginTest").to.be.visible;
   this.section.searchResults.expect


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes e2e tests

## Changes Proposed

- Previously, the e2e test was searching for users using "Lastname, Firstname" in the search box. This is not supported in the new backend search implementation (it's also arbitrary to expect this behavior). This PR changes the e2e search to just look for a patient's last name.