### PR TITLE
Add English <-> Spanish language toggler to patient experience pages

### DIFF
--- a/frontend/src/app/commonComponents/USAGovBanner.jsx
+++ b/frontend/src/app/commonComponents/USAGovBanner.jsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { Trans } from "react-i18next";
+import { Trans, withTranslation } from "react-i18next";
 
 import i18n from "../../i18n";
 import iconDotGov from "../../../node_modules/uswds/dist/img/icon-dot-gov.svg";
 import usFlagSmall from "../../../node_modules/uswds/dist/img/us_flag_small.png";
 import iconHttps from "../../../node_modules/uswds/dist/img/icon-https.svg";
 
-export default class USAGovBanner extends React.Component {
+class USAGovBanner extends React.Component {
   constructor() {
     super();
     this.state = {
@@ -104,3 +104,5 @@ export default class USAGovBanner extends React.Component {
     );
   }
 }
+
+export default withTranslation()(USAGovBanner);

--- a/frontend/src/app/commonComponents/YesNoRadioGroup.tsx
+++ b/frontend/src/app/commonComponents/YesNoRadioGroup.tsx
@@ -1,6 +1,7 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
-import { YES_NO_UNKNOWN_VALUES } from "../constants";
+import { useTranslatedConstants } from "../constants";
 
 import RadioGroup from "./RadioGroup";
 
@@ -27,7 +28,8 @@ const YesNoRadioGroup: React.FC<Props> = ({
   errorMessage,
   required,
 }) => {
-  const values = YES_NO_UNKNOWN_VALUES;
+  const { t } = useTranslation();
+  const { YES_NO_UNKNOWN_VALUES: values } = useTranslatedConstants(t);
 
   return (
     <RadioGroup

--- a/frontend/src/app/commonComponents/YesNoRadioGroup.tsx
+++ b/frontend/src/app/commonComponents/YesNoRadioGroup.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
 
 import { useTranslatedConstants } from "../constants";
 
@@ -28,8 +27,7 @@ const YesNoRadioGroup: React.FC<Props> = ({
   errorMessage,
   required,
 }) => {
-  const { t } = useTranslation();
-  const { YES_NO_UNKNOWN_VALUES: values } = useTranslatedConstants(t);
+  const { YES_NO_UNKNOWN_VALUES: values } = useTranslatedConstants();
 
   return (
     <RadioGroup

--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -13,19 +13,17 @@ export const COVID_RESULTS: { [key: string]: TestResult } = {
   UNKNOWN: "UNKNOWN",
 };
 
-const testResultDescriptions = (t: TFunction) => {
-  const result: Record<TestResult, string> = {
+const testResultDescriptions = (t: TFunction): Record<TestResult, string> => {
+  return {
     NEGATIVE: i18n.t("constants.testResults.NEGATIVE"),
     POSITIVE: i18n.t("constants.testResults.POSITIVE"),
     UNDETERMINED: i18n.t("constants.testResults.UNDETERMINED"),
     UNKNOWN: i18n.t("constants.testResults.UNKNOWN"),
   };
-
-  return result;
 };
 
-const raceValues = (t: TFunction) => {
-  const result: { value: Race; label: string }[] = [
+const raceValues = (t: TFunction): { value: Race; label: string }[] => {
+  return [
     { value: "native", label: i18n.t("constants.race.native") },
     { value: "asian", label: i18n.t("constants.race.asian") },
     { value: "black", label: i18n.t("constants.race.black") },
@@ -34,23 +32,21 @@ const raceValues = (t: TFunction) => {
     { value: "other", label: i18n.t("constants.race.other") },
     { value: "refused", label: i18n.t("constants.race.refused") },
   ];
-
-  return result;
 };
 
-const roleValues = (t: TFunction) => {
-  const result: { value: Role; label: string }[] = [
+const roleValues = (t: TFunction): { value: Role; label: string }[] => {
+  return [
     { label: i18n.t("constants.role.STAFF"), value: "STAFF" },
     { label: i18n.t("constants.role.RESIDENT"), value: "RESIDENT" },
     { label: i18n.t("constants.role.STUDENT"), value: "STUDENT" },
     { label: i18n.t("constants.role.VISITOR"), value: "VISITOR" },
   ];
-
-  return result;
 };
 
-const ethnicityValues = (t: TFunction) => {
-  const result: { value: Ethnicity; label: string }[] = [
+const ethnicityValues = (
+  t: TFunction
+): { value: Ethnicity; label: string }[] => {
+  return [
     { label: i18n.t("constants.ethnicity.hispanic"), value: "hispanic" },
     {
       label: i18n.t("constants.ethnicity.not_hispanic"),
@@ -58,61 +54,55 @@ const ethnicityValues = (t: TFunction) => {
     },
     { label: i18n.t("constants.ethnicity.refused"), value: "refused" },
   ];
-
-  return result;
 };
 
-const genderValues = (t: TFunction) => {
-  const result: { value: Gender; label: string }[] = [
+const genderValues = (t: TFunction): { value: Gender; label: string }[] => {
+  return [
     { label: i18n.t("constants.gender.female"), value: "female" },
     { label: i18n.t("constants.gender.male"), value: "male" },
     { label: i18n.t("constants.gender.other"), value: "other" },
     { label: i18n.t("constants.gender.refused"), value: "refused" },
   ];
-
-  return result;
 };
 
-const yesNoValues = (t: TFunction) => {
-  const result: { value: YesNo; label: string }[] = [
+const yesNoValues = (t: TFunction): { value: YesNo; label: string }[] => {
+  return [
     { label: i18n.t("constants.yesNoUnk.YES"), value: "YES" },
     { label: i18n.t("constants.yesNoUnk.NO"), value: "NO" },
   ];
-
-  return result;
 };
 
-const phoneTypeValues = (t: TFunction) => {
-  const result: { value: PhoneType; label: string }[] = [
+const phoneTypeValues = (
+  t: TFunction
+): { value: PhoneType; label: string }[] => {
+  return [
     { label: i18n.t("constants.phoneType.MOBILE"), value: "MOBILE" },
     { label: i18n.t("constants.phoneType.LANDLINE"), value: "LANDLINE" },
   ];
-
-  return result;
 };
 
-const testResultDeliveryPreferenceValues = (t: TFunction) => {
-  const result: {
-    value: TestResultDeliveryPreference;
-    label: string;
-  }[] = [
+const testResultDeliveryPreferenceValues = (
+  t: TFunction
+): {
+  value: TestResultDeliveryPreference;
+  label: string;
+}[] => {
+  return [
     { label: i18n.t("constants.yesNoUnk.YES"), value: "SMS" },
     { label: i18n.t("constants.yesNoUnk.NO"), value: "NONE" },
   ];
-
-  return result;
 };
 
-const yesNoUnkownValues = (t: TFunction) => {
-  const result: {
-    value: YesNoUnknown;
-    label: string;
-  }[] = [
+const yesNoUnkownValues = (
+  t: TFunction
+): {
+  value: YesNoUnknown;
+  label: string;
+}[] => {
+  return [
     ...yesNoValues(i18n.t),
     { value: "UNKNOWN", label: i18n.t("constants.yesNoUnk.UNKNOWN") },
   ];
-
-  return result;
 };
 
 const fullTribalAffiliationValueSetMap: { [key: string]: TribalAffiliation } = {

--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -1,4 +1,5 @@
 import { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
 
 import { TestResult } from "../testQueue/QueueItem";
 import i18n from "../../i18n";
@@ -716,7 +717,9 @@ export const TEST_RESULT_DELIVERY_PREFERENCE_VALUES = testResultDeliveryPreferen
 );
 export const YES_NO_UNKNOWN_VALUES = yesNoUnkownValues(i18n.t);
 
-export const useTranslatedConstants = (t: TFunction) => {
+export const useTranslatedConstants = () => {
+  const { t } = useTranslation();
+
   return {
     TEST_RESULT_DESCRIPTIONS: testResultDescriptions(t),
     RACE_VALUES: raceValues(t),

--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -1,3 +1,5 @@
+import { TFunction } from "i18next";
+
 import { TestResult } from "../testQueue/QueueItem";
 import i18n from "../../i18n";
 
@@ -11,67 +13,107 @@ export const COVID_RESULTS: { [key: string]: TestResult } = {
   UNKNOWN: "UNKNOWN",
 };
 
-export const TEST_RESULT_DESCRIPTIONS: Record<TestResult, string> = {
-  NEGATIVE: i18n.t("constants.testResults.NEGATIVE"),
-  POSITIVE: i18n.t("constants.testResults.POSITIVE"),
-  UNDETERMINED: i18n.t("constants.testResults.UNDETERMINED"),
-  UNKNOWN: i18n.t("constants.testResults.UNKNOWN"),
+const testResultDescriptions = (t: TFunction) => {
+  const result: Record<TestResult, string> = {
+    NEGATIVE: i18n.t("constants.testResults.NEGATIVE"),
+    POSITIVE: i18n.t("constants.testResults.POSITIVE"),
+    UNDETERMINED: i18n.t("constants.testResults.UNDETERMINED"),
+    UNKNOWN: i18n.t("constants.testResults.UNKNOWN"),
+  };
+
+  return result;
 };
 
-export const RACE_VALUES: { value: Race; label: string }[] = [
-  { value: "native", label: i18n.t("constants.race.native") },
-  { value: "asian", label: i18n.t("constants.race.asian") },
-  { value: "black", label: i18n.t("constants.race.black") },
-  { value: "pacific", label: i18n.t("constants.race.pacific") },
-  { value: "white", label: i18n.t("constants.race.white") },
-  { value: "other", label: i18n.t("constants.race.other") },
-  { value: "refused", label: i18n.t("constants.race.refused") },
-];
+const raceValues = (t: TFunction) => {
+  const result: { value: Race; label: string }[] = [
+    { value: "native", label: i18n.t("constants.race.native") },
+    { value: "asian", label: i18n.t("constants.race.asian") },
+    { value: "black", label: i18n.t("constants.race.black") },
+    { value: "pacific", label: i18n.t("constants.race.pacific") },
+    { value: "white", label: i18n.t("constants.race.white") },
+    { value: "other", label: i18n.t("constants.race.other") },
+    { value: "refused", label: i18n.t("constants.race.refused") },
+  ];
 
-export const ROLE_VALUES: { value: Role; label: string }[] = [
-  { label: i18n.t("constants.role.STAFF"), value: "STAFF" },
-  { label: i18n.t("constants.role.RESIDENT"), value: "RESIDENT" },
-  { label: i18n.t("constants.role.STUDENT"), value: "STUDENT" },
-  { label: i18n.t("constants.role.VISITOR"), value: "VISITOR" },
-];
+  return result;
+};
 
-export const ETHNICITY_VALUES: { value: Ethnicity; label: string }[] = [
-  { label: i18n.t("constants.ethnicity.hispanic"), value: "hispanic" },
-  { label: i18n.t("constants.ethnicity.not_hispanic"), value: "not_hispanic" },
-  { label: i18n.t("constants.ethnicity.refused"), value: "refused" },
-];
-export const GENDER_VALUES: { value: Gender; label: string }[] = [
-  { label: i18n.t("constants.gender.female"), value: "female" },
-  { label: i18n.t("constants.gender.male"), value: "male" },
-  { label: i18n.t("constants.gender.other"), value: "other" },
-  { label: i18n.t("constants.gender.refused"), value: "refused" },
-];
+const roleValues = (t: TFunction) => {
+  const result: { value: Role; label: string }[] = [
+    { label: i18n.t("constants.role.STAFF"), value: "STAFF" },
+    { label: i18n.t("constants.role.RESIDENT"), value: "RESIDENT" },
+    { label: i18n.t("constants.role.STUDENT"), value: "STUDENT" },
+    { label: i18n.t("constants.role.VISITOR"), value: "VISITOR" },
+  ];
 
-export const YES_NO_VALUES: { value: YesNo; label: string }[] = [
-  { label: i18n.t("constants.yesNoUnk.YES"), value: "YES" },
-  { label: i18n.t("constants.yesNoUnk.NO"), value: "NO" },
-];
+  return result;
+};
 
-export const PHONE_TYPE_VALUES: { value: PhoneType; label: string }[] = [
-  { label: i18n.t("constants.phoneType.MOBILE"), value: "MOBILE" },
-  { label: i18n.t("constants.phoneType.LANDLINE"), value: "LANDLINE" },
-];
+const ethnicityValues = (t: TFunction) => {
+  const result: { value: Ethnicity; label: string }[] = [
+    { label: i18n.t("constants.ethnicity.hispanic"), value: "hispanic" },
+    {
+      label: i18n.t("constants.ethnicity.not_hispanic"),
+      value: "not_hispanic",
+    },
+    { label: i18n.t("constants.ethnicity.refused"), value: "refused" },
+  ];
 
-export const TEST_RESULT_DELIVERY_PREFERENCE_VALUES: {
-  value: TestResultDeliveryPreference;
-  label: string;
-}[] = [
-  { label: i18n.t("constants.yesNoUnk.YES"), value: "SMS" },
-  { label: i18n.t("constants.yesNoUnk.NO"), value: "NONE" },
-];
+  return result;
+};
 
-export const YES_NO_UNKNOWN_VALUES: {
-  value: YesNoUnknown;
-  label: string;
-}[] = [
-  ...YES_NO_VALUES,
-  { value: "UNKNOWN", label: i18n.t("constants.yesNoUnk.UNKNOWN") },
-];
+const genderValues = (t: TFunction) => {
+  const result: { value: Gender; label: string }[] = [
+    { label: i18n.t("constants.gender.female"), value: "female" },
+    { label: i18n.t("constants.gender.male"), value: "male" },
+    { label: i18n.t("constants.gender.other"), value: "other" },
+    { label: i18n.t("constants.gender.refused"), value: "refused" },
+  ];
+
+  return result;
+};
+
+const yesNoValues = (t: TFunction) => {
+  const result: { value: YesNo; label: string }[] = [
+    { label: i18n.t("constants.yesNoUnk.YES"), value: "YES" },
+    { label: i18n.t("constants.yesNoUnk.NO"), value: "NO" },
+  ];
+
+  return result;
+};
+
+const phoneTypeValues = (t: TFunction) => {
+  const result: { value: PhoneType; label: string }[] = [
+    { label: i18n.t("constants.phoneType.MOBILE"), value: "MOBILE" },
+    { label: i18n.t("constants.phoneType.LANDLINE"), value: "LANDLINE" },
+  ];
+
+  return result;
+};
+
+const testResultDeliveryPreferenceValues = (t: TFunction) => {
+  const result: {
+    value: TestResultDeliveryPreference;
+    label: string;
+  }[] = [
+    { label: i18n.t("constants.yesNoUnk.YES"), value: "SMS" },
+    { label: i18n.t("constants.yesNoUnk.NO"), value: "NONE" },
+  ];
+
+  return result;
+};
+
+const yesNoUnkownValues = (t: TFunction) => {
+  const result: {
+    value: YesNoUnknown;
+    label: string;
+  }[] = [
+    ...yesNoValues(i18n.t),
+    { value: "UNKNOWN", label: i18n.t("constants.yesNoUnk.UNKNOWN") },
+  ];
+
+  return result;
+};
 
 const fullTribalAffiliationValueSetMap: { [key: string]: TribalAffiliation } = {
   "Village of Afognak": "338",
@@ -671,3 +713,31 @@ export const AUTH_OR_IDENTITY_METHODS_BUTTONS: {
   label: e[1],
   value: e[0],
 }));
+
+export const TEST_RESULT_DESCRIPTIONS = testResultDescriptions(i18n.t);
+export const RACE_VALUES = raceValues(i18n.t);
+export const ROLE_VALUES = roleValues(i18n.t);
+export const ETHNICITY_VALUES = ethnicityValues(i18n.t);
+export const GENDER_VALUES = genderValues(i18n.t);
+export const YES_NO_VALUES = yesNoValues(i18n.t);
+export const PHONE_TYPE_VALUES = phoneTypeValues(i18n.t);
+export const TEST_RESULT_DELIVERY_PREFERENCE_VALUES = testResultDeliveryPreferenceValues(
+  i18n.t
+);
+export const YES_NO_UNKNOWN_VALUES = yesNoUnkownValues(i18n.t);
+
+export const useTranslatedConstants = (t: TFunction) => {
+  return {
+    TEST_RESULT_DESCRIPTIONS: testResultDescriptions(t),
+    RACE_VALUES: raceValues(t),
+    ROLE_VALUES: roleValues(t),
+    ETHNICITY_VALUES: ethnicityValues(t),
+    GENDER_VALUES: genderValues(t),
+    TEST_RESULT_DELIVERY_PREFERENCE_VALUES: testResultDeliveryPreferenceValues(
+      t
+    ),
+    PHONE_TYPE_VALUES: phoneTypeValues(t),
+    YES_NO_VALUES: yesNoValues(t),
+    YES_NO_UNKNOWN_VALUES: yesNoUnkownValues(t),
+  };
+};

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -2,18 +2,15 @@ import React, { useCallback, useState, useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslation } from "react-i18next";
 
-import {
-  PHONE_TYPE_VALUES,
-  TEST_RESULT_DELIVERY_PREFERENCE_VALUES,
-} from "../../constants";
 import Button from "../../commonComponents/Button/Button";
 import Input from "../../commonComponents/Input";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import {
+  getAllPhoneNumberErrors,
   PhoneNumberErrors,
-  allPhoneNumberErrors,
   phoneNumberUpdateSchema,
 } from "../personSchema";
+import { useTranslatedConstants } from "../../constants";
 
 interface Props {
   phoneNumbers: PhoneNumber[];
@@ -33,6 +30,13 @@ const ManagePhoneNumbers: React.FC<Props> = ({
   const [errors, setErrors] = useState<PhoneNumberErrors[]>([]);
 
   const { t } = useTranslation();
+
+  const allPhoneNumberErrors = getAllPhoneNumberErrors(t);
+
+  const {
+    PHONE_TYPE_VALUES,
+    TEST_RESULT_DELIVERY_PREFERENCE_VALUES,
+  } = useTranslatedConstants(t);
 
   const phoneNumbersOrDefault = useMemo(
     () =>
@@ -88,7 +92,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
         });
       }
     },
-    [phoneNumbersOrDefault, clearError]
+    [phoneNumbersOrDefault, clearError, allPhoneNumberErrors]
   );
 
   const onPhoneTypeChange = (index: number, newPhoneType: string) => {

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -36,7 +36,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
   const {
     PHONE_TYPE_VALUES,
     TEST_RESULT_DELIVERY_PREFERENCE_VALUES,
-  } = useTranslatedConstants(t);
+  } = useTranslatedConstants();
 
   const phoneNumbersOrDefault = useMemo(
     () =>

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -20,7 +20,7 @@ import {
   personUpdateSchema,
   selfRegistrationSchema,
   PersonUpdateFields,
-  getPersonErrors,
+  usePersonErrors,
 } from "../personSchema";
 import YesNoRadioGroup from "../../commonComponents/YesNoRadioGroup";
 import Input from "../../commonComponents/Input";
@@ -111,7 +111,7 @@ const PersonForm = (props: Props) => {
 
   const { t } = useTranslation();
 
-  const allPersonErrors: Required<PersonErrors> = getPersonErrors(t);
+  const allPersonErrors: Required<PersonErrors> = usePersonErrors();
   const clearError = useCallback(
     (field: keyof PersonErrors) => {
       if (errors[field]) {
@@ -234,7 +234,7 @@ const PersonForm = (props: Props) => {
     ETHNICITY_VALUES,
     GENDER_VALUES,
     ROLE_VALUES,
-  } = useTranslatedConstants(t);
+  } = useTranslatedConstants();
 
   return (
     <>

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { Prompt } from "react-router-dom";
 import { toast } from "react-toastify";
 import { SchemaOf } from "yup";
@@ -112,6 +112,24 @@ const PersonForm = (props: Props) => {
   const { t } = useTranslation();
 
   const allPersonErrors: Required<PersonErrors> = usePersonErrors();
+
+  // Detect language change for form validations
+  useEffect(() => {
+    const translatedErrors = Object.entries(errors).reduce(
+      (acc, [key, value]) => {
+        const errorKey = key as keyof PersonErrors;
+        if (allPersonErrors[errorKey] !== value) {
+          acc[errorKey] = allPersonErrors[errorKey];
+        }
+        return acc;
+      },
+      {} as PersonErrors
+    );
+    if (Object.keys(translatedErrors).length) {
+      setErrors(translatedErrors);
+    }
+  }, [allPersonErrors, errors]);
+
   const clearError = useCallback(
     (field: keyof PersonErrors) => {
       if (errors[field]) {

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -7,23 +7,20 @@ import { useTranslation } from "react-i18next";
 import { stateCodes } from "../../../config/constants";
 import getLanguages from "../../utils/languages";
 import {
-  RACE_VALUES,
-  ETHNICITY_VALUES,
-  GENDER_VALUES,
-  ROLE_VALUES,
   TRIBAL_AFFILIATION_VALUES,
+  useTranslatedConstants,
 } from "../../constants";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import RequiredMessage from "../../commonComponents/RequiredMessage";
 import { showError } from "../../utils";
 import FormGroup from "../../commonComponents/FormGroup";
 import {
-  allPersonErrors,
   personSchema,
   PersonErrors,
   personUpdateSchema,
   selfRegistrationSchema,
   PersonUpdateFields,
+  getPersonErrors,
 } from "../personSchema";
 import YesNoRadioGroup from "../../commonComponents/YesNoRadioGroup";
 import Input from "../../commonComponents/Input";
@@ -114,6 +111,7 @@ const PersonForm = (props: Props) => {
 
   const { t } = useTranslation();
 
+  const allPersonErrors: Required<PersonErrors> = getPersonErrors(t);
   const clearError = useCallback(
     (field: keyof PersonErrors) => {
       if (errors[field]) {
@@ -135,7 +133,7 @@ const PersonForm = (props: Props) => {
         }));
       }
     },
-    [patient, clearError, schema]
+    [patient, clearError, schema, allPersonErrors]
   );
 
   const onPersonChange = <K extends keyof PersonFormData>(field: K) => (
@@ -230,6 +228,13 @@ const PersonForm = (props: Props) => {
     getValidationStatus: validationStatus,
     errors: errors,
   };
+
+  const {
+    RACE_VALUES,
+    ETHNICITY_VALUES,
+    GENDER_VALUES,
+    ROLE_VALUES,
+  } = useTranslatedConstants(t);
 
   return (
     <>

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -1,6 +1,7 @@
 import * as yup from "yup";
 import { PhoneNumberUtil } from "google-libphonenumber";
 import moment from "moment";
+import { TFunction } from "i18next";
 
 import {
   RACE_VALUES,
@@ -13,7 +14,6 @@ import {
 } from "../constants";
 import { Option } from "../commonComponents/Dropdown";
 import { languages } from "../../config/constants";
-import i18n from "../../i18n";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
 
@@ -169,38 +169,42 @@ export const selfRegistrationSchema: yup.SchemaOf<SelfRegistationFields> = yup.o
 
 export type PersonErrors = Partial<Record<keyof PersonFormData, string>>;
 
-export const allPersonErrors: Required<PersonErrors> = {
-  firstName: i18n.t("patient.form.errors.firstName"),
-  middleName: i18n.t("patient.form.errors.middleName"),
-  lastName: i18n.t("patient.form.errors.lastName"),
-  lookupId: i18n.t("patient.form.errors.lookupId"),
-  role: i18n.t("patient.form.errors.role"),
-  facilityId: i18n.t("patient.form.errors.facilityId"),
-  birthDate: i18n.t("patient.form.errors.birthDate"),
-  telephone: i18n.t("patient.form.errors.telephone"),
-  phoneNumbers: i18n.t("patient.form.errors.phoneNumbers"),
-  email: i18n.t("patient.form.errors.email"),
-  street: i18n.t("patient.form.errors.street"),
-  streetTwo: i18n.t("patient.form.errors.streetTwo"),
-  zipCode: i18n.t("patient.form.errors.zipCode"),
-  state: i18n.t("patient.form.errors.state"),
-  city: i18n.t("patient.form.errors.city"),
-  county: i18n.t("patient.form.errors.county"),
-  race: i18n.t("patient.form.errors.race"),
-  tribalAffiliation: i18n.t("patient.form.errors.tribalAffiliation"),
-  ethnicity: i18n.t("patient.form.errors.ethnicity"),
-  gender: i18n.t("patient.form.errors.gender"),
-  residentCongregateSetting: i18n.t(
-    "patient.form.errors.residentCongregateSetting"
-  ),
-  employedInHealthcare: i18n.t("patient.form.errors.employedInHealthcare"),
-  preferredLanguage: i18n.t("patient.form.errors.preferredLanguage"),
-  testResultDelivery: i18n.t("patient.form.errors.testResultDelivery"),
+export const getPersonErrors = (t: TFunction) => {
+  return {
+    firstName: t("patient.form.errors.firstName"),
+    middleName: t("patient.form.errors.middleName"),
+    lastName: t("patient.form.errors.lastName"),
+    lookupId: t("patient.form.errors.lookupId"),
+    role: t("patient.form.errors.role"),
+    facilityId: t("patient.form.errors.facilityId"),
+    birthDate: t("patient.form.errors.birthDate"),
+    telephone: t("patient.form.errors.telephone"),
+    phoneNumbers: t("patient.form.errors.phoneNumbers"),
+    email: t("patient.form.errors.email"),
+    street: t("patient.form.errors.street"),
+    streetTwo: t("patient.form.errors.streetTwo"),
+    zipCode: t("patient.form.errors.zipCode"),
+    state: t("patient.form.errors.state"),
+    city: t("patient.form.errors.city"),
+    county: t("patient.form.errors.county"),
+    race: t("patient.form.errors.race"),
+    tribalAffiliation: t("patient.form.errors.tribalAffiliation"),
+    ethnicity: t("patient.form.errors.ethnicity"),
+    gender: t("patient.form.errors.gender"),
+    residentCongregateSetting: t(
+      "patient.form.errors.residentCongregateSetting"
+    ),
+    employedInHealthcare: t("patient.form.errors.employedInHealthcare"),
+    preferredLanguage: t("patient.form.errors.preferredLanguage"),
+    testResultDelivery: t("patient.form.errors.testResultDelivery"),
+  };
 };
 
 export type PhoneNumberErrors = Partial<Record<keyof PhoneNumber, string>>;
 
-export const allPhoneNumberErrors: Required<PhoneNumberErrors> = {
-  number: i18n.t("patient.form.errors.telephone"),
-  type: "Phone type is missing or invalid",
+export const getAllPhoneNumberErrors = (t: TFunction) => {
+  return {
+    number: t("patient.form.errors.telephone"),
+    type: "Phone type is missing or invalid",
+  };
 };

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -2,6 +2,7 @@ import * as yup from "yup";
 import { PhoneNumberUtil } from "google-libphonenumber";
 import moment from "moment";
 import { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
 
 import {
   RACE_VALUES,
@@ -169,7 +170,9 @@ export const selfRegistrationSchema: yup.SchemaOf<SelfRegistationFields> = yup.o
 
 export type PersonErrors = Partial<Record<keyof PersonFormData, string>>;
 
-export const getPersonErrors = (t: TFunction) => {
+export const usePersonErrors = () => {
+  const { t } = useTranslation();
+
   return {
     firstName: t("patient.form.errors.firstName"),
     middleName: t("patient.form.errors.middleName"),

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -220,27 +220,33 @@ export const es: LanguageConfig = {
       testDevice: "Dispositivo de prueba",
       meaning: "¿Qué significa mi resultado?",
       information:
-        "Para obtener más información, visite el <0>sitio web de los Centros para el Control y la Prevención de Enfermedades (CDC)</0> o comuníquese con su departamento de salud local.",
+        "Para obtener más información, visite el <0>sitio web de los Centros para el Control y la Prevención de Enfermedades (CDC)</0> o comuníquese con su departamento de " +
+        "salud local.",
       notes: {
         positive: {
           p1:
-            "La mayoría de las personas que contraen COVID-19 pueden recuperarse en casa.  Asegúrese de seguir las directrices de los CDC para las personas que se están recuperando en casa y sus cuidadores, por ejemplo:",
+            "La mayoría de las personas que contraen COVID-19 pueden recuperarse en casa.  Asegúrese de seguir las directrices de los CDC para las personas que se están " +
+            "recuperando en casa y sus cuidadores, por ejemplo:",
           guidelines: {
             li0:
               "Quédese en casa cuando esté enfermo, excepto para recibir atención médica.",
             li1:
               "Autoaíslese durante 10 días completos después de que aparezcan los síntomas (o a partir del día siguiente a la realización de la prueba, si no tiene síntomas).",
             li2:
-              "Si se autoaísla en su casa, donde viven otras personas, use una habitación y un baño separado para los miembros del grupo familiar que estan enfermos (si es posible). Limpie las habitaciones compartidas según sea necesario, para evitar la transmisión del virus",
+              "Si se autoaísla en su casa, donde viven otras personas, use una habitación y un baño separado para los miembros del grupo familiar que estan enfermos " +
+              "(si es posible). Limpie las habitaciones compartidas según sea necesario, para evitar la transmisión del virus",
             li3:
-              "Lávese las manos con frecuencia, con agua y jabón, durante al menos 20 segundos, especialmente después de sonarse la nariz, toser o estornudar; después de ir al baño y antes de comer o preparar alimentos. ",
+              "Lávese las manos con frecuencia, con agua y jabón, durante al menos 20 segundos, especialmente después de sonarse la nariz, toser o estornudar; después de " +
+              "ir al baño y antes de comer o preparar alimentos. ",
             li4:
               "Si no cuenta con agua y jabón, use un desinfectante de manos a base de alcohol que tenga, al menos, un 60 % de alcohol.",
             li5:
-              "Tenga un suministro de mascarillas limpias y desechables. Todos, independientemente de su diagnóstico de COVID-19, deben usar mascarillas mientras estén en la casa.",
+              "Tenga un suministro de mascarillas limpias y desechables. Todos, independientemente de su diagnóstico de COVID-19, deben usar mascarillas mientras estén en la " +
+              "casa.",
           },
           p2:
-            "Esté atento a los síntomas y <0> sepa cuándo buscar atención médica de emergencia</0>. Si alguien presenta alguno de estos síntomas, busque atención médica de emergencia de inmediato:",
+            "Esté atento a los síntomas y <0> sepa cuándo buscar atención médica de emergencia</0>. Si alguien presenta alguno de estos síntomas, busque atención médica de " +
+            "emergencia de inmediato:",
           emergency: {
             li0: "Dificultad para respirar",
             li1: "Dolor o presión persistente en el pecho",
@@ -251,7 +257,8 @@ export const es: LanguageConfig = {
           p3:
             "Llame al 911 o llame primero a su sala de emergencias local: dígale al operador que necesita atención para alguien que tiene o podría tener COVID-19.",
           difficultNewsLink:
-            "Obtener un resultado positivo en la prueba de COVID-19 puede ser una noticia difícil, por lo que es importante tomar <0> medidas para sobrellevar el estrés </0> durante este periodo. Comuníquese con su sistema de apoyo y programe una cita por teléfono o video con un profesional de salud mental si es necesario.",
+            "Obtener un resultado positivo en la prueba de COVID-19 puede ser una noticia difícil, por lo que es importante tomar <0> medidas para sobrellevar el estrés </0> " +
+            "durante este periodo. Comuníquese con su sistema de apoyo y programe una cita por teléfono o video con un profesional de salud mental si es necesario.",
         },
         negative: {
           p0:
@@ -272,73 +279,129 @@ export const es: LanguageConfig = {
         },
         inconclusive: {
           p0:
-            "Un resultado no concluyente no es ni positivo ni negativo. Esto puede suceder debido a problemas en la recolección de la muestra, porque la infección por el virus que causa el COVID-19 se encuentra en una etapa inicial o en el caso de pacientes con COVID-19 que están terminando de recuperarse. Cuando se obtiene un resultado no concluyente, se recomienda recolectar y analizar otra muestra.",
+            "Un resultado no concluyente no es ni positivo ni negativo. Esto puede suceder debido a problemas en la recolección de la muestra, porque la infección por el " +
+            "virus que causa el COVID-19 se encuentra en una etapa inicial o en el caso de pacientes con COVID-19 que están terminando de recuperarse. Cuando se obtiene un " +
+            "resultado no concluyente, se recomienda recolectar y analizar otra muestra.",
           p1:
-            "Programe una cita para que le realicen otra prueba lo antes posible. Si se ha realizado la prueba porque tiene síntomas de COVID-19, se recomienda que se autoaísle hasta que obtenga los resultados de la nueva prueba.",
+            "Programe una cita para que le realicen otra prueba lo antes posible. Si se ha realizado la prueba porque tiene síntomas de COVID-19, se recomienda que se " +
+            "autoaísle hasta que obtenga los resultados de la nueva prueba.",
         },
       },
       tos: {
         header: "Condiciones del servicio",
         introText:
-          "Este centro de pruebas utiliza <0>SimpleReport</0> para gestionar las pruebas de COVID-19 y sus correspondientes notificaciones. Los términos a continuación explican las políticas y condiciones del servicio de SimpleReport.",
+          "Este centro de pruebas utiliza <0>SimpleReport</0> para gestionar las pruebas de COVID-19 y sus correspondientes notificaciones. Los términos a continuación " +
+          "explican las políticas y condiciones del servicio de SimpleReport.",
         consent: "Al aceptar, usted acepta nuestras condiciones del servicio.",
         submit: "Acepto",
         document: {
           intro: {
             p0:
-              "Como Centro de Pruebas (Centro) o su usuario (Usuario del Centro) que accede o utiliza SimpleReport (Aplicación) proporcionado por los Centros para el Control y la Prevención de Enfermedades (CDC) y el Departamento de Salud y Servicios Humanos (HHS) de los EE. UU., en un entorno de nube de los CDC (“Plataforma de los CDC”), usted reconoce y acepta que es el único responsable del cumplimiento de estas Condiciones del Servicio, así como de cualquier sección pertinente de las <0>Políticas de Privacidad de los CDC</0> (colectivamente, las Condiciones).",
+              "Como Centro de Pruebas (Centro) o su usuario (Usuario del Centro) que accede o utiliza SimpleReport (Aplicación) proporcionado por los Centros para el Control " +
+              "y la Prevención de Enfermedades (CDC) y el Departamento de Salud y Servicios Humanos (HHS) de los EE. UU., en un entorno de nube de los CDC (“Plataforma de los " +
+              "CDC”), usted reconoce y acepta que es el único responsable del cumplimiento de estas Condiciones del Servicio, así como de cualquier sección pertinente de las " +
+              "<0>Políticas de Privacidad de los CDC</0> (colectivamente, las Condiciones).",
           },
           scope: {
             heading: "Alcance",
             p0:
-              "SimpleReport es una herramienta gratuita que facilita a los centros de pruebas de la enfermedad del coronavirus 2019 (COVID-19) el registro de los resultados de las pruebas rápidas en los puntos de atención y la notificación rápida de los datos necesarios a los departamentos de salud pública. Esta Aplicación es proporcionada por el HHS y los CDC para permitir que un Centro registre su flujo de trabajo de pruebas, según las necesidades de mantenimiento de registros y para enviar los datos de pruebas relevantes y necesarios a las autoridades de salud pública estatales, locales, tribales y territoriales (agencias de salud pública estatales, tribales, locales y territoriales) para promover las actividades de respuesta de salud pública relacionadas con el COVID-19. También permite al Centro designar a ciertos usuarios de los datos, según se establece en estas Condiciones. La Aplicación a través de la cual interactúa con datos de salud pública relevantes está sujeta a estas Condiciones. El uso de la Aplicación constituye la aceptación de estas Condiciones.",
+              "SimpleReport es una herramienta gratuita que facilita a los centros de pruebas de la enfermedad del coronavirus 2019 (COVID-19) el registro de los resultados de " +
+              "las pruebas rápidas en los puntos de atención y la notificación rápida de los datos necesarios a los departamentos de salud pública. Esta Aplicación es " +
+              "proporcionada por el HHS y los CDC para permitir que un Centro registre su flujo de trabajo de pruebas, según las necesidades de mantenimiento de registros y " +
+              "para enviar los datos de pruebas relevantes y necesarios a las autoridades de salud pública estatales, locales, tribales y territoriales (agencias de salud " +
+              "pública estatales, tribales, locales y territoriales) para promover las actividades de respuesta de salud pública relacionadas con el COVID-19. También permite " +
+              "al Centro designar a ciertos usuarios de los datos, según se establece en estas Condiciones. La Aplicación a través de la cual interactúa con datos de salud " +
+              "pública relevantes está sujeta a estas Condiciones. El uso de la Aplicación constituye la aceptación de estas Condiciones.",
           },
           dataRights: {
             heading: "Derechos y uso de los datos",
             subheading: "Cuentas/Inscripción",
             l0: "Usuarios de los centros en general",
             p0:
-              "Si usted utiliza la Aplicación en nombre de un Centro, usted declara y garantiza que tiene autoridad para obligar a ese Centro a cumplir las Condiciones y, al aceptarlas, lo hace en nombre de ese Centro (y todas las referencias a “usted” en las Condiciones se refieren a usted y a ese Centro). Para acceder a la Aplicación, como parte del proceso de inscripción en la Aplicación, y para su uso continuo de la Aplicación, es posible que deba proporcionar cierta información (como identificación o detalles de contacto). Dicha información que proporcione a los CDC o al HHS debe ser precisa y estar actualizada, y debe informarnos de inmediato sobre cualquier actualización para que podamos mantenerlo informado sobre cualquier cambio en la Aplicación o en estas Condiciones que pueda afectar su uso de la Aplicación. Una vez completadas la inscripción del Centro y la creación de cuentas de Usuario del Centro dentro de la Aplicación, el HHS o los CDC le entregarán credenciales (como contraseñas, claves, tokens e identificaciones [ID] del Centro y del Usuario del Centro). Estas credenciales están destinadas a ser utilizadas únicamente por usted y para identificar cualquier software o API que esté utilizando. Usted acepta mantener la confidencialidad de sus credenciales y realizar los esfuerzos razonables para evitar que otras personas utilicen sus credenciales y disuadirlas para que no lo hagan.",
+              "Si usted utiliza la Aplicación en nombre de un Centro, usted declara y garantiza que tiene autoridad para obligar a ese Centro a cumplir las Condiciones y, al " +
+              "aceptarlas, lo hace en nombre de ese Centro (y todas las referencias a “usted” en las Condiciones se refieren a usted y a ese Centro). Para acceder a la " +
+              "Aplicación, como parte del proceso de inscripción en la Aplicación, y para su uso continuo de la Aplicación, es posible que deba proporcionar cierta información " +
+              "(como identificación o detalles de contacto). Dicha información que proporcione a los CDC o al HHS debe ser precisa y estar actualizada, y debe informarnos de " +
+              "inmediato sobre cualquier actualización para que podamos mantenerlo informado sobre cualquier cambio en la Aplicación o en estas Condiciones que pueda afectar " +
+              "su uso de la Aplicación. Una vez completadas la inscripción del Centro y la creación de cuentas de Usuario del Centro dentro de la Aplicación, el HHS o los CDC " +
+              "le entregarán credenciales (como contraseñas, claves, tokens e identificaciones [ID] del Centro y del Usuario del Centro). Estas credenciales están destinadas a " +
+              "ser utilizadas únicamente por usted y para identificar cualquier software o API que esté utilizando. Usted acepta mantener la confidencialidad de sus " +
+              "credenciales y realizar los esfuerzos razonables para evitar que otras personas utilicen sus credenciales y disuadirlas para que no lo hagan.",
             l1: "Usuario administrador",
             p1:
-              "Una vez completada la inscripción del Centro (y de forma continua, según sea necesario), el Centro debe designar al menos a un usuario del Centro como Administrador. Este Administrador tendrá una verificación de identidad más detallada. Una vez que el Administrador haya verificado su identidad, podrá añadir otros Usuarios del Centro a la aplicación. El Administrador acepta verificar la identidad de los Usuarios del Centro que se añadan y desactivar a los Usuarios del Centro que ya no deban tener acceso. El Administrador también acepta establecer permisos de manera adecuada para determinar el acceso mínimo necesario para que los Usuarios del Centro completen sus tareas laborales requeridas.",
+              "Una vez completada la inscripción del Centro (y de forma continua, según sea necesario), el Centro debe designar al menos a un usuario del Centro como " +
+              "Administrador. Este Administrador tendrá una verificación de identidad más detallada. Una vez que el Administrador haya verificado su identidad, podrá añadir " +
+              "otros Usuarios del Centro a la aplicación. El Administrador acepta verificar la identidad de los Usuarios del Centro que se añadan y desactivar a los Usuarios " +
+              "del Centro que ya no deban tener acceso. El Administrador también acepta establecer permisos de manera adecuada para determinar el acceso mínimo necesario para " +
+              "que los Usuarios del Centro completen sus tareas laborales requeridas.",
           },
           privacy: {
             heading: "Privacidad",
             p0:
-              "Usted puede utilizar la Aplicación para buscar, mostrar, analizar, recuperar, visualizar y, en general, “obtener” información de los datos que envía a través de la Aplicación y la Plataforma. Tenga en cuenta que los datos que envía a través de la Aplicación pueden estar sujetos a la Ley de Privacidad de 1974, la Ley de Portabilidad y Responsabilidad del Seguro Médico (HIPAA) de 1996 y otras leyes, y requiere protección especial. Al acceder y utilizar la Aplicación, usted acepta cumplir estrictamente todas las leyes federales y estatales aplicables con respecto a la recolección, el uso, la protección y la divulgación de la información obtenida o enviada a través de la Aplicación. Si desea obtener más información sobre la aplicación de la Ley de Privacidad en los CDC, <0>haga clic aquí</0>.",
+              "Usted puede utilizar la Aplicación para buscar, mostrar, analizar, recuperar, visualizar y, en general, “obtener” información de los datos que envía a través " +
+              "de la Aplicación y la Plataforma. Tenga en cuenta que los datos que envía a través de la Aplicación pueden estar sujetos a la Ley de Privacidad de 1974, la " +
+              "Ley de Portabilidad y Responsabilidad del Seguro Médico (HIPAA) de 1996 y otras leyes, y requiere protección especial. Al acceder y utilizar la Aplicación, " +
+              "usted acepta cumplir estrictamente todas las leyes federales y estatales aplicables con respecto a la recolección, el uso, la protección y la divulgación de " +
+              "la información obtenida o enviada a través de la Aplicación. Si desea obtener más información sobre la aplicación de la Ley de Privacidad en los CDC, " +
+              "<0>haga clic aquí</0>.",
             p1:
-              "Para los fines del uso de esta Aplicación, si usted es una entidad cubierta por la HIPAA o actúa en nombre de una como socio comercial o si los datos se mantienen en un conjunto de registros designados y cubiertos por la HIPAA, usted reconoce además que cumplirá con la normativa aplicable de la HIPAA (Código de Regulaciones Federales [CFR], Título 45, Partes 160 y 164) para los fines de almacenamiento, transmisión, uso y divulgación adecuados de cualquier información de salud protegida.",
+              "Para los fines del uso de esta Aplicación, si usted es una entidad cubierta por la HIPAA o actúa en nombre de una como socio comercial o si los datos se " +
+              "mantienen en un conjunto de registros designados y cubiertos por la HIPAA, usted reconoce además que cumplirá con la normativa aplicable de la HIPAA " +
+              "(Código de Regulaciones Federales [CFR], Título 45, Partes 160 y 164) para los fines de almacenamiento, transmisión, uso y divulgación adecuados de " +
+              "cualquier información de salud protegida.",
           },
           useOfData: {
             heading: "Uso de datos",
             p0:
-              "Esta Aplicación se proporciona con el fin de permitir el registro del flujo de trabajo de las pruebas de los Centros y las necesidades de mantenimiento de registros, y para el envío de los datos relevantes a las agencias de salud pública estatales, tribales, locales y territoriales en apoyo de las actividades de respuesta de salud pública relacionadas con la pandemia de COVID-19. El HHS y los CDC reconocen que, si bien los CDC proporcionan la Plataforma, no tienen la intención de acceder a los datos ni de revisarlos o analizarlos. Por ello, los CDC no tienen la intención de asumir la custodia o el control de los datos enviados a través de la Aplicación. El Usuario del Centro reconoce y acepta que los CDC y los Usuarios Administrativos pueden gestionar los datos enviados a través de la Aplicación con el fin de operar la Plataforma de los CDC y transmitir dichos datos a las agencias de salud pública estatales, tribales, locales y territoriales, y facilitar su uso. Salvo que lo exija la ley federal aplicable, los CDC no pueden divulgar los datos enviados a través de la Aplicación para otros fines que no sean los descritos a continuación. En caso de que se solicite la divulgación de datos a los CDC, los CDC notificarán al solicitante que los CDC no tienen acceso a estos datos y remitirán al solicitante al Centro.",
+              "Esta Aplicación se proporciona con el fin de permitir el registro del flujo de trabajo de las pruebas de los Centros y las necesidades de mantenimiento de " +
+              "registros, y para el envío de los datos relevantes a las agencias de salud pública estatales, tribales, locales y territoriales en apoyo de las actividades " +
+              "de respuesta de salud pública relacionadas con la pandemia de COVID-19. El HHS y los CDC reconocen que, si bien los CDC proporcionan la Plataforma, no tienen " +
+              "la intención de acceder a los datos ni de revisarlos o analizarlos. Por ello, los CDC no tienen la intención de asumir la custodia o el control de los datos " +
+              "enviados a través de la Aplicación. El Usuario del Centro reconoce y acepta que los CDC y los Usuarios Administrativos pueden gestionar los datos enviados a " +
+              "través de la Aplicación con el fin de operar la Plataforma de los CDC y transmitir dichos datos a las agencias de salud pública estatales, tribales, locales " +
+              "y territoriales, y facilitar su uso. Salvo que lo exija la ley federal aplicable, los CDC no pueden divulgar los datos enviados a través de la Aplicación para " +
+              "otros fines que no sean los descritos a continuación. En caso de que se solicite la divulgación de datos a los CDC, los CDC notificarán al solicitante que los " +
+              "CDC no tienen acceso a estos datos y remitirán al solicitante al Centro.",
           },
           sharingOfData: {
             heading: "Intercambio de datos",
             p0:
-              "Los datos registrados y almacenados en la Aplicación son para que el Centro los utilice según sea necesario para el flujo de trabajo, el mantenimiento de registros y el envío de notificaciones. Todos los resultados de las pruebas de COVID-19 se notificarán automáticamente a la agencia de salud pública estatal, tribal, local o territorial correspondiente en función tanto del código postal del centro de pruebas como del código postal del paciente, incluidos todos los campos relevantes según lo definido en los <0>requisitos de notificación del HHS sobre el COVID-19 para los laboratorios</0>. Al ingresar los resultados que se notifican a la agencia de salud pública estatal, tribal, local o territorial, el Centro certifica que está autorizado a notificar los datos a través de la Aplicación. Aunque los CDC no accederán activamente a la Aplicación ni obtendrán datos de esta, el Centro, directamente o en coordinación con la agencia de salud pública estatal, tribal, local o territorial correspondiente, puede decidir utilizar la Aplicación para enviar datos sin información identificadora a los CDC; dichos datos enviados a los CDC se mantendrán de acuerdo con las leyes federales aplicables.",
+              "Los datos registrados y almacenados en la Aplicación son para que el Centro los utilice según sea necesario para el flujo de trabajo, el mantenimiento de " +
+              "registros y el envío de notificaciones. Todos los resultados de las pruebas de COVID-19 se notificarán automáticamente a la agencia de salud pública estatal, " +
+              "tribal, local o territorial correspondiente en función tanto del código postal del centro de pruebas como del código postal del paciente, incluidos todos los " +
+              "campos relevantes según lo definido en los <0>requisitos de notificación del HHS sobre el COVID-19 para los laboratorios</0>. Al ingresar los resultados que " +
+              "se notifican a la agencia de salud pública estatal, tribal, local o territorial, el Centro certifica que está autorizado a notificar los datos a través de la " +
+              "Aplicación. Aunque los CDC no accederán activamente a la Aplicación ni obtendrán datos de esta, el Centro, directamente o en coordinación con la agencia de " +
+              "salud pública estatal, tribal, local o territorial correspondiente, puede decidir utilizar la Aplicación para enviar datos sin información identificadora a " +
+              "los CDC; dichos datos enviados a los CDC se mantendrán de acuerdo con las leyes federales aplicables.",
           },
           otherResponsibilities: {
             heading: "Otras responsabilidades",
             ul: {
               li0:
-                "Usted será plenamente responsable de todos los datos que envíe y cooperará con los CDC o sus agentes en caso de que los CDC tengan una inquietud de seguridad con respecto a cualquier consulta, envío o recepción de datos hacia o desde los CDC.",
+                "Usted será plenamente responsable de todos los datos que envíe y cooperará con los CDC o sus agentes en caso de que los CDC tengan una inquietud de seguridad " +
+                "con respecto a cualquier consulta, envío o recepción de datos hacia o desde los CDC.",
               li1:
-                "Informará de inmediato a los CDC en caso de que detecte un uso indebido de la información de salud individualmente identificable o de la información de salud protegida que envíe o a la que acceda desde la Plataforma de los CDC.",
+                "Informará de inmediato a los CDC en caso de que detecte un uso indebido de la información de salud individualmente identificable o de la información de salud " +
+                "protegida que envíe o a la que acceda desde la Plataforma de los CDC.",
               li2:
                 "Informará de inmediato a los CDC en caso de que ya no pueda cumplir con cualquiera de las disposiciones establecidas en estas Condiciones.",
               li3:
                 "Usted cesará inmediatamente el uso de la Aplicación cuando deje de cumplir cualquiera de los términos de estas Condiciones.",
               li4:
-                "Debe cumplir con las medidas de seguridad básicas de escritorio para garantizar la seguridad de cualquier información individualmente identificable o información de salud protegida a la que tenga acceso en la Aplicación.",
+                "Debe cumplir con las medidas de seguridad básicas de escritorio para garantizar la seguridad de cualquier información individualmente identificable o " +
+                "información de salud protegida a la que tenga acceso en la Aplicación.",
               li5:
-                "Según lo exija la ley aplicable, usted acepta obtener el consentimiento y notificar a las personas cuyos datos se ingresarán en la Aplicación que su información personal se recopilará y utilizará con fines de salud pública.",
+                "Según lo exija la ley aplicable, usted acepta obtener el consentimiento y notificar a las personas cuyos datos se ingresarán en la Aplicación que su " +
+                "información personal se recopilará y utilizará con fines de salud pública.",
               li6:
-                "Cuando se realicen cambios importantes en la Aplicación o Plataforma (p. ej., la divulgación o los usos de datos hayan cambiado desde la notificación en el momento de la recopilación original), se le notificará por medio de un correo electrónico, y usted será responsable de notificar y obtener el consentimiento de las personas cuya información de salud protegida o individualmente identificable se encuentre en la Aplicación.",
+                "Cuando se realicen cambios importantes en la Aplicación o Plataforma (p. ej., la divulgación o los usos de datos hayan cambiado desde la notificación en " +
+                "el momento de la recopilación original), se le notificará por medio de un correo electrónico, y usted será responsable de notificar y obtener el " +
+                "consentimiento de las personas cuya información de salud protegida o individualmente identificable se encuentre en la Aplicación.",
               li7:
-                "En el improbable caso de que se produzca una intromisión que pueda comprometer la seguridad de la información, se deberá notificar a las personas cuya información de salud protegida o individualmente identificable se encuentre en la Aplicación y que se vea afectada por dicha intromisión. Los CDC pueden ofrecer asistencia para ayudar en este proceso.",
+                "En el improbable caso de que se produzca una intromisión que pueda comprometer la seguridad de la información, se deberá notificar a las personas cuya " +
+                "información de salud protegida o individualmente identificable se encuentre en la Aplicación y que se vea afectada por dicha intromisión. Los CDC pueden " +
+                "ofrecer asistencia para ayudar en este proceso.",
               li8:
                 "Usted está obligado a garantizar que cualquier persona que utilice la Aplicación haya recibido capacitación sobre el manejo de información sensible y personal.",
             },
@@ -347,30 +410,52 @@ export const es: LanguageConfig = {
             heading: "Gestión de servicios",
             subheading: "Derecho a limitar",
             p0:
-              "El uso que usted haga de la Aplicación puede estar sujeto a ciertas limitaciones de acceso o uso, tal y como se establece en estas Condiciones o en otras disposiciones de los CDC. Estas limitaciones están diseñadas para gestionar la carga en el sistema, promover el acceso equitativo y garantizar la protección adecuada de la privacidad, y estas limitaciones pueden ajustarse sin previo aviso, según lo consideren necesario los CDC. Si los CDC consideran razonablemente que usted ha intentado sobrepasar o eludir estos límites, su capacidad para utilizar la Aplicación puede ser bloqueada de forma temporal o permanente. Los CDC pueden monitorear el uso que usted hace de la Aplicación para mejorar el servicio o para garantizar el cumplimiento de estas Condiciones y se reservan el derecho de denegar a cualquier usuario el acceso a la Aplicación a su discreción razonable.",
+              "El uso que usted haga de la Aplicación puede estar sujeto a ciertas limitaciones de acceso o uso, tal y como se establece en estas Condiciones o en otras " +
+              "disposiciones de los CDC. Estas limitaciones están diseñadas para gestionar la carga en el sistema, promover el acceso equitativo y garantizar la protección " +
+              "adecuada de la privacidad, y estas limitaciones pueden ajustarse sin previo aviso, según lo consideren necesario los CDC. Si los CDC consideran razonablemente " +
+              "que usted ha intentado sobrepasar o eludir estos límites, su capacidad para utilizar la Aplicación puede ser bloqueada de forma temporal o permanente. Los " +
+              "CDC pueden monitorear el uso que usted hace de la Aplicación para mejorar el servicio o para garantizar el cumplimiento de estas Condiciones y se reservan el " +
+              "derecho de denegar a cualquier usuario el acceso a la Aplicación a su discreción razonable.",
           },
           serviceTermination: {
             heading: "Cancelación del servicio",
             p0:
               "Si desea cancelar su acceso y uso de la Aplicación, puede hacerlo desactivando su cuenta o absteniéndose de seguir utilizando la Aplicación.",
             p1:
-              "Los CDC se reservan el derecho (aunque no la obligación) de (1) negarse a proporcionarle la Aplicación, si los CDC consideran que su uso infringe cualquier ley federal o política de los CDC; o (2) cancelar o denegarle el acceso y el uso de la totalidad o parte de la Aplicación en cualquier momento y por cualquier motivo que, a entera discreción de los CDC, consideren necesario, incluso para evitar la infracción de la ley federal o la política de los CDC. Puede solicitar a los CDC que le vuelvan a dar acceso a la Aplicación a través de la dirección de correo electrónico de soporte proporcionada por los CDC para la Aplicación. Si los CDC determinan, a su entera discreción, que ya no existen las circunstancias que dieron lugar a la denegación para proporcionar la Aplicación o cancelar el acceso a la Aplicación, entonces los CDC podrán restablecer su acceso. Todas las disposiciones de estas Condiciones, que por su naturaleza deben continuar vigentes después de la cancelación, continuarán vigentes después de la cancelación incluidas, sin limitación, las renuncias de garantía y las limitaciones de responsabilidad.",
+              "Los CDC se reservan el derecho (aunque no la obligación) de (1) negarse a proporcionarle la Aplicación, si los CDC consideran que su uso infringe cualquier ley " +
+              "federal o política de los CDC; o (2) cancelar o denegarle el acceso y el uso de la totalidad o parte de la Aplicación en cualquier momento y por cualquier motivo " +
+              "que, a entera discreción de los CDC, consideren necesario, incluso para evitar la infracción de la ley federal o la política de los CDC. Puede solicitar a los " +
+              "CDC que le vuelvan a dar acceso a la Aplicación a través de la dirección de correo electrónico de soporte proporcionada por los CDC para la Aplicación. Si los " +
+              "CDC determinan, a su entera discreción, que ya no existen las circunstancias que dieron lugar a la denegación para proporcionar la Aplicación o cancelar el " +
+              "acceso a la Aplicación, entonces los CDC podrán restablecer su acceso. Todas las disposiciones de estas Condiciones, que por su naturaleza deben continuar " +
+              "vigentes después de la cancelación, continuarán vigentes después de la cancelación incluidas, sin limitación, las renuncias de garantía y las limitaciones " +
+              "de responsabilidad.",
           },
           intellectualProperty: {
             heading:
               "Propiedad intelectual: concesión de licencias y restricciones.",
             p0:
-              "La Aplicación proporcionada al Usuario es para su uso. El Usuario no puede modificar, copiar, distribuir, transmitir, mostrar, realizar, reproducir, publicar, licenciar, crear trabajos derivados, transferir o vender ninguna información, software, productos o servicios obtenidos de los CDC. El material proporcionado por los CDC es propiedad del Departamento de Salud y Servicios Humanos (“HHS”) de los Estados Unidos y de los Centros para el Control y la Prevención de Enfermedades (CDC) o está autorizado por estos. El HHS/los CDC le otorgan una licencia limitada, no exclusiva e intransferible para acceder a la Aplicación en los Estados Unidos para los usos establecidos en estas Condiciones.",
+              "La Aplicación proporcionada al Usuario es para su uso. El Usuario no puede modificar, copiar, distribuir, transmitir, mostrar, realizar, reproducir, publicar, " +
+              "licenciar, crear trabajos derivados, transferir o vender ninguna información, software, productos o servicios obtenidos de los CDC. El material proporcionado " +
+              "por los CDC es propiedad del Departamento de Salud y Servicios Humanos (“HHS”) de los Estados Unidos y de los Centros para el Control y la Prevención de " +
+              "Enfermedades (CDC) o está autorizado por estos. El HHS/los CDC le otorgan una licencia limitada, no exclusiva e intransferible para acceder a la Aplicación " +
+              "en los Estados Unidos para los usos establecidos en estas Condiciones.",
           },
           disclaimerOfWarranties: {
             heading: "Descargo de responsabilidad de garantía",
             p0:
-              "La Plataforma de la Aplicación se proporciona “tal cual” y “según disponibilidad”. Si bien los CDC harán todo lo posible para garantizar que el servicio esté disponible y funcione en todo momento, por la presente, los CDC rechazan todas las garantías de cualquier tipo, expresas o implícitas, incluidas, sin limitación, las garantías de comercialización, idoneidad para un fin determinado y no infracción. Los CDC no garantizan que los datos estarán libres de errores o que el acceso a ellos será continuo o ininterrumpido.",
+              "La Plataforma de la Aplicación se proporciona “tal cual” y “según disponibilidad”. Si bien los CDC harán todo lo posible para garantizar que el servicio esté " +
+              "disponible y funcione en todo momento, por la presente, los CDC rechazan todas las garantías de cualquier tipo, expresas o implícitas, incluidas, sin " +
+              "limitación, las garantías de comercialización, idoneidad para un fin determinado y no infracción. Los CDC no garantizan que los datos estarán libres de " +
+              "errores o que el acceso a ellos será continuo o ininterrumpido.",
           },
           limitationOfLiability: {
             heading: "Limitaciones de responsabilidad",
             p0:
-              "En ningún caso el HHS o los CDC serán responsables con respecto a cualquier cuestión abordada en estas Condiciones o el uso que usted haga de la Aplicación en virtud de cualquier contrato, negligencia, responsabilidad estricta u otra teoría legal o equitativa por (1) cualquier lesión personal, o cualquier daño especial, incidental, indirecto o consecuente; (2) el costo de la adquisición de productos o servicios sustitutos; o (3) por pérdida de ganancias, interrupción de uso o pérdida o corrupción de datos o cualquier otro daño o pérdida comercial.",
+              "En ningún caso el HHS o los CDC serán responsables con respecto a cualquier cuestión abordada en estas Condiciones o el uso que usted haga de la Aplicación en " +
+              "virtud de cualquier contrato, negligencia, responsabilidad estricta u otra teoría legal o equitativa por (1) cualquier lesión personal, o cualquier daño " +
+              "especial, incidental, indirecto o consecuente; (2) el costo de la adquisición de productos o servicios sustitutos; o (3) por pérdida de ganancias, interrupción " +
+              "de uso o pérdida o corrupción de datos o cualquier otro daño o pérdida comercial.",
             p1:
               "El HHS y los CDC no son responsables de la confidencialidad ni de ninguna información compartida por el Centro u otro usuario de la Aplicación.",
           },
@@ -378,12 +463,16 @@ export const es: LanguageConfig = {
             heading:
               "Disputas, elección de derecho aplicable, jurisdicción y conflictos",
             p0:
-              "Cualquier disputa que surja de estas Condiciones y del acceso o uso de la Aplicación se regirá por la legislación federal aplicable de los Estados Unidos. Asimismo, usted acepta y está de acuerdo con la jurisdicción de los tribunales federales ubicados dentro del Distrito de Columbia y los tribunales de apelación de ese lugar, y renuncia a cualquier reclamación de falta de jurisdicción o <em>forum non conveniens.</em>",
+              "Cualquier disputa que surja de estas Condiciones y del acceso o uso de la Aplicación se regirá por la legislación federal aplicable de los Estados Unidos. " +
+              "Asimismo, usted acepta y está de acuerdo con la jurisdicción de los tribunales federales ubicados dentro del Distrito de Columbia y los tribunales de apelación " +
+              "de ese lugar, y renuncia a cualquier reclamación de falta de jurisdicción o <em>forum non conveniens.</em>",
           },
           indemnification: {
             heading: "Indemnización",
             p0:
-              "Usted acepta indemnizar y eximir de responsabilidad al HHS, incluidos los CDC, sus contratistas, empleados, agentes y similares, de y contra cualquier reclamación y gasto, incluidos los honorarios de los abogados, que surjan del uso que usted haga de la Aplicación, lo que incluye, entre otras cosas, la infracción de estas Condiciones.",
+              "Usted acepta indemnizar y eximir de responsabilidad al HHS, incluidos los CDC, sus contratistas, empleados, agentes y similares, de y contra cualquier " +
+              "reclamación y gasto, incluidos los honorarios de los abogados, que surjan del uso que usted haga de la Aplicación, lo que incluye, entre otras cosas, la " +
+              "infracción de estas Condiciones.",
           },
           noWaiverOfRights: {
             heading: "Sin renuncia a derechos",
@@ -393,7 +482,11 @@ export const es: LanguageConfig = {
           dataAnalytics: {
             heading: "Análisis de datos y métricas de seguimiento",
             p0:
-              "Durante el uso de la Aplicación, es posible que se recopilen y almacenen automáticamente ciertos datos generales de análisis sobre los patrones de uso y el rendimiento de la Aplicación para ayudar con su diseño y desarrollo. Estos datos de uso general no están vinculados a la identidad de una persona, pero es posible que se incluya la dirección IP y la información del dispositivo. Las transacciones se revisan y almacenan para el monitoreo, el rendimiento y la resolución de problemas del sitio y pueden estar vinculadas a la persona que realiza una actividad. Estos datos se mantendrán de acuerdo con las leyes federales aplicables.",
+              "Durante el uso de la Aplicación, es posible que se recopilen y almacenen automáticamente ciertos datos generales de análisis sobre los patrones de uso y el " +
+              "rendimiento de la Aplicación para ayudar con su diseño y desarrollo. Estos datos de uso general no están vinculados a la identidad de una persona, pero es " +
+              "posible que se incluya la dirección IP y la información del dispositivo. Las transacciones se revisan y almacenan para el monitoreo, el rendimiento y la " +
+              "resolución de problemas del sitio y pueden estar vinculadas a la persona que realiza una actividad. Estos datos se mantendrán de acuerdo con las leyes " +
+              "federales aplicables.",
           },
         },
       },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -203,7 +203,7 @@ export const es: LanguageConfig = {
       },
       confirmation: {
         registered:
-          "<0>{{personName}}</0>, gracias por completar su perfil de paciente en {{nombre del centro de pruebas}}.",
+          "<0>{{personName}}</0>, gracias por completar su perfil de paciente en {{entityName}}.",
         checkIn:
           "Cuando llegue para su examen, regístrese dando su nombre y apellido.",
       },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -205,7 +205,7 @@ export const es: LanguageConfig = {
         registered:
           "<0>{{personName}}</0>, gracias por completar su perfil de paciente en {{entityName}}.",
         checkIn:
-          "Cuando llegue para su examen, regístrese dando su nombre y apellido.",
+          "Cuando llegue para su prueba, regístrese dando su nombre y apellido.",
       },
     },
     testResult: {
@@ -402,7 +402,7 @@ export const es: LanguageConfig = {
         enterDOB: "Ingrese su fecha de nacimiento",
         enterDOB2:
           "Ingrese su fecha de nacimiento para acceder a su portal de pruebas de COVID-19.",
-        format: "MM/DD/AAAA or MMDDAAAA",
+        format: "MM/DD/AAAA o MMDDAAAA",
         error:
           "No se encontró el resultado de la prueba o la fecha de nacimiento proporcionada es incorrecta.",
         validating: "Validación de la fecha de nacimiento...",

--- a/frontend/src/patientApp/PatientHeader.test.tsx
+++ b/frontend/src/patientApp/PatientHeader.test.tsx
@@ -1,0 +1,57 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+
+import PatientHeader from "./PatientHeader";
+
+describe("PatientHeader", () => {
+  const mockStore = configureStore([]);
+  const store = mockStore({
+    facilities: [{ id: "fake-id", name: "123" }],
+  });
+
+  it("matches snapshot", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <PatientHeader />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it("contains language toggler", () => {
+    const { getByText, getByRole } = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <PatientHeader />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    expect(getByText("Español")).toBeInTheDocument();
+    expect(getByRole("button")).toBeInTheDocument();
+  });
+
+  it("language toggler switches display language when clicked", async () => {
+    const { queryByText, getByText, getByRole } = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <PatientHeader />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    expect(getByText("Español")).toBeInTheDocument();
+
+    await act(async () => {
+      await fireEvent.click(getByRole("button"));
+    });
+
+    expect(queryByText("Español")).not.toBeInTheDocument();
+    expect(getByText("English")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -45,7 +45,7 @@ const PatientHeader = () => {
             className="usa-button--unstyled"
             onClick={async () => {
               const displayLanguage = i18n.language === "en" ? "es" : "en";
-              i18n.changeLanguage(displayLanguage);
+              await i18n.changeLanguage(displayLanguage);
             }}
           >
             {i18n.language === "en" ? "Español" : "English"}

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -43,7 +43,7 @@ const PatientHeader = () => {
           <Button
             icon={"globe"}
             className="usa-button--unstyled"
-            onClick={() => {
+            onClick={async () => {
               const displayLanguage = i18n.language === "en" ? "es" : "en";
               i18n.changeLanguage(displayLanguage);
             }}

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -2,6 +2,9 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 import siteLogo from "../img/simplereport-logomark-color.svg";
+import "../styles/fontAwesome";
+import i18n from "../i18n";
+import Button from "../app/commonComponents/Button/Button";
 
 const PatientHeader = () => {
   const organization = useSelector(
@@ -12,7 +15,7 @@ const PatientHeader = () => {
 
   return (
     <header className="border-bottom border-base-lighter">
-      <div className="display-flex flex-align-center maxw-tablet grid-container">
+      <div className="display-flex flex-align-center maxw-tablet grid-container patient-header">
         <div className="padding-y-1">
           <div className="margin-bottom-0" id="basic-logo">
             <div
@@ -35,6 +38,18 @@ const PatientHeader = () => {
               </div>
             </div>
           </div>
+        </div>
+        <div className="display-flex flex-align-end">
+          <Button
+            icon={"globe"}
+            className="usa-button--unstyled"
+            onClick={() => {
+              const displayLanguage = i18n.language === "en" ? "es" : "en";
+              i18n.changeLanguage(displayLanguage);
+            }}
+          >
+            {i18n.language === "en" ? "Español" : "English"}
+          </Button>
         </div>
       </div>
     </header>

--- a/frontend/src/patientApp/__snapshots__/PatientHeader.test.tsx.snap
+++ b/frontend/src/patientApp/__snapshots__/PatientHeader.test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatientHeader matches snapshot 1`] = `
+<div>
+  <header
+    class="border-bottom border-base-lighter"
+  >
+    <div
+      class="display-flex flex-align-center maxw-tablet grid-container patient-header"
+    >
+      <div
+        class="padding-y-1"
+      >
+        <div
+          class="margin-bottom-0"
+          id="basic-logo"
+        >
+          <div
+            aria-label="Home"
+            class="display-flex flex-align-center"
+            title="Home"
+          >
+            <img
+              alt="{process.env.REACT_APP_TITLE}"
+              class="width-4"
+              src="simplereport-logomark-color.svg"
+            />
+            <div
+              class="logo-text margin-left-1 display-flex flex-column"
+            >
+              <span
+                class="prime-organization-name margin-left-0 font-body-md text-primary-darker text-bold"
+              />
+              <span
+                class="prime-organization-name margin-left-0 margin-top-05 text-primary-darker"
+              >
+                COVID-19 Testing Portal
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="display-flex flex-align-end"
+      >
+        <button
+          class="usa-button usa-button--unstyled"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-globe fa-w-16 margin-right-1"
+            data-icon="globe"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 496 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
+              fill="currentColor"
+            />
+          </svg>
+          Español
+        </button>
+      </div>
+    </div>
+  </header>
+</div>
+`;

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -592,6 +592,9 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
 }
 
 // header and navbar customizations
+.patient-header {
+  justify-content: space-between;
+}
 
 .prime-nav {
   justify-content: left;

--- a/frontend/src/styles/fontAwesome.js
+++ b/frontend/src/styles/fontAwesome.js
@@ -26,6 +26,7 @@ import {
   faSignOutAlt,
   faWindowClose,
   faEdit,
+  faGlobe,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(
@@ -53,5 +54,6 @@ library.add(
   faCog,
   faSignOutAlt,
   faWindowClose,
-  faEdit
+  faEdit,
+  faGlobe
 );


### PR DESCRIPTION
## Related Issue or Background Info

Closes #2115 

## Changes Proposed
* Add a button to the patient experience header to toggle the display language between English and Spanish

## Additional Information
- N/A

## Screenshots / Demos
**Self-registration**:

https://user-images.githubusercontent.com/27730981/128412168-efb0673a-3c5a-4d2d-ab82-f4cf99ec0323.mov

https://user-images.githubusercontent.com/27730981/128412134-f93f81de-014a-4d53-999a-d669ba71408a.mov

**View test result**:

https://user-images.githubusercontent.com/27730981/128412271-201758fc-d684-42fb-98f5-e2fe2ce1982d.mov

## Checklist for Author and Reviewer
- [x] @kenieh - everything look good design-wise? How's the placement/size of the icon and text for the toggle?
- [ ] @aliciabeckett-gov - to your knowledge, does this fully satisfy the requirements of this epic?
- [ ] @nickscialli-usds - general technical review. My CSS feels a little gross but hopefully it's OK.
- [ ] @Rebecca-LM - if you notice any mistakes in either the English or Spanish copy, please let me know!

### UI
- [x] Any changes to the UI/UX are approved by design
- [x] Any new or updated content (e.g. error messages) are approved by design

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] ~Database changes are submitted as a separate PR~
  - [x] ~Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~
  - [x] ~Any changes to tables that have custom no-PHI views are accompanied by changes to those views~
        ~(including re-granting permission to the no-PHI user if need be)~
  - [x] ~Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`~
- [x] ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~

## Cloud
- [x] ~DevOps team has been notified if PR requires ops support~
- [x] ~If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification~
