### PR TITLE
prevent duplicate orgname from alerting

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -131,8 +131,10 @@ public class AccountRequestController {
 
       createAdminUser(org, reqVars);
       _crm.submitAccountRequestData(body);
-    } catch (ResourceException e) {
-      // The `ResourceException` is thrown when an account is requested with an existing org
+    } catch (ResourceException | BadRequestException e) {
+      // The `ResourceException` is thrown when an account is requested with an existing user email
+      // address
+      // The `BadRequestException` is thrown when an account is requested with an existing org
       // name. This happens quite frequently and is expected behavior of the current form
       throw e;
     } catch (IOException | RuntimeException e) {
@@ -155,8 +157,10 @@ public class AccountRequestController {
       createAdminUser(org, reqVars);
       _crm.submitAccountRequestData(body);
       return new AccountResponse(org.getExternalId());
-    } catch (ResourceException e) {
-      // The `ResourceException` is thrown when an account is requested with an existing org
+    } catch (ResourceException | BadRequestException e) {
+      // The `ResourceException` is thrown when an account is requested with an existing user email
+      // address
+      // The `BadRequestException` is thrown when an account is requested with an existing org
       // name. This happens quite frequently and is expected behavior of the current form
       throw e;
     } catch (IOException | RuntimeException e) {


### PR DESCRIPTION
## Related Issue or Background Info

- We are getting a lot of pages due to duplicate orgs. This error is on the roadmap to be fixed in the redesign. For now we should give those on call a break. See https://usds.slack.com/archives/C01LTSNKEPP/p1628609802142200

## Changes Proposed

- Capture the exception thrown and don't re throw it with the exception that triggers an alert

## Additional Information

- [stack trace of this issue](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%2C%22ResourceGroup%22%3A%22prime-simple-report-prod%22%2C%22Name%22%3A%22prime-simple-report-prod-insights%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F7d1e3999-6577-4cd5-b296-f518e5c8e677%252FresourceGroups%252Fprime-simple-report-prod%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fprime-simple-report-prod-insights%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%220d624293-f9f1-11eb-9794-c9316320c8b9%22%2C%22timestamp%22%3A%222021-08-10T15%3A38%3A46.171Z%22%2C%22cacheId%22%3A%226ad68326-e96b-43b4-ba0d-20bc7fa83d85%22%2C%22eventTable%22%3A%22requests%22%7D)
- `ResourceException` was an exception thrown by Okta when there is a duplicate user. We had mistaken this as the exception thrown when there was a duplicate org
- `BadRequestException` is thrown in `checkAccountRequestAndCreateOrg` which is called by `submitAccountRequest` and `submitAccountRequestV2`

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
