### PR TITLE
Deploy via a release

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -1,6 +1,7 @@
 name: Deploy Demo
 
 on:
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -1,7 +1,8 @@
 name: Deploy Demo
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -2,7 +2,7 @@ name: Deploy Demo
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -2,7 +2,7 @@ name: Deploy Pentest
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -1,6 +1,7 @@
 name: Deploy Pentest
 
 on:
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -1,7 +1,8 @@
 name: Deploy Pentest
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -2,7 +2,7 @@ name: Deploy Prod
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -1,7 +1,8 @@
 name: Deploy Prod
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
@@ -11,6 +12,7 @@ env:
   ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
   ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
   ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
+  DEPLOY_ENV: prod
 
 jobs:
   deploy-backend:
@@ -18,9 +20,6 @@ jobs:
     defaults:
       run:
         working-directory: ./backend
-    strategy:
-      matrix:
-        deploy_env: [prod, training, demo, pentest]
     steps:
       - uses: actions/checkout@v2
       - name: Set up QEMU
@@ -34,19 +33,16 @@ jobs:
           ./build_and_push.sh
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform Init
-        working-directory: ${{ github.workspace }}/ops/${{ matrix.deploy_env }}
+        working-directory: ${{ github.workspace }}/ops/${{ env.DEPLOY_ENV }}
         run: terraform init
       - name: Azure deploy Api
-        working-directory: ${{ github.workspace }}/ops/${{ matrix.deploy_env }}
+        working-directory: ${{ github.workspace }}/ops/${{ env.DEPLOY_ENV }}
         run: terraform apply -auto-approve -var="acr_image_tag=${GITHUB_SHA::7}" -target="module.simple_report_api.azurerm_app_service.service"
   deploy-frontend:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./frontend
-    strategy:
-      matrix:
-        deploy_env: [prod, training, demo, pentest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -65,6 +61,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Deploy frontend app
-        run: az storage blob upload-batch -s build/ -d '$web' --account-name simplereport${{ matrix.deploy_env }}app --destination-path '/app'
+        run: az storage blob upload-batch -s build/ -d '$web' --account-name simplereport${{ env.DEPLOY_ENV }}app --destination-path '/app'
       - name: Purge CDN
-        run: az cdn endpoint purge --resource-group prime-simple-report-${{ matrix.deploy_env }} --profile-name simple-report-${{ matrix.deploy_env }} --name simple-report-${{ matrix.deploy_env }} --content-paths "/app/*" --no-wait
+        run: az cdn endpoint purge --resource-group prime-simple-report-${{ env.DEPLOY_ENV }} --profile-name simple-report-${{ env.DEPLOY_ENV }} --name simple-report-${{ env.DEPLOY_ENV }} --content-paths "/app/*" --no-wait

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -1,7 +1,8 @@
 name: Deploy Training
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -1,6 +1,7 @@
 name: Deploy Training
 
 on:
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -2,7 +2,7 @@ name: Deploy Training
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Pentest|[/app/static/commit.txt](https://pentest.simplereport.gov/app/static/com
 Navigate to [New Release Form](https://github.com/CDCgov/prime-simplereport/releases/new) pag
 ![release form](https://user-images.githubusercontent.com/80347105/110684538-43187880-81ab-11eb-9793-7cc923956a8b.png)
 
-1. Add a version tag. Example: `v1.0.0`
+1. Add a version tag. If the release was `v1` then this release should be `v2`
 2. Add a release title summarizing the changes
 3. If applicable describe some of the changes in detail in the description
 4. Click publish release

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ https://simplereport.gov/
   - [Linters](#linters)
   - [Deploy](#deploy)
     - [Cloud Environments](#cloud-environments)
-    - [Manually-trigger-deploy](#manually-trigger-deploy)
+    - [Deploy With Release](#deploy-with-release)
+    - [Deploy With Action](#deploy-with-action)
 
 ## Setup
 
@@ -263,18 +264,29 @@ See https://github.com/usds/prime-simplereport-docs/blob/main/azure/manual-app-d
 
 ### Cloud Environments
 
-**Type**|**Frontend**|**API**|**Deployment**|**How to trigger**
-:-----:|:-----:|:-----:|:-----:|:-----:
-Prod|[/app/static/commit.txt](https://simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://simplereport.gov/api/actuator/info)|Manual|[Github Actions](#manually-trigger-deploy)
-Demo|[/app/static/commit.txt](https://demo.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://demo.simplereport.gov/api/actuator/info)|Automed on deploy to prod|[Github Actions](#manually-trigger-deploy)
-Training|[/app/static/commit.txt](https://training.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://training.simplereport.gov/api/actuator/info)|Automed on deploy to prod|[Github Actions](#manually-trigger-deploy)
-Staging|[/app/static/commit.txt](https://stg.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://stg.simplereport.gov/api/actuator/info)|Manual & Daily cron|[Github Actions](#manually-trigger-deploy)
-Dev|[/app/static/commit.txt](https://dev.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://dev.simplereport.gov/api/actuator/info)|Automed on merge to `main`|[Github Actions](#manually-trigger-deploy)
-Test|[/app/static/commit.txt](https://test.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://test.simplereport.gov/api/actuator/info)|Manual|[Github Actions](#manually-trigger-deploy)
-Pentest|[/app/static/commit.txt](https://pentest.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://pentest.simplereport.gov/api/actuator/info)|Manual|[Github Actions](#manually-trigger-deploy)
-Prod|[/app/static/commit.txt](https://simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://simplereport.gov/api/actuator/info)|Manual|[Github Actions](#manually-trigger-deploy)
+**Type**|**Frontend**|**API**|**Deployment**
+:-----:|:-----:|:-----:|:-----:
+Prod|[/app/static/commit.txt](https://simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://simplereport.gov/api/actuator/info)|[Release](#deploy-with-release)
+Demo|[/app/static/commit.txt](https://demo.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://demo.simplereport.gov/api/actuator/info)|[Release](#deploy-with-release) & [Action](#deploy-with-action)
+Training|[/app/static/commit.txt](https://training.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://training.simplereport.gov/api/actuator/info)|[Release](#deploy-with-release) & [Action](#deploy-with-action)
+Staging|[/app/static/commit.txt](https://stg.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://stg.simplereport.gov/api/actuator/info)|[Action](#deploy-with-action) & Daily cron
+Dev|[/app/static/commit.txt](https://dev.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://dev.simplereport.gov/api/actuator/info)|Push to `main`
+Test|[/app/static/commit.txt](https://test.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://test.simplereport.gov/api/actuator/info)|[Action](#deploy-with-action)
+Pentest|[/app/static/commit.txt](https://pentest.simplereport.gov/app/static/commit.txt)|[/api/actuator/info](https://pentest.simplereport.gov/api/actuator/info)|[Release](#deploy-with-release) & [Action](#deploy-with-action)
 
-### Manually-trigger-deploy
+### Deploy With Release
+
+Navigate to [New Release Form](https://github.com/CDCgov/prime-simplereport/releases/new) pag
+![release form](https://user-images.githubusercontent.com/80347105/110684538-43187880-81ab-11eb-9793-7cc923956a8b.png)
+
+1. Add a version tag. Example: `v1.0.0`
+2. Add a release title summarizing the changes
+3. If applicable describe some of the changes in detail in the description
+4. Click publish release
+5. Post a link to the release in [#shared-cdc-prime-simplereport-engineering](https://usds.slack.com/archives/C01LTSNKEPP). Example: `Deploying prod https://github.com/CDCgov/prime-simplereport/releases/tag/0.test`
+6. Verify the changes are live by ensuring the deployed commit hash matches the commit hash on the release. This is done my going to `/app/static/commit.txt` and `/api/actuator/info`
+
+### Deploy With Action
 
 Navigate to the [Github Actions Tab](https://github.com/CDCgov/prime-simplereport/actions)
 ![Screen Shot 2021-02-24 at 11 07 13 AM](https://user-images.githubusercontent.com/53869143/109029807-36673100-7691-11eb-81d1-a474517c1eb6.png)


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes deploy to prod breaking the login link to `demo`, `training`, and `pentest`
- Solves adding a change log [zenhub#978](https://app.zenhub.com/workspaces/simplereport-5ff8be8854ae8b000e378210/issues/cdcgov/prime-simplereport/978)

## Changes Proposed

- deploy `prod`, `demo`, `training`, and `pentest` via a Github release
- remove deploy to prod via manually running a Github action
- Update deploy instructions in readme 


## Additional information

- An additional benefit of this approach the Deploy Prod action will not have a side effect of deploying other env. Meaning that viewing [Deploy Demo](https://github.com/CDCgov/prime-simplereport/actions/workflows/deployDemo.yml) will show all future deploys


