### PR TITLE
Deploy ops/ENV/persistent on every merge

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct release to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-release

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct release to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}-api
+        run: make deploy-${{ env.DEPLOY_ENV }}
       - name: Wait for correct commit to be deployed in staging slot
         timeout-minutes: 5
         run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -20,7 +20,7 @@ SLOT_READY=$(CURL) https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator
 default:
 	@echo "Hello, SimpleReport operator!"
 	@echo "You can use 'make promote-ENV' to promote the $(SOURCE_SLOT) slot of any environment, if you are logged in to azure"
-	@echo "You can also run 'make init-ENV' or 'make deploy-ENV-api' but those may not be as useful locally."
+	@echo "You can also run 'make init-ENV' or 'make deploy-ENV' but those may not be as useful locally."
 	@echo "In addition, there are a variety of targets that start with 'check' or 'wait-for', which you should just look at."
 	@echo "Please note in particular that most if not all 'wait' tasks do not have a built-in timeout."
 
@@ -44,9 +44,11 @@ api.tfvars: /dev/null
 
 init-%: .valid-env-%
 	terraform -chdir=$* init
+	terraform -chdir=$*/persistent init
 
-deploy-%-api: .valid-env-% api.tfvars
+deploy-%: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars
+	terraform -chdir=$*/persistent apply -auto-approve
 
 promote-%: .be-logged-in .valid-env-%
 	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)


### PR DESCRIPTION
## Related Issue or Background Info

#1568 

We're only partially deploying our full Terraform config on every merge; this PR adds the missing portions.

## Changes Proposed

- Modify `ops/Makefile` so that the `init-ENV` and `deploy-ENV` targets also run in `ops/ENV/persistent`.
- Rename the `deploy-ENV-api` target to `deploy-ENV` since this task now does a lot more than deploy the API.

## Checklist for Author and Reviewer

### Testing
- [x] Tested locally using the `Makefile` changes
