### PR TITLE
Add missing test result header

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -209,6 +209,7 @@ export const DetachedTestResultsList: any = ({
                     <th scope="col">Test date</th>
                     <th scope="col">Result</th>
                     <th scope="col">Device</th>
+                    <th scope="col">Symptoms</th>
                     <th scope="col">Submitter</th>
                     <th scope="col">Actions</th>
                   </tr>

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -61,6 +61,11 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   <th
                     scope="col"
                   >
+                    Symptoms
+                  </th>
+                  <th
+                    scope="col"
+                  >
                     Submitter
                   </th>
                   <th


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes bug&mdash;the "Symptoms" column was added to the test results list but the header was not 
- introduced by #1193 (not in production yet)

![missing column](https://user-images.githubusercontent.com/49658917/113185725-ccf4b800-9224-11eb-9507-ea881d76f2fc.png)

## Changes Proposed

- Adds "Symptoms" header