### PR TITLE
Clean up

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/RaceArrayConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/RaceArrayConverter.java
@@ -15,14 +15,14 @@ public class RaceArrayConverter extends StdConverter<JsonNode, String> {
 
   @Override
   public String convert(JsonNode value) {
-    LOG.debug("Attempting to convert a value of {}", value);
+    LOG.trace("Attempting to convert a value of {}", value);
     String converted;
     if (value.isArray()) {
       converted = value.get(0).asText();
     } else {
       converted = value.asText();
     }
-    LOG.debug("Converted to {}", value);
+    LOG.trace("Converted to {}", value);
     return converted;
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -43,7 +43,7 @@ class AccountRequestControllerTest {
         "{\"name\":\"Angela Chan\",\"email\":\"qasas@mailinator.com\",\"phone\":\"+1 (157) 294-1842\",\"state\":\"Exercitation odit pr\",\"organization\":\"Lane Moss LLC\",\"referral\":\"Ea error voluptate v\"}";
 
     MockHttpServletRequestBuilder builder =
-        post("/account-request/waitlist")
+        post(ResourceLinks.WAITLIST_REQUEST)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -70,7 +70,7 @@ class AccountRequestControllerTest {
         "{\"name\":\"Angela Chan\",\"phone\":\"+1 (157) 294-1842\",\"state\":\"Exercitation odit pr\",\"organization\":\"Lane Moss LLC\",\"referral\":\"Ea error voluptate v\"}";
 
     MockHttpServletRequestBuilder builder =
-        post("/account-request/waitlist")
+        post(ResourceLinks.WAITLIST_REQUEST)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -86,7 +86,7 @@ class AccountRequestControllerTest {
         "{\"first-name\":\"Mary\",\"last-name\":\"Lopez\",\"email\":\"kyvuzoxy@mailinator.com\",\"work-phone-number\":\"+1 (969) 768-2863\",\"cell-phone-number\":\"+1 (319) 682-3114\",\"mailing-address1\":\"707 White Milton Extension\",\"apt-suite-other\":\"FL\",\"apt-floor-suite-no\":\"694\",\"city\":\"Reprehenderit nostr\",\"state\":\"RI\",\"zip\":\"13046\",\"county\":\"Et consectetur sunt\",\"organization-name\":\"Day Hayes Trading\",\"facility-name\":\"Fiona Payne\",\"clia-number\":\"474\",\"workflow\":\"Aut ipsum aute aute\",\"op-first-name\":\"Sawyer\",\"op-last-name\":\"Sears\",\"npi\":\"Quis sit eiusmod Nam\",\"op-phone-number\":\"+1 (583) 883-4172\",\"op-mailing-address1\":\"290 East Rocky Second Street\",\"op-apt-suite-other\":\"UNAVAILABLE\",\"op-apt-floor-suite-no\":\"546\",\"op-city\":\"Dicta cumque sit ip\",\"op-state\":\"AE\",\"op-zip\":\"43675\",\"op-county\":\"Asperiores illum in\",\"facility-type\":\"Urgent care center\",\"records-test-results\":\"No\",\"process-time\":\"15–30 minutes\",\"submitting-results-time\":\"Less than 30 minutes\",\"browsers\":\"Other\",\"testing-devices\":\"Abbott ID Now, BD Veritor, LumiraDX\",\"access-devices\":\"Smartphone\"}";
 
     MockHttpServletRequestBuilder builder =
-        post("/account-request")
+        post(ResourceLinks.ACCOUNT_REQUEST)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -114,7 +114,7 @@ class AccountRequestControllerTest {
         "{\"first-name\":\"Mary\",\"last-name\":\"Lopez\",\"work-phone-number\":\"+1 (969) 768-2863\",\"cell-phone-number\":\"+1 (319) 682-3114\",\"mailing-address1\":\"707 White Milton Extension\",\"apt-suite-other\":\"FL\",\"apt-floor-suite-no\":\"694\",\"city\":\"Reprehenderit nostr\",\"state\":\"RI\",\"zip\":\"13046\",\"county\":\"Et consectetur sunt\",\"organization-name\":\"Day Hayes Trading\",\"facility-name\":\"Fiona Payne\",\"clia-number\":\"474\",\"workflow\":\"Aut ipsum aute aute\",\"op-first-name\":\"Sawyer\",\"op-last-name\":\"Sears\",\"npi\":\"Quis sit eiusmod Nam\",\"op-phone-number\":\"+1 (583) 883-4172\",\"op-mailing-address1\":\"290 East Rocky Second Street\",\"op-apt-suite-other\":\"UNAVAILABLE\",\"op-apt-floor-suite-no\":\"546\",\"op-city\":\"Dicta cumque sit ip\",\"op-state\":\"AE\",\"op-zip\":\"43675\",\"op-county\":\"Asperiores illum in\",\"facility-type\":\"Urgent care center\",\"records-test-results\":\"No\",\"process-time\":\"15–30 minutes\",\"submitting-results-time\":\"Less than 30 minutes\",\"browsers\":\"Other\",\"testing-devices\":\"Abbott ID Now, BD Veritor, LumiraDX\",\"access-devices\":\"Smartphone\"}";
 
     MockHttpServletRequestBuilder builder =
-        post("/account-request")
+        post(ResourceLinks.ACCOUNT_REQUEST)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -1,0 +1,11 @@
+package gov.cdc.usds.simplereport.api;
+
+/** Container class for test constants related to REST handler testing */
+public final class ResourceLinks {
+  public static final String VERIFY_LINK = "/pxp/link/verify";
+  public static final String ANSWER_QUESTIONS = "/pxp/questions";
+  public static final String UPDATE_PATIENT = "/pxp/patient";
+
+  public static final String WAITLIST_REQUEST = "/account-request/waitlist";
+  public static final String ACCOUNT_REQUEST = "/account-request";
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import gov.cdc.usds.simplereport.api.ResourceLinks;
 import gov.cdc.usds.simplereport.db.model.ApiAuditEvent;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -115,12 +116,13 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
         .storeTimeOfConsent(any(PatientLink.class));
     HttpEntity<JsonNode> requestEntity = new HttpEntity<JsonNode>(makeVerifyLinkArgs());
     ResponseEntity<String> resp =
-        _restTemplate.exchange("/pxp/link/verify", HttpMethod.PUT, requestEntity, String.class);
+        _restTemplate.exchange(
+            ResourceLinks.VERIFY_LINK, HttpMethod.PUT, requestEntity, String.class);
     LOG.info("Response body is {}", resp.getBody());
     verify(_auditRepo).save(_eventCaptor.capture());
     assertThat(_eventCaptor.getValue())
         .as("Saved audit event")
-        .matches(e -> e.getHttpRequestDetails().getRequestUri().equals("/pxp/link/verify"))
+        .matches(e -> e.getHttpRequestDetails().getRequestUri().equals(ResourceLinks.VERIFY_LINK))
         .hasFieldOrPropertyWithValue("responseCode", 500);
   }
 
@@ -130,12 +132,13 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     when(_auditRepo.save(_eventCaptor.capture())).thenThrow(HibernateException.class);
     HttpEntity<JsonNode> requestEntity = new HttpEntity<JsonNode>(makeVerifyLinkArgs());
     ResponseEntity<String> resp =
-        _restTemplate.exchange("/pxp/link/verify", HttpMethod.PUT, requestEntity, String.class);
+        _restTemplate.exchange(
+            ResourceLinks.VERIFY_LINK, HttpMethod.PUT, requestEntity, String.class);
     assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
     JsonNode responseJson = new ObjectMapper().readTree(resp.getBody());
     assertEquals(400, responseJson.get("status").asInt());
     assertEquals("Bad Request", responseJson.get("error").asText());
-    assertEquals("/pxp/link/verify", responseJson.get("path").asText());
+    assertEquals(ResourceLinks.VERIFY_LINK, responseJson.get("path").asText());
   }
 
   private ObjectNode makeVerifyLinkArgs() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -1,9 +1,9 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -117,17 +117,11 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     ResponseEntity<String> resp =
         _restTemplate.exchange("/pxp/link/verify", HttpMethod.PUT, requestEntity, String.class);
     LOG.info("Response body is {}", resp.getBody());
-    verify(_auditRepo, atLeastOnce()).save(_eventCaptor.capture());
-    _eventCaptor
-        .getAllValues()
-        .forEach(
-            e ->
-                LOG.info(
-                    "Captured REST request {} {} {}",
-                    e.getRequestId(),
-                    e.getHttpRequestDetails().getRequestUri(),
-                    e.getResponseCode()));
-    assertEquals(500, _eventCaptor.getValue().getResponseCode());
+    verify(_auditRepo).save(_eventCaptor.capture());
+    assertThat(_eventCaptor.getValue())
+        .as("Saved audit event")
+        .matches(e -> e.getHttpRequestDetails().getRequestUri().equals("/pxp/link/verify"))
+        .hasFieldOrPropertyWithValue("responseCode", 500);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import gov.cdc.usds.simplereport.api.BaseFullStackTest;
+import gov.cdc.usds.simplereport.api.ResourceLinks;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
@@ -36,9 +37,6 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 class PatientExperienceControllerTest extends BaseFullStackTest {
-
-  private static final String ANSWER_QUESTIONS = "/pxp/questions";
-  private static final String VERIFY_LINK = "/pxp/link/verify";
 
   @Autowired private MockMvc _mockMvc;
 
@@ -78,7 +76,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
         "{\"patientLinkId\":\"" + UUID.randomUUID() + "\",\"dateOfBirth\":\"" + dob + "\"}";
 
     MockHttpServletRequestBuilder builder =
-        put(VERIFY_LINK)
+        put(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -104,7 +102,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(VERIFY_LINK)
+        put(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -112,7 +110,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // THEN
     String requestId = runBuilderReturningRequestId(builder, status().isOk());
-    assertLastAuditEntry(HttpStatus.OK, VERIFY_LINK, requestId);
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, requestId);
   }
 
   @Test
@@ -128,7 +126,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(VERIFY_LINK)
+        put(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -145,7 +143,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .getResponse()
             .getHeader(LoggingConstants.REQUEST_ID_HEADER);
 
-    assertLastAuditEntry(HttpStatus.OK, VERIFY_LINK, requestId);
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, requestId);
   }
 
   @Test
@@ -163,7 +161,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(VERIFY_LINK)
+        put(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -171,7 +169,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // THEN
     String requestId = runBuilderReturningRequestId(builder, status().isGone());
-    assertLastAuditEntry(HttpStatus.GONE, VERIFY_LINK, requestId);
+    assertLastAuditEntry(HttpStatus.GONE, ResourceLinks.VERIFY_LINK, requestId);
   }
 
   @Test
@@ -193,24 +191,24 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder submitBuilder =
-        put(ANSWER_QUESTIONS)
+        put(ResourceLinks.ANSWER_QUESTIONS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
             .content(requestBody);
     String requestId = runBuilderReturningRequestId(submitBuilder, status().isOk());
-    assertLastAuditEntry(HttpStatus.OK, ANSWER_QUESTIONS, requestId);
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.ANSWER_QUESTIONS, requestId);
 
     // OKAY NOW DO IT AGAIN
     MockHttpServletRequestBuilder verifyBuilder =
-        put(VERIFY_LINK)
+        put(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
             .content(requestBody);
 
     MockHttpServletRequestBuilder secondSubmitBuilder =
-        put(ANSWER_QUESTIONS)
+        put(ResourceLinks.ANSWER_QUESTIONS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -218,9 +216,9 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // THEN
     requestId = runBuilderReturningRequestId(verifyBuilder, status().isGone());
-    assertLastAuditEntry(HttpStatus.GONE, VERIFY_LINK, requestId);
+    assertLastAuditEntry(HttpStatus.GONE, ResourceLinks.VERIFY_LINK, requestId);
     requestId = runBuilderReturningRequestId(secondSubmitBuilder, status().isGone());
-    assertLastAuditEntry(HttpStatus.GONE, ANSWER_QUESTIONS, requestId);
+    assertLastAuditEntry(HttpStatus.GONE, ResourceLinks.ANSWER_QUESTIONS, requestId);
   }
 
   @Test
@@ -236,7 +234,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(VERIFY_LINK)
+        put(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -269,7 +267,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put("/pxp/patient")
+        put(ResourceLinks.UPDATE_PATIENT)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -302,7 +300,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ANSWER_QUESTIONS)
+        put(ResourceLinks.ANSWER_QUESTIONS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")


### PR DESCRIPTION
## Related Issue or Background Info

- one test in the audit log story didn't test what it was supposed to, because of a bug that was already fixed
- the RaceArrayConverter class is impossibly noisy at the `debug` level (yes, this can happen)
- a bunch of string constants needed to be made symbolic
- I was being nice and not including the last two in either of my recent larger PRs
