### PR TITLE
Remove 'Compiled application' upload for prod deploys

### DIFF
--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -73,8 +73,6 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Add upload URL to environment
-        run: echo UPLOAD_URL=$(jq -r .release.upload_url < ${GITHUB_EVENT_PATH}| sed -e 's/{?name,label}//') >> $GITHUB_ENV
       - uses: ./.github/actions/build-frontend
         name: Build front-end application
         with:
@@ -83,24 +81,12 @@ jobs:
           base-domain-name: simplereport.gov
           client-tarball: ./client.tgz
       - name: Save compiled frontend application
-        id: upload
+        uses: actions/upload-artifact@v2
         if: success()
-        run: |
-          DOWNLOAD_URL=$(
-            curl -s -X POST --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-              --data-binary @client.tgz \
-              --header "Accept: application/vnd.github.v3+json" \
-              --header "Content-type:  application/gzip" \
-              "$UPLOAD_URL?name=simple-report-client-application.tgz&label=Compiled%20Client%20Application" \
-            | jq .url
-          )
-          if [[ -n "$DOWNLOAD_URL" ]]; then
-            echo Uploaded file to $DOWNLOAD_URL
-            echo "::set-output name=url::$DOWNLOAD_URL"
-          else
-            echo "Upload unsuccessful (probably you already uploaded it?)"
-            exit 1
-          fi
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related Issue or Background Info

The prod deploy workflow assumes that we're making releases for every deploy, but we've stopped doing so in #2188. This causes the step where we upload the compiled application to bundle with the release to fail.

## Changes Proposed

- Remove the compiled application upload.

## Additional Information

- We may decide to put this step back; if so, we'll need to make it optional based on whether this is a release.