### PR TITLE
Add migration to set null telephone numbers to empty strings

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1969,6 +1969,26 @@ databaseChangeLog:
               ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN last_access_time TYPE bigint USING EXTRACT(EPOCH FROM last_access_time);
               ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN expiry_time TYPE bigint USING EXTRACT(EPOCH FROM expiry_time);
   - changeSet:
+      id: set-null-telephone-to-empty-string
+      author: nclyde@skylight.digital
+      comment: Sets null values for telephone in the person table to empty string so that the next migration will run successfully
+      changes:
+          - sql:
+            remarks: Sets null values for telephone in the person table to empty string
+            sql: |
+              WITH migration_user as (
+                SELECT internal_id as migrations_user_id
+                FROM ${database.defaultSchemaName}.api_user
+                WHERE login_email = '${migrations_user_email}')
+              UPDATE ${database.defaultSchemaName}.person SET telephone='', updated_at=now(), updated_by=(SELECT migrations_user_id from migration_user) WHERE telephone IS NULL;
+            rollback:
+              sql: |
+                WITH migration_user as (
+                  SELECT internal_id as migrations_user_id
+                  FROM ${database.defaultSchemaName}.api_user
+                  WHERE login_email = '${migrations_user_email}')
+                UPDATE ${database.defaultSchemaName}.person SET telephone=null, updated_at=now(), updated_by=(SELECT migrations_user_id from migration_user) WHERE telephone='';
+  - changeSet:
       id: add-phone-number-table
       author: nathan@skylight.digital
       comment: Add table to track user phone numbers


### PR DESCRIPTION
## Related Issue or Background Info

- The deploy of `v35` to production failed on a migration introduced by #1532 

## Changes Proposed

- Add an additional migration which overwrites all null telephone values in the `person` table to be empty string instead. This should allow the migration to run successfully in production.

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
