### PR TITLE
Remove PatientLink from GetFacilityQueue in the UI

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -190,7 +190,6 @@ export interface QueueItemProps {
   dateTestedProp: string;
   refetchQueue: () => void;
   facilityId: string;
-  patientLinkId: string;
 }
 
 interface updateQueueItemProps {
@@ -212,7 +211,6 @@ const QueueItem: any = ({
   refetchQueue,
   facilityId,
   dateTestedProp,
-  patientLinkId,
 }: QueueItemProps) => {
   const appInsights = useAppInsightsContext();
   const trackRemovePatientFromQueue = useTrackEvent(

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -74,9 +74,6 @@ export const queueQuery = gql`
       }
       result
       dateTested
-      patientLink {
-        internalId
-      }
     }
     organization {
       testingFacility {
@@ -112,9 +109,6 @@ interface QueueItemData extends AoEAnswers {
   patient: TestQueuePerson;
   result: string;
   dateTested: string;
-  patientLink: {
-    internalId: string;
-  };
 }
 
 const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
@@ -166,7 +160,6 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
           patient,
           result,
           dateTested,
-          patientLink,
           ...questions
         }) => {
           return (
@@ -187,7 +180,6 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
                 refetchQueue={refetch}
                 facilityId={activeFacilityId}
                 dateTestedProp={dateTested}
-                patientLinkId={patientLink?.internalId || null}
               />
             </CSSTransition>
           );

--- a/frontend/src/stories/testQueue/QueueItem.stories.tsx
+++ b/frontend/src/stories/testQueue/QueueItem.stories.tsx
@@ -74,7 +74,6 @@ const defaultProps: QueueItemProps = {
   dateTestedProp: "",
   refetchQueue: () => {},
   facilityId: "100",
-  patientLinkId: "200",
 };
 
 export const Unstarted = Template.bind({});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6567,15 +6567,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001165:
-  version "1.0.30001166"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001166.tgz#ca73e8747acfd16a4fd6c4b784f1b995f9698cf8"
-  integrity sha512-nCL4LzYK7F4mL0TjEMeYavafOGnBa98vTudH5c8lW9izUjnB99InG6pmC1ElAI1p0GlyZajv4ltUdFXvOHIl1A==
-
-caniuse-lite@^1.0.30001208:
-  version "1.0.30001208"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
-  integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001208:
+  version "1.0.30001248"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
+  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Related Issue or Background Info

- Part one of #1815 

## Changes Proposed

- Remove patientLinkId from the front end's GetFacilityQueue and GetFacilityResults queries

## Additional Information

- A follow-up PR will remove patientLink from the GraphQL schema and the custom join formula on TestOrder
- The PatientLink join on TestOrder is causing a good portion of the poor performance on these queries
- With texting AoE questions removed, these values are only used for debugging purposes and can be retrieved manually by developers instead

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
