### PR TITLE
Send Site_of_care to ReportStream

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -38,6 +38,7 @@ public class TestEventExport {
   private final Optional<AskOnEntrySurvey> survey;
   private final Optional<Provider> provider;
   private final Optional<Facility> facility;
+  private final Optional<Organization> organization;
   private final Optional<SpecimenType> specimenType;
   private final Optional<DeviceType> device;
 
@@ -47,6 +48,7 @@ public class TestEventExport {
     this.survey = Optional.ofNullable(testEvent.getSurveyData());
     this.provider = Optional.ofNullable(testEvent.getProviderData());
     this.facility = Optional.ofNullable(testEvent.getFacility());
+    this.organization = Optional.ofNullable(testEvent.getOrganization());
     this.specimenType =
         Optional.ofNullable(testEvent.getDeviceSpecimen()).map(DeviceSpecimenType::getSpecimenType);
     this.device =
@@ -354,10 +356,7 @@ public class TestEventExport {
 
   @JsonProperty("Organization_name")
   public String getOrganizationName() {
-    return facility
-        .map(Facility::getOrganization)
-        .map(Organization::getOrganizationName)
-        .orElse(null);
+    return organization.map(Organization::getOrganizationName).orElse(null);
   }
 
   @JsonProperty("Ordering_facility_phone_number")
@@ -479,6 +478,6 @@ public class TestEventExport {
 
   @JsonProperty("Site_of_care")
   public String getSiteOfCare() {
-    return testEvent.getOrganization().getOrganizationType();
+    return organization.map(Organization::getOrganizationType).orElse(null);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -476,4 +476,9 @@ public class TestEventExport {
     // order_test_date = test_date for antigen testing
     return getTestDate();
   }
+
+  @JsonProperty("Site_of_care")
+  public String getSiteOfCare() {
+    return testEvent.getOrganization().getOrganizationType();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -32,7 +32,7 @@ import java.util.UUID;
  * practice.
  */
 public class TestEventExport {
-  public static final String CSV_API_VERSION = "27Jan2021"; // last time we changed something
+  public static final String CSV_API_VERSION = "05Aug2021"; // last time we changed something
   private final TestEvent testEvent;
   private final Optional<Person> patient;
   private final Optional<AskOnEntrySurvey> survey;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -114,7 +114,7 @@ public class DataHubUploaderService {
     } else {
       // This should only happen when database is empty, throw?
       LOG.error(
-          "No default timestamp, will return everything. Add at least one successful record to the data_hub_upload table.");
+          "No default timestamp, will return everything. Use url to set initial lastEndCreateOn.");
       return null;
     }
   }
@@ -158,8 +158,6 @@ public class DataHubUploaderService {
   }
 
   private void uploadCSVDocument(String apiKey) throws RestClientException {
-    LOG.info("Uploading CSV document");
-
     ByteArrayResource contentsAsResource =
         new ByteArrayResource(this._fileContents.getBytes(StandardCharsets.UTF_8));
 
@@ -211,7 +209,6 @@ public class DataHubUploaderService {
     }
     if (!msgs.isEmpty()) {
       _slack.sendSlackChannelMessage("DataHubUploader not run", msgs, true);
-      msgs.forEach(msg -> LOG.info(msg));
       return;
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -114,7 +114,7 @@ public class DataHubUploaderService {
     } else {
       // This should only happen when database is empty, throw?
       LOG.error(
-          "No default timestamp, will return everything. Use url to set initial lastEndCreateOn.");
+          "No default timestamp, will return everything. Add at least one successful record to the data_hub_upload table.");
       return null;
     }
   }
@@ -158,6 +158,8 @@ public class DataHubUploaderService {
   }
 
   private void uploadCSVDocument(String apiKey) throws RestClientException {
+    LOG.info("Uploading CSV document");
+
     ByteArrayResource contentsAsResource =
         new ByteArrayResource(this._fileContents.getBytes(StandardCharsets.UTF_8));
 
@@ -209,6 +211,7 @@ public class DataHubUploaderService {
     }
     if (!msgs.isEmpty()) {
       _slack.sendSlackChannelMessage("DataHubUploader not run", msgs, true);
+      msgs.forEach(msg -> LOG.info(msg));
       return;
     }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
@@ -79,4 +79,16 @@ class TestEventExportTest {
 
     assertEquals("2106-3", sut.getPatientRace());
   }
+
+  @Test
+  void json_property_site_of_care_reporting() throws Exception {
+    Organization o = _dataFactory.createValidOrg();
+    Facility f = _dataFactory.createValidFacility(o);
+    Person p = _dataFactory.createFullPerson(o);
+    TestEvent te = _dataFactory.createTestEvent(p, f);
+
+    TestEventExport sut = new TestEventExport(te);
+
+    assertEquals(o.getOrganizationType(), sut.getSiteOfCare());
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DataHubUploaderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DataHubUploaderServiceTest.java
@@ -56,12 +56,14 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
     var instrumentId1 = entry1.getInstrumentID();
     var patientId1 = entry1.getPatientId();
     var resultId1 = entry1.getResultID();
+    var siteOfCare1 = entry1.getSiteOfCare();
     var instrumentId2 = entry2.getInstrumentID();
     var patientId2 = entry2.getPatientId();
     var resultId2 = entry2.getResultID();
+    var siteOfCare2 = entry2.getSiteOfCare();
 
     var serialized =
-        "\"Corrected_result_ID\",\"Date_result_released\",\"Device_ID\",\"Employed_in_healthcare\",\"First_test\",\"Illness_onset_date\",\"Instrument_ID\",\"Order_test_date\",\"Ordered_test_code\",\"Ordering_facility_city\",\"Ordering_facility_county\",\"Ordering_facility_email\",\"Ordering_facility_name\",\"Ordering_facility_phone_number\",\"Ordering_facility_state\",\"Ordering_facility_street\",\"Ordering_facility_street_2\",\"Ordering_facility_zip_code\",\"Ordering_provider_ID\",\"Ordering_provider_city\",\"Ordering_provider_county\",\"Ordering_provider_first_name\",\"Ordering_provider_last_name\",\"Ordering_provider_phone_number\",\"Ordering_provider_state\",\"Ordering_provider_street\",\"Ordering_provider_street_2\",\"Ordering_provider_zip_code\",\"Organization_name\",\"Patient_DOB\",\"Patient_ID\",\"Patient_city\",\"Patient_county\",\"Patient_email\",\"Patient_ethnicity\",\"Patient_first_name\",\"Patient_gender\",\"Patient_last_name\",\"Patient_middle_name\",\"Patient_phone_number\",\"Patient_race\",\"Patient_role\",\"Patient_state\",\"Patient_street\",\"Patient_street_2\",\"Patient_suffix\",\"Patient_zip_code\",\"Processing_mode_code\",\"Resident_congregate_setting\",\"Result_ID\",\"Specimen_collection_date_time\",\"Specimen_source_site_code\",\"Specimen_type_code\",\"Symptomatic_for_disease\",\"Test_date\",\"Test_result_code\",\"Test_result_status\",\"Testing_lab_CLIA\",\"Testing_lab_city\",\"Testing_lab_county\",\"Testing_lab_name\",\"Testing_lab_phone_number\",\"Testing_lab_state\",\"Testing_lab_street\",\"Testing_lab_street_2\",\"Testing_lab_zip_code\"\n"
+        "\"Corrected_result_ID\",\"Date_result_released\",\"Device_ID\",\"Employed_in_healthcare\",\"First_test\",\"Illness_onset_date\",\"Instrument_ID\",\"Order_test_date\",\"Ordered_test_code\",\"Ordering_facility_city\",\"Ordering_facility_county\",\"Ordering_facility_email\",\"Ordering_facility_name\",\"Ordering_facility_phone_number\",\"Ordering_facility_state\",\"Ordering_facility_street\",\"Ordering_facility_street_2\",\"Ordering_facility_zip_code\",\"Ordering_provider_ID\",\"Ordering_provider_city\",\"Ordering_provider_county\",\"Ordering_provider_first_name\",\"Ordering_provider_last_name\",\"Ordering_provider_phone_number\",\"Ordering_provider_state\",\"Ordering_provider_street\",\"Ordering_provider_street_2\",\"Ordering_provider_zip_code\",\"Organization_name\",\"Patient_DOB\",\"Patient_ID\",\"Patient_city\",\"Patient_county\",\"Patient_email\",\"Patient_ethnicity\",\"Patient_first_name\",\"Patient_gender\",\"Patient_last_name\",\"Patient_middle_name\",\"Patient_phone_number\",\"Patient_race\",\"Patient_role\",\"Patient_state\",\"Patient_street\",\"Patient_street_2\",\"Patient_suffix\",\"Patient_zip_code\",\"Processing_mode_code\",\"Resident_congregate_setting\",\"Result_ID\",\"Site_of_care\",\"Specimen_collection_date_time\",\"Specimen_source_site_code\",\"Specimen_type_code\",\"Symptomatic_for_disease\",\"Test_date\",\"Test_result_code\",\"Test_result_status\",\"Testing_lab_CLIA\",\"Testing_lab_city\",\"Testing_lab_county\",\"Testing_lab_name\",\"Testing_lab_phone_number\",\"Testing_lab_state\",\"Testing_lab_street\",\"Testing_lab_street_2\",\"Testing_lab_zip_code\"\n"
             + "\"\",\""
             + date
             + "\",\"SFN\",\"UNK\",\"UNK\",\"\",\""
@@ -72,6 +74,8 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
             + patientId1
             + "\",\"\",\"\",\"\",\"U\",\"John\",\"U\",\"Boddie\",\"Brown\",\"503-867-5309\",\"UNK\",\"STAFF\",\"\",\"\",\"\",\"Jr.\",\"\",\"P\",\"UNK\",\""
             + resultId1
+            + "\",\""
+            + siteOfCare1
             + "\",\""
             + date
             + "\",\"986543321\",\"000111222\",\"UNK\",\""
@@ -87,6 +91,8 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
             + patientId2
             + "\",\"\",\"\",\"\",\"U\",\"John\",\"U\",\"Boddie\",\"Brown\",\"503-867-5309\",\"UNK\",\"STAFF\",\"\",\"\",\"\",\"Jr.\",\"\",\"P\",\"UNK\",\""
             + resultId2
+            + "\",\""
+            + siteOfCare2
             + "\",\""
             + date
             + "\",\"986543321\",\"000111222\",\"UNK\",\""


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #1904

## Changes Proposed

- Add `Site_of_care` to the ReportStream upload

## Additional Information

- This was tested in `test` and confirmed from ReportStream personnel that the received `csv` file had the correct `Site_of_care` information.

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
