### PR TITLE
Drop person.test_result_delivery

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1748,3 +1748,13 @@ databaseChangeLog:
                   # This valueComputed backfills the column to have the correct values for all existing device_type rows. It does not apply to new rows.
                   constraints:
                     nullable: false
+  - changeSet:
+      id: remove-person-test_result_delivery
+      author: adam@skylight.digital
+      comment: Remove the orphaned person.test_result_delivery column
+      changes:
+        - dropColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: test_result_delivery


### PR DESCRIPTION
This is part 2 of the migration from #1240

## Related Issue or Background Info

- In order for our database schema to remain compatible with the application in the event of a software rollback, the first part of this migration created the new column but did not remove the old one.

## Changes Proposed

- Drop the `test_result_delivery` column from `person`. This field was moved to `patient_preferences` on #1240

## Additional Information

- We should _not_ ship this to prod in the same deploy at #1240 