### PR TITLE
Fix data source for 4xx error alerts

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -161,7 +161,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
   time_window         = 5
   enabled             = contains(var.disabled_alerts, "http_4xx_errors") ? false : true
 
-  data_source_id = var.app_service_id
+  data_source_id = var.app_insights_id
 
   query = <<-QUERY
 requests


### PR DESCRIPTION
## Related Issue or Background Info

Bug fix for #1780

The data source was wrong for the query alert and `terraform plan` does not catch this type of bug.