### PR TITLE
Fix URL concatenation; don't use `new URL()`'s base path parameter

### DIFF
--- a/frontend/src/app/utils/api.test.ts
+++ b/frontend/src/app/utils/api.test.ts
@@ -3,9 +3,10 @@ import { FetchMock } from "jest-fetch-mock/types";
 import FetchClient from "./api";
 
 describe("FetchClient", () => {
-  let sut = new FetchClient("/");
+  let sut: FetchClient;
 
   beforeEach(() => {
+    sut = new FetchClient("/");
     process.env.REACT_APP_BACKEND_URL = "http://localhost:";
     (fetch as FetchMock).resetMocks();
   });
@@ -16,6 +17,16 @@ describe("FetchClient", () => {
     expect(() => {
       sut.getURL("some-path");
     }).toThrow();
+    process.env.REACT_APP_BACKEND_URL = existing;
+  });
+
+  it("getURL works as expected", () => {
+    const existing = process.env.REACT_APP_BACKEND_URL;
+    process.env.REACT_APP_BACKEND_URL = "https://simplereport.gov/api";
+    sut = new FetchClient("pxp");
+    expect(sut.getURL("some-path")).toEqual(
+      "https://simplereport.gov/api/pxp/some-path"
+    );
     process.env.REACT_APP_BACKEND_URL = existing;
   });
 

--- a/frontend/src/app/utils/api.ts
+++ b/frontend/src/app/utils/api.ts
@@ -14,12 +14,7 @@ export const headers = {
  * joinAbsoluteUrlPath("a/b", "/c/d/", "/e", "f/g", "h") -> "/a/b/c/d/e/f/g/h"
  */
 function joinAbsoluteUrlPath(...args: string[]) {
-  return args
-    .map((pathPart) => {
-      const x = pathPart.replace(/(^\/|\/$)/g, "");
-      return x;
-    })
-    .join("/");
+  return args.map((pathPart) => pathPart.replace(/(^\/|\/$)/g, "")).join("/");
 }
 
 class FetchClient {

--- a/frontend/src/app/utils/api.ts
+++ b/frontend/src/app/utils/api.ts
@@ -35,7 +35,6 @@ class FetchClient {
     if (!process.env.REACT_APP_BACKEND_URL) {
       throw Error("process.env.REACT_APP_BACKEND_URL is falsy");
     }
-    const x = joinAbsoluteUrlPath(this.basePath, path);
     return new URL(
       joinAbsoluteUrlPath(
         process.env.REACT_APP_BACKEND_URL,

--- a/frontend/src/app/utils/api.ts
+++ b/frontend/src/app/utils/api.ts
@@ -14,9 +14,12 @@ export const headers = {
  * joinAbsoluteUrlPath("a/b", "/c/d/", "/e", "f/g", "h") -> "/a/b/c/d/e/f/g/h"
  */
 function joinAbsoluteUrlPath(...args: string[]) {
-  return (
-    "/" + args.map((pathPart) => pathPart.replace(/(^\/|\/$)/g, "")).join("/")
-  );
+  return args
+    .map((pathPart) => {
+      const x = pathPart.replace(/(^\/|\/$)/g, "");
+      return x;
+    })
+    .join("/");
 }
 
 class FetchClient {
@@ -32,9 +35,13 @@ class FetchClient {
     if (!process.env.REACT_APP_BACKEND_URL) {
       throw Error("process.env.REACT_APP_BACKEND_URL is falsy");
     }
+    const x = joinAbsoluteUrlPath(this.basePath, path);
     return new URL(
-      joinAbsoluteUrlPath(this.basePath, path),
-      process.env.REACT_APP_BACKEND_URL
+      joinAbsoluteUrlPath(
+        process.env.REACT_APP_BACKEND_URL,
+        this.basePath,
+        path
+      )
     ).href;
   };
 


### PR DESCRIPTION
## Related Issue or Background Info

- The patient experience is down bc the FetchClient refactor doesn't concatenate the REACT_APP_BACKEND_URL quite right

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
