### PR TITLE
Drop person.telephone

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2154,3 +2154,13 @@ databaseChangeLog:
                   replaceIfExists: true
                   fullDefinition: false
                   selectQuery: SELECT internal_id, created_at, updated_at, last_seen, is_deleted FROM ${database.defaultSchemaName}.api_user
+  - changeSet:
+      id: drop-person-phone
+      author: adam@skylight.digital
+      comment: Drop person.telephone, which is now off-row in the phone_number table. See also person.primary_phone_internal_id
+      changes:
+        - dropColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: telephone


### PR DESCRIPTION
## Related Issue or Background Info

- Telephone moved off-row in #1532. This is the second half of that migration

## Changes Proposed

- Drop `person.telephone`

## Additional Information

- `Person.getTelephone()` now refers to the `phone_number` entity referenced by `person.primary_phone_number_internal_id`

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
