### PR TITLE
Revert spelling change for global outputs

### DIFF
--- a/ops/global/_output.tf
+++ b/ops/global/_output.tf
@@ -1,12 +1,12 @@
-output "acr_simplereport_name" {
+output "acr_simeplereport_name" {
   value = azurerm_container_registry.sr.name
 }
 
-output "acr_simplereport_admin_name" {
+output "acr_simeplereport_admin_name" {
   value = azurerm_container_registry.sr.admin_username
 }
 
-output "acr_simplereport_admin_password" {
+output "acr_simeplereport_admin_password" {
   value = azurerm_container_registry.sr.admin_password
 }
 

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -28,9 +28,9 @@ resource "azurerm_app_service" "service" {
   }
 
   app_settings = merge(var.app_settings, {
-    "DOCKER_REGISTRY_SERVER_PASSWORD"                = data.terraform_remote_state.global.outputs.acr_simplereport_admin_password
-    "DOCKER_REGISTRY_SERVER_URL"                     = "https://${data.terraform_remote_state.global.outputs.acr_simplereport_name}.azurecr.io"
-    "DOCKER_REGISTRY_SERVER_USERNAME"                = data.terraform_remote_state.global.outputs.acr_simplereport_name
+    "DOCKER_REGISTRY_SERVER_PASSWORD"                = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+    "DOCKER_REGISTRY_SERVER_URL"                     = "https://${data.terraform_remote_state.global.outputs.acr_simeplereport_name}.azurecr.io"
+    "DOCKER_REGISTRY_SERVER_USERNAME"                = data.terraform_remote_state.global.outputs.acr_simeplereport_name
     "SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA" = "public"
     "WEBSITES_PORT"                                  = "8080"
     "WEBSITE_DNS_SERVER"                             = "168.63.129.16"


### PR DESCRIPTION
We can't run Terraform locally at the moment to actually deploy global, and so we can't fix these misspellings yet to generate the new outputs.
