### PR TITLE
Don't use plain number as answer key because yup doesn't like it

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.test.tsx
@@ -20,7 +20,7 @@ describe("QuestionsForm", () => {
   it("initializes with the submit button disabled", () => {
     expect(screen.getByText("Submit")).toHaveAttribute("disabled");
   });
-  describe("One filed entered", () => {
+  describe("One field entered", () => {
     beforeEach(() => {
       fireEvent.click(screen.getByLabelText("2002", { exact: false }), {
         target: { value: "1" },

--- a/frontend/src/app/signUp/IdentityVerification/utils.test.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.test.ts
@@ -3,7 +3,7 @@ import { getAnswerKey, toOptions, initAnswers, answersToArray } from "./utils";
 describe("utils", () => {
   describe("getAnswerKey", () => {
     it("adds one to the index", () => {
-      expect(getAnswerKey(0)).toContain("1");
+      expect(getAnswerKey(0)).toContain("answer1");
     });
   });
   describe("toOptions", () => {
@@ -36,30 +36,30 @@ describe("utils", () => {
       expect(Object.keys(answers).length).toBe(3);
     });
     it("sets the first answer to null", () => {
-      expect(answers["1"]).toBeNull();
+      expect(answers["answer1"]).toBeNull();
     });
     it("sets the second answer to null", () => {
-      expect(answers["2"]).toBeNull();
+      expect(answers["answer2"]).toBeNull();
     });
     it("sets the third answer to null", () => {
-      expect(answers["3"]).toBeNull();
+      expect(answers["answer3"]).toBeNull();
     });
   });
   describe("answersToArray", () => {
     const answers: Answers = {
-      3: "5",
-      1: "2",
-      2: "3",
+      answer3: "5",
+      answer1: "2",
+      answer2: "3",
     };
     const answersArray = answersToArray(answers);
     it("correctly sets the first value", () => {
-      expect(answersArray[0]).toBe(parseInt(answers["1"]));
+      expect(answersArray[0]).toBe(parseInt(answers["answer1"]));
     });
     it("correctly sets the second value", () => {
-      expect(answersArray[1]).toBe(parseInt(answers["2"]));
+      expect(answersArray[1]).toBe(parseInt(answers["answer2"]));
     });
     it("correctly sets the third value", () => {
-      expect(answersArray[2]).toBe(parseInt(answers["3"]));
+      expect(answersArray[2]).toBe(parseInt(answers["answer3"]));
     });
   });
 });

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -1,6 +1,6 @@
 import * as yup from "yup";
 
-export const getAnswerKey = (index: number) => `${index + 1}`;
+export const getAnswerKey = (index: number) => `answer${index + 1}`;
 
 export const toOptions = (
   choices: string[]


### PR DESCRIPTION
## Related Issue or Background Info

- The required validation for the `QuestionsForm` in the Experian flow was firing all the time, even if an answer was selected

## Changes Proposed

- change the keys in the `answers` object to be `answer1`, `answer2`, etc. instead of `1`, `2`, etc. because yup doesn't like plain numbers for some reason

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
