### PR TITLE
Use magic hibernate schema string in JoinFormula

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -42,7 +42,7 @@ public class TestOrder extends BaseTestInfo {
   @JoinFormula(
       "("
           + "SELECT pl.internal_id "
-          + "FROM simple_report.patient_link pl "
+          + "FROM {h-schema}patient_link pl "
           + "WHERE pl.test_order_id = internal_id "
           + "ORDER BY pl.created_at DESC "
           + "LIMIT 1"


### PR DESCRIPTION
This fixes the fact that the generated query breaks in remote
environments, which uses the `public` schema instead of
`simple_report`