### PR TITLE
Make human-readable error messages for facility form validation errors

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -11,7 +11,11 @@ import { showNotification } from "../../utils";
 import ManageDevices from "./Components/ManageDevices";
 import OrderingProviderSettings from "./Components/OrderingProvider";
 import FacilityInformation from "./Components/FacilityInformation";
-import { FacilityErrors, facilitySchema } from "./facilitySchema";
+import {
+  allFacilityErrors,
+  FacilityErrors,
+  facilitySchema,
+} from "./facilitySchema";
 
 export type ValidateField = (field: keyof FacilityErrors) => Promise<void>;
 
@@ -70,7 +74,10 @@ const FacilityForm: React.FC<Props> = (props) => {
         clearError(field);
         await facilitySchema.validateAt(field, facility);
       } catch (e) {
-        setErrors((errors) => ({ ...errors, [field]: e.message }));
+        setErrors((errors) => ({
+          ...errors,
+          [field]: allFacilityErrors[field],
+        }));
       }
     },
     [facility, clearError]
@@ -85,7 +92,7 @@ const FacilityForm: React.FC<Props> = (props) => {
           acc: FacilityErrors,
           el: { path: keyof FacilityErrors; message: string }
         ) => {
-          acc[el.path] = el.message;
+          acc[el.path] = allFacilityErrors[el.path];
           return acc;
         },
         {} as FacilityErrors

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -27,31 +27,24 @@ const providerSchema: yup.SchemaOf<RequiredProviderFields> = yup.object({
 });
 
 export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
-  name: yup.string().required("Facility name is missing"),
-  cliaNumber: yup.string().required("Facility CLIA number is missing"),
-  street: yup.string().required("Facility street is missing"),
-  zipCode: yup.string().required("Facility zip code is missing"),
-  deviceTypes: yup
-    .array()
-    .of(yup.string().required())
-    .min(1, "Facility must have at least one device")
-    .required("Facility must have at least one device"),
-  defaultDevice: yup.string().required("Facility must have a default device"),
+  name: yup.string().required(),
+  cliaNumber: yup.string().required(),
+  street: yup.string().required(),
+  zipCode: yup.string().required(),
+  deviceTypes: yup.array().of(yup.string().required()).min(1).required(),
+  defaultDevice: yup.string().required(),
   orderingProvider: providerSchema.required(),
   phone: yup
     .string()
-    .test({
-      test: function (input) {
-        const message = "Invalid phone number";
-        if (!input) {
-          return this.createError({ message });
-        }
-        const number = phoneUtil.parseAndKeepRawInput(input, "US");
-        return phoneUtil.isValidNumber(number) || this.createError({ message });
-      },
+    .test(function (input) {
+      if (!input) {
+        return false;
+      }
+      const number = phoneUtil.parseAndKeepRawInput(input, "US");
+      return phoneUtil.isValidNumber(number);
     })
-    .required("Facility phone number is missing"),
-  state: yup.string().required("Facility state is missing"),
+    .required(),
+  state: yup.string().required(),
   id: yup.string(),
   email: yup.string().email(),
   streetTwo: yup.string(),
@@ -85,7 +78,7 @@ export const allFacilityErrors: Required<FacilityErrors> = {
   defaultDevice: "A default device must be selected",
   deviceTypes: "There must be at least one device",
   name: "Facility name is missing",
-  phone: "Facility phone number is missing or incorrectly formatted",
+  phone: "Facility phone number is missing or invalid",
   street: "Facility street is missing",
   streetTwo: "Facility street is incorrectly formatted",
   zipCode: "Facility zip code is missing",

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -73,3 +73,33 @@ type FacilityErrorKeys =
   | "orderingProvider.zipCode";
 
 export type FacilityErrors = Partial<Record<FacilityErrorKeys, string>>;
+
+const orderingProviderFormatError = (field: string) =>
+  `"Ordering provider ${field} is incorrectly formatted"`;
+
+export const allFacilityErrors: Required<FacilityErrors> = {
+  id: "ID is missing",
+  email: "Email is missing or incorrectly formatted",
+  city: "City is incorrectly formatted",
+  cliaNumber: "CLIA number is missing",
+  defaultDevice: "A default device must be selected",
+  deviceTypes: "There must be at least one device",
+  name: "Facility name is missing",
+  phone: "Facility phone number is missing or incorrectly formatted",
+  street: "Facility street is missing",
+  streetTwo: "Facility street is incorrectly formatted",
+  zipCode: "Facility zip code is missing",
+  state: "Facility state is missing",
+  orderingProvider: "Ordering provider is incorrectly formatted",
+  "orderingProvider.NPI": orderingProviderFormatError("NPI"),
+  "orderingProvider.city": orderingProviderFormatError("city"),
+  "orderingProvider.firstName": orderingProviderFormatError("first name"),
+  "orderingProvider.lastName": orderingProviderFormatError("last name"),
+  "orderingProvider.middleName": orderingProviderFormatError("middle name"),
+  "orderingProvider.phone": orderingProviderFormatError("phone"),
+  "orderingProvider.state": orderingProviderFormatError("state"),
+  "orderingProvider.street": orderingProviderFormatError("street"),
+  "orderingProvider.streetTwo": orderingProviderFormatError("street"),
+  "orderingProvider.suffix": orderingProviderFormatError("suffix"),
+  "orderingProvider.zipCode": orderingProviderFormatError("zip code"),
+};

--- a/frontend/src/app/admin/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/admin/Organization/OrganizationForm.tsx
@@ -6,6 +6,7 @@ import ManageDevices from "../../Settings/Facility/Components/ManageDevices";
 import OrderingProviderSettings from "../../Settings/Facility/Components/OrderingProvider";
 import FacilityInformation from "../../Settings/Facility/Components/FacilityInformation";
 import {
+  allFacilityErrors,
   FacilityErrors,
   facilitySchema,
 } from "../../Settings/Facility/facilitySchema";
@@ -81,7 +82,10 @@ const OrganizationForm: React.FC<Props> = (props) => {
         clearError(field);
         await facilitySchema.validateAt(field, facility);
       } catch (e) {
-        setErrors((errors) => ({ ...errors, [field]: e.message }));
+        setErrors((errors) => ({
+          ...errors,
+          [field]: allFacilityErrors[field],
+        }));
       }
     },
     [facility, clearError]


### PR DESCRIPTION
## Related Issue or Background Info

- #1082 

## Changes Proposed

- Adding `yup` in a previous PR resulted in some gnarly form validation errors, largely due to fields being unexpected types
- yup's error specification framework is good if you want to have very targeted error messages for specific types of validation failures, but I think that's overkill. We really just need one error message per field, which will either say the field "is missing or an incorrect format" or will say the field "is an incorrect format" (the former for required fields and the latter for optional fields).