### PR TITLE
Add migration for creating the text_message_status table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2605,3 +2605,39 @@ databaseChangeLog:
       rollback:
         - dropView:
             viewName: api_audit_event_no_phi
+  - changeSet:
+      id: add-text-message-status-table
+      author: nicholas.a.scialli@omb.eop.gov
+      comment: Add table to track the delivery status of text messages
+      changes:
+        - createTable:
+            tableName: text_message_status
+            remarks: A table to store the various statuses of each text message
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: text_message_sent_internal_id
+                  type: uuid
+                  remarks: A foreign key to a text message sent
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__internal_id__text_message_sent
+                    references: text_message_sent
+              - column:
+                  name: status
+                  type: text
+                  remarks: The status of the text message as reported by Twilio
+                  constraints:
+                    nullable: false
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.text_message_status TO ${noPhiUsername};

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2641,3 +2641,6 @@ databaseChangeLog:
               - column: *updated_by_column
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.text_message_status TO ${noPhiUsername};
+      rollback:
+        sql: |
+          DROP TABLE ${database.defaultSchemaName}.TEXT_MESSAGE_STATUS;


### PR DESCRIPTION
## Related Issue or Background Info

- This is the migration associated with #2109

## Changes Proposed

- Adds a table for text message statuses and grants no-PHI user view on it

## Additional Information

- The associated PR has been approved, this PR exists to fulfill the requirement to merge migrations separately

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
