### PR TITLE
Track DNS Zones and Private Links in Terraform

### DIFF
--- a/ops/demo/persistent/main.tf
+++ b/ops/demo/persistent/main.tf
@@ -54,6 +54,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
   log_workspace_id     = module.monitoring.log_analytics_workspace_id
   nophi_user_password  = random_password.random_nophi_password.result
 

--- a/ops/dev/persistent/main.tf
+++ b/ops/dev/persistent/main.tf
@@ -53,6 +53,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
 
   nophi_user_password = random_password.random_nophi_password.result
   log_workspace_id    = module.monitoring.log_analytics_workspace_id

--- a/ops/pentest/persistent/main.tf
+++ b/ops/pentest/persistent/main.tf
@@ -54,6 +54,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
   administrator_login  = "simplereport"
 
   log_workspace_id    = module.monitoring.log_analytics_workspace_id

--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -55,6 +55,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
   administrator_login  = "simplereport"
   log_workspace_id     = module.monitoring.log_analytics_workspace_id
   nophi_user_password  = random_password.random_nophi_password.result

--- a/ops/services/postgres_db/_var.tf
+++ b/ops/services/postgres_db/_var.tf
@@ -51,6 +51,14 @@ variable "public_access" {
   default = true
 }
 
+variable "subnet_id" {
+  type = string
+}
+
+variable "dns_zone_id" {
+  type = string
+}
+
 variable "nophi_user_password" {
   description = "Password for the simple_report_no_phi user."
   type        = string

--- a/ops/services/postgres_db/networking.tf
+++ b/ops/services/postgres_db/networking.tf
@@ -1,0 +1,18 @@
+resource "azurerm_private_endpoint" "db" {
+  name                = "${var.env}-db-privatelink"
+  location            = var.rg_location
+  resource_group_name = var.rg_name
+  subnet_id           = var.subnet_id
+
+  private_service_connection {
+    name                           = "${var.env}-db-privatelink"
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_postgresql_server.db.id
+    subresource_names              = ["postgresqlServer"]
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [var.dns_zone_id]
+  }
+}

--- a/ops/services/virtual_network/_output.tf
+++ b/ops/services/virtual_network/_output.tf
@@ -10,6 +10,10 @@ output "subnet_webapp_id" {
   value = azurerm_subnet.webapp.id
 }
 
+output "private_dns_zone_id" {
+  value = azurerm_private_dns_zone.default.id
+}
+
 output "network" {
   value = azurerm_virtual_network.vn
 }

--- a/ops/services/virtual_network/main.tf
+++ b/ops/services/virtual_network/main.tf
@@ -55,3 +55,8 @@ resource "azurerm_subnet" "webapp" {
     }
   }
 }
+
+resource "azurerm_private_dns_zone" "default" {
+  name                = "privatelink.postgres.database.azure.com"
+  resource_group_name = var.resource_group_name
+}

--- a/ops/stg/persistent/main.tf
+++ b/ops/stg/persistent/main.tf
@@ -54,6 +54,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
   administrator_login  = "simplereport"
 
   log_workspace_id    = module.monitoring.log_analytics_workspace_id

--- a/ops/test/persistent/main.tf
+++ b/ops/test/persistent/main.tf
@@ -52,6 +52,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
   log_workspace_id     = module.monitoring.log_analytics_workspace_id
   nophi_user_password  = random_password.random_nophi_password.result
 

--- a/ops/training/persistent/main.tf
+++ b/ops/training/persistent/main.tf
@@ -54,6 +54,8 @@ module "db" {
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
   public_access        = false
+  subnet_id            = module.vnet.subnet_vm_id
+  dns_zone_id          = module.vnet.private_dns_zone_id
   administrator_login  = "simplereport"
 
   log_workspace_id    = module.monitoring.log_analytics_workspace_id


### PR DESCRIPTION
## Related Issue or Background Info

#2028

We have a number of Azure resources not captured in Terraform (see #1360), which we need to fix before being able to continuously deploy Terraform properly.

## Changes Proposed

- Capture our existing Private DNS Zones and Private Link endpoints in Terraform

## Additional Information

- These resources already exist, so the trick is to `terraform import` them using the configuration added in this PR. Then, Terraform will be able to manage them going forward and protect them from configuration drift.

### Testing
- [ ] Verify this looks right (this works fine in `test`)

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
