### PR TITLE
Match our Okta console settings with our TF config

### DIFF
--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -23,6 +23,7 @@ resource "okta_app_oauth" "app" {
   post_logout_redirect_uris = var.logout_redirect_uris
   hide_ios                  = false
   hide_web                  = false
+  login_mode                = "SPEC"
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Related Issue or Background Info

#2080

Prerequisite for #1360

## Changes Proposed

- The TF default for`login_mode` is `DISABLED`, but actually running a `terraform apply` against our Okta config suggests that it's set to `SPEC`. The console is more likely to be the current source of truth, so this updates the TF config to match.
- It turns out the rest of the work was just making sure it was okay to make the proposed changes after a `terraform apply` (removing old redirect URLs, etc.).

## Cloud
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
