### PR TITLE
Fix build_and_push.sh

### DIFF
--- a/backend/build_and_push.sh
+++ b/backend/build_and_push.sh
@@ -7,7 +7,7 @@ ACR_TAG="simplereportacr.azurecr.io/api/simple-report-api-build:$GIT_SHA"
 
 export DOCKER_CLI_EXPERIMENTAL=enabled # to get "manifest inspect"
 
-if docker manifest inspect $ACR_TAG >& /dev/null; then
+if docker manifest inspect $ACR_TAG 2>&1 /dev/null; then
     echo "Built image for ${GIT_SHA} already exists in the repository"
     exit 0
 fi


### PR DESCRIPTION
## **The `>&` syntax isn't supported in sh**

## Related Issue or Background Info

- This tiny syntax error was introduced in #1422
