### PR TITLE
Redirect to settings on facility save

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -125,7 +125,7 @@ const createFieldError = (field: keyof FacilityErrors, facility: Facility) => {
 
 type AddressOptions = "facility" | "provider";
 
-interface Props {
+export interface Props {
   facility: Facility;
   deviceOptions: DeviceType[];
   saveFacility: (facility: Facility) => void;
@@ -288,7 +288,9 @@ const FacilityForm: React.FC<Props> = (props) => {
     <>
       <Prompt
         when={formChanged}
-        message="\nYour changes are not saved yet!\n\nClick OK to delete your answers and leave, or Cancel to return and save your progress."
+        message={
+          "\nYour changes are not saved yet!\n\nClick OK to delete your answers and leave, or Cancel to return and save your progress."
+        }
       />
       <div className="">
         <div className="prime-container card-container">

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import configureStore from "redux-mock-store";
+
+import { Props as FacilityFormProps } from "./FacilityForm";
+import FacilityFormContainer, {
+  GET_FACILITY_QUERY,
+  UPDATE_FACILITY_MUTATION,
+} from "./FacilityFormContainer";
+
+const facility: Facility = {
+  id: "12345",
+  cliaNumber: "99D1234567",
+  name: "Testing Site",
+  street: "1001 Rodeo Dr",
+  streetTwo: "qwqweqwe123123",
+  city: "Los Angeles",
+  state: "CA",
+  zipCode: "90000",
+  phone: "(516) 432-1390",
+  email: "testingsite@disorg.com",
+  defaultDevice: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+  deviceTypes: [
+    "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+    "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
+  ],
+  orderingProvider: {
+    firstName: "Fred",
+    middleName: null,
+    lastName: "Flintstone",
+    suffix: null,
+    NPI: "PEBBLES",
+    street: "123 Main Street",
+    streetTwo: "",
+    city: "Oz",
+    state: "KS",
+    zipCode: "12345",
+    phone: "(202) 555-1212",
+  },
+};
+
+jest.mock("./FacilityForm", () => {
+  return (f: FacilityFormProps) => {
+    return (
+      <button type="submit" onClick={() => f.saveFacility(facility)}>
+        I'm a magic fake button click me please
+      </button>
+    );
+  };
+});
+jest.mock("react-router-dom", () => ({
+  Redirect: () => <p>Redirected</p>,
+}));
+
+const store = configureStore([])({
+  organization: {
+    name: "Organization Name",
+  },
+  user: {
+    firstName: "Kim",
+    lastName: "Mendoza",
+  },
+  facilities: [
+    { id: facility.id, name: "Testing Site" },
+    { id: "2", name: "Facility 2" },
+  ],
+  facility: { id: facility.id, name: "Testing Site" },
+});
+
+const mocks = [
+  {
+    request: {
+      query: GET_FACILITY_QUERY,
+    },
+    result: {
+      data: {
+        organization: {
+          internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
+          testingFacility: [
+            {
+              id: facility.id,
+              cliaNumber: "99D1234567",
+              name: "Testing Site",
+              street: "1001 Rodeo Dr",
+              streetTwo: "qwqweqwe123123",
+              city: "Los Angeles",
+              state: "CA",
+              zipCode: "90000",
+              phone: "(516) 432-1390",
+              email: "testingsite@disorg.com",
+              defaultDeviceType: {
+                internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+              },
+              deviceTypes: [
+                {
+                  internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+                },
+                {
+                  internalId: "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
+                },
+              ],
+              orderingProvider: {
+                firstName: "Fred",
+                middleName: null,
+                lastName: "Flintstone",
+                suffix: null,
+                NPI: "PEBBLES",
+                street: "123 Main Street",
+                streetTwo: "",
+                city: "Oz",
+                state: "KS",
+                zipCode: "12345",
+                phone: "(202) 555-1212",
+              },
+            },
+          ],
+        },
+        deviceType: [
+          {
+            internalId: "a9bd36fe-0df1-4256-93e8-9e503cabdc8b",
+            name: "Abbott IDNow",
+          },
+        ],
+      },
+    },
+  },
+  {
+    request: {
+      query: UPDATE_FACILITY_MUTATION,
+      variables: {
+        facilityId: facility.id,
+        testingFacilityName: facility.name,
+        cliaNumber: facility.cliaNumber,
+        street: facility.street,
+        streetTwo: facility.streetTwo,
+        city: facility.city,
+        state: facility.state,
+        zipCode: facility.zipCode,
+        phone: facility.phone,
+        email: facility.email,
+        orderingProviderFirstName: facility.orderingProvider.firstName,
+        orderingProviderMiddleName: facility.orderingProvider.middleName,
+        orderingProviderLastName: facility.orderingProvider.lastName,
+        orderingProviderSuffix: facility.orderingProvider.suffix,
+        orderingProviderNPI: facility.orderingProvider.NPI,
+        orderingProviderStreet: facility.orderingProvider.street,
+        orderingProviderStreetTwo: facility.orderingProvider.streetTwo,
+        orderingProviderCity: facility.orderingProvider.city,
+        orderingProviderState: facility.orderingProvider.state,
+        orderingProviderZipCode: facility.orderingProvider.zipCode,
+        orderingProviderPhone: facility.orderingProvider.phone || null,
+        devices: facility.deviceTypes,
+        defaultDevice: facility.defaultDevice,
+      },
+    },
+    result: {
+      data: {
+        updateFacility:
+          "this doesn't get serialized, it's an object pointer, whoops",
+      },
+    },
+  },
+];
+
+describe("FacilityFormContainer", () => {
+  beforeEach(() => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <FacilityFormContainer facilityId={facility.id} />
+          </MockedProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+  });
+
+  it("redirects on successful save", async () => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await fireEvent.click(screen.getByRole("button"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(await screen.findByText("Redirected")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -12,7 +12,7 @@ import { showNotification } from "../../utils";
 
 import FacilityForm from "./FacilityForm";
 
-const GET_FACILITY_QUERY = gql`
+export const GET_FACILITY_QUERY = gql`
   query GetFacilities {
     organization {
       internalId
@@ -55,7 +55,7 @@ const GET_FACILITY_QUERY = gql`
   }
 `;
 
-const UPDATE_FACILITY_MUTATION = gql`
+export const UPDATE_FACILITY_MUTATION = gql`
   mutation UpdateFacility(
     $facilityId: ID!
     $testingFacilityName: String!
@@ -189,9 +189,9 @@ const FacilityFormContainer: any = (props: Props) => {
     return <p>Error: facility not found</p>;
   }
 
-  // if(saveSuccess) {
-  //   return <Redirect push to={{ pathname: "/settings/facilities" }} />
-  // }
+  if (saveSuccess) {
+    return <Redirect push to={{ pathname: "/settings/facilities" }} />;
+  }
 
   const saveFacility = async (facility: Facility) => {
     if (appInsights) {

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import { toast } from "react-toastify";
 import {
   useAppInsightsContext,
   useTrackEvent,
 } from "@microsoft/applicationinsights-react-js";
+import { Redirect } from "react-router-dom";
 
 import Alert from "../../commonComponents/Alert";
 import { showNotification } from "../../utils";
@@ -175,6 +176,7 @@ const FacilityFormContainer: any = (props: Props) => {
   const [updateFacility] = useMutation(UPDATE_FACILITY_MUTATION);
   const [addFacility] = useMutation(ADD_FACILITY_MUTATION);
   const trackSaveSettings = useTrackEvent(appInsights, "Save Settings", null);
+  const [saveSuccess, updateSaveSuccess] = useState(false);
 
   if (loading) {
     return <p> Loading... </p>;
@@ -186,6 +188,10 @@ const FacilityFormContainer: any = (props: Props) => {
   if (data === undefined) {
     return <p>Error: facility not found</p>;
   }
+
+  // if(saveSuccess) {
+  //   return <Redirect push to={{ pathname: "/settings/facilities" }} />
+  // }
 
   const saveFacility = async (facility: Facility) => {
     if (appInsights) {
@@ -228,6 +234,7 @@ const FacilityFormContainer: any = (props: Props) => {
       />
     );
     showNotification(toast, alert);
+    updateSaveSuccess(true);
   };
 
   const getFacilityData = (): Facility => {

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -227,7 +227,7 @@ const PersonForm = (props: Props) => {
     <>
       <Prompt
         when={formChanged}
-        message={() =>
+        message={
           "\nYour changes are not yet saved!\n\nClick OK discard changes, Cancel to continue editing."
         }
       />


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #1734 

## Changes Proposed

- After saving Facility, redirect back to the `Settings > Facility` page

## Additional Information

- Testing these three lines of code was a substantial pain in the butt

## Screenshots / Demos

https://user-images.githubusercontent.com/18486822/121448162-b2de0100-c95c-11eb-830c-f70271170017.mp4

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design: @hmyers-cms 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
