### PR TITLE
Disable most alerts in dev, stg, and test

### DIFF
--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -6,8 +6,17 @@ module "metric_alerts" {
   app_service_id                 = module.simple_report_api.app_service_id
   rg_name                        = data.azurerm_resource_group.rg.name
   tags                           = local.management_tags
-  disabled_alerts                = ["cpu_util", "mem_util"]
   http_response_time_aggregation = "Minimum"
+  disabled_alerts = [
+    "cpu_util",
+    "mem_util",
+    "http_2xx_failed_requests",
+    "http_4xx_errors",
+    "http_5xx_errors",
+    "first_error_in_a_week",
+    "account_request_failures",
+    "frontend_error_boundary",
+  ]
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_demo_action_id

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -14,6 +14,21 @@ variable "disabled_alerts" {
   default     = []
   description = "All alerts are enabled for an environment by default. You can disable alert(s) for an environment by including their resource name in this list. Example: [\"cpu_util\"] would disable the CPU utilization alert, since it matches the azurerm_monitor_metric_alert.cpu_util resource."
   type        = list(string)
+  validation {
+    // Set the list of valid disabled alerts to prevent misconfigured commits
+    condition = length(setsubtract(var.disabled_alerts, [
+      "cpu_util",
+      "mem_util",
+      "http_response_time",
+      "http_2xx_failed_requests",
+      "http_4xx_errors",
+      "http_5xx_errors",
+      "first_error_in_a_week",
+      "account_request_failures",
+      "frontend_error_boundary",
+    ])) == 0
+    error_message = "One or more disabled_alert values are invalid."
+  }
 }
 variable "rg_name" {
   description = "Name of resource group to deploy into"

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -67,7 +67,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "first_error_in_a_week" {
   }
 
   data_source_id = var.app_insights_id
-  enabled        = true
+  enabled        = contains(var.disabled_alerts, "first_error_in_a_week") ? false : true
 
   # - Collect all requests that were exceptions in the week preceeding today
   # - Do the same for today
@@ -115,7 +115,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "account_request_failures
   }
 
   data_source_id = var.app_insights_id
-  enabled        = true
+  enabled        = contains(var.disabled_alerts, "account_request_failures") ? false : true
 
   query = <<-QUERY
 requests
@@ -149,7 +149,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "frontend_error_boundary"
   }
 
   data_source_id = var.app_insights_id
-  enabled        = true
+  enabled        = contains(var.disabled_alerts, "frontend_error_boundary") ? false : true
 
   query = <<-QUERY
  exceptions

--- a/ops/stg/alerts.tf
+++ b/ops/stg/alerts.tf
@@ -6,6 +6,14 @@ module "metric_alerts" {
   app_service_id      = module.simple_report_api.app_service_id
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
+  disabled_alerts = [
+    "http_2xx_failed_requests",
+    "http_4xx_errors",
+    "http_5xx_errors",
+    "first_error_in_a_week",
+    "account_request_failures",
+    "frontend_error_boundary",
+  ]
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_prod_action_id

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -6,8 +6,17 @@ module "metric_alerts" {
   app_service_id                 = module.simple_report_api.app_service_id
   rg_name                        = data.azurerm_resource_group.rg.name
   tags                           = local.management_tags
-  disabled_alerts                = ["cpu_util", "mem_util"]
   http_response_time_aggregation = "Minimum"
+  disabled_alerts = [
+    "cpu_util",
+    "mem_util",
+    "http_2xx_failed_requests",
+    "http_4xx_errors",
+    "http_5xx_errors",
+    "first_error_in_a_week",
+    "account_request_failures",
+    "frontend_error_boundary",
+  ]
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_demo_action_id


### PR DESCRIPTION
We don't want to be paged for the following alerts
in these environments, regardless of time:

* 2xx/4xx/5xx requests
* First error in a week
* Account request failures
* Frontend error boundary

## Related Issue or Background Info

#2135

## Changes Proposed

* Disable alerts in envs as described above
* Add validation for the `disabled_alerts` variable so we can't accidentally commit something that disables an alert that doesn't exist

## Additional Information

The alerts that were not disabled in these envs will be restricted to business hours in PagerDuty.

## Checklist for Author and Reviewer

## Cloud
- [-] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
