### PR TITLE
Grey out "Submit" during edits; remove extra API call

### DIFF
--- a/frontend/e2e/pages/home.js
+++ b/frontend/e2e/pages/home.js
@@ -39,6 +39,7 @@ function conductTest(patientName) {
   this.section.queueCard.expect.element("@negativeResult").to.be.visible;
   this.section.queueCard.click("@negativeResult");
   this.section.queueCard.expect.element("@submitResultButton").to.be.visible;
+  this.section.queueCard.expect.element("@submitResultButton").to.be.enabled;
   this.section.queueCard.click("@submitResultButton");
   this.expect
     .section("@app")

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -409,7 +409,6 @@ const QueueItem: any = ({
   const isMounted = useRef(false);
   const DEBOUNCE_TIME = 500;
   useEffect(() => {
-    // console.info(deviceId, dateTested, testResultValue, patient);
     let debounceTimer: ReturnType<typeof setTimeout>;
     if (!isMounted.current) {
       isMounted.current = true;

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -239,6 +239,7 @@ const QueueItem: any = ({
     EditQueueItemResponse,
     EditQueueItemParams
   >(EDIT_QUEUE_ITEM);
+  const [debouncingEdit, setDebouncingEdit] = useState(false);
 
   const [isAoeModalOpen, updateIsAoeModalOpen] = useState(false);
   const [aoeAnswers, setAoeAnswers] = useState(askOnEntry);
@@ -351,7 +352,7 @@ const QueueItem: any = ({
 
   const updateQueueItem = useCallback(
     ({ deviceId, result, dateTested }: updateQueueItemProps) => {
-      editQueueItem({
+      return editQueueItem({
         variables: {
           id: internalId,
           deviceId,
@@ -386,6 +387,14 @@ const QueueItem: any = ({
     const newDateTested = date.toISOString();
     const isValidDate = isValidCustomDateTested(newDateTested);
 
+    // the date string returned from the server is only precise to seconds; moment's
+    // toISOString method returns millisecond precision. as a result, an onChange event
+    // was being fired when this component initialized, sending an EditQueueItem to
+    // the back end w/ the same data that it already had. this prevents it:
+    if (moment(dateTested).isSame(date)) {
+      return;
+    }
+
     if (isValidDate) {
       /* the custom date input field manages its own state in the DOM, not in the react state
       The reason for this is an invalid custom date would update react. Updating another field in the queue item, like the test result, would attempt to submit the invalid date to the backend
@@ -398,22 +407,26 @@ const QueueItem: any = ({
   };
 
   const isMounted = useRef(false);
-  const DEBOUNCE_TIME = 700;
+  const DEBOUNCE_TIME = 500;
   useEffect(() => {
+    // console.info(deviceId, dateTested, testResultValue, patient);
     let debounceTimer: ReturnType<typeof setTimeout>;
     if (!isMounted.current) {
       isMounted.current = true;
     } else {
-      debounceTimer = setTimeout(() => {
-        updateQueueItem({
+      setDebouncingEdit(true);
+      debounceTimer = setTimeout(async () => {
+        await updateQueueItem({
           deviceId,
           dateTested,
           result: testResultValue,
         });
+        setDebouncingEdit(false);
       }, DEBOUNCE_TIME);
     }
     return () => {
       clearTimeout(debounceTimer);
+      setDebouncingEdit(false);
     };
   }, [deviceId, dateTested, testResultValue, updateQueueItem]);
 
@@ -709,6 +722,7 @@ const QueueItem: any = ({
                 testResultValue={testResultValue}
                 isSubmitDisabled={
                   loading ||
+                  debouncingEdit ||
                   (!shouldUseCurrentDateTime() &&
                     !isValidCustomDateTested(dateTested))
                 }


### PR DESCRIPTION
## Related Issue or Background Info

- The debounce added in #2125 was resulting in EditQueueItems being sent _after_ their SubmitTestResult.
- A naive string comparison around the QueueItem's DatePicker was causing an EditQueueItem to be sent on initial render of any test order with a backdate  

## Changes Proposed

- Gray out the submit button during "edit" debounced
- Prevent the extra EditQueueItem send from the DatePicker's formatting confusion 

## Screenshots / Demos

https://user-images.githubusercontent.com/18486822/127693902-367fa81c-40b8-425a-93af-684db5b4f3fa.mp4

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
