### PR TITLE
Add SendGrid key to training _data.tf

### DIFF
--- a/ops/training/_data.tf
+++ b/ops/training/_data.tf
@@ -100,6 +100,11 @@ data "azurerm_key_vault_secret" "twilio_auth_token" {
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
+data "azurerm_key_vault_secret" "sendgrid_api_key" {
+  name         = "sendgrid-api-key"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
 data "azurerm_key_vault_secret" "smarty_auth_id" {
   name         = "smarty-auth-id"
   key_vault_id = data.azurerm_key_vault.global.id


### PR DESCRIPTION
## Related Issue or Background Info

- SendGrid's terraform config was borked for the `training` environment. See [this](https://github.com/CDCgov/prime-simplereport/runs/2123680212?check_suite_focus=true) failed CI run

## Changes Proposed

- Adds the data config
