### PR TITLE
demo length directive (#743)

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/validation/LengthDirective.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/validation/LengthDirective.java
@@ -1,0 +1,60 @@
+package gov.cdc.usds.simplereport.api.validation;
+
+import gov.cdc.usds.simplereport.api.validation.errors.LengthError;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.idl.SchemaDirectiveWiring;
+import graphql.schema.idl.SchemaDirectiveWiringEnvironment;
+
+public class LengthDirective implements SchemaDirectiveWiring {
+
+  private static final int DEFAULT_MIN = 0;
+  private static final int DEFAULT_MAX = 256;
+
+  @Override
+  public GraphQLArgument onArgument(SchemaDirectiveWiringEnvironment<GraphQLArgument> env) {
+    GraphQLDirective lengthDirective = env.getDirective();
+
+    GraphQLArgument minLenArg = lengthDirective.getArgument("min");
+    int minLen = minLenArg == null ? DEFAULT_MIN : (int) minLenArg.getValue();
+
+    GraphQLArgument maxLenArg = lengthDirective.getArgument("max");
+    int maxLen = maxLenArg == null ? DEFAULT_MAX : (int) maxLenArg.getValue();
+
+    GraphQLArgument argument = env.getElement();
+    final String argumentName = argument.getName();
+
+    DataFetcher<?> originalDataFetcher =
+        env.getCodeRegistry().getDataFetcher(env.getFieldsContainer(), env.getFieldDefinition());
+
+    DataFetcher<?> newFetcher =
+        dfe -> {
+          String runtimeValue = dfe.getArgument(argumentName);
+          if (runtimeValue != null) {
+            int runtimeLength = runtimeValue.length();
+
+            DataFetcherResult.Builder<Object> resultBuilder = DataFetcherResult.newResult();
+            if (runtimeLength < minLen || runtimeLength > maxLen) {
+              resultBuilder.error(new LengthError(argumentName, minLen, maxLen));
+            }
+
+            DataFetcherResult<Object> result = resultBuilder.build();
+            if (!result.getErrors().isEmpty()) {
+              return result;
+            }
+          }
+
+          return originalDataFetcher.get(dfe);
+        };
+
+    FieldCoordinates coordinates =
+        FieldCoordinates.coordinates(env.getFieldsContainer(), env.getFieldDefinition());
+
+    env.getCodeRegistry().dataFetcher(coordinates, newFetcher);
+
+    return argument;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/validation/ValidationConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/validation/ValidationConfiguration.java
@@ -1,0 +1,14 @@
+package gov.cdc.usds.simplereport.api.validation;
+
+import graphql.kickstart.tools.boot.SchemaDirective;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ValidationConfiguration {
+
+  @Bean
+  public SchemaDirective lengthDirective() {
+    return new SchemaDirective("length", new LengthDirective());
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/validation/errors/LengthError.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/validation/errors/LengthError.java
@@ -1,0 +1,37 @@
+package gov.cdc.usds.simplereport.api.validation.errors;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LengthError implements GraphQLError {
+
+  private final String fieldName;
+  private final int minimumLength;
+  private final int maximumLength;
+
+  public LengthError(String fieldName, int minimumLength, int maximumLength) {
+    this.fieldName = fieldName;
+    this.minimumLength = minimumLength;
+    this.maximumLength = maximumLength;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format(
+        "%s: length is invalid (expected %d <= len <= %d)",
+        fieldName, minimumLength, maximumLength);
+  }
+
+  @Override
+  public List<SourceLocation> getLocations() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public ErrorType getErrorType() {
+    return ErrorType.ValidationError;
+  }
+}

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -1,3 +1,6 @@
+# this not not used, but provided so schema validates and for clarity
+directive @length(min: Int = 0, max: Int = 256) on ARGUMENT_DEFINITION
+
 # java.util.Date implementation
 scalar DateTime
 # java.time.LocalDate
@@ -357,8 +360,8 @@ type Mutation {
     street: String!
     streetTwo: String
     city: String
-    state: String!
-    zipCode: String!
+    state: String! @length(min: 2, max: 2)
+    zipCode: String! @length(min: 5, max: 10)
     telephone: String!
     role: String
     email: String


### PR DESCRIPTION
## Related Issue or Background Info

- [#743](https://github.com/CDCgov/prime-simplereport/issues/743)

## Changes Proposed

- Add a directive to validate length of values passed to string arguments

## Additional Information

* graphql-java-extended-validation `@Size` not used because:
  * I could not get it to hook ARGUMENT_DEFINITION
  * Custom directives will be necessary anyway for trimming strings
* For demonstration, only the `state` and `zipCode` arguments of
  the `updatePatient` mutation have this directive on them.  An error
  can be triggered by, for example, setting the zipCode to a 4
  character string.
