### PR TITLE
tweaks to default issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,21 +7,21 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Description
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### Steps to reproduce
+If applicable, add screenshots to help explain your problem.
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+If applicable, add screenshots to help explain the solution.
 
-**Additional context**
+### Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,11 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+### Description
+A clear and concise description of what the feature request. Example: As a user having X would help me accomplish Y.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+### Proposed solution 
+A clear and concise description of what you want to happen with screenshots when applicable.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+### Additional context
+Add any other context about the feature, alternatives considered, link to Figma, etc.


### PR DESCRIPTION
## Related Issue or Background Info

- A am planing on doing a lot of ticket writing today and going to make changes to the default template as I see fit

## Changes Proposed
- bold sections -> headers
- remove screenshot section and prompt to include them inline where applicable