### PR TITLE
Use spaces in person search input

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -18,7 +18,6 @@ import gov.cdc.usds.simplereport.db.repository.PatientPreferencesRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -118,7 +117,10 @@ public class PersonService {
   protected Specification<Person> buildPersonSearchFilter(
       UUID facilityId, boolean isArchived, String namePrefixMatch) {
 
-    List<String> namePrefixMatchList = StringUtils.isEmpty(namePrefixMatch) ? Collections.emptyList() : Arrays.stream(namePrefixMatch.split(" ")).collect(Collectors.toList());
+    List<String> namePrefixMatchList =
+        StringUtils.isEmpty(namePrefixMatch)
+            ? Collections.emptyList()
+            : Arrays.stream(namePrefixMatch.split(" ")).collect(Collectors.toList());
 
     // build up filter based on params
     Specification<Person> filter = inCurrentOrganizationFilter().and(isDeletedFilter(isArchived));
@@ -128,7 +130,7 @@ public class PersonService {
       filter = filter.and(inFacilityFilter(facilityId));
     }
 
-    for(var prefixMatch : namePrefixMatchList) {
+    for (var prefixMatch : namePrefixMatchList) {
       filter = filter.and(nameMatchesFilter(prefixMatch));
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -18,7 +18,9 @@ import gov.cdc.usds.simplereport.db.repository.PatientPreferencesRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -115,6 +117,9 @@ public class PersonService {
   // called by List function and Count function
   protected Specification<Person> buildPersonSearchFilter(
       UUID facilityId, boolean isArchived, String namePrefixMatch) {
+
+    List<String> namePrefixMatchList = StringUtils.isEmpty(namePrefixMatch) ? Collections.emptyList() : Arrays.stream(namePrefixMatch.split(" ")).collect(Collectors.toList());
+
     // build up filter based on params
     Specification<Person> filter = inCurrentOrganizationFilter().and(isDeletedFilter(isArchived));
     if (facilityId == null) {
@@ -123,9 +128,10 @@ public class PersonService {
       filter = filter.and(inFacilityFilter(facilityId));
     }
 
-    if (StringUtils.isNotBlank(namePrefixMatch)) {
-      filter = filter.and(nameMatchesFilter(namePrefixMatch));
+    for(var prefixMatch : namePrefixMatchList) {
+      filter = filter.and(nameMatchesFilter(prefixMatch));
     }
+
     return filter;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -466,7 +466,6 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
     assertPatientList(patients3, JANNELLE);
   }
 
-
   @Test
   @WithSimpleReportOrgAdminUser
   void getPatients_counts() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -41,11 +41,11 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
   private static final PersonName FRANK = new PersonName("Frank", "Mathew", "Bones", "3");
 
   // used for pagination and searching
-  private static final PersonName GALE = new PersonName("Gale", "Mary", "Vittorio", "PhD");
+  private static final PersonName GALE = new PersonName("Gale", "Mary", "Croger", "PhD");
   private static final PersonName HEINRICK = new PersonName("Heinrick", "Mark", "Silver", "III");
   private static final PersonName IAN = new PersonName("Ian", "Brou", "Rutter", null);
   private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
-  private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
+  private static final PersonName KACEY = new PersonName("Kacey", "Cross", "Mathie", null);
   private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
 
   @Autowired private OrganizationService _orgService;
@@ -391,9 +391,9 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
     List<Person> patients_org_page2 = _service.getPatients(null, 2, 5, false, null);
     List<Person> patients_org_page3 = _service.getPatients(null, 3, 5, false, null);
 
-    assertPatientList(patients_org_page0, CHARLES, FRANK, JANNELLE, BRAD, DEXTER);
-    assertPatientList(patients_org_page1, KACEY, ELIZABETH, LEELOO, AMOS, IAN);
-    assertPatientList(patients_org_page2, HEINRICK, GALE);
+    assertPatientList(patients_org_page0, CHARLES, FRANK, GALE, JANNELLE, BRAD);
+    assertPatientList(patients_org_page1, DEXTER, KACEY, ELIZABETH, LEELOO, AMOS);
+    assertPatientList(patients_org_page2, IAN, HEINRICK);
     assertEquals(0, patients_org_page3.size());
 
     List<Person> patients_site2_page0 =
@@ -426,7 +426,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     // all facilities, not deleted, "ma"
     List<Person> patients = _service.getPatients(null, 0, 100, false, "ma");
-    assertPatientList(patients, JANNELLE, KACEY, ELIZABETH, HEINRICK, GALE);
+    assertPatientList(patients, GALE, JANNELLE, KACEY, ELIZABETH, HEINRICK);
 
     // site2, not deleted, "ma"
     patients = _service.getPatients(site2Id, 0, 100, false, "ma");
@@ -438,7 +438,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     // all facilities, not deleted, "mar"
     patients = _service.getPatients(null, 0, 100, false, "mar");
-    assertPatientList(patients, JANNELLE, ELIZABETH, HEINRICK, GALE);
+    assertPatientList(patients, GALE, JANNELLE, ELIZABETH, HEINRICK);
 
     // all facilities, not deleted, "MARTHA"
     patients = _service.getPatients(null, 0, 100, false, "MARTHA");
@@ -447,6 +447,25 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
     assertEquals(0, _service.getPatientsCount(null, false, "M"));
     assertEquals(0, _service.getPatientsCount(null, false, ""));
   }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getPatients_search_with_spaces() {
+    makedata(true);
+
+    // "ma" returns a bunch of folks
+    List<Person> patients = _service.getPatients(null, 0, 100, false, "ma");
+    assertPatientList(patients, CHARLES, FRANK, GALE, JANNELLE, KACEY, ELIZABETH, HEINRICK);
+
+    // "ma cr" returns less folks, but not none!
+    List<Person> patients2 = _service.getPatients(null, 0, 100, false, "ma cr");
+    assertPatientList(patients2, GALE, JANNELLE, KACEY);
+
+    // "ma cr ja" returns just janelle
+    List<Person> patients3 = _service.getPatients(null, 0, 100, false, "ma cr ja");
+    assertPatientList(patients3, JANNELLE);
+  }
+
 
   @Test
   @WithSimpleReportOrgAdminUser


### PR DESCRIPTION
## Related Issue or Background Info

- Currently the exact search input is used directly for a prefix match on first, middle, OR last name. This means that if a user searches for `john doe`, it will not match a user with the name John Doe – but only a user whose full first name is "John Doe"
- This change splits search inputs on spaces, and creates an additional `and first_name OR middle_name OR last_name` where condition for each word in the input. This allows greater search flexibility without impacting search performance: **these N filters do _not_ introduce additional sequential table scans**

## Changes Proposed

- Split search input on space; use each word as an additional search condition

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
