### PR TITLE
Updated sensitive outputs and deprecations in terraform.

### DIFF
--- a/ops/global/_output.tf
+++ b/ops/global/_output.tf
@@ -7,7 +7,8 @@ output "acr_simeplereport_admin_name" {
 }
 
 output "acr_simeplereport_admin_password" {
-  value = azurerm_container_registry.sr.admin_password
+  value     = azurerm_container_registry.sr.admin_password
+  sensitive = true
 }
 
 output "slack_alert_action_id" {

--- a/ops/global/vault_db.tf
+++ b/ops/global/vault_db.tf
@@ -8,7 +8,6 @@ resource "azurerm_key_vault" "db_keys" {
   resource_group_name        = data.azurerm_resource_group.rg.name
   sku_name                   = "standard"
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  soft_delete_enabled        = true
   soft_delete_retention_days = 90
   purge_protection_enabled   = true
 

--- a/ops/global/vault_global.tf
+++ b/ops/global/vault_global.tf
@@ -6,7 +6,6 @@ resource "azurerm_key_vault" "sr" {
   resource_group_name = data.azurerm_resource_group.rg.name
   sku_name            = "standard"
   tenant_id           = data.azurerm_client_config.current.tenant_id
-  soft_delete_enabled = true
 
   tags = local.management_tags
 }

--- a/ops/services/app_gateway/_output.tf
+++ b/ops/services/app_gateway/_output.tf
@@ -1,5 +1,6 @@
 output "app_gateway_hostname" {
-  value = azurerm_application_gateway.load_balancer
+  value     = azurerm_application_gateway.load_balancer
+  sensitive = true
 }
 
 output "app_gateway_public_ip" {

--- a/ops/services/monitoring/outputs.tf
+++ b/ops/services/monitoring/outputs.tf
@@ -7,11 +7,13 @@ output "app_insights_app_id" {
 }
 
 output "app_insights_instrumentation_key" {
-  value = azurerm_application_insights.app_insights.instrumentation_key
+  value     = azurerm_application_insights.app_insights.instrumentation_key
+  sensitive = true
 }
 
 output "app_insights_connection_string" {
-  value = azurerm_application_insights.app_insights.connection_string
+  value     = azurerm_application_insights.app_insights.connection_string
+  sensitive = true
 }
 
 output "log_analytics_workspace_id" {


### PR DESCRIPTION
Marked module outputs that should be considered sensitive as sensitive, to prevent leakages (and prevent 0.15.0 from breaking when we upgrade). Also removed an argument to the azurerm vault resource that was throwing a deprecation warning.

## Related Issue or Background Info

- https://www.terraform.io/docs/language/expressions/references.html#sensitive-resource-attributes describes (in a blue box at the bottom of the section) the enforcement change in terraform 0.15.0
- https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-change

## Changes Proposed

- remove deprecated arguments from vault configuration
- update module outputs that contain sensitive attributes to themselves be flagged as sensitive
