### PR TITLE
Add session column to audit log table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2424,15 +2424,15 @@ databaseChangeLog:
               DELETE FROM ${database.defaultSchemaName}.patient_registration_link 
               USING migration_user m
               WHERE created_by = m.migrations_user_id;
-- changeSet:
-      id: audit-http-session
-      author: emma@skylight.digital
-      comment: Add HTTP session column to api_audit_event.
-      changes:
-        - addColumn:
-            tableName: api_audit_event
-            columns:
-              - column:
-                  name: session
-                  type: jsonb
-                  remarks: The HTTP session information for this request (only applies to REST requests).
+  - changeSet:
+        id: audit-http-session
+        author: emma@skylight.digital
+        comment: Add HTTP session column to api_audit_event.
+        changes:
+          - addColumn:
+              tableName: api_audit_event
+              columns:
+                - column:
+                    name: session
+                    type: jsonb
+                    remarks: The HTTP session information for this request (only applies to REST requests).

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2424,3 +2424,15 @@ databaseChangeLog:
               DELETE FROM ${database.defaultSchemaName}.patient_registration_link 
               USING migration_user m
               WHERE created_by = m.migrations_user_id;
+- changeSet:
+      id: audit-http-session
+      author: emma@skylight.digital
+      comment: Add HTTP session column to api_audit_event.
+      changes:
+        - addColumn:
+            tableName: api_audit_event
+            columns:
+              - column:
+                  name: session
+                  type: jsonb
+                  remarks: The HTTP session information for this request (only applies to REST requests).


### PR DESCRIPTION
## Related Issue or Background Info

First step for #1925 

## Changes Proposed

- Add a new column to store session information in the audit log. This is required for some anonymous requests (like the ones from `UserAccountCreationController`.)

## Additional Information
The follow-up PR that uses this session information is #2015. 

https://skylight-hq.slack.com/archives/C01LTSNKEPP/p1626278825348200

## Checklist for Author and Reviewer

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
