### PR TITLE
Got fix deploy

### DIFF
--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -47,7 +47,7 @@ jobs:
         run: make deploy-${{ env.DEPLOY_ENV }}-api
       - name: Wait for correct release to be deployed in staging slot
         timeout-minutes: 5
-        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-release
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
       - name: Wait for staging deploy to be ready
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness


### PR DESCRIPTION
## Related Issue or Background Info

- deploy to st failed as it is using the out release check and is no longer being deployed via a release. 
- App correctly deployed to the  staging slot https://simple-report-api-stg-staging.azurewebsites.net/actuator/info
- app was not promoted due to the bad check https://github.com/CDCgov/prime-simplereport/actions/runs/1091277943

## Changes Proposed

- use `wait-for-stg-slot-commit` not `wait-for-stg-slot-release` as it is no longer deployed via a release

## Additional Information
## Screenshots / Demos
![Screen Shot 2021-08-02 at 2 52 13 PM](https://user-images.githubusercontent.com/53869143/127909644-bbed32cd-8924-47c7-9235-0a72dc1f2cbf.png)

## Checklist for Author and Reviewer
- [ ] merge and see is `stg` deploys
- [ ] checkscreen shot to see how other deploys work

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a ] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
