### PR TITLE
'U' -> 'UNK'

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -90,7 +90,7 @@ public class TestEventExport {
 
   private String boolToYesNoUnk(Boolean value) {
     if (value == null) {
-      return "U";
+      return "UNK";
     } else if (value) {
       return "Y";
     } else {


### PR DESCRIPTION
## Related Issue or Background Info

Warning returned for Report Stream. This is viewable on Metabase and @jimduff-usds notified us of the warnings from the latest code changes on their side
“Invalid code: ‘U’ does not match any codes for ‘Resident_congregate_setting’"


## Changes Proposed

- Update "U" -> "UNK"


## Additional Information

- This changes the unknown value for the following fields
  - `Employed_in_healthcare`
  - `Resident_congregate_setting` 
  - `First_test`
  - `Symptomatic_for_disease`

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [N/A] Any changes to the UI/UX are approved by design 
- [N/A] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [N/A] Database changes are submitted as a separate PR
  - [N/A] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [N/A] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [N/A] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [N/A] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [N/A] Any dependencies introduced have been vetted and discussed

## Cloud
- [N/A] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
