### PR TITLE
Ensure input used for reading attachment gets closed

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
@@ -72,16 +72,19 @@ public class EmailService {
         templateData.getTemplateName(), templateData.toTemplateVariables());
   }
 
-  private Attachments getAttachmentsFromResource(final String attachmentResourceName) {
+  private Attachments getAttachmentsFromResource(final String attachmentResourceName)
+      throws IOException {
     final String resourcePath = "attachments/" + attachmentResourceName;
-    final InputStream content = getClass().getClassLoader().getResourceAsStream(resourcePath);
-    if (content == null) {
-      return null;
-    }
+    try (final InputStream content =
+        getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+      if (content == null) {
+        return null;
+      }
 
-    return new Attachments.Builder(attachmentResourceName, content)
-        .withType("application/pdf")
-        .build();
+      return new Attachments.Builder(attachmentResourceName, content)
+          .withType("application/pdf")
+          .build();
+    }
   }
 
   public String send(


### PR DESCRIPTION
close() was not being called on the input stream in EmailService when sending an email with an attachment (currently only the new user next-steps email)

## Related Issue or Background Info

- https://github.com/CDCgov/prime-simplereport/issues/1333

## Changes Proposed

- wrap with try to ensure close() is called
