### PR TITLE
Hotfix: Fix the date format at the source

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/PriorTestInputs.tsx
+++ b/frontend/src/app/testQueue/AoEForm/PriorTestInputs.tsx
@@ -66,7 +66,12 @@ const PriorTestInputs: React.FC<Props> = ({
         minDate="2020-02-01"
         maxDate={new Date().toISOString().split("T")[0]}
         disabled={!lastTestDateKnown}
-        onChange={setPriorTestDate}
+        onChange={(date) => {
+          const formattedDate = date
+            ? moment(date).format("YYYY-MM-DD")
+            : undefined;
+          setPriorTestDate(formattedDate);
+        }}
       />
       <Checkboxes
         legend="Date of most recent test unknown?"

--- a/frontend/src/app/testQueue/AoEForm/SymptomInputs.tsx
+++ b/frontend/src/app/testQueue/AoEForm/SymptomInputs.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DatePicker, Label } from "@trussworks/react-uswds";
+import moment from "moment";
 
 import { globalSymptomDefinitions } from "../../../patientApp/timeOfTest/constants";
 import Checkboxes from "../../commonComponents/Checkboxes";
@@ -88,9 +89,11 @@ const SymptomInputs: React.FC<Props> = ({
             minDate="2020-02-01"
             maxDate={new Date().toISOString().split("T")[0]}
             onChange={(date) => {
-              if (date) {
-                setOnsetDate(date);
+              if (!date) {
+                return;
               }
+              const formattedDate = moment(date).format("YYYY-MM-DD");
+              setOnsetDate(formattedDate);
             }}
             required={Object.keys(currentSymptoms).some(
               (key) => currentSymptoms[key]


### PR DESCRIPTION
## Related Issue or Background Info

- There was still a failing frontend codepath for the new DatePicker
    - We fixed date entry on the Queue item card, but not during initial test creation

## Changes Proposed

- This change fixes date entry where `<Datepicker />` is used rather than the various handlers up the React tree

## Checklist for Author and Reviewer

### UI
- [N/A] Any changes to the UI/UX are approved by design 
- [N/A] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [N/A] Database changes are submitted as a separate PR
  - [N/A] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [N/A] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [N/A] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [N/A] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [N/A] Any dependencies introduced have been vetted and discussed

## Cloud
- [N/A] DevOps team has been notified if PR requires ops support
- [N/A] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
