### PR TITLE
Fix test result submit button bug

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -239,7 +239,7 @@ const QueueItem: any = ({
 
   const [mutationError, updateMutationError] = useState(null);
   const [removePatientFromQueue] = useMutation(REMOVE_PATIENT_FROM_QUEUE);
-  const [submitTestResult] = useMutation(SUBMIT_TEST_RESULT);
+  const [submitTestResult, { loading }] = useMutation(SUBMIT_TEST_RESULT);
   const [updateAoe] = useMutation(UPDATE_AOE);
   const [editQueueItem] = useMutation<
     EditQueueItemResponse,
@@ -251,8 +251,6 @@ const QueueItem: any = ({
   useEffect(() => {
     setAoeAnswers(askOnEntry);
   }, [askOnEntry]);
-
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [deviceId, updateDeviceId] = useState(
     selectedDeviceId || defaultDevice.internalId
@@ -317,10 +315,8 @@ const QueueItem: any = ({
   };
 
   const onTestResultSubmit = (e?: React.MouseEvent<HTMLButtonElement>) => {
-    setIsSubmitting(true);
     if (e) e.preventDefault();
     if (forceSubmit || areAnswersComplete(aoeAnswers)) {
-      if (e) e.currentTarget.disabled = true;
       trackSubmitTestResult({});
       setConfirmationType("none");
       submitTestResult({
@@ -336,9 +332,6 @@ const QueueItem: any = ({
         .then(() => removeTimer(internalId))
         .catch((error) => {
           updateMutationError(error);
-          // Re-enable Submit in the hopes it will work
-          setIsSubmitting(false);
-          if (e) e.currentTarget.disabled = false;
         });
     } else {
       setConfirmationType("submitResult");
@@ -638,7 +631,7 @@ const QueueItem: any = ({
                 queueItemId={internalId}
                 testResultValue={testResultValue}
                 isSubmitDisabled={
-                  isSubmitting ||
+                  loading ||
                   (!shouldUseCurrentDateTime() &&
                     !isValidCustomDateTested(dateTested))
                 }

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -298,8 +298,6 @@ const QueueItem: any = ({
 
   const [removePatientId, setRemovePatientId] = useState<string>();
 
-  let forceSubmit = false;
-
   if (mutationError) {
     throw mutationError;
   }
@@ -314,8 +312,7 @@ const QueueItem: any = ({
     showNotification(toast, alert);
   };
 
-  const onTestResultSubmit = (e?: React.MouseEvent<HTMLButtonElement>) => {
-    if (e) e.preventDefault();
+  const onTestResultSubmit = (forceSubmit: boolean = false) => {
     if (forceSubmit || areAnswersComplete(aoeAnswers)) {
       trackSubmitTestResult({});
       setConfirmationType("none");
@@ -601,8 +598,7 @@ const QueueItem: any = ({
                   continueHandler={
                     confirmationType === "submitResult"
                       ? () => {
-                          forceSubmit = true;
-                          onTestResultSubmit();
+                          onTestResultSubmit(true);
                         }
                       : removeFromQueue
                   }

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -22,6 +22,7 @@ const onExiting = (node: HTMLElement) => {
   node.style.marginBottom = `-${node.offsetHeight}px`;
   node.style.opacity = "0";
   node.style.transition = `opacity ${transitionDuration}ms ease-out, margin ${transitionDuration}ms ease-out`;
+  node.style.pointerEvents = "none";
 };
 
 const emptyQueueMessage = (


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #1229

## Changes Proposed

- Rather than using our own `isSubmitting` state (which was being set too early in the flow!), just use the `loading` prop returned by `useMutation` since that will definitely be correct
- Remove some hacky disable logic on the submit button in favor of setting `pointerEvent` to `"none"` in the CSS exit transition