### PR TITLE
Add additional provider info to provider_no_phi_view

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2371,3 +2371,5 @@ databaseChangeLog:
             replaceIfExists: true
             fullDefinition: false
             selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, is_deleted, provider_id FROM ${database.defaultSchemaName}.provider
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.provider_no_phi_view TO ${noPhiUsername};

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2351,3 +2351,23 @@ databaseChangeLog:
               - column: *updated_by_column
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.text_message_sent TO ${noPhiUsername};
+  - changeSet:
+      id: add-columns-to-provider-view
+      author: josh@skylight.digital
+      comment: Add additional columns to provider_no_phi_view.
+      changes:
+        - createView:
+            viewName: provider_no_phi_view
+            remarks: A subset of the provider table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, is_deleted, provider_id, first_name, last_name, telephone, street, city, county, state, postal_code FROM ${database.defaultSchemaName}.provider;
+      rollback:
+        - dropView:
+            viewName: provider_no_phi_view
+        - createView:
+            viewName: provider_no_phi_view
+            remarks: A subset of the provider table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, is_deleted, provider_id FROM ${database.defaultSchemaName}.provider


### PR DESCRIPTION
## Related Issue or Background Info

Request from @aliciabeckett-gov to add additional provider contact information.

## Changes Proposed

- Add `first_name`, `last_name`, `telephone`, `street`, `city`, `county`, `state`, `postal_code` columns

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end