### PR TITLE
remove hardcoded url

### DIFF
--- a/frontend/src/app/accountCreation/AccountCreationApp.tsx
+++ b/frontend/src/app/accountCreation/AccountCreationApp.tsx
@@ -2,7 +2,12 @@ import { FunctionComponent, useEffect } from "react";
 import { ToastContainer } from "react-toastify";
 import { useDispatch, useSelector } from "react-redux";
 import "react-toastify/dist/ReactToastify.css";
-import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  BrowserRouter as Router,
+  RouteComponentProps,
+} from "react-router-dom";
 
 import PrimeErrorBoundary from "../PrimeErrorBoundary";
 import USAGovBanner from "../commonComponents/USAGovBanner";
@@ -41,7 +46,7 @@ const AccountCreation404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const AccountCreationApp = () => {
+const AccountCreationApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
   const dispatch = useDispatch();
   const activationToken = useSelector<RootState, string>(
     (state) => state.activationToken
@@ -61,7 +66,7 @@ const AccountCreationApp = () => {
         <div id="main-wrapper">
           <USAGovBanner />
           <AccountCreation404Wrapper activationToken={activationToken}>
-            <Router basename={`${process.env.PUBLIC_URL}/uac`}>
+            <Router basename={match.url}>
               <Switch>
                 <Route path="/" exact component={PasswordForm} />
                 <Route path="/set-password" component={PasswordForm} />

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -2,7 +2,12 @@ import { FunctionComponent, useEffect } from "react";
 import { ToastContainer } from "react-toastify";
 import { useDispatch, connect, useSelector } from "react-redux";
 import "react-toastify/dist/ReactToastify.css";
-import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  BrowserRouter as Router,
+  RouteComponentProps,
+} from "react-router-dom";
 
 import PrimeErrorBoundary from "../app/PrimeErrorBoundary";
 import USAGovBanner from "../app/commonComponents/USAGovBanner";
@@ -36,7 +41,7 @@ const PatientLinkURL404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const PatientApp = () => {
+const PatientApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
   const dispatch = useDispatch();
   const plid = useSelector((state: any) => state.plid);
   const patient = useSelector((state: any) => state.patient);
@@ -57,7 +62,7 @@ const PatientApp = () => {
           <USAGovBanner />
           <PatientHeader />
           <PatientLinkURL404Wrapper plid={plid}>
-            <Router basename={`${process.env.PUBLIC_URL}/pxp`}>
+            <Router basename={match.url}>
               <Switch>
                 <Route path="/" exact component={TermsOfService} />
                 <Route path="/terms-of-service" component={TermsOfService} />


### PR DESCRIPTION
## Related Issue or Background Info

- While prototyping the new "`ExperianApp`" I noticed a hard coded path in the `AbcApp` files that is duplicate of the path in `index.tsx`

### Testing
 - `pxp` routes are tested by e2e tests
 - account creation routes are not currently in use

## Changes Proposed

- use `match.url` instead of a hard coded path 

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
