### PR TITLE
Allow Site Admin Access Without Org

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
         organization: {
           name: data.whoami.organization?.name,
         },
-        facilities: data.whoami.organization.testingFacility,
+        facilities: data.whoami.organization?.testingFacility || [],
         facility: null,
         user: {
           id: data.whoami.id,

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -12,6 +12,7 @@ import { PATIENT_TERM_PLURAL_CAP } from "../../config/constants";
 import { formatFullName } from "../utils/user";
 import siteLogo from "../../img/simplereport-logo-color.svg";
 import { hasPermission, appPermissions } from "../permissions";
+import { RootState } from "../store";
 
 import Button from "./Button/Button";
 import Dropdown from "./Dropdown";
@@ -29,6 +30,9 @@ const Header: React.FC<{}> = () => {
     }
   };
 
+  const isAdmin = useSelector<RootState, boolean>(
+    (state) => state.user.isAdmin
+  );
   const organization = useSelector(
     (state) => (state as any).organization as Organization
   );
@@ -73,6 +77,8 @@ const Header: React.FC<{}> = () => {
     appPermissions.tests.canView
   );
 
+  const siteLogoLinkPath = isAdmin ? "/admin" : "/queue";
+
   const logout = () => {
     // Fetch the id_token from local storage
     const id_token = localStorage.getItem("id_token");
@@ -98,7 +104,7 @@ const Header: React.FC<{}> = () => {
       <div className="usa-nav-container">
         <div className="usa-navbar">
           <div className="usa-logo" id="basic-logo">
-            <LinkWithQuery to={`/queue`} title="Home" aria-label="Home">
+            <LinkWithQuery to={siteLogoLinkPath} title="Home" aria-label="Home">
               <img
                 className="width-card desktop:width-full"
                 src={siteLogo}
@@ -283,16 +289,18 @@ const Header: React.FC<{}> = () => {
               </li>
             ) : null}
           </ul>
-          <div className="prime-facility-select">
-            <Dropdown
-              selectedValue={facility.id}
-              onChange={onFacilitySelect}
-              options={facilities.map(({ name, id }) => ({
-                label: name,
-                value: id,
-              }))}
-            />
-          </div>
+          {facilities && facilities.length > 0 ? (
+            <div className="prime-facility-select">
+              <Dropdown
+                selectedValue={facility.id}
+                onChange={onFacilitySelect}
+                options={facilities.map(({ name, id }) => ({
+                  label: name,
+                  value: id,
+                }))}
+              />
+            </div>
+          ) : null}
           <ul className="usa-nav__primary usa-accordion">
             <li className="usa-nav__primary-item nav__primary-item-icon">
               <LinkWithQuery

--- a/frontend/src/app/facilitySelect/WithFacility.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.tsx
@@ -15,6 +15,9 @@ interface Props {}
 const WithFacility: React.FC<Props> = ({ children }) => {
   const dispatch = useDispatch();
   const history = useHistory();
+  const isAdmin = useSelector<RootState, boolean>(
+    (state) => state.user.isAdmin
+  );
   const dataLoaded = useSelector<RootState, boolean>(
     (state) => state.dataLoaded
   );
@@ -39,6 +42,11 @@ const WithFacility: React.FC<Props> = ({ children }) => {
 
   if (!dataLoaded) {
     return <Loading />;
+  }
+
+  if (isAdmin && facilities.length === 0) {
+    // site admin without an organization
+    return <>{children}</>;
   }
 
   if (facilities.length === 0) {


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/1313

## Changes Proposed

- Fix render for admin when no org access is set
- Change path on logo click to `/admin` when user is an admin

## Additional Information

- The link path on the logo for site admins was changed mainly because `/queue` isn't usable without an org, but also because it allows the admin to get back to `/admin` from anywhere in the app

## Screenshots / Demos

Example header when no org access is configured:

![header-for-admin-without-org](https://user-images.githubusercontent.com/77013690/123553097-6578d680-d747-11eb-877b-727a0829bddc.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
