### PR TITLE
Render new facility form on org's first login

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -129,6 +129,7 @@ export interface Props {
   facility: Facility;
   deviceOptions: DeviceType[];
   saveFacility: (facility: Facility) => void;
+  newOrg?: boolean;
 }
 
 const FacilityForm: React.FC<Props> = (props) => {
@@ -292,25 +293,31 @@ const FacilityForm: React.FC<Props> = (props) => {
           "\nYour changes are not saved yet!\n\nClick OK to delete your answers and leave, or Cancel to return and save your progress."
         }
       />
-      <div className="">
+      <div className="padding-bottom-2">
         <div className="prime-container card-container">
           <div className="usa-card__header">
             <div>
               <div className="display-flex flex-align-center">
-                <svg
-                  className="usa-icon text-base margin-left-neg-2px"
-                  aria-hidden="true"
-                  focusable="false"
-                  role="img"
-                >
-                  <use xlinkHref={iconSprite + "#arrow_back"}></use>
-                </svg>
-                <LinkWithQuery
-                  to={`/settings/facilities`}
-                  className="margin-left-05"
-                >
-                  All facilities
-                </LinkWithQuery>
+                {props.newOrg ? (
+                  <h2 className="margin-top-05">Welcome to SimpleReport!</h2>
+                ) : (
+                  <>
+                    <svg
+                      className="usa-icon text-base margin-left-neg-2px"
+                      aria-hidden="true"
+                      focusable="false"
+                      role="img"
+                    >
+                      <use xlinkHref={iconSprite + "#arrow_back"}></use>
+                    </svg>
+                    <LinkWithQuery
+                      to={`/settings/facilities`}
+                      className="margin-left-05"
+                    >
+                      All facilities
+                    </LinkWithQuery>
+                  </>
+                )}
               </div>
               <h1 className="font-heading-lg margin-y-0">{facility.name}</h1>
             </div>
@@ -331,6 +338,9 @@ const FacilityForm: React.FC<Props> = (props) => {
             </div>
           </div>
           <div className="usa-card__body padding-top-2">
+            {props.newOrg ? (
+              <h3>To get started, add a testing facility.</h3>
+            ) : null}
             <RequiredMessage />
             <FacilityInformation
               facility={facility}
@@ -355,7 +365,7 @@ const FacilityForm: React.FC<Props> = (props) => {
           errors={errors}
           validateField={validateField}
         />
-        <div className="float-right margin-bottom-4">
+        <div className="float-right margin-bottom-4 margin-top-4">
           <Button
             className="margin-right-0"
             type="button"

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -163,6 +163,7 @@ const ADD_FACILITY_MUTATION = gql`
 
 interface Props {
   facilityId: string;
+  newOrg?: boolean;
 }
 
 const FacilityFormContainer: any = (props: Props) => {
@@ -190,6 +191,9 @@ const FacilityFormContainer: any = (props: Props) => {
   }
 
   if (saveSuccess) {
+    if (props.newOrg) {
+      window.location.pathname = "/";
+    }
     return <Redirect push to={{ pathname: "/settings/facilities" }} />;
   }
 
@@ -288,6 +292,7 @@ const FacilityFormContainer: any = (props: Props) => {
       facility={getFacilityData()}
       deviceOptions={data.deviceType}
       saveFacility={saveFacility}
+      newOrg={props.newOrg}
     />
   );
 };

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -192,7 +192,7 @@ const FacilityFormContainer: any = (props: Props) => {
 
   if (saveSuccess) {
     if (props.newOrg) {
-      window.location.pathname = "/";
+      window.location.pathname = process.env.REACT_APP_BASE_URL || "";
     }
     return <Redirect push to={{ pathname: "/settings/facilities" }} />;
   }

--- a/frontend/src/app/facilitySelect/WithFacility.test.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.test.tsx
@@ -2,18 +2,45 @@ import React from "react";
 import { Provider } from "react-redux";
 import renderer from "react-test-renderer";
 import configureStore from "redux-mock-store";
+import { act, render, screen } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
 
+import { appPermissions } from "../permissions";
 import { updateFacility } from "../store";
+import { GET_FACILITY_QUERY } from "../Settings/Facility/FacilityFormContainer";
 
 import WithFacility from "./WithFacility";
 
 const mockStore = configureStore([]);
 const mockHistoryPush = jest.fn();
 jest.mock("react-router-dom", () => ({
+  Prompt: (props: any) => <></>,
   useHistory: () => ({
     push: mockHistoryPush,
   }),
 }));
+
+const mocks = [
+  {
+    request: {
+      query: GET_FACILITY_QUERY,
+    },
+    result: {
+      data: {
+        organization: {
+          internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
+          testingFacility: [],
+        },
+        deviceType: [
+          {
+            internalId: "a9bd36fe-0df1-4256-93e8-9e503cabdc8b",
+            name: "Abbott IDNow",
+          },
+        ],
+      },
+    },
+  },
+];
 
 describe("WithFacility", () => {
   let store: any;
@@ -32,6 +59,7 @@ describe("WithFacility", () => {
         user: {
           firstName: "Kim",
           lastName: "Mendoza",
+          permissions: [],
         },
         facilities: [],
       });
@@ -58,6 +86,7 @@ describe("WithFacility", () => {
         user: {
           firstName: "Kim",
           lastName: "Mendoza",
+          permissions: [],
         },
         facilities: [{ id: "1", name: "Facility 1" }],
       });
@@ -98,6 +127,7 @@ describe("WithFacility", () => {
         user: {
           firstName: "Kim",
           lastName: "Mendoza",
+          permissions: [],
         },
         facilities: [
           { id: "1", name: "Facility 1" },
@@ -136,6 +166,41 @@ describe("WithFacility", () => {
       it("should set the facility id search param", () => {
         expect(mockHistoryPush).toHaveBeenCalledWith({ search: "?facility=1" });
       });
+    });
+  });
+  describe("A new org", () => {
+    beforeEach(async () => {
+      store = mockStore({
+        dataLoaded: true,
+        organization: {
+          name: "Organization Name",
+        },
+        user: {
+          firstName: "Kim",
+          lastName: "Mendoza",
+          permissions: appPermissions.settings.canView,
+        },
+        facilities: [],
+      });
+      store.dispatch = jest.fn();
+      render(
+        <Provider store={store}>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <WithFacility>App</WithFacility>
+          </MockedProvider>
+        </Provider>
+      );
+      await act(async () => {
+        await screen.findAllByText("Welcome to SimpleReport", { exact: false });
+      });
+    });
+
+    it("should render the facility form", async () => {
+      expect(
+        await screen.getByText("To get started, add a testing facility", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/facilitySelect/WithFacility.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { useDispatch, useSelector, connect } from "react-redux";
 import { useHistory } from "react-router-dom";
 
+import { appPermissions } from "../permissions";
+import FacilityFormContainer from "../Settings/Facility/FacilityFormContainer";
 import { RootState, updateFacility } from "../store";
 import { getFacilityIdFromUrl } from "../utils/url";
 
@@ -17,6 +19,11 @@ const WithFacility: React.FC<Props> = ({ children }) => {
   const history = useHistory();
   const isAdmin = useSelector<RootState, boolean>(
     (state) => state.user.isAdmin
+  );
+  const canViewSettings = useSelector<RootState, boolean>((state) =>
+    appPermissions.settings.canView.every((requiredPermission) =>
+      state.user.permissions.includes(requiredPermission)
+    )
   );
   const dataLoaded = useSelector<RootState, boolean>(
     (state) => state.dataLoaded
@@ -47,6 +54,17 @@ const WithFacility: React.FC<Props> = ({ children }) => {
   if (isAdmin && facilities.length === 0) {
     // site admin without an organization
     return <>{children}</>;
+  }
+
+  if (canViewSettings && facilities.length === 0) {
+    // new org needs to create a facility
+    return (
+      <main className="prime-home">
+        <div className="grid-container">
+          <FacilityFormContainer newOrg={true} />
+        </div>
+      </main>
+    );
   }
 
   if (facilities.length === 0) {

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -2,6 +2,8 @@ import { createStore } from "redux";
 
 import { COVID_RESULTS } from "../app/constants";
 
+import { UserPermission } from "./permissions";
+
 const SET_INITIAL_STATE = "SET_INITIAL_STATE";
 const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
 const UPDATE_FACILITY = "UPDATE_FACILITY";
@@ -26,7 +28,7 @@ const initialState = {
     lastName: "",
     suffix: "",
     email: "",
-    permissions: [],
+    permissions: [] as UserPermission[],
     roleDescription: "",
     isAdmin: false,
   },


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2052 

## Changes Proposed

- Change `WithFacility` to render the add facility form if an org admin logs in and there are no facilities in the org
- After the facility is saved, it reloads the app so the user is redirected to the testing queue

## Additional Information

- Added some copy to the form to explain that a new org needs to add a facility first. Let me know if this needs to change

## Screenshots / Demos


https://user-images.githubusercontent.com/9121162/128574812-83f97abc-169e-442f-b53e-8eb9397d95a5.mp4



## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
