### PR TITLE
Added structured person-name input to relevant mutations.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.api;
 import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -13,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
@@ -217,5 +219,20 @@ public class Translators {
 
   public static String sanitize(String input) {
     return input == null ? "" : Jsoup.clean(input, Whitelist.basic());
+  }
+
+  public static PersonName consolidateNameArguments(
+      PersonName name, String firstName, String middleName, String lastName, String suffix) {
+    if (name != null && !StringUtils.isAllBlank(firstName, middleName, lastName, suffix)) {
+      throw new IllegalGraphqlArgumentException(
+          "Do not specify both unrolled and structured name arguments");
+    }
+    if (name == null) {
+      name = new PersonName(firstName, middleName, lastName, suffix);
+    }
+    if (StringUtils.isBlank(name.getLastName())) {
+      throw new IllegalGraphqlArgumentException("lastName cannot be empty");
+    }
+    return name;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -1,7 +1,9 @@
 package gov.cdc.usds.simplereport.api.apiuser;
 
+import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.User;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.model.UserInfo;
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -21,6 +23,7 @@ public class UserMutationResolver implements GraphQLMutationResolver {
   }
 
   public User addUser(
+      PersonName name,
       String firstName,
       String middleName,
       String lastName,
@@ -28,27 +31,33 @@ public class UserMutationResolver implements GraphQLMutationResolver {
       String email,
       String organizationExternalID,
       Role role) {
-    UserInfo user =
-        _us.createUser(
-            email, firstName, middleName, lastName, suffix, organizationExternalID, role);
+    name = Translators.consolidateNameArguments(name, firstName, middleName, lastName, suffix);
+    UserInfo user = _us.createUser(email, name, organizationExternalID, role);
     return new User(user);
   }
 
   public User addUserToCurrentOrg(
+      PersonName name,
       String firstName,
       String middleName,
       String lastName,
       String suffix,
       String email,
       Role role) {
-    UserInfo user =
-        _us.createUserInCurrentOrg(email, firstName, middleName, lastName, suffix, role);
+    name = Translators.consolidateNameArguments(name, firstName, middleName, lastName, suffix);
+    UserInfo user = _us.createUserInCurrentOrg(email, name, role);
     return new User(user);
   }
 
   public User updateUser(
-      UUID id, String firstName, String middleName, String lastName, String suffix) {
-    UserInfo user = _us.updateUser(id, firstName, middleName, lastName, suffix);
+      UUID id,
+      PersonName name,
+      String firstName,
+      String middleName,
+      String lastName,
+      String suffix) {
+    name = Translators.consolidateNameArguments(name, firstName, middleName, lastName, suffix);
+    UserInfo user = _us.updateUser(id, name);
     return new User(user);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/IdentityAttributes.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/IdentityAttributes.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service.model;
 
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+import javax.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 /**
@@ -15,6 +16,10 @@ public class IdentityAttributes extends PersonName {
       String username, String firstName, String middleName, String lastName, String suffix) {
     super(firstName, middleName, lastName, suffix);
     this.username = username;
+  }
+
+  public IdentityAttributes(String username, @NotNull PersonName name) {
+    this(username, name.getFirstName(), name.getMiddleName(), name.getLastName(), name.getSuffix());
   }
 
   public String getUsername() {

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -21,9 +21,10 @@ extend type Mutation {
     swabType: String
   ): DeviceType
   addUser( # not actually used in the admin console (currently)
+    name: NameInput
     firstName: String
     middleName: String
-    lastName: String!
+    lastName: String
     suffix: String
     email: String!
     organizationExternalId: String!

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -275,18 +275,20 @@ type Mutation {
   updateOrganization(name: String!): String
     @requiredPermissions(allOf: ["EDIT_ORGANIZATION"])
   addUserToCurrentOrg(
+    name: NameInput
     firstName: String
     middleName: String
-    lastName: String!
+    lastName: String
     suffix: String
     email: String!
     role: Role!
   ): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   updateUser(
     id: ID!
+    name: NameInput
     firstName: String
     middleName: String
-    lastName: String!
+    lastName: String
     suffix: String
   ): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   updateUserPrivileges(

--- a/backend/src/main/resources/graphql/wiring.graphqls
+++ b/backend/src/main/resources/graphql/wiring.graphqls
@@ -82,7 +82,7 @@ enum TestResultDeliveryPreference {
 type NameInfo {
   firstName: String
   middleName: String
-  lastName: String
+  lastName: String!
   suffix: String
 }
 
@@ -93,4 +93,11 @@ type AddressInfo {
   county: String
   state: String
   postalCode: String
+}
+
+input NameInput {
+  firstName: String
+  middleName: String
+  lastName: String
+  suffix: String
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ApiUserManagementTest extends BaseGraphqlTest {
 
@@ -38,6 +40,11 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   void whoami_standardUser_okResponses() {
     ObjectNode who = (ObjectNode) runQuery("current-user-query").get("whoami");
     assertEquals("Bobbity", who.get("firstName").asText());
+    assertEquals("Bobbity", who.path("name").get("firstName").asText());
+    assertEquals("Bob", who.get("middleName").asText());
+    assertEquals("Bob", who.path("name").get("middleName").asText());
+    assertEquals("Bobberoo", who.get("lastName").asText());
+    assertEquals("Bobberoo", who.path("name").get("lastName").asText());
     assertEquals("Standard user", who.get("roleDescription").asText());
     assertFalse(who.get("isAdmin").asBoolean());
     assertEquals(who.get("role").asText(), Role.USER.name());
@@ -164,11 +171,12 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     assertUserHasNoOrg(who);
   }
 
-  @Test
-  void addUser_superUser_success() {
+  @ParameterizedTest
+  @ValueSource(strings = {"addUserOp", "addUserLegacy"})
+  void addUser_superUser_success(String operation) {
     useSuperUser();
-    ObjectNode user = runBoilerplateAddUser(Role.ADMIN);
-    assertEquals("Rhonda", user.get("firstName").asText());
+    ObjectNode user = runBoilerplateAddUser(Role.ADMIN, operation);
+    assertEquals("Rhonda", user.path("name").get("firstName").asText());
     assertEquals(USERNAMES.get(0), user.get("email").asText());
     assertEquals(
         TestUserIdentities.DEFAULT_ORGANIZATION,
@@ -177,21 +185,38 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     assertEquals(Set.of(Role.ADMIN), extractRolesFromUser(user));
     assertEquals(EnumSet.allOf(UserPermission.class), extractPermissionsFromUser(user));
 
-    useOrgAdmin();
     assertUserCanAccessAllFacilities(user);
+  }
+
+  @Test
+  void addUser_newArgStructure_success() {
+    useSuperUser();
+    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, true);
+    JsonNode user = runQuery("add-user", "addUserNovel", variables, null).get("addUser");
+    assertEquals("Rhonda", user.get("name").get("firstName").asText());
+  }
+
+  @Test
+  void addUser_invalidNames_failure() {
+    useSuperUser();
+    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, false);
+    variables.remove("lastName");
+    runQuery("add-user", "addUserNovel", variables, "cannot be empty");
+    variables = makeBoilerplateArgs(Role.ADMIN, true).put("lastName", "Oopsies");
+    runQuery("add-user", "addUserNovel", variables, "both unrolled and structured name arguments");
   }
 
   @Test
   void addUser_adminUser_failure() {
     useOrgAdmin();
     ObjectNode variables = makeBoilerplateArgs(Role.USER);
-    runQuery("add-user", variables, ACCESS_ERROR);
+    runQuery("add-user", "addUserOp", variables, ACCESS_ERROR);
   }
 
   @Test
   void addUser_orgUser_failure() {
     ObjectNode variables = makeBoilerplateArgs(Role.USER);
-    runQuery("add-user", variables, ACCESS_ERROR);
+    runQuery("add-user", "addUserOp", variables, ACCESS_ERROR);
     assertLastAuditEntry(
         TestUserIdentities.STANDARD_USER,
         "addUserOp",
@@ -207,10 +232,11 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         List.of("addUser"));
   }
 
-  @Test
-  void addUserToCurrentOrg_adminUser_success() {
+  @ParameterizedTest
+  @ValueSource(strings = {"addUserToCurrentOrgOp", "addUserToCurrentOrgLegacyOp"})
+  void addUserToCurrentOrg_adminUser_success(String operation) {
     useOrgAdmin();
-    ObjectNode user = runBoilerplateAddUserToCurrentOrg(Role.ENTRY_ONLY);
+    ObjectNode user = runBoilerplateAddUserToCurrentOrg(Role.ENTRY_ONLY, operation);
     assertEquals("Rhonda", user.get("firstName").asText());
     assertEquals(USERNAMES.get(0), user.get("email").asText());
     assertEquals(
@@ -227,17 +253,41 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         extractPermissionsFromUser(user));
     assertLastAuditEntry(
         TestUserIdentities.ORG_ADMIN_USER,
-        "addUserToCurrentOrgOp",
+        operation,
         EnumSet.allOf(UserPermission.class),
         List.of());
     assertUserCanAccessExactFacilities(user, Set.of());
   }
 
   @Test
+  void addUserToCurrentOrg_newArgStructure_success() {
+    useOrgAdmin();
+    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, true);
+    JsonNode user =
+        runQuery("add-user-to-current-org", "addUserToCurrentOrgNovel", variables, null)
+            .get("addUserToCurrentOrg");
+    assertEquals("Rhonda", user.get("firstName").asText());
+  }
+
+  @Test
+  void addUserToCurrentOrg_invalidNames_failure() {
+    useOrgAdmin();
+    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, false);
+    variables.remove("lastName");
+    runQuery("add-user-to-current-org", "addUserToCurrentOrgNovel", variables, "cannot be empty");
+    variables = makeBoilerplateArgs(Role.ADMIN, true).put("lastName", "Oopsies");
+    runQuery(
+        "add-user-to-current-org",
+        "addUserToCurrentOrgNovel",
+        variables,
+        "both unrolled and structured name arguments");
+  }
+
+  @Test
   void addUserToCurrentOrg_superUser_failure() {
     useSuperUser();
     ObjectNode variables = makeBoilerplateArgs(Role.USER);
-    runQuery("add-user-to-current-org", variables, ACCESS_ERROR);
+    runQuery("add-user-to-current-org", "addUserToCurrentOrgOp", variables, ACCESS_ERROR);
     assertLastAuditEntry(
         TestUserIdentities.SITE_ADMIN_USER,
         "addUserToCurrentOrgOp",
@@ -250,6 +300,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode variables = makeBoilerplateArgs(Role.USER);
     runQuery(
         "add-user-to-current-org",
+        "addUserToCurrentOrgOp",
         variables,
         "Current user does not have permission to request [/addUserToCurrentOrg]");
   }
@@ -262,7 +313,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String id = addUser.get("id").asText();
 
     ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
-    ObjectNode updateResp = runQuery("update-user", updateVariables);
+    ObjectNode updateResp = runQuery("update-user", "updateUser", updateVariables, null);
     ObjectNode updateUser = (ObjectNode) updateResp.get("updateUser");
     assertEquals("Ronda", updateUser.get("firstName").asText());
     assertEquals(USERNAMES.get(0), updateUser.get("email").asText());
@@ -290,7 +341,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String id = addUser.get("id").asText();
 
     ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
-    ObjectNode resp = runQuery("update-user", updateVariables);
+    ObjectNode resp = runQuery("update-user", "updateUser", updateVariables, null);
     ObjectNode updateUser = (ObjectNode) resp.get("updateUser");
     assertEquals("Ronda", updateUser.get("firstName").asText());
     assertEquals(USERNAMES.get(0), updateUser.get("email").asText());
@@ -298,7 +349,6 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     assertEquals(Set.of(Role.ADMIN), extractRolesFromUser(updateUser));
     assertEquals(EnumSet.allOf(UserPermission.class), extractPermissionsFromUser(updateUser));
 
-    useOrgAdmin();
     assertUserCanAccessAllFacilities(updateUser);
   }
 
@@ -314,6 +364,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
     runQuery(
         "update-user",
+        "updateUser",
         updateVariables,
         "Current user does not have permission to request [/updateUser]");
   }
@@ -324,7 +375,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode updateVariables =
         getUpdateUserVariables(
             "fa2efa2e-fa2e-fa2e-fa2e-fa2efa2efa2e", "Ronda", "J", "Jones", "III");
-    runQuery("update-user", updateVariables, NO_USER_ERROR);
+    runQuery("update-user", "updateUser", updateVariables, NO_USER_ERROR);
   }
 
   @Test
@@ -334,7 +385,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String id = who.get("id").asText();
 
     ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
-    ObjectNode resp = runQuery("update-user", updateVariables);
+    ObjectNode resp = runQuery("update-user", "updateUser", updateVariables, null);
     ObjectNode updateUser = (ObjectNode) resp.get("updateUser");
     assertEquals("Ronda", updateUser.get("firstName").asText());
     assertEquals(TestUserIdentities.ORG_ADMIN_USER, updateUser.get("email").asText());
@@ -439,20 +490,33 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   }
 
   private ObjectNode runBoilerplateAddUserToCurrentOrg(Role newUserRole) {
+    return runBoilerplateAddUserToCurrentOrg(newUserRole, "addUserToCurrentOrgOp");
+  }
+
+  private ObjectNode runBoilerplateAddUserToCurrentOrg(Role newUserRole, String operation) {
+
     ObjectNode addVariables = makeBoilerplateArgs(newUserRole);
-    ObjectNode addResp = runQuery("add-user-to-current-org", addVariables);
+    ObjectNode addResp = runQuery("add-user-to-current-org", operation, addVariables, null);
     ObjectNode addUser = (ObjectNode) addResp.get("addUserToCurrentOrg");
     return addUser;
   }
 
   private ObjectNode runBoilerplateAddUser(Role newUserRole) {
+    return runBoilerplateAddUser(newUserRole, "addUserOp");
+  }
+
+  private ObjectNode runBoilerplateAddUser(Role newUserRole, String operation) {
     ObjectNode addVariables = makeBoilerplateArgs(Role.ADMIN);
-    ObjectNode addResp = runQuery("add-user", addVariables);
+    ObjectNode addResp = runQuery("add-user", operation, addVariables, null);
     ObjectNode addUser = (ObjectNode) addResp.get("addUser");
     return addUser;
   }
 
   private ObjectNode makeBoilerplateArgs(Role role) {
+    return makeBoilerplateArgs(role, false);
+  }
+
+  private ObjectNode makeBoilerplateArgs(Role role, boolean useNestedName) {
     return getAddUserVariables(
         "Rhonda",
         "Janet",
@@ -460,7 +524,8 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         "III",
         USERNAMES.get(0),
         TestUserIdentities.DEFAULT_ORGANIZATION,
-        role.name());
+        role.name(),
+        useNestedName);
   }
 
   @Test
@@ -675,7 +740,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
                 TestUserIdentities.DEFAULT_ORGANIZATION,
                 Role.ADMIN.name()));
     for (ObjectNode userVariables : usersAdded) {
-      runQuery("add-user-to-current-org", userVariables);
+      runQuery("add-user-to-current-org", "addUserToCurrentOrgOp", userVariables, null);
     }
 
     List<ObjectNode> usersRetrieved = fetchUserList();
@@ -724,18 +789,37 @@ class ApiUserManagementTest extends BaseGraphqlTest {
       String suffix,
       String email,
       String orgExternalId,
-      String role) {
+      String role,
+      boolean nestedName) {
     ObjectNode variables =
         JsonNodeFactory.instance
             .objectNode()
-            .put("firstName", firstName)
-            .put("middleName", middleName)
-            .put("lastName", lastName)
-            .put("suffix", suffix)
             .put("email", email)
             .put("organizationExternalId", orgExternalId)
             .put("role", role);
+    ObjectNode forNameFields = variables;
+    if (nestedName) {
+      forNameFields = JsonNodeFactory.instance.objectNode();
+      variables.set("name", forNameFields);
+    }
+    forNameFields
+        .put("firstName", firstName)
+        .put("middleName", middleName)
+        .put("lastName", lastName)
+        .put("suffix", suffix);
     return variables;
+  }
+
+  private ObjectNode getAddUserVariables(
+      String firstName,
+      String middleName,
+      String lastName,
+      String suffix,
+      String email,
+      String orgExternalId,
+      String role) {
+    return getAddUserVariables(
+        firstName, middleName, lastName, suffix, email, orgExternalId, role, false);
   }
 
   private ObjectNode getUpdateUserVariables(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/BaseGraphqlTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/BaseGraphqlTest.java
@@ -209,8 +209,7 @@ public abstract class BaseGraphqlTest extends BaseFullStackTest {
    * @param queryFileName the resource file name of the query (to be found in
    *     src/test/resources/queries, unless a "/" is found in the filename)
    * @param operationName the operation name from the query file, in the event that the query file
-   *     is a multi-operation document (apparently). This turns out not to be needed for any of our
-   *     cases, but we can leave it supported for the day when it is.
+   *     is a multi-operation document.
    * @return the "data" key from the server response.
    * @throws AssertionFailedError if the response has errors
    * @throws RuntimeException for unexpected errors

--- a/backend/src/test/resources/queries/add-user
+++ b/backend/src/test/resources/queries/add-user
@@ -1,6 +1,48 @@
 mutation addUserOp(
     $firstName: String,
     $middleName: String,
+    $lastName: String,
+    $suffix: String,
+    $email: String!,
+    $organizationExternalId: String!,
+    $role: Role!
+    ){
+  addUser(
+    name: {
+      firstName: $firstName
+      middleName: $middleName
+      lastName: $lastName
+      suffix: $suffix
+    }
+    email: $email
+    organizationExternalId: $organizationExternalId
+    role: $role
+  ) {
+      id
+      name {
+        firstName
+        middleName
+        lastName
+        suffix
+      }
+      email
+      permissions
+      role
+      roles
+      organization {
+        name
+        externalId
+        facilities {
+          name
+          id
+        }
+      }
+    }
+}
+
+mutation addUserLegacy(
+    $firstName: String,
+    $middleName: String,
     $lastName: String!,
     $suffix: String,
     $email: String!,
@@ -16,15 +58,54 @@ mutation addUserOp(
     organizationExternalId: $organizationExternalId
     role: $role
   ) {
-      id,
-      firstName,
-      middleName,
-      lastName,
-      suffix,
-      email,
-      permissions,
-      role,
-      roles,
+      id
+      name {
+        firstName
+        middleName
+        lastName
+        suffix
+      }
+      email
+      permissions
+      role
+      roles
+      organization {
+        name
+        externalId
+        facilities {
+          name
+          id
+        }
+      }
+    }
+}
+
+
+mutation addUserNovel(
+    $name: NameInput
+    $lastName: String
+    $email: String!
+    $organizationExternalId: String!
+    $role: Role!
+    ){
+  addUser(
+    name: $name
+    lastName: $lastName
+    email: $email
+    organizationExternalId: $organizationExternalId
+    role: $role
+  ) {
+      id
+      name {
+        firstName
+        middleName
+        lastName
+        suffix
+      }
+      email
+      permissions
+      role
+      roles
       organization {
         name
         externalId

--- a/backend/src/test/resources/queries/add-user-to-current-org
+++ b/backend/src/test/resources/queries/add-user-to-current-org
@@ -1,16 +1,88 @@
 mutation addUserToCurrentOrgOp(
     $firstName: String,
-    $middleName: String,
-    $lastName: String!,
-    $suffix: String,
-    $email: String!,
-    $role: Role!,
+    $middleName: String
+    $lastName: String!
+    $suffix: String
+    $email: String!
+    $role: Role!
+    ){
+  addUserToCurrentOrg(
+    name: {
+      firstName: $firstName
+      middleName: $middleName
+      lastName: $lastName
+      suffix: $suffix
+    }
+    email: $email
+    role: $role
+  ) {
+      id,
+      firstName,
+      middleName,
+      lastName,
+      suffix,
+      email,
+      permissions,
+      role,
+      roles,
+      organization {
+        name
+        externalId
+        facilities {
+          name
+          id
+        }
+      }
+    }
+}
+
+mutation addUserToCurrentOrgLegacyOp(
+    $firstName: String,
+    $middleName: String
+    $lastName: String!
+    $suffix: String
+    $email: String!
+    $role: Role!
     ){
   addUserToCurrentOrg(
     firstName: $firstName
     middleName: $middleName
     lastName: $lastName
     suffix: $suffix
+    email: $email
+    role: $role
+  ) {
+      id,
+      firstName,
+      middleName,
+      lastName,
+      suffix,
+      email,
+      permissions,
+      role,
+      roles,
+      organization {
+        name
+        externalId
+        facilities {
+          name
+          id
+        }
+      }
+    }
+}
+
+mutation addUserToCurrentOrgNovel(
+    $firstName: String
+    $lastName: String
+    $name: NameInput
+    $email: String!
+    $role: Role!
+    ){
+  addUserToCurrentOrg(
+    name: $name
+    firstName: $firstName
+    lastName: $lastName
     email: $email
     role: $role
   ) {

--- a/backend/src/test/resources/queries/current-user-query
+++ b/backend/src/test/resources/queries/current-user-query
@@ -5,6 +5,12 @@ query whoDat {
     middleName
     lastName
     suffix
+    name {
+      firstName
+      middleName
+      lastName
+      suffix
+    }
     email
     role
     roles

--- a/backend/src/test/resources/queries/update-user
+++ b/backend/src/test/resources/queries/update-user
@@ -6,6 +6,42 @@ mutation updateUser(
     $suffix: String,
     ){
   updateUser(
+    id: $id
+    name: {
+      firstName: $firstName
+      middleName: $middleName
+      lastName: $lastName
+      suffix: $suffix
+    }
+  ) {
+      id
+      firstName,
+      middleName,
+      lastName,
+      suffix,
+      email,
+      permissions,
+      role,
+      roles,
+      organization {
+        name
+        externalId
+        facilities {
+          name
+          id
+        }
+      }
+    }
+}
+
+mutation updateUserLegacy(
+    $id: ID!,
+    $firstName: String,
+    $middleName: String,
+    $lastName: String!,
+    $suffix: String,
+    ){
+  updateUser(
     id: $id,
     firstName: $firstName
     middleName: $middleName


### PR DESCRIPTION
Added a NameInput that looks a lot like NameInfo (which looks a lot like PersonName, to be fair). Used it in all the User mutations that take a first/middle/last name, and pushed it through to the service layer with a (reasonably exhaustively tested) translator utility that handles both old and new argument styles.

## Related Issue or Background Info

Sonar keeps complaining (correctly) that we have too many methods on the server side with 20+ string arguments. This is a first step to fixing that.

## Changes Proposed

- Make `name : {firstName: $first, lastName: $last}` a valid substitute for `firstName: $first, lastName: $last` in incoming mutation requests
