### PR TITLE
Fix cron for training DB reset workflow; rewrite 2xx alert

### DIFF
--- a/.github/workflows/resetTrainingDB.yml
+++ b/.github/workflows/resetTrainingDB.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run this on a daily timer as well in order to reset the training DB
-    - cron: '* 9 * * *'
+    - cron: '0 9 * * *'
 
 env:
   DEPLOY_ENV: training

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -44,5 +44,5 @@ variable "cpu_window_size" {
 }
 
 variable "http_response_time_aggregation" {
-  default = "Minimum"
+  default = "Average"
 }

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -107,7 +107,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "http_2xx_failed_requests
 
   query = <<-QUERY
 requests
-| where toint(resultCode) between (200 .. 299) and success == false and timestamp > ago(5m)
+| where toint(resultCode) between (200 .. 299) and success == false and timestamp >= ago(5m)
   QUERY
 
   trigger {
@@ -160,7 +160,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
 
   query = <<-QUERY
 requests
-| where toint(resultCode) >= 400 and toint(resultCode) < 500 and toint(resultCode) != 401 and timestamp > ago(5m)
+| where toint(resultCode) >= 400 and toint(resultCode) < 500 and toint(resultCode) != 401 and timestamp >= ago(5m)
   QUERY
 
   trigger {

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -93,41 +93,30 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
   }
 }
 
-resource "azurerm_monitor_metric_alert" "http_2xx_failed_requests" {
+resource "azurerm_monitor_scheduled_query_rules_alert" "http_2xx_failed_requests" {
   name                = "${var.env}-api-2xx-failed-requests"
   description         = "${local.env_title} HTTP Server 2xx Errors (where successful request == false) >= 10"
+  location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
-  scopes              = [var.app_insights_id]
-  frequency           = "PT1M"
-  window_size         = "PT5M"
   severity            = var.severity
+  frequency           = 5
+  time_window         = 5
   enabled             = contains(var.disabled_alerts, "http_2xx_failed_requests") ? false : true
 
-  criteria {
-    aggregation      = "Count"
-    metric_name      = "requests/count"
-    metric_namespace = "Microsoft.Insights/Components"
-    operator         = "GreaterThanOrEqual"
-    threshold        = 10
+  data_source_id = var.app_insights_id
 
-    dimension {
-      name     = "request/success"
-      operator = "Include"
-      values   = ["False"]
-    }
+  query = <<-QUERY
+requests
+| where toint(resultCode) between (200 .. 299) and success == false and timestamp > ago(5m)
+  QUERY
 
-    dimension {
-      name     = "request/resultCode"
-      operator = "StartsWith"
-      values   = ["2"]
-    }
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 9
   }
 
-  dynamic "action" {
-    for_each = var.action_group_ids
-    content {
-      action_group_id = action.value
-    }
+  action {
+    action_group = var.action_group_ids
   }
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

This PR addresses the following alerting issues:

* Our reset training DB workflow has a bad cron syntax (`* 9 * * *`) which is causing it to run every minute for an hour a day. The correct behavior should be to run once a day at that hour (`0 9 * * *`). The existing behavior is both bad and causing a bunch of unnecessary alerts due to constant app cycling.

* Additionally, dimensions don't work like I had assumed in Azure - each dimension causes a separate alert. Meaning, an alert for 2xx requests where `success = false` alerts on 2xx _or_ `success = false`, not _and_.

* Finally, the default aggregation type for HTTP response time alerts should be `Average`, not `Minimum`.

## Changes Proposed

- Fix the reset training DB cron job syntax
- Rewrite the 2xx alerts to use query language to capture the multiple conditions rather than alert dimensions
- Change `var.http_response_time_aggregation` to default to `Average`