### PR TITLE
Add API endpoints for account creation

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,12 +20,6 @@ repositories {
     mavenCentral()
 }
 
-// dependencyManagement {
-//   imports {
-//     mavenBom 'org.springframework.session:spring-session-bom:2020.0.3'
-//   }
-// }
-
 dependencies {
     // core infrastructure
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -63,10 +57,6 @@ dependencies {
 
     // SendGrid for Email
     implementation 'com.sendgrid:sendgrid-java:4.7.2'
-
-    // Spring Session
-    // compile 'org.springframework.session:spring-session-core'
-    // compile 'org.springframework.session:spring-session-jdbc'
 
     // graphql-java-extended-validation schema directives
     compile 'com.graphql-java:graphql-java-extended-validation:16.0.0'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,12 @@ repositories {
     mavenCentral()
 }
 
+// dependencyManagement {
+//   imports {
+//     mavenBom 'org.springframework.session:spring-session-bom:2020.0.3'
+//   }
+// }
+
 dependencies {
     // core infrastructure
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -57,6 +63,10 @@ dependencies {
 
     // SendGrid for Email
     implementation 'com.sendgrid:sendgrid-java:4.7.2'
+
+    // Spring Session
+    // compile 'org.springframework.session:spring-session-core'
+    // compile 'org.springframework.session:spring-session-jdbc'
 
     // graphql-java-extended-validation schema directives
     compile 'com.graphql-java:graphql-java-extended-validation:16.0.0'

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -6,14 +6,13 @@ import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller used for user account creation. */
-// Note: this authorization logic hasn't yet been implemented and will currently allow all requests.
-@PreAuthorize("@apiUserService.verifyAccountCreationRequest()")
+// NOTE: This class is not currently functional; it's a WIP so that the frontend has endpoints to
+// query.
 @RestController
 @RequestMapping(USER_ACCOUNT_REQUEST)
 public class UserAccountCreationController {
@@ -24,9 +23,27 @@ public class UserAccountCreationController {
     LOG.info("User account request REST endpoint enabled");
   }
 
-  /** Dummy controller that returns the given session id. */
-  @PostMapping("")
-  String uid(HttpSession session) {
+  /**
+   * WIP Validates that the requesting user has been sent an invitation to SimpleReport, ensures the
+   * given password meets all requirements, and sets the password in Okta. If the password doesn't
+   * meet requirements, sends a notice back to the frontend.
+   *
+   * @param session
+   * @return the session id (temporary)
+   */
+  @PostMapping("/set_password")
+  String setPassword(HttpSession session) {
+    return session.getId();
+  }
+
+  /**
+   * WIP Sets a recovery question for the given session/user in Okta.
+   *
+   * @param session
+   * @return the session id (temporary)
+   */
+  @PostMapping("/set_recovery_question")
+  String setRecoveryQuestions(HttpSession session) {
     return session.getId();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller used for user account creation. */
+// Note: this authorization logic hasn't yet been implemented and will currently allow all requests.
 @PreAuthorize("@apiUserService.verifyAccountCreationRequest()")
 @RestController
 @RequestMapping(USER_ACCOUNT_REQUEST)
@@ -26,7 +27,6 @@ public class UserAccountCreationController {
   /** Dummy controller that returns the given session id. */
   @PostMapping("")
   String uid(HttpSession session) {
-    System.out.println("BOOYAH" + session.getId());
     return session.getId();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -1,0 +1,58 @@
+package gov.cdc.usds.simplereport.api.apiuser;
+
+import static gov.cdc.usds.simplereport.config.WebConfiguration.USER_ACCOUNT_REQUEST;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+
+/** 
+ * Controller used for user account creation.
+ */
+@PreAuthorize("@apiUserService.verifyAccountCreationRequest()")
+@RestController
+@RequestMapping(USER_ACCOUNT_REQUEST)
+public class UserAccountCreationController {
+    
+    /**
+     * Dummy controller that returns the given session id.
+     */
+    @GetMapping("/")
+    String uid(HttpSession session) {
+        System.out.println("BOOYAH" + session.getId());
+        return session.getId();
+    }
+
+
+    // note: most of the tutorials/guides online specify adding a 
+    // WebSecurityConfigurerAdapter to protect unauthorized users from
+    // accessing the API.
+    // SimpleReport has one (SecurityConfiguration) but that's likely too
+    // strict for this use case (since it requires Okta signin)
+    // options are going to be either altering that SecurityConfiguration file
+    // so that this endpoint isn't covered, or creating a new
+    //  SecurityConfiguration just for this
+    // the patient experience controller is probably a good example here,
+    // since they have to do the same thing
+
+    // ok, PatientExperienceController is definitely a good example to follow
+    // they use verifyPatientLink to control access, rather than the more restrictive
+    // rules in SecurityConfiguration
+    // we probably ? want to do something similar, querying the database to see
+    // if an invite has been sent to the given email address
+    // that might be a V2 though, since we're not expecting anything right now
+    // But: the plan is as follows.
+    // - Update the SecurityConfiguration file to allow all traffic to go to UserAccountCreationController
+    // - Add some kind of logic here for now to restrict the allowed traffic (emails from DB, maybe?)
+    // - add the actual API logic for account creation (password verification, recovery questions, etc)
+
+
+    // AccountRequestController is handled a little differently: all requests are allowed (I think)
+    // "Account requests are unauthorized"
+    // I assume this means anyone/anything can send a request to this resource
+
+    // also need to consider what kind of HTTP method this is - probably a POST to Okta
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -2,57 +2,31 @@ package gov.cdc.usds.simplereport.api.apiuser;
 
 import static gov.cdc.usds.simplereport.config.WebConfiguration.USER_ACCOUNT_REQUEST;
 
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpSession;
-
-/** 
- * Controller used for user account creation.
- */
+/** Controller used for user account creation. */
 @PreAuthorize("@apiUserService.verifyAccountCreationRequest()")
 @RestController
 @RequestMapping(USER_ACCOUNT_REQUEST)
 public class UserAccountCreationController {
-    
-    /**
-     * Dummy controller that returns the given session id.
-     */
-    @GetMapping("/")
-    String uid(HttpSession session) {
-        System.out.println("BOOYAH" + session.getId());
-        return session.getId();
-    }
+  private static final Logger LOG = LoggerFactory.getLogger(UserAccountCreationController.class);
 
+  @PostConstruct
+  private void init() {
+    LOG.info("User account request REST endpoint enabled");
+  }
 
-    // note: most of the tutorials/guides online specify adding a 
-    // WebSecurityConfigurerAdapter to protect unauthorized users from
-    // accessing the API.
-    // SimpleReport has one (SecurityConfiguration) but that's likely too
-    // strict for this use case (since it requires Okta signin)
-    // options are going to be either altering that SecurityConfiguration file
-    // so that this endpoint isn't covered, or creating a new
-    //  SecurityConfiguration just for this
-    // the patient experience controller is probably a good example here,
-    // since they have to do the same thing
-
-    // ok, PatientExperienceController is definitely a good example to follow
-    // they use verifyPatientLink to control access, rather than the more restrictive
-    // rules in SecurityConfiguration
-    // we probably ? want to do something similar, querying the database to see
-    // if an invite has been sent to the given email address
-    // that might be a V2 though, since we're not expecting anything right now
-    // But: the plan is as follows.
-    // - Update the SecurityConfiguration file to allow all traffic to go to UserAccountCreationController
-    // - Add some kind of logic here for now to restrict the allowed traffic (emails from DB, maybe?)
-    // - add the actual API logic for account creation (password verification, recovery questions, etc)
-
-
-    // AccountRequestController is handled a little differently: all requests are allowed (I think)
-    // "Account requests are unauthorized"
-    // I assume this means anyone/anything can send a request to this resource
-
-    // also need to consider what kind of HTTP method this is - probably a POST to Okta
+  /** Dummy controller that returns the given session id. */
+  @PostMapping("")
+  String uid(HttpSession session) {
+    System.out.println("BOOYAH" + session.getId());
+    return session.getId();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -73,6 +73,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter
         .antMatchers(HttpMethod.POST, WebConfiguration.ACCOUNT_REQUEST + "/**")
         .permitAll()
 
+        // User account creation request authorization is handled in UserAccountCreationController
+        .antMatchers(HttpMethod.GET, WebConfiguration.USER_ACCOUNT_REQUEST + "**")
+        .permitAll()
+
         // Anything else goes through Okta
         .anyRequest()
         .authenticated()

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -74,7 +74,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter
         .permitAll()
 
         // User account creation request authorization is handled in UserAccountCreationController
-        .antMatchers(HttpMethod.GET, WebConfiguration.USER_ACCOUNT_REQUEST + "**")
+        .antMatchers(HttpMethod.GET, WebConfiguration.USER_ACCOUNT_REQUEST + "/**")
         .permitAll()
 
         // Anything else goes through Okta

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -74,7 +74,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter
         .permitAll()
 
         // User account creation request authorization is handled in UserAccountCreationController
-        .antMatchers(HttpMethod.GET, WebConfiguration.USER_ACCOUNT_REQUEST + "/**")
+        .antMatchers(HttpMethod.GET, WebConfiguration.USER_ACCOUNT_REQUEST)
         .permitAll()
 
         // Anything else goes through Okta

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
@@ -19,6 +19,7 @@ public class WebConfiguration implements WebMvcConfigurer {
   public static final String HEALTH_CHECK = "/health";
   public static final String PATIENT_EXPERIENCE = "/pxp/**";
   public static final String ACCOUNT_REQUEST = "/account-request";
+  public static final String USER_ACCOUNT_REQUEST = "/user-account-request";
 
   @Autowired private PatientExperienceLoggingInterceptor _loggingInterceptor;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
@@ -19,7 +19,7 @@ public class WebConfiguration implements WebMvcConfigurer {
   public static final String HEALTH_CHECK = "/health";
   public static final String PATIENT_EXPERIENCE = "/pxp/**";
   public static final String ACCOUNT_REQUEST = "/account-request";
-  public static final String USER_ACCOUNT_REQUEST = "/user-account-request";
+  public static final String USER_ACCOUNT_REQUEST = "/user";
 
   @Autowired private PatientExperienceLoggingInterceptor _loggingInterceptor;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -316,4 +316,8 @@ public class ApiUserService {
         new OrganizationRoles(org, accessibleFacilities, claims.getGrantedRoles());
     return new UserInfo(apiUser, Optional.of(orgRoles), isAdmin(apiUser));
   }
+
+  public boolean verifyAccountCreationRequest() {
+    return true;
+  }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -19,6 +19,8 @@ spring:
   jackson:
     serialization:
       FAIL_ON_EMPTY_BEANS: false
+  session:
+    store-type: "jdbc"
 graphql:
   servlet:
     mapping: /graphql

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -8,5 +8,7 @@ public final class ResourceLinks {
 
   public static final String WAITLIST_REQUEST = "/account-request/waitlist";
   public static final String ACCOUNT_REQUEST = "/account-request";
-  public static final String USER_ACCOUNT_REQUEST = "/user-account-request";
+  public static final String USER_ACCOUNT_REQUEST = "/user";
+  public static final String USER_SET_PASSWORD = "/user/set_password";
+  public static final String USER_SET_RECOVERY_QUESTION = "/user/set_recovery_question";
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -8,4 +8,5 @@ public final class ResourceLinks {
 
   public static final String WAITLIST_REQUEST = "/account-request/waitlist";
   public static final String ACCOUNT_REQUEST = "/account-request";
+  public static final String USER_ACCOUNT_REQUEST = "/user-account-request";
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/UserAccountCreationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/UserAccountCreationControllerTest.java
@@ -1,22 +1,24 @@
 package gov.cdc.usds.simplereport.api;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import gov.cdc.usds.simplereport.api.apiuser.UserAccountCreationController;
+import gov.cdc.usds.simplereport.config.TemplateConfiguration;
+import gov.cdc.usds.simplereport.config.WebConfiguration;
+import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
-import gov.cdc.usds.simplereport.config.TemplateConfiguration;
-import gov.cdc.usds.simplereport.config.WebConfiguration;
-import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
-
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @WebMvcTest(
-    controllers = UserAccountCreationControllerTest.class,
+    controllers = UserAccountCreationController.class,
     includeFilters =
         @Filter(
             classes = {TemplateConfiguration.class},
@@ -25,18 +27,35 @@ import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
         @Filter(
             classes = {AuditLoggingAdvice.class, WebConfiguration.class},
             type = FilterType.ASSIGNABLE_TYPE))
-
-
 class UserAccountCreationControllerTest {
 
-    @Autowired private MockMvc _mockMvc;
-    
-    @Test
-    void getSessionUidIsOk() throws Exception {
-        MockHttpServletRequestBuilder builder = 
-            get(ResourceLinks.USER_ACCOUNT_REQUEST);
+  @Autowired private MockMvc _mockMvc;
 
-        this._mockMvc.perform(builder).andExpect(status().isOk());
-    }
+  @Test
+  void getSessionUidIsOk() throws Exception {
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.USER_ACCOUNT_REQUEST)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content("{}");
 
+    String firstRequest =
+        this._mockMvc
+            .perform(builder)
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    assertThat(firstRequest).isEqualTo("1");
+
+    String secondRequest =
+        this._mockMvc
+            .perform(builder)
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    assertThat(secondRequest).isEqualTo("2");
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/UserAccountCreationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/UserAccountCreationControllerTest.java
@@ -1,0 +1,42 @@
+package gov.cdc.usds.simplereport.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import gov.cdc.usds.simplereport.config.TemplateConfiguration;
+import gov.cdc.usds.simplereport.config.WebConfiguration;
+import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
+
+
+@WebMvcTest(
+    controllers = UserAccountCreationControllerTest.class,
+    includeFilters =
+        @Filter(
+            classes = {TemplateConfiguration.class},
+            type = FilterType.ASSIGNABLE_TYPE),
+    excludeFilters =
+        @Filter(
+            classes = {AuditLoggingAdvice.class, WebConfiguration.class},
+            type = FilterType.ASSIGNABLE_TYPE))
+
+
+class UserAccountCreationControllerTest {
+
+    @Autowired private MockMvc _mockMvc;
+    
+    @Test
+    void getSessionUidIsOk() throws Exception {
+        MockHttpServletRequestBuilder builder = 
+            get(ResourceLinks.USER_ACCOUNT_REQUEST);
+
+        this._mockMvc.perform(builder).andExpect(status().isOk());
+    }
+
+}

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -10,6 +10,8 @@ spring:
     properties:
       hibernate:
         default_schema: simple_report
+  session:
+    store-type: "jdbc"
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Related Issue or Background Info

#1376 
#1384 

## Changes Proposed

- Adds a UserAccountCreationController to provide an API for creating user accounts (setting password and recovery questions). This is WIP and not currently functional! It just provides endpoints so that frontend development can continue.
- Adds preliminary unit tests for UserAccountCreationController.

## Testing Information
The tests as written mainly validate that SpringSession is working correctly, and that the request paths are correctly wired. They individually validate `setPassword` and `setRecoveryQuestion`, then test that requests coming from different "users" (sessions) will have different session ids. The final test mocks the flow when a single user sets their password then recovery question (for now, this is just verifying that the session information is persisted). These are largely skeleton tests and will be more fully fleshed out when the API logic is added.

## Additional Information

- Next steps: add the Okta logic to the set password and set recovery questions endpoint. This will also require adding logic to authenticate the user (via the Okta authentication token passed in the account request email).

## Checklist for Author and Reviewer

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
