### PR TITLE
Fix register birthDate format

### DIFF
--- a/frontend/src/app/Settings/types.d.ts
+++ b/frontend/src/app/Settings/types.d.ts
@@ -1,5 +1,7 @@
 type Nullable<T> = { [P in keyof T]: T[P] | null };
 
+type ISODate = `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
+
 interface Address {
   street: string;
   streetTwo: string | null;

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -37,6 +37,7 @@ export type SelfRegistrationData = Omit<
   UpdatePatientData,
   "facilityId" | "address"
 > & {
+  birthDate: ISODate;
   registrationLink: string;
   address: Omit<UpdatePatientData["address"], "zipCode"> & {
     postalCode: string | null;

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useParams } from "react-router";
 import { toast, ToastContainer } from "react-toastify";
+import moment from "moment";
 import "react-toastify/dist/ReactToastify.css";
 
 import USAGovBanner from "../../app/commonComponents/USAGovBanner";
@@ -35,11 +36,17 @@ export const SelfRegistration = () => {
       county,
       zipCode,
       facilityId,
+      birthDate,
       ...withoutAddress
     } = person;
 
+    const formattedBirthDate = moment(birthDate).format(
+      "YYYY-MM-DD"
+    ) as ISODate;
+
     const data: SelfRegistrationData = {
       registrationLink,
+      birthDate: formattedBirthDate,
       ...withoutAddress,
       address: {
         street: [street, streetTwo],


### PR DESCRIPTION
## Related Issue or Background Info

- There are status code 400 errors on the patient self-registration site
- It turns out that we were relying on the formatting provided by native `"date"` input types, but these input types aren't supported in all browsers (e.g., Safari). Therefore, seemingly random date failures appear to be due by browsers that don't support the date input.

The failure can be replicated in any environment using Safari desktop whereas Chome desktop succeeds.

## Changes Proposed

- Uses moment.js to ensure format of dates sent to the api are `YYYY-MM-DD`

## Checklist for Author and Reviewer

### UI
- [N/A] Any changes to the UI/UX are approved by design 
- [N/A] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [N/A] Database changes are submitted as a separate PR
  - [N/A] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [N/A] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [N/A] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [N/A] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [N/A] Any dependencies introduced have been vetted and discussed

## Cloud
- [N/A] DevOps team has been notified if PR requires ops support
- [N/A] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
