### PR TITLE
Prepare self-registration for translation

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -178,8 +178,7 @@ sonarqube {
         property "sonar.host.url", "https://sonarcloud.io"
         // In order to get both the frontend and backend code to report, we need to set the sonar project to the root directory.
         property "sonar.sources", "backend/src/main/java,frontend/src"
-        property "sonar.exclusions", "frontend/src/**/*.test.*,frontend/src/stories/**/*,frontend/src/**/*.stories.tsx"
-        property "sonar.cpd.exclusions", "frontend/src/lang/*.ts"
+        property "sonar.exclusions", "frontend/src/**/*.test.*,frontend/src/stories/**/*,frontend/src/**/*.stories.tsx", "frontend/src/lang/*.ts"
         property "sonar.javascript.lcov.reportPaths", "frontend/coverage/lcov.info"
     }
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -178,7 +178,8 @@ sonarqube {
         property "sonar.host.url", "https://sonarcloud.io"
         // In order to get both the frontend and backend code to report, we need to set the sonar project to the root directory.
         property "sonar.sources", "backend/src/main/java,frontend/src"
-        property "sonar.exclusions", "frontend/src/**/*.test.*,frontend/src/stories/**/*,frontend/src/**/*.stories.tsx", "frontend/src/lang/*.ts"
+        property "sonar.exclusions", "frontend/src/**/*.test.*,frontend/src/stories/**/*,frontend/src/**/*.stories.tsx"
+        property "sonar.cpd.exclusions", "frontend/src/lang/*.ts"
         property "sonar.javascript.lcov.reportPaths", "frontend/coverage/lcov.info"
     }
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -179,6 +179,7 @@ sonarqube {
         // In order to get both the frontend and backend code to report, we need to set the sonar project to the root directory.
         property "sonar.sources", "backend/src/main/java,frontend/src"
         property "sonar.exclusions", "frontend/src/**/*.test.*,frontend/src/stories/**/*,frontend/src/**/*.stories.tsx"
+        property "sonar.cpd.exclusions", "frontend/src/lang/*.ts"
         property "sonar.javascript.lcov.reportPaths", "frontend/coverage/lcov.info"
     }
 }

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -6,6 +6,7 @@ import * as state from "../utils/state";
 
 import { allFacilityErrors } from "./Facility/facilitySchema";
 import FacilityForm from "./Facility/FacilityForm";
+import "../../i18n";
 
 let saveFacility: jest.Mock;
 

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -8,6 +8,7 @@ import { displayFullName } from "../../utils";
 
 import ManageUsers, { SettingsUsers } from "./ManageUsers";
 import { GET_USER } from "./ManageUsersContainer";
+import "../../../i18n";
 
 const organization = { testingFacility: [{ id: "a1", name: "Foo Org" }] };
 const allFacilities = [

--- a/frontend/src/app/accountCreation/SecurityQuestion/SecurityQuestion.test.tsx
+++ b/frontend/src/app/accountCreation/SecurityQuestion/SecurityQuestion.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route } from "react-router";
 
 import { SecurityQuestion } from "./SecurityQuestion";
+import "../../../i18n";
 
 jest.mock("../AccountCreationApiService", () => ({
   AccountCreationApi: {

--- a/frontend/src/app/commonComponents/AddressConfirmationModal.tsx
+++ b/frontend/src/app/commonComponents/AddressConfirmationModal.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslation } from "react-i18next";
 
 import { formatAddress, newLineSpan } from "../utils/address";
 
@@ -24,7 +25,7 @@ interface Props<T extends string> {
 }
 
 type addressOptions = "userAddress" | "suggested";
-const ERROR_MESSAGE = "Please choose an address or go back to edit";
+
 export const AddressConfirmationModal = <T extends string>({
   addressSuggestionConfig,
   showModal,
@@ -34,6 +35,7 @@ export const AddressConfirmationModal = <T extends string>({
   const [selectedAddress, setSelectedAddress] = useState<
     Partial<Record<T, addressOptions>>
   >({});
+
   const addressSuggestionConfigMap = addressSuggestionConfig.reduce(
     (acc, el) => {
       acc[el.key] = el;
@@ -42,7 +44,9 @@ export const AddressConfirmationModal = <T extends string>({
     {} as Record<T, AddressSuggestionConfig<T>>
   );
 
-  const multipleAddresses = addressSuggestionConfig.length > 1;
+  const { t } = useTranslation();
+
+  const ERROR_MESSAGE = t("address.errors.incomplete");
 
   const [error, setError] = useState(new Set<T>());
 
@@ -93,12 +97,13 @@ export const AddressConfirmationModal = <T extends string>({
     ) {
       return null;
     }
+
     return (
       <Alert
         type="warning"
-        body={`The address${
-          multipleAddresses ? "es" : ""
-        } you entered could not be verified`}
+        body={t("address.errors.unverified", {
+          count: addressSuggestionConfig.length,
+        })}
         role="alert"
         slim
       />
@@ -129,7 +134,7 @@ export const AddressConfirmationModal = <T extends string>({
       return {
         value: "suggested",
         label: getLabel(
-          "Use suggested address",
+          t("address.getSuggested"),
           addressSuggestionConfigMap[key].suggestedAddress!
         ),
       };
@@ -138,7 +143,7 @@ export const AddressConfirmationModal = <T extends string>({
       value: "suggested",
       label: (
         <span className="address__no-suggestion">
-          No suggested address found
+          {t("address.noSuggestedFound")}
         </span>
       ),
       disabled: true,
@@ -167,20 +172,20 @@ export const AddressConfirmationModal = <T extends string>({
 
   return (
     <Modal onClose={closeModal} showModal={showModal}>
-      <Modal.Header>Address validation</Modal.Header>
+      <Modal.Header>{t("address.heading")}</Modal.Header>
       <div className="border-top border-base-lighter margin-x-neg-205"></div>
       {getAlert()}
       {addressSuggestionConfig.map((address) => (
         <RadioGroup
           key={address.key}
           name={`addressSelect-${address.key}`}
-          legend={address.label || "Please select an option to continue:"}
+          legend={address.label || t("address.select")}
           className="address__select margin-top-0"
           buttons={[
             {
               value: "userAddress",
               label: getLabel(
-                "Use address as entered",
+                t("address.useAddress"),
                 address.userEnteredAddress
               ),
             },
@@ -200,7 +205,7 @@ export const AddressConfirmationModal = <T extends string>({
           <Button variant="unstyled" onClick={closeModal}>
             <FontAwesomeIcon icon={"arrow-left"} />
             <span className="margin-left-1">
-              Go back to edit address{multipleAddresses ? "es" : ""}
+              {t("address.goBack", { count: addressSuggestionConfig.length })}
             </span>
           </Button>
           <Button
@@ -210,7 +215,7 @@ export const AddressConfirmationModal = <T extends string>({
               ({ key }) => !selectedAddress[key]
             )}
           >
-            Save changes
+            {t("address.save")}
           </Button>
         </Modal.Footer>
       </div>

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import classnames from "classnames";
 import { UIDConsumer } from "react-uid";
-import { useTranslation } from "react-i18next";
 
 import Required from "../commonComponents/Required";
 
@@ -39,7 +38,7 @@ const Dropdown: React.FC<Props & SelectProps> = ({
   onChange,
   disabled,
   className,
-  defaultOption, // value of the default option
+  defaultOption = "- Select -", // value of the default option
   selectedValue,
   defaultSelect,
   required,
@@ -49,8 +48,6 @@ const Dropdown: React.FC<Props & SelectProps> = ({
   hintText,
   ...inputProps
 }) => {
-  const { t } = useTranslation();
-
   return (
     <UIDConsumer>
       {(id) => (
@@ -97,9 +94,7 @@ const Dropdown: React.FC<Props & SelectProps> = ({
             disabled={disabled}
             {...inputProps}
           >
-            {defaultSelect && (
-              <option value="">{t("common.defaultDropdownOption")}</option>
-            )}
+            {defaultSelect && <option value="">{defaultOption}</option>}
             {options.map(({ value, label, disabled }) => (
               <option key={value} value={value} disabled={disabled}>
                 {label}

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import { UIDConsumer } from "react-uid";
+import { useTranslation } from "react-i18next";
 
 import Required from "../commonComponents/Required";
 
@@ -48,6 +49,8 @@ const Dropdown: React.FC<Props & SelectProps> = ({
   hintText,
   ...inputProps
 }) => {
+  const { t } = useTranslation();
+
   return (
     <UIDConsumer>
       {(id) => (
@@ -94,7 +97,9 @@ const Dropdown: React.FC<Props & SelectProps> = ({
             disabled={disabled}
             {...inputProps}
           >
-            {defaultSelect && <option value="">- Select -</option>}
+            {defaultSelect && (
+              <option value="">{t("common.defaultDropdownOption")}</option>
+            )}
             {options.map(({ value, label, disabled }) => (
               <option key={value} value={value} disabled={disabled}>
                 {label}

--- a/frontend/src/app/commonComponents/PageNotFound.tsx
+++ b/frontend/src/app/commonComponents/PageNotFound.tsx
@@ -1,13 +1,14 @@
+import { useTranslation } from "react-i18next";
+
 const PageNotFound = () => {
+  const { t } = useTranslation();
+
   return (
     <main>
       <div className="grid-container usa-section maxw-tablet usa-prose">
-        <h1>Page not found</h1>
-        <p>
-          We're sorry, we can't find the page you're looking for. It might have
-          been removed, had its name changed, or is otherwise unavailable.{" "}
-        </p>
-        <p>Error code: 404</p>
+        <h1>{t("common.pageNotFound.heading")}</h1>
+        <p>{t("common.pageNotFound.text")}</p>
+        <p>{t("common.pageNotFound.errorCode")}</p>
       </div>
     </main>
   );

--- a/frontend/src/app/commonComponents/RequiredMessage.tsx
+++ b/frontend/src/app/commonComponents/RequiredMessage.tsx
@@ -8,9 +8,10 @@ const RequiredMessage = () => {
 
   return (
     <p className="message--required">
-      {t("common.required")} (<Required />).
+      {t("common.required")} (<Required />
+      ).
     </p>
   );
-}
+};
 
 export default RequiredMessage;

--- a/frontend/src/app/commonComponents/RequiredMessage.tsx
+++ b/frontend/src/app/commonComponents/RequiredMessage.tsx
@@ -1,12 +1,16 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import Required from "./Required";
 
-const RequiredMessage = () => (
-  <p className="message--required">
-    Required fields are marked with an asterisk (<Required />
-    ).
-  </p>
-);
+const RequiredMessage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <p className="message--required">
+      {t("common.required")} (<Required />).
+    </p>
+  );
+}
 
 export default RequiredMessage;

--- a/frontend/src/app/commonComponents/RequiredMessage.tsx
+++ b/frontend/src/app/commonComponents/RequiredMessage.tsx
@@ -8,7 +8,8 @@ const RequiredMessage = () => {
 
   return (
     <p className="message--required">
-      {t("common.required")} (<Required />).
+      {t("common.required")} (<Required />
+      ).
     </p>
   );
 };

--- a/frontend/src/app/commonComponents/RequiredMessage.tsx
+++ b/frontend/src/app/commonComponents/RequiredMessage.tsx
@@ -1,14 +1,18 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
 
 import Required from "./Required";
 
-const RequiredMessage = () => {
-  const { t } = useTranslation();
+interface Props {
+  message?: string;
+}
+
+const RequiredMessage = (props: Props) => {
+  const message =
+    props.message || "Required fields are marked with an asterisk";
 
   return (
     <p className="message--required">
-      {t("common.required")} (<Required />
+      {message} (<Required />
       ).
     </p>
   );

--- a/frontend/src/app/commonComponents/RequiredMessage.tsx
+++ b/frontend/src/app/commonComponents/RequiredMessage.tsx
@@ -8,8 +8,7 @@ const RequiredMessage = () => {
 
   return (
     <p className="message--required">
-      {t("common.required")} (<Required />
-      ).
+      {t("common.required")} (<Required />).
     </p>
   );
 };

--- a/frontend/src/app/commonComponents/Select.tsx
+++ b/frontend/src/app/commonComponents/Select.tsx
@@ -15,6 +15,7 @@ interface Props<T> {
   value: T;
   onChange: (value: T) => void;
   onBlur?: () => void;
+  defaultOption?: string;
   defaultSelect?: boolean;
   required?: boolean;
   validationStatus?: "error" | "success";
@@ -30,6 +31,7 @@ const Select = <T extends string>({
   onBlur,
   validationStatus,
   errorMessage,
+  defaultOption,
   defaultSelect,
   required,
 }: Props<T>): React.ReactElement => {
@@ -47,6 +49,7 @@ const Select = <T extends string>({
       validationStatus={validationStatus}
       errorMessage={errorMessage}
       required={required}
+      defaultOption={defaultOption}
       defaultSelect={defaultSelect}
     />
   );

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -5,6 +5,7 @@ import createMockStore from "redux-mock-store";
 import { useTrackEvent } from "@microsoft/applicationinsights-react-js";
 
 import Header from "../Header";
+import "../../../i18n";
 
 const mockStore = createMockStore([]);
 

--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -1,4 +1,5 @@
 import { TestResult } from "../testQueue/QueueItem";
+import i18n from "../../i18n";
 
 export const DATE_FORMAT_MM_DD_YYYY =
   "^([0-9]{1,2}/[0-9]{1,2}/[0-9]{4})|([0-9]{1,2}-[0-9]{1,2}-[0-9]{4})|([0-9]{8})$";
@@ -11,55 +12,58 @@ export const COVID_RESULTS: { [key: string]: TestResult } = {
 };
 
 export const TEST_RESULT_DESCRIPTIONS: Record<TestResult, string> = {
-  NEGATIVE: "Negative",
-  POSITIVE: "Positive",
-  UNDETERMINED: "Inconclusive",
-  UNKNOWN: "Unknown",
+  NEGATIVE: i18n.t("constants.testResults.NEGATIVE"),
+  POSITIVE: i18n.t("constants.testResults.POSITIVE"),
+  UNDETERMINED: i18n.t("constants.testResults.UNDETERMINED"),
+  UNKNOWN: i18n.t("constants.testResults.UNKNOWN"),
 };
 
 export const RACE_VALUES: { value: Race; label: string }[] = [
-  { value: "native", label: "American Indian/Alaskan Native" },
-  { value: "asian", label: "Asian" },
-  { value: "black", label: "Black/African American" },
-  { value: "pacific", label: "Native Hawaiian/other Pacific Islander" },
-  { value: "white", label: "White" },
-  { value: "other", label: "Other" },
-  { value: "refused", label: "Prefer not to answer" },
+  { value: "native", label: i18n.t("constants.race.native") },
+  { value: "asian", label: i18n.t("constants.race.asian") },
+  { value: "black", label: i18n.t("constants.race.black") },
+  { value: "pacific", label: i18n.t("constants.race.pacific") },
+  { value: "white", label: i18n.t("constants.race.white") },
+  { value: "other", label: i18n.t("constants.race.other") },
+  { value: "refused", label: i18n.t("constants.race.refused") },
 ];
 
 export const ROLE_VALUES: { value: Role; label: string }[] = [
-  { label: "Staff", value: "STAFF" },
-  { label: "Resident", value: "RESIDENT" },
-  { label: "Student", value: "STUDENT" },
-  { label: "Visitor", value: "VISITOR" },
+  { label: i18n.t("constants.role.STAFF"), value: "STAFF" },
+  { label: i18n.t("constants.role.RESIDENT"), value: "RESIDENT" },
+  { label: i18n.t("constants.role.STUDENT"), value: "STUDENT" },
+  { label: i18n.t("constants.role.VISITOR"), value: "VISITOR" },
 ];
 
 export const ETHNICITY_VALUES: { value: Ethnicity; label: string }[] = [
-  { label: "Yes", value: "hispanic" },
-  { label: "No", value: "not_hispanic" },
-  { label: "Prefer not to answer", value: "refused" },
+  { label: i18n.t("constants.ethnicity.hispanic"), value: "hispanic" },
+  { label: i18n.t("constants.ethnicity.not_hispanic"), value: "not_hispanic" },
+  { label: i18n.t("constants.ethnicity.refused"), value: "refused" },
 ];
 export const GENDER_VALUES: { value: Gender; label: string }[] = [
-  { label: "Female", value: "female" },
-  { label: "Male", value: "male" },
-  { label: "Other", value: "other" },
-  { label: "Prefer not to answer", value: "refused" },
+  { label: i18n.t("constants.gender.female"), value: "female" },
+  { label: i18n.t("constants.gender.male"), value: "male" },
+  { label: i18n.t("constants.gender.other"), value: "other" },
+  { label: i18n.t("constants.gender.refused"), value: "refused" },
 ];
 
 export const YES_NO_VALUES: { value: YesNo; label: string }[] = [
-  { label: "Yes", value: "YES" },
-  { label: "No", value: "NO" },
+  { label: i18n.t("constants.yesNoUnk.YES"), value: "YES" },
+  { label: i18n.t("constants.yesNoUnk.NO"), value: "NO" },
 ];
 
 export const PHONE_TYPE_VALUES: { value: PhoneType; label: string }[] = [
-  { label: "Mobile", value: "MOBILE" },
-  { label: "Landline", value: "LANDLINE" },
+  { label: i18n.t("constants.phoneType.MOBILE"), value: "MOBILE" },
+  { label: i18n.t("constants.phoneType.LANDLINE"), value: "LANDLINE" },
 ];
 
 export const YES_NO_UNKNOWN_VALUES: {
   value: YesNoUnknown;
   label: string;
-}[] = [...YES_NO_VALUES, { value: "UNKNOWN", label: "Unknown" }];
+}[] = [
+  ...YES_NO_VALUES,
+  { value: "UNKNOWN", label: i18n.t("constants.yesNoUnk.UNKNOWN") },
+];
 
 const fullTribalAffiliationValueSetMap: { [key: string]: TribalAffiliation } = {
   "Village of Afognak": "338",

--- a/frontend/src/app/passwordReset/securityQuestion/SecurityQuestion.test.tsx
+++ b/frontend/src/app/passwordReset/securityQuestion/SecurityQuestion.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 
 import { SecurityAnswer } from "./SecurityQuestion";
+import "../../../i18n";
 
 describe("Verify Email MFA", () => {
   beforeEach(() => {

--- a/frontend/src/app/patients/Components/FacilitySelect.tsx
+++ b/frontend/src/app/patients/Components/FacilitySelect.tsx
@@ -32,7 +32,10 @@ const FacilitySelect: React.FC<Props> = (props) => {
     label: f.name,
     value: f.id,
   }));
-  facilityList.unshift({ label: t("facility.form.allFacilities"), value: ALL_FACILITIES });
+  facilityList.unshift({
+    label: t("facility.form.allFacilities"),
+    value: ALL_FACILITIES,
+  });
 
   const onChange = (value: string | null) => {
     props.onChange(value === ALL_FACILITIES ? null : value);

--- a/frontend/src/app/patients/Components/FacilitySelect.tsx
+++ b/frontend/src/app/patients/Components/FacilitySelect.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import Select from "../../commonComponents/Select";
@@ -18,8 +17,6 @@ const ALL_FACILITIES = "~~ALL-FACILITIES~~";
 const NAME = "facilityId";
 
 const FacilitySelect: React.FC<Props> = (props) => {
-  const { t } = useTranslation();
-
   const facilities = useSelector<RootState, Facility[]>(
     (state) => state.facilities
   );
@@ -32,10 +29,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
     label: f.name,
     value: f.id,
   }));
-  facilityList.unshift({
-    label: t("facility.form.allFacilities"),
-    value: ALL_FACILITIES,
-  });
+  facilityList.unshift({ label: "All facilities", value: ALL_FACILITIES });
 
   const onChange = (value: string | null) => {
     props.onChange(value === ALL_FACILITIES ? null : value);
@@ -43,7 +37,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
 
   return (
     <Select
-      label={t("facility.form.heading")}
+      label="Facility"
       name={NAME}
       value={props.facilityId === null ? ALL_FACILITIES : props.facilityId}
       onChange={onChange}
@@ -51,7 +45,6 @@ const FacilitySelect: React.FC<Props> = (props) => {
       validationStatus={props.validationStatus(NAME)}
       errorMessage={props.errors[NAME]}
       options={facilityList}
-      defaultOption={t("common.defaultDropdownOption")}
       defaultSelect={true}
       required
     />

--- a/frontend/src/app/patients/Components/FacilitySelect.tsx
+++ b/frontend/src/app/patients/Components/FacilitySelect.tsx
@@ -51,6 +51,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
       validationStatus={props.validationStatus(NAME)}
       errorMessage={props.errors[NAME]}
       options={facilityList}
+      defaultOption={t("common.defaultDropdownOption")}
       defaultSelect={true}
       required
     />

--- a/frontend/src/app/patients/Components/FacilitySelect.tsx
+++ b/frontend/src/app/patients/Components/FacilitySelect.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import Select from "../../commonComponents/Select";
@@ -17,6 +18,8 @@ const ALL_FACILITIES = "~~ALL-FACILITIES~~";
 const NAME = "facilityId";
 
 const FacilitySelect: React.FC<Props> = (props) => {
+  const { t } = useTranslation();
+
   const facilities = useSelector<RootState, Facility[]>(
     (state) => state.facilities
   );
@@ -29,7 +32,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
     label: f.name,
     value: f.id,
   }));
-  facilityList.unshift({ label: "All facilities", value: ALL_FACILITIES });
+  facilityList.unshift({ label: t("facility.form.allFacilities"), value: ALL_FACILITIES });
 
   const onChange = (value: string | null) => {
     props.onChange(value === ALL_FACILITIES ? null : value);
@@ -37,7 +40,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
 
   return (
     <Select
-      label="Facility"
+      label={t("facility.form.heading")}
       name={NAME}
       value={props.facilityId === null ? ALL_FACILITIES : props.facilityId}
       onChange={onChange}

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -10,6 +10,7 @@ import {
   allPhoneNumberErrors,
   phoneNumberUpdateSchema,
 } from "../personSchema";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   phoneNumbers: PhoneNumber[];
@@ -21,6 +22,8 @@ const ManagePhoneNumbers: React.FC<Props> = ({
   updatePhoneNumbers,
 }) => {
   const [errors, setErrors] = useState<PhoneNumberErrors[]>([]);
+
+  const { t } = useTranslation();
 
   const phoneNumbersOrDefault = useMemo(
     () =>
@@ -127,7 +130,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
               className="flex-fill"
               field="number"
               label={
-                isPrimary ? "Primary phone number" : "Additional phone number"
+                isPrimary ? t("patient.form.contact.primaryPhoneNumber") : t("patient.form.contact.additionalPhoneNumber")
               }
               required={isPrimary}
               formObject={phoneNumber}
@@ -150,7 +153,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
           <RadioGroup
             name={`phoneType-${idx}`}
             className="margin-top-3"
-            legend="Phone type"
+            legend={t("patient.form.contact.phoneType")}
             buttons={PHONE_TYPE_VALUES}
             selectedRadio={phoneNumber.type}
             required={isPrimary}
@@ -168,7 +171,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
         className="margin-top-2"
         onClick={onAddPhoneNumber}
         variant="unstyled"
-        label="Add another number"
+        label={t("patient.form.contact.addNumber")}
         icon="plus"
       />
     </div>

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslation } from "react-i18next";
 
 import { PHONE_TYPE_VALUES } from "../../constants";
 import Button from "../../commonComponents/Button/Button";
@@ -10,7 +11,6 @@ import {
   allPhoneNumberErrors,
   phoneNumberUpdateSchema,
 } from "../personSchema";
-import { useTranslation } from "react-i18next";
 
 interface Props {
   phoneNumbers: PhoneNumber[];
@@ -130,7 +130,9 @@ const ManagePhoneNumbers: React.FC<Props> = ({
               className="flex-fill"
               field="number"
               label={
-                isPrimary ? t("patient.form.contact.primaryPhoneNumber") : t("patient.form.contact.additionalPhoneNumber")
+                isPrimary
+                  ? t("patient.form.contact.primaryPhoneNumber")
+                  : t("patient.form.contact.additionalPhoneNumber")
               }
               required={isPrimary}
               formObject={phoneNumber}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -35,6 +35,8 @@ import ComboBox from "../../commonComponents/ComboBox";
 
 import FacilitySelect from "./FacilitySelect";
 import ManagePhoneNumbers from "./ManagePhoneNumbers";
+import { useTranslation } from "react-i18next";
+import "../../../i18n";
 
 export type ValidateField = (field: keyof PersonErrors) => Promise<void>;
 
@@ -105,6 +107,8 @@ const PersonForm = (props: Props) => {
   >();
   const { view = PersonFormView.APP } = props;
   const schema = schemata[view];
+
+  const { t } = useTranslation();
 
   const clearError = useCallback(
     (field: keyof PersonErrors) => {
@@ -194,7 +198,8 @@ const PersonForm = (props: Props) => {
           document.getElementsByName(name)[0]?.focus();
           focusedOnError = true;
         }
-        showError(toast, "Please correct before submitting", error);
+        //showError(toast, "Please correct before submitting", error);
+        showError(toast, t("patient.form.errors.validationMsg"), error);
       });
       return;
     }
@@ -227,21 +232,19 @@ const PersonForm = (props: Props) => {
     <>
       <Prompt
         when={formChanged}
-        message={
-          "\nYour changes are not yet saved!\n\nClick OK discard changes, Cancel to continue editing."
-        }
+        message={t("patient.form.errors.unsaved")}
       />
       {view === PersonFormView.APP && props.getHeader && (
         <div className="patient__header">
           {props.getHeader(patient, validateForm, formChanged)}
         </div>
       )}
-      <FormGroup title="General information">
+      <FormGroup title={t("patient.form.general.heading")}>
         <RequiredMessage />
         <div className="usa-form">
           <Input
             {...commonInputProps}
-            label="First name"
+            label={t("patient.form.general.firstName")}
             field="firstName"
             required={view !== PersonFormView.PXP}
             disabled={view === PersonFormView.PXP}
@@ -249,20 +252,20 @@ const PersonForm = (props: Props) => {
           <Input
             {...commonInputProps}
             field="middleName"
-            label="Middle name"
+            label={t("patient.form.general.middleName")}
             disabled={view === PersonFormView.PXP}
           />
           <Input
             {...commonInputProps}
             field="lastName"
-            label="Last name"
+            label={t("patient.form.general.lastName")}
             required={view !== PersonFormView.PXP}
             disabled={view === PersonFormView.PXP}
           />
         </div>
         <div className="usa-form">
           <Select
-            label="Role"
+            label={t("patient.form.general.role.heading")}
             name="role"
             value={patient.role || ""}
             onChange={onPersonChange("role")}
@@ -270,7 +273,7 @@ const PersonForm = (props: Props) => {
             defaultSelect={true}
           />
           {patient.role === "STUDENT" && (
-            <Input {...commonInputProps} field="lookupId" label="Student ID" />
+            <Input {...commonInputProps} field="lookupId" label={t("patient.form.general.studentId")}/>
           )}
           {view !== PersonFormView.SELF_REGISTRATION && (
             <FacilitySelect
@@ -286,7 +289,7 @@ const PersonForm = (props: Props) => {
           )}
           <div className="usa-form-group">
             <label className="usa-label" htmlFor="preferred-language">
-              Preferred language
+              {t("patient.form.general.preferredLanguage")}
             </label>
             <ComboBox
               id="preferred-language-wrapper"
@@ -309,14 +312,14 @@ const PersonForm = (props: Props) => {
           <Input
             {...commonInputProps}
             field="birthDate"
-            label="Date of birth (mm/dd/yyyy)"
+            label={t("patient.form.general.preferredLanguage") + " (mm/dd/yyyy)"}
             type="date"
             required={view !== PersonFormView.PXP}
             disabled={view === PersonFormView.PXP}
           />
         </div>
       </FormGroup>
-      <FormGroup title="Contact information">
+      <FormGroup title={t("patient.form.contact.heading")}>
         <ManagePhoneNumbers
           phoneNumbers={patient.phoneNumbers || []}
           updatePhoneNumbers={onPersonChange("phoneNumbers")}
@@ -325,7 +328,7 @@ const PersonForm = (props: Props) => {
           <Input
             {...commonInputProps}
             field="email"
-            label="Email address"
+            label={t("patient.form.contact.email")}
             type="email"
           />
         </div>
@@ -333,7 +336,7 @@ const PersonForm = (props: Props) => {
           <Input
             {...commonInputProps}
             field="street"
-            label="Street address 1"
+            label={t("patient.form.contact.street1")}
             required
           />
         </div>
@@ -341,18 +344,18 @@ const PersonForm = (props: Props) => {
           <Input
             {...commonInputProps}
             field="streetTwo"
-            label="Street address 2"
+            label={t("patient.form.contact.street2")}
           />
         </div>
         <div className="usa-form">
-          <Input {...commonInputProps} field="city" label="City" />
+          <Input {...commonInputProps} field="city" label={t("patient.form.contact.city")} />
           {view !== PersonFormView.SELF_REGISTRATION && (
-            <Input {...commonInputProps} field="county" label="County" />
+            <Input {...commonInputProps} field="county" label={t("patient.form.contact.county")} />
           )}
           <div className="grid-row grid-gap">
             <div className="mobile-lg:grid-col-6">
               <Select
-                label="State"
+                label={t("patient.form.contact.state")}
                 name="state"
                 value={patient.state || ""}
                 options={stateCodes.map((c) => ({ label: c, value: c }))}
@@ -370,20 +373,19 @@ const PersonForm = (props: Props) => {
               <Input
                 {...commonInputProps}
                 field="zipCode"
-                label="Zip code"
+                label={t("patient.form.contact.zip")}
                 required
               />
             </div>
           </div>
         </div>
       </FormGroup>
-      <FormGroup title="Demographics">
+      <FormGroup title={t("patient.form.demographics.heading")}>
         <p className="usa-hint maxw-prose">
-          This information is collected as part of public health efforts to
-          recognize and address inequality in health outcomes.
+          {t("patient.form.demographics.helpText")}
         </p>
         <RadioGroup
-          legend="Race"
+          legend={t("patient.form.demographics.race.heading")}
           name="race"
           buttons={RACE_VALUES}
           selectedRadio={patient.race}
@@ -391,7 +393,7 @@ const PersonForm = (props: Props) => {
         />
         <div className="usa-form-group">
           <label className="usa-legend" htmlFor="tribal-affiliation">
-            Tribal affiliation
+              {t("patient.form.demographics.tribalAffiliation.heading")}
           </label>
           <ComboBox
             id="tribal-affiliation"
@@ -404,14 +406,14 @@ const PersonForm = (props: Props) => {
           />
         </div>
         <RadioGroup
-          legend="Are you Hispanic or Latino?"
+          legend={t("patient.form.demographics.ethnicity.heading")}
           name="ethnicity"
           buttons={ETHNICITY_VALUES}
           selectedRadio={patient.ethnicity}
           onChange={onPersonChange("ethnicity")}
         />
         <RadioGroup
-          legend="Biological sex"
+          legend={t("patient.form.demographics.gender.heading")}
           name="gender"
           buttons={GENDER_VALUES}
           selectedRadio={patient.gender}
@@ -420,8 +422,8 @@ const PersonForm = (props: Props) => {
       </FormGroup>
       <FormGroup title="Other">
         <YesNoRadioGroup
-          legend="Are you a resident in a congregate living setting?"
-          hintText="For example: nursing home, group home, prison, jail, or military"
+          legend={t("patient.form.other.congregateLiving.heading")}
+          hintText={t("patient.form.other.congregateLiving.helpText")}
           name="residentCongregateSetting"
           value={boolToYesNoUnknown(patient.residentCongregateSetting)}
           onChange={(v) =>
@@ -435,7 +437,7 @@ const PersonForm = (props: Props) => {
           required
         />
         <YesNoRadioGroup
-          legend="Are you a health care worker?"
+          legend={t("patient.form.other.healthcareWorker.heading")}
           name="employedInHealthcare"
           value={boolToYesNoUnknown(patient.employedInHealthcare)}
           onChange={(v) =>

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import { Prompt } from "react-router-dom";
 import { toast } from "react-toastify";
 import { SchemaOf } from "yup";
+import { useTranslation } from "react-i18next";
 
 import { languages, stateCodes } from "../../../config/constants";
 import {
@@ -35,7 +36,6 @@ import ComboBox from "../../commonComponents/ComboBox";
 
 import FacilitySelect from "./FacilitySelect";
 import ManagePhoneNumbers from "./ManagePhoneNumbers";
-import { useTranslation } from "react-i18next";
 import "../../../i18n";
 
 export type ValidateField = (field: keyof PersonErrors) => Promise<void>;
@@ -230,10 +230,7 @@ const PersonForm = (props: Props) => {
 
   return (
     <>
-      <Prompt
-        when={formChanged}
-        message={t("patient.form.errors.unsaved")}
-      />
+      <Prompt when={formChanged} message={t("patient.form.errors.unsaved")} />
       {view === PersonFormView.APP && props.getHeader && (
         <div className="patient__header">
           {props.getHeader(patient, validateForm, formChanged)}
@@ -265,7 +262,7 @@ const PersonForm = (props: Props) => {
         </div>
         <div className="usa-form">
           <Select
-            label={t("patient.form.general.role.heading")}
+            label={t("patient.form.general.role")}
             name="role"
             value={patient.role || ""}
             onChange={onPersonChange("role")}
@@ -273,7 +270,11 @@ const PersonForm = (props: Props) => {
             defaultSelect={true}
           />
           {patient.role === "STUDENT" && (
-            <Input {...commonInputProps} field="lookupId" label={t("patient.form.general.studentId")}/>
+            <Input
+              {...commonInputProps}
+              field="lookupId"
+              label={t("patient.form.general.studentId")}
+            />
           )}
           {view !== PersonFormView.SELF_REGISTRATION && (
             <FacilitySelect
@@ -312,7 +313,7 @@ const PersonForm = (props: Props) => {
           <Input
             {...commonInputProps}
             field="birthDate"
-            label={t("patient.form.general.preferredLanguage") + " (mm/dd/yyyy)"}
+            label={t("patient.form.general.dob") + " (mm/dd/yyyy)"}
             type="date"
             required={view !== PersonFormView.PXP}
             disabled={view === PersonFormView.PXP}
@@ -348,9 +349,17 @@ const PersonForm = (props: Props) => {
           />
         </div>
         <div className="usa-form">
-          <Input {...commonInputProps} field="city" label={t("patient.form.contact.city")} />
+          <Input
+            {...commonInputProps}
+            field="city"
+            label={t("patient.form.contact.city")}
+          />
           {view !== PersonFormView.SELF_REGISTRATION && (
-            <Input {...commonInputProps} field="county" label={t("patient.form.contact.county")} />
+            <Input
+              {...commonInputProps}
+              field="county"
+              label={t("patient.form.contact.county")}
+            />
           )}
           <div className="grid-row grid-gap">
             <div className="mobile-lg:grid-col-6">
@@ -385,7 +394,7 @@ const PersonForm = (props: Props) => {
           {t("patient.form.demographics.helpText")}
         </p>
         <RadioGroup
-          legend={t("patient.form.demographics.race.heading")}
+          legend={t("patient.form.demographics.race")}
           name="race"
           buttons={RACE_VALUES}
           selectedRadio={patient.race}
@@ -393,7 +402,7 @@ const PersonForm = (props: Props) => {
         />
         <div className="usa-form-group">
           <label className="usa-legend" htmlFor="tribal-affiliation">
-              {t("patient.form.demographics.tribalAffiliation.heading")}
+            {t("patient.form.demographics.tribalAffiliation")}
           </label>
           <ComboBox
             id="tribal-affiliation"
@@ -406,21 +415,21 @@ const PersonForm = (props: Props) => {
           />
         </div>
         <RadioGroup
-          legend={t("patient.form.demographics.ethnicity.heading")}
+          legend={t("patient.form.demographics.ethnicity")}
           name="ethnicity"
           buttons={ETHNICITY_VALUES}
           selectedRadio={patient.ethnicity}
           onChange={onPersonChange("ethnicity")}
         />
         <RadioGroup
-          legend={t("patient.form.demographics.gender.heading")}
+          legend={t("patient.form.demographics.gender")}
           name="gender"
           buttons={GENDER_VALUES}
           selectedRadio={patient.gender}
           onChange={onPersonChange("gender")}
         />
       </FormGroup>
-      <FormGroup title="Other">
+      <FormGroup title={t("patient.form.other.heading")}>
         <YesNoRadioGroup
           legend={t("patient.form.other.congregateLiving.heading")}
           hintText={t("patient.form.other.congregateLiving.helpText")}
@@ -437,7 +446,7 @@ const PersonForm = (props: Props) => {
           required
         />
         <YesNoRadioGroup
-          legend={t("patient.form.other.healthcareWorker.heading")}
+          legend={t("patient.form.other.healthcareWorker")}
           name="employedInHealthcare"
           value={boolToYesNoUnknown(patient.employedInHealthcare)}
           onChange={(v) =>

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -236,7 +236,7 @@ const PersonForm = (props: Props) => {
         </div>
       )}
       <FormGroup title={t("patient.form.general.heading")}>
-        <RequiredMessage />
+        <RequiredMessage message={t("common.required")} />
         <div className="usa-form">
           <Input
             {...commonInputProps}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -266,6 +266,7 @@ const PersonForm = (props: Props) => {
             value={patient.role || ""}
             onChange={onPersonChange("role")}
             options={ROLE_VALUES}
+            defaultOption={t("common.defaultDropdownOption")}
             defaultSelect={true}
           />
           {patient.role === "STUDENT" && (
@@ -367,6 +368,7 @@ const PersonForm = (props: Props) => {
                 name="state"
                 value={patient.state || ""}
                 options={stateCodes.map((c) => ({ label: c, value: c }))}
+                defaultOption={t("common.defaultDropdownOption")}
                 defaultSelect
                 onChange={onPersonChange("state")}
                 onBlur={() => {

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -198,7 +198,6 @@ const PersonForm = (props: Props) => {
           document.getElementsByName(name)[0]?.focus();
           focusedOnError = true;
         }
-        //showError(toast, "Please correct before submitting", error);
         showError(toast, t("patient.form.errors.validationMsg"), error);
       });
       return;

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -80,7 +80,8 @@ Object {
                   <p
                     class="message--required"
                   >
-                    Required fields are marked with an asterisk (
+                    Required fields are marked with an asterisk
+                     (
                     <abbr
                       class="usa-hint usa-hint--required"
                       title="required"
@@ -1499,7 +1500,8 @@ Object {
                 <p
                   class="message--required"
                 >
-                  Required fields are marked with an asterisk (
+                  Required fields are marked with an asterisk
+                   (
                   <abbr
                     class="usa-hint usa-hint--required"
                     title="required"

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -12,6 +12,7 @@ import {
 } from "../constants";
 import { Option } from "../commonComponents/Dropdown";
 import { languages } from "../../config/constants";
+import i18n from "../../i18n";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
 
@@ -161,36 +162,36 @@ export const selfRegistrationSchema: yup.SchemaOf<SelfRegistationFields> = yup.o
 export type PersonErrors = Partial<Record<keyof PersonFormData, string>>;
 
 export const allPersonErrors: Required<PersonErrors> = {
-  firstName: "First name is required",
-  middleName: "Middle name is incorrectly formatted",
-  lastName: "Last name is required",
-  lookupId: "Lookup ID is incorrectly formatted",
-  role: "Role is incorrectly formatted",
-  facilityId: "Facility is required",
-  birthDate:
-    "Date of birth must be present, correctly formatted (MM/DD/YYYY), and in the past",
-  telephone: "Phone number is missing or invalid",
-  phoneNumbers: "Phone number is missing or invalid",
-  email: "Email is missing or incorrectly formatted",
-  street: "Street is missing",
-  streetTwo: "Street Two is incorrectly formatted",
-  zipCode: "Zip code is missing or incorrectly formatted",
-  state: "State is missing or incorrectly formatted",
-  city: "City is incorrectly formatted",
-  county: "County is incorrectly formatted",
-  race: "Race is incorrectly formatted",
-  tribalAffiliation: "Tribal Affiliation is incorrectly formatted",
-  ethnicity: "Ethnicity is incorrectly formatted",
-  gender: "Biological Sex is incorrectly formatted",
-  residentCongregateSetting:
-    "Are you a resident in a congregate living setting? is required",
-  employedInHealthcare: "Are you a health care worker? is required",
-  preferredLanguage: "Preferred language is incorrectly formatted",
+  firstName: i18n.t("patient.form.errors.firstName"),
+  middleName: i18n.t("patient.form.errors.middleName"),
+  lastName: i18n.t("patient.form.errors.lastName"),
+  lookupId: i18n.t("patient.form.errors.lookupId"),
+  role: i18n.t("patient.form.errors.role"),
+  facilityId: i18n.t("patient.form.errors.facilityId"),
+  birthDate: i18n.t("patient.form.errors.birthDate"),
+  telephone: i18n.t("patient.form.errors.telephone"),
+  phoneNumbers: i18n.t("patient.form.errors.phoneNumbers"),
+  email: i18n.t("patient.form.errors.email"),
+  street: i18n.t("patient.form.errors.street"),
+  streetTwo: i18n.t("patient.form.errors.streetTwo"),
+  zipCode: i18n.t("patient.form.errors.zipCode"),
+  state: i18n.t("patient.form.errors.state"),
+  city: i18n.t("patient.form.errors.city"),
+  county: i18n.t("patient.form.errors.county"),
+  race: i18n.t("patient.form.errors.race"),
+  tribalAffiliation: i18n.t("patient.form.errors.tribalAffiliation"),
+  ethnicity: i18n.t("patient.form.errors.ethnicity"),
+  gender: i18n.t("patient.form.errors.gender"),
+  residentCongregateSetting: i18n.t(
+    "patient.form.errors.residentCongregateSetting"
+  ),
+  employedInHealthcare: i18n.t("patient.form.errors.employedInHealthcare"),
+  preferredLanguage: i18n.t("patient.form.errors.preferredLanguage"),
 };
 
 export type PhoneNumberErrors = Partial<Record<keyof PhoneNumber, string>>;
 
 export const allPhoneNumberErrors: Required<PhoneNumberErrors> = {
-  number: "Phone number is missing or invalid",
+  number: i18n.t("patient.form.errors.telephone"),
   type: "Phone type is missing or invalid",
 };

--- a/frontend/src/app/testQueue/AoEForm/__snapshots__/PriorTestInputs.test.tsx.snap
+++ b/frontend/src/app/testQueue/AoEForm/__snapshots__/PriorTestInputs.test.tsx.snap
@@ -206,7 +206,7 @@ Array [
       id="3"
       name="prior_test_type"
       onChange={[Function]}
-      value=""
+      value="- Select -"
     >
       <option
         value=""

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -1,34 +1,88 @@
 const YES = "Yes";
 const NO = "No";
 const OTHER = "Other";
-const PREFER_NOT_TO_ANSWER = "Prefer not to answer";
+const REFUSED = "Prefer not to answer";
 const UNKNOWN = "Unknown";
 
 export const en = {
   translation: {
     header: "COVID-19 Testing Portal",
+    constants: {
+      testResults: {
+        POSITIVE: "Positive",
+        NEGATIVE: "Negative",
+        UNDETERMINED: "Inconclusive",
+        UNKNOWN: UNKNOWN,
+      },
+      role: {
+        STAFF: "Staff",
+        RESIDENT: "Resident",
+        STUDENT: "Student",
+        VISITOR: "Visitor",
+      },
+      race: {
+        native: "American Indian/Alaskan Native",
+        asian: "Asian",
+        black: "Black/African American",
+        pacific: "Native Hawaiian/other Pacific Islander",
+        white: "White",
+        other: OTHER,
+        refused: REFUSED,
+      },
+      gender: {
+        female: "Female",
+        male: "Male",
+        other: OTHER,
+        refused: REFUSED,
+      },
+      ethnicity: {
+        hispanic: YES,
+        not_hispanic: NO,
+        refused: REFUSED,
+      },
+      phoneType: {
+        MOBILE: "Mobile",
+        LANDLINE: "Landline",
+      },
+      yesNoUnk: {
+        YES,
+        NO,
+        UNKNOWN,
+      },
+    },
     common: {
       required: "Required fields are marked with an asterisk",
+      defaultDropdownOption: "- Select -",
       button: {
-        submit: "Submit"
+        submit: "Submit",
       },
       pageNotFound: {
         heading: "Page not found",
-        text: "We're sorry, we can't find the page you're looking for. It might have been removed, had its name changed, or is otherwise unavailable.",
-        errorCode: "Error code: 404"
-      }
+        text:
+          "We're sorry, we can't find the page you're looking for. It might have been removed, had its name changed, or is otherwise unavailable.",
+        errorCode: "Error code: 404",
+      },
     },
     address: {
+      heading: "Address validation",
+      select: "Please select an option to continue:",
+      useAddress: "Use address as entered",
+      getSuggested: "Use suggested address",
+      noSuggestedFound: "No suggested address found",
+      goBack: "Go back to edit address",
+      goBack_plural: "Go back to edit addresses",
+      save: "Save changes",
       errors: {
         incomplete: "Please choose an address or go back to edit",
-        unverified: "The address${ multipleAddresses you entered could not be verified`"
-      }
+        unverified: "The address you entered could not be verified",
+        unverified_plural: "The addresses you entered could not be verified",
+      },
     },
     facility: {
       form: {
         heading: "Facility",
         allFacilities: "All facilities",
-      }
+      },
     },
     patient: {
       form: {
@@ -38,29 +92,16 @@ export const en = {
           firstName: "First name",
           middleName: "Middle name",
           lastName: "Last name",
-          role: {
-            heading: "Role",
-            options: [
-              "- Select -",
-              "Staff",
-              "Resident",
-              "Student",
-              "Visitor",
-            ]
-          },
+          role: "Role",
           studentId: "Student ID",
-          preferredLanguage: "Preferred Language",
+          preferredLanguage: "Preferred language",
           dob: "Date of birth",
         },
         contact: {
           heading: "Contact information",
           primaryPhoneNumber: "Primary phone number",
           additionalPhoneNumber: "Additional phone number",
-          phoneType: {
-            heading: "Phone type",
-            mobile: "Mobile",
-            landline: "Landline",
-          },
+          phoneType: "Phone type",
           addNumber: "Add another number",
           email: "Email address",
           street1: "Street address 1",
@@ -68,52 +109,56 @@ export const en = {
           county: "County",
           city: "City",
           state: "State",
-          zip: "Zip code"
+          zip: "Zip code",
         },
         demographics: {
           heading: "Demographics",
-          helpText: "This information is collected as part of public health efforts to recognize and address inequality in health outcomes.",
-          race: {
-            heading: "Race",
-            options: [
-              "American Indian/Alaskan Native",
-              "Asian",
-              "Black/African American",
-              "Native Hawaiian/other Pacific Islander",
-              "White",
-              "Other",
-              "Prefer not to answer",
-            ]
-          },
-          tribalAffiliation: {
-            heading: "Tribal affiliation",
-            options: [YES, NO, PREFER_NOT_TO_ANSWER]
-          },
-          ethnicity: {
-            heading: "Are you Hispanic or Latino?",
-            options: [YES, NO, PREFER_NOT_TO_ANSWER]
-          },
-          gender: {
-            heading: "Biological sex",
-            options: ["Female", "Male", OTHER, PREFER_NOT_TO_ANSWER]
-          },
+          helpText:
+            "This information is collected as part of public health efforts to recognize and address inequality in health outcomes.",
+          race: "Race",
+          tribalAffiliation: "Tribal affiliation",
+          ethnicity: "Are you Hispanic or Latino?",
+          gender: "Biological sex",
         },
         other: {
           heading: "Other",
           congregateLiving: {
             heading: "Are you a resident in a congregate living setting?",
-            helpText: "For example: nursing home, group home, prison, jail, or military",
-            options: [YES, NO, UNKNOWN]
+            helpText:
+              "For example: nursing home, group home, prison, jail, or military",
           },
-          healthcareWorker: {
-            heading: "Are you a health care worker?",
-            options: [YES, NO, UNKNOWN]
-          }
+          healthcareWorker: "Are you a health care worker?",
         },
         errors: {
-          unsaved: "\nYour changes are not yet saved!\n\nClick OK discard changes, Cancel to continue editing.",
+          unsaved:
+            "\nYour changes are not yet saved!\n\nClick OK discard changes, Cancel to continue editing.",
           validationMsg: "Please correct before submitting",
-        }
+          firstName: "First name is required",
+          middleName: "Middle name is incorrectly formatted",
+          lastName: "Last name is required",
+          lookupId: "Lookup ID is incorrectly formatted",
+          role: "Role is incorrectly formatted",
+          facilityId: "Facility is required",
+          birthDate:
+            "Date of birth must be present, correctly formatted (MM/DD/YYYY), and in the past",
+          telephone: "Phone number is missing or invalid",
+          phoneNumbers: "Phone number is missing or invalid",
+          email: "Email is missing or incorrectly formatted",
+          street: "Street is missing",
+          streetTwo: "Street Two is incorrectly formatted",
+          zipCode: "Zip code is missing or incorrectly formatted",
+          state: "State is missing or incorrectly formatted",
+          city: "City is incorrectly formatted",
+          county: "County is incorrectly formatted",
+          race: "Race is incorrectly formatted",
+          tribalAffiliation: "Tribal Affiliation is incorrectly formatted",
+          ethnicity: "Ethnicity is incorrectly formatted",
+          gender: "Biological Sex is incorrectly formatted",
+          residentCongregateSetting:
+            "Are you a resident in a congregate living setting? is required",
+          employedInHealthcare: "Are you a health care worker? is required",
+          preferredLanguage: "Preferred language is incorrectly formatted",
+        },
       },
     },
     selfRegistration: {
@@ -123,12 +168,14 @@ export const en = {
         error: {
           heading: "Registration error",
           text: "There was a registration error",
-        }
+        },
       },
       confirmation: {
-        registered: "<span className=\"text-bold\"><2>{{personName}}</2></span>, you're registered for a COVID-19 test at <4>{{entityName}}</4>.",
-        checkIn: "When you arrive for your test, check in by providing your first and last name."
-      }
+        registered:
+          "<0>{{personName}}</0>, you're registered for a COVID-19 test at {{entityName}}",
+        checkIn:
+          "When you arrive for your test, check in by providing your first and last name.",
+      },
     },
     testResult: {
       result: "SARS-CoV-2 result",

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -1,7 +1,136 @@
+const YES = "Yes";
+const NO = "No";
+const OTHER = "Other";
+const PREFER_NOT_TO_ANSWER = "Prefer not to answer";
+const UNKNOWN = "Unknown";
+
 export const en = {
   translation: {
     header: "COVID-19 Testing Portal",
-  },
+    common: {
+      required: "Required fields are marked with an asterisk",
+      button: {
+        submit: "Submit"
+      },
+      pageNotFound: {
+        heading: "Page not found",
+        text: "We're sorry, we can't find the page you're looking for. It might have been removed, had its name changed, or is otherwise unavailable.",
+        errorCode: "Error code: 404"
+      }
+    },
+    address: {
+      errors: {
+        incomplete: "Please choose an address or go back to edit",
+        unverified: "The address${ multipleAddresses you entered could not be verified`"
+      }
+    },
+    facility: {
+      form: {
+        heading: "Facility",
+        allFacilities: "All facilities",
+      }
+    },
+    patient: {
+      form: {
+        general: {
+          heading: "General information",
+          helpText: "Required fields are marked with an asterisk",
+          firstName: "First name",
+          middleName: "Middle name",
+          lastName: "Last name",
+          role: {
+            heading: "Role",
+            options: [
+              "- Select -",
+              "Staff",
+              "Resident",
+              "Student",
+              "Visitor",
+            ]
+          },
+          studentId: "Student ID",
+          preferredLanguage: "Preferred Language",
+          dob: "Date of birth",
+        },
+        contact: {
+          heading: "Contact information",
+          primaryPhoneNumber: "Primary phone number",
+          additionalPhoneNumber: "Additional phone number",
+          phoneType: {
+            heading: "Phone type",
+            mobile: "Mobile",
+            landline: "Landline",
+          },
+          addNumber: "Add another number",
+          email: "Email address",
+          street1: "Street address 1",
+          street2: "Street address 2",
+          county: "County",
+          city: "City",
+          state: "State",
+          zip: "Zip code"
+        },
+        demographics: {
+          heading: "Demographics",
+          helpText: "This information is collected as part of public health efforts to recognize and address inequality in health outcomes.",
+          race: {
+            heading: "Race",
+            options: [
+              "American Indian/Alaskan Native",
+              "Asian",
+              "Black/African American",
+              "Native Hawaiian/other Pacific Islander",
+              "White",
+              "Other",
+              "Prefer not to answer",
+            ]
+          },
+          tribalAffiliation: {
+            heading: "Tribal affiliation",
+            options: [YES, NO, PREFER_NOT_TO_ANSWER]
+          },
+          ethnicity: {
+            heading: "Are you Hispanic or Latino?",
+            options: [YES, NO, PREFER_NOT_TO_ANSWER]
+          },
+          gender: {
+            heading: "Biological sex",
+            options: ["Female", "Male", OTHER, PREFER_NOT_TO_ANSWER]
+          },
+        },
+        other: {
+          heading: "Other",
+          congregateLiving: {
+            heading: "Are you a resident in a congregate living setting?",
+            helpText: "For example: nursing home, group home, prison, jail, or military",
+            options: [YES, NO, UNKNOWN]
+          },
+          healthcareWorker: {
+            heading: "Are you a health care worker?",
+            options: [YES, NO, UNKNOWN]
+          }
+        },
+        errors: {
+          unsaved: "\nYour changes are not yet saved!\n\nClick OK discard changes, Cancel to continue editing.",
+          validationMsg: "Please correct before submitting",
+        }
+      },
+    },
+    selfRegistration: {
+      form: {
+        complete: "Registration complete",
+        inProgress: "Register for your test",
+        error: {
+          heading: "Registration error",
+          text: "There was a registration error",
+        }
+      },
+      confirmation: {
+        registered: "<span className=\"text-bold\"><2>{{personName}}</2></span>, you\'re registered for a COVID-19 test at <4>{{entityName}}</4>.",
+        checkIn: "When you arrive for your test, check in by providing your first and last name."
+      }
+    }
+  }
 };
 
 export type LanguageConfig = typeof en;

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -1,30 +1,89 @@
 import { LanguageConfig } from "./en";
 
+const YES = "";
+const NO = "";
+const OTHER = "";
+const REFUSED = "";
+const UNKNOWN = "";
+
 export const es: LanguageConfig = {
   translation: {
     header: "Portal de pruebas COVID-19",
+    constants: {
+      testResults: {
+        POSITIVE: "",
+        NEGATIVE: "",
+        UNDETERMINED: "",
+        UNKNOWN: UNKNOWN,
+      },
+      role: {
+        STAFF: "",
+        RESIDENT: "",
+        STUDENT: "",
+        VISITOR: "",
+      },
+      race: {
+        native: "",
+        asian: "",
+        black: "",
+        pacific: "",
+        white: "",
+        other: OTHER,
+        refused: REFUSED,
+      },
+      gender: {
+        female: "",
+        male: "",
+        other: OTHER,
+        refused: REFUSED,
+      },
+      ethnicity: {
+        hispanic: YES,
+        not_hispanic: NO,
+        refused: REFUSED,
+      },
+      phoneType: {
+        MOBILE: "",
+        LANDLINE: "",
+      },
+      yesNoUnk: {
+        YES,
+        NO,
+        UNKNOWN,
+      },
+    },
     common: {
       required: "",
+      defaultDropdownOption: "",
       button: {
-        submit: ""
+        submit: "",
       },
       pageNotFound: {
         heading: "",
         text: "",
-        errorCode: ""
-      }
+        errorCode: "",
+      },
     },
     address: {
+      heading: "",
+      select: "",
+      useAddress: "",
+      getSuggested: "",
+      noSuggestedFound: "",
+      goBack: "",
+      goBack_plural: "",
+      save: "",
       errors: {
         incomplete: "",
-        unverified: ""
-      }
+        unverified: "",
+        unverified_plural: "",
+      },
     },
     facility: {
       form: {
         heading: "",
         allFacilities: "",
-      }
+      },
     },
     patient: {
       form: {
@@ -34,16 +93,7 @@ export const es: LanguageConfig = {
           firstName: "",
           middleName: "",
           lastName: "",
-          role: {
-            heading: "",
-            options: [
-              "",
-              "",
-              "",
-              "",
-              "",
-            ]
-          },
+          role: "",
           studentId: "",
           preferredLanguage: "",
           dob: "",
@@ -52,11 +102,7 @@ export const es: LanguageConfig = {
           heading: "",
           primaryPhoneNumber: "",
           additionalPhoneNumber: "",
-          phoneType: {
-            heading: "",
-            mobile: "",
-            landline: "",
-          },
+          phoneType: "",
           addNumber: "",
           email: "",
           street1: "",
@@ -64,53 +110,52 @@ export const es: LanguageConfig = {
           county: "",
           city: "",
           state: "",
-          zip: ""
+          zip: "",
         },
         demographics: {
           heading: "",
           helpText: "",
-          race: {
-            heading: "",
-            options: [
-              "",
-              "",
-              "",
-              "",
-              "",
-              "",
-              "",
-            ]
-          },
-          tribalAffiliation: {
-            heading: "",
-            options: []
-          },
-          ethnicity: {
-            heading: "",
-            options: []
-          },
-          gender: {
-            heading: "",
-            options: []
-          },
+          race: "",
+          tribalAffiliation: "",
+          ethnicity: "",
+          gender: "",
         },
         other: {
           heading: "",
           congregateLiving: {
             heading: "",
             helpText: "",
-            options: []
           },
-          healthcareWorker: {
-            heading: "",
-            options: []
-          }
+          healthcareWorker: "",
         },
         errors: {
           unsaved: "",
           validationMsg: "",
-        }
-      }
+          firstName: "",
+          middleName: "",
+          lastName: "",
+          lookupId: "",
+          role: "",
+          facilityId: "",
+          birthDate: "",
+          telephone: "",
+          phoneNumbers: "",
+          email: "",
+          street: "",
+          streetTwo: "",
+          zipCode: "",
+          state: "",
+          city: "",
+          county: "",
+          race: "",
+          tribalAffiliation: "",
+          ethnicity: "",
+          gender: "",
+          residentCongregateSetting: "",
+          employedInHealthcare: "",
+          preferredLanguage: "",
+        },
+      },
     },
     selfRegistration: {
       form: {
@@ -119,12 +164,12 @@ export const es: LanguageConfig = {
         error: {
           heading: "",
           text: "",
-        }
+        },
       },
       confirmation: {
         registered: "",
-        checkIn: ""
-      }
+        checkIn: "",
+      },
     },
     testResult: {
       result: "",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -3,5 +3,128 @@ import { LanguageConfig } from "./en";
 export const es: LanguageConfig = {
   translation: {
     header: "Portal de pruebas COVID-19",
-  },
+    common: {
+      required: "",
+      button: {
+        submit: ""
+      },
+      pageNotFound: {
+        heading: "",
+        text: "",
+        errorCode: ""
+      }
+    },
+    address: {
+      errors: {
+        incomplete: "",
+        unverified: ""
+      }
+    },
+    facility: {
+      form: {
+        heading: "",
+        allFacilities: "",
+      }
+    },
+    patient: {
+      form: {
+        general: {
+          heading: "",
+          helpText: "",
+          firstName: "",
+          middleName: "",
+          lastName: "",
+          role: {
+            heading: "",
+            options: [
+              "",
+              "",
+              "",
+              "",
+              "",
+            ]
+          },
+          studentId: "",
+          preferredLanguage: "",
+          dob: "",
+        },
+        contact: {
+          heading: "",
+          primaryPhoneNumber: "",
+          additionalPhoneNumber: "",
+          phoneType: {
+            heading: "",
+            mobile: "",
+            landline: "",
+          },
+          addNumber: "",
+          email: "",
+          street1: "",
+          street2: "",
+          county: "",
+          city: "",
+          state: "",
+          zip: ""
+        },
+        demographics: {
+          heading: "",
+          helpText: "",
+          race: {
+            heading: "",
+            options: [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+            ]
+          },
+          tribalAffiliation: {
+            heading: "",
+            options: []
+          },
+          ethnicity: {
+            heading: "",
+            options: []
+          },
+          gender: {
+            heading: "",
+            options: []
+          },
+        },
+        other: {
+          heading: "",
+          congregateLiving: {
+            heading: "",
+            helpText: "",
+            options: []
+          },
+          healthcareWorker: {
+            heading: "",
+            options: []
+          }
+        },
+        errors: {
+          unsaved: "",
+          validationMsg: "",
+        }
+      }
+    },
+    selfRegistration: {
+      form: {
+        complete: "",
+        inProgress: "",
+        error: {
+          heading: "",
+          text: "",
+        }
+      },
+      confirmation: {
+        registered: "",
+        checkIn: ""
+      }
+    }
+  }
 };

--- a/frontend/src/patientApp/selfRegistration/Confirmation.tsx
+++ b/frontend/src/patientApp/selfRegistration/Confirmation.tsx
@@ -1,5 +1,6 @@
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Trans, useTranslation } from "react-i18next";
 
 type Props = {
   personName: string;
@@ -7,6 +8,8 @@ type Props = {
 };
 
 export const Confirmation = ({ personName, entityName }: Props) => {
+  const { t } = useTranslation();
+
   return (
     <div className="grid-container maxw-tablet padding-y-3">
       <div className="prime-formgroup">
@@ -16,14 +19,14 @@ export const Confirmation = ({ personName, entityName }: Props) => {
             icon={faCheckCircle}
           />
           <p className="padding-left-2">
-            <span className="text-bold">{personName}</span>, you're registered
-            for a COVID-19 test at {entityName}.
+            <Trans t={t} i18nKey="selfRegistration.confirmation.registered">
+              <span className="text-bold">{{personName}}</span>, you're registered for a COVID-19 test at {{entityName}}.
+            </Trans>
           </p>
         </div>
         <div>
           <p>
-            When you arrive for your test, check in by providing your first and
-            last name.
+            {t("selfRegistration.confirmation.checkIn")}
           </p>
         </div>
       </div>

--- a/frontend/src/patientApp/selfRegistration/Confirmation.tsx
+++ b/frontend/src/patientApp/selfRegistration/Confirmation.tsx
@@ -20,14 +20,13 @@ export const Confirmation = ({ personName, entityName }: Props) => {
           />
           <p className="padding-left-2">
             <Trans t={t} i18nKey="selfRegistration.confirmation.registered">
-              <span className="text-bold">{{personName}}</span>, you're registered for a COVID-19 test at {{entityName}}.
+              <span className="text-bold">{{ personName }}</span>, you're
+              registered for a COVID-19 test at {{ entityName }}.
             </Trans>
           </p>
         </div>
         <div>
-          <p>
-            {t("selfRegistration.confirmation.checkIn")}
-          </p>
+          <p>{t("selfRegistration.confirmation.checkIn")}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
@@ -5,6 +5,7 @@ import createMockStore from "redux-mock-store";
 import faker from "faker";
 
 import { SelfRegistration } from "./SelfRegistration";
+import "../../i18n";
 
 const VALID_LINK = "foo-facility";
 

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
@@ -6,7 +6,6 @@ import faker from "faker";
 import "../../i18n";
 
 import { SelfRegistration } from "./SelfRegistration";
-import "../../i18n";
 
 const VALID_LINK = "foo-facility";
 

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router";
 import { toast, ToastContainer } from "react-toastify";
 import moment from "moment";
 import "react-toastify/dist/ReactToastify.css";
+import { useTranslation } from "react-i18next";
 
 import USAGovBanner from "../../app/commonComponents/USAGovBanner";
 import { showError } from "../../app/utils";
@@ -26,6 +27,8 @@ export const SelfRegistration = () => {
   const [step, setStep] = useState(RegistrationStep.TERMS);
   const [entityName, setEntityName] = useState("");
   const [personName, setPersonName] = useState("");
+
+  const { t } = useTranslation();
 
   const savePerson = async (person: Nullable<PersonFormData>) => {
     const {
@@ -62,7 +65,11 @@ export const SelfRegistration = () => {
       setPersonName(formatFullName(person) || "");
       setStep(RegistrationStep.FINISHED);
     } catch (e) {
-      showError(toast, "There was a registration error", "Registration error");
+      showError(
+        toast, 
+        t("selfRegistration.form.error.heading"),
+        t("selfRegistration.form.error.text")
+      );
     }
   };
 
@@ -80,8 +87,9 @@ export const SelfRegistration = () => {
           <div className="grid-container maxw-tablet">
             <h1 className="margin-top-0 margin-bottom-1">
               {step === RegistrationStep.FINISHED
-                ? "Registration complete"
-                : "Register for your test"}
+                ? t("selfRegistration.form.complete")
+                : t("selfRegistration.form.inProgress")
+              }
             </h1>
             <h2 className="margin-y-0 text-normal">{entityName}</h2>
           </div>

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -66,7 +66,7 @@ export const SelfRegistration = () => {
       setStep(RegistrationStep.FINISHED);
     } catch (e) {
       showError(
-        toast, 
+        toast,
         t("selfRegistration.form.error.heading"),
         t("selfRegistration.form.error.text")
       );
@@ -88,8 +88,7 @@ export const SelfRegistration = () => {
             <h1 className="margin-top-0 margin-bottom-1">
               {step === RegistrationStep.FINISHED
                 ? t("selfRegistration.form.complete")
-                : t("selfRegistration.form.inProgress")
-              }
+                : t("selfRegistration.form.inProgress")}
             </h1>
             <h2 className="margin-y-0 text-normal">{entityName}</h2>
           </div>

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 import Button from "../../app/commonComponents/Button/Button";
 import { EMPTY_PERSON } from "../../app/patients/AddPatient";
 import PersonForm, {
@@ -9,6 +11,8 @@ type Props = {
 };
 
 export const SelfRegistrationForm = ({ savePerson }: Props) => {
+  const { t } = useTranslation();
+
   return (
     <div
       id="registration-container"
@@ -23,7 +27,7 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
             className="self-registration-button margin-top-3"
             onClick={onSave}
           >
-            Submit
+          {t("common.button.submit")}
           </Button>
         )}
         view={PersonFormView.SELF_REGISTRATION}

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -27,7 +27,7 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
             className="self-registration-button margin-top-3"
             onClick={onSave}
           >
-          {t("common.button.submit")}
+            {t("common.button.submit")}
           </Button>
         )}
         view={PersonFormView.SELF_REGISTRATION}

--- a/frontend/src/patientApp/timeOfTest/PatientFormContainer.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/PatientFormContainer.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import PatientFormContainer from "./PatientFormContainer";
+import "../../i18n";
 
 jest.mock("../..//app/commonComponents/ComboBox", () => () => <></>);
 const mockStore = configureStore([]);

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/AoEPatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/AoEPatientFormContainer.test.tsx.snap
@@ -88,7 +88,8 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
       <p
         className="message--required"
       >
-        Required fields are marked with an asterisk (
+        Required fields are marked with an asterisk
+         (
         <abbr
           className="usa-hint usa-hint--required"
           title="required"

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                   id="4"
                   name="role"
                   onChange={[Function]}
-                  value=""
+                  value="- Select -"
                 >
                   <option
                     value=""
@@ -554,7 +554,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                       name="state"
                       onBlur={[Function]}
                       onChange={[Function]}
-                      value=""
+                      value="- Select -"
                     >
                       <option
                         value=""

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
@@ -99,7 +99,8 @@ exports[`PatientFormContainer snapshot 1`] = `
             <p
               className="message--required"
             >
-              Required fields are marked with an asterisk (
+              Required fields are marked with an asterisk
+               (
               <abbr
                 className="usa-hint usa-hint--required"
                 title="required"


### PR DESCRIPTION
## Related Issue or Background Info

Closes #1557 

## Changes Proposed

- Extract English copy from self-registration components into separate translation configuration files:
    - Terms of service
        - `TermsOfService.tsx` and `ToS`.tsx (already done in #1979)
    - Patient sign-up form
        - `SelfRegistration.tsx`
            - `PersonForm.tsx`
                - `RequiredMessage.tsx`
                - `ManagePhoneNumbers.tsx`
                - `AddressConfirmationModal.tsx`
                - `personSchema.ts`
    - Confirmation screen 
        - `Confirmation.tsx`

## Additional Information
* Translation strings were simply chucked into the standalone `en.ts` file. In the future we may find it desirable to think about modularizing our translation strings
* The default value for dropdowns is defined in the `Dropdown.tsx` component itself, so any component that includes a dropdown as a child had to import the `i18next` instance.

## Screenshots / Demos
* Please see the test snapshots for verification that the content of the application is unaffected.
* For local testing, I forced the application to read from the Spanish translation configuration and went through the self-registration process. No English text was visible in the UI.

## Checklist for Author and Reviewer
- [ ] Did I miss any English copy that should be extracted into a translation string?
- [ ] It may not be the _most_ elegant right now, but does anyone feel the `en.ts` translation file is too unwieldy to be maintainable right now?

### UI
- [x] ~Any changes to the UI/UX are approved by design~
- [x] ~Any new or updated content (e.g. error messages) are approved by design~

### Testing
- Do you see any copy-and-paste errors, missed snippets of text, or anything else?

### Changes are Backwards Compatible
- [x] ~Database changes are submitted as a separate PR~
  - [x] ~Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~
  - [x] ~Any changes to tables that have custom no-PHI views are accompanied by changes to those views~
        ~(including re-granting permission to the no-PHI user if need be)~
  - [x] ~Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`~
- [x] ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~

## Cloud
- [x] ~DevOps team has been notified if PR requires ops support~
- [x] ~If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification~
