### PR TITLE
Release to staging on pre-release instead of cron.

### DIFF
--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -1,9 +1,9 @@
 name: Deploy Stg
 
 on:
-  schedule:
-    - cron: '0 9 * * *' # Daily at 09:00 UTC
   workflow_dispatch:
+  release:
+    types: [prereleased]
 
 env:
   DEPLOY_ENV: stg


### PR DESCRIPTION
Do a stg release when we publish a pre-release, rather than doing it in the middle of the night.

## Related Issue or Background Info

- #1632 

## Changes Proposed

- What it says on the tin
- change 2

## Additional information

This is hard to test without just doing it, but I tested the event behavior in a separate repository and absent remarkable gremlins this should just work.