### PR TITLE
Upgrade to Lighthouse v7 for GitHub Actions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -25,4 +25,4 @@ jobs:
         configPath: ./lighthouserc.yml
         runs: 1
       env:
-        SITE_URL: https://demo.simplereport.gov/
+        SITE_URL: https://demo.simplereport.gov

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -21,7 +21,7 @@ jobs:
           $SITE_URL/app/settings/
           $SITE_URL/app/settings/facilities/
           $SITE_URL/app/settings/add-facility/
-        uploadArtifacts: false
+        uploadArtifacts: true
         configPath: ./lighthouserc.yml
         runs: 1
       env:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -25,4 +25,4 @@ jobs:
         configPath: ./lighthouserc.yml
         runs: 1
       env:
-        SITE_URL: https://demo.simplereport.gov
+        SITE_URL: https://training.simplereport.gov

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,16 +13,17 @@ jobs:
       with:
         urls: |
           $SITE_URL/
-          $SITE_URL/app/
-          $SITE_URL/app/queue/
-          $SITE_URL/app/results/
-          $SITE_URL/app/patients/
-          $SITE_URL/app/add-patient/
-          $SITE_URL/app/settings/
-          $SITE_URL/app/settings/facilities/
-          $SITE_URL/app/settings/add-facility/
+          $SITE_URL/app/$FACILITY_ID
+          $SITE_URL/app/queue/$FACILITY_ID
+          $SITE_URL/app/results/$FACILITY_ID
+          $SITE_URL/app/patients/$FACILITY_ID
+          $SITE_URL/app/add-patient/$FACILITY_ID
+          $SITE_URL/app/settings/$FACILITY_ID
+          $SITE_URL/app/settings/facilities/$FACILITY_ID
+          $SITE_URL/app/settings/add-facility/$FACILITY_ID
         uploadArtifacts: true
         configPath: ./lighthouserc.yml
         runs: 1
       env:
         SITE_URL: https://training.simplereport.gov
+        FACILITY_ID: ?facility=adddb27d-3be3-48b7-b959-ea506fd92ce6

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Lighthouse CI Action
-      uses: treosh/lighthouse-ci-action@v2
+      uses: treosh/lighthouse-ci-action@v7
       with:
         urls: |
           $SITE_URL/


### PR DESCRIPTION
We're currently using Lighthouse v2 for the GitHub Action and this upgrades it to v7 which has many more checks. 

This also:
- Enables upload artifacts
- Removes the trailing slash in `SITE_URL` b/c it [shows up as a double slash in the tests](https://github.com/CDCgov/prime-simplereport/runs/2396006523?check_suite_focus=true)
- Uses the training site for `SITE_URL` b/c we should probably test against the app populated with data and content instead of a blank app
- Adds `$FACILITY_ID` as a new env variable and adds it to URLs
  - TODO: check if this is done right

Note: the [current configuration](https://github.com/CDCgov/prime-simplereport/actions/workflows/lighthouse.yml) looks like it runs once per day against the demo site.