### PR TITLE
Require stg prerelease

### DIFF
--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -11,6 +11,17 @@ concurrency:
   group: prod-deploy
 
 jobs:
+  check-stg-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check that the current release is in the stg environment
+        env:
+            CURL_TIMEOUT: 5
+        run: make check-stg-release check-stg-readiness
   docker-build:
     runs-on: ubuntu-latest
     defaults:
@@ -26,7 +37,7 @@ jobs:
         run: ./build_and_push.sh
   deploy-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: [docker-build, check-stg-release]
     defaults:
       run:
         working-directory: ./ops
@@ -59,6 +70,7 @@ jobs:
         run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
+    needs: [check-stg-release]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -11,7 +11,7 @@ concurrency:
   group: prod-deploy
 
 jobs:
-  check-stg-release:
+  verify-stg-is-released:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -37,7 +37,7 @@ jobs:
         run: ./build_and_push.sh
   deploy-backend:
     runs-on: ubuntu-latest
-    needs: [docker-build, check-stg-release]
+    needs: [docker-build, verify-stg-is-released]
     defaults:
       run:
         working-directory: ./ops
@@ -70,7 +70,7 @@ jobs:
         run: make check-${{ env.DEPLOY_ENV }}-readiness
   deploy-frontend:
     runs-on: ubuntu-latest
-    needs: [check-stg-release]
+    needs: [verify-stg-is-released]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Navigate to [New Release Form](https://github.com/CDCgov/prime-simplereport/rele
 3. If applicable describe some of the changes in detail in the description
 3. Check the "This is a pre-release" box.
 4. Click publish release (this will trigger the release to `stg`)
-5. Verify the changes are live in `stg` by ensuring the deployed commit hash matches the commit hash on the release and the deployed release tag matches. This is done my going to `/app/static/commit.txt` and `/api/actuator/info`
+5. Verify the changes are live in `stg` by ensuring the deployed commit hash matches the commit hash on the release and the deployed release tag matches. This is done by going to `/app/static/commit.txt` and `/api/actuator/info`
 6. Return to the release page and select "Edit release"
 7. Un-check the "This is a pre-release" checkbox and save/publish (this will trigger the release to other environments)
 8. Verify that the changes are live in `prod`, `demo` and `training`.

--- a/README.md
+++ b/README.md
@@ -332,11 +332,18 @@ Pentest|[/app/static/commit.txt](https://pentest.simplereport.gov/app/static/com
 Navigate to [New Release Form](https://github.com/CDCgov/prime-simplereport/releases/new) page
 ![release form](https://user-images.githubusercontent.com/80347105/110684538-43187880-81ab-11eb-9793-7cc923956a8b.png)
 
+1. Select the commit you want to release. This is likely to be the last commit on `main`, but select
+   the commit explicitly so that you do not accidentally release changes that somebody else is in the
+   process of merging.
 1. Add a version tag. If the release was `v1` then this release should be `v2`
 2. Add a release title summarizing the changes
 3. If applicable describe some of the changes in detail in the description
-4. Click publish release
-5. Verify the changes are live by ensuring the deployed commit hash matches the commit hash on the release. This is done my going to `/app/static/commit.txt` and `/api/actuator/info`
+3. Check the "This is a pre-release" box.
+4. Click publish release (this will trigger the release to `stg`)
+5. Verify the changes are live in `stg` by ensuring the deployed commit hash matches the commit hash on the release and the deployed release tag matches. This is done my going to `/app/static/commit.txt` and `/api/actuator/info`
+6. Return to the release page and select "Edit release"
+7. Un-check the "This is a pre-release" checkbox and save/publish (this will trigger the release to other environments)
+8. Verify that the changes are live in `prod`, `demo` and `training`.
 
 ### Revert to a Previous Release
 

--- a/README.md
+++ b/README.md
@@ -330,12 +330,15 @@ Pentest|[/app/static/commit.txt](https://pentest.simplereport.gov/app/static/com
 ### Deploy With Release
 
 Navigate to [New Release Form](https://github.com/CDCgov/prime-simplereport/releases/new) page
-![release form](https://user-images.githubusercontent.com/80347105/110684538-43187880-81ab-11eb-9793-7cc923956a8b.png)
 
-1. Select the commit you want to release. This is likely to be the last commit on `main`, but select
+![full-dialog](https://user-images.githubusercontent.com/28784751/121424756-b31bd380-c93f-11eb-987d-38934f0570ae.png)
+
+1. <img align="right" width="517" alt="select-commit" src="https://user-images.githubusercontent.com/28784751/121423065-df365500-c93d-11eb-9b95-a63130d602e6.png">
+   Select the commit you want to release. This is likely to be the last commit on `main`, but select
    the commit explicitly so that you do not accidentally release changes that somebody else is in the
-   process of merging.
-1. Add a version tag. If the release was `v1` then this release should be `v2`
+   process of merging.<br clear="right" />
+2. <img align="right" width="399" alt="new-release-name" src="https://user-images.githubusercontent.com/28784751/121423127-f07f6180-c93d-11eb-9e76-53aa5187a633.png">
+   Add a version tag. If the release was `v1` then this release should be `v2` 
 2. Add a release title summarizing the changes
 3. If applicable describe some of the changes in detail in the description
 3. Check the "This is a pre-release" box.

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Navigate to [New Release Form](https://github.com/CDCgov/prime-simplereport/rele
 4. Click publish release (this will trigger the release to `stg`)
 5. Verify the changes are live in `stg` by ensuring the deployed commit hash matches the commit hash on the release and the deployed release tag matches. This is done by going to `/app/static/commit.txt` and `/api/actuator/info`
 6. Return to the release page and select "Edit release"
-7. Un-check the "This is a pre-release" checkbox and save/publish (this will trigger the release to other environments)
+7. Un-check the "This is a pre-release" checkbox and click "Update release" (this will trigger the release to other environments)
 8. Verify that the changes are live in `prod`, `demo` and `training`.
 
 ### Revert to a Previous Release


### PR DESCRIPTION
## Related Issue or Background Info

- #1634
- #1633

Draft PR against another feature branch to get both moving.

## Changes Proposed

- require the current release to be present in `stg` in order to run the `prod` deployment

## Additional Information

There is an argument that this should be something we can override manually. Doing that is at best complicated: this is simple. For the sake of argument, here's what I came up with (bearing in mind that allowing manual releases is not on the table):
  - run this stg-check job.
  - if it fails, run a new job step that is tied to a special deployment environment that has an approval list, such that it'll block and require a sign-off from another person before it can complete
  - somehow require for the deployment to go forward that one of those two jobs have completed. (This is the step I'm not 100% sure is possible.)

Considering that the staging release takes under 10 minutes, not allowing it seemed simpler.

## Screenshots / Demos

## Checklist for Author and Reviewer

### Testing
- let me explain about testing the production release workflow...

