### PR TITLE
Change to sex assigned at birth and add hint text

### DIFF
--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -461,6 +461,7 @@ const PersonForm = (props: Props) => {
         />
         <RadioGroup
           legend={t("patient.form.demographics.gender")}
+          hintText={t("patient.form.demographics.genderHelpText")}
           name="gender"
           buttons={GENDER_VALUES}
           selectedRadio={patient.gender}

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -290,7 +290,7 @@ describe("EditPatient", () => {
     });
 
     it("shows prefer not to answer options", () => {
-      ["Race", "Are you Hispanic or Latino?", "Biological sex"].forEach(
+      ["Race", "Are you Hispanic or Latino?", "Sex assigned at birth"].forEach(
         (legend) => {
           const fieldset = screen.getByText(legend).closest("fieldset");
           if (fieldset === null) {

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -1203,8 +1203,13 @@ Object {
                       <legend
                         class="usa-legend"
                       >
-                        Biological sex
+                        Sex assigned at birth
                       </legend>
+                      <span
+                        class="usa-hint"
+                      >
+                        This is usually the gender that is written on your original birth certificate.
+                      </span>
                       <div
                         class=""
                       >
@@ -2667,8 +2672,13 @@ Object {
                     <legend
                       class="usa-legend"
                     >
-                      Biological sex
+                      Sex assigned at birth
                     </legend>
+                    <span
+                      class="usa-hint"
+                    >
+                      This is usually the gender that is written on your original birth certificate.
+                    </span>
                     <div
                       class=""
                     >

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -138,7 +138,9 @@ export const en = {
           race: "Race",
           tribalAffiliation: "Tribal affiliation",
           ethnicity: "Are you Hispanic or Latino?",
-          gender: "Biological sex",
+          gender: "Sex assigned at birth",
+          genderHelpText:
+            "This is usually the gender that is written on your original birth certificate.",
         },
         other: {
           heading: "Other",
@@ -173,7 +175,7 @@ export const en = {
           race: "Race is incorrectly formatted",
           tribalAffiliation: "Tribal affiliation is incorrectly formatted",
           ethnicity: "Ethnicity is incorrectly formatted",
-          gender: "Biological sex is incorrectly formatted",
+          gender: "Sex assigned at birth is incorrectly formatted",
           residentCongregateSetting:
             "Are you a resident in a congregate living setting? is required",
           employedInHealthcare: "Are you a health care worker? is required",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -146,7 +146,9 @@ export const es: LanguageConfig = {
           race: "Raza",
           tribalAffiliation: "Afiliación tribal",
           ethnicity: "¿Es usted hispano o latino?",
-          gender: "Sexo biológico",
+          gender: "Sexo asignado al nacer",
+          genderHelpText:
+            "Por lo general, este es el género que está escrito en su certificado de nacimiento original.",
         },
         other: {
           heading: "Otro",
@@ -182,7 +184,7 @@ export const es: LanguageConfig = {
           race: "La raza tiene un formato incorrecto",
           tribalAffiliation: "La afiliación tribal tiene un formato incorrecto",
           ethnicity: "La etnia tiene un formato incorrecto",
-          gender: "El sexo biológico tiene un formato incorrecto",
+          gender: "El sexo asignado al nacer tiene un formato incorrecto",
           residentCongregateSetting:
             "¿Reside usted en un entorno compartido por muchas personas?  Se requiere una respuesta",
           employedInHealthcare:

--- a/frontend/src/patientApp/timeOfTest/PatientProfile.tsx
+++ b/frontend/src/patientApp/timeOfTest/PatientProfile.tsx
@@ -79,7 +79,7 @@ const PatientProfile = ({ patient }: Props) => {
       <p>{ethnicity || notProvided}</p>
       <h3 className="font-heading-sm">Tribal affiliation</h3>
       <p>{tribalAffiliation || notProvided}</p>
-      <h3 className="font-heading-sm">Biological sex</h3>
+      <h3 className="font-heading-sm">Sex assigned at birth</h3>
       <p>{gender || notProvided}</p>
       <h2 className="prime-formgroup-heading font-heading-lg">Other</h2>
       <h3 className="font-heading-sm">

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
@@ -1173,8 +1173,13 @@ exports[`PatientFormContainer snapshot 1`] = `
                 <legend
                   className="usa-legend"
                 >
-                  Biological sex
+                  Sex assigned at birth
                 </legend>
+                <span
+                  className="usa-hint"
+                >
+                  This is usually the gender that is written on your original birth certificate.
+                </span>
                 <div
                   className=""
                 >

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientProfile.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientProfile.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`PatientProfile snapshot 1`] = `
   <h3
     className="font-heading-sm"
   >
-    Biological sex
+    Sex assigned at birth
   </h3>
   <p>
     Not provided

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientProfileContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientProfileContainer.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`PatientProfileContainer snapshot 1`] = `
       <h3
         className="font-heading-sm"
       >
-        Biological sex
+        Sex assigned at birth
       </h3>
       <p>
         Not provided


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #2112

## Changes Proposed

- Change "Biological sex" to "Sex assigned at birth" and add hint text
- Adds both English and Spanish translations

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
