### PR TITLE
hotfix for org duplicate names

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -39,15 +39,15 @@ import javax.annotation.PostConstruct;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 
 /** Note that this controller is automatically authorized. */
 @PreAuthorize("@" + AUTHORIZER_BEAN + ".permitAllAccountRequests()")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -45,6 +45,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 /** Note that this controller is automatically authorized. */
 @PreAuthorize("@" + AUTHORIZER_BEAN + ".permitAllAccountRequests()")
@@ -78,6 +81,11 @@ public class AccountRequestController {
     this._es = es;
     this._crm = crm;
     this.objectMapper = new ObjectMapper();
+  }
+
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<String> handleException(BadRequestException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
   }
 
   @PostConstruct

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -172,7 +172,8 @@ public class AccountRequestController {
       throws IOException {
 
     // verify that the organization doesn't already exist
-    Optional<Organization> potentialDuplicateOrg = _os.getOrganizationByName(reqVars.get("organizationName"));
+    Optional<Organization> potentialDuplicateOrg =
+        _os.getOrganizationByName(reqVars.get("organizationName"));
     if (potentialDuplicateOrg.isPresent()) {
       throw new BadRequestException("Organization is a duplicate.");
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -12,6 +12,7 @@ import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.accountrequest.AccountRequest;
 import gov.cdc.usds.simplereport.api.model.accountrequest.AccountResponse;
 import gov.cdc.usds.simplereport.api.model.accountrequest.WaitlistRequest;
+import gov.cdc.usds.simplereport.api.model.errors.BadRequestException;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -169,6 +170,13 @@ public class AccountRequestController {
 
   private Organization checkAccountRequestAndCreateOrg(Map<String, String> reqVars)
       throws IOException {
+
+    // verify that the organization doesn't already exist
+    Optional<Organization> potentialDuplicateOrg = _os.getOrganizationByName(reqVars.get("organizationName"));
+    if (potentialDuplicateOrg.isPresent()) {
+      throw new BadRequestException("Organization is a duplicate.");
+    }
+
     List<DeviceType> devices = _dts.fetchDeviceTypes();
     Map<String, String> deviceNamesToIds =
         devices.stream()

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -17,4 +17,7 @@ public interface OrganizationRepository extends EternalAuditedEntityRepository<O
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.identityVerified = :identityVerified")
   List<Organization> findAllByIdentityVerified(boolean identityVerified);
+
+  @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.organizationName = :name")
+  Optional<Organization> findByName(String name);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -138,6 +138,10 @@ public class OrganizationService {
                 "An organization with external_id=" + externalId + " does not exist"));
   }
 
+  public Optional<Organization> getOrganizationByName(String name) {
+    return _repo.findByName(name);
+  }
+
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public List<Organization> getOrganizations(Boolean identityVerified) {
     return identityVerified == null


### PR DESCRIPTION
## Related Issue or Background Info

Orgs can be duped in Okta, since we use the orgname + uuid. This changes the logic to throw a bad request exception if the org already exists.

## Changes Proposed

- throws badrequestexception if name is duped

## Additional Information

- verified that this works on test (throws a 400 to the signup form)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
