### PR TITLE
Remove semicolon from first-error-in-a-week alert

### DIFF
--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -91,7 +91,7 @@ exceptions
 
 todayErrors
 | join kind= leftanti (lastWeekErrors) on combinedErrorString
-| distinct exceptionType, failedMethod, requestName;
+| distinct exceptionType, failedMethod, requestName
   QUERY
 
   severity    = 2


### PR DESCRIPTION
## Related Issue or Background Info

#1887 (created to track alerts created in #1782)

Basically, the "first alert in a week" isn't firing when it should. It turns out that there's one gotcha when testing queries in Azure Monitor Logs vs. Azure Monitor Alerts - queries run in Logs will run when ended with a semicolon, but queries used in Alerts won't run unless there _isn't_ a semicolon. As a result, this query has ever actually run.

## Changes Proposed

- Remove the semicolon at the end of the query

## Additional Information

n/a