### PR TITLE
Import "Everyone" group into global configuration.

### DIFF
--- a/ops/global/_data.tf
+++ b/ops/global/_data.tf
@@ -6,3 +6,7 @@ data "azurerm_key_vault_secret" "slack_metrics_webhook" {
   key_vault_id = azurerm_key_vault.sr.id
   name         = "simple-report-global-slack-webhook"
 }
+
+data "okta_group" "everyone" {
+  name = "Everyone"
+}

--- a/ops/global/main.tf
+++ b/ops/global/main.tf
@@ -35,6 +35,8 @@ resource "azurerm_log_analytics_workspace" "sr" {
 // Okta configuration
 module "okta" {
   source = "../services/okta-global"
+
+  all_users_group_id = data.okta_group.everyone.id
 }
 
 // App Insights for Azure Functions

--- a/ops/services/okta-global/_var.tf
+++ b/ops/services/okta-global/_var.tf
@@ -1,0 +1,5 @@
+variable "all_users_group_id" {
+  description = "Group to include in universal Okta resources such as MFA rules"
+  type        = string
+  sensitive   = true
+}

--- a/ops/services/okta-global/main.tf
+++ b/ops/services/okta-global/main.tf
@@ -38,7 +38,7 @@ resource "okta_policy_signon" "mfa_require" {
   name            = "simple-report-mfa-require"
   status          = "ACTIVE"
   description     = "Require MFA for all users"
-  groups_included = []
+  groups_included = [var.all_users_group_id]
 }
 
 resource "okta_policy_rule_signon" "app_mfa" {


### PR DESCRIPTION
We need everyone to have an MFA login requirement even after redeploys. Currently, planning in `global` shows that we would remove this group from the MFA policy requirement if we deployed that configuration, which would be ... very bad.