### PR TITLE
Remove audit logging from UserAccountCreationController and AccountRequestController

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -45,7 +45,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Note that this controller is automatically authorized. */
 @PreAuthorize("@" + AUTHORIZER_BEAN + ".permitAllAccountRequests()")
-@PostAuthorize("@restAuditLogManager.logAnonymousRestSuccess(#request, returnObject)")
 @RestController
 @RequestMapping(ACCOUNT_REQUEST)
 public class AccountRequestController {
@@ -86,7 +85,7 @@ public class AccountRequestController {
   /** Read the waitlist request and generate an email body, then send with the emailService */
   @PostMapping("/waitlist")
   public void submitWaitlistRequest(
-      @Valid @RequestBody WaitlistRequest body, HttpServletRequest request) throws IOException {
+      @Valid @RequestBody WaitlistRequest body) throws IOException {
     String subject = "New waitlist request";
     if (LOG.isInfoEnabled()) {
       LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
@@ -101,7 +100,7 @@ public class AccountRequestController {
   @PostMapping("")
   @Transactional(readOnly = false)
   public void submitAccountRequest(
-      @Valid @RequestBody AccountRequest body, HttpServletRequest request) throws IOException {
+      @Valid @RequestBody AccountRequest body) throws IOException {
     try {
       String subject = "New account request";
       if (LOG.isInfoEnabled()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -31,11 +31,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -84,8 +82,7 @@ public class AccountRequestController {
 
   /** Read the waitlist request and generate an email body, then send with the emailService */
   @PostMapping("/waitlist")
-  public void submitWaitlistRequest(
-      @Valid @RequestBody WaitlistRequest body) throws IOException {
+  public void submitWaitlistRequest(@Valid @RequestBody WaitlistRequest body) throws IOException {
     String subject = "New waitlist request";
     if (LOG.isInfoEnabled()) {
       LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
@@ -99,8 +96,7 @@ public class AccountRequestController {
    */
   @PostMapping("")
   @Transactional(readOnly = false)
-  public void submitAccountRequest(
-      @Valid @RequestBody AccountRequest body) throws IOException {
+  public void submitAccountRequest(@Valid @RequestBody AccountRequest body) throws IOException {
     try {
       String subject = "New account request";
       if (LOG.isInfoEnabled()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserAccountCreationController.java
@@ -50,9 +50,6 @@ import org.springframework.web.bind.annotation.SessionAttribute;
  */
 @RestController
 @RequestMapping(USER_ACCOUNT_REQUEST)
-// All auditable requests need to include `HttpServletRequest request`, even if they don't use it
-// directly.
-@PostAuthorize("@restAuditLogManager.logAnonymousRestSuccess(#request, returnObject)")
 public class UserAccountCreationController {
   private static final Logger LOG = LoggerFactory.getLogger(UserAccountCreationController.class);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -178,6 +178,8 @@ class AuditLoggingTest extends BaseGraphqlTest {
     assertEquals("simplereport.simple", httpDetails.getOriginalHostName());
   }
 
+  // Temporarily disabled while audit logging on AccountRequestController is resolved.
+  /*
   @Test
   void anonymousRestRequest_auditCorrect() throws Exception {
     String requestBody =
@@ -198,4 +200,5 @@ class AuditLoggingTest extends BaseGraphqlTest {
     _mockMvc.perform(req).andExpect(status().isOk());
     assertLastAuditEntry(HttpStatus.OK, ResourceLinks.WAITLIST_REQUEST, null);
   }
+  */
 }


### PR DESCRIPTION
## Related Issue or Background Info

Audit logging failures are causing bad UI for account initialization errors:
![Screen Shot 2021-07-21 at 4 08 02 PM](https://user-images.githubusercontent.com/80282552/126571517-6574c52f-5a2d-42a7-9a29-514de3b0ae9a.png)

## Changes Proposed

Remove audit logging from these two files for now (they're both anonymous requests)

### Testing
- [x] Includes a summary of what a code reviewer should verify

