### PR TITLE
Automatically trigger demo/training/prod deploys

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -13,18 +13,6 @@ concurrency:
   group: demo-deploy
 
 jobs:
-  verify-lower-envs-are-released:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./ops
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check that the current release is in the stg environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-stg-commit check-stg-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -1,9 +1,12 @@
 name: Deploy Demo
 
 on:
-  workflow_dispatch:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Deploy Dev,", "Deploy Stg"]
+    branches:
+      - main
+    types:
+      - completed
 
 env:
   DEPLOY_ENV: demo
@@ -13,6 +16,7 @@ concurrency:
 
 jobs:
   verify-lower-envs-are-released:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +32,7 @@ jobs:
             CURL_TIMEOUT: 5
         run: make check-dev-commit check-dev-readiness
   build-docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,6 +46,7 @@ jobs:
       - name: Build and push Docker images
         run: ./build_and_push.sh
   prerelease-backend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: [build-docker, verify-lower-envs-are-released]
     defaults:
@@ -67,6 +73,7 @@ jobs:
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
   build-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: [verify-lower-envs-are-released]
     steps:
@@ -97,6 +104,7 @@ jobs:
           path: client.tgz
           retention-days: 1
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: Demo

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -2,9 +2,7 @@ name: Deploy Demo
 
 on:
   workflow_run:
-    workflows: ["Deploy Dev,", "Deploy Stg"]
-    branches:
-      - main
+    workflows: ["Deploy Stg"]
     types:
       - completed
 
@@ -27,10 +25,6 @@ jobs:
         env:
             CURL_TIMEOUT: 5
         run: make check-stg-commit check-stg-readiness
-      - name: Check that the current release is in the dev environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-dev-commit check-dev-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - jdorothy/auto-prod-deploys
 
 env:
   DEPLOY_ENV: dev
@@ -101,3 +101,14 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
+  verify-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check that the current release is in the dev environment
+        env:
+            CURL_TIMEOUT: 5
+        run: make check-dev-commit check-dev-readiness

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - jdorothy/auto-prod-deploys
+      - main
 
 env:
   DEPLOY_ENV: dev
@@ -109,7 +109,7 @@ jobs:
         working-directory: ./ops
     steps:
       - uses: actions/checkout@v2
-      - name: Check that the current release is in the dev environment
+      - name: Check that the current release is in the ${{env.DEPLOY_ENV}} environment
         env:
             CURL_TIMEOUT: 5
-        run: make check-dev-commit check-dev-readiness
+        run: make check-${{env.DEPLOY_ENV}}-commit check-${{env.DEPLOY_ENV}}-readiness

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -103,6 +103,7 @@ jobs:
           deploy-env: ${{env.DEPLOY_ENV}}
   verify-release:
     runs-on: ubuntu-latest
+    needs: [deploy]
     defaults:
       run:
         working-directory: ./ops

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -32,7 +32,7 @@ jobs:
     defaults:
       run:
         working-directory: ./ops
-    env: # all Azure interaction is through terraform
+    env: # all Azure interaction is through Terraform
       ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -13,18 +13,6 @@ concurrency:
   group: prod-deploy
 
 jobs:
-  verify-lower-envs-are-released:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./ops
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check that the current release is in the stg environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-stg-commit check-stg-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -2,9 +2,7 @@ name: Deploy Prod
 
 on:
   workflow_run:
-    workflows: ["Deploy Dev,", "Deploy Stg"]
-    branches:
-      - main
+    workflows: ["Deploy Stg"]
     types:
       - completed
 
@@ -27,10 +25,6 @@ jobs:
         env:
             CURL_TIMEOUT: 5
         run: make check-stg-commit check-stg-readiness
-      - name: Check that the current release is in the dev environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-dev-commit check-dev-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -1,8 +1,12 @@
 name: Deploy Prod
 
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Deploy Dev,", "Deploy Stg"]
+    branches:
+      - main
+    types:
+      - completed
 
 env:
   DEPLOY_ENV: prod
@@ -12,6 +16,7 @@ concurrency:
 
 jobs:
   verify-lower-envs-are-released:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,6 +32,7 @@ jobs:
             CURL_TIMEOUT: 5
         run: make check-dev-commit check-dev-readiness
   build-docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -40,6 +46,7 @@ jobs:
       - name: Build and push Docker images
         run: ./build_and_push.sh
   prerelease-backend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: [build-docker, verify-lower-envs-are-released]
     defaults:
@@ -66,6 +73,7 @@ jobs:
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
   build-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: [verify-lower-envs-are-released]
     outputs:
@@ -113,6 +121,7 @@ jobs:
             exit 1
           fi
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: Production

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -13,18 +13,6 @@ concurrency:
   group: stg-deploy
 
 jobs:
-  verify-lower-envs-are-released:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./ops
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check that the current release is in the dev environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-dev-commit check-dev-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -1,9 +1,10 @@
 name: Deploy Stg
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Deploy Dev"]
+    types:
+      - completed
 
 env:
   DEPLOY_ENV: stg
@@ -12,7 +13,20 @@ concurrency:
   group: stg-deploy
 
 jobs:
+  verify-lower-envs-are-released:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ops
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check that the current release is in the dev environment
+        env:
+            CURL_TIMEOUT: 5
+        run: make check-dev-commit check-dev-readiness
   build-docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -26,6 +40,7 @@ jobs:
       - name: Build and push Docker images
         run: ./build_and_push.sh
   prerelease-backend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: build-docker
     defaults:
@@ -52,6 +67,7 @@ jobs:
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
   build-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -81,6 +97,7 @@ jobs:
           path: client.tgz
           retention-days: 1
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: Staging

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -105,3 +105,16 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
+  verify-release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    defaults:
+      run:
+        working-directory: ./ops
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check that the current release is in the ${{env.DEPLOY_ENV}} environment
+        env:
+            CURL_TIMEOUT: 5
+        run: make check-${{env.DEPLOY_ENV}}-commit check-${{env.DEPLOY_ENV}}-readiness

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -1,9 +1,12 @@
 name: Deploy Training
 
 on:
-  workflow_dispatch:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Deploy Dev,", "Deploy Stg"]
+    branches:
+      - main
+    types:
+      - completed
 
 env:
   DEPLOY_ENV: training
@@ -13,6 +16,7 @@ concurrency:
 
 jobs:
   verify-lower-envs-are-released:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +32,7 @@ jobs:
             CURL_TIMEOUT: 5
         run: make check-dev-commit check-dev-readiness
   build-docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,6 +46,7 @@ jobs:
       - name: Build and push Docker images
         run: ./build_and_push.sh
   prerelease-backend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: [build-docker, verify-lower-envs-are-released]
     defaults:
@@ -67,6 +73,7 @@ jobs:
         timeout-minutes: 1
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
   build-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     needs: [verify-lower-envs-are-released]
     steps:
@@ -98,6 +105,7 @@ jobs:
           path: client.tgz
           retention-days: 1
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: Training

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -13,18 +13,6 @@ concurrency:
   group: training-deploy
 
 jobs:
-  verify-lower-envs-are-released:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./ops
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check that the current release is in the stg environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-stg-commit check-stg-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -2,9 +2,7 @@ name: Deploy Training
 
 on:
   workflow_run:
-    workflows: ["Deploy Dev,", "Deploy Stg"]
-    branches:
-      - main
+    workflows: ["Deploy Stg"]
     types:
       - completed
 
@@ -27,10 +25,6 @@ jobs:
         env:
             CURL_TIMEOUT: 5
         run: make check-stg-commit check-stg-readiness
-      - name: Check that the current release is in the dev environment
-        env:
-            CURL_TIMEOUT: 5
-        run: make check-dev-commit check-dev-readiness
   build-docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,9 @@ name: Run end-to-end tests
 # Run this on pushes to any branch that change a backend file or the workflow definition
 on:
   workflow_dispatch: # because sometimes you just want to force a branch to have tests run
-  push:
-    branches:
-      - "**"
+  # push:
+  #   branches:
+  #     - "**"
 
 env:
   NODE_VERSION: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,9 @@ name: Run end-to-end tests
 # Run this on pushes to any branch that change a backend file or the workflow definition
 on:
   workflow_dispatch: # because sometimes you just want to force a branch to have tests run
-  # push:
-  #   branches:
-  #     - "**"
+  push:
+    branches:
+      - "**"
 
 env:
   NODE_VERSION: 14


### PR DESCRIPTION
## Related Issue or Background Info

Continuous deployment - it's _finally time_

#1884, #1885

## Changes Proposed

- Remove all triggers on `[release]`/`[prerelease]`
- Enforce the following release workflow: `dev` -> `stg` -> `[demo, training, prod]`
- Change the triggering condition on `demo`, `training`, and `prod` to `workflow_run`, which depends on `Deploy Stg` deploying successfully. Do the same for `stg`, but `Deploy Dev`.
- In other words, a successful deploy to `dev` will trigger `stg` , and a successful deploy to `stg` will automatically trigger deploys to `demo`, `training`, and `prod` in parallel.

## Additional Information

- It turns out `workflow_run` conditions work if _any_ of the downstream workflows succeed, rather than _all_, which makes deploying `dev` and `stg` together a little risky. So, for now, we'll trade a little bit of speed for correctness.

## Checklist for Author and Reviewer

- [x] Tested on `main` in a test repo
