### PR TITLE
Fix invalid window size for CPU alerts

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -8,7 +8,7 @@ module "metric_alerts" {
   rg_name                        = data.azurerm_resource_group.rg.name
   tags                           = local.management_tags
   mem_threshold                  = 85
-  cpu_window_size                = 10
+  cpu_window_size                = 15
   http_response_time_aggregation = "Minimum"
 
   action_group_ids = [


### PR DESCRIPTION
## Related Issue or Background Info

Addresses bug in #1788.

An invalid window size was used (10) - the value should be 15.