### PR TITLE
Spread data back in to console methods for correct browser logging

### DIFF
--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -62,7 +62,7 @@ export function withInsights(console: Console) {
     ];
 
     console[method] = (...data: any[]) => {
-      originalConsole[method](data);
+      originalConsole[method](...data);
 
       if (method === "error" || method === "warn") {
         const exception = data[0] instanceof Error ? data[0] : undefined;


### PR DESCRIPTION
## Related Issue or Background Info

- Corrects a small error in #1948. The `data` array should be spread when passed back to the original console method

## Changes Proposed

- change `data` to `...data`

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
