### PR TITLE
Add cors configuration

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport;
 
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
 import gov.cdc.usds.simplereport.config.BeanProfiles;
+import gov.cdc.usds.simplereport.config.CorsProperties;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
@@ -26,7 +27,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
   DataHubConfig.class,
   DemoUserConfiguration.class,
   SmartyStreetsProperties.class,
-  SendGridProperties.class
+  SendGridProperties.class,
+  CorsProperties.class
 })
 @EnableScheduling
 public class SimpleReportApplication {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CorsProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CorsProperties.java
@@ -1,0 +1,26 @@
+package gov.cdc.usds.simplereport.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConfigurationProperties(prefix = "cors")
+@ConstructorBinding
+public class CorsProperties {
+
+  private final List<String> allowedOrigins;
+  private final List<String> allowedMethods;
+
+  public CorsProperties(List<String> allowedOrigins, List<String> allowedMethods) {
+    this.allowedOrigins = allowedOrigins;
+    this.allowedMethods = allowedMethods;
+  }
+
+  public List<String> getAllowedOrigins() {
+    return allowedOrigins;
+  }
+
+  public List<String> getAllowedMethods() {
+    return allowedMethods;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CorsProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CorsProperties.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-@ConfigurationProperties(prefix = "cors")
+@ConfigurationProperties(prefix = "simple-report.cors")
 @ConstructorBinding
 public class CorsProperties {
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -3,8 +3,10 @@ package gov.cdc.usds.simplereport.config;
 import com.okta.spring.boot.oauth.Okta;
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.info.InfoEndpoint;
@@ -18,6 +20,9 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.servlet.config.annotation.CorsRegistration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Live (with Okta integration) request-level security configuration. Not to be confused with {@link
@@ -27,7 +32,10 @@ import org.springframework.security.oauth2.jwt.Jwt;
 @Configuration
 @Profile("!" + BeanProfiles.NO_SECURITY) // Activate this profile to disable security
 @ConditionalOnWebApplication
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter
+    implements WebMvcConfigurer {
+
+  @Autowired CorsProperties _corsProperties;
 
   public static final String SAVED_REQUEST_HEADER = "SPRING_SECURITY_SAVED_REQUEST";
   private static final Logger LOG = LoggerFactory.getLogger(SecurityConfiguration.class);
@@ -40,7 +48,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests()
+    http.cors()
+        .and()
+        .authorizeRequests()
         .antMatchers("/")
         .permitAll()
         .antMatchers(HttpMethod.OPTIONS, "/**")
@@ -108,5 +118,20 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
       throw new RuntimeException(
           "Unexpected authentication principal of type " + principal.getClass());
     };
+  }
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    CorsRegistration reg = registry.addMapping("/**");
+
+    List<String> methods = _corsProperties.getAllowedMethods();
+    if (methods != null && !methods.isEmpty()) {
+      reg.allowedMethods(methods.toArray(String[]::new));
+    }
+
+    List<String> origins = _corsProperties.getAllowedOrigins();
+    if (origins != null && !origins.isEmpty()) {
+      reg.allowedOrigins(origins.toArray(String[]::new));
+    }
   }
 }

--- a/backend/src/main/resources/application-azure-demo.yaml
+++ b/backend/src/main/resources/application-azure-demo.yaml
@@ -1,13 +1,13 @@
 spring:
   profiles.include: no-security, no-okta-mgmt, create-sample-data
-cors:
-  allowed-origins:
-    - https://simple-report-api-demo.azurewebsites.net
-    - https://simple-report-demo.azureedge.net
-    - https://demo.simplereport.gov
 simple-report:
   patient-link-url: https://demo.simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: false
+  cors:
+    allowed-origins:
+      - https://simple-report-api-demo.azurewebsites.net
+      - https://simple-report-demo.azureedge.net
+      - https://demo.simplereport.gov
 twilio:
   enabled: false

--- a/backend/src/main/resources/application-azure-demo.yaml
+++ b/backend/src/main/resources/application-azure-demo.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: no-security, no-okta-mgmt, create-sample-data
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simple-report-api-demo.azurewebsites.net
     - https://simple-report-demo.azureedge.net

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: okta-dev, server-debug
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simplereportdevapp.z13.web.core.windows.net
     - https://simple-report-api-dev.azurewebsites.net

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -1,11 +1,5 @@
 spring:
   profiles.include: okta-dev, server-debug
-cors:
-  allowed-origins:
-    - https://simplereportdevapp.z13.web.core.windows.net
-    - https://simple-report-api-dev.azurewebsites.net
-    - https://simple-report-dev.azureedge.net
-    - https://dev.simplereport.gov
 simple-report:
   data-hub:
     upload-enabled: false
@@ -15,5 +9,11 @@ simple-report:
   patient-link-url: https://dev.simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: false
+  cors:
+    allowed-origins:
+      - https://simplereportdevapp.z13.web.core.windows.net
+      - https://simple-report-api-dev.azurewebsites.net
+      - https://simple-report-dev.azureedge.net
+      - https://dev.simplereport.gov
 twilio:
   enabled: true

--- a/backend/src/main/resources/application-azure-pentest.yaml
+++ b/backend/src/main/resources/application-azure-pentest.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: okta-pentest
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simple-report-api-pentest.azurewebsites.net
     - https://simple-report-pentest.azureedge.net

--- a/backend/src/main/resources/application-azure-pentest.yaml
+++ b/backend/src/main/resources/application-azure-pentest.yaml
@@ -1,13 +1,13 @@
 spring:
   profiles.include: okta-pentest
-cors:
-  allowed-origins:
-    - https://simple-report-api-pentest.azurewebsites.net
-    - https://simple-report-pentest.azureedge.net
-    - https://pentest.simplereport.gov
 simple-report:
   patient-link-url: https://pentest.simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: true
+  cors:
+    allowed-origins:
+      - https://simple-report-api-pentest.azurewebsites.net
+      - https://simple-report-pentest.azureedge.net
+      - https://pentest.simplereport.gov
 twilio:
   enabled: true

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: okta-prod
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simple-report-api-prod.azurewebsites.net
     - https://simple-report-prod.azureedge.net

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -1,11 +1,5 @@
 spring:
   profiles.include: okta-prod
-cors:
-  allowed-origins:
-    - https://simple-report-api-prod.azurewebsites.net
-    - https://simple-report-prod.azureedge.net
-    - https://prod.simplereport.gov
-    - https://simplereport.gov
 simple-report:
   data-hub:
     upload-enabled: true
@@ -14,6 +8,12 @@ simple-report:
   patient-link-url: https://simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: true
+  cors:
+    allowed-origins:
+      - https://simple-report-api-prod.azurewebsites.net
+      - https://simple-report-prod.azureedge.net
+      - https://www.simplereport.gov
+      - https://simplereport.gov
 twilio:
   enabled: true
   from-number: "+14045312484"

--- a/backend/src/main/resources/application-azure-stg.yaml
+++ b/backend/src/main/resources/application-azure-stg.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: okta-stg
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simple-report-api-stg.azurewebsites.net
     - https://simple-report-stg.azureedge.net

--- a/backend/src/main/resources/application-azure-stg.yaml
+++ b/backend/src/main/resources/application-azure-stg.yaml
@@ -1,9 +1,9 @@
 spring:
   profiles.include: okta-stg
-cors:
-  allowed-origins:
-    - https://simple-report-api-stg.azurewebsites.net
-    - https://simple-report-stg.azureedge.net
-    - https://stg.simplereport.gov
 simple-report:
   patient-link-url: https://stg.simplereport.gov/app/pxp?plid=
+  cors:
+    allowed-origins:
+      - https://simple-report-api-stg.azurewebsites.net
+      - https://simple-report-stg.azureedge.net
+      - https://stg.simplereport.gov

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -1,13 +1,13 @@
 spring:
   profiles.include: okta-test, server-debug
-cors:
-  allowed-origins:
-    - https://simple-report-api-test.azurewebsites.net
-    - https://simple-report-test.azureedge.net
-    - https://test.simplereport.gov
 simple-report:
   patient-link-url: https://test.simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: false
+  cors:
+    allowed-origins:
+      - https://simple-report-api-test.azurewebsites.net
+      - https://simple-report-test.azureedge.net
+      - https://test.simplereport.gov
 twilio:
   enabled: true

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: okta-test, server-debug
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simple-report-api-test.azurewebsites.net
     - https://simple-report-test.azureedge.net

--- a/backend/src/main/resources/application-azure-training.yaml
+++ b/backend/src/main/resources/application-azure-training.yaml
@@ -1,13 +1,13 @@
 spring:
   profiles.include: no-security, no-okta-mgmt, create-sample-data
-cors:
-  allowed-origins:
-    - https://simple-report-api-training.azurewebsites.net
-    - https://simple-report-training.azureedge.net
-    - https://training.simplereport.gov
 simple-report:
   patient-link-url: https://training.simplereport.gov/app/pxp?plid=
   sendgrid:
     enabled: false
+  cors:
+    allowed-origins:
+      - https://simple-report-api-training.azurewebsites.net
+      - https://simple-report-training.azureedge.net
+      - https://training.simplereport.gov
 twilio:
   enabled: false

--- a/backend/src/main/resources/application-azure-training.yaml
+++ b/backend/src/main/resources/application-azure-training.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles.include: no-security, no-okta-mgmt, create-sample-data
-graphql.servlet.cors:
+cors:
   allowed-origins:
     - https://simple-report-api-training.azurewebsites.net
     - https://simple-report-training.azureedge.net

--- a/backend/src/main/resources/application-okta-local.yaml
+++ b/backend/src/main/resources/application-okta-local.yaml
@@ -8,6 +8,9 @@ spring:
       hibernate:
         show_sql: true
         default_schema: simple_report
+simple-report:
+  cors:
+    allowed-origins: http://localhost:3000
 logging:
   level:
     # NOTE: look in application-dev.yaml for other things that might be worth turning on

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,10 +1,10 @@
 spring:
   profiles.include: okta-prod
-cors:
-  allowed-origins:
-    - https://www.simplereport.gov
-    - https://simplereport.gov
 simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports"
+  cors:
+    allowed-origins:
+      - https://www.simplereport.gov
+      - https://simplereport.gov

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,8 +1,9 @@
 spring:
   profiles.include: okta-prod
-graphql.servlet.cors:
+cors:
   allowed-origins:
-    - https://simplereport.cdc.gov
+    - https://www.simplereport.gov
+    - https://simplereport.gov
 simple-report:
   data-hub:
     upload-enabled: true

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -19,11 +19,6 @@ spring:
   jackson:
     serialization:
       FAIL_ON_EMPTY_BEANS: false
-cors:
-  allowed-methods:
-    - GET
-    - HEAD
-    - POST
 graphql:
   servlet:
     mapping: /graphql
@@ -73,6 +68,11 @@ simple-report:
       - Protect-ServiceDesk@hhs.gov
     waitlist-recipient: 
       - support@simplereport.gov
+  cors:
+    allowed-methods:
+      - GET
+      - HEAD
+      - POST
 twilio:
   from-number: "+12023014570"
 logging:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
   jackson:
     serialization:
       FAIL_ON_EMPTY_BEANS: false
+cors:
+  allowed-methods:
+    - GET
+    - HEAD
+    - POST
 graphql:
   servlet:
     mapping: /graphql


### PR DESCRIPTION
## Related Issue or Background Info

- https://github.com/CDCgov/prime-simplereport/issues/1202

## Changes Proposed

- Add a basic cors configuration

## Additional Information

- The graphql servlet cors configuration wasn't working, but currently doesn't affect anything since we aren't making cross-origin requests on the cloud environments
- The rest endpoints did not support cors
- The main purpose of this right now is to facilitate local testing using the okta spring profiles.  In this case, cross-origin requests are made and the pre-flight requests would fail

## Testing

The configuration can be verified by starting the app with one of the okta profiles and then using the frontend locally or by making pre-flight requests from the command line.

For example, using httpie:

```bash
http --print HBhb OPTIONS http://localhost:8080/graphql \
    Origin:http://localhost:3000 \
    Access-Control-Request-Method:POST \
    Access-Control-Request-Headers:authorization,content-type
```

A successful response is an http 200 and contains the headers:

```
Access-Control-Allow-Headers: authorization, content-type
Access-Control-Allow-Methods: GET,HEAD,POST
Access-Control-Allow-Origin: http://localhost:3000
```