### PR TITLE
API name and address model refactor

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/InternalIdResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/InternalIdResolver.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.api;
+
+import gov.cdc.usds.simplereport.db.model.DatabaseEntity;
+import java.util.UUID;
+import graphql.kickstart.tools.GraphQLResolver;
+
+/** Resolver mix-in to alias "id" to "internalId" */
+public interface InternalIdResolver<T extends DatabaseEntity> extends GraphQLResolver<T> {
+
+  default UUID getId(T entity) {
+    return entity.getInternalId();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/InternalIdResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/InternalIdResolver.java
@@ -1,8 +1,8 @@
 package gov.cdc.usds.simplereport.api;
 
 import gov.cdc.usds.simplereport.db.model.DatabaseEntity;
-import java.util.UUID;
 import graphql.kickstart.tools.GraphQLResolver;
+import java.util.UUID;
 
 /** Resolver mix-in to alias "id" to "internalId" */
 public interface InternalIdResolver<T extends DatabaseEntity> extends GraphQLResolver<T> {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/PersonNameResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/PersonNameResolver.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.api;
+
+import gov.cdc.usds.simplereport.db.model.PersonEntity;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+import graphql.kickstart.tools.GraphQLResolver;
+
+/** Resolver mix-in to handle aliasing "nameInfo" to "name" */
+public interface PersonNameResolver<T extends PersonEntity> extends GraphQLResolver<T> {
+
+  default PersonName getName(T entity) {
+    return entity.getNameInfo();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/ApiUserDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/ApiUserDataResolver.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.api.apiuser;
+
+import gov.cdc.usds.simplereport.api.PersonNameResolver;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolver for the "name" field of ApiUser, where ApiUser is the type with that name in the API,
+ * and not the thing resolved by the ApiUserResolver. This may produce some confusion until/unless
+ * we rename that class.
+ */
+@Component
+public class ApiUserDataResolver implements PersonNameResolver<ApiUser> {}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -1,78 +1,45 @@
 package gov.cdc.usds.simplereport.api.model;
 
+import gov.cdc.usds.simplereport.api.model.facets.LocatedWrapper;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
-import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
+import gov.cdc.usds.simplereport.service.model.WrappedEntity;
 import java.util.List;
-import java.util.UUID;
+import java.util.Optional;
 
-public class ApiFacility {
-
-  private Facility facility;
-  private StreetAddress address;
+public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapper<Facility> {
 
   public ApiFacility(Facility wrapped) {
-    super();
-    this.facility = wrapped;
-    this.address = facility.getAddress();
-  }
-
-  public UUID getId() {
-    return facility.getInternalId();
+    super(wrapped);
   }
 
   public String getName() {
-    return facility.getFacilityName();
+    return getWrapped().getFacilityName();
   }
 
   public String getCliaNumber() {
-    return facility.getCliaNumber();
-  }
-
-  public String getStreet() {
-    return address == null ? "" : address.getStreetOne();
-  }
-
-  public String getStreetTwo() {
-    return address == null ? "" : address.getStreetTwo();
-  }
-
-  public String getCity() {
-    return address == null ? "" : address.getCity();
-  }
-
-  public String getCounty() {
-    return address == null ? "" : address.getCounty();
-  }
-
-  public String getState() {
-    return address == null ? "" : address.getState();
-  }
-
-  public String getZipCode() {
-    return address == null ? "" : address.getPostalCode();
+    return getWrapped().getCliaNumber();
   }
 
   public String getPhone() {
-    return facility.getTelephone();
+    return getWrapped().getTelephone();
   }
 
   public String getEmail() {
-    return facility.getEmail();
+    return getWrapped().getEmail();
   }
 
   public List<DeviceType> getDeviceTypes() {
-    return facility.getDeviceTypes();
+    return getWrapped().getDeviceTypes();
   }
 
   public DeviceType getDefaultDeviceType() {
-    return facility.getDefaultDeviceType();
+    return getWrapped().getDefaultDeviceType();
   }
 
   public ApiProvider getOrderingProvider() {
-    if (facility.getOrderingProvider() == null) {
-      return null;
-    }
-    return new ApiProvider(facility.getOrderingProvider());
+    return Optional.ofNullable(getWrapped().getOrderingProvider())
+        .map(ApiProvider::new)
+        .orElse(null);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiProvider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiProvider.java
@@ -1,79 +1,22 @@
 package gov.cdc.usds.simplereport.api.model;
 
+import gov.cdc.usds.simplereport.api.model.facets.LocatedWrapper;
+import gov.cdc.usds.simplereport.api.model.facets.PersonWrapper;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.service.model.WrappedEntity;
 
-public class ApiProvider {
-
-  private Provider orderingProvider;
+public class ApiProvider extends WrappedEntity<Provider>
+    implements PersonWrapper<Provider>, LocatedWrapper<Provider> {
 
   public ApiProvider(Provider orderingProvider) {
-    super();
-    this.orderingProvider = orderingProvider;
-  }
-
-  public String getFirstName() {
-    return orderingProvider.getNameInfo().getFirstName();
-  }
-
-  public String getMiddleName() {
-    return orderingProvider.getNameInfo().getMiddleName();
-  }
-
-  public String getLastName() {
-    return orderingProvider.getNameInfo().getLastName();
-  }
-
-  public String getSuffix() {
-    return orderingProvider.getNameInfo().getSuffix();
+    super(orderingProvider);
   }
 
   public String getNPI() {
-    return orderingProvider.getProviderId();
-  }
-
-  public String getStreet() {
-    if (orderingProvider.getAddress() == null) {
-      return "";
-    }
-    return orderingProvider.getAddress().getStreetOne();
-  }
-
-  public String getStreetTwo() {
-    if (orderingProvider.getAddress() == null) {
-      return "";
-    }
-    return orderingProvider.getAddress().getStreetTwo();
-  }
-
-  public String getCity() {
-    if (orderingProvider.getAddress() == null) {
-      return "";
-    }
-    return orderingProvider.getAddress().getCity();
-  }
-
-  public String getCounty() {
-    if (orderingProvider.getAddress() == null) {
-      return "";
-    }
-    return orderingProvider.getAddress().getCounty();
-  }
-
-  public String getState() {
-    if (orderingProvider.getAddress() == null) {
-      return "";
-    }
-    return orderingProvider.getAddress().getState();
-  }
-
-  public String getZipCode() {
-    if (orderingProvider.getAddress() == null) {
-      return "";
-    }
-    return orderingProvider.getAddress().getPostalCode();
+    return getWrapped().getProviderId();
   }
 
   public String getPhone() {
-    return orderingProvider.getTelephone();
+    return getWrapped().getTelephone();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
@@ -1,17 +1,17 @@
 package gov.cdc.usds.simplereport.api.model;
 
+import gov.cdc.usds.simplereport.api.model.facets.PersonWrapper;
 import gov.cdc.usds.simplereport.config.authorization.UserPermission;
 import gov.cdc.usds.simplereport.service.model.UserInfo;
+import gov.cdc.usds.simplereport.service.model.WrappedEntity;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public class User {
-
-  private UserInfo wrapped;
+public class User extends WrappedEntity<UserInfo> implements PersonWrapper<UserInfo> {
 
   public User(UserInfo user) {
-    this.wrapped = user;
+    super(user);
   }
 
   public UUID getId() {
@@ -20,22 +20,6 @@ public class User {
 
   public Optional<ApiOrganization> getOrganization() {
     return wrapped.getOrganization().map(o -> new ApiOrganization(o, wrapped.getFacilities()));
-  }
-
-  public String getFirstName() {
-    return wrapped.getFirstName();
-  }
-
-  public String getMiddleName() {
-    return wrapped.getMiddleName();
-  }
-
-  public String getLastName() {
-    return wrapped.getLastName();
-  }
-
-  public String getSuffix() {
-    return wrapped.getSuffix();
   }
 
   // Note: we assume a user's email and login username are the same thing.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
@@ -6,16 +6,11 @@ import gov.cdc.usds.simplereport.service.model.UserInfo;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public class User extends WrappedEntity<UserInfo> implements PersonWrapper<UserInfo> {
 
   public User(UserInfo user) {
     super(user);
-  }
-
-  public UUID getId() {
-    return wrapped.getId();
   }
 
   public Optional<ApiOrganization> getOrganization() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/facets/LocatedWrapper.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/facets/LocatedWrapper.java
@@ -1,0 +1,52 @@
+package gov.cdc.usds.simplereport.api.model.facets;
+
+import gov.cdc.usds.simplereport.db.model.LocatedEntity;
+import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
+import gov.cdc.usds.simplereport.service.model.Wrapper;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Mix-in interface to handle retrieving individual address fields, or the entire address object, as
+ * required.
+ *
+ * @param <T> an entity that has a street address
+ */
+public interface LocatedWrapper<T extends LocatedEntity> extends Wrapper<T> {
+
+  default StreetAddress getAddress() {
+    return getWrapped().getAddress();
+  }
+
+  default String getAddressField(Function<? super StreetAddress, String> mapper) {
+    return Optional.ofNullable(getAddress()).map(mapper).orElse("");
+  }
+
+  default String getStreet() {
+    return getAddressField(StreetAddress::getStreetOne);
+  }
+
+  default String getStreetTwo() {
+    return getAddressField(StreetAddress::getStreetTwo);
+  }
+
+  default String getCity() {
+    return getAddressField(StreetAddress::getCity);
+  }
+
+  default String getCounty() {
+    return getAddressField(StreetAddress::getCounty);
+  }
+
+  default String getState() {
+    return getAddressField(StreetAddress::getState);
+  }
+
+  default String getZipCode() {
+    return getPostalCode();
+  }
+
+  default String getPostalCode() {
+    return getAddressField(StreetAddress::getPostalCode);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/facets/PersonWrapper.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/facets/PersonWrapper.java
@@ -1,0 +1,33 @@
+package gov.cdc.usds.simplereport.api.model.facets;
+
+import gov.cdc.usds.simplereport.db.model.PersonEntity;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+import gov.cdc.usds.simplereport.service.model.Wrapper;
+
+/**
+ * Mix-in class to handle fetching components of a person's name, or the entire name, as desired.
+ *
+ * @param <T> an entity representing a person with a name.
+ */
+public interface PersonWrapper<T extends PersonEntity> extends Wrapper<T> {
+
+  default PersonName getName() {
+    return getWrapped().getNameInfo();
+  }
+
+  default String getFirstName() {
+    return getName().getFirstName();
+  }
+
+  default String getLastName() {
+    return getName().getLastName();
+  }
+
+  default String getMiddleName() {
+    return getName().getMiddleName();
+  }
+
+  default String getSuffix() {
+    return getName().getSuffix();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
@@ -7,9 +7,9 @@ import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.service.TestEventService;
+import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import graphql.kickstart.tools.GraphQLResolver;
 
 @Component
 public class PatientDataResolver

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
@@ -1,23 +1,21 @@
 package gov.cdc.usds.simplereport.api.patient;
 
+import gov.cdc.usds.simplereport.api.InternalIdResolver;
+import gov.cdc.usds.simplereport.api.PersonNameResolver;
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
-import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.service.TestEventService;
-import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import graphql.kickstart.tools.GraphQLResolver;
 
 @Component
-public class PatientDataResolver implements GraphQLResolver<Person> {
+public class PatientDataResolver
+    implements GraphQLResolver<Person>, PersonNameResolver<Person>, InternalIdResolver<Person> {
 
   @Autowired private TestEventService _testEventService;
-
-  public PersonName getName(Person p) {
-    return p.getNameInfo();
-  }
 
   public TestEvent getLastTest(Person p) {
     return _testEventService.getLastTestResultsForPatientPermRestricted(p);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
@@ -4,6 +4,7 @@ import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.service.TestEventService;
 import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,10 @@ import org.springframework.stereotype.Component;
 public class PatientDataResolver implements GraphQLResolver<Person> {
 
   @Autowired private TestEventService _testEventService;
+
+  public PersonName getName(Person p) {
+    return p.getNameInfo();
+  }
 
   public TestEvent getLastTest(Person p) {
     return _testEventService.getLastTestResultsForPatientPermRestricted(p);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.testresult;
 
+import gov.cdc.usds.simplereport.api.InternalIdResolver;
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.api.model.TestDescription;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
@@ -11,19 +12,14 @@ import graphql.kickstart.tools.GraphQLResolver;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TestResultDataResolver implements GraphQLResolver<TestEvent> {
+public class TestResultDataResolver implements GraphQLResolver<TestEvent>, InternalIdResolver<TestEvent> {
 
   private AskOnEntrySurvey getSurvey(TestEvent testEvent) {
     return testEvent.getSurveyData();
-  }
-
-  public UUID getId(TestEvent testEvent) {
-    return testEvent.getInternalId();
   }
 
   public Person getPatient(TestEvent testEvent) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
@@ -16,7 +16,8 @@ import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TestResultDataResolver implements GraphQLResolver<TestEvent>, InternalIdResolver<TestEvent> {
+public class TestResultDataResolver
+    implements GraphQLResolver<TestEvent>, InternalIdResolver<TestEvent> {
 
   private AskOnEntrySurvey getSurvey(TestEvent testEvent) {
     return testEvent.getSurveyData();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/ApiUserAwareGraphQlContextBuilder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/ApiUserAwareGraphQlContextBuilder.java
@@ -62,7 +62,7 @@ class ApiUserAwareGraphQlContextBuilder implements GraphQLServletContextBuilder 
     var currentUser = apiUserService.getCurrentUserInfo();
     var principals = new HashSet<Principal>();
 
-    principals.add(new ApiUserPrincipal(currentUser.getWrappedUser()));
+    principals.add(new ApiUserPrincipal(currentUser.getWrapped()));
 
     if (currentUser.getIsAdmin()) {
       principals.add(SiteAdminPrincipal.getInstance());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.NaturalId;
  */
 @Entity
 @DynamicUpdate
-public class ApiUser extends EternalSystemManagedEntity {
+public class ApiUser extends EternalSystemManagedEntity implements PersonEntity {
 
   @Column(nullable = false, updatable = false, unique = true)
   @NaturalId

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
@@ -25,7 +25,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
-public abstract class AuditedEntity {
+public abstract class AuditedEntity implements DatabaseEntity {
 
   @Column(updatable = false, nullable = false)
   @Id

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DatabaseEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DatabaseEntity.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.util.UUID;
+
+/**
+ * Common interface to say "this is a thing we store in the database". Already being lightly abused,
+ * and I haven't even committed it yet.
+ */
+public interface DatabaseEntity {
+
+  UUID getInternalId();
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DatabaseEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DatabaseEntity.java
@@ -9,5 +9,4 @@ import java.util.UUID;
 public interface DatabaseEntity {
 
   UUID getInternalId();
-
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -18,7 +18,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 
 @Entity
-public class Facility extends OrganizationScopedEternalEntity {
+public class Facility extends OrganizationScopedEternalEntity implements LocatedEntity {
 
   @Column(nullable = false, unique = false) // unique within an organization only
   private String facilityName;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/LocatedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/LocatedEntity.java
@@ -1,0 +1,10 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
+
+/** Marker interface for an entity that has a street address */
+public interface LocatedEntity {
+
+  StreetAddress getAddress();
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/LocatedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/LocatedEntity.java
@@ -6,5 +6,4 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 public interface LocatedEntity {
 
   StreetAddress getAddress();
-
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.Type;
  * this object, you will likely break many things, so do not do that.
  */
 @Entity
-public class Person extends OrganizationScopedEternalEntity {
+public class Person extends OrganizationScopedEternalEntity implements PersonEntity, LocatedEntity {
 
   // NOTE: facility==NULL means this person appears in ALL facilities for a given Organization.
   // this is common for imported patients.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonEntity.java
@@ -1,0 +1,9 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+
+/** Marker interface for entities that represent a person with a name. */
+public interface PersonEntity {
+
+  PersonName getNameInfo();
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Provider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Provider.java
@@ -10,7 +10,7 @@ import javax.persistence.Entity;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Entity
-public class Provider extends EternalAuditedEntity {
+public class Provider extends EternalAuditedEntity implements PersonEntity, LocatedEntity {
 
   @Embedded @JsonUnwrapped private PersonName nameInfo;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SystemManagedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SystemManagedEntity.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.UpdateTimestamp;
  * UpdateTimestamp}, and feel kind of weird about it.
  */
 @MappedSuperclass
-public abstract class SystemManagedEntity {
+public abstract class SystemManagedEntity implements DatabaseEntity {
 
   @Column(updatable = false, nullable = false)
   @Id

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/UserInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/UserInfo.java
@@ -3,8 +3,11 @@ package gov.cdc.usds.simplereport.service.model;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.config.authorization.UserPermission;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.DatabaseEntity;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.PersonEntity;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -12,9 +15,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class UserInfo {
+public class UserInfo extends WrappedEntity<ApiUser> implements DatabaseEntity, PersonEntity {
 
-  private ApiUser wrapped;
   private Optional<Organization> org;
   private boolean isAdmin;
   private List<UserPermission> permissions;
@@ -22,7 +24,7 @@ public class UserInfo {
   private List<Facility> facilities;
 
   public UserInfo(ApiUser user, Optional<OrganizationRoles> orgwrapper, boolean isAdmin) {
-    this.wrapped = user;
+    super(user);
     this.org = orgwrapper.map(OrganizationRoles::getOrganization);
     this.permissions = new ArrayList<>();
     this.roles =
@@ -35,28 +37,18 @@ public class UserInfo {
     this.isAdmin = isAdmin;
   }
 
-  public UUID getId() {
+  @Override
+  public UUID getInternalId() {
     return wrapped.getInternalId();
+  }
+
+  @Override
+  public PersonName getNameInfo() {
+    return getWrapped().getNameInfo();
   }
 
   public Optional<Organization> getOrganization() {
     return org;
-  }
-
-  public String getFirstName() {
-    return wrapped.getNameInfo().getFirstName();
-  }
-
-  public String getMiddleName() {
-    return wrapped.getNameInfo().getMiddleName();
-  }
-
-  public String getLastName() {
-    return wrapped.getNameInfo().getLastName();
-  }
-
-  public String getSuffix() {
-    return wrapped.getNameInfo().getSuffix();
   }
 
   // Note: we assume a user's email and login username are the same thing.

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/UserInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/UserInfo.java
@@ -71,8 +71,4 @@ public class UserInfo extends WrappedEntity<ApiUser> implements DatabaseEntity, 
   public List<Facility> getFacilities() {
     return facilities;
   }
-
-  public ApiUser getWrappedUser() {
-    return wrapped;
-  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/WrappedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/WrappedEntity.java
@@ -1,0 +1,25 @@
+package gov.cdc.usds.simplereport.service.model;
+
+import gov.cdc.usds.simplereport.db.model.DatabaseEntity;
+import java.util.UUID;
+
+public class WrappedEntity<T extends DatabaseEntity> implements Wrapper<T> {
+
+  protected T wrapped;
+
+  protected WrappedEntity(T model) {
+    wrapped = model;
+  }
+
+  public T getWrapped() {
+    return wrapped;
+  }
+
+  public UUID getInternalId() {
+    return wrapped.getInternalId();
+  }
+
+  public UUID getId() {
+    return getInternalId();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/Wrapper.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/Wrapper.java
@@ -1,0 +1,7 @@
+package gov.cdc.usds.simplereport.service.model;
+
+/** Base interface for wrapper objects, to allow consistent mixin/facet design. */
+public interface Wrapper<T> {
+
+  T getWrapped();
+}

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -2,7 +2,7 @@
 # All queries and mutations in this file implicitly require site admin access,
 # which is enforced in the API not in the schema validator.
 extend type Query {
-  organizations: [Organization!]!
+  organizations: [Organization!]! # not actually used in the admin console (yet)
 }
 extend type Mutation {
   createDeviceType(
@@ -20,7 +20,7 @@ extend type Mutation {
     loincCode: String
     swabType: String
   ): DeviceType
-  addUser(
+  addUser( # not actually used in the admin console (currently)
     firstName: String
     middleName: String
     lastName: String!

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -75,7 +75,7 @@ type User {
   organization: Organization
   # for backward compatibility, currently maintaining both `role` and `roles`
   role: Role
-  roles: [Role!]!
+  roles: [Role!]! @deprecated(reason: "Users have only one role now")
 }
 
 type ApiUser {

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -15,6 +15,7 @@ type Facility {
   id: ID
   name: String
   cliaNumber: String
+  address: AddressInfo
   street: String
   streetTwo: String
   city: String
@@ -35,6 +36,7 @@ type Provider {
   lastName: String
   suffix: String
   NPI: String
+  address: AddressInfo
   street: String
   streetTwo: String
   city: String
@@ -83,13 +85,6 @@ type ApiUser {
   nameInfo: NameInfo @deprecated(reason: "needless connection of type to field name")
 }
 
-type NameInfo {
-  firstName: String
-  middleName: String
-  lastName: String
-  suffix: String
-}
-
 # Patient and test types
 
 type Patient
@@ -109,6 +104,7 @@ type Patient
   gender: String
     @requiredPermissions(anyOf: ["READ_PATIENT_LIST", "UPDATE_TEST"])
   ethnicity: String @requiredPermissions(allOf: ["READ_PATIENT_LIST"])
+  address: AddressInfo @requiredPermissions(allOf: ["READ_PATIENT_LIST"])
   street: String @requiredPermissions(allOf: ["READ_PATIENT_LIST"])
   streetTwo: String @requiredPermissions(allOf: ["READ_PATIENT_LIST"])
   city: String @requiredPermissions(allOf: ["READ_PATIENT_LIST"])

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -29,6 +29,7 @@ type Facility {
 }
 
 type Provider {
+  name: NameInfo
   firstName: String
   middleName: String
   lastName: String
@@ -62,6 +63,7 @@ type TestDescription {
 # Note: the login username is the user's email
 type User {
   id: ID
+  name: NameInfo
   firstName: String
   middleName: String
   lastName: String!
@@ -77,7 +79,8 @@ type User {
 }
 
 type ApiUser {
-  nameInfo: NameInfo
+  name: NameInfo
+  nameInfo: NameInfo @deprecated(reason: "needless connection of type to field name")
 }
 
 type NameInfo {
@@ -96,6 +99,7 @@ type Patient
   internalId: ID
   facility: Facility
   lookupId: String
+  name: NameInfo
   firstName: String
   middleName: String
   lastName: String

--- a/backend/src/main/resources/graphql/wiring.graphqls
+++ b/backend/src/main/resources/graphql/wiring.graphqls
@@ -1,5 +1,5 @@
-# Directives and enumerated types go here, so that they can be easily referred to
-# side by side with the more complex types
+# Directives, enumerations, and utility types (e.g. structured name/address information, input types, etc.)
+# go here, so that they can be easily referred to side by side with the more complex types
 
 # Requires that the requester have a certain permission level.
 #
@@ -77,4 +77,19 @@ enum TestCorrectionStatus {
 enum TestResultDeliveryPreference {
   SMS
   NONE
+}
+
+type NameInfo {
+  firstName: String
+  middleName: String
+  lastName: String
+  suffix: String
+}
+
+type AddressInfo {
+  streetOne: String
+  streetTwo: String
+  city: String
+  county: String
+  postalCode: String
 }

--- a/backend/src/main/resources/graphql/wiring.graphqls
+++ b/backend/src/main/resources/graphql/wiring.graphqls
@@ -91,5 +91,6 @@ type AddressInfo {
   streetTwo: String
   city: String
   county: String
+  state: String
   postalCode: String
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -66,6 +66,21 @@ class ApiUserManagementTest extends BaseGraphqlTest {
             UserPermission.UPDATE_TEST,
             UserPermission.SUBMIT_TEST),
         null);
+
+    JsonNode facilityNode = who.path("organization").path("facilities").get(0);
+    assertEquals("Injection Site", facilityNode.get("name").asText());
+    assertEquals("2797 N Cerrada de Beto", facilityNode.get("street").asText());
+    assertEquals("2797 N Cerrada de Beto", facilityNode.path("address").get("streetOne").asText());
+
+    JsonNode providerNode = facilityNode.get("orderingProvider");
+    assertEquals("Flintstone", providerNode.get("lastName").asText());
+    assertEquals("Flintstone", providerNode.path("name").get("lastName").asText());
+    assertEquals("123 Main Street", providerNode.get("street").asText());
+    assertEquals("123 Main Street", providerNode.path("address").get("streetOne").asText());
+    assertEquals("Oz", providerNode.get("city").asText());
+    assertEquals("Oz", providerNode.path("address").get("city").asText());
+    assertEquals("12345", providerNode.get("zipCode").asText());
+    assertEquals("12345", providerNode.path("address").get("postalCode").asText());
   }
 
   @Test
@@ -1069,7 +1084,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
   // map from each facility's name to its UUID; includes all facilities user can access
   private Map<String, UUID> extractFacilitiesFromUser(ObjectNode user) {
-    Iterator<JsonNode> facilitiesIter = user.get("organization").get("testingFacility").elements();
+    Iterator<JsonNode> facilitiesIter = user.get("organization").get("facilities").elements();
     Map<String, UUID> facilities = new HashMap<>();
     while (facilitiesIter.hasNext()) {
       JsonNode facility = facilitiesIter.next();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -51,7 +51,7 @@ class PatientManagementTest extends BaseGraphqlTest {
   }
 
   @Test
-  void createAndFetchOnePatientIsoDate() throws Exception {
+  void createAndFetchOnePatient() throws Exception {
     useOrgAdmin();
     String firstName = "Sansa";
     JsonNode patients =
@@ -59,7 +59,17 @@ class PatientManagementTest extends BaseGraphqlTest {
             firstName, "Stark", "1100-12-25", "1-800-BIZ-NAME", "notbitter", Optional.empty());
     assertTrue(patients.has(0), "At least one patient found");
     JsonNode sansa = patients.get(0);
+    org.slf4j.LoggerFactory.getLogger(getClass()).info("Sansa looks like {}", sansa);
+    // check name through both flat and structured graph nodes
     assertEquals(firstName, sansa.get("firstName").asText());
+    assertEquals(firstName, sansa.path("name").get("firstName").asText());
+    // check address through both flat and structured graph nodes
+    assertEquals("Top Floor", sansa.get("street").asText());
+    assertEquals("Top Floor", sansa.path("address").get("streetOne").asText());
+    assertEquals("Winterfell", sansa.get("city").asText());
+    assertEquals("Winterfell", sansa.path("address").get("city").asText());
+    assertEquals("NY", sansa.get("state").asText());
+    assertEquals("NY", sansa.path("address").get("state").asText());
     assertEquals("1100-12-25", sansa.get("birthDate").asText());
     assertEquals("(800) 249-6263", sansa.get("telephone").asText());
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/config/ApiUserAwareGraphQlContextBuilderTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/config/ApiUserAwareGraphQlContextBuilderTest.java
@@ -69,7 +69,7 @@ class ApiUserAwareGraphQlContextBuilderTest {
         userInfo.getOrganization().map(OrganizationPrincipal::new).orElse(null),
         subject.getPrincipals(OrganizationPrincipal.class).stream().findFirst().orElse(null));
     assertEquals(
-        new ApiUserPrincipal(userInfo.getWrappedUser()),
+        new ApiUserPrincipal(userInfo.getWrapped()),
         subject.getPrincipals(ApiUserPrincipal.class).stream().findFirst().orElseThrow());
     assertEquals(userInfo.getIsAdmin(), !subject.getPrincipals(SiteAdminPrincipal.class).isEmpty());
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/AuditServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/AuditServiceTest.java
@@ -38,7 +38,7 @@ class AuditServiceTest extends BaseServiceTest<AuditService> {
     _service.logGraphQlEvent(
         state,
         List.of(),
-        userInfo.getWrappedUser(),
+        userInfo.getWrapped(),
         userInfo.getPermissions(),
         userInfo.getIsAdmin(),
         userInfo.getOrganization().orElse(null));

--- a/backend/src/test/resources/queries/add-user
+++ b/backend/src/test/resources/queries/add-user
@@ -28,7 +28,7 @@ mutation addUserOp(
       organization {
         name
         externalId
-        testingFacility {
+        facilities {
           name
           id
         }

--- a/backend/src/test/resources/queries/add-user-to-current-org
+++ b/backend/src/test/resources/queries/add-user-to-current-org
@@ -26,7 +26,7 @@ mutation addUserToCurrentOrgOp(
       organization {
         name
         externalId
-        testingFacility {
+        facilities {
           name
           id
         }

--- a/backend/src/test/resources/queries/current-user-query
+++ b/backend/src/test/resources/queries/current-user-query
@@ -12,13 +12,36 @@ query whoDat {
     roleDescription
     isAdmin
     organization {
-      testingFacility {
+      facilities {
         name
         id
-        __typename
+
+        street
+        streetTwo
+        city
+        address {
+          streetOne
+          streetTwo
+          city
+        }
+
+        orderingProvider {
+          firstName
+          lastName
+          name {
+            firstName
+            lastName
+          }
+          street
+          city
+          zipCode
+          address {
+            streetOne
+            city
+            postalCode
+          }
+        }
       }
-      __typename
     }
-    __typename
   }
 }

--- a/backend/src/test/resources/queries/person-query
+++ b/backend/src/test/resources/queries/person-query
@@ -2,7 +2,21 @@ query GetPatients($facilityId: ID = null) {
   patients(facilityId: $facilityId) {
     firstName
     lastName
+    name {
+      firstName
+      lastName
+    }
     birthDate
     telephone
+
+    street
+    city
+    state
+
+    address {
+      streetOne
+      city
+      state
+    }
   }
 }

--- a/backend/src/test/resources/queries/person-with-facility-query
+++ b/backend/src/test/resources/queries/person-with-facility-query
@@ -2,6 +2,20 @@
   patients {
     firstName
     lastName
+    name {
+      firstName
+      lastName
+    }
+
+    street
+    city
+    state
+    address {
+      streetOne
+      city
+      state
+    }
+
     birthDate
     telephone
     facility {

--- a/backend/src/test/resources/queries/update-user
+++ b/backend/src/test/resources/queries/update-user
@@ -24,7 +24,7 @@ mutation updateUser(
       organization {
         name
         externalId
-        testingFacility {
+        facilities {
           name
           id
         }

--- a/backend/src/test/resources/queries/update-user-privileges
+++ b/backend/src/test/resources/queries/update-user-privileges
@@ -23,7 +23,7 @@ mutation updateUserPrivileges(
       organization {
         name
         externalId
-        testingFacility {
+        facilities {
           name
           id
         }


### PR DESCRIPTION
## Related Issue or Background Info

Refactor of graphql model (no breaking changes!) to include structured name and address information in more places, and do it in a more maintainable (probably) way.

## Changes Proposed

- add AddressInfo type, and add it to things that have addresses
- make some classes that currently unroll facility information directly, use a mixin instead
- same for "id" and "name" because it seemed reasonable to do those at the same time
- some tests for all of this
