### PR TITLE
Update backend org type mapping for "Lab" to match frontend

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -330,7 +330,7 @@ public class Translators {
           Map.entry("employer", "Employer"),
           Map.entry("government_agency", "Government Agency"),
           Map.entry("camp", "Camp"),
-          Map.entry("lab", "lab"),
+          Map.entry("lab", "Lab"),
           Map.entry("other", "Other"));
 
   private static final Set<String> ORGANIZATION_TYPE_KEYS = ORGANIZATION_TYPES.keySet();


### PR DESCRIPTION
## Related Issue or Background Info

- When organization type of "Lab" is chosen on the account request form, the frontend sends `Lab` and the backend expects `lab`.  This could cause an error when an account request was submitted with lab chosen

## Changes Proposed

- update mapping to use `Lab`

## Additional Information

- Account requests where organization type was submitted as `Lab` would fail

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [n/a] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
