### PR TITLE
Fix provider bug in Azure DB logging

### DIFF
--- a/ops/services/postgres_db/monitor.tf
+++ b/ops/services/postgres_db/monitor.tf
@@ -1,5 +1,3 @@
-# Ignore changes in TF plan, the state seems to not recognize it has already been saved.
-# https://github.com/terraform-providers/terraform-provider-azurerm/issues/7235
 resource "azurerm_monitor_diagnostic_setting" "postgres" {
   name                       = "simple-report-${var.env}-db-diag"
   target_resource_id         = azurerm_postgresql_server.db.id

--- a/ops/services/postgres_db/monitor.tf
+++ b/ops/services/postgres_db/monitor.tf
@@ -1,4 +1,5 @@
 # Ignore changes in TF plan, the state seems to not recognize it has already been saved.
+# https://github.com/terraform-providers/terraform-provider-azurerm/issues/7235
 resource "azurerm_monitor_diagnostic_setting" "postgres" {
   name                       = "simple-report-${var.env}-db-diag"
   target_resource_id         = azurerm_postgresql_server.db.id
@@ -9,6 +10,7 @@ resource "azurerm_monitor_diagnostic_setting" "postgres" {
     enabled  = true
 
     retention_policy {
+      days    = 0
       enabled = false
     }
   }
@@ -18,6 +20,29 @@ resource "azurerm_monitor_diagnostic_setting" "postgres" {
     enabled  = true
 
     retention_policy {
+      enabled = false
+    }
+  }
+
+  # These two log categories are no-ops and we don't use them, but not adding them here triggers constant
+  # plan/apply changes due to a provider bug.
+  # See: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7235
+  log {
+    category = "QueryStoreRuntimeStatistics"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "QueryStoreWaitStatistics"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
       enabled = false
     }
   }


### PR DESCRIPTION
## Related Issue or Background Info

#2066

We have a number of Azure resources not captured in Terraform (see #1360), which we need to fix before being able to continuously deploy Terraform properly.

## Changes Proposed

Due to a bug in the Azure Terraform provider (https://github.com/terraform-providers/terraform-provider-azurerm/issues/7235), our `terraform plan` and `terraform apply` constantly show changes to be applied when there are none. The issue contains a workaround, implemented in this PR, which is to explicitly add the logging sections the provider is expecting, with the expected defaults, and just set `enabled` to `false`.

## Additional Information

These resources already exist, so the trick is to terraform import them using the configuration added in this PR. Then, Terraform will be able to manage them going forward and protect them from configuration drift.

### Checklist for Author and Reviewer

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
