### PR TITLE
Install dependencies on start

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "yup": "^0.32.9"
   },
   "scripts": {
-    "prestart": "rm -rf .eslintcache",
+    "prestart": "rm -rf .eslintcache && yarn",
     "start": "REACT_APP_CURRENT_COMMIT=$(git rev-parse HEAD) npm-run-all -p watch-css start-js",
     "start-js": "react-scripts start",
     "prebuild": "yarn compile-scss",


### PR DESCRIPTION
## Related Issue or Background Info

- Dev quality of life improvement to cut down on the times some one has to ask. Why isn't `main` working on my machine.
- Prompted by https://usds.slack.com/archives/C01LTSNKEPP/p1615857302000700

## Changes Proposed

- Install JS dependencies when running `yarn start`

## Additional Information

- Now when you switch a branch and there is a dependency change you don't have to remember to run `yarn`. Note: you still will need to remember to restart the app
- This should make no difference in app start time as yarn will not install anything if the dependencies are up to date


