### PR TITLE
Fix Okta Terraform provider source

### DIFF
--- a/ops/demo/persistent/_config.tf
+++ b/ops/demo/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/dev/persistent/_config.tf
+++ b/ops/dev/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/global/_config.tf
+++ b/ops/global/_config.tf
@@ -11,7 +11,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
     pagerduty = {
       source = "pagerduty/pagerduty"

--- a/ops/pentest/persistent/_config.tf
+++ b/ops/pentest/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/prod/persistent/_config.tf
+++ b/ops/prod/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/services/okta-app/versions.tf
+++ b/ops/services/okta-app/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/services/okta-global/versions.tf
+++ b/ops/services/okta-global/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/stg/persistent/_config.tf
+++ b/ops/stg/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/test/persistent/_config.tf
+++ b/ops/test/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"

--- a/ops/training/persistent/_config.tf
+++ b/ops/training/persistent/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~>2.0"
     }
     okta = {
-      source = "oktadeveloper/okta"
+      source = "okta/okta"
     }
   }
   required_version = ">= 0.15.1"


### PR DESCRIPTION
## Related Issue or Background Info
See: https://github.com/okta/terraform-provider-okta/issues/480

We don't comprehensively manage our TF provider versioning and so we're susceptible to bad upstream changes like the one in the linked issue.

## Changes Proposed

The Okta provider team changed the `source` to `okta/okta` while addressing the above issue. We're fine to just change the source and move on - this will keep our current functionality of remaining unpinned. #1692 was added to address this issue longterm.

### Testing
- [x] This should test itself by passing the `check-terraform-validate` check
