### PR TITLE
CORS: Allow PUT requests

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -78,6 +78,7 @@ simple-report:
       - GET
       - HEAD
       - POST
+      - PUT
 twilio:
   from-number: "+12023014570"
 logging:


### PR DESCRIPTION
## Related Issue or Background Info

- #1265 seems to have broken the patient experience, because the frontend uses PUT requests, and those weren't explicitly allowed in the CORS configuration made by that PR

## Changes Proposed

- Allow PUT requests

