### PR TITLE
Add full stack trace to first-error-in-a-week alert

### DIFF
--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -80,7 +80,7 @@ requests
     | where timestamp <= now() and timestamp > now(-1d)
     )
     on operation_Id
-| project exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name)
+| project stackTrace = details[0].rawStack, exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name)
 | join kind= leftanti (
     requests
     | where timestamp <= now(-1d) and timestamp > now(-8d) and success == false
@@ -89,10 +89,10 @@ requests
         | where timestamp <= now(-1d) and timestamp > now(-8d)
         )
         on operation_Id
-    | project exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name)
+    | project stackTrace = details[0].rawStack, exceptionType = type, failedMethod = method, requestName = name, combinedErrorString = strcat(type, method, name)
     )
     on combinedErrorString
-| distinct exceptionType, failedMethod, requestName
+| summarize stackTrace = any(stackTrace) by failedMethod, requestName, exceptionType
   QUERY
 
   severity    = 2


### PR DESCRIPTION
## Related Issue or Background Info

Needed to provide enough context for troubleshooting.

## Changes Proposed

- Add the full stack trace to the summaries returned by the first-error-in-a-week alert

## Checklist for Author and Reviewer

## Cloud
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
