### PR TITLE
Dependency-ordering of deploys

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -1,0 +1,60 @@
+name: Build SimpleReport Front End
+description: Build the React application
+inputs:
+  deploy-env:
+    description: The environment being deployed (e.g. "prod" or "test")
+    required: true
+  smarty-streets-key:
+    description: The Smarty-Streets API token for this environment. (Should be fetched from vault but is not)
+    required: true
+  base-domain-name:
+    description: The domain where the application is deployed (e.g. "simplereport.gov" or "test.simplereport.gov")
+    required: false
+  is-training-site:
+    description: If this is set, special training branding will be applied.
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      working-directory: ./frontend
+      shell: bash
+      run: |
+        echo "::group::Install dependencies (hopefully cached)"
+        yarn install
+        echo "::endgroup::"
+    - name: Set build variables
+      shell: bash
+      working-directory: ./frontend
+      run: |
+          echo "::group::Set build variables"
+          az config set extension.use_dynamic_install=yes_without_prompt > /dev/null 2>&1
+          INSIGHTS_KEY=$(
+            az monitor app-insights component show \
+              -g prime-simple-report-${{inputs.deploy-env}} \
+              -a prime-simple-report-${{inputs.deploy-env}}-insights \
+            | jq -r '.instrumentationKey')
+          echo "REACT_APP_APPINSIGHTS_KEY=${INSIGHTS_KEY}" > .env.production.local
+          if [[ -n "${{ inputs.base-domain-name }}" ]]
+            then echo "REACT_APP_BASE_URL=https://${{inputs.base-domain-name}}" >> .env.production.local
+          fi
+          if [[ "true" == "${{ inputs.is-training-site }}" ]]
+            then echo "REACT_APP_IS_TRAINING_SITE=true" >> .env.production.local
+          fi
+          echo "::endgroup::"
+    - name: Build deployable application
+      shell: bash
+      working-directory: ./frontend
+      env:
+        REACT_APP_SMARTY_STREETS_KEY: ${{ inputs.smarty-streets-key }}
+        DEPLOY_ENV: ${{ inputs.deploy-env }}
+      run: |
+        echo "::group::Build application"
+        yarn run build
+        echo "::endgroup::"
+    - name: Create client build archive
+      shell: bash
+      run: |
+        echo "::group::Create application archive"
+        tar -C ./frontend/build -czf ${{inputs.client-tarball}} .
+        echo "::endgroup::"

--- a/.github/actions/deploy-application/action.yml
+++ b/.github/actions/deploy-application/action.yml
@@ -1,0 +1,48 @@
+name: Deploy SimpleReport Application
+description: Promote API from secondary slot, and deploy client from tarball
+inputs:
+  deploy-env:
+    description: The environment being deployed (e.g. "prod" or "test")
+    required: true
+  client-tarball:
+    description: The path to the tar file containing the client code to deploy
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Unpack client
+      shell: bash
+      run: |
+        echo "::group::Unpack client"
+        mkdir client-build;
+        tar -C client-build -zxvf ${{inputs.client-tarball}}
+        echo "::endgroup::"
+    - name: Promote API to production and verify that it is ready
+      shell: bash
+      working-directory: ./ops
+      run: |
+        echo "::group::Promote API and verify readiness"
+        make promote-${{ env.DEPLOY_ENV }} check-${{ env.DEPLOY_ENV }}-readiness
+        echo "::endgroup::"
+    - name: Check for production app readiness
+      shell: bash
+      working-directory: ./ops
+      run: make
+    - name: Deploy frontend app
+      shell: bash
+      run: |
+        echo "::group::Deploy frontend app"
+        az storage blob upload-batch -s client-build/ -d '$web' \
+          --account-name simplereport${{ inputs.deploy-env }}app \
+          --destination-path '/app'
+        echo "::endgroup::"
+    - name: Purge CDN
+      shell: bash
+      run: |
+        echo "::group::Purge CDN"
+        az cdn endpoint purge \
+          --resource-group prime-simple-report-${{ inputs.deploy-env }} \
+          --profile-name simple-report-${{ inputs.deploy-env }} \
+          --name simple-report-${{ inputs.deploy-env }} \
+          --content-paths "/app/*" --no-wait
+        echo "::endgroup::"

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -12,7 +12,7 @@ concurrency:
   group: demo-deploy
 
 jobs:
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,28 +25,25 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
@@ -54,11 +51,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -74,8 +67,36 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Demo
+      url: https://demo.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,28 +27,25 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
@@ -56,11 +53,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -76,8 +69,36 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Dev
+      url: https://dev.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -12,7 +12,7 @@ concurrency:
   group: pentest-deploy
 
 jobs:
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,28 +25,25 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
@@ -54,11 +51,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -74,8 +67,36 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Test
+      url: https://test.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -22,7 +22,7 @@ jobs:
         env:
             CURL_TIMEOUT: 5
         run: make check-stg-release check-stg-readiness
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -35,28 +35,25 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: [docker-build, verify-stg-is-released]
+    needs: [build-docker, verify-stg-is-released]
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct release to be deployed in staging slot
         timeout-minutes: 5
@@ -64,11 +61,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     needs: [verify-stg-is-released]
     steps:
@@ -85,9 +78,37 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
           base-domain-name: simplereport.gov
+          client-tarball: ./client.tgz
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Production
+      url: https://simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -11,7 +11,7 @@ concurrency:
   group: stg-deploy
 
 jobs:
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,28 +24,25 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct release to be deployed in staging slot
         timeout-minutes: 5
@@ -53,11 +50,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,8 +66,36 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Test
+      url: https://test.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -11,7 +11,7 @@ env:
   NODE_VERSION: 14
 
 jobs:
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,9 +24,9 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     defaults:
       run:
         working-directory: ./ops
@@ -45,7 +45,7 @@ jobs:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
@@ -53,11 +53,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,8 +69,36 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Test
+      url: https://test.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -30,16 +30,13 @@ jobs:
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -12,7 +12,7 @@ concurrency:
   group: training-deploy
 
 jobs:
-  docker-build:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,28 +25,25 @@ jobs:
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images
         run: ./build_and_push.sh
-  deploy-backend:
+  prerelease-backend:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     defaults:
       run:
         working-directory: ./ops
-    env:
+    env: # all Azure interaction is through terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.15.1
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
-      - name: Azure deploy Api
+      - name: Terraform deploy (infrastructure and staging slot)
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
@@ -54,13 +51,7 @@ jobs:
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-      - name: Promote staging to production
-        run: make promote-${{ env.DEPLOY_ENV }}
-      - name: Check for production app readiness
-        env:
-          CURL_TIMEOUT: 5 # 1 second seems to be too tight for the initial launch
-        run: make check-${{ env.DEPLOY_ENV }}-readiness
-  deploy-frontend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -76,9 +67,37 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/deploy-front-end
-        name: Build and deploy front-end application
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
           is-training-site: true
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Training
+      url: https://training.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}


### PR DESCRIPTION
## Related Issue or Background Info

- resolves #1635 

## Changes Proposed

Split deploys into four pieces:

  * build API
  * build frontend
  * attempt to deploy API to deployment slot
  * promote API to main slot and deploy frontend

The dependencies are such that the client build can take place while the API is being deployed to the staging/prerelease slot, but the production release of the client depends on the successful production release of the API.

In addition, it is proposed that we use the `environment` key of the `deploy` job to indicate which environment we are deploying to, which will allow us to see what the most recent deploy is in various places in github, and also in slack (whether we like it or not). (We will probably not like it for `test` and `dev`—likely this should go into a channel where nobody expects to maintain an intelligible conversation.)

## Additional Information

https://github.community/t/misleading-actions-workflow-visualization/174730
😞 
![broken-graph-trimmed](https://user-images.githubusercontent.com/28784751/121115238-e006a400-c7e2-11eb-9392-d0ab12f92f3c.png)

## Checklist for Author and Reviewer

Tested repeatedly in dev and test; no impact anticipated on happy-path releases.

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
