### PR TITLE
Fix site background so it's full height

### DIFF
--- a/frontend/src/scss/AppLayout.scss
+++ b/frontend/src/scss/AppLayout.scss
@@ -12,7 +12,7 @@ body,
 .main-wrapper {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  min-height: 100vh;
 }
 
 main {


### PR DESCRIPTION
Ensure the gray background extends the full height of the page.

## Before
<img width="871" alt="Screen Shot 2021-05-25 at 4 51 45 PM" src="https://user-images.githubusercontent.com/5249443/119582589-a1e89980-bd79-11eb-8d74-abc18276c8c2.png">


## After
<img width="859" alt="Screen Shot 2021-05-25 at 4 52 20 PM" src="https://user-images.githubusercontent.com/5249443/119582578-9f863f80-bd79-11eb-8756-3606de68f50b.png">

