### PR TITLE
Configure 404 page for app Storage Accounts

### DIFF
--- a/ops/demo/main.tf
+++ b/ops/demo/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }

--- a/ops/training/main.tf
+++ b/ops/training/main.tf
@@ -21,7 +21,8 @@ resource "azurerm_storage_account" "app" {
   min_tls_version           = "TLS1_2"
 
   static_website {
-    index_document = "index.html"
+    index_document     = "index.html"
+    error_404_document = "404.html"
   }
   tags = local.management_tags
 }


### PR DESCRIPTION
## Related Issue or Background Info

#1668
#1656

## Changes Proposed

Use our custom 404 page as the Storage Account default 404 page as well, preventing the ugly default 404 page.

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Testing
- [x] Verify that test.simplereport.gov/thisisa404 shows the new page (TODO: cache invalidation, as the old custom page is still being shown)

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
