### PR TITLE
Add conditional migration for the automated corrections api_user

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2171,3 +2171,19 @@ databaseChangeLog:
       changes:
         sql: |
           GRANT SELECT ON TABLE ${database.defaultSchemaName}.patient_registration_link TO ${noPhiUsername};
+  - changeSet:
+      id: add-automated-corrections-api_user
+      author: adam@skylight.digital
+      comment: Adds the automated corrections api_user to the database if they do not already exist
+      preConditions:
+        - onSqlOutput: FAIL
+        - onFail: MARK_RAN
+        - sqlCheck:
+            sql: |
+              SELECT case when count(1) = 0 then 0 else 1 end FROM ${database.defaultSchemaName}.api_user
+              WHERE login_email='corrections-noreply@simplereport.gov';
+            expectedResult: 0
+      changes:
+        sql: |
+          INSERT INTO api_user (internal_id, created_at, updated_at, is_deleted, last_seen, login_email, first_name, last_name)
+          VALUES (gen_random_uuid(), now(), now(), false, null, 'corrections-noreply@simplereport.gov', 'SimpleReport', 'Automated Correction');


### PR DESCRIPTION
## Related Issue or Background Info

- @timothybest-usds  and I created this `api_user` by hand in production when programmatically correcting some bad data. This migration enshrines this user in code for consistency and history.

## Changes Proposed

- Add an `api_user` with the email address `corrections-noreply@simplereport.gov` if one does not exist

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
