### PR TITLE
Corrected copy-paste errors in deployment workflows.

### DIFF
--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -83,8 +83,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: Test
-      url: https://test.simplereport.gov
+      name: Pentest
+      url: https://pentest.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -82,8 +82,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: Test
-      url: https://test.simplereport.gov
+      name: Staging
+      url: https://stg.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Related Issue or Background Info

- Follow up to #1804 

## Changes Proposed

- Fix incorrect `stg` environment name and URL
- Fix incorrect `pentest` environment name and URL

## Additional Information

Using `patch` and `git cherry-pick` when you're so tired your eyes are crossing is a dangerous game.
