### PR TITLE
empty strings submitted via account request form no longer nullified

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -44,7 +44,7 @@ public class Translators {
   }
 
   public static String parsePhoneNumber(String userSuppliedPhoneNumber) {
-    if (userSuppliedPhoneNumber == null) {
+    if (StringUtils.isBlank(userSuppliedPhoneNumber)) {
       return null;
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -104,7 +104,7 @@ public class AccountRequestController {
                 (m, e) ->
                     m.put(
                         e.getKey(),
-                        e.getValue() == null || e.getValue().toString().length() == 0
+                        e.getValue() == null
                             ? null
                             : e.getValue().toString()),
                 HashMap::putAll);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -101,12 +101,7 @@ public class AccountRequestController {
         body.toTemplateVariables().entrySet().stream()
             .collect(
                 HashMap::new,
-                (m, e) ->
-                    m.put(
-                        e.getKey(),
-                        e.getValue() == null
-                            ? null
-                            : e.getValue().toString()),
+                (m, e) -> m.put(e.getKey(), e.getValue() == null ? null : e.getValue().toString()),
                 HashMap::putAll);
 
     List<DeviceType> devices = _dts.fetchDeviceTypes();


### PR DESCRIPTION
## Related Issue or Background Info

- NPI sometimes come through account request sign up form as empty string, and app converts it to null. This violates DB non-null constraint for NPI. This is a problem!

## Changes Proposed

- Removing the empty-string-to-null conversion for account request form data.

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
