### PR TITLE
Certain backend errors no longer cause requests to not be logged in the audit log

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/AuditLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/AuditLoggingInstrumentation.java
@@ -79,7 +79,7 @@ public class AuditLoggingInstrumentation extends SimpleInstrumentation {
       LOG.trace("End of execution, audit entry being saved.");
       List<String> errorPaths =
           result.getErrors().stream()
-              .map(e -> e.getPath() == null ? Collections.emptyList() : e.getPath())
+              .map(e -> e.getPath() == null ? new ArrayList<Object>() : e.getPath())
               .flatMap(List::stream)
               .map(Object::toString)
               .collect(Collectors.toList());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/AuditLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/AuditLoggingInstrumentation.java
@@ -8,7 +8,6 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.GraphQlInputs;
 import gov.cdc.usds.simplereport.db.model.auxiliary.HttpRequestDetails;
 import gov.cdc.usds.simplereport.service.AuditService;
 import graphql.ExecutionResult;
-import graphql.GraphQLError;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimpleInstrumentation;
@@ -80,7 +79,7 @@ public class AuditLoggingInstrumentation extends SimpleInstrumentation {
       LOG.trace("End of execution, audit entry being saved.");
       List<String> errorPaths =
           result.getErrors().stream()
-              .map(GraphQLError::getPath)
+              .map(e -> e.getPath() == null ? Collections.emptyList() : e.getPath())
               .flatMap(List::stream)
               .map(Object::toString)
               .collect(Collectors.toList());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/AuditLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/AuditLoggingInstrumentation.java
@@ -15,6 +15,7 @@ import graphql.execution.instrumentation.SimpleInstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.kickstart.servlet.context.GraphQLServletContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
@@ -79,7 +80,7 @@ public class AuditLoggingInstrumentation extends SimpleInstrumentation {
       LOG.trace("End of execution, audit entry being saved.");
       List<String> errorPaths =
           result.getErrors().stream()
-              .map(e -> e.getPath() == null ? new ArrayList<Object>() : e.getPath())
+              .map(e -> e.getPath() == null ? Collections.emptyList() : e.getPath())
               .flatMap(List::stream)
               .map(Object::toString)
               .collect(Collectors.toList());


### PR DESCRIPTION
## Related Issue or Background Info

Closes #1779 

## Changes Proposed
- Add a null-check in `AuditLoggingInstrumentation.java` so the request is logged in the audit log

## Additional Information
- The ticket states that the expected behavior of a result of this patch includes a `200` response from the API in the event of an `CoercingParseValueException`.
- Discussed with @nullflux - our feeling is that keeping the response as a `400` is sufficient at this time. While the `200` may be more technically correct, a `400` response does accurately indicate the nature of the error (i.e. "your request was bad, change something and try again").
- This decision was made with an eye towards velocity but if a reviewer feels strongly that we should undertake the work to send a `200` response please comment below

## Screenshots / Demos
<img width="1027" alt="Screen Shot 2021-06-29 at 2 10 53 PM" src="https://user-images.githubusercontent.com/27730981/123864810-2d18fa00-d8f9-11eb-86fa-d5a76ee54037.png">


## Checklist for Author and Reviewer
- [ ] Is keeping the response code as a `400` for this case acceptable?

### UI
- [x] ~Any changes to the UI/UX are approved by design~
- [x] ~Any new or updated content (e.g. error messages) are approved by design~

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] ~Database changes are submitted as a separate PR~
  - [x] ~Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~
  - [x] ~Any changes to tables that have custom no-PHI views are accompanied by changes to those views~
        ~(including re-granting permission to the no-PHI user if need be)~
  - [x] ~Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`~
- [x] ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~

## Cloud
- [x] ~DevOps team has been notified if PR requires ops support~
- [x] ~If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification~
