### PR TITLE
Add WebAuthn code for security keys 

### DIFF
--- a/frontend/src/app/accountCreation/AccountCreationApiService.ts
+++ b/frontend/src/app/accountCreation/AccountCreationApiService.ts
@@ -23,7 +23,11 @@ const request = (path: string, body: any): Promise<any> => {
     if (!res.ok) {
       throw res;
     }
-    return "success";
+    try {
+      return res.json();
+    } catch {
+      return "success";
+    }
   });
 };
 
@@ -52,6 +56,14 @@ export class AccountCreationApi {
 
   static enrollEmailMfa(email: string) {
     return request("/enroll-email-mfa", { userInput: email });
+  }
+
+  static enrollSecurityKeyMfa() {
+    return request("/enroll-security-key-mfa", null);
+  }
+
+  static activateSecurityKeyMfa(attestation: string, clientData: string) {
+    return request("/activate-security-key-mfa", { attestation, clientData });
   }
 
   static verifyActivationPasscode(code: string) {

--- a/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.stories.tsx
+++ b/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.stories.tsx
@@ -6,9 +6,44 @@ export default {
   title: "App/Account set up/Step 3a: Security key",
   component: MfaSecurityKey,
   argTypes: {},
+  args: {
+    location: {
+      state: {
+        activation: {
+          attestation: "direct",
+          authenticatorSelection: {
+            userVerification: "preferred",
+            requireResidentKey: false,
+          },
+          challenge: "cdsZ1V10E0BGE4GcG3IK",
+          excludeCredentials: [],
+          pubKeyCredParams: [
+            {
+              type: "public-key",
+              alg: -7,
+            },
+            {
+              type: "public-key",
+              alg: -257,
+            },
+          ],
+          rp: {
+            name: "Rain-Cloud59",
+          },
+          user: {
+            displayName: "Bob Tester",
+            name: "bob.tester@gmail.com",
+            id: "00u15s1KDETTQMQYABRL",
+          },
+        },
+      },
+    },
+  },
 } as Meta;
 
-const Template: Story = (args) => <MfaSecurityKey {...args} />;
+type Props = React.ComponentProps<typeof MfaSecurityKey>;
+
+const Template: Story<Props> = (args) => <MfaSecurityKey {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
@@ -7,6 +7,7 @@ import Button from "../../commonComponents/Button/Button";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import StepIndicator from "../../commonComponents/StepIndicator";
 import { accountCreationSteps } from "../../../config/constants";
+import { AccountCreationApi } from "../AccountCreationApiService";
 
 type MfaOptions = "SMS" | "Okta" | "Google" | "FIDO" | "Phone" | "Email" | "";
 
@@ -42,7 +43,11 @@ export const MfaSelect = () => {
       case "Google":
         return <Redirect to="/mfa-google-auth" />;
       case "FIDO":
-        return <Redirect to="/mfa-security-key" />;
+        const state = Promise.resolve(
+          AccountCreationApi.enrollSecurityKeyMfa()
+        );
+        return <Redirect to={{ pathname: "/mfa-security-key", state }} />;
+
       case "Phone":
         return <Redirect to="/mfa-phone" />;
       case "Email":

--- a/frontend/src/app/utils/text.ts
+++ b/frontend/src/app/utils/text.ts
@@ -42,3 +42,38 @@ export function toLowerStripWhitespace(s: string | null): string {
   }
   return s.toLocaleLowerCase().replace(/\s/g, "");
 }
+
+// From Okta: https://github.com/okta/okta-signin-widget/blob/master/src/util/CryptoUtil.js
+
+/**
+ * Converts any url safe characters in a base64 string to regular base64 characters
+ * @param str base64 string that might contain url safe characters
+ * @returns base64 formatted string
+ */
+export function base64UrlSafeToBase64(str: string) {
+  return str
+    .replace(new RegExp("_", "g"), "/")
+    .replace(new RegExp("-", "g"), "+");
+}
+
+/**
+ * Converts an ArrayBuffer object that contains binary data to base64 encoded string
+ * @param bin ArrayBuffer object
+ * @returns base64 encoded string
+ */
+export function binToStr(bin: ArrayBuffer) {
+  return btoa(
+    new Uint8Array(bin).reduce((s, byte) => s + String.fromCharCode(byte), "")
+  );
+}
+
+/**
+ * Converts base64 string to binary data view
+ * @param str in base64 or base64UrlSafe format
+ * @returns converted Uint8Array view of binary data
+ */
+export function strToBin(str: string) {
+  return Uint8Array.from(atob(base64UrlSafeToBase64(str)), (c) =>
+    c.charCodeAt(0)
+  );
+}


### PR DESCRIPTION
## Related Issue or Background Info

- Depends on #1675 
- Resolves #1663 

## Changes Proposed

- On `MfaSelect`, when the security key option is selected and submitted, send a request to the backend to enroll a security key, get an `activation` object in response
- On `MfaSecurityKey`, use WebAuthn to register a security key and get `attestation` and `clientData` to send to the backend for final activation

## Additional Information

- Okta docs for WebAuthn enroll response: https://developer.okta.com/docs/reference/api/factors/#enroll-webauthn-response-example
- Okta docs for WebAuthn activate request: https://developer.okta.com/docs/reference/api/factors/#activate-webauthn-factor

## Screenshots / Demos


https://user-images.githubusercontent.com/9121162/120399618-3e1e1d80-c2f1-11eb-8abd-bc21e2a93999.mp4



## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
