### PR TITLE
Support new experian workflow during account request

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -121,7 +121,11 @@ public class AccountRequestController {
 
       createAdminUser(org, reqVars);
       _crm.submitAccountRequestData(body);
-    } catch (IOException e) {
+    } catch (ResourceException e) {
+      // The `ResourceException` is thrown when an account is requested with an existing org
+      // name. This happens quite frequently and is expected behavior of the current form
+      throw e;
+    } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
     }
   }
@@ -130,6 +134,7 @@ public class AccountRequestController {
    * Account request for experian id verification workflow. It differs from v1 in that it will not
    * send email to the user or to our support staff and it returns the org external id
    */
+  @SuppressWarnings("checkstyle:illegalcatch")
   @PostMapping("/organization-create")
   @Transactional(readOnly = false)
   public AccountResponse submitAccountRequestV2(@Valid @RequestBody AccountRequest body)
@@ -140,17 +145,12 @@ public class AccountRequestController {
       createAdminUser(org, reqVars);
       _crm.submitAccountRequestData(body);
       return new AccountResponse(org.getExternalId());
-    } catch (IOException e) {
+    } catch (ResourceException e) {
+      // The `ResourceException` is thrown when an account is requested with an existing org
+      // name. This happens quite frequently and is expected behavior of the current form
+      throw e;
+    } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
-    } catch (RuntimeException e) {
-      if (e instanceof ResourceException) {
-        // The `ResourceException` is thrown when an account is requested with an existing
-        // organization name. This happens quite frequently and is expected behavior of the current
-        // form
-        throw e;
-      } else {
-        throw new AccountRequestFailureException(e);
-      }
     }
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -88,9 +88,7 @@ public class AccountRequestController {
   @PostMapping("/waitlist")
   public void submitWaitlistRequest(@Valid @RequestBody WaitlistRequest body) throws IOException {
     String subject = "New waitlist request";
-    if (LOG.isInfoEnabled()) {
-      LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
-    }
+    LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
     _es.send(sendGridProperties.getWaitlistRecipient(), subject, body);
   }
 
@@ -156,9 +154,7 @@ public class AccountRequestController {
 
   private Map<String, String> convertAccountRequestToMap(AccountRequest accountRequest)
       throws JsonProcessingException {
-    if (LOG.isInfoEnabled()) {
-      LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(accountRequest));
-    }
+    LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(accountRequest));
 
     return accountRequest.toTemplateVariables().entrySet().stream()
         .collect(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -88,7 +88,9 @@ public class AccountRequestController {
   @PostMapping("/waitlist")
   public void submitWaitlistRequest(@Valid @RequestBody WaitlistRequest body) throws IOException {
     String subject = "New waitlist request";
-    LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(body));
+    }
     _es.send(sendGridProperties.getWaitlistRecipient(), subject, body);
   }
 
@@ -154,7 +156,9 @@ public class AccountRequestController {
 
   private Map<String, String> convertAccountRequestToMap(AccountRequest accountRequest)
       throws JsonProcessingException {
-    LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(accountRequest));
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(accountRequest));
+    }
 
     return accountRequest.toTemplateVariables().entrySet().stream()
         .collect(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -3,14 +3,17 @@ package gov.cdc.usds.simplereport.api.accountrequest;
 import static gov.cdc.usds.simplereport.config.AuthorizationConfiguration.AUTHORIZER_BEAN;
 import static gov.cdc.usds.simplereport.config.WebConfiguration.ACCOUNT_REQUEST;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.okta.sdk.resource.ResourceException;
 import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.accountrequest.errors.AccountRequestFailureException;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.accountrequest.AccountRequest;
+import gov.cdc.usds.simplereport.api.model.accountrequest.AccountResponse;
 import gov.cdc.usds.simplereport.api.model.accountrequest.WaitlistRequest;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
@@ -100,108 +103,8 @@ public class AccountRequestController {
   @Transactional(readOnly = false)
   public void submitAccountRequest(@Valid @RequestBody AccountRequest body) throws IOException {
     try {
-      String subject = "New account request";
-      if (LOG.isInfoEnabled()) {
-        LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(body));
-      }
-
-      Map<String, String> reqVars =
-          body.toTemplateVariables().entrySet().stream()
-              .collect(
-                  HashMap::new,
-                  (m, e) ->
-                      m.put(e.getKey(), e.getValue() == null ? null : e.getValue().toString()),
-                  HashMap::putAll);
-
-      List<DeviceType> devices = _dts.fetchDeviceTypes();
-      Map<String, String> deviceNamesToIds =
-          devices.stream()
-              .collect(Collectors.toMap(d -> d.getName(), d -> d.getInternalId().toString()));
-      Map<String, String> deviceModelsToIds =
-          devices.stream()
-              .collect(Collectors.toMap(d -> d.getModel(), d -> d.getInternalId().toString()));
-
-      List<String> testingDevicesSubmitted =
-          new ArrayList<>(Arrays.asList(reqVars.get("testingDevices").split(", ")));
-      testingDevicesSubmitted.removeIf(d -> d.toLowerCase().startsWith("other"));
-      List<String> unregisteredTestingDevices = new ArrayList<>();
-      List<String> testingDeviceIds =
-          testingDevicesSubmitted.stream()
-              .map(
-                  d -> {
-                    String deviceId =
-                        Optional.ofNullable(deviceNamesToIds.get(d))
-                            .orElse(deviceModelsToIds.get(d));
-                    if (deviceId == null) {
-                      unregisteredTestingDevices.add(d);
-                    }
-                    return deviceId;
-                  })
-              .collect(Collectors.toList());
-      // Can't easily catch a thrown exception in a stream, so move the throw outside of the stream:
-      if (!unregisteredTestingDevices.isEmpty()) {
-        throw new IOException(
-            String.format(
-                "Submitted device=%s not registered in DB.",
-                unregisteredTestingDevices.iterator().next()));
-      }
-      String defaultTestingDeviceId =
-          Optional.ofNullable(deviceNamesToIds.get(reqVars.get("defaultTestingDevice")))
-              .orElse(deviceModelsToIds.get(reqVars.get("defaultTestingDevice")));
-      if (defaultTestingDeviceId == null) {
-        throw new IOException(
-            String.format(
-                "Submitted default device=%s not registered in DB.",
-                reqVars.get("defaultTestingDevice")));
-      }
-      DeviceSpecimenTypeHolder deviceSpecimenTypes =
-          _dts.getTypesForFacility(defaultTestingDeviceId, testingDeviceIds);
-
-      StreetAddress facilityAddress =
-          _avs.getValidatedAddress(
-              reqVars.get("streetAddress1"),
-              reqVars.get("streetAddress2"),
-              reqVars.get("city"),
-              reqVars.get("state"),
-              reqVars.get("zip"),
-              _avs.FACILITY_DISPLAY_NAME);
-      StreetAddress providerAddress =
-          new StreetAddress(
-              Translators.parseString(reqVars.get("opStreetAddress1")),
-              Translators.parseString(reqVars.get("opStreetAddress2")),
-              Translators.parseString(reqVars.get("opCity")),
-              Translators.parseState(reqVars.get("opState")),
-              Translators.parseString(reqVars.get("opZip")),
-              Translators.parseString(reqVars.get("opCounty")));
-
-      PersonName providerName =
-          Translators.consolidateNameArguments(
-              null, reqVars.get("opFirstName"), null, reqVars.get("opLastName"), null, true);
-      PersonName adminName =
-          Translators.consolidateNameArguments(
-              null, reqVars.get("firstName"), null, reqVars.get("lastName"), null);
-
-      String orgExternalId =
-          String.format(
-              "%s-%s-%s",
-              reqVars.get("state"),
-              reqVars.get("organizationName").replace(' ', '-').replace(':', '-'),
-              UUID.randomUUID().toString());
-
-      _os.createOrganization(
-          reqVars.get("organizationName"),
-          Translators.parseOrganizationTypeFromName(reqVars.get("organizationType")),
-          orgExternalId,
-          reqVars.get("facilityName"),
-          reqVars.get("cliaNumber"),
-          facilityAddress,
-          Translators.parsePhoneNumber(reqVars.get("facilityPhoneNumber")),
-          null,
-          deviceSpecimenTypes,
-          providerName,
-          providerAddress,
-          Translators.parsePhoneNumber(reqVars.get("opPhoneNumber")),
-          reqVars.get("npi"));
+      Map<String, String> reqVars = convertAccountRequestToMap(body);
+      Organization org = checkAccountRequestAndCreateOrg(reqVars);
 
       /**
        * Note: we are sending the emails *after* creating the organization so the validation logic
@@ -211,13 +114,32 @@ public class AccountRequestController {
        * Okta rollback mechanisms down the road, this won't be an issue.)
        */
       // send summary email to SR support
+      String subject = "New account request";
       _es.send(sendGridProperties.getAccountRequestRecipient(), subject, body);
       // send next-steps email to requester
       _es.sendWithProviderTemplate(body.getEmail(), EmailProviderTemplate.ACCOUNT_REQUEST);
 
-      _aus.createUser(reqVars.get("email"), adminName, orgExternalId, Role.ADMIN);
-
+      createAdminUser(org, reqVars);
       _crm.submitAccountRequestData(body);
+    } catch (IOException e) {
+      throw new AccountRequestFailureException(e);
+    }
+  }
+
+  /**
+   * Account request for experian id verification workflow. It differs from v1 in that it will not
+   * send email to the user or to our support staff and it returns the org external id
+   */
+  @PostMapping("/organization-create")
+  @Transactional(readOnly = false)
+  public AccountResponse submitAccountRequestV2(@Valid @RequestBody AccountRequest body)
+      throws IOException {
+    try {
+      Map<String, String> reqVars = convertAccountRequestToMap(body);
+      Organization org = checkAccountRequestAndCreateOrg(reqVars);
+      createAdminUser(org, reqVars);
+      _crm.submitAccountRequestData(body);
+      return new AccountResponse(org.getExternalId());
     } catch (IOException e) {
       throw new AccountRequestFailureException(e);
     } catch (RuntimeException e) {
@@ -230,5 +152,114 @@ public class AccountRequestController {
         throw new AccountRequestFailureException(e);
       }
     }
+  }
+
+  private Map<String, String> convertAccountRequestToMap(AccountRequest accountRequest)
+      throws JsonProcessingException {
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Account request submitted: {}", objectMapper.writeValueAsString(accountRequest));
+    }
+
+    return accountRequest.toTemplateVariables().entrySet().stream()
+        .collect(
+            HashMap::new,
+            (m, e) -> m.put(e.getKey(), e.getValue() == null ? null : e.getValue().toString()),
+            HashMap::putAll);
+  }
+
+  private Organization checkAccountRequestAndCreateOrg(Map<String, String> reqVars)
+      throws IOException {
+    List<DeviceType> devices = _dts.fetchDeviceTypes();
+    Map<String, String> deviceNamesToIds =
+        devices.stream()
+            .collect(Collectors.toMap(d -> d.getName(), d -> d.getInternalId().toString()));
+    Map<String, String> deviceModelsToIds =
+        devices.stream()
+            .collect(Collectors.toMap(d -> d.getModel(), d -> d.getInternalId().toString()));
+
+    List<String> testingDevicesSubmitted =
+        new ArrayList<>(Arrays.asList(reqVars.get("testingDevices").split(", ")));
+    testingDevicesSubmitted.removeIf(d -> d.toLowerCase().startsWith("other"));
+    List<String> unregisteredTestingDevices = new ArrayList<>();
+    List<String> testingDeviceIds =
+        testingDevicesSubmitted.stream()
+            .map(
+                d -> {
+                  String deviceId =
+                      Optional.ofNullable(deviceNamesToIds.get(d)).orElse(deviceModelsToIds.get(d));
+                  if (deviceId == null) {
+                    unregisteredTestingDevices.add(d);
+                  }
+                  return deviceId;
+                })
+            .collect(Collectors.toList());
+    // Can't easily catch a thrown exception in a stream, so move the throw outside of the stream:
+    if (!unregisteredTestingDevices.isEmpty()) {
+      throw new IOException(
+          String.format(
+              "Submitted device=%s not registered in DB.",
+              unregisteredTestingDevices.iterator().next()));
+    }
+    String defaultTestingDeviceId =
+        Optional.ofNullable(deviceNamesToIds.get(reqVars.get("defaultTestingDevice")))
+            .orElse(deviceModelsToIds.get(reqVars.get("defaultTestingDevice")));
+    if (defaultTestingDeviceId == null) {
+      throw new IOException(
+          String.format(
+              "Submitted default device=%s not registered in DB.",
+              reqVars.get("defaultTestingDevice")));
+    }
+    DeviceSpecimenTypeHolder deviceSpecimenTypes =
+        _dts.getTypesForFacility(defaultTestingDeviceId, testingDeviceIds);
+
+    StreetAddress facilityAddress =
+        _avs.getValidatedAddress(
+            reqVars.get("streetAddress1"),
+            reqVars.get("streetAddress2"),
+            reqVars.get("city"),
+            reqVars.get("state"),
+            reqVars.get("zip"),
+            _avs.FACILITY_DISPLAY_NAME);
+    StreetAddress providerAddress =
+        new StreetAddress(
+            Translators.parseString(reqVars.get("opStreetAddress1")),
+            Translators.parseString(reqVars.get("opStreetAddress2")),
+            Translators.parseString(reqVars.get("opCity")),
+            Translators.parseState(reqVars.get("opState")),
+            Translators.parseString(reqVars.get("opZip")),
+            Translators.parseString(reqVars.get("opCounty")));
+
+    PersonName providerName =
+        Translators.consolidateNameArguments(
+            null, reqVars.get("opFirstName"), null, reqVars.get("opLastName"), null, true);
+
+    String orgExternalId =
+        String.format(
+            "%s-%s-%s",
+            reqVars.get("state"),
+            reqVars.get("organizationName").replace(' ', '-').replace(':', '-'),
+            UUID.randomUUID().toString());
+
+    return _os.createOrganization(
+        reqVars.get("organizationName"),
+        Translators.parseOrganizationTypeFromName(reqVars.get("organizationType")),
+        orgExternalId,
+        reqVars.get("facilityName"),
+        reqVars.get("cliaNumber"),
+        facilityAddress,
+        Translators.parsePhoneNumber(reqVars.get("facilityPhoneNumber")),
+        null,
+        deviceSpecimenTypes,
+        providerName,
+        providerAddress,
+        Translators.parsePhoneNumber(reqVars.get("opPhoneNumber")),
+        reqVars.get("npi"));
+  }
+
+  private void createAdminUser(Organization org, Map<String, String> reqVars) {
+    PersonName adminName =
+        Translators.consolidateNameArguments(
+            null, reqVars.get("firstName"), null, reqVars.get("lastName"), null);
+    _aus.createUser(reqVars.get("email"), adminName, org.getExternalId(), Role.ADMIN);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/IdentityVerificationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/IdentityVerificationController.java
@@ -125,7 +125,7 @@ public class IdentityVerificationController {
     // send summary email to SR support
     _es.send(
         sendGridProperties.getAccountRequestRecipient(),
-        "New account request",
+        "New account ID verification failure",
         new AccountRequestOrganizationCreateTemplate(orgExternalId, orgAdminEmail));
     // send next-steps email to requester
     _es.sendWithProviderTemplate(orgAdminEmail, EmailProviderTemplate.ID_VERIFICATION_FAILED);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/IdentityVerificationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/IdentityVerificationController.java
@@ -111,8 +111,8 @@ public class IdentityVerificationController {
     verificationResponse.setEmail(orgAdminEmail);
 
     if (verificationResponse.isPassed()) {
-      // enable the organization and send response email
-      _orgService.setIdentityVerified(requestBody.getOrgExternalId(), true);
+      // enable the organization and send account activation email (through okta)
+      _orgService.verifyOrganizationNoPermissions(requestBody.getOrgExternalId());
     } else {
       sendIdentityVerificationFailedEmails(org.getExternalId(), orgAdminEmail);
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/IdentityVerificationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/IdentityVerificationController.java
@@ -3,18 +3,32 @@ package gov.cdc.usds.simplereport.api.accountrequest;
 import static gov.cdc.usds.simplereport.config.AuthorizationConfiguration.AUTHORIZER_BEAN;
 import static gov.cdc.usds.simplereport.config.WebConfiguration.IDENTITY_VERIFICATION;
 
+import gov.cdc.usds.simplereport.api.model.accountrequest.AccountRequestOrganizationCreateTemplate;
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationAnswersRequest;
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationAnswersResponse;
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationQuestionsRequest;
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationQuestionsResponse;
+import gov.cdc.usds.simplereport.api.model.errors.BadRequestException;
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import gov.cdc.usds.simplereport.properties.SendGridProperties;
 import gov.cdc.usds.simplereport.service.OrganizationService;
+import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
+import gov.cdc.usds.simplereport.service.email.EmailService;
+import gov.cdc.usds.simplereport.service.errors.ExperianPersonMatchException;
 import gov.cdc.usds.simplereport.service.idverification.ExperianService;
+import java.io.IOException;
+import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +43,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(IDENTITY_VERIFICATION)
 public class IdentityVerificationController {
 
+  @Autowired private EmailService _es;
   @Autowired private ExperianService _experianService;
+  @Autowired private OktaRepository _oktaRepo;
   @Autowired private OrganizationService _orgService;
+  @Autowired private SendGridProperties sendGridProperties;
 
   private static final Logger LOG = LoggerFactory.getLogger(IdentityVerificationController.class);
 
@@ -39,31 +56,78 @@ public class IdentityVerificationController {
     LOG.info("WIP: Identity verification REST endpoint enabled.");
   }
 
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<String> handleException(BadRequestException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+  }
+
+  @ExceptionHandler(ExperianPersonMatchException.class)
+  public ResponseEntity<String> handleException(ExperianPersonMatchException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+  }
+
+  @ExceptionHandler(IllegalGraphqlArgumentException.class)
+  public ResponseEntity<String> handleException(IllegalGraphqlArgumentException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+  }
+
   @PostMapping("/get-questions")
   public IdentityVerificationQuestionsResponse getQuestions(
-      @Valid @RequestBody IdentityVerificationQuestionsRequest requestBody) {
-    return _experianService.getQuestions(requestBody);
+      @Valid @RequestBody IdentityVerificationQuestionsRequest requestBody) throws IOException {
+    Organization org = _orgService.getOrganization(requestBody.getOrgExternalId());
+    Set<String> orgUserEmailSet = _oktaRepo.getAllUsersForOrganization(org);
+    if (org.getIdentityVerified() || orgUserEmailSet.size() != 1) {
+      throw new BadRequestException("The organization must be unverified and only have 1 member");
+    }
+
+    try {
+      return _experianService.getQuestions(requestBody);
+    } catch (ExperianPersonMatchException e) {
+      // could not match a person with the details in the request
+      String orgAdminEmail = orgUserEmailSet.iterator().next();
+      sendIdentityVerificationFailedEmails(org.getExternalId(), orgAdminEmail);
+      throw e;
+    }
   }
 
   @PostMapping("/submit-answers")
   public IdentityVerificationAnswersResponse submitAnswers(
-      @Valid @RequestBody IdentityVerificationAnswersRequest requestBody) {
+      @Valid @RequestBody IdentityVerificationAnswersRequest requestBody) throws IOException {
     /**
      * example request body: {"answers":["1","2","3","4","5"]} where "1" represents the user
      * selecting "2002" for "Please select the model year of the vehicle you purchased or leased
      * prior to January 2011"
      */
+    Organization org = _orgService.getOrganization(requestBody.getOrgExternalId());
+    Set<String> orgUserEmailSet = _oktaRepo.getAllUsersForOrganization(org);
+    if (org.getIdentityVerified() || orgUserEmailSet.size() != 1) {
+      throw new BadRequestException("The organization must be unverified and only have 1 member");
+    }
+
     IdentityVerificationAnswersResponse verificationResponse =
         _experianService.submitAnswers(requestBody);
+
+    String orgAdminEmail = orgUserEmailSet.iterator().next();
+    verificationResponse.setEmail(orgAdminEmail);
 
     if (verificationResponse.isPassed()) {
       // enable the organization and send response email
       _orgService.setIdentityVerified(requestBody.getOrgExternalId(), true);
     } else {
-      // todo: update this before moving to prod
-      verificationResponse.setEmail("fakeemail.updatethis@example.com");
+      sendIdentityVerificationFailedEmails(org.getExternalId(), orgAdminEmail);
     }
 
     return verificationResponse;
+  }
+
+  private void sendIdentityVerificationFailedEmails(String orgExternalId, String orgAdminEmail)
+      throws IOException {
+    // send summary email to SR support
+    _es.send(
+        sendGridProperties.getAccountRequestRecipient(),
+        "New account request",
+        new AccountRequestOrganizationCreateTemplate(orgExternalId, orgAdminEmail));
+    // send next-steps email to requester
+    _es.sendWithProviderTemplate(orgAdminEmail, EmailProviderTemplate.ID_VERIFICATION_FAILED);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountRequestOrganizationCreateTemplate.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountRequestOrganizationCreateTemplate.java
@@ -1,0 +1,32 @@
+package gov.cdc.usds.simplereport.api.model.accountrequest;
+
+import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AccountRequestOrganizationCreateTemplate implements TemplateVariablesProvider {
+
+  private static final String TEMPLATE_NAME = "account-request-organization-create";
+
+  private final String orgExternalId;
+  private final String adminEmail;
+
+  public AccountRequestOrganizationCreateTemplate(String orgExternalId, String adminEmail) {
+    this.orgExternalId = orgExternalId;
+    this.adminEmail = adminEmail;
+  }
+
+  @Override
+  public String getTemplateName() {
+    return TEMPLATE_NAME;
+  }
+
+  @Override
+  public Map<String, Object> toTemplateVariables() {
+    Map<String, Object> variableMap = new HashMap<>();
+    variableMap.put("orgExternalId", orgExternalId);
+    variableMap.put("adminEmail", adminEmail);
+
+    return variableMap;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountResponse.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/AccountResponse.java
@@ -1,0 +1,10 @@
+package gov.cdc.usds.simplereport.api.model.accountrequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AccountResponse {
+  private final String orgExternalId;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/IdentityVerificationAnswersRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/IdentityVerificationAnswersRequest.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class IdentityVerificationAnswersRequest {
+
   @JsonProperty @NotNull private String orgExternalId;
   // experian session id from getting questions
   @JsonProperty @NotNull private String sessionId;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/IdentityVerificationQuestionsRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/IdentityVerificationQuestionsRequest.java
@@ -8,6 +8,11 @@ import lombok.Setter;
 @Getter
 @Setter
 public class IdentityVerificationQuestionsRequest {
+
+  // our org
+  @JsonProperty @NotNull private String orgExternalId;
+
+  // properties to pass to experian
   @JsonProperty @NotNull private String firstName;
   @JsonProperty @NotNull private String lastName;
   @JsonProperty private String middleName;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -294,6 +294,22 @@ public class OrganizationService {
     return newStatus;
   }
 
+  /**
+   * This method is for verifying an organization after the Experian identity verification process.
+   * It should not be used for any other purpose and once we move to the updated account request
+   * workflow this should be removed.
+   */
+  @Transactional(readOnly = false)
+  public void verifyOrganizationNoPermissions(String externalId) {
+    Organization org = getOrganization(externalId);
+    if (org.getIdentityVerified()) {
+      throw new IllegalStateException("Organization is already verified.");
+    }
+    org.setIdentityVerified(true);
+    _repo.save(org);
+    _oktaRepo.activateOrganization(org);
+  }
+
   @Transactional(readOnly = false)
   public Facility createFacilityNoPermissions(
       Organization organization,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailProviderTemplate.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailProviderTemplate.java
@@ -6,5 +6,8 @@ public enum EmailProviderTemplate {
    */
 
   // new account request next-steps email (to account requester)
-  ACCOUNT_REQUEST;
+  ACCOUNT_REQUEST,
+
+  // identity verification failed email (to account requester)
+  ID_VERIFICATION_FAILED;
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -88,6 +88,7 @@ simple-report:
       # The values of the map are the GUID value for the Dynamic Template (also found in the SendGrid web
       # app).  New versions of the template do not change this value.
       ACCOUNT_REQUEST: d-7b0c7810ce5643f295e169f38b8db015
+      ID_VERIFICATION_FAILED: d-b629fce77d604a31a2872746674cf08e
   dynamics:
     enabled: false
     client-id: ${DYNAMICS_CLIENT_ID:MISSING}

--- a/backend/src/main/resources/templates/account-request-organization-create.html
+++ b/backend/src/main/resources/templates/account-request-organization-create.html
@@ -1,9 +1,5 @@
-A new SimpleReport account request has been submitted with the details below. This organization was created in SimpleReport and the admin now needs their identity verified. After identity verification the organization can be enabled by going to https://simplereport.gov/app/admin/pending-organizations and marking the org with the matching external ID.
-
-<h1>Organization</h1>
-
-<b>External ID: </b>[[${orgExternalId}]]<br>
-
-<h1>Facility administrator</h1>
-
-<b>Email address: </b>[[${adminEmail}]]<br>
+Greetings from SimpleReport,<br>
+<br>
+A new organization with the email [[${adminEmail}]] signed up in SimpleReport but failed Experian's identity verification process. We've sent them information to schedule an identity verification video call with HHS support, and they'll appear on the list of unverified organizations.<br>
+<br>
+After you've verified their identity you can activate the organization by going to <a href="https://simplereport.gov/app/admin/pending-organizations">https://simplereport.gov/app/admin/pending-organizations</a>, searching for their <b>External ID ([[${orgExternalId}]])</b>, then marking their identify as verified.

--- a/backend/src/main/resources/templates/account-request-organization-create.html
+++ b/backend/src/main/resources/templates/account-request-organization-create.html
@@ -1,0 +1,9 @@
+A new SimpleReport account request has been submitted with the details below. This organization was created in SimpleReport and the admin now needs their identity verified. After identity verification the organization can be enabled by going to https://simplereport.gov/app/admin/pending-organizations and marking the org with the matching external ID.
+
+<h1>Organization</h1>
+
+<b>External ID: </b>[[${orgExternalId}]]<br>
+
+<h1>Facility administrator</h1>
+
+<b>Email address: </b>[[${adminEmail}]]<br>

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
@@ -102,7 +102,7 @@ class IdentityVerificationControllerTest {
     _experianService.addSessionId(VALID_SESSION_UUID);
 
     Organization org = mock(Organization.class);
-    when(_orgService.getOrganization(eq(FAKE_ORG_EXTERNAL_ID))).thenReturn(org);
+    when(_orgService.getOrganization(FAKE_ORG_EXTERNAL_ID)).thenReturn(org);
     when(_orgService.getOrganization(not(eq(FAKE_ORG_EXTERNAL_ID))))
         .thenThrow(IllegalGraphqlArgumentException.class);
     when(org.getExternalId()).thenReturn(FAKE_ORG_EXTERNAL_ID);
@@ -214,7 +214,7 @@ class IdentityVerificationControllerTest {
     // should send email to requester
     verify(_emailService, times(1))
         .sendWithProviderTemplate(
-            eq(FAKE_ORG_ADMIN_EMAIL), eq(EmailProviderTemplate.ID_VERIFICATION_FAILED));
+            FAKE_ORG_ADMIN_EMAIL, EmailProviderTemplate.ID_VERIFICATION_FAILED);
   }
 
   private void verifyEmailsNotSent() throws IOException {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
@@ -261,7 +261,7 @@ class IdentityVerificationControllerTest {
     verify(_emailService, times(1))
         .send(
             anyList(),
-            eq("New account request"),
+            eq("New account ID verification failure"),
             any(AccountRequestOrganizationCreateTemplate.class));
 
     // should send email to requester

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -11,6 +11,8 @@ public final class ResourceLinks {
 
   public static final String WAITLIST_REQUEST = "/account-request/waitlist";
   public static final String ACCOUNT_REQUEST = "/account-request";
+  public static final String ACCOUNT_REQUEST_ORGANIZATION_CREATE =
+      "/account-request/organization-create";
   public static final String USER_ACCOUNT_REQUEST = "/user-account";
   public static final String USER_GET_STATUS = "/user-account/user-status";
   public static final String USER_ACTIVATE_ACCOUNT_REQUEST = "/user-account/initialize";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -189,4 +189,24 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
             AccessDeniedException.class, () -> _service.updateOrganization("Foo org", "k12"));
     assertEquals("Access is denied", caught.getMessage());
   }
+
+  @Test
+  void verifyOrganizationNoPermissions_noUser_success() {
+    Organization org = _dataFactory.createUnverifiedOrg();
+    _service.verifyOrganizationNoPermissions(org.getExternalId());
+
+    org = _service.getOrganization(org.getExternalId());
+    assertTrue(org.getIdentityVerified());
+  }
+
+  @Test
+  void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
+    Organization org = _dataFactory.createValidOrg();
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> _service.verifyOrganizationNoPermissions(org.getExternalId()));
+
+    assertEquals("Organization is already verified.", e.getMessage());
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -202,10 +202,11 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
     Organization org = _dataFactory.createValidOrg();
+    String orgExternalId = org.getExternalId();
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
-            () -> _service.verifyOrganizationNoPermissions(org.getExternalId()));
+            () -> _service.verifyOrganizationNoPermissions(orgExternalId));
 
     assertEquals("Organization is already verified.", e.getMessage());
   }


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/2058
Fixes https://github.com/CDCgov/prime-simplereport/issues/2060
Fixes https://github.com/CDCgov/prime-simplereport/issues/2061

## Changes Proposed

- Add new endpoint in AccountRequestController to handle account requests that will follow identity verification workflow
- During new workflow, send emails when identity verification fails instead of immediately on account request

## Additional Information

- Account request will use a new endpoint to make transition to the identity verification workflow easier
- A PR to `prime-simplereport-site` that changes the account request submission endpoint will be required to enable the new workflow
- Testing can be performed by running the static site locally with a modified submission endpoint
- Until we get more test data from Experian, it isn't possible to get a successful identity verification (for testing purposes, we can submit a fake SSN to achieve an `ACCEPT` decision, though)

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification