### PR TITLE
HOTFIX: hhs site admin access

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/UserAuthorizationVerifier.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/UserAuthorizationVerifier.java
@@ -78,7 +78,7 @@ public class UserAuthorizationVerifier {
 
   public boolean userHasSiteAdminRole() {
     IdentityAttributes id = _supplier.get();
-    return id != null && _admins.contains(id.getUsername());
+    return id != null && _admins.contains(id.getUsername().toLowerCase());
   }
 
   public boolean userHasPermissions(Set<UserPermission> permissions) {

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -17,7 +17,6 @@ simple-report:
     - jeremy.a.zitomer@omb.eop.gov
     - nicholas.scialli@usds.dhs.gov
     - qrk8@cdc.gov # Sparkle
-    - David.w.methvin@omb.eop.gov
     - thomas.a.nielsen@omb.eop.gov
     - adam@skylight.digital
     - josh@skylight.digital

--- a/backend/src/main/resources/application-azure-pentest.yaml
+++ b/backend/src/main/resources/application-azure-pentest.yaml
@@ -16,7 +16,6 @@ simple-report:
     - jeremy.a.zitomer@omb.eop.gov
     - nicholas.scialli@usds.dhs.gov
     - qrk8@cdc.gov # Sparkle
-    - David.w.methvin@omb.eop.gov
     - thomas.a.nielsen@omb.eop.gov
     - adam@skylight.digital
     - josh@skylight.digital

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -21,7 +21,6 @@ simple-report:
     - jeremy.a.zitomer@omb.eop.gov
     - nicholas.scialli@usds.dhs.gov
     - qrk8@cdc.gov # Sparkle
-    - David.w.methvin@omb.eop.gov
     - thomas.a.nielsen@omb.eop.gov
     - adam@skylight.digital
     - josh@skylight.digital

--- a/backend/src/main/resources/application-azure-stg.yaml
+++ b/backend/src/main/resources/application-azure-stg.yaml
@@ -16,7 +16,6 @@ simple-report:
     - jeremy.a.zitomer@omb.eop.gov
     - nicholas.scialli@usds.dhs.gov
     - qrk8@cdc.gov # Sparkle
-    - David.w.methvin@omb.eop.gov
     - thomas.a.nielsen@omb.eop.gov
     - adam@skylight.digital
     - josh@skylight.digital

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -16,7 +16,6 @@ simple-report:
     - jeremy.a.zitomer@omb.eop.gov
     - nicholas.scialli@usds.dhs.gov
     - qrk8@cdc.gov # Sparkle
-    - David.w.methvin@omb.eop.gov
     - thomas.a.nielsen@omb.eop.gov
     - adam@skylight.digital
     - josh@skylight.digital


### PR DESCRIPTION
## Related Issue or Background Info

- the hhs users can't access the admin page. I think this is because the emails in okta have capitalization that doesn't exist in the application yml allowed emails list
