### PR TITLE
Remove redundant modifiers from interfaces

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/InternalIdResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/InternalIdResolver.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 /** Resolver mix-in to alias "id" to "internalId" */
 public interface InternalIdResolver<T extends DatabaseEntity> extends GraphQLResolver<T> {
-
   default UUID getId(T entity) {
     return entity.getInternalId();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/PersonNameResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/PersonNameResolver.java
@@ -6,7 +6,6 @@ import graphql.kickstart.tools.GraphQLResolver;
 
 /** Resolver mix-in to handle aliasing "nameInfo" to "name" */
 public interface PersonNameResolver<T extends PersonEntity> extends GraphQLResolver<T> {
-
   default PersonName getName(T entity) {
     return entity.getNameInfo();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TemplateVariablesProvider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TemplateVariablesProvider.java
@@ -11,12 +11,12 @@ public interface TemplateVariablesProvider {
    * @return resolvable name of template to be filled
    */
   @JsonIgnore
-  public String getTemplateName();
+  String getTemplateName();
 
   /**
    * Convert object fields to parameters used to fill a template.
    *
    * @return map of variables used to fill a template
    */
-  public Map<String, Object> toTemplateVariables();
+  Map<String, Object> toTemplateVariables();
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -42,9 +42,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter
   private static final Logger LOG = LoggerFactory.getLogger(SecurityConfiguration.class);
 
   public interface OktaAttributes {
-    public static String EMAIL = "email";
-    public static String FIRST_NAME = "given_name";
-    public static String LAST_NAME = "family_name";
+    String EMAIL = "email";
+    String FIRST_NAME = "given_name";
+    String LAST_NAME = "family_name";
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolder.java
@@ -38,7 +38,7 @@ public interface PermissionHolder {
    * effective. e.g. [NO_ACCESS, ALL_FACILITIES, ENTRY_ONLY, USER] => [ALL_FACILITIES, USER] e.g.
    * [NO_ACCESS, ENTRY_ONLY, USER, ADMIN] => [ADMIN]
    */
-  public static Set<OrganizationRole> getEffectiveRoles(Collection<OrganizationRole> roles) {
+  static Set<OrganizationRole> getEffectiveRoles(Collection<OrganizationRole> roles) {
     List<OrganizationRole> grantedRoles = new ArrayList<>(roles);
     grantedRoles.sort(new OrganizationRole.EffectiveRoleComparator());
     // set of all permissions granted by the user's granted roles
@@ -74,7 +74,7 @@ public interface PermissionHolder {
     return granted;
   }
 
-  public static boolean grantsAllFacilityAccess(Collection<OrganizationRole> roles) {
+  static boolean grantsAllFacilityAccess(Collection<OrganizationRole> roles) {
     return getPermissionsFromRoles(roles).contains(UserPermission.ACCESS_ALL_FACILITIES);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Eternal.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Eternal.java
@@ -3,7 +3,7 @@ package gov.cdc.usds.simplereport.db.model;
 /** Marker interface for an entity that gets soft-deleted when it is "destroyed". */
 public interface Eternal {
 
-  public boolean isDeleted();
+  boolean isDeleted();
 
-  public void setIsDeleted(boolean deleted);
+  void setIsDeleted(boolean deleted);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/AdvisoryLockManager.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/AdvisoryLockManager.java
@@ -27,7 +27,7 @@ public interface AdvisoryLockManager {
       // can't tell hibernate that Types.OTHER is a "void" result in this case:
       // just cast it to text
       value = "select cast(pg_advisory_xact_lock(:lockCategory, :lock) as text)")
-  public void waitForLock(int lockCategory, int lock);
+  void waitForLock(int lockCategory, int lock);
 
   /**
    * Attempt to take the advisory lock defined by the two arguments. If the lock is available,
@@ -41,5 +41,5 @@ public interface AdvisoryLockManager {
    * @return true if the lock was obtained, false otherwise
    */
   @Procedure("pg_try_advisory_xact_lock")
-  public boolean tryLock(int lockCategory, int lock);
+  boolean tryLock(int lockCategory, int lock);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
@@ -10,24 +10,24 @@ import org.springframework.data.jpa.repository.Query;
 /** Interface specification for fetching and manipulating {@link ApiUser} entities */
 public interface ApiUserRepository extends EternalSystemManagedEntityRepository<ApiUser> {
 
-  public static final String NAME_ORDER =
+  String NAME_ORDER =
       " order by last_name, first_name, middle_name, internal_id";
 
   // Defining this method explicitly means that findById() will not be able to find soft-deleted
   // users,
   // rendering un-deletion near-impossible
   @Query(BASE_QUERY + " and internalId = :id")
-  public Optional<ApiUser> findById(UUID id);
+  Optional<ApiUser> findById(UUID id);
 
   @Query("FROM #{#entityName} e WHERE internalId = :id")
-  public Optional<ApiUser> findByIdIncludeArchived(UUID id);
+  Optional<ApiUser> findByIdIncludeArchived(UUID id);
 
   @Query(BASE_QUERY + " and loginEmail = :email")
-  public Optional<ApiUser> findByLoginEmail(String email);
+  Optional<ApiUser> findByLoginEmail(String email);
 
   @Query("FROM #{#entityName} e WHERE loginEmail = lower(:email)")
-  public Optional<ApiUser> findByLoginEmailIncludeArchived(String email);
+  Optional<ApiUser> findByLoginEmailIncludeArchived(String email);
 
   @Query(BASE_QUERY + " and loginEmail IN :emails" + NAME_ORDER)
-  public List<ApiUser> findAllByLoginEmailInOrderByName(Collection<String> emails);
+  List<ApiUser> findAllByLoginEmailInOrderByName(Collection<String> emails);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
@@ -10,8 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 /** Interface specification for fetching and manipulating {@link ApiUser} entities */
 public interface ApiUserRepository extends EternalSystemManagedEntityRepository<ApiUser> {
 
-  String NAME_ORDER =
-      " order by last_name, first_name, middle_name, internal_id";
+  String NAME_ORDER = " order by last_name, first_name, middle_name, internal_id";
 
   // Defining this method explicitly means that findById() will not be able to find soft-deleted
   // users,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DataHubUploadRespository.java
@@ -15,15 +15,15 @@ public interface DataHubUploadRespository
    */
   int SCHEDULED_UPLOAD_LOCK = 66037627; // arbitrary 32-bit integer for our lock
 
-  public DataHubUpload save(DataHubUpload entity);
+  DataHubUpload save(DataHubUpload entity);
 
   // @Query("FROM #{#entityName} e WHERE e.job_status=?1 ORDER BY latest_recorded_timestamp DESC
   // LIMIT 1")
-  public DataHubUpload findDistinctTopByJobStatusOrderByLatestRecordedTimestampDesc(
+  DataHubUpload findDistinctTopByJobStatusOrderByLatestRecordedTimestampDesc(
       DataHubUploadStatus jobStatus);
 
   // used by unit tests
-  public List<DataHubUpload> findAll();
+  List<DataHubUpload> findAll();
 
   /**
    * Try to obtain the lock for the scheduled upload task. (It will be released automatically when

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
@@ -15,17 +15,17 @@ public interface DeviceSpecimenTypeRepository
   @Override
   @EntityGraph(attributePaths = {"deviceType", "specimenType"})
   @Query(BASE_QUERY + " and e.deviceType.isDeleted = false and e.specimenType.isDeleted = false")
-  public List<DeviceSpecimenType> findAll();
+  List<DeviceSpecimenType> findAll();
 
   @EntityGraph(attributePaths = {"deviceType", "specimenType"})
   @Query(BASE_QUERY + " and e.deviceType = :deviceType and e.specimenType = :specimenType")
-  public Optional<DeviceSpecimenType> find(DeviceType deviceType, SpecimenType specimenType);
+  Optional<DeviceSpecimenType> find(DeviceType deviceType, SpecimenType specimenType);
 
   // INSTA-DEPRECATION: this should only be used until we fix the API to not need
   // it
   @Deprecated
   @EntityGraph(attributePaths = {"deviceType", "specimenType"})
-  public Optional<DeviceSpecimenType> findFirstByDeviceTypeInternalIdOrderByCreatedAt(
+  Optional<DeviceSpecimenType> findFirstByDeviceTypeInternalIdOrderByCreatedAt(
       UUID deviceTypeId); // IGNORES
   // DELETION
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/EternalAuditedEntityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/EternalAuditedEntityRepository.java
@@ -16,16 +16,16 @@ import org.springframework.data.repository.NoRepositoryBean;
 public interface EternalAuditedEntityRepository<T extends EternalAuditedEntity>
     extends AuditedEntityRepository<T> {
 
-  public static final String BASE_QUERY = "from #{#entityName} e where e.isDeleted = false ";
-  public static final String BASE_ALLOW_DELETED_QUERY = "from #{#entityName} e where ";
+  String BASE_QUERY = "from #{#entityName} e where e.isDeleted = false ";
+  String BASE_ALLOW_DELETED_QUERY = "from #{#entityName} e where ";
 
   @Override
   @Query(BASE_QUERY)
-  public List<T> findAll();
+  List<T> findAll();
 
   @Override
   @Modifying // (flushAutomatically = true) // probably not? It's not clear when this would arise
   // actually
   @Query("update #{#entityName} e set e.isDeleted = true where e = :victim")
-  public void delete(T victim);
+  void delete(T victim);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/EternalSystemManagedEntityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/EternalSystemManagedEntityRepository.java
@@ -18,15 +18,15 @@ import org.springframework.data.repository.NoRepositoryBean;
 public interface EternalSystemManagedEntityRepository<T extends EternalSystemManagedEntity>
     extends CrudRepository<T, UUID> {
 
-  public static final String BASE_QUERY = "from #{#entityName} e where e.isDeleted = false ";
+  String BASE_QUERY = "from #{#entityName} e where e.isDeleted = false ";
 
   @Override
   @Query(BASE_QUERY)
-  public List<T> findAll();
+  List<T> findAll();
 
   @Override
   @Modifying // (flushAutomatically = true) // probably not? It's not clear when this would arise
   // actually
   @Query("update #{#entityName} e set e.isDeleted = true where e = :victim")
-  public void delete(T victim);
+  void delete(T victim);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -12,22 +12,22 @@ import org.springframework.data.jpa.repository.Query;
 public interface FacilityRepository extends EternalAuditedEntityRepository<Facility> {
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.organization = :org")
-  public Set<Facility> findAllByOrganization(Organization org);
+  Set<Facility> findAllByOrganization(Organization org);
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.organization = :org and e.id = :id")
-  public Optional<Facility> findByOrganizationAndInternalId(Organization org, UUID id);
+  Optional<Facility> findByOrganizationAndInternalId(Organization org, UUID id);
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.organization = :org and e.id in :ids")
-  public Set<Facility> findAllByOrganizationAndInternalId(Organization org, Collection<UUID> ids);
+  Set<Facility> findAllByOrganizationAndInternalId(Organization org, Collection<UUID> ids);
 
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.organization = :org and e.facilityName = :facilityName")
-  public Optional<Facility> findByOrganizationAndFacilityName(
+  Optional<Facility> findByOrganizationAndFacilityName(
       Organization org, String facilityName);
 
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.organization = :org order by e.facilityName")
-  public List<Facility> findByOrganizationOrderByFacilityName(Organization org);
+  List<Facility> findByOrganizationOrderByFacilityName(Organization org);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -23,8 +23,7 @@ public interface FacilityRepository extends EternalAuditedEntityRepository<Facil
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.organization = :org and e.facilityName = :facilityName")
-  Optional<Facility> findByOrganizationAndFacilityName(
-      Organization org, String facilityName);
+  Optional<Facility> findByOrganizationAndFacilityName(Organization org, String facilityName);
 
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -10,11 +10,11 @@ import org.springframework.data.jpa.repository.Query;
 public interface OrganizationRepository extends EternalAuditedEntityRepository<Organization> {
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.externalId = :externalId")
-  public Optional<Organization> findByExternalId(String externalId);
+  Optional<Organization> findByExternalId(String externalId);
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.externalId in (:externalIds)")
-  public List<Organization> findAllByExternalId(Collection<String> externalIds);
+  List<Organization> findAllByExternalId(Collection<String> externalIds);
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.identityVerified = :identityVerified")
-  public List<Organization> findAllByIdentityVerified(boolean identityVerified);
+  List<Organization> findAllByIdentityVerified(boolean identityVerified);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface PatientLinkRepository extends EternalAuditedEntityRepository<PatientLink> {
 
-  public Optional<PatientLink> findByTestOrder(TestOrder to);
+  Optional<PatientLink> findByTestOrder(TestOrder to);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepository.java
@@ -8,13 +8,13 @@ import java.util.Optional;
 public interface PatientRegistrationLinkRepository
     extends EternalAuditedEntityRepository<PatientSelfRegistrationLink> {
 
-  public Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkIgnoreCase(
+  Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkIgnoreCase(
       String patientRegistrationLink);
 
-  public Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkIgnoreCaseAndIsDeleted(
+  Optional<PatientSelfRegistrationLink> findByPatientRegistrationLinkIgnoreCaseAndIsDeleted(
       String patientRegistrationLink, Boolean isDeleted);
 
-  public Optional<PatientSelfRegistrationLink> findByOrganization(Organization org);
+  Optional<PatientSelfRegistrationLink> findByOrganization(Organization org);
 
-  public Optional<PatientSelfRegistrationLink> findByFacility(Facility fac);
+  Optional<PatientSelfRegistrationLink> findByFacility(Facility fac);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PersonRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PersonRepository.java
@@ -12,12 +12,12 @@ import org.springframework.data.jpa.repository.Query;
 /** Interface specification for fetching and manipulating {@link Person} entities */
 public interface PersonRepository extends EternalAuditedEntityRepository<Person> {
 
-  public List<Person> findAll(Specification<Person> searchSpec, Pageable p);
+  List<Person> findAll(Specification<Person> searchSpec, Pageable p);
 
-  public int count(Specification<Person> searchSpec);
+  int count(Specification<Person> searchSpec);
 
   @Query(
       BASE_ALLOW_DELETED_QUERY
           + " e.isDeleted = :isDeleted AND e.internalId = :id and e.organization = :org")
-  public Optional<Person> findByIdAndOrganization(UUID id, Organization org, boolean isDeleted);
+  Optional<Person> findByIdAndOrganization(UUID id, Organization org, boolean isDeleted);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TenantDataAccessRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TenantDataAccessRepository.java
@@ -9,5 +9,5 @@ public interface TenantDataAccessRepository
     extends EternalAuditedEntityRepository<TenantDataAccess> {
 
   @Query(BASE_QUERY + " and api_user_internal_id = :uuid and e.expiresAt > NOW()")
-  public List<TenantDataAccess> findValidByApiUserId(UUID uuid);
+  List<TenantDataAccess> findValidByApiUserId(UUID uuid);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -24,19 +24,19 @@ public interface TestEventRepository
   @Deprecated
   /** @deprecated (for sonar) */
   @Query("FROM #{#entityName} e WHERE e.patient = :p and e.facility in :facilities")
-  public List<TestEvent> findAllByPatientAndFacilities(Person p, Collection<Facility> facilities);
+  List<TestEvent> findAllByPatientAndFacilities(Person p, Collection<Facility> facilities);
 
   @Deprecated
   /** @deprecated (for sonar) */
-  public List<TestEvent> findAllByOrganizationOrderByCreatedAtDesc(Organization o);
+  List<TestEvent> findAllByOrganizationOrderByCreatedAtDesc(Organization o);
 
   @Deprecated
   /** @deprecated (for sonar) */
-  public List<TestEvent> findAllByOrganizationAndFacility(Organization o, Facility f);
+  List<TestEvent> findAllByOrganizationAndFacility(Organization o, Facility f);
 
   @Deprecated
   /** @deprecated (for sonar) */
-  public TestEvent findFirst1ByPatientOrderByCreatedAtDesc(Person p);
+  TestEvent findFirst1ByPatientOrderByCreatedAtDesc(Person p);
 
   @Deprecated
   /** @deprecated (for sonar) */
@@ -46,12 +46,12 @@ public interface TestEventRepository
               + " WHERE patient_id IN :patientIds"
               + " ORDER BY patient_id, coalesced_last_test_date DESC",
       nativeQuery = true)
-  public List<TestEvent> findLastTestsByPatient(Collection<UUID> patientIds);
+  List<TestEvent> findLastTestsByPatient(Collection<UUID> patientIds);
 
   @Deprecated
   /** @deprecated (for sonar) */
   @EntityGraph(attributePaths = {"patient", "order"})
-  public TestEvent findByOrganizationAndInternalId(Organization o, UUID id);
+  TestEvent findByOrganizationAndInternalId(Organization o, UUID id);
 
   @Deprecated
   /** @deprecated (for sonar) */
@@ -59,7 +59,7 @@ public interface TestEventRepository
   // This is across all Orgs/facilities because datahub uploader users
   @Query(
       "FROM #{#entityName} q WHERE q.createdAt > :before AND q.createdAt <= :after ORDER BY q.createdAt")
-  public List<TestEvent> queryMatchAllBetweenDates(Date before, Date after, Pageable p);
+  List<TestEvent> queryMatchAllBetweenDates(Date before, Date after, Pageable p);
 
   // @Query("FROM #{#entityName} q WHERE q.facility = :facility and q.createdAt >
   // :newerThanDate
@@ -68,7 +68,7 @@ public interface TestEventRepository
   // public List<TestEvent> getTestEventResults(Facility facility, Date
   // newerThanDate);
 
-  public Page<TestEvent> findAll(Specification<TestEvent> searchSpec, Pageable p);
+  Page<TestEvent> findAll(Specification<TestEvent> searchSpec, Pageable p);
 
-  public long count(Specification<TestEvent> searchSpec);
+  long count(Specification<TestEvent> searchSpec);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -13,34 +13,34 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> {
 
-  public static final String BASE_QUERY =
+  String BASE_QUERY =
       "from #{#entityName} q "
           + "where q.organization.isDeleted = false "
           + "and q.patient.isDeleted = false ";
-  public static final String BASE_ORG_QUERY = BASE_QUERY + " and q.organization = :org ";
-  public static final String FACILITY_QUERY = BASE_ORG_QUERY + " and q.facility = :facility ";
-  public static final String IS_PENDING = " and q.orderStatus = 'PENDING' ";
-  public static final String IS_COMPLETED = " and q.orderStatus = 'COMPLETED' ";
-  public static final String ORDER_CREATION_ORDER = " order by q.createdAt ";
-  public static final String RESULT_RECENT_ORDER = " order by updatedAt desc ";
+  String BASE_ORG_QUERY = BASE_QUERY + " and q.organization = :org ";
+  String FACILITY_QUERY = BASE_ORG_QUERY + " and q.facility = :facility ";
+  String IS_PENDING = " and q.orderStatus = 'PENDING' ";
+  String IS_COMPLETED = " and q.orderStatus = 'COMPLETED' ";
+  String ORDER_CREATION_ORDER = " order by q.createdAt ";
+  String RESULT_RECENT_ORDER = " order by updatedAt desc ";
 
   @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)
   @EntityGraph(attributePaths = {"patient", "patientLink"})
-  public List<TestOrder> fetchQueue(Organization org, Facility facility);
+  List<TestOrder> fetchQueue(Organization org, Facility facility);
 
   @Query(BASE_ORG_QUERY + IS_PENDING + " and q.patient = :patient")
   @EntityGraph(attributePaths = "patient")
-  public Optional<TestOrder> fetchQueueItem(Organization org, Person patient);
+  Optional<TestOrder> fetchQueueItem(Organization org, Person patient);
 
   @Query(BASE_QUERY + IS_PENDING + " and q.id = :id")
-  public Optional<TestOrder> fetchQueueItemById(UUID id);
+  Optional<TestOrder> fetchQueueItemById(UUID id);
 
   @Query(BASE_ORG_QUERY + IS_PENDING + " and q.id = :id")
-  public Optional<TestOrder> fetchQueueItemByOrganizationAndId(Organization org, UUID id);
+  Optional<TestOrder> fetchQueueItemByOrganizationAndId(Organization org, UUID id);
 
   @Query(FACILITY_QUERY + IS_COMPLETED + RESULT_RECENT_ORDER)
   @EntityGraph(attributePaths = "patient")
-  public List<TestOrder> fetchPastResults(Organization org, Facility facility);
+  List<TestOrder> fetchPastResults(Organization org, Facility facility);
 
   @Query(BASE_ORG_QUERY + " and q.testEvent = :testEvent")
   TestOrder findByTestEvent(Organization org, TestEvent testEvent);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TimeOfConsentRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TimeOfConsentRepository.java
@@ -7,6 +7,5 @@ import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface TimeOfConsentRepository extends CrudRepository<TimeOfConsent, UUID> {
-
-  public List<TimeOfConsent> findAllByPatientLink(PatientLink pl);
+  List<TimeOfConsent> findAllByPatientLink(PatientLink pl);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/authentication/OktaAuthentication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/authentication/OktaAuthentication.java
@@ -24,7 +24,7 @@ public interface OktaAuthentication {
    * @param factorId nullable, a user's Okta factor id.
    * @return a UserAccountStatus enum.
    */
-  public UserAccountStatus getUserStatus(String activationToken, String userId, String factorId);
+  UserAccountStatus getUserStatus(String activationToken, String userId, String factorId);
 
   /**
    * Converts an activation token into a user id. If successful, the user is moved into a
@@ -38,7 +38,7 @@ public interface OktaAuthentication {
    * @throws InvalidActivationLinkException if the activation token is invalid, expired, or has
    *     already been used.
    */
-  public String activateUser(String activationToken, String crossForwardedHeader, String userAgent)
+  String activateUser(String activationToken, String crossForwardedHeader, String userAgent)
       throws InvalidActivationLinkException;
 
   /**
@@ -50,7 +50,7 @@ public interface OktaAuthentication {
    *     id is invalid.)
    * @throws BadRequestException if the user-provided password does not meet Okta requirements.
    */
-  public void setPassword(String userId, char[] password)
+  void setPassword(String userId, char[] password)
       throws OktaAuthenticationFailureException, BadRequestException;
 
   /**
@@ -63,7 +63,7 @@ public interface OktaAuthentication {
    * @throws OktaAuthenticationFailureException if setting the recovery question fails (i.e.,
    *     because the user isn't in the correct state or cannot be found).
    */
-  public void setRecoveryQuestion(String userId, String question, String answer)
+  void setRecoveryQuestion(String userId, String question, String answer)
       throws OktaAuthenticationFailureException, BadRequestException;
 
   /**
@@ -76,7 +76,7 @@ public interface OktaAuthentication {
    * @throws BadRequestException if the phone number is invalid.
    * @throws OktaAuthenticationFailureException if Okta cannot enroll the user in SMS MFA.
    */
-  public String enrollSmsMfa(String userId, String phoneNumber)
+  String enrollSmsMfa(String userId, String phoneNumber)
       throws OktaAuthenticationFailureException, BadRequestException;
 
   /**
@@ -89,7 +89,7 @@ public interface OktaAuthentication {
    * @throws BadRequestException if the phone number is invalid.
    * @throws OktaAuthenticationFailureException if Okta cannot enroll the user in voice call MFA.
    */
-  public String enrollVoiceCallMfa(String userId, String phoneNumber)
+  String enrollVoiceCallMfa(String userId, String phoneNumber)
       throws OktaAuthenticationFailureException, BadRequestException;
 
   /**
@@ -101,7 +101,7 @@ public interface OktaAuthentication {
    * @throws OktaAuthenticationFailureException if the email is invalid or Okta cannot enroll it as
    *     an MFA option.
    */
-  public String enrollEmailMfa(String userId) throws OktaAuthenticationFailureException;
+  String enrollEmailMfa(String userId) throws OktaAuthenticationFailureException;
 
   /**
    * Enroll a user in an authentication app for MFA. If successful, this method returns the factor
@@ -114,7 +114,7 @@ public interface OktaAuthentication {
    * @throws OktaAuthenticationFailureException if the app type is not recognized, Okta fails to
    *     enroll the MFA option, or the result from Okta does not contain a QR code.
    */
-  public FactorAndQrCode enrollAuthenticatorAppMfa(String userId, String appType)
+  FactorAndQrCode enrollAuthenticatorAppMfa(String userId, String appType)
       throws OktaAuthenticationFailureException;
 
   /**
@@ -126,7 +126,7 @@ public interface OktaAuthentication {
    * @throws OktaAuthenticationFailureException if the user id is not recognized or the factor
    *     cannot be enrolled.
    */
-  public JSONObject enrollSecurityKey(String userId) throws OktaAuthenticationFailureException;
+  JSONObject enrollSecurityKey(String userId) throws OktaAuthenticationFailureException;
 
   /**
    * Activates a security key using the provided frontend-generated credentials.
@@ -136,7 +136,7 @@ public interface OktaAuthentication {
    * @param attestation the base64-encoded attestation from the WebAuthn JavaScript call
    * @param clientData the base64-encoded client data from the WebAuthn JavaScript call
    */
-  public void activateSecurityKey(
+  void activateSecurityKey(
       String userId, String factorId, String attestation, String clientData)
       throws OktaAuthenticationFailureException;
 
@@ -152,7 +152,7 @@ public interface OktaAuthentication {
    * @throws OktaAuthenticationFailureException if the factor could not be activated (because the
    *     user or factor doesn't exist).
    */
-  public void verifyActivationPasscode(String userId, String factorId, String passcode)
+  void verifyActivationPasscode(String userId, String factorId, String passcode)
       throws OktaAuthenticationFailureException;
 
   /**
@@ -169,6 +169,6 @@ public interface OktaAuthentication {
    * @throws IllegalStateException if the resend request comes too soon (Okta enforces a minimum 30
    *     second pause between activation code requests.)
    */
-  public void resendActivationPasscode(String userId, String factorId)
+  void resendActivationPasscode(String userId, String factorId)
       throws OktaAuthenticationFailureException;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/authentication/OktaAuthentication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/authentication/OktaAuthentication.java
@@ -136,8 +136,7 @@ public interface OktaAuthentication {
    * @param attestation the base64-encoded attestation from the WebAuthn JavaScript call
    * @param clientData the base64-encoded client data from the WebAuthn JavaScript call
    */
-  void activateSecurityKey(
-      String userId, String factorId, String attestation, String clientData)
+  void activateSecurityKey(String userId, String factorId, String attestation, String clientData)
       throws OktaAuthenticationFailureException;
 
   /**

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -15,33 +15,33 @@ import java.util.Set;
  */
 public interface OktaRepository {
 
-  public Optional<OrganizationRoleClaims> createUser(
+  Optional<OrganizationRoleClaims> createUser(
       IdentityAttributes userIdentity,
       Organization org,
       Set<Facility> facilities,
       Set<OrganizationRole> roles,
       boolean active);
 
-  public Optional<OrganizationRoleClaims> updateUser(IdentityAttributes userIdentity);
+  Optional<OrganizationRoleClaims> updateUser(IdentityAttributes userIdentity);
 
-  public void reprovisionUser(IdentityAttributes userIdentity);
+  void reprovisionUser(IdentityAttributes userIdentity);
 
-  public Optional<OrganizationRoleClaims> updateUserPrivileges(
+  Optional<OrganizationRoleClaims> updateUserPrivileges(
       String username, Organization org, Set<Facility> facilities, Set<OrganizationRole> roles);
 
-  public void setUserIsActive(String username, Boolean active);
+  void setUserIsActive(String username, Boolean active);
 
-  public Set<String> getAllUsersForOrganization(Organization org);
+  Set<String> getAllUsersForOrganization(Organization org);
 
-  public void createOrganization(Organization org);
+  void createOrganization(Organization org);
 
-  public void activateOrganization(Organization org);
+  void activateOrganization(Organization org);
 
-  public void createFacility(Facility facility);
+  void createFacility(Facility facility);
 
-  public void deleteOrganization(Organization org);
+  void deleteOrganization(Organization org);
 
-  public void deleteFacility(Facility facility);
+  void deleteFacility(Facility facility);
 
-  public Optional<OrganizationRoleClaims> getOrganizationRoleClaimsForUser(String username);
+  Optional<OrganizationRoleClaims> getOrganizationRoleClaimsForUser(String username);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/crm/CrmProvider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/crm/CrmProvider.java
@@ -3,5 +3,5 @@ package gov.cdc.usds.simplereport.service.crm;
 import gov.cdc.usds.simplereport.service.model.crm.AccountRequestDynamicsData;
 
 public interface CrmProvider {
-  public void submitAccountRequestData(final AccountRequestDynamicsData dynamicsData);
+  void submitAccountRequestData(final AccountRequestDynamicsData dynamicsData);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailProvider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailProvider.java
@@ -4,5 +4,5 @@ import com.sendgrid.helpers.mail.Mail;
 import java.io.IOException;
 
 public interface EmailProvider {
-  public String send(Mail mail) throws IOException;
+  String send(Mail mail) throws IOException;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/ExperianService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/ExperianService.java
@@ -5,5 +5,5 @@ import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationRe
 public interface ExperianService {
 
   /** Retrieves questions from Experian, given user data. */
-  public String getQuestions(IdentityVerificationRequest userData);
+  String getQuestions(IdentityVerificationRequest userData);
 }


### PR DESCRIPTION
## Related Issue or Background Info

- `public`, `static`, and `final` are redundant modifiers on interface methods and properties.

## Changes Proposed

- Remove the redundant modifiers.

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
