### PR TITLE
Hotfix: prevent app insights useTrackEvent hook from crashing

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -188,10 +188,8 @@ const FacilityFormContainer: any = (props: Props) => {
   }
 
   const saveFacility = async (facility: Facility) => {
-    try {
+    if (appInsights) {
       trackSaveSettings(null);
-    } catch (e) {
-      console.log(e);
     }
     const provider = facility.orderingProvider;
     const saveFacility = props.facilityId ? updateFacility : addFacility;

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -174,12 +174,7 @@ const FacilityFormContainer: any = (props: Props) => {
   const appInsights = useAppInsightsContext();
   const [updateFacility] = useMutation(UPDATE_FACILITY_MUTATION);
   const [addFacility] = useMutation(ADD_FACILITY_MUTATION);
-  const trackSaveSettings = useTrackEvent(
-    appInsights,
-    "Save Settings",
-    null,
-    false
-  );
+  const trackSaveSettings = useTrackEvent(appInsights, "Save Settings", null);
 
   if (loading) {
     return <p> Loading... </p>;

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -193,8 +193,10 @@ const FacilityFormContainer: any = (props: Props) => {
   }
 
   const saveFacility = async (facility: Facility) => {
-    if (appInsights) {
+    try {
       trackSaveSettings(null);
+    } catch (e) {
+      console.log(e);
     }
     const provider = facility.orderingProvider;
     const saveFacility = props.facilityId ? updateFacility : addFacility;

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -58,10 +58,8 @@ const ManageOrganizationContainer: any = () => {
   }
 
   const onSave = (name: string) => {
-    try {
+    if (appInsights) {
       trackSaveSettings(null);
-    } catch (e) {
-      console.log(e);
     }
     setOrganization({
       variables: {

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -43,8 +43,7 @@ const ManageOrganizationContainer: any = () => {
   const trackSaveSettings = useTrackEvent(
     appInsights,
     "Save Organization",
-    null,
-    false
+    null
   );
 
   if (loading) {

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -59,8 +59,10 @@ const ManageOrganizationContainer: any = () => {
   }
 
   const onSave = (name: string) => {
-    if (appInsights) {
+    try {
       trackSaveSettings(null);
+    } catch (e) {
+      console.log(e);
     }
     setOrganization({
       variables: {

--- a/frontend/src/app/admin/Organization/OrganizationFormContainer.tsx
+++ b/frontend/src/app/admin/Organization/OrganizationFormContainer.tsx
@@ -128,9 +128,12 @@ const OrganizationFormContainer: any = (props: Props) => {
     facility: Facility,
     admin: FacilityAdmin
   ) => {
-    if (appInsights) {
+    try {
       trackSaveSettings(null);
+    } catch (err) {
+      console.log(err);
     }
+
     const provider = facility.orderingProvider;
     createOrganization({
       variables: {

--- a/frontend/src/app/admin/Organization/OrganizationFormContainer.tsx
+++ b/frontend/src/app/admin/Organization/OrganizationFormContainer.tsx
@@ -123,12 +123,9 @@ const OrganizationFormContainer: any = (props: Props) => {
     facility: Facility,
     admin: FacilityAdmin
   ) => {
-    try {
+    if (appInsights) {
       trackSaveSettings(null);
-    } catch (err) {
-      console.log(err);
     }
-
     const provider = facility.orderingProvider;
     createOrganization({
       variables: {

--- a/frontend/src/app/admin/Organization/OrganizationFormContainer.tsx
+++ b/frontend/src/app/admin/Organization/OrganizationFormContainer.tsx
@@ -105,12 +105,7 @@ const OrganizationFormContainer: any = (props: Props) => {
   );
   const appInsights = useAppInsightsContext();
   const [createOrganization] = useMutation(CREATE_ORGANIZATION_MUTATION);
-  const trackSaveSettings = useTrackEvent(
-    appInsights,
-    "Save Settings",
-    null,
-    false
-  );
+  const trackSaveSettings = useTrackEvent(appInsights, "Save Settings", null);
 
   if (loading) {
     return <p> Loading... </p>;

--- a/frontend/src/app/commonComponents/QueryWrapper.tsx
+++ b/frontend/src/app/commonComponents/QueryWrapper.tsx
@@ -37,6 +37,15 @@ export function QueryWrapper<ComponentProps>({
 }): React.ReactElement {
   const appInsights = useAppInsightsContext();
   const trackAction = useTrackEvent(appInsights, "User Action", {});
+
+  const safeTrackAction = (action: any) => {
+    try {
+      trackAction(action);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
   const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
     query,
     {
@@ -56,7 +65,7 @@ export function QueryWrapper<ComponentProps>({
   };
   const props = ({
     ...componentProps,
-    trackAction,
+    trackAction: safeTrackAction,
     data,
     loading,
     refetch: passOnRefetch,

--- a/frontend/src/app/commonComponents/QueryWrapper.tsx
+++ b/frontend/src/app/commonComponents/QueryWrapper.tsx
@@ -37,15 +37,6 @@ export function QueryWrapper<ComponentProps>({
 }): React.ReactElement {
   const appInsights = useAppInsightsContext();
   const trackAction = useTrackEvent(appInsights, "User Action", {});
-
-  const safeTrackAction = (action: any) => {
-    try {
-      trackAction(action);
-    } catch (err) {
-      console.log(err);
-    }
-  };
-
   const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
     query,
     {
@@ -65,7 +56,7 @@ export function QueryWrapper<ComponentProps>({
   };
   const props = ({
     ...componentProps,
-    trackAction: safeTrackAction,
+    trackAction,
     data,
     loading,
     refetch: passOnRefetch,


### PR DESCRIPTION
## Related Issue or Background Info

- Hotfix for organization and facility screens crashing

## Changes Proposed

- Wraps several instances of `useTrackEvent` in try/catch blocks until we can figure out what's going on

## Checklist for Author and Reviewer

### UI
- [N/A] Any changes to the UI/UX are approved by design 
- [N/A] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [N/A] Database changes are submitted as a separate PR
  - [N/A] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [N/A] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [N/A] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [N/A] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [N/A] Any dependencies introduced have been vetted and discussed

## Cloud
- [N/A] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
