### PR TITLE
Create self-registration links for new orgs and facilities

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepository.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
 import java.util.Optional;
@@ -7,11 +8,13 @@ import java.util.Optional;
 public interface PatientRegistrationLinkRepository
     extends EternalAuditedEntityRepository<PatientSelfRegistrationLink> {
 
-  public Optional<PatientSelfRegistrationLink> findByPatientRegistrationLink(
+  public Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkIgnoreCase(
       String patientRegistrationLink);
 
-  public Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkAndIsDeleted(
+  public Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkIgnoreCaseAndIsDeleted(
       String patientRegistrationLink, Boolean isDeleted);
 
   public Optional<PatientSelfRegistrationLink> findByOrganization(Organization org);
+
+  public Optional<PatientSelfRegistrationLink> findByFacility(Facility fac);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -351,7 +351,6 @@ public class OrganizationService {
             providerAddress,
             providerTelephone,
             providerNPI);
-    _psrlService.createRegistrationLink(fac);
     return fac;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -338,18 +338,19 @@ public class OrganizationService {
       StreetAddress providerAddress,
       String providerTelephone,
       String providerNPI) {
-    Facility fac = createFacilityNoPermissions(
-        getCurrentOrganization(),
-        testingFacilityName,
-        cliaNumber,
-        facilityAddress,
-        phone,
-        email,
-        deviceSpecimenTypes,
-        providerName,
-        providerAddress,
-        providerTelephone,
-        providerNPI);
+    Facility fac =
+        createFacilityNoPermissions(
+            getCurrentOrganization(),
+            testingFacilityName,
+            cliaNumber,
+            facilityAddress,
+            phone,
+            email,
+            deviceSpecimenTypes,
+            providerName,
+            providerAddress,
+            providerTelephone,
+            providerNPI);
     _psrlService.createRegistrationLink(fac);
     return fac;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -338,19 +338,17 @@ public class OrganizationService {
       StreetAddress providerAddress,
       String providerTelephone,
       String providerNPI) {
-    Facility fac =
-        createFacilityNoPermissions(
-            getCurrentOrganization(),
-            testingFacilityName,
-            cliaNumber,
-            facilityAddress,
-            phone,
-            email,
-            deviceSpecimenTypes,
-            providerName,
-            providerAddress,
-            providerTelephone,
-            providerNPI);
-    return fac;
+    return createFacilityNoPermissions(
+        getCurrentOrganization(),
+        testingFacilityName,
+        cliaNumber,
+        facilityAddress,
+        phone,
+        email,
+        deviceSpecimenTypes,
+        providerName,
+        providerAddress,
+        providerTelephone,
+        providerNPI);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -42,6 +42,7 @@ public class OrganizationService {
   private OktaRepository _oktaRepo;
   private CurrentOrganizationRolesContextHolder _currentOrgRolesContextHolder;
   private OrderingProviderRequiredValidator _orderingProviderRequiredValidator;
+  private PatientSelfRegistrationLinkService _psrlService;
 
   public OrganizationService(
       OrganizationRepository repo,
@@ -50,7 +51,8 @@ public class OrganizationService {
       ProviderRepository providerRepo,
       OktaRepository oktaRepo,
       CurrentOrganizationRolesContextHolder currentOrgRolesContextHolder,
-      OrderingProviderRequiredValidator orderingProviderRequiredValidator) {
+      OrderingProviderRequiredValidator orderingProviderRequiredValidator,
+      PatientSelfRegistrationLinkService patientSelfRegistrationLinkService) {
     _repo = repo;
     _facilityRepo = facilityRepo;
     _authService = authService;
@@ -58,6 +60,7 @@ public class OrganizationService {
     _oktaRepo = oktaRepo;
     _currentOrgRolesContextHolder = currentOrgRolesContextHolder;
     _orderingProviderRequiredValidator = orderingProviderRequiredValidator;
+    _psrlService = patientSelfRegistrationLinkService;
   }
 
   public Optional<OrganizationRoles> getCurrentOrganizationRoles() {
@@ -253,6 +256,7 @@ public class OrganizationService {
         providerAddress,
         providerTelephone,
         providerNPI);
+    _psrlService.createRegistrationLink(org);
     return org;
   }
 
@@ -316,6 +320,7 @@ public class OrganizationService {
             deviceSpecimenTypes.getDefault(),
             deviceSpecimenTypes.getFullList());
     facility = _facilityRepo.save(facility);
+    _psrlService.createRegistrationLink(facility);
     _oktaRepo.createFacility(facility);
     return facility;
   }
@@ -333,7 +338,7 @@ public class OrganizationService {
       StreetAddress providerAddress,
       String providerTelephone,
       String providerNPI) {
-    return createFacilityNoPermissions(
+    Facility fac = createFacilityNoPermissions(
         getCurrentOrganization(),
         testingFacilityName,
         cliaNumber,
@@ -345,5 +350,7 @@ public class OrganizationService {
         providerAddress,
         providerTelephone,
         providerNPI);
+    _psrlService.createRegistrationLink(fac);
+    return fac;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
@@ -20,6 +20,7 @@ public class PatientSelfRegistrationLinkService {
   private PatientRegistrationLinkRepository prlrepo;
   private CurrentPatientContextHolder contextHolder;
   public static final int LINK_LENGTH = 5;
+  public static final String LINK_CHARACTERS = "2346789abcdefghjkmnpqrtuvwxyz";
 
   PatientSelfRegistrationLinkService(
       PatientRegistrationLinkRepository prlrepo,
@@ -99,6 +100,6 @@ public class PatientSelfRegistrationLinkService {
   }
 
   private static String generateRandomLink() {
-    return RandomStringUtils.random(LINK_LENGTH, "2346789abcdefghjkmnpqrtuvwxyz");
+    return RandomStringUtils.random(LINK_LENGTH, LINK_CHARACTERS);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
@@ -20,6 +20,7 @@ public class PatientSelfRegistrationLinkService {
 
   private PatientRegistrationLinkRepository prlrepo;
   private CurrentPatientContextHolder contextHolder;
+  public static final int LINK_LENGTH = 5;
 
   PatientSelfRegistrationLinkService(
       PatientRegistrationLinkRepository prlrepo,
@@ -113,6 +114,6 @@ public class PatientSelfRegistrationLinkService {
   }
 
   private static String generateLink() {
-    return RandomStringUtils.random(5, "123456789abcdefghjkmnpqrstuvwxyz");
+    return RandomStringUtils.random(LINK_LENGTH, "123456789abcdefghjkmnpqrstuvwxyz");
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
@@ -8,7 +8,6 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
 import gov.cdc.usds.simplereport.db.repository.PatientRegistrationLinkRepository;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,30 +89,21 @@ public class PatientSelfRegistrationLinkService {
   }
 
   public String createRegistrationLink(Organization org) {
-    boolean retried = false;
-    while (true) {
-      try {
-        return createRegistrationLink(org, generateLink());
-      } catch (DataIntegrityViolationException e) {
-        if (retried) throw e;
-        retried = true;
-      }
-    }
+    return createRegistrationLink(org, generateUniqueLink());
   }
 
   public String createRegistrationLink(Facility fac) {
-    boolean retried = false;
-    while (true) {
-      try {
-        return createRegistrationLink(fac, generateLink());
-      } catch (DataIntegrityViolationException e) {
-        if (retried) throw e;
-        retried = true;
-      }
-    }
+    return createRegistrationLink(fac, generateUniqueLink());
   }
 
-  private static String generateLink() {
+  private String generateUniqueLink() {
+    String link = generateRandomLink();
+    return prlrepo.findByPatientRegistrationLinkIgnoreCase(link).isPresent()
+        ? generateRandomLink()
+        : link;
+  }
+
+  private static String generateRandomLink() {
     return RandomStringUtils.random(LINK_LENGTH, "123456789abcdefghjkmnpqrstuvwxyz");
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
@@ -35,12 +35,7 @@ public class PatientSelfRegistrationLinkService {
             .findByPatientRegistrationLinkIgnoreCase(patientRegistrationLink)
             .orElseThrow(InvalidPatientSelfRegistrationLinkException::new);
 
-    Organization org =
-        link.getOrganization() != null
-            ? link.getOrganization()
-            : link.getFacility().getOrganization();
-
-    if (!org.getIdentityVerified()) {
+    if (!link.getOrganization().getIdentityVerified()) {
       throw new InvalidPatientSelfRegistrationLinkException();
     }
 
@@ -104,6 +99,6 @@ public class PatientSelfRegistrationLinkService {
   }
 
   private static String generateRandomLink() {
-    return RandomStringUtils.random(LINK_LENGTH, "123456789abcdefghjkmnpqrstuvwxyz");
+    return RandomStringUtils.random(LINK_LENGTH, "2346789abcdefghjkmnpqrtuvwxyz");
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkService.java
@@ -41,7 +41,7 @@ public class PatientSelfRegistrationLinkService {
             ? link.getOrganization()
             : link.getFacility().getOrganization();
 
-    if (org.getIdentityVerified() == false) {
+    if (!org.getIdentityVerified()) {
       throw new InvalidPatientSelfRegistrationLinkException();
     }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepositoryTest.java
@@ -27,7 +27,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
     _repo.save(new PatientSelfRegistrationLink(otherFac, "bar-facility"));
 
     Optional<PatientSelfRegistrationLink> retrieved =
-        _repo.findByPatientRegistrationLink("foo-facility");
+        _repo.findByPatientRegistrationLinkIgnoreCase("foo-facility");
     assertEquals(true, retrieved.isPresent());
     assertEquals(retrieved.get().getFacility().getInternalId(), fac.getInternalId());
   }
@@ -41,7 +41,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
     _repo.save(new PatientSelfRegistrationLink(org, "happy-org"));
 
     Optional<PatientSelfRegistrationLink> retrieved =
-        _repo.findByPatientRegistrationLink("happy-org");
+        _repo.findByPatientRegistrationLinkIgnoreCase("happy-org");
     assertEquals(true, retrieved.isPresent());
     assertEquals(retrieved.get().getOrganization().getInternalId(), org.getInternalId());
   }
@@ -55,7 +55,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
     _repo.save(new PatientSelfRegistrationLink(fac, "foo-facility"));
 
     Optional<PatientSelfRegistrationLink> retrieved =
-        _repo.findByPatientRegistrationLink("some-bad-link");
+        _repo.findByPatientRegistrationLinkIgnoreCase("some-bad-link");
     assertEquals(false, retrieved.isPresent());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -11,8 +11,10 @@ import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+import gov.cdc.usds.simplereport.db.repository.PatientRegistrationLinkRepository;
 import gov.cdc.usds.simplereport.service.model.DeviceSpecimenTypeHolder;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
@@ -28,6 +30,7 @@ import org.springframework.security.access.AccessDeniedException;
 class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Autowired private TestDataFactory _dataFactory;
+  @Autowired private PatientRegistrationLinkRepository _prlRepo;
 
   @BeforeEach
   void setupData() {
@@ -67,9 +70,16 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     List<Facility> facilities = _service.getFacilities(org);
     assertNotNull(facilities);
     assertEquals(1, facilities.size());
-    assertEquals("Facility 1", facilities.get(0).getFacilityName());
-    assertNotNull(facilities.get(0).getDefaultDeviceType());
-    assertEquals("Bill", facilities.get(0).getDefaultDeviceType().getName());
+
+    Facility fac = facilities.get(0);
+    assertEquals("Facility 1", fac.getFacilityName());
+    assertNotNull(fac.getDefaultDeviceType());
+    assertEquals("Bill", fac.getDefaultDeviceType().getName());
+
+    PatientSelfRegistrationLink orgLink = _prlRepo.findByOrganization(org).get();
+    PatientSelfRegistrationLink facLink = _prlRepo.findByFacility(fac).get();
+    assertEquals(5, orgLink.getLink().length());
+    assertEquals(5, facLink.getLink().length());
   }
 
   private DeviceSpecimenTypeHolder getDeviceConfig() {
@@ -107,9 +117,15 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     List<Facility> facilities = _service.getFacilities(org);
     assertNotNull(facilities);
     assertEquals(1, facilities.size());
-    assertEquals("Facility 1", facilities.get(0).getFacilityName());
-    assertNotNull(facilities.get(0).getDefaultDeviceType());
-    assertEquals("Bill", facilities.get(0).getDefaultDeviceType().getName());
+    Facility fac = facilities.get(0);
+    assertEquals("Facility 1", fac.getFacilityName());
+    assertNotNull(fac.getDefaultDeviceType());
+    assertEquals("Bill", fac.getDefaultDeviceType().getName());
+
+    PatientSelfRegistrationLink orgLink = _prlRepo.findByOrganization(org).get();
+    PatientSelfRegistrationLink facLink = _prlRepo.findByFacility(fac).get();
+    assertEquals(5, orgLink.getLink().length());
+    assertEquals(5, facLink.getLink().length());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkServiceTest.java
@@ -167,7 +167,11 @@ class PatientSelfRegistrationLinkServiceTest
     _psrlService.createRegistrationLink(_fac, "abcde");
 
     _rsl = mockStatic(RandomStringUtils.class);
-    _rsl.when(() -> RandomStringUtils.random(5, "123456789abcdefghjkmnpqrstuvwxyz"))
+    _rsl.when(
+            () ->
+                RandomStringUtils.random(
+                    PatientSelfRegistrationLinkService.LINK_LENGTH,
+                    PatientSelfRegistrationLinkService.LINK_CHARACTERS))
         .thenReturn("abcde")
         .thenReturn("uniqe");
 
@@ -181,7 +185,11 @@ class PatientSelfRegistrationLinkServiceTest
     _psrlService.createRegistrationLink(_org, "abcde");
 
     _rsl = mockStatic(RandomStringUtils.class);
-    _rsl.when(() -> RandomStringUtils.random(5, "123456789abcdefghjkmnpqrstuvwxyz"))
+    _rsl.when(
+            () ->
+                RandomStringUtils.random(
+                    PatientSelfRegistrationLinkService.LINK_LENGTH,
+                    PatientSelfRegistrationLinkService.LINK_CHARACTERS))
         .thenReturn("abcde")
         .thenReturn("uniqe");
 
@@ -195,7 +203,11 @@ class PatientSelfRegistrationLinkServiceTest
     _psrlService.createRegistrationLink(_fac, "abcde");
 
     _rsl = mockStatic(RandomStringUtils.class);
-    _rsl.when(() -> RandomStringUtils.random(5, "123456789abcdefghjkmnpqrstuvwxyz"))
+    _rsl.when(
+            () ->
+                RandomStringUtils.random(
+                    PatientSelfRegistrationLinkService.LINK_LENGTH,
+                    PatientSelfRegistrationLinkService.LINK_CHARACTERS))
         .thenReturn("abcde")
         .thenReturn("abcde")
         .thenReturn("uniqe");
@@ -210,7 +222,11 @@ class PatientSelfRegistrationLinkServiceTest
     _psrlService.createRegistrationLink(_org, "abcde");
 
     _rsl = mockStatic(RandomStringUtils.class);
-    _rsl.when(() -> RandomStringUtils.random(5, "123456789abcdefghjkmnpqrstuvwxyz"))
+    _rsl.when(
+            () ->
+                RandomStringUtils.random(
+                    PatientSelfRegistrationLinkService.LINK_LENGTH,
+                    PatientSelfRegistrationLinkService.LINK_CHARACTERS))
         .thenReturn("abcde")
         .thenReturn("abcde")
         .thenReturn("uniqe");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -19,6 +19,7 @@ import gov.cdc.usds.simplereport.service.BaseServiceTest;
 import gov.cdc.usds.simplereport.service.LoggedInAuthorizationService;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
+import gov.cdc.usds.simplereport.service.PatientSelfRegistrationLinkService;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 import gov.cdc.usds.simplereport.validators.OrderingProviderRequiredValidator;
 import java.lang.annotation.ElementType;
@@ -85,7 +86,8 @@ import org.springframework.security.test.context.support.WithMockUser;
   CurrentPatientContextHolder.class,
   CurrentAccountRequestContextHolder.class,
   CurrentOrganizationRolesContextHolder.class,
-  OrderingProviderRequiredValidator.class
+  OrderingProviderRequiredValidator.class,
+  PatientSelfRegistrationLinkService.class
 })
 @EnableConfigurationProperties({
   InitialSetupProperties.class,


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #1942

## Changes Proposed

- Adds a static link generator method to the patient self registration link service
- Adds a method to create random org and facility links. These methods should catch a collision and retry. Two collisions is basically impossible.
- Generates random links wherever orgs or facilities are created in the app

## Additional Information

- A couple somewhat hidden requirements presented themselves while working on the ticket:
    - Links should be case-insensitive
    - Unverified facility links should not work
- I made the assumption that we should generate a link for unverified orgs and their associated facilities upon creation and simply throw an error if someone tries to access those links. This seemed easier than trying to generate the links only for new verified organizations and then trying to retroactively create links when organizations are verified (this would be especially complicated if organizations could become unverified after being verified, but I don't think that's a use case yet). 

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
