### PR TITLE
Add patient search debounce

### DIFF
--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -10,6 +10,7 @@ interface SearchResultsProps {
   facilityId: string;
   patientsInQueue: string[];
   shouldShowSuggestions: boolean;
+  loading: boolean;
 }
 
 const SearchResults = ({
@@ -18,6 +19,7 @@ const SearchResults = ({
   facilityId,
   patientsInQueue,
   shouldShowSuggestions,
+  loading,
 }: SearchResultsProps) => {
   const [dialogPatient, setDialogPatient] = useState(null);
   const [canAddToQueue, setCanAddToQueue] = useState(false);
@@ -26,46 +28,52 @@ const SearchResults = ({
     return patientsInQueue.indexOf(patientId) === -1;
   };
   let results;
-  if (patients.length === 0) {
-    results = <h3>No results</h3>;
-    if (canAddToQueue) setCanAddToQueue(false);
+
+  if (!shouldShowSuggestions) {
+    results = null;
   } else {
     results = (
       <div className="usa-card__container shadow-3 results-dropdown">
         <div className="usa-card__body">
-          <table className="usa-table usa-table--borderless">
-            <thead>
-              <tr>
-                <th scope="col">Full name</th>
-                <th scope="col">Date of birth</th>
-                <th scope="col">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {patients.map((p) => (
-                <tr key={p.internalId}>
-                  <td>
-                    {displayFullName(p.firstName, p.middleName, p.lastName)}
-                  </td>
-                  <td>{p.birthDate}</td>
-                  <td>
-                    {canAddToTestQueue(p.internalId) ? (
-                      <Button
-                        variant="unstyled"
-                        label="Begin test"
-                        onClick={() => {
-                          setDialogPatient(p);
-                          setCanAddToQueue(canAddToTestQueue(p.internalId));
-                        }}
-                      />
-                    ) : (
-                      "Test in progress"
-                    )}
-                  </td>
+          {loading ? (
+            <p>Searching...</p>
+          ) : patients.length === 0 ? (
+            <p>No results</p>
+          ) : (
+            <table className="usa-table usa-table--borderless">
+              <thead>
+                <tr>
+                  <th scope="col">Full name</th>
+                  <th scope="col">Date of birth</th>
+                  <th scope="col">Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {patients.map((p) => (
+                  <tr key={p.internalId}>
+                    <td>
+                      {displayFullName(p.firstName, p.middleName, p.lastName)}
+                    </td>
+                    <td>{p.birthDate}</td>
+                    <td>
+                      {canAddToTestQueue(p.internalId) ? (
+                        <Button
+                          variant="unstyled"
+                          label="Begin test"
+                          onClick={() => {
+                            setDialogPatient(p);
+                            setCanAddToQueue(canAddToTestQueue(p.internalId));
+                          }}
+                        />
+                      ) : (
+                        "Test in progress"
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/app/testQueue/addToQueue/__snapshots__/SearchResults.test.tsx.snap
+++ b/frontend/src/app/testQueue/addToQueue/__snapshots__/SearchResults.test.tsx.snap
@@ -1,9 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchResults should say 'No Results' for no matches 1`] = `
-<h3>
-  No results
-</h3>
+<div
+  className="usa-card__container shadow-3 results-dropdown"
+>
+  <div
+    className="usa-card__body"
+  >
+    <p>
+      No results
+    </p>
+  </div>
+</div>
 `;
 
 exports[`SearchResults should show matching results 1`] = `

--- a/frontend/src/app/testQueue/addToQueue/useDebounce.ts
+++ b/frontend/src/app/testQueue/addToQueue/useDebounce.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+
+type Options<T> = {
+  debounceTime: number;
+  runIf?: (value: T) => boolean;
+};
+
+export function useDebounce<T>(
+  initialValue: T,
+  { debounceTime, runIf }: Options<T>
+): [T, T, React.Dispatch<T>] {
+  const [value, setValue] = useState<T>(initialValue);
+  const [debouncedValue, setDebouncedValue] = useState<T>(initialValue);
+
+  useEffect(() => {
+    const debounce = setTimeout(() => {
+      if (!runIf || runIf(value)) {
+        setDebouncedValue(value);
+      }
+    }, debounceTime);
+    return () => {
+      clearTimeout(debounce);
+    };
+  }, [value, debounceTime, runIf]);
+
+  return [debouncedValue, value, setValue];
+}


### PR DESCRIPTION
## Related Issue or Background Info

- Debounces the patient search

## Changes Proposed

- Adds a custom `useDebounce` hook that only executes after 0.5s (we can change this). Also only executes if query string is >= 2 characters.
- Does some better formatting for the search result component, now the "No Results" indicator appears in the modal rather than randomly to the side 
- Also adds a "Searching..." indicator to the search result modal to let the user know when the debouncing is happening.

Note that this will fail e2e for the same reason the current PR is failing e2e but should by fixed by my other PR (#1032)