### PR TITLE
Tim best/duplicate urls

### DIFF
--- a/frontend/src/app/accountCreation/AccountCreationApp.tsx
+++ b/frontend/src/app/accountCreation/AccountCreationApp.tsx
@@ -1,6 +1,11 @@
 import { FunctionComponent, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  BrowserRouter as Router,
+  RouteComponentProps,
+} from "react-router-dom";
 
 import PrimeErrorBoundary from "../PrimeErrorBoundary";
 import Page from "../commonComponents/Page/Page";
@@ -39,7 +44,7 @@ const AccountCreation404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const AccountCreationApp = () => {
+const AccountCreationApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
   const dispatch = useDispatch();
   const activationToken = useSelector<RootState, string>(
     (state) => state.activationToken
@@ -57,7 +62,7 @@ const AccountCreationApp = () => {
     <PrimeErrorBoundary>
       <Page>
         <AccountCreation404Wrapper activationToken={activationToken}>
-          <Router basename={`${process.env.PUBLIC_URL}/uac`}>
+          <Router basename={match.url}>
             <Switch>
               <Route path="/" exact component={PasswordForm} />
               <Route path="/set-password" component={PasswordForm} />

--- a/frontend/src/app/accountCreation/AccountCreationApp.tsx
+++ b/frontend/src/app/accountCreation/AccountCreationApp.tsx
@@ -1,11 +1,6 @@
 import { FunctionComponent, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  Route,
-  Switch,
-  BrowserRouter as Router,
-  RouteComponentProps,
-} from "react-router-dom";
+import { Route, Switch, RouteComponentProps } from "react-router-dom";
 
 import PrimeErrorBoundary from "../PrimeErrorBoundary";
 import Page from "../commonComponents/Page/Page";
@@ -44,7 +39,7 @@ const AccountCreation404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const AccountCreationApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
+const AccountCreationApp: React.FC<RouteComponentProps> = ({ match }) => {
   const dispatch = useDispatch();
   const activationToken = useSelector<RootState, string>(
     (state) => state.activationToken
@@ -62,31 +57,50 @@ const AccountCreationApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
     <PrimeErrorBoundary>
       <Page>
         <AccountCreation404Wrapper activationToken={activationToken}>
-          <Router basename={match.url}>
-            <Switch>
-              <Route path="/" exact component={PasswordForm} />
-              <Route path="/set-password" component={PasswordForm} />
-              <Route
-                path="/set-recovery-question"
-                component={SecurityQuestion}
-              />
-              <Route path="/mfa-select" component={MfaSelect} />
-              <Route path="/mfa-sms/verify" component={MfaSmsVerify} />
-              <Route path="/mfa-sms" component={MfaSms} />
-              <Route path="/mfa-okta/verify" component={MfaOktaVerify} />
-              <Route path="/mfa-okta" component={MfaOkta} />
-              <Route
-                path="/mfa-google-auth/verify"
-                component={MfaGoogleAuthVerify}
-              />
-              <Route path="/mfa-google-auth" component={MfaGoogleAuth} />
-              <Route path="/mfa-security-key" component={MfaSecurityKey} />
-              <Route path="/mfa-phone/verify" component={MfaPhoneVerify} />
-              <Route path="/mfa-phone" component={MfaPhone} />
-              <Route path="/mfa-email/verify" component={MfaEmailVerify} />
-              <Route path="/success" component={MfaComplete} />
-            </Switch>
-          </Router>
+          <Switch>
+            <Route path={match.path} exact component={PasswordForm} />
+            <Route
+              path={`${match.path}/set-password`}
+              component={PasswordForm}
+            />
+            <Route
+              path={`${match.path}/set-recovery-question`}
+              component={SecurityQuestion}
+            />
+            <Route path={`${match.path}/mfa-select`} component={MfaSelect} />
+            <Route
+              path={`${match.path}/mfa-sms/verify`}
+              component={MfaSmsVerify}
+            />
+            <Route path={`${match.path}/mfa-sms`} component={MfaSms} />
+            <Route
+              path={`${match.path}/mfa-okta/verify`}
+              component={MfaOktaVerify}
+            />
+            <Route path={`${match.path}/mfa-okta`} component={MfaOkta} />
+            <Route
+              path={`${match.path}/mfa-google-auth/verify`}
+              component={MfaGoogleAuthVerify}
+            />
+            <Route
+              path={`${match.path}/mfa-google-auth`}
+              component={MfaGoogleAuth}
+            />
+            <Route
+              path={`${match.path}/mfa-security-key`}
+              component={MfaSecurityKey}
+            />
+            <Route
+              path={`${match.path}/mfa-phone/verify`}
+              component={MfaPhoneVerify}
+            />
+            <Route path={`${match.path}/mfa-phone`} component={MfaPhone} />
+            <Route
+              path={`${match.path}/mfa-email/verify`}
+              component={MfaEmailVerify}
+            />
+            <Route path={`${match.path}/success`} component={MfaComplete} />
+          </Switch>
         </AccountCreation404Wrapper>
       </Page>
     </PrimeErrorBoundary>

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -1,6 +1,11 @@
 import { FunctionComponent, useEffect } from "react";
 import { useDispatch, connect, useSelector } from "react-redux";
-import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  BrowserRouter as Router,
+  RouteComponentProps,
+} from "react-router-dom";
 
 import PrimeErrorBoundary from "../app/PrimeErrorBoundary";
 import Page from "../app/commonComponents/Page/Page";
@@ -34,7 +39,7 @@ const PatientLinkURL404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const PatientApp = () => {
+const PatientApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
   const dispatch = useDispatch();
   const plid = useSelector((state: any) => state.plid);
   const patient = useSelector((state: any) => state.patient);
@@ -53,7 +58,7 @@ const PatientApp = () => {
       <Page>
         <PatientHeader />
         <PatientLinkURL404Wrapper plid={plid}>
-          <Router basename={`${process.env.PUBLIC_URL}/pxp`}>
+          <Router basename={match.url}>
             <Switch>
               <Route path="/" exact component={TermsOfService} />
               <Route path="/terms-of-service" component={TermsOfService} />

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -1,11 +1,6 @@
 import { FunctionComponent, useEffect } from "react";
 import { useDispatch, connect, useSelector } from "react-redux";
-import {
-  Route,
-  Switch,
-  BrowserRouter as Router,
-  RouteComponentProps,
-} from "react-router-dom";
+import { Route, Switch, RouteComponentProps } from "react-router-dom";
 
 import PrimeErrorBoundary from "../app/PrimeErrorBoundary";
 import Page from "../app/commonComponents/Page/Page";
@@ -39,7 +34,7 @@ const PatientLinkURL404Wrapper: FunctionComponent<WrapperProps> = ({
   return <>{children}</>;
 };
 
-const PatientApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
+const PatientApp: React.FC<RouteComponentProps> = ({ match }) => {
   const dispatch = useDispatch();
   const plid = useSelector((state: any) => state.plid);
   const patient = useSelector((state: any) => state.patient);
@@ -58,38 +53,42 @@ const PatientApp: React.FC<RouteComponentProps<{}>> = ({ match }) => {
       <Page>
         <PatientHeader />
         <PatientLinkURL404Wrapper plid={plid}>
-          <Router basename={match.url}>
-            <Switch>
-              <Route path="/" exact component={TermsOfService} />
-              <Route path="/terms-of-service" component={TermsOfService} />
-              <Route path="/birth-date-confirmation" component={DOB} />
-              <GuardedRoute
-                auth={auth}
-                path="/patient-info-confirm"
-                component={PatientProfileContainer}
-              />
-              <GuardedRoute
-                auth={auth}
-                path="/patient-info-edit"
-                component={PatientFormContainer}
-              />
-              <GuardedRoute
-                auth={auth}
-                path="/patient-info-symptoms"
-                component={AoEPatientFormContainer}
-              />
-              <GuardedRoute
-                auth={auth}
-                path="/success"
-                component={PatientLanding}
-              />
-              <GuardedRoute
-                auth={auth}
-                path="/test-result"
-                component={TestResult}
-              />
-            </Switch>
-          </Router>
+          <Switch>
+            <Route path={`${match.path}`} exact component={TermsOfService} />
+            <Route
+              path={`${match.path}/terms-of-service`}
+              component={TermsOfService}
+            />
+            <Route
+              path={`${match.path}/birth-date-confirmation`}
+              component={DOB}
+            />
+            <GuardedRoute
+              auth={auth}
+              path={`${match.path}/patient-info-confirm`}
+              component={PatientProfileContainer}
+            />
+            <GuardedRoute
+              auth={auth}
+              path={`${match.path}/patient-info-edit`}
+              component={PatientFormContainer}
+            />
+            <GuardedRoute
+              auth={auth}
+              path={`${match.path}/patient-info-symptoms`}
+              component={AoEPatientFormContainer}
+            />
+            <GuardedRoute
+              auth={auth}
+              path={`${match.path}/success`}
+              component={PatientLanding}
+            />
+            <GuardedRoute
+              auth={auth}
+              path={`${match.path}/test-result`}
+              component={TestResult}
+            />
+          </Switch>
         </PatientLinkURL404Wrapper>
       </Page>
     </PrimeErrorBoundary>


### PR DESCRIPTION
## Related Issue or Background Info

-  https://usds.slack.com/archives/C01LTSNKEPP/p1624567571126800
- Figuring out this issue now so that I don't have to use the hard coded URL in the ID proofing

## Changes Proposed

- Remove duplicate Routers
- Add match.url to every route

## Additional Information

> ...Pretty sure you can only have one BrowserRouter, so our sub-BrowserRouters are basically blowing away the basepath of the main app BrowserRouter https://reactrouter.com/web/guides/quick-start/2nd-example-nested-routing

## Screenshots / Demos

## Checklist for Author and Reviewer
- [ ] make sure routes work locally
- [ ] deploy to test and make sure `/app` paths work 

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
