### PR TITLE
Add try/catch with custom exception for /account-request; add alert when this exception is seen

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/errors/AccountRequestFailureException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/errors/AccountRequestFailureException.java
@@ -1,0 +1,14 @@
+package gov.cdc.usds.simplereport.api.accountrequest.errors;
+
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class AccountRequestFailureException extends IOException {
+  private static final long serialVersionUID = 1L;
+
+  public AccountRequestFailureException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.sendgrid.helpers.mail.Mail;
 import gov.cdc.usds.simplereport.api.accountrequest.AccountRequestController;
+import gov.cdc.usds.simplereport.api.accountrequest.errors.AccountRequestFailureException;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
 import gov.cdc.usds.simplereport.api.model.accountrequest.AccountRequest;
@@ -338,5 +340,33 @@ class AccountRequestControllerTest {
     verifyNoInteractions(addressValidationService);
     verifyNoInteractions(orgService);
     verifyNoInteractions(apiUserService);
+  }
+
+  @Test
+  void accountRequestSubmittedDeviceNotRegistered() throws Exception {
+    String requestBody =
+        "{\"first-name\":\"Mary\",\"last-name\":\"Lopez\",\"email\":\"kyvuzoxy@mailinator.com\",\"work-phone-number\":\"+1 (969) 768-2863\",\"cell-phone-number\":\"+1 (319) 682-3114\",\"street-address1\":\"707 White Milton Extension\",\"street-address2\":\"Apt 3\",\"city\":\"Reprehenderit nostr\",\"state\":\"RI\",\"zip\":\"13046\",\"county\":\"Et consectetur sunt\",\"organization-name\":\"Day Hayes Trading\",\"organization-type\":\"Homeless Shelter\",\"facility-name\":\"Fiona Payne\",\"facility-phone-number\":\"800-888-8888\",\"clia-number\":\"474\",\"workflow\":\"Aut ipsum aute aute\",\"op-first-name\":\"Sawyer\",\"op-last-name\":\"Sears\",\"npi\":\"Quis sit eiusmod Nam\",\"op-phone-number\":\"+1 (583) 883-4172\",\"op-street-address1\":\"290 East Rocky Second Street\",\"op-street-address2\":\"UNAVAILABLE\",\"op-city\":\"Dicta cumque sit ip\",\"op-state\":\"AR\",\"op-zip\":\"43675\",\"op-county\":\"Asperiores illum in\",\"records-test-results\":\"No\",\"process-time\":\"15–30 minutes\",\"submitting-results-time\":\"Less than 30 minutes\",\"browsers\":\"Other\",\"testing-devices\":\"Invalid Device\",\"default-testing-device\":\"LumiraDX\",\"access-devices\":\"Smartphone\"}";
+
+    DeviceType device1 = mock(DeviceType.class);
+    UUID deviceUuid1 = UUID.randomUUID();
+    when(device1.getName()).thenReturn("Abbott IDNow");
+    when(device1.getModel()).thenReturn("ID Now");
+    when(device1.getInternalId()).thenReturn(deviceUuid1);
+    when(deviceTypeService.fetchDeviceTypes()).thenReturn(List.of(device1));
+
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.ACCOUNT_REQUEST)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    this._mockMvc
+        .perform(builder)
+        .andExpect(status().isInternalServerError())
+        .andExpect(
+            result ->
+                assertTrue(
+                    result.getResolvedException() instanceof AccountRequestFailureException));
   }
 }

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -103,3 +103,37 @@ requests
     threshold = 0
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "account_request_failures" {
+  name                = "${var.env}-account-request-failures"
+  description         = "${local.env_title} alert when an AccountRequestFailureException is seen"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+
+  action {
+    action_group = var.action_group_ids
+  }
+
+  data_source_id = var.app_insights_id
+  enabled        = true
+
+  query = <<-QUERY
+requests
+| where timestamp > ago(2h) and success == false
+| join kind= inner (
+    exceptions
+    | where timestamp > ago(2h)
+    )
+    on operation_Id
+| where type hassuffix "AccountRequestFailureException"
+| project timestamp, exceptionType = type, failedMethod = method, requestName = name
+  QUERY
+
+  severity    = 3
+  frequency   = 5
+  time_window = 5
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 0
+  }
+}


### PR DESCRIPTION
## Related Issue or Background Info

#1837 

## Changes Proposed

- Wrap the entire `/account-request` flow (e.g. the `submitAccountRequest` method) in a `try`/`catch`. Then, use a new custom exception, `AccountRequestFailureException`, to wrap the caught exception and then `throw` it.
- This should preserve existing status code and messaging behavior while providing a catch-all string for account request failures to alert on when seen.
- Change the existing `RuntimeException`s to `IOException`s to be able to properly catch them.
- One exception was being thrown as part of a `stream()`, so that null check and resulting `throw` was moved outside of the stream.
- Add a test to verify the above

## Additional Information

- This could be done without the custom exception by alerting on any 5xx request to `/account-request` but relying on the URL alone could potentially introduce false positives.

## Checklist for Author and Reviewer

- [ ] These changes have been deployed to/tested in `test`
- [ ] These changes make sense and are a reasonable way to accomplish this