### PR TITLE
Add a page component

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
-import { ToastContainer } from "react-toastify";
 import { useDispatch, connect } from "react-redux";
-import "react-toastify/dist/ReactToastify.css";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 
 import ProtectedRoute from "./commonComponents/ProtectedRoute";
 import PrimeErrorBoundary from "./PrimeErrorBoundary";
 import Header from "./commonComponents/Header";
-import USAGovBanner from "./commonComponents/USAGovBanner";
+import Page from "./commonComponents/Page/Page";
 import LoginView from "./LoginView";
 import { setInitialState } from "./store";
 import TestResultsList from "./testResults/TestResultsList";
@@ -94,82 +92,72 @@ const App = () => {
   return (
     <PrimeErrorBoundary>
       <WithFacility>
-        <div className="App">
-          <div id="main-wrapper">
-            <USAGovBanner />
-            <Header />
-            <Switch>
-              <Route path="/login" component={LoginView} />
-              <Route
-                path="/queue"
-                render={() => {
-                  return <TestQueueContainer />;
-                }}
-              />
-              <Route
-                path="/"
-                exact
-                render={({ location }) => (
-                  <Redirect
-                    to={{
-                      ...location,
-                      pathname: data.whoami.isAdmin ? "/admin" : "/queue",
-                    }}
-                  />
-                )}
-              />
-              <ProtectedRoute
-                path="/results/:page?"
-                render={({ match }: any) => {
-                  return <TestResultsList page={match.params.page} />;
-                }}
-                requiredPermissions={appPermissions.results.canView}
-                userPermissions={data.whoami.permissions}
-              />
-              <ProtectedRoute
-                path={`/patients/:page?`}
-                render={({ match }: any) => {
-                  return <ManagePatientsContainer page={match.params.page} />;
-                }}
-                requiredPermissions={appPermissions.people.canView}
-                userPermissions={data.whoami.permissions}
-              />
-              <ProtectedRoute
-                path={`/patient/:patientId`}
-                render={({ match }: any) => (
-                  <EditPatientContainer patientId={match.params.patientId} />
-                )}
-                requiredPermissions={appPermissions.people.canEdit}
-                userPermissions={data.whoami.permissions}
-              />
-              <ProtectedRoute
-                path={`/add-patient/`}
-                render={() => <AddPatient />}
-                requiredPermissions={appPermissions.people.canEdit}
-                userPermissions={data.whoami.permissions}
-              />
-              <ProtectedRoute
-                path="/settings"
-                component={Settings}
-                requiredPermissions={appPermissions.settings.canView}
-                userPermissions={data.whoami.permissions}
-              />
-              <Route
-                path={"/admin"}
-                render={({ match }) => (
-                  <AdminRoutes match={match} isAdmin={data.whoami.isAdmin} />
-                )}
-              />
-            </Switch>
-            <ToastContainer
-              autoClose={5000}
-              closeButton={false}
-              limit={2}
-              position="bottom-center"
-              hideProgressBar={true}
+        <Page>
+          <Header />
+          <Switch>
+            <Route path="/login" component={LoginView} />
+            <Route
+              path="/queue"
+              render={() => {
+                return <TestQueueContainer />;
+              }}
             />
-          </div>
-        </div>
+            <Route
+              path="/"
+              exact
+              render={({ location }) => (
+                <Redirect
+                  to={{
+                    ...location,
+                    pathname: data.whoami.isAdmin ? "/admin" : "/queue",
+                  }}
+                />
+              )}
+            />
+            <ProtectedRoute
+              path="/results/:page?"
+              render={({ match }: any) => {
+                return <TestResultsList page={match.params.page} />;
+              }}
+              requiredPermissions={appPermissions.results.canView}
+              userPermissions={data.whoami.permissions}
+            />
+            <ProtectedRoute
+              path={`/patients/:page?`}
+              render={({ match }: any) => {
+                return <ManagePatientsContainer page={match.params.page} />;
+              }}
+              requiredPermissions={appPermissions.people.canView}
+              userPermissions={data.whoami.permissions}
+            />
+            <ProtectedRoute
+              path={`/patient/:patientId`}
+              render={({ match }: any) => (
+                <EditPatientContainer patientId={match.params.patientId} />
+              )}
+              requiredPermissions={appPermissions.people.canEdit}
+              userPermissions={data.whoami.permissions}
+            />
+            <ProtectedRoute
+              path={`/add-patient/`}
+              render={() => <AddPatient />}
+              requiredPermissions={appPermissions.people.canEdit}
+              userPermissions={data.whoami.permissions}
+            />
+            <ProtectedRoute
+              path="/settings"
+              component={Settings}
+              requiredPermissions={appPermissions.settings.canView}
+              userPermissions={data.whoami.permissions}
+            />
+            <Route
+              path={"/admin"}
+              render={({ match }) => (
+                <AdminRoutes match={match} isAdmin={data.whoami.isAdmin} />
+              )}
+            />
+          </Switch>
+        </Page>
       </WithFacility>
     </PrimeErrorBoundary>
   );

--- a/frontend/src/app/accountCreation/AccountCreationApp.tsx
+++ b/frontend/src/app/accountCreation/AccountCreationApp.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent, useEffect } from "react";
-import { ToastContainer } from "react-toastify";
 import { useDispatch, useSelector } from "react-redux";
-import "react-toastify/dist/ReactToastify.css";
 import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 
 import PrimeErrorBoundary from "../PrimeErrorBoundary";
-import USAGovBanner from "../commonComponents/USAGovBanner";
+import Page from "../commonComponents/Page/Page";
 import { RootState, setInitialState } from "../store";
 import { getActivationTokenFromUrl } from "../utils/url";
 import PageNotFound from "../commonComponents/PageNotFound";
@@ -57,45 +55,35 @@ const AccountCreationApp = () => {
 
   return (
     <PrimeErrorBoundary>
-      <div className="App">
-        <div id="main-wrapper">
-          <USAGovBanner />
-          <AccountCreation404Wrapper activationToken={activationToken}>
-            <Router basename={`${process.env.PUBLIC_URL}/uac`}>
-              <Switch>
-                <Route path="/" exact component={PasswordForm} />
-                <Route path="/set-password" component={PasswordForm} />
-                <Route
-                  path="/set-recovery-question"
-                  component={SecurityQuestion}
-                />
-                <Route path="/mfa-select" component={MfaSelect} />
-                <Route path="/mfa-sms/verify" component={MfaSmsVerify} />
-                <Route path="/mfa-sms" component={MfaSms} />
-                <Route path="/mfa-okta/verify" component={MfaOktaVerify} />
-                <Route path="/mfa-okta" component={MfaOkta} />
-                <Route
-                  path="/mfa-google-auth/verify"
-                  component={MfaGoogleAuthVerify}
-                />
-                <Route path="/mfa-google-auth" component={MfaGoogleAuth} />
-                <Route path="/mfa-security-key" component={MfaSecurityKey} />
-                <Route path="/mfa-phone/verify" component={MfaPhoneVerify} />
-                <Route path="/mfa-phone" component={MfaPhone} />
-                <Route path="/mfa-email/verify" component={MfaEmailVerify} />
-                <Route path="/success" component={MfaComplete} />
-              </Switch>
-            </Router>
-            <ToastContainer
-              autoClose={5000}
-              closeButton={false}
-              limit={2}
-              position="bottom-center"
-              hideProgressBar={true}
-            />
-          </AccountCreation404Wrapper>
-        </div>
-      </div>
+      <Page>
+        <AccountCreation404Wrapper activationToken={activationToken}>
+          <Router basename={`${process.env.PUBLIC_URL}/uac`}>
+            <Switch>
+              <Route path="/" exact component={PasswordForm} />
+              <Route path="/set-password" component={PasswordForm} />
+              <Route
+                path="/set-recovery-question"
+                component={SecurityQuestion}
+              />
+              <Route path="/mfa-select" component={MfaSelect} />
+              <Route path="/mfa-sms/verify" component={MfaSmsVerify} />
+              <Route path="/mfa-sms" component={MfaSms} />
+              <Route path="/mfa-okta/verify" component={MfaOktaVerify} />
+              <Route path="/mfa-okta" component={MfaOkta} />
+              <Route
+                path="/mfa-google-auth/verify"
+                component={MfaGoogleAuthVerify}
+              />
+              <Route path="/mfa-google-auth" component={MfaGoogleAuth} />
+              <Route path="/mfa-security-key" component={MfaSecurityKey} />
+              <Route path="/mfa-phone/verify" component={MfaPhoneVerify} />
+              <Route path="/mfa-phone" component={MfaPhone} />
+              <Route path="/mfa-email/verify" component={MfaEmailVerify} />
+              <Route path="/success" component={MfaComplete} />
+            </Switch>
+          </Router>
+        </AccountCreation404Wrapper>
+      </Page>
     </PrimeErrorBoundary>
   );
 };

--- a/frontend/src/app/commonComponents/Page/Page.stories.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.stories.tsx
@@ -1,0 +1,20 @@
+import { Story, Meta } from "@storybook/react";
+
+import Page from "./Page";
+
+export default {
+  title: "Components/Page",
+  component: Page,
+  argTypes: {},
+} as Meta;
+
+const Template: Story = () => <Page />;
+
+export const WithChildren = Template.bind({});
+WithChildren.args = {
+  children: (
+    <>
+      <p>This is some test content</p>
+    </>
+  ),
+};

--- a/frontend/src/app/commonComponents/Page/Page.test.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+
+import Page from "./Page";
+
+describe("Page", () => {
+  describe("No children", () => {
+    it("renders", () => {
+      expect(<Page />).toMatchSnapshot();
+    });
+  });
+  describe("With children", () => {
+    it("displays children", () => {
+      const { getByText } = render(<Page>Hello World</Page>);
+      expect(getByText("Hello World")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+import USAGovBanner from "../USAGovBanner";
+
+const Page: React.FC<{}> = ({ children }) => (
+  <div className="App">
+    <div id="main-wrapper">
+      <USAGovBanner />
+      {children}
+      <ToastContainer
+        autoClose={5000}
+        closeButton={false}
+        limit={2}
+        position="bottom-center"
+        hideProgressBar={true}
+      />
+    </div>
+  </div>
+);
+
+export default Page;

--- a/frontend/src/app/commonComponents/Page/__snapshots__/Page.test.tsx.snap
+++ b/frontend/src/app/commonComponents/Page/__snapshots__/Page.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page No children renders 1`] = `<Page />`;

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent, useEffect } from "react";
-import { ToastContainer } from "react-toastify";
 import { useDispatch, connect, useSelector } from "react-redux";
-import "react-toastify/dist/ReactToastify.css";
 import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 
 import PrimeErrorBoundary from "../app/PrimeErrorBoundary";
-import USAGovBanner from "../app/commonComponents/USAGovBanner";
+import Page from "../app/commonComponents/Page/Page";
 import { setInitialState } from "../app/store";
 import { getPatientLinkIdFromUrl } from "../app/utils/url";
 import PageNotFound from "../app/commonComponents/PageNotFound";
@@ -52,53 +50,43 @@ const PatientApp = () => {
 
   return (
     <PrimeErrorBoundary>
-      <div className="App">
-        <div id="main-wrapper">
-          <USAGovBanner />
-          <PatientHeader />
-          <PatientLinkURL404Wrapper plid={plid}>
-            <Router basename={`${process.env.PUBLIC_URL}/pxp`}>
-              <Switch>
-                <Route path="/" exact component={TermsOfService} />
-                <Route path="/terms-of-service" component={TermsOfService} />
-                <Route path="/birth-date-confirmation" component={DOB} />
-                <GuardedRoute
-                  auth={auth}
-                  path="/patient-info-confirm"
-                  component={PatientProfileContainer}
-                />
-                <GuardedRoute
-                  auth={auth}
-                  path="/patient-info-edit"
-                  component={PatientFormContainer}
-                />
-                <GuardedRoute
-                  auth={auth}
-                  path="/patient-info-symptoms"
-                  component={AoEPatientFormContainer}
-                />
-                <GuardedRoute
-                  auth={auth}
-                  path="/success"
-                  component={PatientLanding}
-                />
-                <GuardedRoute
-                  auth={auth}
-                  path="/test-result"
-                  component={TestResult}
-                />
-              </Switch>
-            </Router>
-            <ToastContainer
-              autoClose={5000}
-              closeButton={false}
-              limit={2}
-              position="bottom-center"
-              hideProgressBar={true}
-            />
-          </PatientLinkURL404Wrapper>
-        </div>
-      </div>
+      <Page>
+        <PatientHeader />
+        <PatientLinkURL404Wrapper plid={plid}>
+          <Router basename={`${process.env.PUBLIC_URL}/pxp`}>
+            <Switch>
+              <Route path="/" exact component={TermsOfService} />
+              <Route path="/terms-of-service" component={TermsOfService} />
+              <Route path="/birth-date-confirmation" component={DOB} />
+              <GuardedRoute
+                auth={auth}
+                path="/patient-info-confirm"
+                component={PatientProfileContainer}
+              />
+              <GuardedRoute
+                auth={auth}
+                path="/patient-info-edit"
+                component={PatientFormContainer}
+              />
+              <GuardedRoute
+                auth={auth}
+                path="/patient-info-symptoms"
+                component={AoEPatientFormContainer}
+              />
+              <GuardedRoute
+                auth={auth}
+                path="/success"
+                component={PatientLanding}
+              />
+              <GuardedRoute
+                auth={auth}
+                path="/test-result"
+                component={TestResult}
+              />
+            </Switch>
+          </Router>
+        </PatientLinkURL404Wrapper>
+      </Page>
     </PrimeErrorBoundary>
   );
 };


### PR DESCRIPTION
## Related Issue or Background Info

- While building the identity verification FE I noticed out Apps have a common pattern. I created a component to capture this pattern

## Changes Proposed

- Add a `Page` component

## Additional Information

- It would be nice to include the `PrimaryErrorBoundry` in the `Page` component as well but as implemented this would add  `USAGovBanner` to the facility selector and I wanted to avoid making UI changes
- It would also be nice to refactor `SelfRegistration` so that it could use `Page` too but that seems out of scope

## Screenshots / Demos

## Checklist for Author and Reviewer
- [ ] the provider app, account creation, and the patient experience should render identically to how they did before
- [ ] I wasn't sure how to unit test the Toast (e2e test should test it in the provider app and patient experience )

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
