### PR TITLE
[WIP] Simple preloader

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -22,6 +22,7 @@ import WithFacility from "./facilitySelect/WithFacility";
 import { appPermissions } from "./permissions";
 import Settings from "./Settings/Settings";
 import { getAppInsights } from "./TelemetryService";
+import Loading from "./commonComponents/Loading";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -82,7 +83,7 @@ const App = () => {
   }, [data]);
 
   if (loading) {
-    return <p>Loading account information...</p>;
+    return <Loading message="Loading account information..." />;
   }
 
   if (error) {

--- a/frontend/src/app/commonComponents/Loading/Loading.scss
+++ b/frontend/src/app/commonComponents/Loading/Loading.scss
@@ -1,0 +1,33 @@
+.logo-container {
+  text-align: center;
+
+  &__image {
+    border-radius: 100%;
+    box-shadow: 0 0 0 0 rgba(52, 172, 224, 1);
+    animation: pulse 2s infinite;
+    margin-bottom: 1rem;
+    max-width: 80px;
+    max-height: 80px;
+  }
+
+  &__message {
+    font-weight: 700;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(52, 172, 224, 0.7);
+  }
+
+  70% {
+    transform: scale(1);
+    box-shadow: 0 0 0 10px rgba(52, 172, 224, 0);
+  }
+
+  100% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(52, 172, 224, 0);
+  }
+}

--- a/frontend/src/app/commonComponents/Loading/Loading.stories.tsx
+++ b/frontend/src/app/commonComponents/Loading/Loading.stories.tsx
@@ -1,0 +1,14 @@
+import { Story, Meta } from "@storybook/react";
+
+import Loading from "./index";
+
+export default {
+  title: "Components/Loading",
+  component: Loading,
+  argTypes: {},
+} as Meta;
+
+const Template: Story = (args) => <Loading {...args} />;
+
+export const Default = Template.bind({});
+Default.args = { message: "Loading" };

--- a/frontend/src/app/commonComponents/Loading/index.tsx
+++ b/frontend/src/app/commonComponents/Loading/index.tsx
@@ -1,0 +1,20 @@
+import { FC } from "react";
+import cls from "classnames";
+
+import { ReactComponent as LogoMark } from "../../../img/simplereport-logomark-color.svg";
+
+import "./Loading.scss";
+
+interface Props {
+  message?: string | undefined;
+  className?: string;
+}
+
+const Loading: FC<Props> = ({ message, className }) => (
+  <div className={cls(className, "logo-container flex-align-center padding-5")}>
+    <LogoMark className="logo-container__image" />
+    <div className="logo-container__message">{message}</div>
+  </div>
+);
+
+export default Loading;

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import { showError } from "../utils";
+import Loading from "../commonComponents/Loading";
 
 import AddToQueueSearch from "./addToQueue/AddToQueueSearch";
 import QueueItem from "./QueueItem";
@@ -143,7 +144,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     throw error;
   }
   if (loading) {
-    return <p>Loading patients...</p>;
+    return <Loading message="Loading patients..." />;
   }
 
   const facility = data.organization.testingFacility.find(


### PR DESCRIPTION
## Changes Proposed

We don't have any pretty loader for a now on the FE side, just text variants when data loading.
So I created a simple component with SimpleReport logo within, added it to the Storybook and to the few places you can see it on the Demo. 

## Screenshots / Demos

https://user-images.githubusercontent.com/7571965/120332374-5b55ea80-c2f7-11eb-95a8-35051052db96.mov


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 
