### PR TITLE
Change spring session columns to use bigint instead of datetime

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1957,3 +1957,13 @@ databaseChangeLog:
           - addPrimaryKey:
               tableName: spring_session_attributes
               columnNames: session_primary_id, attribute_name
+  - changeSet:
+        id: alter-spring-session-types
+        author: emma@skylight.digital
+        comment: Change the creation_time, last_access_time, and expiry_time columns to be of type bigint instead of DATETIME. Spring expects bigints for these columns: https://github.com/spring-projects/spring-session/blob/main/spring-session-jdbc/src/main/resources/org/springframework/session/jdbc/schema-postgresql.sql
+        changes:
+          - sql:
+            sql: |
+              ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN creation_time TYPE bigint USING EXTRACT(EPOCH FROM creation_time);
+              ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN last_access_time TYPE bigint USING EXTRACT(EPOCH FROM last_access_time);
+              ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN expiry_time TYPE bigint USING EXTRACT(EPOCH FROM expiry_time);

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1960,7 +1960,7 @@ databaseChangeLog:
   - changeSet:
         id: alter-spring-session-types
         author: emma@skylight.digital
-        comment: Change the creation_time, last_access_time, and expiry_time columns to be of type bigint instead of DATETIME. Spring expects bigints for these columns: https://github.com/spring-projects/spring-session/blob/main/spring-session-jdbc/src/main/resources/org/springframework/session/jdbc/schema-postgresql.sql
+        comment: Change the creation_time, last_access_time, and expiry_time columns to be of type bigint instead of DATETIME. Spring expects bigints for these columns.
         changes:
           - sql:
             sql: |

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1961,6 +1961,7 @@ databaseChangeLog:
         id: alter-spring-session-types
         author: emma@skylight.digital
         comment: Change the creation_time, last_access_time, and expiry_time columns to be of type bigint instead of DATETIME. Spring expects bigints for these columns.
+        # https://github.com/spring-projects/spring-session/blob/main/spring-session-jdbc/src/main/resources/org/springframework/session/jdbc/schema-postgresql.sql#L4
         changes:
           - sql:
             sql: |


### PR DESCRIPTION
## Related Issue or Background Info

- Spring is expecting all the date columns to use bigints, rather than datetime values. This change adds a new liquibase changeset to do the conversion. There shouldn't be any existing data in the spring_session table, so this change should be a no-op.
This is the table Spring expects: https://github.com/spring-projects/spring-session/blob/main/spring-session-jdbc/src/main/resources/org/springframework/session/jdbc/schema-postgresql.sql#L4

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX have been approved by design 
- [x] Any new or edited error messages have been approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
