### PR TITLE
Allow users to save person when optional fields contain a empty string

### DIFF
--- a/frontend/src/app/commonComponents/ComboBox/ComboBox.test.tsx
+++ b/frontend/src/app/commonComponents/ComboBox/ComboBox.test.tsx
@@ -389,7 +389,7 @@ describe("ComboBox component", () => {
       );
     });
 
-    it("calls onChange prop with undefined on click", () => {
+    it("calls onChange prop with null on click", () => {
       const onChange = jest.fn();
       const { getByTestId } = render(
         <ComboBox
@@ -402,7 +402,7 @@ describe("ComboBox component", () => {
 
       fireEvent.click(getByTestId("combo-box-clear-button"));
 
-      expect(onChange).toHaveBeenCalledWith(undefined);
+      expect(onChange).toHaveBeenCalledWith(null);
     });
 
     it("clears the input on click", () => {
@@ -439,7 +439,7 @@ describe("ComboBox component", () => {
 
       expect(getByTestId("combo-box-clear-button")).not.toBeVisible();
       expect(getByTestId("combo-box-input")).toHaveValue("");
-      expect(onChange).toHaveBeenNthCalledWith(2, undefined);
+      expect(onChange).toHaveBeenNthCalledWith(2, null);
       expect(getByTestId("combo-box-option-list")).not.toBeVisible();
       expect(getByTestId("combo-box-option-list").children.length).toBe(
         fruitOptions.length

--- a/frontend/src/app/commonComponents/ComboBox/ComboBox.tsx
+++ b/frontend/src/app/commonComponents/ComboBox/ComboBox.tsx
@@ -37,9 +37,9 @@ interface ComboBoxProps {
   name: string;
   className?: string;
   options: ComboBoxOption[];
-  defaultValue?: string;
+  defaultValue?: string | null;
   disabled?: boolean;
-  onChange: (value?: string) => void;
+  onChange: (value?: string | null) => void;
   assistiveHint?: string;
   noResults?: string;
   inputProps?: JSX.IntrinsicElements["input"];
@@ -98,7 +98,7 @@ export const ComboBox = ({
 
   const initialState: State = {
     isOpen: false,
-    selectedOption: defaultOption ? defaultOption : undefined,
+    selectedOption: defaultOption ? defaultOption : null,
     focusedOption: undefined,
     focusMode: FocusMode.None,
     filteredOptions: options,
@@ -112,7 +112,7 @@ export const ComboBox = ({
   const itemRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
-    onChange && onChange(state.selectedOption?.value || undefined);
+    onChange && onChange(state.selectedOption?.value || null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.selectedOption]);
 

--- a/frontend/src/app/commonComponents/ComboBox/useCombobox.ts
+++ b/frontend/src/app/commonComponents/ComboBox/useCombobox.ts
@@ -40,8 +40,8 @@ export type Action =
     };
 export interface State {
   isOpen: boolean;
-  selectedOption?: ComboBoxOption;
-  focusedOption?: ComboBoxOption;
+  selectedOption?: ComboBoxOption | null;
+  focusedOption?: ComboBoxOption | null;
   focusMode: FocusMode;
   filter?: string;
   filteredOptions: ComboBoxOption[];
@@ -129,7 +129,7 @@ export const useCombobox = (
           inputValue: "",
           isOpen: false,
           focusMode: FocusMode.Input,
-          selectedOption: undefined,
+          selectedOption: null,
           filter: undefined,
           filteredOptions: optionsList.filter(isPartialMatch("")),
         };

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -160,7 +160,11 @@ const PersonForm = (props: Props) => {
     setPatient(person);
     setAddressModalOpen(false);
     setFormChanged(false);
-    props.savePerson(person);
+    props.savePerson(
+      Object.fromEntries(
+        Object.entries(person).map(([key, value]) => [key, value || null])
+      ) as any
+    );
   };
 
   const commonInputProps = {

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -83,6 +83,9 @@ const PersonForm = (props: Props) => {
   const onPersonChange = <K extends keyof PersonFormData>(field: K) => (
     value: PersonFormData[K]
   ) => {
+    if (patient[field] === value) {
+      return;
+    }
     setFormChanged(true);
     setPatient({ ...patient, [field]: value });
   };
@@ -325,9 +328,11 @@ const PersonForm = (props: Props) => {
             name="tribal-affiliation"
             options={TRIBAL_AFFILIATION_VALUES}
             onChange={
-              onPersonChange("tribalAffiliation") as (value?: string) => void
+              onPersonChange("tribalAffiliation") as (
+                value?: string | null
+              ) => void
             }
-            defaultValue={String(patient.tribalAffiliation)}
+            defaultValue={patient.tribalAffiliation}
           />
         </fieldset>
         <RadioGroup

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -3,9 +3,9 @@ import { MockedProvider } from "@apollo/client/testing";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route } from "react-router";
 
-import EditPatient, { GET_PATIENT } from "./EditPatient";
+import EditPatient, { GET_PATIENT, UPDATE_PATIENT } from "./EditPatient";
 
 jest.mock("../commonComponents/ComboBox", () => () => <></>);
 
@@ -134,6 +134,8 @@ describe("EditPatient", () => {
   describe("Form Submit", () => {
     describe("Only required fields", () => {
       let component: any;
+      let testLocation: any;
+
       beforeEach(async () => {
         const mocks = [
           {
@@ -155,7 +157,7 @@ describe("EditPatient", () => {
                   city: "",
                   state: "DC",
                   zipCode: "20503",
-                  telephone: "(634) 397-4114",
+                  telephone: "(301) 458-4775",
                   role: "",
                   email: "",
                   county: "",
@@ -167,6 +169,39 @@ describe("EditPatient", () => {
                   employedInHealthcare: true,
                   facility: null,
                 },
+              },
+            },
+          },
+          {
+            request: {
+              query: UPDATE_PATIENT,
+              variables: {
+                patientId: mockPatientID,
+                firstName: "Gina",
+                middleName: null,
+                lastName: "Franecki",
+                birthDate: "1939-10-11",
+                street: "736 Jackson PI NW",
+                streetTwo: null,
+                city: null,
+                state: "DC",
+                zipCode: "20503",
+                telephone: "(301) 458-4775",
+                role: null,
+                email: null,
+                county: null,
+                race: null,
+                ethnicity: null,
+                gender: null,
+                tribalAffiliation: null,
+                residentCongregateSetting: true,
+                employedInHealthcare: true,
+                facilityId: null,
+              },
+            },
+            result: {
+              data: {
+                internalId: "153f661f-b6ea-4711-b9ab-487b95198cce",
               },
             },
           },
@@ -182,6 +217,13 @@ describe("EditPatient", () => {
                 />
               </MockedProvider>
             </Provider>
+            <Route
+              path="*"
+              render={({ location }) => {
+                testLocation = location;
+                return <div>Redirect</div>;
+              }}
+            />
           </MemoryRouter>
         );
         await act(async () => {
@@ -204,6 +246,23 @@ describe("EditPatient", () => {
         });
         it("save is enabled", () => {
           expect(screen.getAllByText("Save changes")[0]).not.toBeDisabled();
+        });
+        describe("On save", () => {
+          beforeEach(async () => {
+            await act(async () => {
+              fireEvent.click(
+                screen.queryAllByText("Save", {
+                  exact: false,
+                })[0]
+              );
+              // for some reason the 1 second time out works but this does not
+              // await screen.getAllByText("Redirect")
+              await new Promise((resolve) => setTimeout(resolve, 1000));
+            });
+          });
+          it("redirects to the person tab", () => {
+            expect(testLocation.pathname).toBe("/patients/");
+          });
         });
       });
     });

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -72,6 +72,7 @@ describe("EditPatient", () => {
                 race: null,
                 ethnicity: null,
                 gender: null,
+                tribalAffiliation: [null],
                 residentCongregateSetting: true,
                 employedInHealthcare: true,
                 facility: null,
@@ -126,6 +127,84 @@ describe("EditPatient", () => {
           target: { value: mockFacilityID },
         });
         expect(facilityInput.value).toBe(mockFacilityID);
+      });
+    });
+  });
+
+  describe("Form Submit", () => {
+    describe("Only required fields", () => {
+      let component: any;
+      beforeEach(async () => {
+        const mocks = [
+          {
+            request: {
+              query: GET_PATIENT,
+              variables: {
+                id: mockPatientID,
+              },
+            },
+            result: {
+              data: {
+                patient: {
+                  firstName: "Eugenia",
+                  middleName: "",
+                  lastName: "Franecki",
+                  birthDate: "1939-10-11",
+                  street: "736 Jackson PI NW",
+                  streetTwo: "",
+                  city: "",
+                  state: "DC",
+                  zipCode: "20503",
+                  telephone: "(634) 397-4114",
+                  role: "",
+                  email: "",
+                  county: "",
+                  race: "",
+                  ethnicity: "",
+                  gender: "",
+                  tribalAffiliation: [null],
+                  residentCongregateSetting: true,
+                  employedInHealthcare: true,
+                  facility: null,
+                },
+              },
+            },
+          },
+        ];
+
+        component = render(
+          <MemoryRouter>
+            <Provider store={store}>
+              <MockedProvider mocks={mocks} addTypename={false}>
+                <EditPatient
+                  facilityId={mockFacilityID}
+                  patientId={mockPatientID}
+                />
+              </MockedProvider>
+            </Provider>
+          </MemoryRouter>
+        );
+        await act(async () => {
+          await screen.findAllByText("Franecki, Eugenia", { exact: false });
+        });
+      });
+      it("can't be saved", () => {
+        expect(screen.getAllByText("Save changes")[0]).toBeDisabled();
+      });
+      describe("After field update", () => {
+        beforeEach(() => {
+          fireEvent.change(
+            screen.getByLabelText("First Name", {
+              exact: false,
+            }),
+            {
+              target: { value: "Gina" },
+            }
+          );
+        });
+        it("save is enabled", () => {
+          expect(screen.getAllByText("Save changes")[0]).not.toBeDisabled();
+        });
       });
     });
   });

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -70,7 +70,7 @@ export const GET_PATIENT = gql`
   }
 `;
 
-const UPDATE_PATIENT = gql`
+export const UPDATE_PATIENT = gql`
   mutation UpdatePatient(
     $facilityId: ID
     $patientId: ID!
@@ -186,6 +186,8 @@ const EditPatient = (props: Props) => {
   const getTitle = (person: Nullable<PersonFormData>) =>
     displayFullName(person.firstName, person.middleName, person.lastName);
 
+  const { facility, ...personFormData } = data.patient;
+
   return (
     <div className="bg-base-lightest">
       <div className="grid-container">
@@ -193,7 +195,7 @@ const EditPatient = (props: Props) => {
           <div className={"margin-bottom-4"}>
             <PersonForm
               patient={{
-                ...data.patient,
+                ...personFormData,
                 tribalAffiliation: data.patient.tribalAffiliation[0],
                 facilityId:
                   data.patient.facility === null

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -12,6 +12,34 @@ import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 
 import PersonForm from "./Components/PersonForm";
 
+interface PatientDetails {
+  patient: {
+    firstName: string;
+    middleName: string | null;
+    lastName: string;
+    birthDate: string;
+    street: string;
+    streetTwo: string | null;
+    city: string | null;
+    state: string;
+    zipCode: string;
+    telephone: string;
+    role: Role;
+    lookupId: string | null;
+    email: string | null;
+    county: string | null;
+    race: Race | null;
+    ethnicity: Ethnicity | null;
+    tribalAffiliation: [TribalAffiliation | null];
+    gender: Gender | null;
+    residentCongregateSetting: boolean;
+    employedInHealthcare: boolean;
+    facility: {
+      id: string;
+    } | null;
+  };
+}
+
 export const GET_PATIENT = gql`
   query GetPatientDetails($id: ID!) {
     patient(id: $id) {
@@ -110,7 +138,7 @@ interface EditPatientResponse {
 }
 
 const EditPatient = (props: Props) => {
-  const { data, loading, error } = useQuery(GET_PATIENT, {
+  const { data, loading, error } = useQuery<PatientDetails>(GET_PATIENT, {
     variables: { id: props.patientId || "" },
     fetchPolicy: "no-cache",
   });
@@ -130,6 +158,10 @@ const EditPatient = (props: Props) => {
   }
   if (error) {
     return <p>error loading patient with id {props.patientId}...</p>;
+  }
+
+  if (data === undefined) {
+    return <p>Patient with id {props.patientId} not found</p>;
   }
 
   const savePerson = async (person: Nullable<PersonFormData>) => {
@@ -162,6 +194,7 @@ const EditPatient = (props: Props) => {
             <PersonForm
               patient={{
                 ...data.patient,
+                tribalAffiliation: data.patient.tribalAffiliation[0],
                 facilityId:
                   data.patient.facility === null
                     ? null


### PR DESCRIPTION
## Related Issue or Background Info

- While fixing a [person without a state](https://usds.slack.com/archives/C01SY3DRMNY/p1618256507000300) issue I discovered the `@Size` decorator for email in the graphql schema definition fails on `email=""` as the min for email is 3 characters. In investigating this issue I found a regression with the new tribal affiliation code that allows the edit form to be submitted when no data has been edited

## Changes Proposed

- Convert optional fields from `""` to `null`
- Migrate `ComboBox` null value from `undefined` -> `null`
- Only set `formChanged` when a value changes

## Additional Information

- The `ComboBox` and `formChanged` changes are a quick fix to the fact that `ComboBox` manages it input value internally


