### PR TITLE
Revert "remove hardcoded url"

### DIFF
--- a/frontend/src/app/accountCreation/AccountCreationApp.tsx
+++ b/frontend/src/app/accountCreation/AccountCreationApp.tsx
@@ -1,11 +1,6 @@
 import { FunctionComponent, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  Route,
-  Switch,
-  BrowserRouter as Router,
-  RouteComponentProps,
-} from "react-router-dom";
+import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 
 import PrimeErrorBoundary from "../PrimeErrorBoundary";
 import Page from "../commonComponents/Page/Page";
@@ -44,7 +39,7 @@ const AccountCreation404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const AccountCreationApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
+const AccountCreationApp = () => {
   const dispatch = useDispatch();
   const activationToken = useSelector<RootState, string>(
     (state) => state.activationToken
@@ -62,7 +57,7 @@ const AccountCreationApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
     <PrimeErrorBoundary>
       <Page>
         <AccountCreation404Wrapper activationToken={activationToken}>
-          <Router basename={match.url}>
+          <Router basename={`${process.env.PUBLIC_URL}/uac`}>
             <Switch>
               <Route path="/" exact component={PasswordForm} />
               <Route path="/set-password" component={PasswordForm} />

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -1,11 +1,6 @@
 import { FunctionComponent, useEffect } from "react";
 import { useDispatch, connect, useSelector } from "react-redux";
-import {
-  Route,
-  Switch,
-  BrowserRouter as Router,
-  RouteComponentProps,
-} from "react-router-dom";
+import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 
 import PrimeErrorBoundary from "../app/PrimeErrorBoundary";
 import Page from "../app/commonComponents/Page/Page";
@@ -39,7 +34,7 @@ const PatientLinkURL404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const PatientApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
+const PatientApp = () => {
   const dispatch = useDispatch();
   const plid = useSelector((state: any) => state.plid);
   const patient = useSelector((state: any) => state.patient);
@@ -58,7 +53,7 @@ const PatientApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
       <Page>
         <PatientHeader />
         <PatientLinkURL404Wrapper plid={plid}>
-          <Router basename={match.url}>
+          <Router basename={`${process.env.PUBLIC_URL}/pxp`}>
             <Switch>
               <Route path="/" exact component={TermsOfService} />
               <Route path="/terms-of-service" component={TermsOfService} />


### PR DESCRIPTION
Reverts CDCgov/prime-simplereport#1889

This is actually breaking the Patient App in any env with a `PUBLIC_URL` set