### PR TITLE
Add email templating

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "com.zhokhov.graphql:graphql-datetime-spring-boot-starter:3.0.0"
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // Okta dependencies
     implementation 'com.okta.spring:okta-spring-boot-starter:2.0.0'
@@ -56,9 +57,6 @@ dependencies {
 
     // SendGrid for Email
     implementation 'com.sendgrid:sendgrid-java:4.7.2'
-
-    // Jsoup for input sanitization
-    implementation 'org.jsoup:jsoup:1.13.1'
 
     // graphql-java-extended-validation schema directives
     compile 'com.graphql-java:graphql-java-extended-validation:16.0.0'

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -81,6 +81,7 @@ org.apache.logging.log4j:log4j-to-slf4j:2.13.3
 org.apache.tomcat.embed:tomcat-embed-core:9.0.41
 org.apache.tomcat.embed:tomcat-embed-websocket:9.0.41
 org.aspectj:aspectjweaver:1.9.6
+org.attoparser:attoparser:2.0.5.RELEASE
 org.bouncycastle:bcprov-jdk15on:1.68
 org.dom4j:dom4j:2.1.3
 org.glassfish.jaxb:jaxb-runtime:2.3.3
@@ -102,7 +103,6 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2
 org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.4.2
 org.jetbrains:annotations:13.0
 org.json:json:20201115
-org.jsoup:jsoup:1.13.1
 org.liquibase:liquibase-core:3.10.3
 org.ow2.asm:asm:5.0.4
 org.reactivestreams:reactive-streams:1.0.3
@@ -118,6 +118,7 @@ org.springframework.boot:spring-boot-starter-jdbc:2.4.1
 org.springframework.boot:spring-boot-starter-json:2.4.1
 org.springframework.boot:spring-boot-starter-logging:2.4.1
 org.springframework.boot:spring-boot-starter-security:2.4.1
+org.springframework.boot:spring-boot-starter-thymeleaf:2.4.1
 org.springframework.boot:spring-boot-starter-tomcat:2.4.1
 org.springframework.boot:spring-boot-starter-validation:2.4.1
 org.springframework.boot:spring-boot-starter-web:2.4.1
@@ -147,4 +148,8 @@ org.springframework:spring-tx:5.3.2
 org.springframework:spring-web:5.3.2
 org.springframework:spring-webmvc:5.3.2
 org.springframework:spring-websocket:5.3.2
+org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE
+org.thymeleaf:thymeleaf-spring5:3.0.11.RELEASE
+org.thymeleaf:thymeleaf:3.0.11.RELEASE
+org.unbescape:unbescape:1.1.6.RELEASE
 org.yaml:snakeyaml:1.27

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -90,6 +90,7 @@ org.apache.logging.log4j:log4j-to-slf4j:2.13.3
 org.apache.tomcat.embed:tomcat-embed-core:9.0.41
 org.apache.tomcat.embed:tomcat-embed-websocket:9.0.41
 org.aspectj:aspectjweaver:1.9.6
+org.attoparser:attoparser:2.0.5.RELEASE
 org.bouncycastle:bcpkix-jdk15on:1.66
 org.bouncycastle:bcprov-jdk15on:1.68
 org.checkerframework:checker-qual:3.5.0
@@ -113,7 +114,6 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2
 org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.4.2
 org.jetbrains:annotations:13.0
 org.json:json:20201115
-org.jsoup:jsoup:1.13.1
 org.latencyutils:LatencyUtils:2.0.3
 org.liquibase:liquibase-core:3.10.3
 org.ow2.asm:asm:5.0.4
@@ -133,6 +133,7 @@ org.springframework.boot:spring-boot-starter-jdbc:2.4.1
 org.springframework.boot:spring-boot-starter-json:2.4.1
 org.springframework.boot:spring-boot-starter-logging:2.4.1
 org.springframework.boot:spring-boot-starter-security:2.4.1
+org.springframework.boot:spring-boot-starter-thymeleaf:2.4.1
 org.springframework.boot:spring-boot-starter-tomcat:2.4.1
 org.springframework.boot:spring-boot-starter-validation:2.4.1
 org.springframework.boot:spring-boot-starter-web:2.4.1
@@ -162,4 +163,8 @@ org.springframework:spring-tx:5.3.2
 org.springframework:spring-web:5.3.2
 org.springframework:spring-webmvc:5.3.2
 org.springframework:spring-websocket:5.3.2
+org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE
+org.thymeleaf:thymeleaf-spring5:3.0.11.RELEASE
+org.thymeleaf:thymeleaf:3.0.11.RELEASE
+org.unbescape:unbescape:1.1.6.RELEASE
 org.yaml:snakeyaml:1.27

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -14,8 +14,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
-import org.jsoup.Jsoup;
-import org.jsoup.safety.Whitelist;
 
 /**
  * Static package for utilities to translate things to or from wireline format in non copy-paste
@@ -213,9 +211,5 @@ public class Translators {
       symptomsMap.put(key, value);
     }
     return symptomsMap;
-  }
-
-  public static String sanitize(String input) {
-    return input == null ? "" : Jsoup.clean(input, Whitelist.basic());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -38,25 +38,24 @@ public class AccountRequestController {
   private void init() {
     LOG.info("Account request REST endpoint enabled");
   }
+
   /** Read the waitlist request and generate an email body, then send with the emailService */
   @PostMapping("/waitlist")
   public void submitWaitlistRequest(@Valid @RequestBody WaitlistRequest body) throws IOException {
     String subject = "New waitlist request";
-    String content = body.generateEmailBody();
     if (LOG.isInfoEnabled()) {
       LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
     }
-    emailService.send(sendGridProperties.getWaitlistRecipient(), subject, content);
+    emailService.send(sendGridProperties.getWaitlistRecipient(), subject, body);
   }
 
   /** Read the account request and generate an email body, then send with the emailService */
   @PostMapping("")
   public void submitAccountRequest(@Valid @RequestBody AccountRequest body) throws IOException {
     String subject = "New account request";
-    String content = body.generateEmailBody();
     if (LOG.isInfoEnabled()) {
       LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(body));
     }
-    emailService.send(sendGridProperties.getAccountRequestRecipient(), subject, content);
+    emailService.send(sendGridProperties.getAccountRequestRecipient(), subject, body);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TemplateVariablesProvider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TemplateVariablesProvider.java
@@ -1,0 +1,22 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Map;
+
+public interface TemplateVariablesProvider {
+  /**
+   * Get the name of the template to use. This is the name of the template without path or
+   * extension, so "template-name" for "resources/templates/template-name.html"
+   *
+   * @return resolvable name of template to be filled
+   */
+  @JsonIgnore
+  public String getTemplateName();
+
+  /**
+   * Convert object fields to parameters used to fill a template.
+   *
+   * @return map of variables used to fill a template
+   */
+  public Map<String, Object> toTemplateVariables();
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountRequest.java
@@ -1,13 +1,16 @@
 package gov.cdc.usds.simplereport.api.model.accountrequest;
 
-import static gov.cdc.usds.simplereport.api.Translators.sanitize;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
+import java.util.HashMap;
+import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
-public class AccountRequest {
+public class AccountRequest implements TemplateVariablesProvider {
+  private static final String TEMPLATE_NAME = "account-request";
+
   @NotNull private String firstName;
   @NotNull private String lastName;
   @NotNull private String email;
@@ -43,52 +46,51 @@ public class AccountRequest {
   private String opZip;
   private String opCounty;
 
-  public String generateEmailBody() {
-    String newLine = "<br>";
-    return String.join(
-        newLine,
-        "A new SimpleReport account request has been submitted with the following details:",
-        "",
-        "<h1>Facility administrator</h1>",
-        "<b>First Name: </b>" + sanitize(firstName),
-        "<b>Last Name: </b>" + sanitize(lastName),
-        "<b>Email address: </b>" + sanitize(email),
-        "<b>Work Phone Number: </b>" + sanitize(workPhoneNumber),
-        "<b>Cell Phone Number: </b>" + sanitize(cellPhoneNumber),
-        "",
-        "<h1>Testing facility information</h1>",
-        "<b>Street Adress: </b>" + sanitize(mailingAddress1),
-        "<b>Unit Type: </b>" + sanitize(aptSuiteOther),
-        "<b>Unit number: </b>" + sanitize(aptFloorSuiteNo),
-        "<b>City: </b>" + sanitize(city),
-        "<b>State: </b>" + sanitize(state),
-        "<b>ZIP code: </b>" + sanitize(zip),
-        "<b>County: </b>" + sanitize(county),
-        "<b>Facility Type: </b>" + sanitize(facilityType),
-        "<b>Organization name: </b>" + sanitize(organizationName),
-        "<b>Testing facility name: </b>" + sanitize(facilityName),
-        "<b>Clinical Laboratory Improvement Amendments (CLIA) number: </b>" + sanitize(cliaNumber),
-        "<b>Testing devices: </b>" + sanitize(testingDevices),
-        "<b>Devices accessing SimpleReport: </b>" + sanitize(accessDevices),
-        "<b>Web browsers: </b>" + sanitize(browsers),
-        "<b>Workflow description: </b>" + sanitize(workflow),
-        "<b>Does the person who checks people in also record test results: </b>"
-            + sanitize(recordsTestResults),
-        "<b>Single person registration and testing process time: </b>" + sanitize(processTime),
-        "<b>Time spent submitting results daily: </b>" + sanitize(submittingResultsTime),
-        "",
-        "<h1>Ordering provider</h1>",
-        "<b>First name: </b>" + sanitize(opFirstName),
-        "<b>Last name: </b>" + sanitize(opLastName),
-        "<b>National Provider Identifier (NPI): </b>" + sanitize(npi),
-        "<b>Phone number: </b>" + sanitize(opPhoneNumber),
-        "<b>Street address: </b>" + sanitize(opMailingAddress1),
-        "<b>Unit type: </b>" + sanitize(opAptSuiteOther),
-        "<b>Unit number: </b>" + sanitize(opAptFloorSuiteNo),
-        "<b>City: </b>" + sanitize(opCity),
-        "<b>State: </b>" + sanitize(opState),
-        "<b>Zip Code: </b>" + sanitize(opZip),
-        "<b>County: </b>" + sanitize(opCounty));
+  @Override
+  public String getTemplateName() {
+    return TEMPLATE_NAME;
+  }
+
+  @Override
+  public Map<String, Object> toTemplateVariables() {
+    Map<String, Object> variableMap = new HashMap<>();
+
+    variableMap.put("firstName", firstName);
+    variableMap.put("lastName", lastName);
+    variableMap.put("email", email);
+    variableMap.put("workPhoneNumber", workPhoneNumber);
+    variableMap.put("cellPhoneNumber", cellPhoneNumber);
+    variableMap.put("mailingAddress1", mailingAddress1);
+    variableMap.put("aptSuiteOther", aptSuiteOther);
+    variableMap.put("aptFloorSuiteNo", aptFloorSuiteNo);
+    variableMap.put("city", city);
+    variableMap.put("state", state);
+    variableMap.put("zip", zip);
+    variableMap.put("county", county);
+    variableMap.put("facilityType", facilityType);
+    variableMap.put("organizationName", organizationName);
+    variableMap.put("facilityName", facilityName);
+    variableMap.put("cliaNumber", cliaNumber);
+    variableMap.put("testingDevices", testingDevices);
+    variableMap.put("accessDevices", accessDevices);
+    variableMap.put("browsers", browsers);
+    variableMap.put("workflow", workflow);
+    variableMap.put("recordsTestResults", recordsTestResults);
+    variableMap.put("processTime", processTime);
+    variableMap.put("submittingResultsTime", submittingResultsTime);
+    variableMap.put("opFirstName", opFirstName);
+    variableMap.put("opLastName", opLastName);
+    variableMap.put("npi", npi);
+    variableMap.put("opPhoneNumber", opPhoneNumber);
+    variableMap.put("opMailingAddress1", opMailingAddress1);
+    variableMap.put("opAptSuiteOther", opAptSuiteOther);
+    variableMap.put("opAptFloorSuiteNo", opAptFloorSuiteNo);
+    variableMap.put("opCity", opCity);
+    variableMap.put("opState", opState);
+    variableMap.put("opZip", opZip);
+    variableMap.put("opCounty", opCounty);
+
+    return variableMap;
   }
 
   public String getFirstName() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/WaitlistRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/WaitlistRequest.java
@@ -1,13 +1,16 @@
 package gov.cdc.usds.simplereport.api.model.accountrequest;
 
-import static gov.cdc.usds.simplereport.api.Translators.sanitize;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
+import java.util.HashMap;
+import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
-public class WaitlistRequest {
+public class WaitlistRequest implements TemplateVariablesProvider {
+  private static final String TEMPLATE_NAME = "waitlist-request";
+
   @NotNull private String name;
   @NotNull private String email;
   @NotNull private String phone;
@@ -15,18 +18,23 @@ public class WaitlistRequest {
   @NotNull private String organization;
   private String referral;
 
-  public String generateEmailBody() {
-    String newLine = "<br>";
-    return String.join(
-        newLine,
-        "A new SimpleReport waitlist request has been submitted with the following details:",
-        "",
-        "<b>Name: </b>" + sanitize(name),
-        "<b>Email address: </b>" + sanitize(email),
-        "<b>Phone number: </b>" + sanitize(phone),
-        "<b>State: </b>" + sanitize(state),
-        "<b>Organization: </b>" + sanitize(organization),
-        "<b>Referral: </b>" + sanitize(referral));
+  @Override
+  public String getTemplateName() {
+    return TEMPLATE_NAME;
+  }
+
+  @Override
+  public Map<String, Object> toTemplateVariables() {
+    Map<String, Object> variableMap = new HashMap<>();
+
+    variableMap.put("name", name);
+    variableMap.put("email", email);
+    variableMap.put("phone", phone);
+    variableMap.put("state", state);
+    variableMap.put("organization", organization);
+    variableMap.put("referral", referral);
+
+    return variableMap;
   }
 
   public String getName() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/TemplateConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/TemplateConfiguration.java
@@ -1,0 +1,29 @@
+package gov.cdc.usds.simplereport.config;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+@Configuration
+public class TemplateConfiguration {
+
+  @Bean(name = "simpleReportTemplateEngine")
+  public SpringTemplateEngine springTemplateEngine() {
+    SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+    templateEngine.addTemplateResolver(htmlTemplateResolver());
+    return templateEngine;
+  }
+
+  @Bean
+  public ClassLoaderTemplateResolver htmlTemplateResolver() {
+    ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+    templateResolver.setPrefix("/templates/");
+    templateResolver.setSuffix(".html");
+    templateResolver.setTemplateMode(TemplateMode.HTML);
+    templateResolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    return templateResolver;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
@@ -4,33 +4,51 @@ import com.sendgrid.helpers.mail.Mail;
 import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Email;
 import com.sendgrid.helpers.mail.objects.Personalization;
+import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
 
 @Service
 public class EmailService {
   private final EmailProvider emailProvider;
   private final SendGridProperties sendGridProperties;
+  private final SpringTemplateEngine templateEngine;
 
-  public EmailService(EmailProvider emailProvider, SendGridProperties sendGridProperties) {
+  public EmailService(
+      EmailProvider emailProvider,
+      SendGridProperties sendGridProperties,
+      SpringTemplateEngine templateEngine) {
     this.emailProvider = emailProvider;
     this.sendGridProperties = sendGridProperties;
+    this.templateEngine = templateEngine;
   }
 
-  public String send(List<String> toEmail, String subject, String message) throws IOException {
+  private String getContentFromTemplate(final TemplateVariablesProvider templateData) {
+    final Context context = new Context();
+    context.setVariables(templateData.toTemplateVariables());
+
+    return templateEngine.process(templateData.getTemplateName(), context);
+  }
+
+  public String send(
+      List<String> toEmail, String subject, final TemplateVariablesProvider templateData)
+      throws IOException {
     Mail mail = new Mail();
     mail.setFrom(new Email(sendGridProperties.getFromEmail()));
     mail.setSubject(subject);
     Personalization personalization = new Personalization();
     toEmail.stream().map(Email::new).forEach(personalization::addTo);
     mail.addPersonalization(personalization);
-    mail.addContent(new Content("text/html", message));
+    mail.addContent(new Content("text/html", getContentFromTemplate(templateData)));
     return emailProvider.send(mail);
   }
 
-  public String send(String toEmail, String subject, String message) throws IOException {
-    return send(List.of(toEmail), subject, message);
+  public String send(String toEmail, String subject, final TemplateVariablesProvider templateData)
+      throws IOException {
+    return send(List.of(toEmail), subject, templateData);
   }
 }

--- a/backend/src/main/resources/templates/account-request.html
+++ b/backend/src/main/resources/templates/account-request.html
@@ -1,0 +1,44 @@
+A new SimpleReport account request has been submitted with the following details:
+
+<h1>Facility administrator</h1>
+
+<b>First Name: </b>[[${firstName}]]<br>
+<b>Last Name: </b>[[${lastName}]]<br>
+<b>Email address: </b>[[${email}]]<br>
+<b>Work Phone Number: </b>[[${workPhoneNumber}]]<br>
+<b>Cell Phone Number: </b>[[${cellPhoneNumber}]]
+
+<h1>Testing facility information</h1>
+
+<b>Street Address: </b>[[${mailingAddress1}]]<br>
+<b>Unit Type: </b>[[${aptSuiteOther}]]<br>
+<b>Unit number: </b>[[${aptFloorSuiteNo}]]<br>
+<b>City: </b>[[${city}]]<br>
+<b>State: </b>[[${state}]]<br>
+<b>ZIP code: </b>[[${zip}]]<br>
+<b>County: </b>[[${county}]]<br>
+<b>Facility Type: </b>[[${facilityType}]]<br>
+<b>Organization name: </b>[[${organizationName}]]<br>
+<b>Testing facility name: </b>[[${facilityName}]]<br>
+<b>Clinical Laboratory Improvement Amendments (CLIA) number: </b>[[${cliaNumber}]]<br>
+<b>Testing devices: </b>[[${testingDevices}]]<br>
+<b>Devices accessing SimpleReport: </b>[[${accessDevices}]]<br>
+<b>Web browsers: </b>[[${browsers}]]<br>
+<b>Workflow description: </b>[[${workflow}]]<br>
+<b>Does the person who checks people in also record test results: </b>[[${recordsTestResults}]]<br>
+<b>Single person registration and testing process time: </b>[[${processTime}]]<br>
+<b>Time spent submitting results daily: </b>[[${submittingResultsTime}]]
+
+<h1>Ordering provider</h1>
+
+<b>First name: </b>[[${opFirstName}]]<br>
+<b>Last name: </b>[[${opLastName}]]<br>
+<b>National Provider Identifier (NPI): </b>[[${npi}]]<br>
+<b>Phone number: </b>[[${opPhoneNumber}]]<br>
+<b>Street address: </b>[[${opMailingAddress1}]]<br>
+<b>Unit type: </b>[[${opAptSuiteOther}]]<br>
+<b>Unit number: </b>[[${opAptFloorSuiteNo}]]<br>
+<b>City: </b>[[${opCity}]]<br>
+<b>State: </b>[[${opState}]]<br>
+<b>Zip Code: </b>[[${opZip}]]<br>
+<b>County: </b>[[${opCounty}]]

--- a/backend/src/main/resources/templates/waitlist-request.html
+++ b/backend/src/main/resources/templates/waitlist-request.html
@@ -1,0 +1,8 @@
+A new SimpleReport waitlist request has been submitted with the following details:<br>
+<br>
+<b>Name: </b>[[${name}]]<br>
+<b>Email address: </b>[[${email}]]<br>
+<b>Phone number: </b>[[${phone}]]<br>
+<b>State: </b>[[${state}]]<br>
+<b>Organization: </b>[[${organization}]]<br>
+<b>Referral: </b>[[${referral}]]

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/email/EmailServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/email/EmailServiceTest.java
@@ -1,13 +1,18 @@
 package gov.cdc.usds.simplereport.service.email;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.Mail;
+import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
+import gov.cdc.usds.simplereport.service.BaseServiceTest;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,9 +20,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.thymeleaf.spring5.SpringTemplateEngine;
 
 @ExtendWith(MockitoExtension.class)
-class EmailServiceTest {
+class EmailServiceTest extends BaseServiceTest<EmailService> {
+  @Qualifier("simpleReportTemplateEngine")
+  @Autowired
+  SpringTemplateEngine _templateEngine;
 
   private static final SendGridProperties FAKE_PROPERTIES =
       new SendGridProperties(true, null, "me@example.com", List.of(), List.of());
@@ -29,7 +40,32 @@ class EmailServiceTest {
 
   @BeforeEach
   void initService() {
-    _service = new EmailService(mockSendGrid, FAKE_PROPERTIES);
+    _service = new EmailService(mockSendGrid, FAKE_PROPERTIES, _templateEngine);
+  }
+
+  public static class FooBarTemplate implements TemplateVariablesProvider {
+    private final String foo;
+    private final String bar;
+
+    public FooBarTemplate(final String foo, final String bar) {
+      this.foo = foo;
+      this.bar = bar;
+    }
+
+    @Override
+    public String getTemplateName() {
+      return "test-template";
+    }
+
+    @Override
+    public Map<String, Object> toTemplateVariables() {
+      return new HashMap<>() {
+        {
+          put("foo", foo);
+          put("bar", bar);
+        }
+      };
+    }
   }
 
   @Test
@@ -38,16 +74,17 @@ class EmailServiceTest {
     // GIVEN
     String toEmail = "test@foo.com";
     String subject = "Testing the email service";
-    String message = "Here's a message for ya";
+    FooBarTemplate fbTemplate = new FooBarTemplate("var 1", "var 2");
 
     // WHEN
-    _service.send(toEmail, subject, message);
+    _service.send(toEmail, subject, fbTemplate);
 
     // THEN
     verify(mockSendGrid, times(1)).send(mail.capture());
     assertEquals(mail.getValue().getPersonalization().get(0).getTos().get(0).getEmail(), toEmail);
     assertEquals(mail.getValue().getSubject(), subject);
-    assertEquals(mail.getValue().getContent().get(0).getValue(), message);
+    assertThat(mail.getValue().getContent().get(0).getValue())
+        .contains("<b>Foo:</b> var 1", "<b>Bar:</b> var 2");
   }
 
   @Test
@@ -61,10 +98,10 @@ class EmailServiceTest {
             "banana@foo.com",
             "onemore@foo.com");
     String subject = "Testing the email service";
-    String message = "Here's a message for ya";
+    FooBarTemplate fbTemplate = new FooBarTemplate("var 1", "var 2");
 
     // WHEN
-    _service.send(tos, subject, message);
+    _service.send(tos, subject, fbTemplate);
 
     // THEN
     verify(mockSendGrid, times(1)).send(mail.capture());
@@ -73,6 +110,7 @@ class EmailServiceTest {
           mail.getValue().getPersonalization().get(0).getTos().get(i).getEmail(), tos.get(i));
     }
     assertEquals(mail.getValue().getSubject(), subject);
-    assertEquals(mail.getValue().getContent().get(0).getValue(), message);
+    assertThat(mail.getValue().getContent().get(0).getValue())
+        .contains("<b>Foo:</b> var 1", "<b>Bar:</b> var 2");
   }
 }

--- a/backend/src/test/resources/templates/test-template.html
+++ b/backend/src/test/resources/templates/test-template.html
@@ -1,0 +1,4 @@
+<div>
+  <b>Foo:</b> [[${foo}]]
+  <b>Bar:</b> [[${bar}]]
+</div>


### PR DESCRIPTION
## Related Issue or Background Info

- https://github.com/CDCgov/prime-simplereport/issues/1086

## Changes Proposed

- Use ThymeLeaf to fill email templates instead of building strings
- Notable change:  Strings are no longer cleaned, but are escaped instead.  This would be noticeable, for example, if a user entered html into one of the text input fields.  The escaped string in the filled template is safe for a client to render.

## Additional Information

Other alternatives considered were StringTemplate (no Spring integration) and Google Closure Templates (provided by Google, but not officially maintained).  ThymeLeaf is a good choice because of Apache 2.0 license, Spring integration, active maintenance, HTML awareness, ability to automatically escape strings, and other conveniences.

https://www.thymeleaf.org/index.html