### PR TITLE
fix date validation for results filters

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -18,6 +18,7 @@ import { DatePicker, Label } from "@trussworks/react-uswds";
 
 import { PATIENT_TERM_CAP } from "../../config/constants";
 import { displayFullName, displayFullNameInOrder } from "../utils";
+import { isValidDate } from "../utils/date";
 import {
   InjectedQueryWrapperProps,
   QueryWrapper,
@@ -30,7 +31,6 @@ import {
   COVID_RESULTS,
   ROLE_VALUES,
   TEST_RESULT_DESCRIPTIONS,
-  DATE_FORMAT_MM_DD_YYYY,
 } from "../constants";
 import "./TestResultsList.scss";
 import Button from "../commonComponents/Button/Button";
@@ -323,7 +323,7 @@ export const DetachedTestResultsList: any = ({
   function processDates() {
     var validStart = false;
     if (startDateEntry) {
-      if (!startDateEntry.match(DATE_FORMAT_MM_DD_YYYY)) {
+      if (!isValidDate(startDateEntry)) {
         setStartDateError("Date must be in format MM/DD/YYYY or MM-DD-YYYY");
         setStartDateFilter("");
       } else {
@@ -334,7 +334,7 @@ export const DetachedTestResultsList: any = ({
       }
     }
     if (endDateEntry) {
-      if (!endDateEntry.match(DATE_FORMAT_MM_DD_YYYY)) {
+      if (!isValidDate(endDateEntry)) {
         setEndDateError("Date must be in format MM/DD/YYYY or MM-DD-YYYY");
       } else {
         const endDate = moment(endDateEntry).endOf("day");

--- a/frontend/src/app/utils/date.ts
+++ b/frontend/src/app/utils/date.ts
@@ -13,3 +13,10 @@ export const formatDate = (date: string | undefined | null): ISODate | null => {
 
   return moment(date).format("YYYY-MM-DD") as ISODate;
 };
+
+export const isValidDate = (date: string): boolean => {
+  return (
+    moment(date, "MM-DD-YYYY", false).isValid() ||
+    moment(date, "MM/DD/YYYY", false).isValid()
+  );
+};


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #2262 

## Changes Proposed

- change to use moment library validation, as the regex was allowing plain numbers to slip through

## Screenshots / Demos
<img width="966" alt="Screen Shot 2021-08-12 at 10 52 01 AM" src="https://user-images.githubusercontent.com/80282552/129245054-46e61026-a3de-4a5f-bf19-9d3ad2f55cb9.png">


## Checklist for Author and Reviewer


### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- n/a Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
