### PR TITLE
Fixing CSP connect-src rule.

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,7 @@
             %REACT_APP_CONTENT_SECURITY_POLICY_SCRIPT_SRC%
             style-src 'self' 'unsafe-inline';
             img-src 'self' data:;
-            connect-src 'self'  https://us-street.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track %REACT_APP_BACKEND_URL%;
+            connect-src 'self'  https://us-street.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track %REACT_APP_BACKEND_URL%/ ;
         ">
         <% } %>
     <meta charset="utf-8" />


### PR DESCRIPTION
Very slightly modified the default content security policy configuration so that it actually behaves as expected.

## Related Issue or Background Info

- #1699 points out that the API is not callable from the client app if the app is on `www.simplereport.gov` rather than `simplereport.gov`. This is despite the fact that https://simplereport.gov/api (the base URL for the API in production) is in the connect-src rule in the content security policy. After some experimentation, we determined that for something to be treated as a directory root rather than a single allowed path, it must terminate with a directory separator, so that (in many fewer keystrokes than this paragraph) is what this pull request does.

## Changes Proposed

- add a '/' to the end of the CSP connect-src rule.
- that's the tweet

## Additional information

It was difficult to test in `test` because of our Akamai configuration (doubtless it was possible if I tried hard enough; I just used `dev` instead).

## Screenshots / Demos

Proof of concept can currently be found (until we delete the CORS configuration by redeploying from `main`) at https://20.62.136.248/register/org-registration-link .

## Checklist for Author and Reviewer

### Testing
- N/A Includes a summary of what a code reviewer should verify

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
