### PR TITLE
Apply previous alerting change to training env

### DIFF
--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -1,7 +1,6 @@
 module "metric_alerts" {
   source              = "../services/alerts/app_service_metrics"
   env                 = local.env
-  enabled             = true
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
   action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id


### PR DESCRIPTION
Previous alerting changes MR missed `training` env - whoops.