### PR TITLE
Attempt to resolve intermittent CI test failure

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     // used to autoconfigure WireMock for testing
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
     testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner'
+    testImplementation 'org.awaitility:awaitility:4.1.0'
 
     // dev tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -123,7 +123,7 @@ class QueueManagementTest extends BaseGraphqlTest {
             () -> {
               try {
                 // sleeping here to try to avoid a dreaded race condition in an async test
-                Thread.sleep(5);
+                Thread.sleep(100);
               } catch (InterruptedException e) {
                 // noop
               }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -121,12 +123,7 @@ class QueueManagementTest extends BaseGraphqlTest {
         CompletableFuture.runAsync(() -> runQuery("edit-queue-item", variables, null)),
         CompletableFuture.runAsync(
             () -> {
-              try {
-                // sleeping here to try to avoid a dreaded race condition in an async test
-                Thread.sleep(100);
-              } catch (InterruptedException e) {
-                // noop
-              }
+              await().atMost(100, MILLISECONDS);
               runQuery(
                   "edit-queue-item", variables, "Another user is interacting with this queue item");
             }));


### PR DESCRIPTION
## Related Issue or Background Info

- My very naive `Thread.sleep(5)` in this test was causing intermittent failures

## Changes Proposed

- Use awaitility instead

## Additional Information

- Since it was an intermittent failure, this is a bit of a 🤞  scenario – it's possible that we'll still see failures and need to further adjust how this test is implemented 

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
