### PR TITLE
Alert improvements

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -46,3 +46,8 @@ variable "cpu_window_size" {
 variable "http_response_time_aggregation" {
   default = "Average"
 }
+
+variable "failed_http_2xx_threshold" {
+  // The resource that uses this value doesn't have a >= check, so we need n - 1 here
+  default = 9
+}

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -73,24 +73,25 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "first_error_in_a_week" {
   # - Do the same for today
   # - leftanti join the two result sets to return only results from today that were not found in the week preceeding today
   query = <<-QUERY
-let lastWeekErrors = requests
-| where timestamp <= ago(1d) and timestamp > ago(8d) and success == false
+requests
+| where timestamp <= now() and timestamp > now(-1d) and success == false
 | join kind= inner (
-exceptions
-| where timestamp <= ago(1d) and timestamp > ago(8d)
-) on operation_Id
-| project combinedErrorString = strcat(type, method, name);
-
-let todayErrors = requests
-| where timestamp > ago(1d) and success == false
-| join kind= inner (
-exceptions
-| where timestamp > ago(1d)
-) on operation_Id
-| project exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name);
-
-todayErrors
-| join kind= leftanti (lastWeekErrors) on combinedErrorString
+    exceptions
+    | where timestamp <= now() and timestamp > now(-1d)
+    )
+    on operation_Id
+| project exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name)
+| join kind= leftanti (
+    requests
+    | where timestamp <= now(-1d) and timestamp > now(-8d) and success == false
+    | join kind= inner (
+        exceptions
+        | where timestamp <= now(-1d) and timestamp > now(-8d)
+        )
+        on operation_Id
+    | project exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name)
+    )
+    on combinedErrorString
 | distinct exceptionType, failedMethod, requestName
   QUERY
 

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -112,7 +112,7 @@ requests
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 9
+    threshold = var.failed_http_2xx_threshold
   }
 
   action {

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -9,6 +9,7 @@ module "metric_alerts" {
   mem_threshold                  = 85
   cpu_window_size                = 15
   http_response_time_aggregation = "Minimum"
+  failed_http_2xx_threshold      = 14
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_demo_action_id


### PR DESCRIPTION
## Related Issue or Background Info

- Our training alerts for failed HTTP 2xx requests per 5 minutes is too sensitive. It's set to 10, which basically triggers every morning when the training DB is reset
- Rework the "first time we've seen this error in a week" alert.

## Changes Proposed

- Upping the HTTP 2xx threshold to 15 for training (which hasn't been reached yet on DB resets, so this should silence most of them and we can go from there)
- The "first time we've seen this error in a week" query had a bug for `todayErrors`, where we searched for errors matching certain criteria using `ago(1d)`. In effect, this meant that we were relying on an implicit `now()` for the other side of the timespan. This works when run live, but it breaks once you follow a link in a PagerDuty alert, say, a day later.
  - Example: you click an alert link that's 2 days old. Since the implied `now()` was the time the alert was triggered, `todayResults` now contains 3 days of results - `ago(1d)` plus the two days since the alert was triggered. Whoops!
  - The fix is to explicitly bound `ago(1d)` with `now()` in the `todayError` query.
- Using `let` makes a query more readable, since we can store subqueries in a variable. It also seems to break the ability to run the query directly from a link, since it'll only run up to the first `;`. The fix is to avoid using temporary variables and run the subqueries as part of a single query statement.

## Screenshots / Demos

## Checklist for Author and Reviewer

### Testing
- [x] These queries still return the same results as the previous queries
- [x] These queries are still treated as valid queries in an existing `first_error_in_a_week` alert rule
- [ ] These changes have been deployed to test  
