### PR TITLE
Test results list: "Clear Filter" button clears dates from text box

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -899,6 +899,54 @@ describe("TestResultsList", () => {
     expect(await screen.queryByText("Colleer, Barde X")).toBeInTheDocument();
   });
 
+  it("should be able to clear date filters", async () => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <TestResultsList page={1} />
+          </MockedProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+
+    // Apply filter
+    userEvent.type(
+      screen.getAllByTestId("date-picker-external-input")[0],
+      "03/18/2021"
+    );
+
+    userEvent.tab();
+
+    // Filter applied
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Cragell, Barb Whitaker")
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen
+        .getAllByTestId("date-picker-external-input")[0]
+        .getAttribute("value")
+    ).toEqual("03/18/2021");
+    // Clear filter
+    expect(await screen.findByText("Clear filters")).toBeInTheDocument();
+    userEvent.click(screen.getByText("Clear filters"));
+
+    // Filter no longer applied
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+
+    // Date picker no longer displays the selected date
+    expect(
+      screen
+        .getAllByTestId("date-picker-external-input")[0]
+        .getAttribute("value")
+    ).toEqual("");
+  });
+
   it("opens the test detail view", async () => {
     render(
       <MemoryRouter>

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -246,6 +246,7 @@ export const DetachedTestResultsList: any = ({
   const [endDateEntry, setEndDateEntry] = useState<string>();
   const [startDateError, setStartDateError] = useState<string | undefined>();
   const [endDateError, setEndDateError] = useState<string | undefined>();
+  const [resetCount, setResetCount] = useState<number>(0);
 
   const [queryString, debounced, setDebounced] = useDebounce("", {
     debounceTime: SEARCH_DEBOUNCE_TIME,
@@ -383,6 +384,15 @@ export const DetachedTestResultsList: any = ({
                     setRoleFilter("");
                     setStartDateFilter("");
                     setEndDateFilter("");
+                    setStartDateEntry("");
+                    setEndDateEntry("");
+
+                    // The DatePicker component contains bits of state that represent the selected date
+                    // as represented internally to the component and displayed externally to the DOM. Directly
+                    // changing the value of the date via props does not cause the internal state to be updated.
+                    // This hack forces the DatePicker component to be fully re-mounted whenever the filters are
+                    // cleared, therefore resetting the external date display.
+                    setResetCount(resetCount + 1);
                   }}
                 >
                   Clear filters
@@ -423,6 +433,7 @@ export const DetachedTestResultsList: any = ({
                   )}
                   <DatePicker
                     id="start-date"
+                    key={resetCount}
                     name="start-date"
                     data-testid="start-date"
                     value={startDateEntry}
@@ -442,6 +453,7 @@ export const DetachedTestResultsList: any = ({
                   )}
                   <DatePicker
                     id="end-date"
+                    key={resetCount + 1}
                     name="end-date"
                     data-testid="end-date"
                     value={endDateEntry}


### PR DESCRIPTION
## Related Issue or Background Info

Closes #2264 

## Changes Proposed
- Add a counter to `TestResultsList` state that updates whenever filters are cleared
- Uses counter as a `key` for the `DatePicker` components to force them to re-mount when the filters are cleared
    - The `DatePicker` component tracks an "external date display" state that doesn't always update when the `value` prop changes, so here we're forcing the entire component to re-render and update the internal state to the new (blank) values

## Additional Information
- N/A

## Screenshots / Demos

https://user-images.githubusercontent.com/27730981/129260535-166e070d-a06d-491c-a69c-89fd9f9230fd.mov

## Checklist for Author and Reviewer
- [ ] Anything I missed?

### UI
- [x] Any changes to the UI/UX are approved by design
- [x] ~Any new or updated content (e.g. error messages) are approved by design~

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] ~Database changes are submitted as a separate PR~
  - [x] ~Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~
  - [x] ~Any changes to tables that have custom no-PHI views are accompanied by changes to those views~
        ~(including re-granting permission to the no-PHI user if need be)~
  - [x] ~Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`~
- [x] ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~

## Cloud
- [x] ~DevOps team has been notified if PR requires ops support~
- [x] ~If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification~
