### PR TITLE
Remove service desk email in prep for salesforce

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -79,7 +79,6 @@ simple-report:
     from-display-name: SimpleReport Support (CDC)
     account-request-recipient:
       - support@simplereport.gov
-      - Protect-ServiceDesk@hhs.gov
     waitlist-recipient: 
       - support@simplereport.gov
     dynamic-templates:

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -229,7 +229,7 @@ class AccountRequestControllerTest {
     // mail 1: to us (contains formatted request data)
     verify(emailService, times(1))
         .send(
-            eq(List.of("support@simplereport.gov", "Protect-ServiceDesk@hhs.gov")),
+            eq(List.of("support@simplereport.gov")),
             eq("New account request"),
             contentCaptor.capture());
     assertThat(contentCaptor.getValue().getTemplateName()).isEqualTo("account-request");

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -43,7 +43,6 @@ simple-report:
     from-email: support@simplereport.gov
     account-request-recipient:
       - support@simplereport.gov
-      - Protect-ServiceDesk@hhs.gov
     waitlist-recipient:
       - support@simplereport.gov
   demo-users:


### PR DESCRIPTION
## Related Issue or Background Info

- https://usds.slack.com/archives/C024ZEUGWDV/p1626358291007300

## Changes Proposed

- remove `Protect-ServiceDesk@hhs.gov` from new account request emails

## Additional Information

-My understanding is that this property is only used in one place https://github.com/CDCgov/prime-simplereport/blob/main/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java#L212
- Not sure how to test this one outside of waiting for a production account request to show up in the support inbox and not the protect one(not sure who on our team has access to that inbox)

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
