### PR TITLE
do not require test workflow fields on account-request form

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountRequest.java
@@ -39,9 +39,9 @@ public class AccountRequest implements TemplateVariablesProvider {
   @JsonProperty @NotNull private String browsers;
   @JsonProperty private String browsersOther;
   @JsonProperty private String workflow;
-  @JsonProperty @NotNull private String recordsTestResults;
-  @JsonProperty @NotNull private String processTime;
-  @JsonProperty @NotNull private String submittingResultsTime;
+  @JsonProperty private String recordsTestResults;
+  @JsonProperty private String processTime;
+  @JsonProperty private String submittingResultsTime;
   @JsonProperty private String opFirstName;
   @JsonProperty private String opLastName;
   @JsonProperty private String npi;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/crm/DynamicsValueMapping.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/crm/DynamicsValueMapping.java
@@ -115,8 +115,12 @@ public enum DynamicsValueMapping {
     }
   }
 
-  // Build a key and look it up
+  // Build a key and look it up, try to fail with something that will create a record in Dynamics
   private static int getDynamicsCodeFromName(final Prefix prefix, final String inputString) {
+    if (inputString == null || inputString.equals("")) {
+      return DEFAULT_VALUE;
+    }
+
     String keyPart =
         inputString.strip().toUpperCase().replaceAll("\\s+", "_").replaceAll("[^A-Z0-9_]", "");
     return DynamicsValueMapping.valueOf(prefix + "_" + keyPart).value;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/crm/DynamicsValueMapping.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/crm/DynamicsValueMapping.java
@@ -117,7 +117,7 @@ public enum DynamicsValueMapping {
 
   // Build a key and look it up, try to fail with something that will create a record in Dynamics
   private static int getDynamicsCodeFromName(final Prefix prefix, final String inputString) {
-    if (inputString == null || inputString.equals("")) {
+    if (inputString == null || "".equals(inputString)) {
       return DEFAULT_VALUE;
     }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/crm/DynamicsValueMappingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/crm/DynamicsValueMappingTest.java
@@ -19,6 +19,16 @@ class DynamicsValueMappingTest {
   }
 
   @Test
+  void convertToCode_emptyInput_success() {
+    assertEquals(810050000, DynamicsValueMapping.convertToCode(Prefix.AD, ""));
+  }
+
+  @Test
+  void convertToCode_nullInput_success() {
+    assertEquals(810050000, DynamicsValueMapping.convertToCode(Prefix.AD, null));
+  }
+
+  @Test
   void convertToValues_multipleOptions_success() {
     assertEquals(
         "810050001,810050002", DynamicsValueMapping.convertToValues(Prefix.B, "Firefox, Chrome"));


### PR DESCRIPTION
This is to allow https://github.com/CDCgov/prime-simplereport-site/pull/170 to proceed

## Related Issue or Background Info

- https://skylight-hq.slack.com/archives/C01T5NC1WMN/p1623162400126400
- The account-request REST endpoint requires some fields that are no long desired, they need to be made optional to allow them to be removed form the form on the static site

## Changes Proposed

- Make account-request `records-test-results`, `process-time`, and `submitting-results-time` optional
- Handle null and empty string inputs for code-type fields when preparing data for Dynamics

## Additional Information

Once this has been deployed and the static site has been updated, then:
- Remove the fields from `AccountRequest`
- Remove the fields from the email templates
- Update Dynamics to send default values for those fields (they will still be required in Dynamics until we coordinate their removal)

This can be tested by submitting requests to `/account-request` with above-mentioned 3 fields either omitted from the request or with null values.

## Checklist for Author and Reviewer

### UI
- ~~[ ] Any changes to the UI/UX are approved by design~~
- ~~[ ] Any new or updated content (e.g. error messages) are approved by design~~

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- ~~[ ] Database changes are submitted as a separate PR~~
  - ~~[ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~~
  - ~~[ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views~~
- ~~[ ] GraphQL schema changes are backward compatible with older version of the front-end~~

### Security
- ~~[ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~~
- ~~[ ] Any dependencies introduced have been vetted and discussed~~

## Cloud
- ~~[ ] DevOps team has been notified if PR requires ops support~~
- ~~[ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification~~
