### PR TITLE
Remove duplicate call to _oktaRepo.createFacility

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -240,20 +240,18 @@ public class OrganizationService {
     // for now, all new organizations have identity_verified = false by default
     Organization org = _repo.save(new Organization(name, externalId, false));
     _oktaRepo.createOrganization(org);
-    Facility facility =
-        createFacilityNoPermissions(
-            org,
-            testingFacilityName,
-            cliaNumber,
-            facilityAddress,
-            phone,
-            email,
-            deviceSpecimenTypes,
-            providerName,
-            providerAddress,
-            providerTelephone,
-            providerNPI);
-    _oktaRepo.createFacility(facility);
+    createFacilityNoPermissions(
+        org,
+        testingFacilityName,
+        cliaNumber,
+        facilityAddress,
+        phone,
+        email,
+        deviceSpecimenTypes,
+        providerName,
+        providerAddress,
+        providerTelephone,
+        providerNPI);
     return org;
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

- Release `v57` broke our org sign up form. Error message from the logs: `Api validation failed: name - name: An object with this field already exists in the current organization`. The breaking change came from #1736 - `_oktaRepo.createFacility` is getting called twice during the execution of `createOrganization`, once [here](https://github.com/CDCgov/prime-simplereport/pull/1736/files#diff-60fd73cb50bc75b36431f16d5366d70763f7528671e8e92746d601cd05c9e3b4R256), and again [here](https://github.com/CDCgov/prime-simplereport/pull/1736/files#diff-60fd73cb50bc75b36431f16d5366d70763f7528671e8e92746d601cd05c9e3b4R311). 

## Changes Proposed

- Remove duplicate call so it is only called once

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
