### PR TITLE
Add requestId as a header to GraphQL responses.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -7,6 +7,7 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
+import graphql.kickstart.servlet.context.GraphQLServletContext;
 import graphql.language.Field;
 import graphql.language.OperationDefinition;
 import graphql.validation.ValidationError;
@@ -53,8 +54,10 @@ public class QueryLoggingInstrumentation extends SimpleInstrumentation {
       InstrumentationExecutionParameters parameters) {
     final long queryStart = System.currentTimeMillis();
     final String executionId = parameters.getExecutionInput().getExecutionId().toString();
-    // Add the execution ID to the sfl4j MDC
+    // Add the execution ID to the sfl4j MDC and the response headers
     MDC.put(LoggingConstants.REQUEST_ID_MDC_KEY, executionId);
+    GraphQLServletContext context = parameters.getContext();
+    context.getHttpServletResponse().setHeader(LoggingConstants.REQUEST_ID_HEADER, executionId);
 
     // Create a new Azure Telemetry Event
     final RequestTelemetry requestTelemetry = new RequestTelemetry();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -52,9 +52,21 @@ public abstract class BaseFullStackTest {
       String operationName,
       Set<UserPermission> permissions,
       List<String> errorPaths) {
+    return assertLastAuditEntry(null, username, operationName, permissions, errorPaths);
+  }
+
+  protected ApiAuditEvent assertLastAuditEntry(
+      String requestId,
+      String username,
+      String operationName,
+      Set<UserPermission> permissions,
+      List<String> errorPaths) {
     ApiAuditEvent event = getTimeCheckedEvent();
     assertEquals(username, event.getUser().getLoginEmail());
     assertEquals(operationName, event.getGraphqlQueryDetails().getOperationName());
+    if (requestId != null) {
+      assertEquals(requestId, event.getRequestId());
+    }
     if (permissions != null) {
       assertEquals(
           permissions.stream().map(UserPermission::name).collect(Collectors.toSet()),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -50,9 +51,10 @@ class AuditLoggingTest extends BaseGraphqlTest {
   void auditableGraphqlRequest_noInterestingHeaders_boringAudit() {
     useOrgUser();
     runQuery("current-user-query");
+    String requestId = getGraphqlRequestIdHeader();
     ApiAuditEvent event =
         assertLastAuditEntry(
-            TestUserIdentities.STANDARD_USER, "whoDat", STANDARD_PERMS_TODAY, null);
+            requestId, TestUserIdentities.STANDARD_USER, "whoDat", STANDARD_PERMS_TODAY, null);
     assertTimestampSanity(event);
     assertEquals(TestUserIdentities.DEFAULT_ORGANIZATION, event.getOrganization().getExternalId());
 
@@ -74,9 +76,10 @@ class AuditLoggingTest extends BaseGraphqlTest {
     addHeader("X-forwarded-Proto", "ssh");
     addHeader("x-ORIGINAL-host", "simplereport.ly");
     runQuery("current-user-query");
+    String requestId = getGraphqlRequestIdHeader();
     ApiAuditEvent event =
         assertLastAuditEntry(
-            TestUserIdentities.STANDARD_USER, "whoDat", STANDARD_PERMS_TODAY, null);
+            requestId, TestUserIdentities.STANDARD_USER, "whoDat", STANDARD_PERMS_TODAY, null);
     assertTimestampSanity(event);
     assertEquals(TestUserIdentities.DEFAULT_ORGANIZATION, event.getOrganization().getExternalId());
 
@@ -92,6 +95,7 @@ class AuditLoggingTest extends BaseGraphqlTest {
     runQuery("current-user-query");
     ApiAuditEvent event =
         assertLastAuditEntry(
+            getGraphqlRequestIdHeader(),
             TestUserIdentities.OTHER_ORG_ADMIN,
             "whoDat",
             EnumSet.allOf(UserPermission.class),
@@ -100,6 +104,12 @@ class AuditLoggingTest extends BaseGraphqlTest {
     assertEquals(
         "DAT_ORG", // this should be a constant
         event.getOrganization().getExternalId());
+  }
+
+  private String getGraphqlRequestIdHeader() {
+    List<String> header = getLastResponse().getHeaders().get("X-Simplereport-RequestId");
+    assertThat(header).isNotNull().hasSize(1);
+    return header.get(0);
   }
 
   @Test


### PR DESCRIPTION
Added the execution ID to the HTTP response, and added tests to verify
that it is there and matches what went into the audit log.

## Related Issue or Background Info

- Follow-up from #1122 