### PR TITLE
Add GH Actions for API rollback

### DIFF
--- a/.github/actions/rollback-application/action.yml
+++ b/.github/actions/rollback-application/action.yml
@@ -1,0 +1,17 @@
+name: Roll Back SimpleReport Application
+description: Roll back API to secondary slot version (i.e. the previous deploy)
+inputs:
+  deploy-env:
+    description: The environment being deployed (e.g. "prod" or "test")
+    required: true
+runs:
+  using: composite
+  steps:
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackDemoAPI.yml
+++ b/.github/workflows/rollbackDemoAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Demo API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: demo
+concurrency:
+  group: demo-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackDemoAPI.yml
+++ b/.github/workflows/rollbackDemoAPI.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/rollbackDevAPI.yml
+++ b/.github/workflows/rollbackDevAPI.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/rollbackDevAPI.yml
+++ b/.github/workflows/rollbackDevAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Dev API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: dev
+concurrency:
+  group: dev-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackPentestAPI.yml
+++ b/.github/workflows/rollbackPentestAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Pentest API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: pentest
+concurrency:
+  group: pentest-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackPentestAPI.yml
+++ b/.github/workflows/rollbackPentestAPI.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/rollbackProdAPI.yml
+++ b/.github/workflows/rollbackProdAPI.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/rollbackProdAPI.yml
+++ b/.github/workflows/rollbackProdAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Prod API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: prod
+concurrency:
+  group: prod-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackStgAPI.yml
+++ b/.github/workflows/rollbackStgAPI.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/rollbackStgAPI.yml
+++ b/.github/workflows/rollbackStgAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Stg API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: stg
+concurrency:
+  group: stg-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackTestAPI.yml
+++ b/.github/workflows/rollbackTestAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Test API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: test
+concurrency:
+  group: test-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackTestAPI.yml
+++ b/.github/workflows/rollbackTestAPI.yml
@@ -2,6 +2,9 @@ name: Rollback Test API
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'jdorothy/add-rollback-workflow'
 
 env:
   DEPLOY_ENV: test
@@ -25,10 +28,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/rollbackTestAPI.yml
+++ b/.github/workflows/rollbackTestAPI.yml
@@ -2,9 +2,6 @@ name: Rollback Test API
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - 'jdorothy/add-rollback-workflow'
 
 env:
   DEPLOY_ENV: test

--- a/.github/workflows/rollbackTrainingAPI.yml
+++ b/.github/workflows/rollbackTrainingAPI.yml
@@ -1,0 +1,34 @@
+name: Rollback Training API
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_ENV: training
+concurrency:
+  group: training-deploy
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Roll back to previous release
+        shell: bash
+        working-directory: ./ops
+        run: |
+          echo "::group::Roll back API to previous release and verify readiness"
+          make promote-${{ env.DEPLOY_ENV }}
+          make check-${{ env.DEPLOY_ENV }}-readiness
+          echo "::endgroup::"

--- a/.github/workflows/rollbackTrainingAPI.yml
+++ b/.github/workflows/rollbackTrainingAPI.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Roll back to previous release
-        shell: bash
-        working-directory: ./ops
-        run: |
-          echo "::group::Roll back API to previous release and verify readiness"
-          make promote-${{ env.DEPLOY_ENV }}
-          make check-${{ env.DEPLOY_ENV }}-readiness
-          echo "::endgroup::"
+        uses: ./.github/actions/rollback-application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}


### PR DESCRIPTION
## Related Issue or Background Info

#1415

## Changes Proposed

- Add a GH Action for each environment to roll back the deployed version to the previous release by swapping the current production deploy slot with the staging deploy slot (which contains the previous production deploy).

## Additional Information

- Note: this is not a rollback to an arbitrary commit. We're relying on the existing deployment slot set up to give us a quick emergency rollback.

## Checklist for Author and Reviewer

### Testing
- [ ] Proof of rollback success here: https://github.com/CDCgov/prime-simplereport/actions/runs/1038284243

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
