### PR TITLE
Add img-src to CSP to allow img blobs to be loaded

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,7 @@
             default-src 'self';
             script-src 'self' dap.digitalgov.gov www.google-analytics.com;
             style-src 'self' 'unsafe-inline';
+            img-src 'self' data:;
             connect-src 'self' www.google-analytics.com https://dc.services.visualstudio.com/v2/track %REACT_APP_BACKEND_URL%;
         ">
     <meta charset="utf-8" />


### PR DESCRIPTION
## Related Issue or Background Info

- #1140 breaks image blob loading:
![image](https://user-images.githubusercontent.com/9121162/112391200-c90ce700-8cb4-11eb-9ddd-1d87a08b4e6a.png)

## Changes Proposed

- Add `img-src 'self' data:;` to the CSP to allow loading blobs. Note that [this is unsafe](https://security.stackexchange.com/a/95011) and we need to either convert our images to be hosted as files or find some other solution, but we need to get this out to prod for now.
