### PR TITLE
Terraform rewrite rules

### DIFF
--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -253,7 +253,22 @@ resource "azurerm_application_gateway" "load_balancer" {
         reroute = true
       }
     }
+    rewrite_rule {
+      name          = "registration-link"
+      rule_sequence = 102
 
+      condition {
+        ignore_case = true
+        pattern     = "^/register/"
+        variable    = "var_uri_path"
+      }
+
+      url {
+        path    = "/app"
+        query_string = null
+        reroute = true
+      }
+    }
     rewrite_rule {
       name          = "HSTS"
       rule_sequence = 101

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -232,8 +232,8 @@ resource "azurerm_application_gateway" "load_balancer" {
       }
 
       url {
-        path         = "/{var_uri_path_1}"
-        reroute      = false
+        path    = "/{var_uri_path_1}"
+        reroute = false
         # Per documentation, we should be able to leave this pass-through out. See however
         # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
         query_string = "{var_query_string}"
@@ -252,7 +252,7 @@ resource "azurerm_application_gateway" "load_balancer" {
       }
 
       url {
-        path         = "/app"
+        path = "/app"
         # This is probably excessive, but it was happening anyway: see
         # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
         query_string = ""
@@ -270,7 +270,7 @@ resource "azurerm_application_gateway" "load_balancer" {
       }
 
       url {
-        path         = "/app"
+        path = "/app"
         # This is probably excessive, but it was happening anyway: see
         # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
         query_string = ""

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -234,6 +234,8 @@ resource "azurerm_application_gateway" "load_balancer" {
       url {
         path         = "/{var_uri_path_1}"
         reroute      = false
+        # Per documentation, we should be able to leave this pass-through out. See however
+        # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
         query_string = "{var_query_string}"
       }
     }
@@ -251,7 +253,9 @@ resource "azurerm_application_gateway" "load_balancer" {
 
       url {
         path         = "/app"
-        query_string = "{var_query_string}"
+        # This is probably excessive, but it was happening anyway: see
+        # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
+        query_string = ""
         reroute      = true
       }
     }
@@ -267,7 +271,9 @@ resource "azurerm_application_gateway" "load_balancer" {
 
       url {
         path         = "/app"
-        query_string = "{var_query_string}"
+        # This is probably excessive, but it was happening anyway: see
+        # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
+        query_string = ""
         reroute      = true
       }
     }

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -232,8 +232,9 @@ resource "azurerm_application_gateway" "load_balancer" {
       }
 
       url {
-        path    = "/{var_uri_path_1}"
-        reroute = false
+        path         = "/{var_uri_path_1}"
+        reroute      = false
+        query_string = "{var_query_string}"
       }
     }
 
@@ -249,8 +250,9 @@ resource "azurerm_application_gateway" "load_balancer" {
       }
 
       url {
-        path    = "/app"
-        reroute = true
+        path         = "/app"
+        query_string = "{var_query_string}"
+        reroute      = true
       }
     }
     rewrite_rule {
@@ -264,9 +266,9 @@ resource "azurerm_application_gateway" "load_balancer" {
       }
 
       url {
-        path    = "/app"
-        query_string = null
-        reroute = true
+        path         = "/app"
+        query_string = "{var_query_string}"
+        reroute      = true
       }
     }
     rewrite_rule {


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #1655

## Changes Proposed

- remove lifecycle-ignore notation for url map, rewrite rules and identity from the app_gateway resource
- add self-register link-shortening rule
- work around terraform-providers/terraform-provider-azurerm#11563

### Review highlights

* most of this is just uncommenting code that was written against a version of the provider that didn't support everything we needed
* the rest is just version-control for what we already do by hand
* accordingly, substantive changes should be a follow-up issue

## Additional Information

- support for rewrite_rule blocks was added recently and still has some... quirks
- the provider has a quirk in which it continually says it has to replace the request_routing_rule blocks, but the replacement is the same as the original. This is annoying but appears harmless. 
- we should dispose of the need for API rewrites by moving to host-based dispatch for the API (and possibly the app?), as previously requested in #1016

## Checklist for Author and Reviewer

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- the removal of query strings from the blobstore side seems at worst harmless

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification

# Manual Release Sequence

- [x] test
- [x] dev
- [x] demo
- [x] training
- [x] pentest
- [x] stg
- [ ] prod