### PR TITLE
Fix content policy on devmode

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <% if (process.env.NODE_ENV !== 'development') { %>
     <meta
         http-equiv="Content-Security-Policy"
         content="
@@ -10,6 +11,7 @@
             img-src 'self' data:;
             connect-src 'self'  https://us-street.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track %REACT_APP_BACKEND_URL%;
         ">
+        <% } %>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/%REACT_APP_ICON%" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Related Issue or Background Info

https://github.com/CDCgov/prime-simplereport/issues/1604

## Changes Proposed

Disabled content-security policy on development mode to be able to test and develop locally on safari 

## Screenshots / Demos
Before: 
![image](https://user-images.githubusercontent.com/7571965/118665710-2fb50980-b7fb-11eb-93a8-488f9e2f1d3c.png)

After:

![Screenshot 2021-05-18 at 16 59 23](https://user-images.githubusercontent.com/7571965/118664759-68a0ae80-b7fa-11eb-9e5a-a8894c656ee9.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
