### PR TITLE
Add saving and error states for queue item cards

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -137,11 +137,7 @@ describe("QueueItem", () => {
 
       // Submit
       await waitFor(() => {
-        fireEvent.click(
-          screen.getByText("Submit", {
-            exact: false,
-          })
-        );
+        fireEvent.click(screen.getByText("Submit"));
       });
 
       await waitFor(() => {

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -152,6 +152,13 @@ describe("QueueItem", () => {
         );
       });
 
+      // Displays submitting indicator
+      expect(
+        await screen.findByText(
+          "Submitting test data for Harry James Potter..."
+        )
+      );
+
       // Verify alert is displayed
       expect(
         await screen.findByText(
@@ -161,6 +168,14 @@ describe("QueueItem", () => {
           }
         )
       ).toBeInTheDocument();
+
+      // Submitting indicator and card are gone
+      await waitFor(() => {
+        expect(screen.queryByText("Potter, Harry James"));
+        expect(
+          screen.queryByText("Submitting test data for Harry James Potter...")
+        );
+      });
     });
   });
 

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -612,9 +612,10 @@ const QueueItem: any = ({
   return (
     <React.Fragment>
       <div className={containerClasses}>
-        {saveState === "saving" && (
-          <QueueItemSubmitLoader name={patientFullName} />
-        )}
+        <QueueItemSubmitLoader
+          show={saveState === "saving"}
+          name={patientFullName}
+        />
         <div className="prime-card-container">
           {saveState !== "saving" && closeButton}
           <div className="grid-row">

--- a/frontend/src/app/testQueue/QueueItemSubmitLoader.scss
+++ b/frontend/src/app/testQueue/QueueItemSubmitLoader.scss
@@ -1,0 +1,13 @@
+.sr-queue-item-submit-loader {
+  background-color: rgba(255, 255, 255, 0.92);
+
+  &-enter {
+    opacity: 0;
+  }
+
+  &-enter-active {
+    display: block;
+    opacity: 1;
+    transition: opacity 300ms;
+  }
+}

--- a/frontend/src/app/testQueue/QueueItemSubmitLoader.scss
+++ b/frontend/src/app/testQueue/QueueItemSubmitLoader.scss
@@ -1,7 +1,9 @@
 .sr-queue-item-submit-loader {
   background-color: rgba(255, 255, 255, 0.92);
+  display: none;
 
   &-enter {
+    display: block;
     opacity: 0;
   }
 
@@ -9,5 +11,23 @@
     display: block;
     opacity: 1;
     transition: opacity 300ms;
+  }
+
+  &-enter-done {
+    display: block;
+  }
+
+  &-exit {
+    display: block;
+    opacity: 1;
+  }
+
+  &-exit-active {
+    opacity: 0;
+    transition: opacity 300ms;
+  }
+
+  &-exit-done {
+    display: none;
   }
 }

--- a/frontend/src/app/testQueue/QueueItemSubmitLoader.tsx
+++ b/frontend/src/app/testQueue/QueueItemSubmitLoader.tsx
@@ -1,19 +1,38 @@
+import classNames from "classnames";
+import { CSSTransition } from "react-transition-group";
 import iconLoader from "uswds/dist/img/loader.svg";
+
+import "./QueueItemSubmitLoader.scss";
 
 type Props = {
   name: string;
+  show: boolean;
 };
 
-export const QueueItemSubmitLoader = ({ name }: Props) => (
-  <div
-    className="z-top position-absolute height-full width-full text-center"
-    style={{
-      backgroundColor: "rgba(255, 255, 255, 0.92)",
-    }}
-  >
-    <h4 className="margin-top-6 margin-bottom-5">
-      Submitting test data for {name}...
-    </h4>
-    <img src={iconLoader} alt="submitting" className="square-5" />
-  </div>
-);
+export const QueueItemSubmitLoader = ({ name, show }: Props) => {
+  const classnames = classNames(
+    !show && "display-none",
+    "sr-queue-item-submit-loader",
+    "z-top",
+    "position-absolute",
+    "height-full",
+    "width-full",
+    "text-center",
+    "radius-lg"
+  );
+
+  return (
+    <CSSTransition
+      in={show}
+      timeout={300}
+      classNames="sr-queue-item-submit-loader"
+    >
+      <div className={classnames} aria-hidden={!show}>
+        <h4 className="margin-top-6 margin-bottom-5">
+          Submitting test data for {name}...
+        </h4>
+        <img src={iconLoader} alt="submitting" className="square-5" />
+      </div>
+    </CSSTransition>
+  );
+};

--- a/frontend/src/app/testQueue/QueueItemSubmitLoader.tsx
+++ b/frontend/src/app/testQueue/QueueItemSubmitLoader.tsx
@@ -1,0 +1,19 @@
+import iconLoader from "uswds/dist/img/loader.svg";
+
+type Props = {
+  name: string;
+};
+
+export const QueueItemSubmitLoader = ({ name }: Props) => (
+  <div
+    className="z-top position-absolute height-full width-full text-center"
+    style={{
+      backgroundColor: "rgba(255, 255, 255, 0.92)",
+    }}
+  >
+    <h4 className="margin-top-6 margin-bottom-5">
+      Submitting test data for {name}...
+    </h4>
+    <img src={iconLoader} alt="submitting" className="square-5" />
+  </div>
+);

--- a/frontend/src/app/testQueue/QueueItemSubmitLoader.tsx
+++ b/frontend/src/app/testQueue/QueueItemSubmitLoader.tsx
@@ -11,7 +11,6 @@ type Props = {
 
 export const QueueItemSubmitLoader = ({ name, show }: Props) => {
   const classnames = classNames(
-    !show && "display-none",
     "sr-queue-item-submit-loader",
     "z-top",
     "position-absolute",

--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`QueueItem correctly renders the test queue 1`] = `
   >
     <div
       aria-hidden="true"
-      class="display-none sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
+      class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
     >
       <h4
         class="margin-top-6 margin-bottom-5"

--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -6,6 +6,23 @@ exports[`QueueItem correctly renders the test queue 1`] = `
     class="position-relative grid-container prime-container prime-queue-item card-container"
   >
     <div
+      aria-hidden="true"
+      class="display-none sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
+    >
+      <h4
+        class="margin-top-6 margin-bottom-5"
+      >
+        Submitting test data for 
+        Harry James Potter
+        ...
+      </h4>
+      <img
+        alt="submitting"
+        class="square-5"
+        src="loader.svg"
+      />
+    </div>
+    <div
       class="prime-card-container"
     >
       <button

--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`QueueItem correctly renders the test queue 1`] = `
 <div>
   <div
-    class="grid-container prime-container prime-queue-item card-container"
+    class="position-relative grid-container prime-container prime-queue-item card-container"
   >
     <div
       class="prime-card-container"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`TestQueue should render the test queue 1`] = `
         </div>
       </div>
       <div
-        class="grid-container prime-container prime-queue-item card-container"
+        class="position-relative grid-container prime-container prime-queue-item card-container"
       >
         <div
           class="prime-card-container"
@@ -351,7 +351,7 @@ exports[`TestQueue should render the test queue 1`] = `
         </div>
       </div>
       <div
-        class="grid-container prime-container prime-queue-item card-container"
+        class="position-relative grid-container prime-container prime-queue-item card-container"
       >
         <div
           class="prime-card-container"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -53,6 +53,23 @@ exports[`TestQueue should render the test queue 1`] = `
         class="position-relative grid-container prime-container prime-queue-item card-container"
       >
         <div
+          aria-hidden="true"
+          class="display-none sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
+        >
+          <h4
+            class="margin-top-6 margin-bottom-5"
+          >
+            Submitting test data for 
+            John A Doe
+            ...
+          </h4>
+          <img
+            alt="submitting"
+            class="square-5"
+            src="loader.svg"
+          />
+        </div>
+        <div
           class="prime-card-container"
         >
           <button
@@ -353,6 +370,23 @@ exports[`TestQueue should render the test queue 1`] = `
       <div
         class="position-relative grid-container prime-container prime-queue-item card-container"
       >
+        <div
+          aria-hidden="true"
+          class="display-none sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
+        >
+          <h4
+            class="margin-top-6 margin-bottom-5"
+          >
+            Submitting test data for 
+            Jane Smith
+            ...
+          </h4>
+          <img
+            alt="submitting"
+            class="square-5"
+            src="loader.svg"
+          />
+        </div>
         <div
           class="prime-card-container"
         >

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`TestQueue should render the test queue 1`] = `
       >
         <div
           aria-hidden="true"
-          class="display-none sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
+          class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
         >
           <h4
             class="margin-top-6 margin-bottom-5"
@@ -372,7 +372,7 @@ exports[`TestQueue should render the test queue 1`] = `
       >
         <div
           aria-hidden="true"
-          class="display-none sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
+          class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center radius-lg"
         >
           <h4
             class="margin-top-6 margin-bottom-5"

--- a/frontend/src/app/testResults/TestResultInputForm.tsx
+++ b/frontend/src/app/testResults/TestResultInputForm.tsx
@@ -26,7 +26,8 @@ const TestResultInputForm: React.FC<Props> = ({
     }
   };
 
-  const allowSubmit = testResultValue && !isSubmitDisabled;
+  const allowSubmit =
+    testResultValue && testResultValue !== "UNKNOWN" && !isSubmitDisabled;
 
   const onResultSubmit = (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -214,13 +214,13 @@
   position: relative;
 
   .prime-card-container {
-    border-left-width: 0.5em;
+    border-left-width: 0.5rem;
     border-left-style: solid;
     border-color: transparent;
   }
 
   .prime-test-name {
-    margin-left: -0.5em;
+    margin-left: -0.5rem;
   }
 
   .result-ready {
@@ -231,13 +231,24 @@
     margin-top: 0.5rem;
   }
 
+  &__error,
+  &__ready {
+    .prime-card-container .usa-card__header {
+      margin-left: 0;
+      padding-left: 0.75rem;
+    }
+  }
+
+  &__error {
+    border-color: color($theme-color-error);
+
+    .prime-card-container {
+      border-color: color($theme-color-error);
+    }
+  }
+
   &__ready {
     border-color: color($theme-color-warning);
-
-    .prime-test-name {
-      margin-left: 0;
-      padding-left: 1.5em;
-    }
 
     .prime-card-container {
       border-color: color($theme-color-warning);

--- a/frontend/src/stories/storyMocks.tsx
+++ b/frontend/src/stories/storyMocks.tsx
@@ -32,15 +32,22 @@ const mocks = {
       })
     );
   }),
-  SubmitTestResults: graphql.mutation("SubmitTestResults", (req, res, ctx) => {
-    return res(
-      ctx.data({
-        submitTestResults: {
-          internalId: req.body?.variables.patientId,
-        },
-      })
-    );
-  }),
+  SubmitTestResult: graphql.mutation(
+    "SubmitTestResult",
+    async (req, res, ctx) => {
+      await new Promise((res) => setTimeout(res, 200));
+
+      const data =
+        req.body?.variables.patientId === "this-should-fail"
+          ? {}
+          : {
+              addTestResultNew: {
+                internalId: req.body?.variables.patientId,
+              },
+            };
+      return res(ctx.data(data));
+    }
+  ),
   GetPatientsLastResult: graphql.query(
     "GetPatientsLastResult",
     (req, res, ctx) => {

--- a/frontend/src/stories/testQueue/QueueItem.stories.tsx
+++ b/frontend/src/stories/testQueue/QueueItem.stories.tsx
@@ -11,7 +11,7 @@ export default {
     layout: "fullscreen",
     msw: getMocks(
       "EditQueueItem",
-      "SubmitTestResults",
+      "SubmitTestResult",
       "GetPatientsLastResult",
       "SendPatientLinkSms",
       "UpdateAOE",
@@ -95,6 +95,18 @@ FilledOut.args = {
   dateTestedProp: "2021-03-03T14:40:00Z",
 };
 
+export const ReadyIndicator = Template.bind({});
+ReadyIndicator.args = {
+  ...defaultProps,
+  internalId: "completed-timer",
+  askOnEntry: {
+    noSymptoms: true,
+    firstTest: true,
+    pregnancy: "no",
+    symptoms: "{}",
+  } as any,
+};
+
 export const CompletedIndicator = Template.bind({});
 CompletedIndicator.args = {
   ...defaultProps,
@@ -106,4 +118,21 @@ CompletedIndicator.args = {
     symptoms: "{}",
   } as any,
   selectedTestResult: "NEGATIVE",
+};
+
+export const FailOnSubmit = Template.bind({});
+FailOnSubmit.args = {
+  ...defaultProps,
+  internalId: "completed_timer",
+  askOnEntry: {
+    noSymptoms: true,
+    firstTest: true,
+    pregnancy: "no",
+    symptoms: "{}",
+  } as any,
+  selectedTestResult: "NEGATIVE",
+  patient: {
+    ...defaultProps.patient,
+    internalId: "this-should-fail",
+  },
 };


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #1960

## Changes Proposed

- Adds different states for queue items
- Adds stories for different states

## Screenshots / Demos


https://user-images.githubusercontent.com/49658917/128251082-01404b99-6c94-46a0-bd7a-dd8a4fb5f314.mov

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
