### PR TITLE
Revert "Revert PG locks (#2132)"

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -233,17 +233,22 @@ public class TestOrderService {
   @Deprecated // switch to specifying device-specimen combo
   public TestOrder editQueueItem(
       UUID testOrderId, String deviceId, String result, Date dateTested) {
-    TestOrder order = this.getTestOrder(testOrderId);
+    lockOrder(testOrderId);
+    try {
+      TestOrder order = this.getTestOrder(testOrderId);
 
-    if (deviceId != null) {
-      order.setDeviceSpecimen(_dts.getDefaultForDeviceId(deviceId));
+      if (deviceId != null) {
+        order.setDeviceSpecimen(_dts.getDefaultForDeviceId(deviceId));
+      }
+
+      order.setResult(result == null ? null : TestResult.valueOf(result));
+
+      order.setDateTestedBackdate(dateTested);
+
+      return _repo.save(order);
+    } finally {
+      unlockOrder(testOrderId);
     }
-
-    order.setResult(result == null ? null : TestResult.valueOf(result));
-
-    order.setDateTestedBackdate(dateTested);
-
-    return _repo.save(order);
   }
 
   @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
@@ -257,43 +262,48 @@ public class TestOrderService {
     TestOrder order =
         _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
 
-    order.setDeviceSpecimen(deviceSpecimen);
-    order.setResult(result);
-    order.setDateTestedBackdate(dateTested);
-    order.markComplete();
+    lockOrder(order.getInternalId());
+    try {
+      order.setDeviceSpecimen(deviceSpecimen);
+      order.setResult(result);
+      order.setDateTestedBackdate(dateTested);
+      order.markComplete();
 
-    TestEvent testEvent = new TestEvent(order);
-    _terepo.save(testEvent);
+      TestEvent testEvent = new TestEvent(order);
+      _terepo.save(testEvent);
 
-    order.setTestEventRef(testEvent);
-    TestOrder savedOrder = _repo.save(order);
+      order.setTestEventRef(testEvent);
+      TestOrder savedOrder = _repo.save(order);
 
-    _testEventReportingService.report(testEvent);
+      _testEventReportingService.report(testEvent);
 
-    if (TestResultDeliveryPreference.SMS
-        == _ps.getPatientPreferences(person).getTestResultDelivery()) {
-      // After adding test result, create a new patient link and text it to the
-      // patient
-      PatientLink patientLink = _pls.createPatientLink(savedOrder.getInternalId());
-      UUID internalId = patientLink.getInternalId();
-      savedOrder.setPatientLink(patientLink);
+      if (TestResultDeliveryPreference.SMS
+          == _ps.getPatientPreferences(person).getTestResultDelivery()) {
+        // After adding test result, create a new patient link and text it to the
+        // patient
+        PatientLink patientLink = _pls.createPatientLink(savedOrder.getInternalId());
+        UUID internalId = patientLink.getInternalId();
+        savedOrder.setPatientLink(patientLink);
 
-      List<SmsAPICallResult> smsSendResults =
-          _smss.sendToPatientLink(
-              internalId,
-              "Your Covid-19 test result is ready to view: " + patientLinkUrl + internalId);
+        List<SmsAPICallResult> smsSendResults =
+            _smss.sendToPatientLink(
+                internalId,
+                "Your Covid-19 test result is ready to view: " + patientLinkUrl + internalId);
 
-      boolean hasDeliveryFailure =
-          smsSendResults.stream().anyMatch(delivery -> !delivery.getDeliverySuccess());
+        boolean hasDeliveryFailure =
+            smsSendResults.stream().anyMatch(delivery -> !delivery.getDeliverySuccess());
 
-      if (hasDeliveryFailure == true) {
-        return new AddTestResultResponse(savedOrder, false);
+        if (hasDeliveryFailure == true) {
+          return new AddTestResultResponse(savedOrder, false);
+        }
+
+        return new AddTestResultResponse(savedOrder, true);
       }
 
-      return new AddTestResultResponse(savedOrder, true);
+      return new AddTestResultResponse(savedOrder);
+    } finally {
+      unlockOrder(order.getInternalId());
     }
-
-    return new AddTestResultResponse(savedOrder);
   }
 
   @AuthorizationConfiguration.RequirePermissionStartTestAtFacility

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -23,6 +25,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,6 +101,32 @@ class QueueManagementTest extends BaseGraphqlTest {
     assertEquals(
         p.getInternalId().toString(), singleQueueEntry.path("patient").path("internalId").asText());
     assertEquals(dateTested, singleQueueEntry.path("dateTested").asText());
+  }
+
+  @Test
+  void twoSimultaneousUpdates() throws Exception {
+    Person p = _dataFactory.createFullPerson(_org);
+    TestOrder o = _dataFactory.createTestOrder(p, _site);
+    UUID orderId = o.getInternalId();
+    DeviceType d = _dataFactory.getGenericDevice();
+    String deviceId = d.getInternalId().toString();
+    String dateTested = "2020-12-31T14:30:30Z";
+    ObjectNode variables =
+        JsonNodeFactory.instance
+            .objectNode()
+            .put("id", orderId.toString())
+            .put("deviceId", deviceId)
+            .put("result", TestResult.POSITIVE.toString())
+            .put("dateTested", dateTested);
+
+    CompletableFuture.allOf(
+        CompletableFuture.runAsync(() -> runQuery("edit-queue-item", variables, null)),
+        CompletableFuture.runAsync(
+            () -> {
+              await().atMost(100, MILLISECONDS);
+              runQuery(
+                  "edit-queue-item", variables, "Another user is interacting with this queue item");
+            }));
   }
 
   @Test


### PR DESCRIPTION
This reverts commit eb23f7e3b56af3012ab540357afc338e7b5551dc.

## Related Issue or Background Info

- Resolves #1771 

## Changes Proposed

- Reverte the revert of the Postgres advisory locks on TestOrder

## Additional Information

- This was previously working correctly but exposed related UI errors and caused lots of PagerDuty noise

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
