### PR TITLE
Adjust permissions on export endpoint

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/export/DataHubUploadController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/export/DataHubUploadController.java
@@ -41,6 +41,8 @@ public class DataHubUploadController {
   public ResponseEntity<?> exportTestEventCSV(
       HttpServletResponse response, @RequestParam(defaultValue = "") String startupdateby)
       throws IOException {
+    var csvContent = _hubuploadservice.createTestCSVForDataHub(startupdateby);
+
     response.setContentType("text/csv");
     DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
     String currentDateTime = dateFormatter.format(new Date());
@@ -48,7 +50,7 @@ public class DataHubUploadController {
     String headerKey = "Content-Disposition";
     String headerValue = "attachment; filename=testEvents_" + currentDateTime + ".csv";
     response.setHeader(headerKey, headerValue);
-    response.getWriter().print(_hubuploadservice.createTestCSVForDataHub(startupdateby));
+    response.getWriter().print(csvContent);
     return ResponseEntity.accepted().build();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -193,15 +193,13 @@ public class DataHubUploaderService {
     _resultJson = restTemplate.postForObject(url, contentsAsResource, String.class);
   }
 
-  @AuthorizationConfiguration.RequirePermissionExportTestEvent
-  public String createTestCSVForDataHub(String lastEndCreateOn) {
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public String createTestCSVForDataHub(String lastEndCreateOn) throws IOException {
     try {
       this.createTestEventCSV(lastEndCreateOn);
       return this._fileContents;
-    } catch (IOException err) {
-      return err.toString();
     } catch (NoResultException err) {
-      return "No matching results for the given time range";
+      return "";
     }
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

- Fortify flagged a stack trace disclosure, and the permissions didn't look quite right on the full export flow.

## Changes Proposed

- Limit export to global admins only.
- Prepare the CSV before sending preliminary headers so that IOExceptions can be converted to 500s by Spring.
