### PR TITLE
Add symptoms to test result table

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -63,6 +63,8 @@ const testResults = [
     patientLink: {
       internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
     },
+    noSymptoms: true,
+    symptoms: "{}",
     __typename: "TestResult",
   },
   {
@@ -95,6 +97,42 @@ const testResults = [
     patientLink: {
       internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
     },
+    noSymptoms: false,
+    symptoms: "{}",
+    __typename: "TestResult",
+  },
+  {
+    internalId: "7c768a5d-ef90-44cd-8050-b96dd7aaa1d5",
+    dateTested: "2021-03-17T19:27:21.052Z",
+    result: "NEGATIVE",
+    correctionStatus: "ORIGINAL",
+    deviceType: {
+      internalId: "8c1a8efe-8951-4f84-a4c9-dcea561d7fbb",
+      name: "Abbott IDNow",
+      __typename: "DeviceType",
+    },
+    patient: {
+      internalId: "f74ad245-3a69-44b5-bb6d-efe06308bb85",
+      firstName: "Sam",
+      middleName: "G",
+      lastName: "Gerard",
+      birthDate: "1960-11-07",
+      gender: "male",
+      lookupId: null,
+      __typename: "Patient",
+    },
+    createdBy: {
+      nameInfo: {
+        firstName: "Ethan",
+        middleName: "",
+        lastName: "Entry",
+      },
+    },
+    patientLink: {
+      internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
+    },
+    noSymptoms: false,
+    symptoms: '{"someSymptom":"true"}',
     __typename: "TestResult",
   },
 ];

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -53,6 +53,8 @@ export const testResultQuery = gql`
       patientLink {
         internalId
       }
+      symptoms
+      noSymptoms
     }
   }
 `;
@@ -64,6 +66,19 @@ interface Props {
   page: number;
   entriesPerPage: number;
   totalEntries: number;
+}
+
+function hasSymptoms(noSymptoms: boolean, symptoms: string) {
+  if (noSymptoms) {
+    return "No";
+  }
+  const symptomsList: Record<string, string> = JSON.parse(symptoms);
+  for (let key in symptomsList) {
+    if (symptomsList[key] === "true") {
+      return "Yes";
+    }
+  }
+  return "Unknown";
 }
 
 export const DetachedTestResultsList: any = ({
@@ -150,6 +165,7 @@ export const DetachedTestResultsList: any = ({
           <td>{moment(r.dateTested).format("lll")}</td>
           <td>{r.result}</td>
           <td>{r.deviceType.name}</td>
+          <td>{hasSymptoms(r.noSymptoms, r.symptoms)}</td>
           <td>
             {displayFullNameInOrder(
               r.createdBy.nameInfo.firstName,

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="sr-showing-results-on-page"
               >
                 Showing 
-                2
+                3
                  of
                  
-                2
+                3
               </span>
             </h2>
           </div>
@@ -92,6 +92,9 @@ exports[`TestResultsList should render a list of tests 1`] = `
                     Abbott IDNow
                   </td>
                   <td>
+                    No
+                  </td>
+                  <td>
                     Arthur A Admin
                   </td>
                   <td>
@@ -147,7 +150,68 @@ exports[`TestResultsList should render a list of tests 1`] = `
                     Abbott IDNow
                   </td>
                   <td>
+                    Unknown
+                  </td>
+                  <td>
                     Ursula User
+                  </td>
+                  <td>
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      class="rc-menu-button sr-actions-menu"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-ellipsis-h fa-w-16 fa-2x "
+                        data-icon="ellipsis-h"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 256c0 39.8-32.2 72-72 72s-72-32.2-72-72 32.2-72 72-72 72 32.2 72 72zm104-72c-39.8 0-72 32.2-72 72s32.2 72 72 72 72-32.2 72-72-32.2-72-72-72zm-352 0c-39.8 0-72 32.2-72 72s32.2 72 72 72 72-32.2 72-72-32.2-72-72-72z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <span
+                        class="usa-sr-only"
+                      >
+                        More actions
+                      </span>
+                    </button>
+                    <div
+                      class="rc-menu-container"
+                      role="presentation"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  class="sr-test-result-row"
+                  data-patient-link="https://simplereport.gov/pxp?plid=68c543e8-7c65-4047-955c-e3f65bb8b58a"
+                  title=""
+                >
+                  <th
+                    scope="row"
+                  >
+                    Gerard, Sam G
+                  </th>
+                  <td>
+                    Mar 17, 2021 7:27 PM
+                  </td>
+                  <td>
+                    NEGATIVE
+                  </td>
+                  <td>
+                    Abbott IDNow
+                  </td>
+                  <td>
+                    Yes
+                  </td>
+                  <td>
+                    Ethan Entry
                   </td>
                   <td>
                     <button


### PR DESCRIPTION
## Related Issue or Background Info

- Part of #513

## Changes Proposed

- Adds Symptoms column to test results

## Additional Information

The way we store symptoms is a bit confusing for understanding this PR: There is a `noSymptoms` property that only reflects the boolean state of the "No Symptoms" checkbox in the Test Questionnaire. If this is `true` (i.e., the No Symptoms box was checked), then we know for a fact that the patient had no symptoms. However, if it's `false`, then all we know is that the "No Symptoms" checkbox wasn't checked, but we _don't_ know that any symptom was actually checked. So to determine if the user affirmatively had symptoms, we have to iterate through the JSON-encoded `symptom` object. (Note that this `symptom` object appears weird itself&mdash;the values appear to be `"true"` or `"false"` strings rather than booleans.