### PR TITLE
HotFix: Empty string can be sent to backend via new datepicker 

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarType.java
@@ -40,6 +40,9 @@ class FlexibleDateCoercion implements Coercing<Object, Object> {
 
   @Override
   public Object parseValue(Object input) {
+    if (((String) input).length() == 0) {
+      return null;
+    }
     LocalDate result = convertImpl(input);
     if (result == null) {
       throw new CoercingParseValueException("Invalid value '" + input + "' for LocalDate");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarTypeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarTypeTest.java
@@ -44,6 +44,7 @@ public class FlexibleDateScalarTypeTest {
     LocalDate y2k = LocalDate.parse("2000-01-01");
     assertEquals(y2k, converter.parseValue("2000-01-01"));
     assertEquals(y2k, converter.parseValue("01/01/2000"));
+    assertEquals(null, converter.parseValue(""));
   }
 
   @Test


### PR DESCRIPTION
## Related Issue or Background Info

- Add a test to the queue. for the prior test date input. select a date with the picker then click the input and remove the date. `''` is sent to the backend raising a `CoercingParseValueException`

so far this has only happened once in production https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%2C%22ResourceGroup%22%3A%22prime-simple-report-prod%22%2C%22Name%22%3A%22prime-simple-report-prod-insights%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F7d1e3999-6577-4cd5-b296-f518e5c8e677%252FresourceGroups%252Fprime-simple-report-prod%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fprime-simple-report-prod-insights%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%223d041bf5-bf15-11eb-af69-59293e3d0461%22%2C%22timestamp%22%3A%222021-05-27T17%3A58%3A36.581Z%22%2C%22cacheId%22%3A%2211d293f0-6b7a-4d41-908f-f43c25578e9c%22%2C%22eventTable%22%3A%22requests%22%7D

## Changes Proposed

- convert empty string to `null` in the flexible date scalar

## Additional Information

- Tested manually with the frontend and added a unit test

## Screenshots / Demos
![Screen Shot 2021-05-28 at 9 54 50 AM](https://user-images.githubusercontent.com/53869143/119994645-c8394f80-bf9a-11eb-8bba-69287aa694f2.png)

## Checklist for Author and Reviewer

### UI
- [N/A] Any changes to the UI/UX are approved by design 
- [N/A] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [N/A] Database changes are submitted as a separate PR
  - [N/A] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [N/A] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [N/A] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [N/A] Any dependencies introduced have been vetted and discussed

## Cloud
- [N/A] DevOps team has been notified if PR requires ops support
- [N/A] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
