### PR TITLE
Harden deploy workflows against bad releases

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -48,11 +48,16 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct commit to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -50,11 +50,16 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct commit to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -48,11 +48,16 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct commit to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -47,11 +47,16 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct release to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-release
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -1,7 +1,6 @@
 name: Deploy Stg
 
 on:
-  workflow_dispatch:
   release:
     types: [prereleased]
 
@@ -48,11 +47,16 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct release to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-release
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -47,11 +47,16 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct commit to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -48,11 +48,18 @@ jobs:
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Azure deploy Api
         run: make deploy-${{ env.DEPLOY_ENV }}-api
-      - name: Wait for staging deploy to complete
-        timeout-minutes: 10
-        run: make wait-for-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct commit to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
       - name: Promote staging to production
         run: make promote-${{ env.DEPLOY_ENV }}
+      - name: Check for production app readiness
+        env:
+          CURL_TIMEOUT: 5 # 1 second seems to be too tight for the initial launch
+        run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ spring:
     jdbc:
         initialize-schema: never
         table-name: ${spring.jpa.properties.hibernate.default_schema}.spring_session
+management:
+  health.probes.enabled: true
 graphql:
   servlet:
     mapping: /graphql

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -5,12 +5,20 @@ SOURCE_SLOT?=staging
 TARGET_SLOT?=production
 DEPLOYED_COMMIT?=$(shell git show --abbrev=7 -s --pretty=%h)
 RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
+
+# Internal DRYing
 API_NAME=simple-report-api-$*
+INFO_ENDPOINT=https://$(API_NAME).azurewebsites.net/actuator/info
+SLOT_INFO_ENDPOINT=https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info
+CURL:=curl --silent --fail --max-time 1
+APP_READY=$(CURL) https://$(API_NAME).azurewebsites.net/actuator/health/readiness > /dev/null
+SLOT_READY=$(CURL) https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/health/readiness > /dev/null
 
 default:
 	@echo "Hello, SimpleReport operator!"
-	@echo "You can use 'make promote-ENV' to promote the staging slot of any environment, if you are logged in to azure"
+	@echo "You can use 'make promote-ENV' to promote the $(SOURCE_SLOT) slot of any environment, if you are logged in to azure"
 	@echo "You can also run 'make init-ENV' or 'make deploy-ENV-api' but those may not be as useful locally."
+	@echo "In addition, there are a variety of targets that start with 'check' or 'wait-for', which you should just look at."
 
 # Internal target: check if we are currently logged in, so we get a friendly error if not
 .be-logged-in:
@@ -39,23 +47,50 @@ deploy-%-api: .valid-env-% api.tfvars
 promote-%: .be-logged-in .valid-env-%
 	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
 
-wait-for-%: .valid-env-%
-	@echo "Starting wait for $(SOURCE_SLOT) slot of $* at `date`"
-	until  [[ "$(DEPLOYED_COMMIT)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info | jq -r .git.commit.id`" ]] ; do sleep 5; done;
+wait-for-%-slot-commit: .valid-env-%
+	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $(SOURCE_SLOT) slot of $* at `date`"
+	until  [[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(SLOT_INFO_ENDPOINT) | jq -r .git.commit.id`" ]] ; do sleep 5; done;
 	@echo "Finished waiting at `date`"
 
+wait-for-%-commit: .valid-env-%
+	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $* at `date`"
+	until  [[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(INFO_ENDPOINT) | jq -r .git.commit.id`" ]] ; do sleep 5; done;
+	@echo "Finished waiting at `date`"
+
+wait-for-%-slot-readiness: .valid-env-% # better use an external timeout for this!
+	@echo "Waiting for a successful readiness probe in $*/$(SOURCE_SLOT)"
+	until $(SLOT_READY); do sleep 5; done;
+
+wait-for-%-readiness: .valid-env-% # better use an external timeout for this!
+	@echo "Waiting for a successful readiness probe in $*"
+	until $(APP_READY); do sleep 5; done;
+
+check-%-slot-commit: .valid-env-%
+	@echo Checking that $(DEPLOYED_COMMIT) is the current deployed commit for $*/$(SOURCE_SLOT)
+	[[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(SLOT_INFO_ENDPOINT) | jq -r .git.commit.id`" ]]
+
 check-%-commit: .valid-env-%
-	@echo Checking that $(DEPLOYED_COMMIT) is the current deployed commit on $*
-	@[[ "$(DEPLOYED_COMMIT)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME).azurewebsites.net/actuator/info | jq -r .git.commit.id`" ]]
+	@echo Checking that $(DEPLOYED_COMMIT) is the current deployed commit for $*
+	[[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(INFO_ENDPOINT) | jq -r .git.commit.id`" ]]
+
+check-%-slot-release: .valid-env-%
+	@echo Checking that $(RELEASE_TAG) is the current release on $*/$(SOURCE_SLOT)
+	[[ "$(RELEASE_TAG)"  == "`$(CURL) $(SLOT_INFO_ENDPOINT) | jq -r .deploy.tag`" ]]
 
 check-%-release: .valid-env-%
 	@echo Checking that $(RELEASE_TAG) is the current release on $*
-	@[[ "$(RELEASE_TAG)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME).azurewebsites.net/actuator/info | jq -r .deploy.tag`" ]]
+	[[ "$(RELEASE_TAG)"  == "`$(CURL) $(INFO_ENDPOINT) | jq -r .deploy.tag`" ]]
 
 check-%-slot-readiness: .valid-env-%
 	@echo Checking the readiness probe for $*/$(SOURCE_SLOT)
-	@curl -sf -m1 https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/health/readiness > /dev/null
+	$(SLOT_READY)
 
 check-%-readiness: .valid-env-%
 	@echo Checking the readiness probe for $*
-	@curl -sf -m1 https://$(API_NAME).azurewebsites.net/actuator/health/readiness > /dev/null
+	$(APP_READY)
+
+# DEPRECATED: This is too greedy a match, replacing it
+wait-for-%: .valid-env-%
+	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $(SOURCE_SLOT) slot of $* at `date`"
+	until  [[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(SLOT_INFO_ENDPOINT) | jq -r .git.commit.id`" ]] ; do sleep 5; done;
+	@echo "Finished waiting at `date`"

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -4,6 +4,8 @@ SHELL:=/bin/bash # I gave up on being compatible with ye olde "sh"
 SOURCE_SLOT?=staging
 TARGET_SLOT?=production
 DEPLOYED_COMMIT?=$(shell git show --abbrev=7 -s --pretty=%h)
+RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
+API_NAME=simple-report-api-$*
 
 default:
 	@echo "Hello, SimpleReport operator!"
@@ -22,7 +24,7 @@ api.tfvars: /dev/null
 	echo "acr_image_tag=\"$(DEPLOYED_COMMIT)\"" > $@; \
 	echo "deploy_workflow=\"${GITHUB_WORKFLOW}\"" >> $@; \
 	if [[ "release" == "$(GITHUB_EVENT_NAME)" ]]; \
-		then echo "deploy_tag=\"$(subst refs/tags/,,$(GITHUB_REF))\"" >> $@;\
+		then echo "deploy_tag=\"$(RELEASE_TAG)\"" >> $@;\
 	fi; \
 	echo "deploy_runnumber=${GITHUB_RUN_NUMBER}" >> $@; \
 	echo "deploy_timestamp=\"$(shell date +%Y-%m-%dT%H:%M:%S%z) \"" >> $@; \
@@ -35,9 +37,17 @@ deploy-%-api: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars
 
 promote-%: .be-logged-in .valid-env-%
-	az webapp deployment slot swap -g prime-simple-report-$* -n simple-report-api-$* --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
+	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
 
 wait-for-%: .valid-env-%
 	@echo "Starting wait for $(SOURCE_SLOT) slot of $* at `date`"
-	until  [[ "$(DEPLOYED_COMMIT)"  == "`curl -s https://simple-report-api-$*-$(SOURCE_SLOT).azurewebsites.net/actuator/info | jq -r .git.commit.id`" ]] ; do sleep 5; done;
+	until  [[ "$(DEPLOYED_COMMIT)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info | jq -r .git.commit.id`" ]] ; do sleep 5; done;
 	@echo "Finished waiting at `date`"
+
+check-%-commit: .valid-env-%
+	@echo Checking that $(DEPLOYED_COMMIT) is the current deployed commit on $*
+	@[[ "$(DEPLOYED_COMMIT)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME).azurewebsites.net/actuator/info | jq -r .git.commit.id`" ]]
+
+check-%-release: .valid-env-%
+	@echo Checking that $(RELEASE_TAG) is the current release on $*
+	@[[ "$(RELEASE_TAG)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME).azurewebsites.net/actuator/info | jq -r .deploy.tag`" ]]

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -5,12 +5,13 @@ SOURCE_SLOT?=staging
 TARGET_SLOT?=production
 DEPLOYED_COMMIT?=$(shell git show --abbrev=7 -s --pretty=%h)
 RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
+CURL_TIMEOUT=1
 
 # Internal DRYing
 API_NAME=simple-report-api-$*
 INFO_ENDPOINT=https://$(API_NAME).azurewebsites.net/actuator/info
 SLOT_INFO_ENDPOINT=https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info
-CURL:=curl --silent --fail --max-time 1
+CURL:=curl --silent --fail --max-time $(CURL_TIMEOUT)
 APP_READY=$(CURL) https://$(API_NAME).azurewebsites.net/actuator/health/readiness > /dev/null
 SLOT_READY=$(CURL) https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/health/readiness > /dev/null
 
@@ -19,6 +20,7 @@ default:
 	@echo "You can use 'make promote-ENV' to promote the $(SOURCE_SLOT) slot of any environment, if you are logged in to azure"
 	@echo "You can also run 'make init-ENV' or 'make deploy-ENV-api' but those may not be as useful locally."
 	@echo "In addition, there are a variety of targets that start with 'check' or 'wait-for', which you should just look at."
+	@echo "Please note in particular that most if not all 'wait' tasks do not have a built-in timeout."
 
 # Internal target: check if we are currently logged in, so we get a friendly error if not
 .be-logged-in:
@@ -57,11 +59,11 @@ wait-for-%-commit: .valid-env-%
 	until  [[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(INFO_ENDPOINT) | jq -r .git.commit.id`" ]] ; do sleep 5; done;
 	@echo "Finished waiting at `date`"
 
-wait-for-%-slot-readiness: .valid-env-% # better use an external timeout for this!
+wait-for-%-slot-readiness: .valid-env-% # could use curl's built-in retry/timeout if we wanted to
 	@echo "Waiting for a successful readiness probe in $*/$(SOURCE_SLOT)"
 	until $(SLOT_READY); do sleep 5; done;
 
-wait-for-%-readiness: .valid-env-% # better use an external timeout for this!
+wait-for-%-readiness: .valid-env-% # could use curl's built-in retry/timeout if we wanted to
 	@echo "Waiting for a successful readiness probe in $*"
 	until $(APP_READY); do sleep 5; done;
 

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,13 +1,15 @@
 # Makefile for az cli shortcuts for SimpleReport operations
 
 SHELL:=/bin/bash # I gave up on being compatible with ye olde "sh"
+
+# Overrideable arguments
 SOURCE_SLOT?=staging
 TARGET_SLOT?=production
 DEPLOYED_COMMIT?=$(shell git show --abbrev=7 -s --pretty=%h)
 RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
-CURL_TIMEOUT=1
+CURL_TIMEOUT?=1
 
-# Internal DRYing
+# Internal DRYing (also overrideable if you are sufficiently desperate)
 API_NAME=simple-report-api-$*
 INFO_ENDPOINT=https://$(API_NAME).azurewebsites.net/actuator/info
 SLOT_INFO_ENDPOINT=https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info
@@ -57,6 +59,16 @@ wait-for-%-slot-commit: .valid-env-%
 wait-for-%-commit: .valid-env-%
 	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $* at `date`"
 	until  [[ "$(DEPLOYED_COMMIT)"  == "`$(CURL) $(INFO_ENDPOINT) | jq -r .git.commit.id`" ]] ; do sleep 5; done;
+	@echo "Finished waiting at `date`"
+
+wait-for-%-release: .valid-env-%
+	@echo "Starting wait for release $(RELEASE_TAG) in $* at `date`"
+	until [[ "$(RELEASE_TAG)"  == "`$(CURL) $(INFO_ENDPOINT) | jq -r .deploy.tag`" ]]; do sleep 5; done
+	@echo "Finished waiting at `date`"
+
+wait-for-%-slot-release: .valid-env-%
+	@echo "Starting wait for release $(RELEASE_TAG) in $* at `date`"
+	until [[ "$(RELEASE_TAG)"  == "`$(CURL) $(SLOT_INFO_ENDPOINT) | jq -r .deploy.tag`" ]]; do sleep 5; done
 	@echo "Finished waiting at `date`"
 
 wait-for-%-slot-readiness: .valid-env-% # could use curl's built-in retry/timeout if we wanted to

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -7,7 +7,7 @@ SOURCE_SLOT?=staging
 TARGET_SLOT?=production
 DEPLOYED_COMMIT?=$(shell git show --abbrev=7 -s --pretty=%h)
 RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
-CURL_TIMEOUT?=1
+CURL_TIMEOUT?=2
 
 # Internal DRYing (also overrideable if you are sufficiently desperate)
 API_NAME=simple-report-api-$*

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -51,3 +51,11 @@ check-%-commit: .valid-env-%
 check-%-release: .valid-env-%
 	@echo Checking that $(RELEASE_TAG) is the current release on $*
 	@[[ "$(RELEASE_TAG)"  == "`curl --silent --fail --max-time 1 https://$(API_NAME).azurewebsites.net/actuator/info | jq -r .deploy.tag`" ]]
+
+check-%-slot-readiness: .valid-env-%
+	@echo Checking the readiness probe for $*/$(SOURCE_SLOT)
+	@curl -sf -m1 https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/health/readiness > /dev/null
+
+check-%-readiness: .valid-env-%
+	@echo Checking the readiness probe for $*
+	@curl -sf -m1 https://$(API_NAME).azurewebsites.net/actuator/health/readiness > /dev/null


### PR DESCRIPTION
## Related Issue or Background Info

We discovered during last week's amazing run of awesome things that it was possible to have something work its way through our ZDD release process without ever actually having a valid health check. This PR addresses several issues related to that problem.

## Changes Proposed

- added readiness check to the application actuator, so that we can test explicitly for all commandlinerunner and initialization code having run
- added configurable timeout for `curl` calls used in deployment jobs to reduce (although sadly not eliminate) the risk of getting a positive result after waiting for 30 seconds for the one successful response that the instance will ever give
- added `check-` and `wait-for-` wildcard targets to check either the main instance or the staging/prerelease slot for
  -  the correct commit being deployed
  - the correct release being deployed (obviously only to be used in release-driven environments)
  - the application returning a non-error response on its readiness-check endpoint
- added checks for the application being "ready" before and after promoting from the deployment slot
- removed the ability to deploy `stg` manually
- made `stg` and `prod` check for the release rather than the commit hash, to make sure that reverts aren't weird

## Additional Information

- this does not include the changes for #1634 because they are quite small in comparison and can be in a separate PR with less noise

## Checklist for Author and Reviewer

Reviewers should probably mostly look at just one deploy (say, `deployDev.yml`, since the changes are the same in all the non-prod deploys (stg and prod have one change that the others do not, since they are now release-driven rather than commit-driven).

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
