### PR TITLE
Bandaid fixes for dependabot pull request checks.

### DIFF
--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -14,8 +14,9 @@ defaults:
     working-directory: ./backend
 
 jobs:
-  latest:
+  scan:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -1,5 +1,4 @@
----
-name: Infra Checks
+name: Terraform Checks
 
 on:
   workflow_dispatch: # because sometimes you just want to force a branch to have tests run
@@ -14,32 +13,33 @@ defaults:
   run:
     working-directory: ./ops
 
-env:
-  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-
 jobs:
-  validation_and_formatting:
+  check-terraform-formatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
-
+        with:
+          terraform_version: 0.14.10
       - name: Terraform fmt
-        run: |
-          terraform fmt -check -recursive
+        run: terraform fmt -check -recursive
 
+  check-terraform-validity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
       - name: Terraform Init
         run: |
-          pushd dev; pushd persistent; echo $PWD && terraform init; popd; echo $PWD && terraform init; popd
-          pushd test; pushd persistent; echo $PWD && terraform init; popd; echo $PWD && terraform init; popd
-          pushd demo; pushd persistent; echo $PWD && terraform init; popd; echo $PWD && terraform init; popd
-          pushd stg; pushd persistent; echo $PWD && terraform init; popd; echo $PWD && terraform init; popd
-          pushd prod; pushd persistent; echo $PWD && terraform init; popd; echo $PWD && terraform init; popd
-          pushd pentest; pushd persistent; echo $PWD && terraform init; popd; echo $PWD && terraform init; popd
-          pushd global; echo $PWD && terraform init;
+          pushd dev; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
+          pushd test; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
+          pushd demo; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
+          pushd stg; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
+          pushd prod; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
+          pushd pentest; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
+          pushd global; terraform init -backend=false;
 
       - name: Terraform Validate
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
         working-directory: ./frontend
         run: yarn test:ci
       - name: Sonar analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
* Made the sonar and coverity scans be skipped when the job was launched by
  dependabot, since dependabot does not have access to secrets.
* Split the terraform validation job into separate formatting and validation
  jobs, so they can run in parallel, and made the validation job skip setting
  up the backend, since there is no specific reason to do so and it requires
  secrets access to authenticate to Azure.
* Took out the redundant printing of the current directory in the init step.

## Related Issue or Background Info

Dependabot-created pull requests run checks as if they were from a forked repository, with no access to secrets. This is fine, and doesn't impair our ability to get useful information out of our checks (dependency changes aren't going to make any differences to Sonar except for method deprecations), but means we need to avoid doing things that require secrets access. Fortunately, that turns out not to be super hard to do.