### PR TITLE
Fix continuous build loop and add start.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ start:
 	make -j start-backend start-frontend watch-backend
 watch-backend:
 	cd backend;\
-	./gradlew build --continuous -xtest -xcheckstyleMain -xcheckstyleTest -xspotlessCheck
+	./gradlew build --continuous -xtest -xcheckstyleMain -xcheckstyleTest -xspotlessCheck -xbootBuildInfo
 start-backend:
 	cd backend;\
 	docker-compose --env-file .env.development up -d db && \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Running spring app locally and db in docker on port 5433
 1. Run ` SR_DB_PORT=5433 gradle bootRun --args='--spring.profiles.active=dev'`
 1. view site at http://localhost:8080
 
-### Running the app with Make
+### Running the app with Make or start.sh
 
 For development, it may be more convenient to start the front and backends simultaneously. This can be done by running the following command in the root directory of the project:
 
@@ -95,6 +95,22 @@ make # "make start" if you're nasty
 
 This will start up both servers in "watch" mode, so that changes to the source
 code result in an immediate rebuild.
+
+If you'd like to use a local installation of PostgreSQL, run the following to create a local database:
+
+```bash
+# Run this to create or reset the local db. Assumes your $USER has superuser privileges.
+# If not, use POSTGRES_USER=postgres
+POSTGRES_USER=$USER LIB_DIR="$(pwd)/backend/db-setup" POSTGRES_DB=postgres ./backend/db-setup/create-db.sh
+```
+
+Then run this to start the app:
+
+```bash
+./start.sh
+```
+
+This will also start up both servers in "watch" mode. Press CTRL-C to exit and cleanup the servers cleanly.
 
 ### Updating user role
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+###########
+# This script is used for local development only.
+# It will spin up a create-react-app dev server and
+# a Spring Boot "bootRun" task, output server logs, and clean
+# up the processes when exited.
+###########
+
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+
+function prepend() { 
+    NC='\033[0m' # No Color
+    while read line; do 
+        echo -e "${2}${1}:${NC} ${line}" 
+    done
+}
+
+# This function kills the server processes when the script is interrupted
+# Takes the PID of the frontend server as an argument
+cleanup() {
+    echo
+    echo "Script stopped, performing cleanup..."
+    kill $1 # kill frontend server
+    cd ${BACKEND_DIR}
+    ./gradlew --stop
+    ./gradlew clean
+
+    rm -rf ${BACKEND_DIR}/.gradle/daemon # Daemons _cannot_ survive script shutdown
+    echo "Cleanup complete!"
+}
+
+# Get dir paths
+ROOT_DIR=$(pwd)
+FRONTEND_DIR=${ROOT_DIR}/frontend
+BACKEND_DIR=${ROOT_DIR}/backend
+
+# Start frontend server
+cd ${FRONTEND_DIR}
+echo "Starting frontend server..."
+BROWSER=none yarn start | prepend "frontend" $GREEN &
+NPM_PID=$!
+echo "frontend server PID: ${NPM_PID}"
+trap "cleanup ${NPM_PID}" EXIT
+
+# Build backend
+cd ${BACKEND_DIR}
+# Start a continuous build process and send to background
+./gradlew --no-daemon -t build -x test -x checkstyleMain -x checkstyleTest -x spotlessCheck -x bootBuildInfo | prepend "backend" $PURPLE &
+# Wait for initial build to complete
+sleep 15
+# Start bootRun without build. It will live reload when the previous process rebuilds
+./gradlew --no-daemon -x build -x test -x checkstyleMain -x checkstyleTest -x spotlessCheck bootRun --args='--spring.profiles.active=dev' | prepend "backend" $PURPLE


### PR DESCRIPTION
## Related Issue or Background Info

When running the app with the Makefile, the continuous build process seems to get stuck in an infinite loop, rebuilding over and over and outputting this:
```
BUILD SUCCESSFUL in 3s
6 actionable tasks: 3 executed, 3 up-to-date
Waiting for changes to input files of tasks...
modified: /home/nick/Code/prime-simplereport/backend/build/tmp/bootJar/MANIFEST.MF
Change detected, executing build...
```

It's likely there’s an interleaving problem where both the bootRun and the build  tasks are alternating edits to the same file, triggering a loop.

## Changes Proposed

- Add `-xbootBuildInfo` to the `watch-backend` task to prevent this from happening
- Somewhat related to the issue above (I discovered the issue while writing this), I added a `start.sh` script as an alternative to the `Makefile`. I prefer to run my own database host on my local instead of docker, and I also like having this start script manage all the app processes and clean them up when I exit. It also prepends the log output with `frontend:` or `backend:` to make the logs a little more readable. This script assumes you already have a local database up and running - I added instructions to the README as well
