### PR TITLE
Pagerduty API alerts

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -6,6 +6,7 @@ module "metric_alerts" {
   severity            = 1
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
+  mem_threshold       = 85
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.slack_alert_action_id,

--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -3,8 +3,13 @@ module "metric_alerts" {
   env                 = local.env
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
-  action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id
   severity            = 1
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
+
+  action_group_ids = [
+    data.terraform_remote_state.global.outputs.slack_alert_action_id,
+    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+  ]
+
 }

--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -3,8 +3,13 @@ module "metric_alerts" {
   env                 = local.env
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
-  action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
   disabled_alerts     = ["cpu_util", "mem_util"]
+
+  action_group_ids = [
+    data.terraform_remote_state.global.outputs.slack_alert_action_id,
+    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+  ]
+
 }

--- a/ops/prod/alerts.tf
+++ b/ops/prod/alerts.tf
@@ -3,10 +3,15 @@ module "metric_alerts" {
   env                 = local.env
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
-  action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id
   severity            = 1
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
 
   mem_threshold = 80
+
+  action_group_ids = [
+    data.terraform_remote_state.global.outputs.slack_alert_action_id,
+    data.terraform_remote_state.global.outputs.pagerduty_prod_action_id
+  ]
+
 }

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -27,3 +27,7 @@ variable "tags" {
 variable "mem_threshold" {
   default = 70
 }
+
+variable "cpu_threshold" {
+  default = 70
+}

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "azurerm_monitor_metric_alert" "cpu_util" {
   name                = "${var.env}-api-cpu"
-  description         = "${local.ucfirst_env} CPU utilization is greater than 70%"
+  description         = "${local.ucfirst_env} CPU utilization is greater than ${var.cpu_threshold}%"
   resource_group_name = var.rg_name
   scopes              = [var.app_service_plan_id]
   frequency           = "PT1M"
@@ -16,7 +16,7 @@ resource "azurerm_monitor_metric_alert" "cpu_util" {
     metric_name      = "CpuPercentage"
     metric_namespace = "Microsoft.Web/serverfarms"
     operator         = "GreaterThanOrEqual"
-    threshold        = 70
+    threshold        = var.cpu_threshold
   }
 
   dynamic "action" {
@@ -29,7 +29,7 @@ resource "azurerm_monitor_metric_alert" "cpu_util" {
 
 resource "azurerm_monitor_metric_alert" "mem_util" {
   name                = "${var.env}-api-mem"
-  description         = "${local.ucfirst_env} Memory utilization is greater than 70%"
+  description         = "${local.ucfirst_env} memory utilization is greater than ${var.mem_threshold}%"
   resource_group_name = var.rg_name
   scopes              = [var.app_service_plan_id]
   frequency           = "PT1M"
@@ -55,7 +55,7 @@ resource "azurerm_monitor_metric_alert" "mem_util" {
 
 resource "azurerm_monitor_metric_alert" "http_response_time" {
   name                = "${var.env}-api-http-response"
-  description         = "${local.ucfirst_env} Network response >= 1000ms(1s)"
+  description         = "${local.ucfirst_env} network response >= 1000ms(1s)"
   resource_group_name = var.rg_name
   scopes              = [var.app_service_id]
   frequency           = "PT1M"
@@ -82,7 +82,7 @@ resource "azurerm_monitor_metric_alert" "http_response_time" {
 
 resource "azurerm_monitor_metric_alert" "http_5xx_errors" {
   name                = "${var.env}-api-5xx-errors"
-  description         = "${local.ucfirst_env} Http Server 5xx Errors >= 10"
+  description         = "${local.ucfirst_env} HTTP Server 5xx Errors >= 10"
   resource_group_name = var.rg_name
   scopes              = [var.app_service_id]
   frequency           = "PT1M"
@@ -108,7 +108,7 @@ resource "azurerm_monitor_metric_alert" "http_5xx_errors" {
 
 resource "azurerm_monitor_metric_alert" "http_4xx_errors" {
   name                = "${var.env}-api-4xx-errors"
-  description         = "${local.ucfirst_env} Http Server 4xx Errors >= 10"
+  description         = "${local.ucfirst_env} HTTP Server 4xx Errors >= 10"
   resource_group_name = var.rg_name
   scopes              = [var.app_service_id]
   frequency           = "PT1M"

--- a/ops/stg/alerts.tf
+++ b/ops/stg/alerts.tf
@@ -3,7 +3,12 @@ module "metric_alerts" {
   env                 = local.env
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
-  action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
+
+  action_group_ids = [
+    data.terraform_remote_state.global.outputs.slack_alert_action_id,
+    data.terraform_remote_state.global.outputs.pagerduty_prod_action_id
+  ]
+
 }

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -3,10 +3,15 @@ module "metric_alerts" {
   env                 = local.env
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
-  action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
   disabled_alerts     = ["cpu_util", "mem_util"]
+
+  action_group_ids = [
+    data.terraform_remote_state.global.outputs.slack_alert_action_id,
+    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+  ]
+
 
   mem_threshold = 80
 }

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -3,7 +3,11 @@ module "metric_alerts" {
   env                 = local.env
   app_service_plan_id = module.simple_report_api.app_service_plan_id
   app_service_id      = module.simple_report_api.app_service_id
-  action_group_id     = data.terraform_remote_state.global.outputs.slack_alert_action_id
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
+
+  action_group_ids = [
+    data.terraform_remote_state.global.outputs.slack_alert_action_id,
+    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+  ]
 }

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -5,6 +5,7 @@ module "metric_alerts" {
   app_service_id      = module.simple_report_api.app_service_id
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
+  mem_threshold       = 85
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.slack_alert_action_id,


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves CDCGov/prime-devops#2

## Changes Proposed

- fix some minor issues about the alerts terraform module
- make stg and prod route alerts to the SimpleReport - Production service, and everything else to SimpleReport - Demo

## Additional Information

This is being deployed already, but we can obviously redeploy if we change things, that's the point.