### PR TITLE
Do not re-prompt for facility when navigating to /admin links

### DIFF
--- a/frontend/src/app/admin/Admin.tsx
+++ b/frontend/src/app/admin/Admin.tsx
@@ -21,17 +21,19 @@ const Admin = () => {
                 </LinkWithQuery>
               </div>
               <div>
-                <Link to="/admin/add-organization-admin">
+                <LinkWithQuery to="/admin/add-organization-admin">
                   Add organization admin
-                </Link>
+                </LinkWithQuery>
               </div>
               <div>
-                <Link to="/admin/create-device-type">
+                <LinkWithQuery to="/admin/create-device-type">
                   Create new device type
-                </Link>
+                </LinkWithQuery>
               </div>
               <div>
-                <Link to="/admin/tenant-data-access">Organization data</Link>
+                <LinkWithQuery to="/admin/tenant-data-access">
+                  Organization data
+                </LinkWithQuery>
               </div>
             </div>
           </div>

--- a/frontend/src/app/admin/Admin.tsx
+++ b/frontend/src/app/admin/Admin.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/2069

## Changes Proposed

- Retain query parameters when clicking links in `/admin`

## Additional Information

- Site admins were being asked to re-select facility after clicking a link (for example, clicking the "Organization data" link) because the selected facility was not being passed along in the link

## Testing

1. As a site admin, go to `/admin`
2. Click "Organization data"
3. Choose an organization with at least 2 facilities (locally, you can use "DAT_ORG")
4. Navigate back to `/admin`
5. Click "Organization data" (You should not be prompted to choose a facility)

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
