### PR TITLE
Change patient experience endpoints to do POST requests

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,7 +75,7 @@ public class PatientExperienceController {
    * Verify that the patient-provided DOB matches the patient on file for the patient link id. It
    * returns the full patient object if so, otherwise it throws an exception
    */
-  @PutMapping("/link/verify")
+  @PostMapping("/link/verify")
   public PxpVerifyResponse getPatientLinkVerify(
       @RequestBody PxpRequestWrapper<Void> body, HttpServletRequest request) {
     UUID plid = UUID.fromString(body.getPatientLinkId());
@@ -89,7 +89,7 @@ public class PatientExperienceController {
     return new PxpVerifyResponse(p, os, te, pp);
   }
 
-  @PutMapping("/patient")
+  @PostMapping("/patient")
   public Person updatePatient(
       @RequestBody PxpRequestWrapper<PersonUpdate> body, HttpServletRequest request) {
     PersonUpdate person = body.getData();
@@ -107,7 +107,7 @@ public class PatientExperienceController {
         person.getPreferredLanguage());
   }
 
-  @PutMapping("/questions")
+  @PostMapping("/questions")
   public void patientLinkSubmit(
       @RequestBody PxpRequestWrapper<AoEQuestions> body, HttpServletRequest request) {
     AoEQuestions data = body.getData();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -66,7 +66,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter
 
         // Patient experience authorization is handled in PatientExperienceController
         // If this configuration changes, please update the documentation on both sides
-        .antMatchers(HttpMethod.PUT, WebConfiguration.PATIENT_EXPERIENCE)
+        .antMatchers(HttpMethod.POST, WebConfiguration.PATIENT_EXPERIENCE)
         .permitAll()
 
         // Account requests are unauthorized

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -117,7 +117,7 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     HttpEntity<JsonNode> requestEntity = new HttpEntity<JsonNode>(makeVerifyLinkArgs());
     ResponseEntity<String> resp =
         _restTemplate.exchange(
-            ResourceLinks.VERIFY_LINK, HttpMethod.PUT, requestEntity, String.class);
+            ResourceLinks.VERIFY_LINK, HttpMethod.POST, requestEntity, String.class);
     LOG.info("Response body is {}", resp.getBody());
     verify(_auditRepo).save(_eventCaptor.capture());
     assertThat(_eventCaptor.getValue())
@@ -133,7 +133,7 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     HttpEntity<JsonNode> requestEntity = new HttpEntity<JsonNode>(makeVerifyLinkArgs());
     ResponseEntity<String> resp =
         _restTemplate.exchange(
-            ResourceLinks.VERIFY_LINK, HttpMethod.PUT, requestEntity, String.class);
+            ResourceLinks.VERIFY_LINK, HttpMethod.POST, requestEntity, String.class);
     assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
     JsonNode responseJson = new ObjectMapper().readTree(resp.getBody());
     assertEquals(400, responseJson.get("status").asInt());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -119,7 +118,7 @@ class AuditLoggingTest extends BaseGraphqlTest {
             .put("dateOfBirth", TestDataFactory.DEFAULT_BDAY.toString())
             .toString();
     _mockMvc
-        .perform(withJsonContent(put(ResourceLinks.VERIFY_LINK), requestBody))
+        .perform(withJsonContent(post(ResourceLinks.VERIFY_LINK), requestBody))
         .andExpect(status().isOk());
 
     ApiAuditEvent event = assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, null);
@@ -159,7 +158,7 @@ class AuditLoggingTest extends BaseGraphqlTest {
             .put("dateOfBirth", TestDataFactory.DEFAULT_BDAY.toString())
             .toString();
     MockHttpServletRequestBuilder req =
-        withJsonContent(put(ResourceLinks.VERIFY_LINK), requestBody)
+        withJsonContent(post(ResourceLinks.VERIFY_LINK), requestBody)
             .header("X-forwarded-PROTO", "gopher")
             .header("x-ORIGINAL-HOST", "simplereport.simple")
             .header("x-forwarded-for", "192.168.153.128:80, 10.3.1.1:443");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -76,7 +76,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
         "{\"patientLinkId\":\"" + UUID.randomUUID() + "\",\"dateOfBirth\":\"" + dob + "\"}";
 
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -102,7 +102,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -126,7 +126,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -161,7 +161,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -191,7 +191,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder submitBuilder =
-        put(ResourceLinks.ANSWER_QUESTIONS)
+        post(ResourceLinks.ANSWER_QUESTIONS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -201,14 +201,14 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // OKAY NOW DO IT AGAIN
     MockHttpServletRequestBuilder verifyBuilder =
-        put(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
             .content(requestBody);
 
     MockHttpServletRequestBuilder secondSubmitBuilder =
-        put(ResourceLinks.ANSWER_QUESTIONS)
+        post(ResourceLinks.ANSWER_QUESTIONS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -234,7 +234,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -267,7 +267,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.UPDATE_PATIENT)
+        post(ResourceLinks.UPDATE_PATIENT)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -300,7 +300,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        put(ResourceLinks.ANSWER_QUESTIONS)
+        post(ResourceLinks.ANSWER_QUESTIONS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -39,7 +39,7 @@ export class PxpApi {
     dateOfBirth: string
   ): Promise<any> {
     return fetch(`${API_URL}/link/verify`, {
-      method: "put",
+      method: "POST",
       mode: "cors",
       headers,
       body: JSON.stringify({
@@ -60,7 +60,7 @@ export class PxpApi {
     data: any
   ) {
     return fetch(`${API_URL}/questions`, {
-      method: "put",
+      method: "POST",
       mode: "cors",
       headers,
       body: JSON.stringify({
@@ -77,7 +77,7 @@ export class PxpApi {
     data: UpdatePatientData
   ) {
     return fetch(`${API_URL}/patient`, {
-      method: "put",
+      method: "POST",
       mode: "cors",
       headers,
       body: JSON.stringify({


### PR DESCRIPTION
## Related Issue or Background Info

- We noticed that the patient experience isn't working in deployed environments. We thought it was the CORS configuration introduced in #1265 that was blocking PUT requests, but after deploying #1508 to test, it seems something else was also blocking PUT requests with a 501:
![image](https://user-images.githubusercontent.com/9121162/117086403-46d70000-ad01-11eb-9934-e070787df0bb.png)


## Changes Proposed

- This changes all of the patient experience endpoints to use POST requests instead. Confirmed working in test

