### PR TITLE
Also catch RuntimeExceptions in AccountRequestController.submitAccountRequest

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -222,7 +222,7 @@ public class AccountRequestController {
       throw new AccountRequestFailureException(e);
     } catch (RuntimeException e) {
       if (e instanceof ResourceException) {
-        // We don't want to wrap this particular Okta exception as it will make alerts too noisy
+        // The `ResourceException` is thrown when an account is requested with an existing organization name. This happens quite frequently and is expected behavior of the current form
         throw e;
       } else {
         throw new AccountRequestFailureException(e);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -4,6 +4,7 @@ import static gov.cdc.usds.simplereport.config.AuthorizationConfiguration.AUTHOR
 import static gov.cdc.usds.simplereport.config.WebConfiguration.ACCOUNT_REQUEST;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.okta.sdk.resource.ResourceException;
 import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.accountrequest.errors.AccountRequestFailureException;
 import gov.cdc.usds.simplereport.api.model.Role;
@@ -94,6 +95,7 @@ public class AccountRequestController {
    * Read the account request and generate an email body, then send with the emailService and create
    * org
    */
+  @SuppressWarnings("checkstyle:illegalcatch")
   @PostMapping("")
   @Transactional(readOnly = false)
   public void submitAccountRequest(@Valid @RequestBody AccountRequest body) throws IOException {
@@ -218,6 +220,13 @@ public class AccountRequestController {
       _crm.submitAccountRequestData(body);
     } catch (IOException e) {
       throw new AccountRequestFailureException(e);
+    } catch (RuntimeException e) {
+      if (e instanceof ResourceException) {
+        // We don't want to wrap this particular Okta exception as it will make alerts too noisy
+        throw e;
+      } else {
+        throw new AccountRequestFailureException(e);
+      }
     }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -222,7 +222,9 @@ public class AccountRequestController {
       throw new AccountRequestFailureException(e);
     } catch (RuntimeException e) {
       if (e instanceof ResourceException) {
-        // The `ResourceException` is thrown when an account is requested with an existing organization name. This happens quite frequently and is expected behavior of the current form
+        // The `ResourceException` is thrown when an account is requested with an existing
+        // organization name. This happens quite frequently and is expected behavior of the current
+        // form
         throw e;
       } else {
         throw new AccountRequestFailureException(e);


### PR DESCRIPTION
## Related Issue or Background Info

In #1987, we wrapped `AccountRequestController.submitAccountRequest` in a try/catch block in order to throw a custom exception for easy metrics tracking. We're only catching `IOException` at the moment, but we should also catch `RuntimeException` (other than `com.okta.sdk.resource.ResourceException`) and override checkstyle's rule against it.

## Changes Proposed

- Add a second `catch` for `RuntimeException`. Throw the same custom exception as `IOException` unless it's an instance of `com.okta.sdk.resource.ResourceException`, in which case the exception should be re-thrown as is.
- Add a `@SuppressWarnings("checkstyle:illegalcatch")` to `submitAccountRequest` to tell checkstyle to ignore the new `catch`.

## Checklist for Author and Reviewer

### Testing
- [x] Tested locally