### PR TITLE
Workflow shenanigans

### DIFF
--- a/.github/actions/deploy-front-end/action.yml
+++ b/.github/actions/deploy-front-end/action.yml
@@ -19,11 +19,15 @@ runs:
     - name: Install dependencies
       working-directory: ./frontend
       shell: bash
-      run: yarn install
+      run: |
+        echo "::group::Install dependencies (hopefully cached)"
+        yarn install
+        echo "::endgroup::"
     - name: Set build variables
       shell: bash
       working-directory: ./frontend
       run: |
+          echo "::group::Set build variables"
           az config set extension.use_dynamic_install=yes_without_prompt > /dev/null 2>&1
           INSIGHTS_KEY=$(
             az monitor app-insights component show \
@@ -37,26 +41,34 @@ runs:
           if [[ "true" == "${{ inputs.is-training-site }}" ]]
             then echo "REACT_APP_IS_TRAINING_SITE=true" >> .env.production.local
           fi
+          echo "::endgroup::"
     - name: Build deployable application
       shell: bash
       working-directory: ./frontend
       env:
         REACT_APP_SMARTY_STREETS_KEY: ${{ inputs.smarty-streets-key }}
         DEPLOY_ENV: ${{ inputs.deploy-env }}
-      run: yarn run build
+      run: |
+        echo "::group::Build application"
+        yarn run build
+        echo "::endgroup::"
     - name: Deploy frontend app
       shell: bash
       working-directory: ./frontend
       run: |
+        echo "::group::Deploy frontend app"
         az storage blob upload-batch -s build/ -d '$web' \
           --account-name simplereport${{ inputs.deploy-env }}app \
           --destination-path '/app'
+        echo "::endgroup::"
     - name: Purge CDN
       shell: bash
       working-directory: ./frontend
       run: |
+        echo "::group::Purge CDN"
         az cdn endpoint purge \
           --resource-group prime-simple-report-${{ inputs.deploy-env }} \
           --profile-name simple-report-${{ inputs.deploy-env }} \
           --name simple-report-${{ inputs.deploy-env }} \
           --content-paths "/app/*" --no-wait
+        echo "::endgroup::"

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -8,6 +8,8 @@ on:
 env:
   DEPLOY_ENV: demo
   NODE_VERSION: 14
+concurrency:
+  group: demo-deploy
 
 jobs:
   docker-build:

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEPLOY_ENV: demo
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -56,7 +57,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -9,6 +9,9 @@ on:
 env:
   DEPLOY_ENV: dev
   NODE_VERSION: 14
+concurrency:
+  group: dev-deploy
+  cancel-in-progress: true
 
 jobs:
   docker-build:

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DEPLOY_ENV: dev
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -57,7 +58,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -8,6 +8,8 @@ on:
 env:
   DEPLOY_ENV: pentest
   NODE_VERSION: 14
+concurrency:
+  group: pentest-deploy
 
 jobs:
   docker-build:

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEPLOY_ENV: pentest
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -56,7 +57,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -7,6 +7,8 @@ on:
 env:
   DEPLOY_ENV: prod
   NODE_VERSION: 14
+concurrency:
+  group: prod-deploy
 
 jobs:
   docker-build:

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   DEPLOY_ENV: prod
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -55,7 +56,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEPLOY_ENV: stg
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -56,7 +57,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -8,6 +8,8 @@ on:
 env:
   DEPLOY_ENV: stg
   NODE_VERSION: 14
+concurrency:
+  group: stg-deploy
 
 jobs:
   docker-build:

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -3,6 +3,9 @@ name: Deploy Test
 on:
   workflow_dispatch:
 
+concurrency:
+  group: test-deploy
+  cancel-in-progress: true
 env:
   DEPLOY_ENV: test
   NODE_VERSION: 14

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   DEPLOY_ENV: test
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -54,7 +55,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -8,6 +8,8 @@ on:
 env:
   DEPLOY_ENV: training
   NODE_VERSION: 14
+concurrency:
+  group: training-deploy
 
 jobs:
   docker-build:

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEPLOY_ENV: training
+  NODE_VERSION: 14
 
 jobs:
   docker-build:
@@ -56,7 +57,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: "14"
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -33,20 +33,18 @@ jobs:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: |
-          pushd dev; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
-          pushd test; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
-          pushd demo; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
-          pushd stg; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
-          pushd prod; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
-          pushd pentest; pushd persistent; terraform init -backend=false; popd; terraform init -backend=false; popd
-          pushd global; terraform init -backend=false;
+          for d in dev dev/persistent test test/persistent demo demo/persistent training training/persistent \
+            stg stg/persistent pentest pentest/persistent prod prod/persistent global
+          do
+            echo "Initializing $d";
+            (cd $d && terraform init -backend=false)
+          done
 
       - name: Terraform Validate
         run: |
-          pushd dev; pushd persistent; echo $PWD && terraform validate -no-color; popd; echo $PWD && terraform validate -no-color; popd
-          pushd test; pushd persistent; echo $PWD && terraform validate -no-color; popd; echo $PWD && terraform validate -no-color; popd
-          pushd demo; pushd persistent; echo $PWD && terraform validate -no-color; popd; echo $PWD && terraform validate -no-color; popd
-          pushd stg; pushd persistent; echo $PWD && terraform validate -no-color; popd; echo $PWD && terraform validate -no-color; popd
-          pushd prod; pushd persistent; echo $PWD && terraform validate -no-color; popd; echo $PWD && terraform validate -no-color; popd
-          pushd pentest; pushd persistent; echo $PWD && terraform validate -no-color; popd; echo $PWD && terraform validate -no-color; popd
-          pushd global; echo $PWD && terraform validate -no-color;
+          for d in dev dev/persistent test test/persistent demo demo/persistent training training/persistent \
+            stg stg/persistent pentest pentest/persistent prod prod/persistent global
+          do
+            echo "Validating $d";
+            (cd $d && terraform validate)
+          done

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -26,6 +26,11 @@ jobs:
 
   check-terraform-validity:
     runs-on: ubuntu-latest
+    env:
+      TERRAFORM_DIRS: |
+          dev dev/persistent test test/persistent demo demo/persistent training training/persistent
+          stg stg/persistent pentest pentest/persistent prod prod/persistent
+          global
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
@@ -33,17 +38,14 @@ jobs:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: |
-          for d in dev dev/persistent test test/persistent demo demo/persistent training training/persistent \
-            stg stg/persistent pentest pentest/persistent prod prod/persistent global
+          for d in $TERRAFORM_DIRS
           do
             echo "Initializing $d";
             (cd $d && terraform init -backend=false)
           done
-
       - name: Terraform Validate
         run: |
-          for d in dev dev/persistent test test/persistent demo demo/persistent training training/persistent \
-            stg stg/persistent pentest pentest/persistent prod prod/persistent global
+          for d in $TERRAFORM_DIRS
           do
             echo "Validating $d";
             (cd $d && terraform validate)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,14 @@ defaults:
     working-directory: backend
 
 jobs:
-  test:
+  test: # remove this job when required checks have been updated to include its dependencies instead
+    runs-on: ubuntu-latest
+    needs: [test-java, test-node]
+    steps:
+      - name: Placeholder step
+        working-directory: /
+        run: echo "This is a dummy job to keep the required checks happy"
+  test-java:
     runs-on: ubuntu-latest
     services:
       test-db:
@@ -37,8 +44,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
       - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:
@@ -67,6 +72,13 @@ jobs:
           TWILIO_ACCOUNT_SID: ${{secrets.TWILIO_TEST_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{secrets.TWILIO_TEST_AUTH_TOKEN }}
         run: ./gradlew jacocoTestReport -PtestDbPort=5432
+      - name: Save Build Output for Sonar
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: java-build-output
+          path: backend/build
+          retention-days: 1
       - name: Archive Test Results
         uses: actions/upload-artifact@v2
         if: failure()
@@ -74,6 +86,10 @@ jobs:
           name: test-report
           path: backend/build/reports/tests/test
           retention-days: 7
+  test-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{env.NODE_VERSION}}
         uses: actions/setup-node@v2.1.5
         with:
@@ -90,12 +106,37 @@ jobs:
       - name: Test
         working-directory: ./frontend
         run: yarn test:ci
+      - name: Save Build Output for Sonar
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: yarn-build-output
+          path: frontend/coverage
+          retention-days: 1
+
+  sonar:
+    runs-on: ubuntu-latest
+    needs: [test-java, test-node]
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
+      - name: Retrieve java build
+        uses: actions/download-artifact@v2
+        with:
+          name: java-build-output
+      - name: Retrieve yarn build
+        uses: actions/download-artifact@v2
+        with:
+          name: yarn-build-output
       - name: Sonar analysis
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        working-directory: ./backend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.PROJECT_ROOT }} --info
+
   build-jar:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
A laundry list of housekeeping improvements to the test and deploy workflows in GitHub Actions:

## Changes Proposed
- [x] terraform check shell scripting/maintainability improvements
- [x] java/node test job splitting (speeds up checks and makes it easier to see what failed)
- [x] node dependency cache in deploy jobs (speeds up all front-end deploys)
- *NO* is this where we do the back-compatibility graphql job? probably not, that's not a refactor
- *NO* maybe we figure out approvals though?
- *NO* well maybe just environments, without approvals?
- [x] used [grouping command](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines) to fix bad behavior of composite-steps action in frontend build/deploy
- [x] serialized deploy jobs to avoid unpleasant collisions