### PR TITLE
Add new hhs suport staff

### DIFF
--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -34,6 +34,7 @@ simple-report:
     - teophanis.khoury@hhs.gov
     - jessica.cox@hhs.gov
     - vanessa.bonetti@hhs.gov
+    - nikolas.cribb@hhs.gov
   patient-link-url: https://simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: true


### PR DESCRIPTION
## Related Issue or Background Info

> Also, can we add Nikolas.Cribb@hhs.gov to the HHS Protect approved / encoded admins that create accounts? (They hired someone new)
-- Will


