### PR TITLE
Revert "Add symptoms to test result table (#1154)"

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -53,7 +53,6 @@ const testResults = [
       lookupId: null,
       __typename: "Patient",
     },
-    noSymptoms: true,
     patientLink: {
       internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
     },
@@ -79,7 +78,6 @@ const testResults = [
       lookupId: null,
       __typename: "Patient",
     },
-    noSymptoms: false,
     patientLink: {
       internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
     },

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -19,16 +19,6 @@ import TestResultCorrectionModal from "./TestResultCorrectionModal";
 
 import "./TestResultsList.scss";
 
-function symptomsDisplay(noSymptoms: boolean | null) {
-  if (noSymptoms === true) {
-    return "No";
-  }
-  if (noSymptoms === false) {
-    return "Yes";
-  }
-  return "Unknown";
-}
-
 export const testResultQuery = gql`
   query GetFacilityResults($facilityId: ID!, $pageNumber: Int, $pageSize: Int) {
     testResults(
@@ -53,7 +43,6 @@ export const testResultQuery = gql`
         gender
         lookupId
       }
-      noSymptoms
       patientLink {
         internalId
       }
@@ -154,7 +143,6 @@ export const DetachedTestResultsList: any = ({
           <td>{moment(r.dateTested).format("lll")}</td>
           <td>{r.result}</td>
           <td>{r.deviceType.name}</td>
-          <td>{symptomsDisplay(r.noSymptoms)}</td>
           <td>
             <ActionsMenu items={actionItems} />
           </td>
@@ -185,7 +173,6 @@ export const DetachedTestResultsList: any = ({
                     <th scope="col">Date of Test</th>
                     <th scope="col">Result</th>
                     <th scope="col">Device</th>
-                    <th scope="col">Symptoms</th>
                     <th scope="col">Actions</th>
                   </tr>
                 </thead>

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -62,11 +62,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   <th
                     scope="col"
                   >
-                    Symptoms
-                  </th>
-                  <th
-                    scope="col"
-                  >
                     Actions
                   </th>
                 </tr>
@@ -90,9 +85,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   </td>
                   <td>
                     Abbott IDNow
-                  </td>
-                  <td>
-                    No
                   </td>
                   <td>
                     <button
@@ -145,9 +137,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   </td>
                   <td>
                     Abbott IDNow
-                  </td>
-                  <td>
-                    Yes
                   </td>
                   <td>
                     <button


### PR DESCRIPTION
This reverts commit 4260874b13694f0c6e2fff00c993a8e062702e64.

## Related Issue or Background Info

- #1168

## Changes Proposed

- Reverts symptom display until we can find a more reliable way to indicate when symptoms are "unknown"
