### PR TITLE
Archive patient permission for regular users

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
@@ -38,6 +38,7 @@ public enum OrganizationRole implements Comparable<OrganizationRole> {
           UserPermission.SEARCH_PATIENTS,
           UserPermission.READ_RESULT_LIST,
           UserPermission.EDIT_PATIENT,
+          UserPermission.ARCHIVE_PATIENT,
           UserPermission.START_TEST,
           UserPermission.UPDATE_TEST,
           UserPermission.SUBMIT_TEST)),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolderTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolderTest.java
@@ -20,6 +20,7 @@ class PermissionHolderTest {
             UserPermission.SEARCH_PATIENTS,
             UserPermission.READ_RESULT_LIST,
             UserPermission.EDIT_PATIENT,
+            UserPermission.ARCHIVE_PATIENT,
             UserPermission.START_TEST,
             UserPermission.UPDATE_TEST,
             UserPermission.SUBMIT_TEST);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -1,7 +1,6 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -125,7 +124,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     // works for regular users
     _service.setIsDeleted(p.getInternalId(), true);
-    assertNull(_service.getAllPatients(PATIENT_PAGEOFFSET, PATIENT_PAGESIZE).get(0));
+    assertEquals(0, _service.getAllPatients(PATIENT_PAGEOFFSET, PATIENT_PAGESIZE).size());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -122,10 +123,9 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
             false,
             false);
 
-    assertSecurityError(() -> _service.setIsDeleted(p.getInternalId(), true));
-    assertEquals(
-        "Fred",
-        _service.getAllPatients(PATIENT_PAGEOFFSET, PATIENT_PAGESIZE).get(0).getFirstName());
+    // works for regular users
+    _service.setIsDeleted(p.getInternalId(), true);
+    assertNull(_service.getAllPatients(PATIENT_PAGEOFFSET, PATIENT_PAGESIZE).get(0));
   }
 
   @Test


### PR DESCRIPTION
- Regular users cannot delete patients.
- Use `SR_DEMO_USER_ROLE=USER` to test this case on dev machine! Wahoo!
- Added permission, updated tests, verified as a regular user.