### PR TITLE
Fixes storybook build command

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,3 +9,4 @@ coverage
 geckodriver.log
 chromedriver.log
 tests_output/
+storybook-static

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,7 @@
     "compile-scss": "node-sass --include-path ./src/scss --include-path ./node_modules/uswds/dist/scss --output-style compressed -o ./src/styles/ ./src/scss/App.scss",
     "watch-css": "yarn compile-scss && node-sass --include-path ./src/scss --include-path ./node_modules/uswds/dist/scss -o src/styles/ --watch --recursive src/scss/App.scss",
     "storybook": "yarn watch-css & start-storybook -p 6006 -s public",
-    "build-storybook": "yarn compile-css && build-storybook -s public"
+    "build-storybook": "yarn compile-scss && build-storybook -s public"
   },
   "prettier": {
     "singleQuote": false


### PR DESCRIPTION
## Related Issue or Background Info

This is a quick fix for the `build-storybook` script, which had a typo. It also git-ignores the output directory for the static assets.

## Changes Proposed

- Fixes typo in `build-storybook` script
- Git-ignores the `storybook-static` directory, which is where the compiled storybook assets end up when you build it

## Checklist for Author and Reviewer

The checklist was reviewed and is all N/A for this change.

### UI
- [x] Any changes to the UI/UX have been approved by design 
- [x] Any new or edited error messages have been approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
