### PR TITLE
Split docker build out from backend deploy job.

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -6,35 +6,38 @@ on:
     types: [released]
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: demo
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -7,35 +7,38 @@ on:
       - main
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: dev
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -6,35 +6,38 @@ on:
     types: [released]
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: pentest
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -5,35 +5,38 @@ on:
     types: [released]
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: prod
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -6,35 +6,38 @@ on:
   workflow_dispatch:
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: stg
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -14,25 +14,30 @@ env:
   DEPLOY_ENV: test
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -4,13 +4,6 @@ on:
   workflow_dispatch:
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: test
 
 jobs:
@@ -33,6 +26,11 @@ jobs:
     defaults:
       run:
         working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
       - uses: azure/login@v1

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -6,35 +6,38 @@ on:
     types: [released]
 
 env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  ACR_ADMIN_USERNAME: ${{ secrets.ACR_ADMIN_USERNAME }}
-  ACR_ADMIN_PASWORD: ${{ secrets.ACR_ADMIN_PASWORD }}
-  ACR_REPO_URL: ${{ secrets.ACR_REPO_URL }}
   DEPLOY_ENV: training
 
 jobs:
-  deploy-backend:
+  docker-build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
-        run: |
-          ./build_and_push.sh
+        run: ./build_and_push.sh
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.10

--- a/backend/build_and_push.sh
+++ b/backend/build_and_push.sh
@@ -7,7 +7,6 @@ ACR_TAG="simplereportacr.azurecr.io/api/simple-report-api-build:$GIT_SHA"
 
 export DOCKER_CLI_EXPERIMENTAL=enabled # to get "manifest inspect"
 
-echo "Trying that inspect plan"
 if docker manifest inspect $ACR_TAG >& /dev/null; then
     echo "Built image for ${GIT_SHA} already exists in the repository"
     exit 0

--- a/backend/build_and_push.sh
+++ b/backend/build_and_push.sh
@@ -5,6 +5,14 @@
 GIT_SHA=$(git rev-parse --short HEAD)
 ACR_TAG="simplereportacr.azurecr.io/api/simple-report-api-build:$GIT_SHA"
 
+export DOCKER_CLI_EXPERIMENTAL=enabled # to get "manifest inspect"
+
+echo "Trying that inspect plan"
+if docker manifest inspect $ACR_TAG >& /dev/null; then
+    echo "Built image for ${GIT_SHA} already exists in the repository"
+    exit 0
+fi
+
 echo "Building backend images"
 docker-compose -f docker-compose.prod.yml build
 


### PR DESCRIPTION
Separated out docker build into its own job, and made the main part of that job smart enough to skip rebuilding the docker image with no changes.

## Related Issue or Background Info

No issue filed, it just always annoys me when we rebuild the same image like five times for no reason.

## Changes Proposed

- split deploy-backend job in deploy workflows into two jobs, one of which builds and pushes the docker image, and the other of which tells azure to deploy that image
- tweak the docker build to not rebuild if the image already exists (which is frequently the case since`dev` auto-builds all commits to `main`.)
- eliminate some unnecessary secret exposure through environment variables

## Additional Information

Leaving this as a draft to collect comments before I try to patch the remaining six deploy scripts to act the same way.
