### PR TITLE
Make filters always open on Patient and Result pages

### DIFF
--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -113,7 +113,6 @@ export const DetachedManagePatients = ({
   activeFacilityId,
 }: Props) => {
   const [archivePerson, setArchivePerson] = useState<Patient | null>(null);
-  const [showFilters, setShowFilters] = useState(false);
   const history = useHistory();
 
   const [queryString, debounced, setDebounced] = useDebounce<string | null>(
@@ -229,18 +228,14 @@ export const DetachedManagePatients = ({
               </h2>
               <div>
                 <Button
-                  variant={!showFilters ? "outline" : undefined}
-                  className={showFilters ? "sr-active-button" : undefined}
+                  className="sr-active-button"
                   icon={faSlidersH}
                   onClick={() => {
-                    if (showFilters) {
-                      setNamePrefixMatch(null);
-                      setDebounced(null);
-                    }
-                    setShowFilters(!showFilters);
+                    setNamePrefixMatch(null);
+                    setDebounced(null);
                   }}
                 >
-                  {showFilters ? "Clear filters" : "Filter"}
+                  Clear filters
                 </Button>
                 {canEditUser ? (
                   <LinkWithQuery
@@ -254,24 +249,22 @@ export const DetachedManagePatients = ({
                 ) : null}
               </div>
             </div>
-            {showFilters && (
-              <div className="display-flex flex-row bg-base-lightest padding-x-3 padding-y-2">
-                <SearchInput
-                  label="Person"
-                  onInputChange={(e) => {
-                    setDebounced(e.target.value);
-                  }}
-                  onSearchClick={(e) => {
-                    e.preventDefault();
-                    setNamePrefixMatch(debounced);
-                  }}
-                  queryString={debounced || ""}
-                  className="display-inline-block"
-                  placeholder=""
-                  focusOnMount
-                />
-              </div>
-            )}
+            <div className="display-flex flex-row bg-base-lightest padding-x-3 padding-y-2">
+              <SearchInput
+                label="Person"
+                onInputChange={(e) => {
+                  setDebounced(e.target.value);
+                }}
+                onSearchClick={(e) => {
+                  e.preventDefault();
+                  setNamePrefixMatch(debounced);
+                }}
+                queryString={debounced || ""}
+                className="display-inline-block"
+                placeholder=""
+                focusOnMount
+              />
+            </div>
             <div className="usa-card__body sr-patient-list">
               <table className="usa-table usa-table--borderless width-full">
                 <thead>

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -765,7 +765,6 @@ describe("TestResultsList", () => {
       await screen.findByText("Cragell, Barb Whitaker")
     ).toBeInTheDocument();
     expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Filter"));
     expect(await screen.findByText("Search by name")).toBeInTheDocument();
     userEvent.type(screen.getByRole("searchbox"), "Cragell");
     expect(await screen.findByText("Filter")).toBeInTheDocument();
@@ -792,7 +791,6 @@ describe("TestResultsList", () => {
       await screen.findByText("Cragell, Barb Whitaker")
     ).toBeInTheDocument();
     expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Filter"));
     expect(
       await screen.findByRole("option", { name: "Negative" })
     ).toBeInTheDocument();
@@ -819,7 +817,6 @@ describe("TestResultsList", () => {
       await screen.findByText("Cragell, Barb Whitaker")
     ).toBeInTheDocument();
     expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Filter"));
     expect(
       await screen.findByRole("option", { name: "Resident" })
     ).toBeInTheDocument();
@@ -847,7 +844,6 @@ describe("TestResultsList", () => {
     ).toBeInTheDocument();
     expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
     expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Filter"));
     expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
     expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
     userEvent.type(
@@ -887,7 +883,6 @@ describe("TestResultsList", () => {
     ).toBeInTheDocument();
 
     // Apply filter
-    userEvent.click(screen.getByText("Filter"));
     expect(await screen.findByText("Search by name")).toBeInTheDocument();
     userEvent.type(screen.getByRole("searchbox"), "Cragell");
     expect(await screen.findByText("Filter")).toBeInTheDocument();

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -241,7 +241,6 @@ export const DetachedTestResultsList: any = ({
   const [printModalId, setPrintModalId] = useState(undefined);
   const [markErrorId, setMarkErrorId] = useState(undefined);
   const [detailsModalId, setDetailsModalId] = useState<string>();
-  const [showFilters, setShowFilters] = useState(false);
   const [showSuggestion, setShowSuggestion] = useState(true);
   const [startDateEntry, setStartDateEntry] = useState<string>();
   const [endDateEntry, setEndDateEntry] = useState<string>();
@@ -375,121 +374,114 @@ export const DetachedTestResultsList: any = ({
               </h2>
               <div>
                 <Button
-                  variant={!showFilters ? "outline" : undefined}
-                  className={showFilters ? "sr-active-button" : undefined}
+                  className="sr-active-button"
                   icon={faSlidersH}
                   onClick={() => {
-                    if (showFilters) {
-                      setDebounced("");
-                      setSelectedPatientId("");
-                      setResultFilter("");
-                      setRoleFilter("");
-                      setStartDateFilter("");
-                      setEndDateFilter("");
-                    }
-
-                    setShowFilters(!showFilters);
+                    setDebounced("");
+                    setSelectedPatientId("");
+                    setResultFilter("");
+                    setRoleFilter("");
+                    setStartDateFilter("");
+                    setEndDateFilter("");
                   }}
                 >
-                  {showFilters ? "Clear filters" : "Filter"}
+                  Clear filters
                 </Button>
               </div>
             </div>
-            {showFilters && (
-              <div
-                id="test-results-search-by-patient-input"
-                className="position-relative bg-base-lightest"
-              >
-                <div className="display-flex grid-row grid-gap flex-row flex-align-end padding-x-3 padding-y-2">
-                  <div className="person-search">
-                    <SearchInput
-                      onSearchClick={onSearchClick}
-                      onInputChange={onInputChange}
-                      queryString={debounced}
-                      disabled={!allowQuery}
-                      label={"Search by name"}
-                      placeholder={""}
-                      className="usa-form-group"
-                    />
-                    <SearchResults
-                      page="test-results"
-                      patients={patientData?.patients || []}
-                      onPatientSelect={onPatientSelect}
-                      shouldShowSuggestions={showDropdown}
-                      loading={debounced !== queryString}
-                      dropDownRef={dropDownRef}
-                    />
-                  </div>
-                  <div className="usa-form-group date-filter-group">
-                    <Label htmlFor="meeting-time">Date range (start)</Label>
-                    {startDateError && (
-                      <span className="usa-error-message" role="alert">
-                        <span className="usa-sr-only">Error: </span>
-                        {startDateError}
-                      </span>
-                    )}
-                    <DatePicker
-                      id="start-date"
-                      name="start-date"
-                      data-testid="start-date"
-                      value={startDateEntry}
-                      minDate="2000-01-01T00:00"
-                      maxDate={moment().format("YYYY-MM-DDThh:mm")}
-                      onChange={(v) => setStartDateEntry(v || "")}
-                      onBlur={processDates}
-                    />
-                  </div>
-                  <div className="usa-form-group date-filter-group">
-                    <Label htmlFor="meeting-time">Date range (end)</Label>
-                    {endDateError && (
-                      <span className="usa-error-message" role="alert">
-                        <span className="usa-sr-only">Error: </span>
-                        {endDateError}
-                      </span>
-                    )}
-                    <DatePicker
-                      id="end-date"
-                      name="end-date"
-                      data-testid="end-date"
-                      value={endDateEntry}
-                      minDate={startDateFilter || "2000-01-01T00:00"}
-                      maxDate={moment().format("YYYY-MM-DDThh:mm")}
-                      onChange={(v) => setEndDateEntry(v || "")}
-                      onBlur={processDates}
-                    />
-                  </div>
-                  <Select
-                    label="Result"
-                    name="result"
-                    value={resultFilter}
-                    options={[
-                      {
-                        value: COVID_RESULTS.POSITIVE,
-                        label: TEST_RESULT_DESCRIPTIONS.POSITIVE,
-                      },
-                      {
-                        value: COVID_RESULTS.NEGATIVE,
-                        label: TEST_RESULT_DESCRIPTIONS.NEGATIVE,
-                      },
-                      {
-                        value: COVID_RESULTS.INCONCLUSIVE,
-                        label: TEST_RESULT_DESCRIPTIONS.UNDETERMINED,
-                      },
-                    ]}
-                    defaultSelect
-                    onChange={setResultFilter}
+            <div
+              id="test-results-search-by-patient-input"
+              className="position-relative bg-base-lightest"
+            >
+              <div className="display-flex grid-row grid-gap flex-row flex-align-end padding-x-3 padding-y-2">
+                <div className="person-search">
+                  <SearchInput
+                    onSearchClick={onSearchClick}
+                    onInputChange={onInputChange}
+                    queryString={debounced}
+                    disabled={!allowQuery}
+                    label={"Search by name"}
+                    placeholder={""}
+                    className="usa-form-group"
                   />
-                  <Select
-                    label="Role"
-                    name="role"
-                    value={roleFilter}
-                    options={ROLE_VALUES}
-                    defaultSelect
-                    onChange={setRoleFilter}
+                  <SearchResults
+                    page="test-results"
+                    patients={patientData?.patients || []}
+                    onPatientSelect={onPatientSelect}
+                    shouldShowSuggestions={showDropdown}
+                    loading={debounced !== queryString}
+                    dropDownRef={dropDownRef}
                   />
                 </div>
+                <div className="usa-form-group date-filter-group">
+                  <Label htmlFor="meeting-time">Date range (start)</Label>
+                  {startDateError && (
+                    <span className="usa-error-message" role="alert">
+                      <span className="usa-sr-only">Error: </span>
+                      {startDateError}
+                    </span>
+                  )}
+                  <DatePicker
+                    id="start-date"
+                    name="start-date"
+                    data-testid="start-date"
+                    value={startDateEntry}
+                    minDate="2000-01-01T00:00"
+                    maxDate={moment().format("YYYY-MM-DDThh:mm")}
+                    onChange={(v) => setStartDateEntry(v || "")}
+                    onBlur={processDates}
+                  />
+                </div>
+                <div className="usa-form-group date-filter-group">
+                  <Label htmlFor="meeting-time">Date range (end)</Label>
+                  {endDateError && (
+                    <span className="usa-error-message" role="alert">
+                      <span className="usa-sr-only">Error: </span>
+                      {endDateError}
+                    </span>
+                  )}
+                  <DatePicker
+                    id="end-date"
+                    name="end-date"
+                    data-testid="end-date"
+                    value={endDateEntry}
+                    minDate={startDateFilter || "2000-01-01T00:00"}
+                    maxDate={moment().format("YYYY-MM-DDThh:mm")}
+                    onChange={(v) => setEndDateEntry(v || "")}
+                    onBlur={processDates}
+                  />
+                </div>
+                <Select
+                  label="Result"
+                  name="result"
+                  value={resultFilter}
+                  options={[
+                    {
+                      value: COVID_RESULTS.POSITIVE,
+                      label: TEST_RESULT_DESCRIPTIONS.POSITIVE,
+                    },
+                    {
+                      value: COVID_RESULTS.NEGATIVE,
+                      label: TEST_RESULT_DESCRIPTIONS.NEGATIVE,
+                    },
+                    {
+                      value: COVID_RESULTS.INCONCLUSIVE,
+                      label: TEST_RESULT_DESCRIPTIONS.UNDETERMINED,
+                    },
+                  ]}
+                  defaultSelect
+                  onChange={setResultFilter}
+                />
+                <Select
+                  label="Role"
+                  name="role"
+                  value={roleFilter}
+                  options={ROLE_VALUES}
+                  defaultSelect
+                  onChange={setRoleFilter}
+                />
               </div>
-            )}
+            </div>
             <div className="usa-card__body">
               <table className="usa-table usa-table--borderless width-full">
                 <thead>

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
             </h2>
             <div>
               <button
-                class="usa-button usa-button--outline"
+                class="usa-button sr-active-button"
                 type="button"
               >
                 <svg
@@ -49,8 +49,259 @@ exports[`TestResultsList should render a list of tests 1`] = `
                     fill="currentColor"
                   />
                 </svg>
-                Filter
+                Clear filters
               </button>
+            </div>
+          </div>
+          <div
+            class="position-relative bg-base-lightest"
+            id="test-results-search-by-patient-input"
+          >
+            <div
+              class="display-flex grid-row grid-gap flex-row flex-align-end padding-x-3 padding-y-2"
+            >
+              <div
+                class="person-search"
+              >
+                <div
+                  class="prime-search-container usa-form-group"
+                >
+                  <form
+                    class="usa-search usa-search--small prime-search-input display-inline-block"
+                    role="search"
+                  >
+                    <label
+                      class="display-block"
+                      for="search-field-small"
+                    >
+                      Search by name
+                    </label>
+                    <div>
+                      <input
+                        autocomplete="off"
+                        class="usa-input"
+                        id="search-field-small"
+                        name="search"
+                        placeholder=""
+                        type="search"
+                        value=""
+                      />
+                      <button
+                        class="usa-button"
+                        disabled=""
+                        type="submit"
+                      >
+                        <span
+                          class="usa-sr-only"
+                        >
+                          Search
+                        </span>
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+              <div
+                class="usa-form-group date-filter-group"
+              >
+                <label
+                  class="usa-label"
+                  data-testid="label"
+                  for="meeting-time"
+                >
+                  Date range (start)
+                </label>
+                <div
+                  class="usa-date-picker usa-date-picker--initialized"
+                  data-testid="date-picker"
+                >
+                  <input
+                    aria-hidden="true"
+                    class="usa-input usa-sr-only usa-date-picker__internal-input"
+                    data-testid="date-picker-internal-input"
+                    name="start-date"
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="usa-date-picker__wrapper"
+                    tabindex="-1"
+                  >
+                    <input
+                      class="usa-input usa-date-picker__external-input"
+                      data-testid="date-picker-external-input"
+                      id="start-date"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Toggle calendar"
+                      class="usa-date-picker__button"
+                      data-testid="date-picker-button"
+                      type="button"
+                    >
+                       
+                    </button>
+                    <div
+                      aria-modal="true"
+                      class="usa-date-picker__calendar"
+                      data-testid="date-picker-calendar"
+                      hidden=""
+                      role="dialog"
+                      style="top: 0px;"
+                    />
+                    <div
+                      aria-live="polite"
+                      class="usa-sr-only usa-date-picker__status"
+                      data-testid="date-picker-status"
+                      role="status"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="usa-form-group date-filter-group"
+              >
+                <label
+                  class="usa-label"
+                  data-testid="label"
+                  for="meeting-time"
+                >
+                  Date range (end)
+                </label>
+                <div
+                  class="usa-date-picker usa-date-picker--initialized"
+                  data-testid="date-picker"
+                >
+                  <input
+                    aria-hidden="true"
+                    class="usa-input usa-sr-only usa-date-picker__internal-input"
+                    data-testid="date-picker-internal-input"
+                    name="end-date"
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="usa-date-picker__wrapper"
+                    tabindex="-1"
+                  >
+                    <input
+                      class="usa-input usa-date-picker__external-input"
+                      data-testid="date-picker-external-input"
+                      id="end-date"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Toggle calendar"
+                      class="usa-date-picker__button"
+                      data-testid="date-picker-button"
+                      type="button"
+                    >
+                       
+                    </button>
+                    <div
+                      aria-modal="true"
+                      class="usa-date-picker__calendar"
+                      data-testid="date-picker-calendar"
+                      hidden=""
+                      role="dialog"
+                      style="top: 0px;"
+                    />
+                    <div
+                      aria-live="polite"
+                      class="usa-sr-only usa-date-picker__status"
+                      data-testid="date-picker-status"
+                      role="status"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="usa-form-group prime-dropdown "
+              >
+                <label
+                  class="usa-label"
+                  for="1"
+                >
+                  Result
+                </label>
+                <select
+                  aria-required="false"
+                  class="usa-select"
+                  id="1"
+                  name="result"
+                >
+                  <option
+                    value=""
+                  >
+                    - Select -
+                  </option>
+                  <option
+                    value="POSITIVE"
+                  >
+                    Positive
+                  </option>
+                  <option
+                    value="NEGATIVE"
+                  >
+                    Negative
+                  </option>
+                  <option
+                    value="UNDETERMINED"
+                  >
+                    Inconclusive
+                  </option>
+                </select>
+              </div>
+              <div
+                class="usa-form-group prime-dropdown "
+              >
+                <label
+                  class="usa-label"
+                  for="2"
+                >
+                  Role
+                </label>
+                <select
+                  aria-required="false"
+                  class="usa-select"
+                  id="2"
+                  name="role"
+                >
+                  <option
+                    value=""
+                  >
+                    - Select -
+                  </option>
+                  <option
+                    value="STAFF"
+                  >
+                    Staff
+                  </option>
+                  <option
+                    value="RESIDENT"
+                  >
+                    Resident
+                  </option>
+                  <option
+                    value="STUDENT"
+                  >
+                    Student
+                  </option>
+                  <option
+                    value="VISITOR"
+                  >
+                    Visitor
+                  </option>
+                </select>
+              </div>
             </div>
           </div>
           <div


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #2139

## Changes Proposed

- Sets filters to always be open on the Results and People pages

## Screenshots / Demos

![results filters](https://user-images.githubusercontent.com/49658917/128042563-6765eb09-35e8-4fca-99a7-db1dab9ec1e8.png)

![people filters](https://user-images.githubusercontent.com/49658917/128042653-9292d8c7-8a16-471c-ac4c-1fed70f4a728.png)

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
