### PR TITLE
Added snapback workflow to revert to immediately past release.

### DIFF
--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -64,6 +64,8 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     needs: [verify-stg-is-released]
+    outputs:
+      download-url: ${{steps.upload.outputs.url}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
@@ -78,6 +80,8 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Add upload URL to environment
+        run: echo UPLOAD_URL=$(jq -r .release.upload_url < ${GITHUB_EVENT_PATH}| sed -e 's/{?name,label}//') >> $GITHUB_ENV
       - uses: ./.github/actions/build-frontend
         name: Build front-end application
         with:
@@ -86,12 +90,24 @@ jobs:
           base-domain-name: simplereport.gov
           client-tarball: ./client.tgz
       - name: Save compiled frontend application
-        uses: actions/upload-artifact@v2
+        id: upload
         if: success()
-        with:
-          name: frontend-tarball
-          path: client.tgz
-          retention-days: 1
+        run: |
+          DOWNLOAD_URL=$(
+            curl -s -X POST --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+              --data-binary @client.tgz
+              --header "Accept: application/vnd.github.v3+json"
+              --header "Content-type:  application/gzip"
+              "$UPLOAD_URL?name=simple-report-client-application.tgz&label=Compiled%20Client%20Application"
+            | jq .url
+          )
+          if [[ -n "$DOWNLOAD_URL" ]]; then
+            echo Uploaded file to $DOWNLOAD_URL
+            echo "::set-output name=url::$DOWNLOAD_URL"
+          else
+            echo "Upload unsuccessful (probably you already uploaded it?)"
+            exit 1
+          fi
   deploy:
     runs-on: ubuntu-latest
     environment:
@@ -103,10 +119,13 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Retrieve frontend build
-        uses: actions/download-artifact@v2
-        with:
-          name: frontend-tarball
+      - name: Retrieve frontend build from release
+        run: |
+          curl -L -v \
+           --header 'Accept: application/octet-stream' \
+           --header 'Authorization: Bearer ${{secrets.GITHUB_TOKEN}}' \
+           ${{needs.build-frontend.outputs.download-url}} \
+           -o client.tgz
       - name: Promote and deploy
         uses: ./.github/actions/deploy-application
         with:

--- a/.github/workflows/snapback.yml
+++ b/.github/workflows/snapback.yml
@@ -1,0 +1,57 @@
+name: Roll back production
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: prod
+  STAGING_SLOT_NAME: staging
+  CLIENT_ASSET_LABEL: Compiled Client Application
+
+concurrency:
+  group: prod-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Add runtime environment variables
+        run: |
+          echo PREVIOUS_RELEASE=$(
+            curl -s https://simple-report-api-prod-${STAGING_SLOT_NAME}.azurewebsites.net/actuator/info |
+            jq -r '.deploy.tag'
+          ) >> $GITHUB_ENV;
+          echo RELEASES_URL=$(jq -r < ${GITHUB_EVENT_PATH} '.repository.releases_url' | sed -e 's/{\/id}//' )\
+           >> $GITHUB_ENV;
+      - name: Retrieve client tarball
+        run: |
+          DOWNLOAD_URL=$(
+            curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$RELEASES_URL/tags/${PREVIOUS_RELEASE}" |
+            jq -r '.assets[] | select(.label == "${CLIENT_ASSET_LABEL}") | .url'
+          )
+          curl -s -H 'Accept: application/octet-stream' -H "Authorization: Bearer $GITHUB_TOKEN" $DOWNLOAD_URL > client.tgz
+          mkdir client-build
+          tar -C client-build -xzf client.tgz
+      - name: Deploy frontend app
+        shell: bash
+        run: |
+          az storage blob upload-batch -s client-build/ -d '$web' \
+            --account-name simplereport${{ env.DEPLOY_ENV }}app \
+            --destination-path '/app'
+      - name: Purge CDN
+        shell: bash
+        run: |
+          az cdn endpoint purge \
+            --resource-group prime-simple-report-${{ env.DEPLOY_ENV }} \
+            --profile-name simple-report-${{ env.DEPLOY_ENV }} \
+            --name simple-report-${{ env.DEPLOY_ENV }} \
+            --content-paths "/app/*" --no-wait
+      - name: Rollback API
+        run: make promote-${DEPLOY_ENV}


### PR DESCRIPTION
## Related Issue or Background Info

- follow-up for #1844: add a workflow to roll back to the previous release with less overhead

## Changes Proposed

- new workflow that re-promotes the old API from the staging slot and re-publishes the stored client code from the release assets
- needs some README enhancements and some manual testing

## Additional Information
- can't be used in lower environments without substantially rewriting the store/fetch logic to get the client from the previous deploy job (though that is a thing we could do if we wanted to test the protocol there)
- doesn't interact correctly with the "Deployments" API, by which I mean doesn't interact at all (we could add some additional API calls to do it right, but using the `environment` key would result in the wrong commit being listed on the new deployment, which seemed worse than just skipping it.
- does not roll back database migrations

## Screenshots / Demos

## Checklist for Author and Reviewer


### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
