### PR TITLE
Fix Person serialization on TestEvent

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -178,6 +178,10 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
     facility = f;
   }
 
+  public PhoneNumber getPrimaryPhone() {
+    return this.primaryPhone;
+  }
+
   public void setPrimaryPhone(PhoneNumber phoneNumber) {
     this.primaryPhone = phoneNumber;
   }
@@ -215,10 +219,7 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
   }
 
   public String getTelephone() {
-    if (primaryPhone == null) {
-      return "";
-    }
-    return primaryPhone.getNumber();
+    return this.getPrimaryPhone().getNumber();
   }
 
   public List<PhoneNumber> getPhoneNumbers() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import java.io.IOException;
 import java.time.LocalDate;
@@ -123,6 +124,8 @@ class PersonSerializationTest {
             "Male-ish",
             true,
             false);
+    PhoneNumber pn = new PhoneNumber(PhoneType.LANDLINE, "5555555555");
+    p.setPrimaryPhone(pn);
     return p;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -5,13 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.model.Facility;
-import gov.cdc.usds.simplereport.db.model.Organization;
-import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.model.TestEvent;
-import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.*;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.time.LocalDate;
@@ -26,6 +22,7 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private TestOrderRepository _repo;
   @Autowired private PersonRepository _personRepo;
+  @Autowired private PhoneNumberRepository _phoneRepo;
   @Autowired private OrganizationRepository _orgRepo;
   @Autowired private TestEventRepository _events;
   @Autowired private TestDataFactory _dataFactory;
@@ -55,6 +52,11 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
                 "",
                 false,
                 false));
+    PhoneNumber pn = new PhoneNumber(PhoneType.LANDLINE, "5555555555");
+    pn.setPerson(hoya);
+    _phoneRepo.save(pn);
+    hoya.setPrimaryPhone(pn);
+    hoya = _personRepo.save(hoya);
     TestOrder order = _repo.save(new TestOrder(hoya, site));
     List<TestOrder> queue = _repo.fetchQueue(gwu, otherSite);
     assertEquals(0, queue.size());
@@ -92,6 +94,11 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
                 "",
                 false,
                 false));
+    PhoneNumber pn = new PhoneNumber(PhoneType.LANDLINE, "5555555555");
+    pn.setPerson(hoya);
+    _phoneRepo.save(pn);
+    hoya.setPrimaryPhone(pn);
+    hoya = _personRepo.save(hoya);
     Facility site = _dataFactory.createValidFacility(gtown);
     TestOrder order = _repo.save(new TestOrder(hoya, site));
     assertNotNull(order);


### PR DESCRIPTION
This adds an explicit getter for primaryPhone, to ensure that Hibernate
fetches the entity. It also removes the null check and "" return in getTelephone,
because that method *should* blow up if there is no phone number

## Additional Information

- TestEvents serialized and sent to ReportStream all have `""` telephones right now.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
