### PR TITLE
Send a default value to Dynamics when no mappable device is selected

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/crm/DynamicsValueMapping.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/crm/DynamicsValueMapping.java
@@ -101,6 +101,17 @@ public enum DynamicsValueMapping {
       }
     }
 
+    if (typeSet.isEmpty()) {
+      // devices were provided, but none were mappable.  return default so dynamics will
+      // succeed, even though we're reporting the incorrect device
+      try {
+        // prefer other, if it exists
+        return String.valueOf(getDynamicsCodeFromName(prefix, "OTHER"));
+      } catch (IllegalArgumentException e) {
+        // no mappable values found and other doesn't exist for this prefix
+        return String.valueOf(DEFAULT_VALUE);
+      }
+    }
     return typeSet.stream().map(String::valueOf).collect(Collectors.joining(","));
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/crm/DynamicsValueMappingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/crm/DynamicsValueMappingTest.java
@@ -35,7 +35,20 @@ class DynamicsValueMappingTest {
   }
 
   @Test
-  void convertToValues_invalidOptions_success() {
-    assertEquals("", DynamicsValueMapping.convertToValues(Prefix.B, "Bad, Choices"));
+  void convertToValues_noMappableOptions_success() {
+    // Expect the value of "Other" to be returned
+    assertEquals("810050003", DynamicsValueMapping.convertToValues(Prefix.B, "Bad, Choices"));
+  }
+
+  @Test
+  void convertToValues_noMappableOptionsNoOther_success() {
+    // Expect the value of default option to be returned
+    assertEquals("810050000", DynamicsValueMapping.convertToValues(Prefix.AD, "Bad, Choices"));
+  }
+
+  @Test
+  void convertToValues_mappableAndUnmappableOptions_success() {
+    // Expect the value of "Chrome" to be returned
+    assertEquals("810050001", DynamicsValueMapping.convertToValues(Prefix.B, "Bad Choice, Chrome"));
   }
 }


### PR DESCRIPTION
One unhandled case for building the Dynamics request body was when the account request did not contain any devices that were mappable to the Dynamics field.  This could happen because Dynamics only has a subset of the devices that SimpleReport now supports.  The error looks like:

https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22%3A%220427e0e3-de7e-11eb-b30c-fb4f621ba0e0%22%2C%22timestamp%22%3A%222021-07-06T17%3A17%3A14.472Z%22%7D/ComponentId/%7B%22Name%22%3A%22prime-simple-report-prod-insights%22%2C%22ResourceGroup%22%3A%22prime-simple-report-prod%22%2C%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%7D

and carries the error message "Edm Object passed should have the options selected."  This PR ensures that the device type passed to Dynamics will carry at least 1 option to avoid this error.

## Related Issue or Background Info

- https://usds.slack.com/archives/C01LTSNKEPP/p1625592328244200

## Changes Proposed

- Ensure at least 1 value is provided when mapping Dynamics multi-value select fields

## Checklist for Author and Reviewer

Some sample requests were made and the resulting organizations can be viewed in our Dynamics UAT environment.

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
