### PR TITLE
Removed okta migration code from app startup.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -6,16 +6,13 @@ import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.config.simplereport.DataHubConfig;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.config.simplereport.SiteAdminEmailList;
-import gov.cdc.usds.simplereport.idp.repository.LiveOktaRepository;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
 import gov.cdc.usds.simplereport.properties.SmartyStreetsProperties;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
-import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.ScheduledTasksService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -44,12 +41,6 @@ public class SimpleReportApplication {
   @Profile(BeanProfiles.CREATE_SAMPLE_DATA)
   public CommandLineRunner initDataOnStartup(OrganizationInitializingService initService) {
     return args -> initService.initAll();
-  }
-
-  @Bean
-  @ConditionalOnBean(LiveOktaRepository.class)
-  public CommandLineRunner migrateOktaGroups(OrganizationService orgService) {
-    return args -> orgService.migrateOktaGroups();
   }
 
   @Bean

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -8,7 +8,6 @@ import gov.cdc.usds.simplereport.config.authorization.PermissionHolder;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
-import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -127,12 +126,10 @@ public class DemoOktaRepository implements OktaRepository {
   }
 
   // this method doesn't mean much in a demo env
-  public void createOrganization(
-      Organization org, Collection<Facility> facilities, boolean migration) {
+  public void createOrganization(Organization org) {
     String externalId = org.getExternalId();
     orgUsernamesMap.putIfAbsent(externalId, new HashSet<>());
     orgFacilitiesMap.putIfAbsent(externalId, new HashSet<>());
-    facilities.forEach(this::createFacility);
   }
 
   public void createFacility(Facility facility) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -5,7 +5,6 @@ import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,12 +31,7 @@ public interface OktaRepository {
 
   public Map<String, OrganizationRoleClaims> getAllUsersForOrganization(Organization org);
 
-  public void createOrganization(
-      Organization org, Collection<Facility> facilities, boolean migration);
-
-  public default void createOrganization(Organization org) {
-    createOrganization(org, Set.of(), false);
-  }
+  public void createOrganization(Organization org);
 
   public void createFacility(Facility facility);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -52,13 +52,6 @@ public class OrganizationService {
     _oktaRepo = oktaRepo;
   }
 
-  public void migrateOktaGroups() {
-    // migrate existing orgs/facilities to Okta groups on startup
-    for (Organization org : _repo.findAll()) {
-      _oktaRepo.createOrganization(org, getFacilities(org), true);
-    }
-  }
-
   public Optional<OrganizationRoles> getCurrentOrganizationRoles() {
     List<OrganizationRoleClaims> orgRoles = _authService.findAllOrganizationRoles();
     List<String> candidateExternalIds =


### PR DESCRIPTION
This was intended as a run-once, but has now run many times (though not _that_ many—like a couple dozen, tops) in production. We don't need it any longer and it's burning up tiny bits of our Okta API quota every time we start, so removing it seems reasonable.