### PR TITLE
Make last two PersonForm questions optional

### DIFF
--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -128,8 +128,6 @@ describe("AddPatient", () => {
               race: null,
               ethnicity: null,
               gender: null,
-              residentCongregateSetting: false,
-              employedInHealthcare: true,
               facilityId: mockFacilityID,
               preferredLanguage: null,
               testResultDelivery: "SMS",
@@ -168,8 +166,6 @@ describe("AddPatient", () => {
               race: null,
               ethnicity: null,
               gender: null,
-              residentCongregateSetting: false,
-              employedInHealthcare: true,
               facilityId: mockFacilityID,
               preferredLanguage: null,
               testResultDelivery: null,
@@ -222,16 +218,6 @@ describe("AddPatient", () => {
             "Would you like to receive your results via text message": {
               label: "Yes",
               value: "SMS",
-              exact: true,
-            },
-            "Are you a resident in a congregate living setting": {
-              label: "No",
-              value: "No",
-              exact: true,
-            },
-            "Are you a health care worker": {
-              label: "Yes",
-              value: "Yes",
               exact: true,
             },
           }

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -446,7 +446,6 @@ const PersonForm = (props: Props) => {
           }}
           validationStatus={validationStatus("residentCongregateSetting")}
           errorMessage={errors.residentCongregateSetting}
-          required
         />
         <YesNoRadioGroup
           legend={t("patient.form.other.healthcareWorker")}
@@ -460,7 +459,6 @@ const PersonForm = (props: Props) => {
           }}
           validationStatus={validationStatus("employedInHealthcare")}
           errorMessage={errors.employedInHealthcare}
-          required
         />
       </FormGroup>
       {props.getFooter && props.getFooter(validateForm, formChanged)}

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -1306,13 +1306,6 @@ Object {
                         class="usa-legend"
                       >
                         Are you a resident in a congregate living setting?
-                        <abbr
-                          class="usa-hint usa-hint--required"
-                          title="required"
-                        >
-                           
-                          *
-                        </abbr>
                       </legend>
                       <span
                         class="usa-hint"
@@ -1328,7 +1321,7 @@ Object {
                           <input
                             checked=""
                             class="usa-radio__input"
-                            data-required="true"
+                            data-required="false"
                             id="64-val-YES"
                             name="residentCongregateSetting"
                             type="radio"
@@ -1346,7 +1339,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="true"
+                            data-required="false"
                             id="64-val-NO"
                             name="residentCongregateSetting"
                             type="radio"
@@ -1364,7 +1357,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="true"
+                            data-required="false"
                             id="64-val-UNKNOWN"
                             name="residentCongregateSetting"
                             type="radio"
@@ -1390,13 +1383,6 @@ Object {
                         class="usa-legend"
                       >
                         Are you a health care worker?
-                        <abbr
-                          class="usa-hint usa-hint--required"
-                          title="required"
-                        >
-                           
-                          *
-                        </abbr>
                       </legend>
                       <div
                         class=""
@@ -1407,7 +1393,7 @@ Object {
                           <input
                             checked=""
                             class="usa-radio__input"
-                            data-required="true"
+                            data-required="false"
                             id="65-val-YES"
                             name="employedInHealthcare"
                             type="radio"
@@ -1425,7 +1411,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="true"
+                            data-required="false"
                             id="65-val-NO"
                             name="employedInHealthcare"
                             type="radio"
@@ -1443,7 +1429,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="true"
+                            data-required="false"
                             id="65-val-UNKNOWN"
                             name="employedInHealthcare"
                             type="radio"
@@ -2784,13 +2770,6 @@ Object {
                       class="usa-legend"
                     >
                       Are you a resident in a congregate living setting?
-                      <abbr
-                        class="usa-hint usa-hint--required"
-                        title="required"
-                      >
-                         
-                        *
-                      </abbr>
                     </legend>
                     <span
                       class="usa-hint"
@@ -2806,7 +2785,7 @@ Object {
                         <input
                           checked=""
                           class="usa-radio__input"
-                          data-required="true"
+                          data-required="false"
                           id="64-val-YES"
                           name="residentCongregateSetting"
                           type="radio"
@@ -2824,7 +2803,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="true"
+                          data-required="false"
                           id="64-val-NO"
                           name="residentCongregateSetting"
                           type="radio"
@@ -2842,7 +2821,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="true"
+                          data-required="false"
                           id="64-val-UNKNOWN"
                           name="residentCongregateSetting"
                           type="radio"
@@ -2868,13 +2847,6 @@ Object {
                       class="usa-legend"
                     >
                       Are you a health care worker?
-                      <abbr
-                        class="usa-hint usa-hint--required"
-                        title="required"
-                      >
-                         
-                        *
-                      </abbr>
                     </legend>
                     <div
                       class=""
@@ -2885,7 +2857,7 @@ Object {
                         <input
                           checked=""
                           class="usa-radio__input"
-                          data-required="true"
+                          data-required="false"
                           id="65-val-YES"
                           name="employedInHealthcare"
                           type="radio"
@@ -2903,7 +2875,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="true"
+                          data-required="false"
                           id="65-val-NO"
                           name="employedInHealthcare"
                           type="radio"
@@ -2921,7 +2893,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="true"
+                          data-required="false"
                           id="65-val-UNKNOWN"
                           name="employedInHealthcare"
                           type="radio"

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
@@ -1288,13 +1288,6 @@ exports[`PatientFormContainer snapshot 1`] = `
                   className="usa-legend"
                 >
                   Are you a resident in a congregate living setting?
-                  <abbr
-                    className="usa-hint usa-hint--required"
-                    title="required"
-                  >
-                     
-                    *
-                  </abbr>
                 </legend>
                 <span
                   className="usa-hint"
@@ -1310,7 +1303,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                     <input
                       checked={true}
                       className="usa-radio__input"
-                      data-required={true}
+                      data-required="false"
                       disabled={false}
                       id="18-val-YES"
                       name="residentCongregateSetting"
@@ -1332,7 +1325,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-radio__input"
-                      data-required={true}
+                      data-required="false"
                       disabled={false}
                       id="18-val-NO"
                       name="residentCongregateSetting"
@@ -1354,7 +1347,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-radio__input"
-                      data-required={true}
+                      data-required="false"
                       disabled={false}
                       id="18-val-UNKNOWN"
                       name="residentCongregateSetting"
@@ -1383,13 +1376,6 @@ exports[`PatientFormContainer snapshot 1`] = `
                   className="usa-legend"
                 >
                   Are you a health care worker?
-                  <abbr
-                    className="usa-hint usa-hint--required"
-                    title="required"
-                  >
-                     
-                    *
-                  </abbr>
                 </legend>
                 <div
                   className=""
@@ -1400,7 +1386,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                     <input
                       checked={true}
                       className="usa-radio__input"
-                      data-required={true}
+                      data-required="false"
                       disabled={false}
                       id="19-val-YES"
                       name="employedInHealthcare"
@@ -1422,7 +1408,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-radio__input"
-                      data-required={true}
+                      data-required="false"
                       disabled={false}
                       id="19-val-NO"
                       name="employedInHealthcare"
@@ -1444,7 +1430,7 @@ exports[`PatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-radio__input"
-                      data-required={true}
+                      data-required="false"
                       disabled={false}
                       id="19-val-UNKNOWN"
                       name="employedInHealthcare"


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #2111

## Changes Proposed

- Remove asterisks from "Do you live in a congregate setting" and "Are you a healthcare worker" questions
- Updates required field test to remove these two fields

## Additional Information

- The backend already had these fields as nullable since that's what the "unknown" option mapped to

## Screenshots / Demos


https://user-images.githubusercontent.com/49658917/128036421-1af34111-7c99-4a70-ab85-076210f64d9c.mov

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
