### PR TITLE
Debounce EditQueueItem query

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -1,7 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { ToastContainer } from "react-toastify";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
 import moment from "moment";
 
 import * as utils from "../utils/index";
@@ -17,9 +16,11 @@ const updatedDate = Date.parse(updatedDateString);
 describe("QueueItem", () => {
   let nowFn = Date.now;
   beforeEach(() => {
+    jest.useFakeTimers();
     Date.now = jest.fn(() => fakeDate);
   });
   afterEach(() => {
+    jest.useRealTimers();
     Date.now = nowFn;
   });
   it("correctly renders the test queue", () => {
@@ -65,13 +66,17 @@ describe("QueueItem", () => {
         ></QueueItem>
       </MockedProvider>
     );
-    await act(async () => {
+    await waitFor(() => {
       fireEvent.change(getByLabelText("Device", { exact: false }), {
         target: { value: "lumira" },
       });
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      jest.advanceTimersByTime(1000);
     });
-    expect(getByTestId("timer")).toHaveTextContent("15:00");
+
+    await waitFor(() => {
+      expect(getByTestId("timer")).toHaveTextContent("15:00");
+      jest.advanceTimersToNextTimer(1000);
+    });
   });
 
   describe("SMS delivery failure", () => {
@@ -114,17 +119,23 @@ describe("QueueItem", () => {
       );
 
       // Select result
-      fireEvent.click(
-        screen.getByLabelText("Inconclusive", {
-          exact: false,
-        }),
-        {
-          target: { value: "UNDETERMINED" },
-        }
-      );
+      await waitFor(() => {
+        fireEvent.click(
+          screen.getByLabelText("Inconclusive", {
+            exact: false,
+          }),
+          {
+            target: { value: "UNDETERMINED" },
+          }
+        );
+      });
+
+      await waitFor(() => {
+        jest.advanceTimersByTime(1000);
+      });
 
       // Submit
-      await act(async () => {
+      await waitFor(() => {
         fireEvent.click(
           screen.getByText("Submit", {
             exact: false,
@@ -132,7 +143,7 @@ describe("QueueItem", () => {
         );
       });
 
-      await act(async () => {
+      await waitFor(() => {
         fireEvent.click(
           screen.getByText("Submit anyway", {
             exact: false,


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2120

## Changes Proposed

- Rather than automatically firing the `update` function on value changes, run a debounced effect

## Additional Information

- Please smoke test locally since this is so critical to test result reporting

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
