### PR TITLE
Standardize DB public access in all envs to false

### DIFF
--- a/ops/demo/persistent/main.tf
+++ b/ops/demo/persistent/main.tf
@@ -53,7 +53,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
   log_workspace_id     = module.monitoring.log_analytics_workspace_id
   nophi_user_password  = random_password.random_nophi_password.result
 

--- a/ops/dev/persistent/main.tf
+++ b/ops/dev/persistent/main.tf
@@ -52,7 +52,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
 
   nophi_user_password = random_password.random_nophi_password.result
   log_workspace_id    = module.monitoring.log_analytics_workspace_id

--- a/ops/pentest/persistent/main.tf
+++ b/ops/pentest/persistent/main.tf
@@ -53,7 +53,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
   administrator_login  = "simplereport"
 
   log_workspace_id    = module.monitoring.log_analytics_workspace_id

--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -54,7 +54,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
   administrator_login  = "simplereport"
   log_workspace_id     = module.monitoring.log_analytics_workspace_id
   nophi_user_password  = random_password.random_nophi_password.result

--- a/ops/services/postgres_db/_var.tf
+++ b/ops/services/postgres_db/_var.tf
@@ -47,10 +47,6 @@ variable "tls_enabled" {
   default = false
 }
 
-variable "public_access" {
-  default = true
-}
-
 variable "nophi_user_password" {
   description = "Password for the simple_report_no_phi user."
   type        = string

--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_postgresql_server" "db" {
   sku_name                      = "GP_Gen5_4"
   version                       = "11"
   ssl_enforcement_enabled       = var.tls_enabled
-  public_network_access_enabled = var.public_access
+  public_network_access_enabled = false
 
   administrator_login          = var.administrator_login
   administrator_login_password = data.azurerm_key_vault_secret.db_password.value
@@ -37,15 +37,4 @@ resource "azurerm_postgresql_database" "simple_report" {
   name                = var.db_table
   resource_group_name = var.rg_name
   server_name         = azurerm_postgresql_server.db.name
-}
-
-# These parameters and names need to be exact: https://github.com/MicrosoftDocs/azure-docs/issues/20758
-# It looks like this only works if we enable public access. Otherwise, we need to use virtual network rules.
-resource "azurerm_postgresql_firewall_rule" "allow_access_to_azure_services" {
-  count               = var.public_access ? 1 : 0
-  name                = "AllowAllAzureIps"
-  resource_group_name = var.rg_name
-  server_name         = azurerm_postgresql_server.db.name
-  start_ip_address    = "0.0.0.0"
-  end_ip_address      = "0.0.0.0"
 }

--- a/ops/stg/persistent/main.tf
+++ b/ops/stg/persistent/main.tf
@@ -53,7 +53,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
   administrator_login  = "simplereport"
 
   log_workspace_id    = module.monitoring.log_analytics_workspace_id

--- a/ops/test/persistent/main.tf
+++ b/ops/test/persistent/main.tf
@@ -51,7 +51,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
   log_workspace_id     = module.monitoring.log_analytics_workspace_id
   nophi_user_password  = random_password.random_nophi_password.result
 

--- a/ops/training/persistent/main.tf
+++ b/ops/training/persistent/main.tf
@@ -53,7 +53,6 @@ module "db" {
   global_vault_id      = data.azurerm_key_vault.global.id
   db_vault_id          = data.azurerm_key_vault.db_keys.id
   db_encryption_key_id = data.azurerm_key_vault_key.db_encryption_key.id
-  public_access        = false
   administrator_login  = "simplereport"
 
   log_workspace_id    = module.monitoring.log_analytics_workspace_id


### PR DESCRIPTION
## Related Issue or Background Info

#2029

We have a number of Azure resources not captured in Terraform (see #1360), which we need to fix before being able to continuously deploy Terraform properly.

## Changes Proposed

- Standardize our DB firewall access rules across all environments. Specifically:
  - Hardcode `public_network_access_enabled` to false and remove the `public_access` variable.
  - Remove `azurerm_postgresql_firewall_rule.allow_access_to_azure_services` resource - it's no longer relevant if public access is always completely blocked.

## Additional Information

- These resources already exist, so the trick is to terraform import them using the configuration added in this PR. Then, Terraform will be able to manage them going forward and protect them from configuration drift.

### Testing
- [ ] Verify this looks right (this works fine in test)

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
