### PR TITLE
Remove address validation from ordering provider

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -62,13 +62,13 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
         _avs.getValidatedAddress(
             street, streetTwo, city, state, zipCode, _avs.FACILITY_DISPLAY_NAME);
     StreetAddress providerAddress =
-        _avs.getValidatedAddress(
-            orderingProviderStreet,
-            orderingProviderStreetTwo,
-            orderingProviderCity,
-            orderingProviderState,
-            orderingProviderZipCode,
-            _avs.PROVIDER_DISPLAY_NAME);
+        new StreetAddress(
+            Translators.parseString(orderingProviderStreet),
+            Translators.parseString(orderingProviderStreetTwo),
+            Translators.parseString(orderingProviderCity),
+            Translators.parseState(orderingProviderState),
+            Translators.parseString(orderingProviderZipCode),
+            Translators.parseString(orderingProviderCounty));
     PersonName providerName =
         new PersonName(
             orderingProviderFirstName,
@@ -122,13 +122,13 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
         _avs.getValidatedAddress(
             street, streetTwo, city, state, zipCode, _avs.FACILITY_DISPLAY_NAME);
     StreetAddress providerAddress =
-        _avs.getValidatedAddress(
-            orderingProviderStreet,
-            orderingProviderStreetTwo,
-            orderingProviderCity,
-            orderingProviderState,
-            orderingProviderZipCode,
-            _avs.PROVIDER_DISPLAY_NAME);
+        new StreetAddress(
+            Translators.parseString(orderingProviderStreet),
+            Translators.parseString(orderingProviderStreetTwo),
+            Translators.parseString(orderingProviderCity),
+            Translators.parseState(orderingProviderState),
+            Translators.parseString(orderingProviderZipCode),
+            Translators.parseString(orderingProviderCounty));
     Facility facility =
         _os.updateFacility(
             facilityId,
@@ -181,13 +181,13 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
         _avs.getValidatedAddress(
             street, streetTwo, city, state, zipCode, _avs.FACILITY_DISPLAY_NAME);
     StreetAddress providerAddress =
-        _avs.getValidatedAddress(
-            orderingProviderStreet,
-            orderingProviderStreetTwo,
-            orderingProviderCity,
-            orderingProviderState,
-            orderingProviderZipCode,
-            _avs.PROVIDER_DISPLAY_NAME);
+        new StreetAddress(
+            Translators.parseString(orderingProviderStreet),
+            Translators.parseString(orderingProviderStreetTwo),
+            Translators.parseString(orderingProviderCity),
+            Translators.parseState(orderingProviderState),
+            Translators.parseString(orderingProviderZipCode),
+            Translators.parseString(orderingProviderCounty));
     PersonName providerName =
         new PersonName(
             orderingProviderFirstName,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AddressValidationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AddressValidationService.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class AddressValidationService {
   public final String FACILITY_DISPLAY_NAME = "facility";
-  public final String PROVIDER_DISPLAY_NAME = "Ordering Provider";
   private Client _client;
   private static final Logger LOG = LoggerFactory.getLogger(AddressValidationService.class);
 


### PR DESCRIPTION
## Related Issue or Background Info

- A user ran into a bad [UX bug](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%2C%22ResourceGroup%22%3A%22prime-simple-report-prod%22%2C%22Name%22%3A%22prime-simple-report-prod-insights%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%2Fsubscriptions%2F7d1e3999-6577-4cd5-b296-f518e5c8e677%2FresourceGroups%2Fprime-simple-report-prod%2Fproviders%2FMicrosoft.Insights%2Fcomponents%2Fprime-simple-report-prod-insights%22%2C%22ResourceType%22%3A%22microsoft.insights%2Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%22e90a0cca-810d-11eb-b4dc-419240dc5fd7%22%2C%22timestamp%22%3A%222021-03-09T19%3A30%3A26.305Z%22%2C%22cacheId%22%3A%22963cd41f-d875-4a5a-b1de-16bf389e055e%22%2C%22eventTable%22%3A%22exceptions%22%7D) last night where the server returns an error saying "The server is unable to verify the address you entered. Please try again later" when the ordering provider's street is missing. 

In investigating the issue it turns out that all the ordering provider fields are optional. See [Zenhub#917](https://app.zenhub.com/workspaces/simplereport-5ff8be8854ae8b000e378210/issues/cdcgov/prime-simplereport/917)

## Changes Proposed

- remove address validation on ordering provider as non of the fields are required

## Additional Information
- Still investigating if we want to conditionally validate the address when available or add back the county input to the UI

