### PR TITLE
Deploy entire azure environment, not just app_service.

### DIFF
--- a/ops/Makefile
+++ b/ops/Makefile
@@ -32,7 +32,7 @@ init-%: .valid-env-%
 	terraform -chdir=$* init
 
 deploy-%-api: .valid-env-% api.tfvars
-	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -target="module.simple_report_api"
+	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars
 
 promote-%: .be-logged-in .valid-env-%
 	az webapp deployment slot swap -g prime-simple-report-$* -n simple-report-api-$* --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)


### PR DESCRIPTION
## Related Issue or Background Info

This has been a bit of a white whale for the devops squad for weeks if not months.

We are still not deploying the `persistent` submodule routinely, because it interacts with some things that have not yet been pulled into terraform, but we are now able to routinely deploy the application service and (almost?) everything that sits in front of it.

## Changes Proposed

- remove deployment target of `module.app_service` from ops Makefile
- this implicitly makes every deploy job run `terraform apply` on the entire environment (minus the `persistent` subdirectory) instead of just running it for the application service

## Checklist for Author and Reviewer

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
