### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: npm
+    # React client
+    directory: /frontend
+    schedule:
+      interval: "daily"
+    labels:
+      - "Front end"
+      - "Security"
+  - package-ecosystem: gradle
+    # Java API
+    directory: /backend
+    schedule:
+      interval: "daily"
+    labels:
+      - "Backend"
+      - "DevOps"
+      - "Security"
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "DevOps"
+      - "Security"
+# This is possible, but doesn't seem actually all that useful
+# - package-ecosystem: terraform
+#   directory: /ops
+#   schedule:
+#     interval: "daily"


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves cdcgov/prime-devops#12

## Changes Proposed

Add a dependabot configuration so that it can find our various manifest files and open pull requests when they need to be updated.

## Additional Information

- it is possible to configure who is assigned or requested for review on PRs opened by dependabot: that can be added to this PR or done separately
- it is possible to check for updates less often, but doing it daily seems reasonable when we have so many dependencies (and, frankly, we may have a backlog to work through)
