### PR TITLE
Fix missing mobile numbers in AoE questionnaire launched from queue item

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
@@ -195,7 +195,10 @@ const AoEForm: React.FC<Props> = ({
               )}
             </p>
             {phoneNumbers.map(({ number }) => (
-              <span className="radio__label-description--checked usa-radio__label-description text-base">
+              <span
+                key={number}
+                className="radio__label-description--checked usa-radio__label-description text-base"
+              >
                 {number}
               </span>
             ))}

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -6,6 +6,7 @@ import moment from "moment";
 import * as utils from "../utils/index";
 
 import QueueItem, { EDIT_QUEUE_ITEM, SUBMIT_TEST_RESULT } from "./QueueItem";
+import { LAST_TEST_QUERY } from "./AoEForm/AoEModalForm";
 
 const initialDateString = "2021-02-14";
 const updatedDateString = "2021-03-10";
@@ -201,6 +202,39 @@ describe("QueueItem", () => {
       });
     });
   });
+
+  it("displays person's mobile phone numbers", async () => {
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <QueueItem
+          internalId={testProps.internalId}
+          patient={testProps.patient}
+          askOnEntry={testProps.askOnEntry}
+          selectedDeviceId={testProps.selectedDeviceId}
+          selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+          selectedTestResult={testProps.selectedTestResult}
+          devices={testProps.devices}
+          defaultDevice={testProps.defaultDevice}
+          refetchQueue={testProps.refetchQueue}
+          facilityId={testProps.facilityId}
+          dateTestedProp={testProps.dateTestedProp}
+          patientLinkId={testProps.patientLinkId}
+        ></QueueItem>
+      </MockedProvider>
+    );
+
+    const questionnaire = await screen.findByText("Test questionnaire");
+    fireEvent.click(questionnaire);
+    await screen.findByText("Required fields are marked", { exact: false });
+    expect(
+      screen.queryByText(testProps.patient.phoneNumbers[0].number, {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(testProps.patient.phoneNumbers[1].number)
+    ).not.toBeInTheDocument();
+  });
 });
 
 const internalId = "f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554";
@@ -216,8 +250,12 @@ const testProps = {
     birthDate: "1990-07-31",
     phoneNumbers: [
       {
-        number: "string",
+        number: "a-mobile-number",
         type: "MOBILE",
+      },
+      {
+        number: "a-landline-number",
+        type: "LANDLINE",
       },
     ],
   },
@@ -392,6 +430,24 @@ const mocks = [
             internalId: internalId,
           },
           deliverySuccess: false,
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: LAST_TEST_QUERY,
+      variables: {
+        patientId: "f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554",
+      },
+    },
+    result: {
+      data: {
+        patient: {
+          lastTest: {
+            dateTested: "2021-06-04T16:01:00",
+            result: "NEGATIVE",
+          },
         },
       },
     },

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -67,6 +67,10 @@ export const queueQuery = gql`
         gender
         testResultDelivery
         preferredLanguage
+        phoneNumbers {
+          type
+          number
+        }
       }
       result
       dateTested


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2140

## Changes Proposed

- Adds the person's `phoneNumbers` to the queueQeury

## Additional Information

- It would be nice to infer query types from what we request from them, not sure if that's doable

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
