### PR TITLE
WIP: Reduce severity of unhandled frontend exception alerts

### DIFF
--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -156,7 +156,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "frontend_error_boundary"
  | where type startswith "PrimeErrorBoundary"
   QUERY
 
-  severity    = 1
+  severity    = 3
   frequency   = 5
   time_window = 5
   trigger {


### PR DESCRIPTION
## Related Issue or Background Info

These errors currently happen way too often to have a severity this high, and are causing too many alerts as a result.

## Changes Proposed

- Change the severity from Error to Information.
