### PR TITLE
Fix leading-zeroes Date Parse issue & add tests

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarType.java
@@ -11,63 +11,62 @@ import java.time.format.DateTimeFormatter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
-public class FlexibleDateScalarType {
+class FlexibleDateCoercion implements Coercing<Object, Object> {
   private static final DateTimeFormatter US_DASHDATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
   private static final DateTimeFormatter US_SLASHDATE_FORMATTER =
-      DateTimeFormatter.ofPattern("MM/dd/yyyy");
+      DateTimeFormatter.ofPattern("M/d/yyyy");
 
+  LocalDate convertImpl(Object input) {
+    if (input instanceof String) {
+      if (((String) input).contains("/")) {
+        return LocalDate.parse((String) input, US_SLASHDATE_FORMATTER);
+      } else if (((String) input).contains("-")) {
+        return LocalDate.parse((String) input, US_DASHDATE_FORMATTER);
+      }
+    } else if (input instanceof LocalDate) {
+      return (LocalDate) input;
+    }
+    return null;
+  }
+
+  @Override
+  public Object serialize(Object dataFetcherResult) {
+    LocalDate result = convertImpl(dataFetcherResult);
+    if (result == null) {
+      throw new CoercingSerializeException("Unable to serialize null value");
+    }
+    return result.format(US_DASHDATE_FORMATTER);
+  }
+
+  @Override
+  public Object parseValue(Object input) {
+    LocalDate result = convertImpl(input);
+    if (result == null) {
+      throw new CoercingParseValueException("Invalid value '" + input + "' for LocalDate");
+    }
+    return result;
+  }
+
+  @Override
+  public Object parseLiteral(Object input) {
+    String value = ((StringValue) input).getValue();
+    LocalDate result = convertImpl(value);
+    if (result == null) {
+      throw new CoercingParseLiteralException("Invalid value '" + input + "' for LocalDate");
+    }
+
+    return result;
+  }
+}
+
+@Configuration
+public class FlexibleDateScalarType {
   @Bean
   public GraphQLScalarType FlexibleDateScalar() {
     return GraphQLScalarType.newScalar()
         .name("LocalDate")
         .description("a scalar for multiple date formats. currently yyyy-MM-dd and MM/dd/yyyy")
-        .coercing(
-            new Coercing() {
-              private LocalDate convertImpl(Object input) {
-                if (input instanceof String) {
-                  if (((String) input).contains("/")) {
-                    return LocalDate.parse((String) input, US_SLASHDATE_FORMATTER);
-                  } else if (((String) input).contains("-")) {
-                    return LocalDate.parse((String) input, US_DASHDATE_FORMATTER);
-                  }
-                } else if (input instanceof LocalDate) {
-                  return (LocalDate) input;
-                }
-                return null;
-              }
-
-              @Override
-              public Object serialize(Object dataFetcherResult) {
-                LocalDate result = convertImpl(dataFetcherResult);
-                if (result == null) {
-                  throw new CoercingSerializeException("Unable to serialize null value");
-                }
-                return result.format(US_DASHDATE_FORMATTER);
-              }
-
-              @Override
-              public Object parseValue(Object input) {
-                LocalDate result = convertImpl(input);
-                if (result == null) {
-                  throw new CoercingParseValueException(
-                      "Invalid value '" + input + "' for LocalDate");
-                }
-                return result;
-              }
-
-              @Override
-              public Object parseLiteral(Object input) {
-                String value = ((StringValue) input).getValue();
-                LocalDate result = convertImpl(value);
-                if (result == null) {
-                  throw new CoercingParseLiteralException(
-                      "Invalid value '" + input + "' for LocalDate");
-                }
-
-                return result;
-              }
-            })
+        .coercing(new FlexibleDateCoercion())
         .build();
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarTypeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarTypeTest.java
@@ -1,0 +1,54 @@
+package gov.cdc.usds.simplereport.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.util.AssertionErrors.assertNull;
+
+import graphql.language.StringValue;
+import graphql.schema.CoercingParseValueException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import org.junit.jupiter.api.Test;
+
+public class FlexibleDateScalarTypeTest {
+  private final FlexibleDateCoercion converter = new FlexibleDateCoercion();
+
+  @Test
+  void convertImpl_succeeds() {
+    LocalDate y2k = LocalDate.parse("2000-01-01");
+    assertEquals(y2k, converter.convertImpl("2000-01-01"));
+    assertEquals(y2k, converter.convertImpl("01/01/2000"));
+  }
+
+  @Test
+  void convertImpl_slashFormatWorksWithoutLeadingZeros() {
+    LocalDate y2k = LocalDate.parse("2000-01-01");
+    assertEquals(y2k, converter.convertImpl("1/01/2000"));
+    assertEquals(y2k, converter.convertImpl("01/1/2000"));
+  }
+
+  @Test
+  void convertImpl_returnsNullOnNoSeparators() {
+    assertNull(null, converter.convertImpl("20000101"));
+  }
+
+  @Test
+  void parseLiteral_succeeds() {
+    LocalDate y2k = LocalDate.parse("2000-01-01");
+    assertEquals(y2k, converter.parseLiteral(new StringValue("2000-01-01")));
+    assertEquals(y2k, converter.parseLiteral(new StringValue("01/01/2000")));
+  }
+
+  @Test
+  void parseValue_succeeds() {
+    LocalDate y2k = LocalDate.parse("2000-01-01");
+    assertEquals(y2k, converter.parseValue("2000-01-01"));
+    assertEquals(y2k, converter.parseValue("01/01/2000"));
+  }
+
+  @Test
+  void parseValue_exceptions() {
+    assertThrows(CoercingParseValueException.class, () -> converter.parseValue("20000101"));
+    assertThrows(DateTimeParseException.class, () -> converter.parseValue("2000-0101"));
+  }
+}


### PR DESCRIPTION
## Changes Proposed

- Adjusts the parse string to be flexible about leading zeroes
- Adds some tests

## Additional Information

- Prod incidents are exciting 🚨 

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
