### PR TITLE
update design of organization data page

### DIFF
--- a/frontend/src/app/admin/Organization/TenantDataAccessForm.test.tsx
+++ b/frontend/src/app/admin/Organization/TenantDataAccessForm.test.tsx
@@ -40,7 +40,7 @@ describe("TenantDataAccessForm", () => {
     fireEvent.change(screen.getByLabelText("Justification", { exact: false }), {
       target: { value: "sample justification text" },
     });
-    const saveButton = await screen.getAllByText("Save changes")[0];
+    const saveButton = await screen.getAllByText("Access data")[0];
     expect(saveButton).toBeEnabled();
     await waitFor(async () => {
       fireEvent.click(saveButton);
@@ -59,6 +59,19 @@ describe("TenantDataAccessForm", () => {
         />
       </MemoryRouter>
     );
+    const organizationDropdown = screen.getByTestId("organization-dropdown");
+    fireEvent.change(organizationDropdown, {
+      target: { selectedValue: organizations[0].externalId },
+    });
+    fireEvent.change(organizationDropdown, {
+      target: { value: organizations[0].externalId },
+    });
+    await waitFor(async () => {
+      fireEvent.blur(organizationDropdown);
+    });
+    fireEvent.change(screen.getByLabelText("Justification", { exact: false }), {
+      target: { value: "sample justification text" },
+    });
     const cancelButton = await screen.getAllByText("Cancel access")[0];
     expect(cancelButton).toBeEnabled();
     await waitFor(async () => {

--- a/frontend/src/app/admin/Organization/TenantDataAccessForm.tsx
+++ b/frontend/src/app/admin/Organization/TenantDataAccessForm.tsx
@@ -80,11 +80,14 @@ const TenantDataAccessForm: React.FC<Props> = (props) => {
             <div className="usa-card__header">
               <div>
                 <h2 className="font-heading-lg">Organization Data Access</h2>
-                <p className="text-base">This page allows you to reproduce a specific user's issues by accessing their account. 
-                Access automatically expires after an hour, or you can leave the organization manually by selecting "Cancel access" below.</p>
+                <p className="text-base">
+                  This page allows you to reproduce a specific user's issues by
+                  accessing their account. Access automatically expires after an
+                  hour, or you can leave the organization manually by selecting
+                  "Cancel access" below.
+                </p>
                 <RequiredMessage />
               </div>
-              
             </div>
           </div>
           <OrganizationDropDown

--- a/frontend/src/app/admin/Organization/TenantDataAccessForm.tsx
+++ b/frontend/src/app/admin/Organization/TenantDataAccessForm.tsx
@@ -79,23 +79,12 @@ const TenantDataAccessForm: React.FC<Props> = (props) => {
           <div className="prime-container card-container">
             <div className="usa-card__header">
               <div>
-                <h2 className="font-heading-lg">Organization data</h2>
+                <h2 className="font-heading-lg">Organization Data Access</h2>
+                <p className="text-base">This page allows you to reproduce a specific user's issues by accessing their account. 
+                Access automatically expires after an hour, or you can leave the organization manually by selecting "Cancel access" below.</p>
                 <RequiredMessage />
               </div>
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                }}
-              >
-                <Button
-                  type="button"
-                  onClick={submitTenantDataAccessRequest}
-                  label="Save changes"
-                  disabled={!formIsValid}
-                />
-              </div>
+              
             </div>
           </div>
           <OrganizationDropDown
@@ -122,6 +111,33 @@ const TenantDataAccessForm: React.FC<Props> = (props) => {
             <div className="usa-card__header">
               <div>
                 <h2 className="font-heading-lg">
+                  Request organization data access
+                </h2>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                }}
+              >
+                <Button
+                  type="button"
+                  onClick={submitTenantDataAccessRequest}
+                  label="Access data"
+                  disabled={!formIsValid}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="grid-container">
+        <div className="grid-row">
+          <div className="prime-container card-container">
+            <div className="usa-card__header">
+              <div>
+                <h2 className="font-heading-lg">
                   Cancel organization data access
                 </h2>
               </div>
@@ -136,6 +152,7 @@ const TenantDataAccessForm: React.FC<Props> = (props) => {
                   type="button"
                   onClick={submitCancellationRequest}
                   label="Cancel access"
+                  disabled={!formIsValid}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2084 

## Changes Proposed

- Adds explanatory text to organization data request
- Moves request button to the bottom of page; changes button text
- Disable "cancel" button until fields are filled out

## Screenshots / Demos
<img width="976" alt="Screen Shot 2021-07-22 at 2 21 06 PM" src="https://user-images.githubusercontent.com/80282552/126712795-09c77ed7-6a6d-4c8f-aac3-da7122c10a33.png">
<img width="973" alt="Screen Shot 2021-07-22 at 2 21 20 PM" src="https://user-images.githubusercontent.com/80282552/126712809-9dad3b70-df88-4014-aee7-ba718cf3080a.png">


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
