### PR TITLE
Defensive changes to test context properties.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -80,6 +80,10 @@ test {
     // people sometimes export this to run local dev more easily: don't let it break the tests
     environment "SPRING_PROFILES_ACTIVE", ""
     useJUnitPlatform()
+    // uncomment this to log to stdout when each test starts, so you can tell what's going on
+    // testLogging {
+    //   events "started", "failed"
+    // }
 }
 
 configurations {

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -1,7 +1,8 @@
 spring:
-  profiles.include: no-security,no-okta-mgmt,local
+  profiles.include: no-security,no-okta-mgmt
   datasource:
     url: jdbc:postgresql://localhost:${test-db-port:5444}/simple_report
+    hikari.minimum-idle: 2 # when a context isn't being used, it should not leave lots of connections lying around
   liquibase:
     user: simple_report_migrations
     password: migrations456
@@ -9,6 +10,14 @@ spring:
     properties:
       hibernate:
         default_schema: simple_report
+management:
+  endpoints:
+    web:
+      exposure:
+        exclude: liquibase # this causes the liquibase connection pool to keep 10 connections active forever
+        # Excluding it here will probably not work, so let's be clear (and grep-friendly): if you get
+        # "org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for non-replication superuser connections"
+        # there is a decent chance that this actuator has been activated and is making liquibase eat your database connections.
 logging:
   level:
     # Always have our own debug logging turned on in tests:


### PR DESCRIPTION
* made "local" properties not load during tests, since they are very likely to have unexpected consequences
* explicitly excluded the liquibase actuator, which has specific unexpected (and fairly terrible) consequences
* shrank the number of idle connections Hikari will keep around when an application context is not actually doing anything (e.g. when the tests that use it are all finished).

## Related Issue or Background Info

People really don't like it when tests fail for no apparent reason.
