### PR TITLE
Fix address validation styles

### DIFF
--- a/frontend/src/app/commonComponents/AddressConfirmation.scss
+++ b/frontend/src/app/commonComponents/AddressConfirmation.scss
@@ -1,5 +1,5 @@
 .address__select {
-  .usa-form-group {
+  > div {
     display: flex;
     gap: 1rem;
   }
@@ -14,7 +14,6 @@
 
   .usa-radio__label {
     margin-bottom: 0 !important;
-    margin-top: 0 !important;
   }
 
   .usa-radio__input:disabled {
@@ -32,8 +31,4 @@
 
 .address__no-suggestion {
   align-self: center;
-}
-
-.address__instructions {
-  font-weight: bold;
 }

--- a/frontend/src/app/commonComponents/AddressConfirmationModal.tsx
+++ b/frontend/src/app/commonComponents/AddressConfirmationModal.tsx
@@ -119,12 +119,10 @@ export const AddressConfirmationModal: React.FC<Props> = ({
       <Modal.Header>Address validation</Modal.Header>
       <div className="border-top border-base-lighter margin-x-neg-205"></div>
       {getAlert()}
-      <p className="address__instructions">
-        Please select an option to continue:
-      </p>
       <RadioGroup
         name="addressSelect"
         className="address__select margin-top-0"
+        legend="Please select an option to continue:"
         buttons={[
           {
             value: "userAddress",


### PR DESCRIPTION
Fixes #1594

Also updates to use `legend`.

<img width="897" alt="Screen Shot 2021-05-14 at 10 16 31 AM" src="https://user-images.githubusercontent.com/5249443/118306607-838fbd80-b49e-11eb-9ca3-10b9a4750d0e.png">
