### PR TITLE
Add rest api logging for account signup requests

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/CurrentAccountRequestContextHolder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/CurrentAccountRequestContextHolder.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api;
 
+import gov.cdc.usds.simplereport.db.model.Organization;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,15 @@ import org.springframework.web.context.WebApplicationContext;
 @Scope(scopeName = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class CurrentAccountRequestContextHolder {
   private boolean _isAccountRequest = false;
+  private Organization _createdOrg;
+
+  public Organization getCreatedOrg() {
+    return _createdOrg;
+  }
+
+  public void setCreatedOrg(Organization _createdOrg) {
+    this._createdOrg = _createdOrg;
+  }
 
   public void setIsAccountRequest(boolean status) {
     this._isAccountRequest = status;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -34,6 +34,7 @@ import javax.annotation.PostConstruct;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,8 @@ public class AccountRequestController {
 
   /** Read the waitlist request and generate an email body, then send with the emailService */
   @PostMapping("/waitlist")
-  public void submitWaitlistRequest(@Valid @RequestBody WaitlistRequest body) throws IOException {
+  public void submitWaitlistRequest(
+      @Valid @RequestBody WaitlistRequest body, HttpServletRequest request) throws IOException {
     String subject = "New waitlist request";
     if (LOG.isInfoEnabled()) {
       LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
@@ -98,7 +100,8 @@ public class AccountRequestController {
    */
   @PostMapping("")
   @Transactional(readOnly = false)
-  public void submitAccountRequest(@Valid @RequestBody AccountRequest body) throws IOException {
+  public void submitAccountRequest(
+      @Valid @RequestBody AccountRequest body, HttpServletRequest request) throws IOException {
     String subject = "New account request";
     if (LOG.isInfoEnabled()) {
       LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(body));


### PR DESCRIPTION
## Related Issue or Background Info

- As discussed in the engineering sync, we aren't logging account signup API requests

## Changes Proposed

- Add @PostAuthorize to the AccountRequestController
- Extend logging in RestAuditLogManager
- Add Organization to the CurrentAccountRequestContextHolder

### Notes

I haven't actually tested this at all, just cobbled it together while the thought was in my brain and put it up for review so we didn't lose it 😬 

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
