### PR TITLE
Add check to fix coverity scan on UserAccountCreationController

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -54,6 +54,9 @@ public class UserAccountCreationController {
             requestBody.getActivationToken(),
             request.getHeader("X-Forwarded-For"),
             request.getHeader("User-Agent"));
+    if (userId.isEmpty()) {
+      throw new OktaAuthenticationFailureException("Returned user id is empty.");
+    }
     request.getSession().setAttribute(USER_ID_KEY, userId);
     _oktaAuth.setPassword(userId, requestBody.getPassword().toCharArray());
   }


### PR DESCRIPTION
## Related Issue or Background Info

https://scan6.coverity.com/reports.htm#v51205/p11394/fileInstanceId=117564154&defectInstanceId=32436977&mergedDefectId=1453271

This PR adds a small check to ensure that the user id is present before adding it to the session. 
