### PR TITLE
Ensure that DataLoader always has rows for PatientPreferences

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/ApiUserAwareGraphQlContextBuilder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/ApiUserAwareGraphQlContextBuilder.java
@@ -99,7 +99,9 @@ class ApiUserAwareGraphQlContextBuilder implements GraphQLServletContextBuilder 
         new DataLoader<>(
             personIds ->
                 supplyAsync(
-                    () -> patientPreferencesRepository.findAllByPersonInternalIdIn(personIds)));
+                    () ->
+                        patientPreferencesRepository.findAllAndCoalesceEmptyByPersonInternalIdIn(
+                            personIds)));
     dataLoaderRegistry.register(PatientPreferences.DATA_LOADER, patientPreferencesLoader);
     return dataLoaderRegistry;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientPreferencesRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientPreferencesRepository.java
@@ -6,9 +6,19 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PatientPreferencesRepository extends AuditedEntityRepository<PatientPreferences> {
   Optional<PatientPreferences> findByPerson(Person person);
 
-  List<PatientPreferences> findAllByPersonInternalIdIn(Collection<UUID> person);
+  @Query(
+      value =
+          "SELECT person.internal_id,"
+              + " COALESCE(patient_preferences.preferred_language, null) preferred_language, COALESCE(patient_preferences.test_result_delivery, 'NONE') test_result_delivery,"
+              + " patient_preferences.created_at, patient_preferences.created_by, patient_preferences.updated_at, patient_preferences.updated_by"
+              + " FROM {h-schema}patient_preferences"
+              + " RIGHT JOIN {h-schema}person ON patient_preferences.internal_id = person.internal_id"
+              + " WHERE person.internal_id IN :patientIds",
+      nativeQuery = true)
+  List<PatientPreferences> findAllAndCoalesceEmptyByPersonInternalIdIn(Collection<UUID> patientIds);
 }


### PR DESCRIPTION
## Related Issue or Background Info

- In the event that a Person does not have a PatientPreferences row, the GraphQL aggregator
gets upset that not every key has a value from the patientPreferencesLoader. This custom
query right joins on person and coalesces the default values so that there's always a
row.

## Changes Proposed

- Replace `findAllByPersonInternalIdIn` with a custom query
