### PR TITLE
admin create org endpoint now creates inactive org and inactive user

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -230,7 +230,7 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             providerAddress,
             Translators.parsePhoneNumber(orderingProviderTelephone),
             orderingProviderNPI);
-    _aus.createUser(adminEmail, adminName, externalId, Role.ADMIN, true);
+    _aus.createUser(adminEmail, adminName, externalId, Role.ADMIN, false);
     List<Facility> facilities = _os.getFacilities(org);
     return new ApiOrganization(org, facilities);
   }


### PR DESCRIPTION
## Related Issue or Background Info

- Stems from https://prime-cdc.pagerduty.com/incidents/PXP11TY/timeline
- Admin create org endpoint was creating inactive orgs and active users (for orgs that are already verified)

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
