### PR TITLE
Deserialize `zipCode` as `postalCode`

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
@@ -98,21 +98,29 @@ public class PatientExperienceController {
   }
 
   @PostMapping("/patient")
-  public Person updatePatient(
+  public PxpVerifyResponse updatePatient(
       @RequestBody PxpRequestWrapper<PersonUpdate> body, HttpServletRequest request) {
     PersonUpdate person = body.getData();
-    return _ps.updateMe(
-        StreetAddress.deAndReSerializeForSafety(person.getAddress()),
-        parsePhoneNumbers(person.getPhoneNumbers()),
-        person.getRole(),
-        parseEmail(person.getEmail()),
-        parseRace(person.getRace()),
-        parseEthnicity(person.getEthnicity()),
-        person.getTribalAffiliation(),
-        parseGender(person.getGender()),
-        person.getResidentCongregateSetting(),
-        person.getEmployedInHealthcare(),
-        person.getPreferredLanguage());
+    Person updated =
+        _ps.updateMe(
+            StreetAddress.deAndReSerializeForSafety(person.getAddress()),
+            parsePhoneNumbers(person.getPhoneNumbers()),
+            person.getRole(),
+            parseEmail(person.getEmail()),
+            parseRace(person.getRace()),
+            parseEthnicity(person.getEthnicity()),
+            person.getTribalAffiliation(),
+            parseGender(person.getGender()),
+            person.getResidentCongregateSetting(),
+            person.getEmployedInHealthcare(),
+            person.getPreferredLanguage());
+
+    UUID plid = UUID.fromString(body.getPatientLinkId());
+    PatientLink pl = _pls.getPatientLink(plid);
+    OrderStatus os = pl.getTestOrder().getOrderStatus();
+    PatientPreferences pp = _ps.getPatientPreferences(updated);
+    TestEvent te = _tes.getLastTestResultsForPatient(updated);
+    return new PxpVerifyResponse(updated, os, te, pp);
   }
 
   @PostMapping("/questions")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/StreetAddress.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/StreetAddress.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.db.model.auxiliary;
 import static gov.cdc.usds.simplereport.api.Translators.parseState;
 import static gov.cdc.usds.simplereport.api.Translators.parseString;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,7 +24,11 @@ public class StreetAddress {
 
   @Column private String city;
   @Column private String state;
-  @Column private String postalCode;
+
+  @JsonAlias({"zipCode", "zipcode"})
+  @Column
+  private String postalCode;
+
   @Column private String county;
 
   protected StreetAddress() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -284,6 +284,76 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   }
 
   @Test
+  void updatePatientAcceptsPostalOrZipCode() throws Exception {
+    // GIVEN
+    String dob = _person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String newTelephone = "(212) 867-5309";
+    String newEmail = "fake@example.com";
+    String zipcode = "97209";
+
+    String requestBody =
+        "{\"patientLinkId\":\""
+            + _patientLink.getInternalId()
+            + "\",\"dateOfBirth\":\""
+            + dob
+            + "\",\"data\":{\"phoneNumbers\":"
+            + "[{\"type\":\"MOBILE\",\"number\":\""
+            + newTelephone
+            + "\"},{\"type\":\"LANDLINE\",\"number\":\"(631) 867-5309"
+            + "\"}],\"role\":\"UNKNOWN\",\"email\":\""
+            + newEmail
+            + "\",\"race\":\"refused\",\"ethnicity\":\"not_hispanic\",\"gender\":\"female\",\"residentCongregateSetting\":false,\"employedInHealthcare\":true,\"address\":{\"street\":[\"12 Someplace\",\"CA\"],\"city\":null,\"state\":\"CA\",\"county\":null,"
+            + "\"zipCode\":\""
+            + zipcode
+            + "\"}}}";
+
+    // WHEN
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.UPDATE_PATIENT)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    // THEN
+    _mockMvc
+        .perform(builder)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.zipCode", is(zipcode)));
+
+    String postalCode = "11561";
+    String requestBody2 =
+        "{\"patientLinkId\":\""
+            + _patientLink.getInternalId()
+            + "\",\"dateOfBirth\":\""
+            + dob
+            + "\",\"data\":{\"phoneNumbers\":"
+            + "[{\"type\":\"MOBILE\",\"number\":\""
+            + newTelephone
+            + "\"},{\"type\":\"LANDLINE\",\"number\":\"(631) 867-5309"
+            + "\"}],\"role\":\"UNKNOWN\",\"email\":\""
+            + newEmail
+            + "\",\"race\":\"refused\",\"ethnicity\":\"not_hispanic\",\"gender\":\"female\",\"residentCongregateSetting\":false,\"employedInHealthcare\":true,\"address\":{\"street\":[\"12 Someplace\",\"CA\"],\"city\":null,\"state\":\"CA\",\"county\":null,"
+            + "\"postalCode\":\""
+            + postalCode
+            + "\"}}}";
+
+    // WHEN
+    MockHttpServletRequestBuilder builder2 =
+        post(ResourceLinks.UPDATE_PATIENT)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody2);
+
+    // THEN
+    _mockMvc
+        .perform(builder2)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.zipCode", is(postalCode)));
+  }
+
+  @Test
   void aoeSubmitCallsUpdate() throws Exception {
     // GIVEN
     String dob = _person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #1624

## Changes Proposed

- Adds a JsonAlias to StreetAddress.postalCode so that incoming data from the Patient Experience, which calls it `zipCode`, can be correctly deserialized
- Update the response shape of PXP's PersonUpdat from Person to instead use PxpVerifyResponse, which correctly maps fields of interest and obscures fields that don't need to be transmitted to the UI

## Checklist for Author and Reviewer

### UI
- NA - ~Any changes to the UI/UX are approved by design~
- NA - ~Any new or updated content (e.g. error messages) are approved by design~

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- NA - ~Database changes are submitted as a separate PR~
- NA - ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- NA - ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- NA - ~Any dependencies introduced have been vetted and discussed~

## Cloud
- NA - ~DevOps team has been notified if PR requires ops support~
- NA - ~If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification~
