### PR TITLE
Add lookup id to metabase

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2605,3 +2605,78 @@ databaseChangeLog:
       rollback:
         - dropView:
             viewName: api_audit_event_no_phi
+  - changeSet:
+      id: add-lookup-id-to-no-phi-view
+      author: tbest@cdc.gov
+      comment: Add lookup_id to person_no_phi_view.
+      changes:
+        - dropView:
+            viewName: person_no_phi_view
+        - createView:
+            viewName: person_no_phi_view
+            remarks: A subset of the person table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: |
+              SELECT
+                p.internal_id,
+                p.created_at,
+                p.created_by,
+                p.updated_at,
+                p.updated_by,
+                p.is_deleted,
+                p.organization_id,
+                p.facility_id,
+                p.race,
+                p.gender,
+                p.ethnicity,
+                p.county,
+                p.state,
+                p.employed_in_healthcare,
+                p.role,
+                p.resident_congregate_setting,
+                p.tribal_affiliation,
+                p.lookup_id,
+                get_census_dob_group(p.birth_date) AS census_dob_group,
+                pp.preferred_language,
+                pp.test_result_delivery
+              FROM ${database.defaultSchemaName}.person p
+              JOIN patient_preferences pp on pp.internal_id=p.internal_id
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
+      rollback:
+        - dropView:
+            viewName: person_no_phi_view
+        - createView:
+            viewName: person_no_phi_view
+            remarks: A subset of the person table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: |
+              SELECT
+                p.internal_id,
+                p.created_at,
+                p.created_by,
+                p.updated_at,
+                p.updated_by,
+                p.is_deleted,
+                p.organization_id,
+                p.facility_id,
+                p.race,
+                p.gender,
+                p.ethnicity,
+                p.county,
+                p.state,
+                p.employed_in_healthcare,
+                p.role,
+                p.resident_congregate_setting,
+                p.tribal_affiliation,
+                get_census_dob_group(p.birth_date) AS census_dob_group,
+                pp.preferred_language,
+                pp.test_result_delivery
+              FROM ${database.defaultSchemaName}.person p
+              JOIN patient_preferences pp on pp.internal_id=p.internal_id
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
+
+


### PR DESCRIPTION
## Related Issue or Background Info

- There is a product need to see if the lookup ID is being used 

## Changes Proposed

- add lookup id to metabase
## Additional Information

## Screenshots / Demos
![Screen Shot 2021-08-03 at 11 41 48 AM](https://user-images.githubusercontent.com/53869143/128045116-ca8b61ae-bb55-4cd3-aa36-d9a85e26a25f.png)
<img width="1113" alt="Screen Shot 2021-08-03 at 11 56 19 AM" src="https://user-images.githubusercontent.com/53869143/128047636-d9f01026-cd4b-4e0f-aa73-973b2cc33233.png">

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
