### PR TITLE
Add a third instance and upgrade instance category

### DIFF
--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -4,6 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
+  instance_size  = "P2v2"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -3,7 +3,7 @@ module "simple_report_api" {
   name   = "${local.name}-api"
   env    = local.env
 
-  instance_count = 2
+  instance_count = 3
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,6 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
+  instance_size  = "P2v2"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -3,7 +3,7 @@ module "simple_report_api" {
   name   = "${local.name}-api"
   env    = local.env
 
-  instance_count = 2
+  instance_count = 3
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
## Related Issue or Background Info

- fixes https://app.zenhub.com/workspaces/prime-devops-606cb208a8c112000fd48349/issues/cdcgov/prime-devops/38

## Changes Proposed

- 2 instances to 3

## Additional Information
- we need to make this change any way to not experience downtime and I would like to observe what effect this has on the metrics in azure independent of adding more memory

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX have been approved by design 
- [x] Any new or edited error messages have been approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
