### PR TITLE
Scialli/registration links UI

### DIFF
--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.scss
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.scss
@@ -2,3 +2,25 @@
   color: color($theme-color-base);
   max-width: 22em;
 }
+
+.sr-organization-link-container {
+  .sr-organization-link-input {
+    margin-top: 0;
+    height: auto;
+  }
+
+  .sr-organization-link-copy-button {
+    @include u-width(full);
+    border-radius: 0 0 4px 4px;
+  }
+
+  @include at-media(mobile-lg) {
+    display: flex;
+
+    .sr-organization-link-copy-button {
+      flex-shrink: 0;
+      border-radius: 0 4px 4px 0;
+      width: auto;
+    }
+  }
+}

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.scss
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.scss
@@ -1,0 +1,4 @@
+.sr-registration-link-description {
+  color: color($theme-color-base);
+  max-width: 22em;
+}

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.stories.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.stories.tsx
@@ -1,0 +1,37 @@
+import { Story, Meta } from "@storybook/react";
+import { ComponentProps } from "react";
+
+import { ManageSelfRegistrationLinks } from "./ManageSelfRegistrationLinks";
+
+export default {
+  title: "Org Admin/Settings/Self-registration",
+  component: ManageSelfRegistrationLinks,
+  argTypes: {
+    isNewFeature: { control: "boolean" },
+  },
+} as Meta;
+
+const Template: Story<ComponentProps<typeof ManageSelfRegistrationLinks>> = (
+  args
+) => <ManageSelfRegistrationLinks {...args} />;
+
+export const View = Template.bind({});
+View.args = {
+  facilitySlugs: [
+    {
+      name: "The Sandwich Emporium",
+      slug: "2q45f",
+    },
+    {
+      name: "Physics Building",
+      slug: "emc22",
+    },
+    {
+      name: "Admissions Facility",
+      slug: "66t6y",
+    },
+  ],
+  organizationSlug: "ab3de",
+  isNewFeature: true,
+  howItWorksLink: "https://example.com",
+};

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.stories.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.stories.tsx
@@ -33,5 +33,6 @@ View.args = {
   ],
   organizationSlug: "ab3de",
   isNewFeature: true,
-  howItWorksLink: "https://example.com",
+  howItWorksPath: "/how-it-works",
+  baseUrl: "https://simplereport.gov/",
 };

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.test.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.test.tsx
@@ -42,7 +42,7 @@ describe("ManageSelfRegistrationLinks", () => {
     expect(navigator.clipboard.writeText).toBeCalledWith(orgUrl);
   });
 
-  it("copies the org link", async () => {
+  it("copies a facility link", async () => {
     const facilityUrl = `${
       props.baseUrl
     }/register/${props.facilitySlugs[1].slug.toUpperCase()}`;

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.test.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ComponentProps } from "react";
+
+import { ManageSelfRegistrationLinks } from "./ManageSelfRegistrationLinks";
+
+const props: ComponentProps<typeof ManageSelfRegistrationLinks> = {
+  organizationSlug: "abc22",
+  facilitySlugs: [
+    { name: "Foo Facility", slug: "foo66" },
+    { name: "Physics Building", slug: "phys2" },
+  ],
+  howItWorksPath: "/how-it-works",
+  isNewFeature: true,
+  baseUrl: "https://some-base-url.com",
+};
+
+describe("ManageSelfRegistrationLinks", () => {
+  const nav = { ...navigator };
+
+  beforeEach(async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    });
+    render(<ManageSelfRegistrationLinks {...props} />);
+    await screen.findByText("Patient self-registration");
+  });
+
+  afterEach(() => {
+    Object.assign(navigator, nav);
+  });
+
+  it("copies the org link", async () => {
+    const orgUrl = `${
+      props.baseUrl
+    }/register/${props.organizationSlug.toUpperCase()}`;
+    const [orgBtn] = screen.getAllByRole("button");
+    await waitFor(() => {
+      fireEvent.click(orgBtn);
+    });
+    expect(navigator.clipboard.writeText).toBeCalledWith(orgUrl);
+  });
+
+  it("copies the org link", async () => {
+    const facilityUrl = `${
+      props.baseUrl
+    }/register/${props.facilitySlugs[1].slug.toUpperCase()}`;
+    const btns = screen.getAllByRole("button");
+    await waitFor(() => {
+      fireEvent.click(btns[2]);
+    });
+    expect(navigator.clipboard.writeText).toBeCalledWith(facilityUrl);
+  });
+});

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
@@ -1,6 +1,6 @@
 import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useEffect, useMemo, useState } from "react";
+import { createRef, RefObject, useEffect, useMemo, useState } from "react";
 
 import "./ManageSelfRegistrationLinks.scss";
 
@@ -150,8 +150,15 @@ function FacilityLinks({
     [slugs]
   );
 
+  const [buttonRefs] = useState<Record<string, RefObject<HTMLButtonElement>>>(
+    slugs.reduce((acc, el) => ({ ...acc, [el.slug]: createRef() }), {})
+  );
+
   return (
     <section aria-label="Facility links" className="margin-top-5">
+      <CopyTooltip
+        buttonRef={copiedSlug ? buttonRefs[copiedSlug] : undefined}
+      />
       <p className="usa-label text-bold">Facility links</p>
       <p className="sr-registration-link-description">
         Patients who register at these links will be visible only at the
@@ -175,6 +182,7 @@ function FacilityLinks({
                     className="usa-button margin-left-1 usa-button--unstyled"
                     onClick={() => copySlug(slug)}
                     arial-label={`Copy patient self-registration link for ${name}`}
+                    ref={buttonRefs[slug]}
                   >
                     <FontAwesomeIcon
                       icon={copiedSlug === slug ? faCheck : faCopy}
@@ -204,3 +212,27 @@ function getRegistrationLink(
 function makeLink(...parts: string[]) {
   return parts.map((part) => part.replace(/(^\/|\/$)/, "")).join("/");
 }
+
+type CopyToolTipProps = {
+  buttonRef?: RefObject<HTMLButtonElement>;
+};
+
+const TOOLTIP_OFFSET = 5;
+
+const CopyTooltip = ({ buttonRef }: CopyToolTipProps) => {
+  const buttonRect = buttonRef?.current?.getBoundingClientRect();
+  const top = buttonRect
+    ? TOOLTIP_OFFSET + buttonRect.top - buttonRect.height
+    : 0;
+  const left = buttonRect ? TOOLTIP_OFFSET + buttonRect.left : 0;
+  const display = buttonRect ? "block" : "none";
+
+  return (
+    <span
+      className="usa-tooltip__body usa-tooltip__body--right is-set is-visible"
+      style={{ display, top, left }}
+    >
+      Copied!
+    </span>
+  );
+};

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
@@ -1,0 +1,123 @@
+import { faCheckCircle, faCopy } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useEffect, useState } from "react";
+
+type Props = {
+  isNewFeature: boolean;
+  organizationSlug: string;
+  facilitySlugs: { name: string; slug: string }[];
+  howItWorksLink: string;
+};
+
+export const ManageSelfRegistrationLinks = ({
+  isNewFeature,
+  organizationSlug,
+  facilitySlugs,
+  howItWorksLink,
+}: Props) => {
+  const [copiedSlug, setCopiedSlug] = useState<String>();
+
+  useEffect(() => {
+    if (!copiedSlug) return;
+    setTimeout(() => {
+      setCopiedSlug(undefined);
+    }, 3000);
+  }, [copiedSlug]);
+
+  async function copySlug(slug: string) {
+    try {
+      await navigator.clipboard.writeText(getRegistrationLink(slug));
+      setCopiedSlug(slug);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  return (
+    <div className="grid-row position-relative">
+      <div className="prime-container card-container">
+        <div className="usa-card__header">
+          <h2 className="display-flex flex-row flex-align-center">
+            <span>Patient self-registration</span>
+            {isNewFeature && (
+              <span className="usa-tag margin-left-1 bg-black padding-y-05">
+                New
+              </span>
+            )}
+          </h2>
+        </div>
+        <div className="usa-card__body maxw-prose padding-y-3">
+          <p>
+            Patients can now register themselves online — saving time during the
+            testing process and reducing data entry for your staff.
+          </p>
+          <p>
+            <a href={howItWorksLink} target="_blank" rel="noreferrer">
+              How patient self-registration works
+            </a>
+          </p>
+          <OrganizationLink
+            slug={organizationSlug}
+            copySlug={() => {
+              copySlug(organizationSlug);
+            }}
+            copied={copiedSlug === organizationSlug}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type OrgLinkProps = {
+  slug: string;
+  copySlug: () => void;
+  copied: boolean;
+};
+
+function OrganizationLink({ slug, copySlug, copied }: OrgLinkProps) {
+  const link = getRegistrationLink(slug);
+
+  return (
+    <section aria-label="Organization link" className="margin-top-5">
+      <label className="usa-label text-bold" htmlFor="org-link">
+        Organization link
+      </label>
+      <p id="org-link-description" className="text-base">
+        Patients who register at this link will be visible at{" "}
+        <span className="text-bold text-italic">all</span> your facilities.
+      </p>
+      <div className="grid-row flex-no-wrap">
+        <input
+          style={{ marginTop: 0, height: "auto" }}
+          className="usa-input"
+          id="org-link"
+          aria-describedby="org-link-description"
+          value={link}
+          disabled
+        />
+        <button
+          style={{
+            flexShrink: 0,
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+          }}
+          className="usa-button"
+          onClick={copySlug}
+        >
+          <FontAwesomeIcon
+            className="margin-right-1"
+            icon={copied ? faCheckCircle : faCopy}
+          />
+          {copied ? "Copied!" : "Copy link"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+const baseUrl = process.env.REACT_APP_BASE_URL?.replace(/\/$/, "");
+
+function getRegistrationLink(slug: string) {
+  return `${baseUrl}/register/${slug.toUpperCase()}`;
+}

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
@@ -1,6 +1,6 @@
 import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { createRef, RefObject, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import "./ManageSelfRegistrationLinks.scss";
 
@@ -150,15 +150,8 @@ function FacilityLinks({
     [slugs]
   );
 
-  const [buttonRefs] = useState<Record<string, RefObject<HTMLButtonElement>>>(
-    slugs.reduce((acc, el) => ({ ...acc, [el.slug]: createRef() }), {})
-  );
-
   return (
     <section aria-label="Facility links" className="margin-top-5">
-      <CopyTooltip
-        buttonRef={copiedSlug ? buttonRefs[copiedSlug] : undefined}
-      />
       <p className="usa-label text-bold">Facility links</p>
       <p className="sr-registration-link-description">
         Patients who register at these links will be visible only at the
@@ -176,18 +169,21 @@ function FacilityLinks({
             <tr key={slug}>
               <td>{name}</td>
               <td>
-                <div className="display-flex flex-justify">
+                <div
+                  style={{ position: "relative" }}
+                  className="display-flex flex-justify"
+                >
                   <span>{getRegistrationLink(baseUrl, slug, false)}</span>
                   <button
                     className="usa-button margin-left-1 usa-button--unstyled"
                     onClick={() => copySlug(slug)}
                     arial-label={`Copy patient self-registration link for ${name}`}
-                    ref={buttonRefs[slug]}
                   >
                     <FontAwesomeIcon
                       icon={copiedSlug === slug ? faCheck : faCopy}
                     />
                   </button>
+                  {copiedSlug === slug && <CopyTooltip />}
                 </div>
               </td>
             </tr>
@@ -213,24 +209,22 @@ function makeLink(...parts: string[]) {
   return parts.map((part) => part.replace(/(^\/|\/$)/, "")).join("/");
 }
 
-type CopyToolTipProps = {
-  buttonRef?: RefObject<HTMLButtonElement>;
-};
+const TOOLTIP_OFFSET = 7;
 
-const TOOLTIP_OFFSET = 5;
+const CopyTooltip = () => {
+  const [spanRef, setSpanRef] = useState<HTMLSpanElement | null>(null);
 
-const CopyTooltip = ({ buttonRef }: CopyToolTipProps) => {
-  const buttonRect = buttonRef?.current?.getBoundingClientRect();
-  const top = buttonRect
-    ? TOOLTIP_OFFSET + buttonRect.top - buttonRect.height
-    : 0;
-  const left = buttonRect ? TOOLTIP_OFFSET + buttonRect.left : 0;
-  const display = buttonRect ? "block" : "none";
+  const marginTop = -TOOLTIP_OFFSET;
+  const marginRight =
+    -1 * (spanRef?.getBoundingClientRect().width || 0) - TOOLTIP_OFFSET;
 
   return (
     <span
+      ref={(node) => {
+        setSpanRef(node);
+      }}
       className="usa-tooltip__body usa-tooltip__body--right is-set is-visible"
-      style={{ display, top, left }}
+      style={{ right: 0, marginRight, marginTop }}
     >
       Copied!
     </span>

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
@@ -24,14 +24,15 @@ export const ManageSelfRegistrationLinks = ({
   const [copiedSlug, setCopiedSlug] = useState<string>();
 
   useEffect(() => {
-    if (!copiedSlug) {
-      return;
-    }
-    const timeout = setTimeout(() => {
-      setCopiedSlug(undefined);
-    }, 3000);
+    const timeout = copiedSlug
+      ? setTimeout(() => {
+          setCopiedSlug(undefined);
+        }, 3000)
+      : undefined;
     return () => {
-      clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
     };
   }, [copiedSlug]);
 
@@ -192,7 +193,7 @@ function FacilityLinks({
 function getRegistrationLink(
   baseUrl: string,
   slug: string,
-  withProtocol: boolean = true
+  withProtocol = true
 ) {
   const link = makeLink(baseUrl, "register", slug.toUpperCase());
   return withProtocol


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #1976

## Changes Proposed

- Adds `ManageSelfRegistrationLinks` component
- Adds storybook component

## Additional Information

- This ticket is to create the component but _not_ add it to the app yet
- The component's design and functionality can be tested in storybook
- The original ticket is "blocked" by the corresponding "how it works" public site ticket, but I don't think it's actually blocking

## Screenshots / Demos

- The story with ability to adjust properties can be reviewed here: https://60a556a7c807cc0039ec6786-zcfscumkgs.chromatic.com/?path=/story/org-admin-settings-self-registration--view
- The story can be accepted or rejected in Chromatic here: https://www.chromatic.com/test?appId=60a556a7c807cc0039ec6786&id=60e75e7e61fef20049d264af

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
