### PR TITLE
revert changes to test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,7 @@ defaults:
     working-directory: backend
 
 jobs:
-  test: # remove this job when required checks have been updated to include its dependencies instead
-    runs-on: ubuntu-latest
-    needs: [test-java, test-node]
-    steps:
-      - name: Placeholder step
-        working-directory: /
-        run: echo "This is a dummy job to keep the required checks happy"
-  test-java:
+  test:
     runs-on: ubuntu-latest
     services:
       test-db:
@@ -44,6 +37,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
       - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:
@@ -72,13 +67,6 @@ jobs:
           TWILIO_ACCOUNT_SID: ${{secrets.TWILIO_TEST_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{secrets.TWILIO_TEST_AUTH_TOKEN }}
         run: ./gradlew jacocoTestReport -PtestDbPort=5432
-      - name: Save Build Output for Sonar
-        uses: actions/upload-artifact@v2
-        if: success()
-        with:
-          name: java-build-output
-          path: backend/build
-          retention-days: 1
       - name: Archive Test Results
         uses: actions/upload-artifact@v2
         if: failure()
@@ -86,10 +74,6 @@ jobs:
           name: test-report
           path: backend/build/reports/tests/test
           retention-days: 7
-  test-node:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
       - name: Use Node.js ${{env.NODE_VERSION}}
         uses: actions/setup-node@v2.1.5
         with:
@@ -106,37 +90,12 @@ jobs:
       - name: Test
         working-directory: ./frontend
         run: yarn test:ci
-      - name: Save Build Output for Sonar
-        uses: actions/upload-artifact@v2
-        if: success()
-        with:
-          name: yarn-build-output
-          path: frontend/coverage
-          retention-days: 1
-
-  sonar:
-    runs-on: ubuntu-latest
-    needs: [test-java, test-node]
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
-      - name: Retrieve java build
-        uses: actions/download-artifact@v2
-        with:
-          name: java-build-output
-      - name: Retrieve yarn build
-        uses: actions/download-artifact@v2
-        with:
-          name: yarn-build-output
       - name: Sonar analysis
-        working-directory: ./backend
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.PROJECT_ROOT }} --info
-
   build-jar:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Related Issue or Background Info

Sonar isn't getting the test coverage artifacts on `main` causing all builds to fail. Testing includes running the CI on this branch and ensuring that the coverage information is correctly uploaded to sonar

## Changes Proposed

- revert to old test action that ran both the frontend and backend in the same job

## Additional Information


## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [N/A] Any changes to the UI/UX are approved by design 
- [[N/A] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [N/A] Database changes are submitted as a separate PR
  - [N/A] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [N/A] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [N/A] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [N/A] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [N/A] Any dependencies introduced have been vetted and discussed

## Cloud
- [N/A] DevOps team has been notified if PR requires ops support
- [N/A] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
