### PR TITLE
Fix failed 2xx alerts to actually filter by 200s

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -115,6 +115,12 @@ resource "azurerm_monitor_metric_alert" "http_2xx_failed_requests" {
       operator = "Include"
       values   = ["False"]
     }
+
+    dimension {
+      name     = "request/resultCode"
+      operator = "Include"
+      values   = ["200", "201", "202", "203", "204", "205", "206"]
+    }
   }
 
   dynamic "action" {

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -118,8 +118,8 @@ resource "azurerm_monitor_metric_alert" "http_2xx_failed_requests" {
 
     dimension {
       name     = "request/resultCode"
-      operator = "Include"
-      values   = ["200", "201", "202", "203", "204", "205", "206"]
+      operator = "StartsWith"
+      values   = ["2"]
     }
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

Fix bug with #1878 where the "alert on failed 2xx requests" wasn't actually filtering for 2xx requests.

## Changes Proposed

- Add a dimension to the alert to filter for request codes starting with `2`