### PR TITLE
Prevent duplicate patient phone numbers

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -342,7 +342,7 @@ public class PersonService {
         phoneNumber -> {
           phoneNumber.setPerson(person);
           if (phoneNumbersSeen.contains(phoneNumber.getNumber())) {
-            throw new IllegalGraphqlArgumentException("Duplicate phone numbers are not allowed");
+            throw new IllegalGraphqlArgumentException("This phone number has already been added");
           }
           phoneNumbersSeen.add(phoneNumber.getNumber());
         });

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -342,7 +342,7 @@ public class PersonService {
         phoneNumber -> {
           phoneNumber.setPerson(person);
           if (phoneNumbersSeen.contains(phoneNumber.getNumber())) {
-            throw new IllegalGraphqlArgumentException("This phone number has already been added");
+            throw new IllegalGraphqlArgumentException("Duplicate phone number entered");
           }
           phoneNumbersSeen.add(phoneNumber.getNumber());
         });

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -20,6 +20,7 @@ import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -35,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = false)
 public class PersonService {
+
   private final CurrentPatientContextHolder _patientContext;
   private final OrganizationService _os;
   private final PersonRepository _repo;
@@ -333,7 +335,17 @@ public class PersonService {
     if (incoming == null) {
       return;
     }
-    incoming.forEach(phoneNumber -> phoneNumber.setPerson(person));
+
+    // we don't want to allow a patient to have any duplicate phone numbers
+    Set<String> phoneNumbersSeen = new HashSet<>();
+    incoming.forEach(
+        phoneNumber -> {
+          phoneNumber.setPerson(person);
+          if (phoneNumbersSeen.contains(phoneNumber.getNumber())) {
+            throw new IllegalGraphqlArgumentException("Duplicate phone numbers are not allowed");
+          }
+          phoneNumbersSeen.add(phoneNumber.getNumber());
+        });
 
     var existingNumbers = person.getPhoneNumbers();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -13,6 +13,7 @@ import gov.cdc.usds.simplereport.db.model.PhoneNumber;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
+import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyAllFacilitiesUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
@@ -249,31 +250,33 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
     phoneNumbers.add(new PhoneNumber(PhoneType.MOBILE, "2342342344"));
     phoneNumbers.add(new PhoneNumber(PhoneType.LANDLINE, "2342342344"));
 
+    LocalDate birthDate = LocalDate.of(1865, 12, 25);
+    StreetAddress address = _dataFactory.getAddress();
+
     IllegalGraphqlArgumentException e =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> {
-              _service.addPatient(
-                  (UUID) null,
-                  "FOO",
-                  "Fred",
-                  null,
-                  "Fosbury",
-                  "Sr.",
-                  LocalDate.of(1865, 12, 25),
-                  _dataFactory.getAddress(),
-                  phoneNumbers,
-                  PersonRole.STAFF,
-                  null,
-                  null,
-                  null,
-                  null,
-                  null,
-                  false,
-                  false,
-                  "English",
-                  null);
-            });
+            () ->
+                _service.addPatient(
+                    (UUID) null,
+                    "FOO",
+                    "Fred",
+                    null,
+                    "Fosbury",
+                    "Sr.",
+                    birthDate,
+                    address,
+                    phoneNumbers,
+                    PersonRole.STAFF,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    false,
+                    "English",
+                    null));
     assertEquals("Duplicate phone number entered", e.getMessage());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.PhoneNumber;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyAllFacilitiesUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
@@ -18,6 +21,7 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -234,6 +238,43 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
                 false,
                 "English",
                 null));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addPatient_duplicatePhoneNumber_failure() {
+    makeFacilities();
+
+    List<PhoneNumber> phoneNumbers = new ArrayList<>();
+    phoneNumbers.add(new PhoneNumber(PhoneType.MOBILE, "2342342344"));
+    phoneNumbers.add(new PhoneNumber(PhoneType.LANDLINE, "2342342344"));
+
+    IllegalGraphqlArgumentException e =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            () -> {
+              _service.addPatient(
+                  (UUID) null,
+                  "FOO",
+                  "Fred",
+                  null,
+                  "Fosbury",
+                  "Sr.",
+                  LocalDate.of(1865, 12, 25),
+                  _dataFactory.getAddress(),
+                  phoneNumbers,
+                  PersonRole.STAFF,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  false,
+                  false,
+                  "English",
+                  null);
+            });
+    assertEquals("Duplicate phone numbers are not allowed", e.getMessage());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -274,7 +274,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
                   "English",
                   null);
             });
-    assertEquals("Duplicate phone numbers are not allowed", e.getMessage());
+    assertEquals("Duplicate phone number entered", e.getMessage());
   }
 
   @Test

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -1,5 +1,5 @@
 import * as yup from "yup";
-import { PhoneNumberUtil } from "google-libphonenumber";
+import { PhoneNumberUtil, PhoneNumberFormat } from "google-libphonenumber";
 import moment from "moment";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
@@ -65,6 +65,15 @@ export function phoneNumberIsValid(input: any) {
   } catch (e) {
     return false;
   }
+}
+
+export function areUniquePhoneNumbers(phoneNumbers: any) {
+  const phoneNumbersSeen = new Set(
+    phoneNumbers.map((p: { number: string }) =>
+      phoneUtil.format(phoneUtil.parse(p.number), PhoneNumberFormat.E164)
+    )
+  );
+  return phoneNumbersSeen.size === phoneNumbers.length;
 }
 
 export function areValidPhoneNumbers(phoneNumbers: any) {
@@ -135,6 +144,7 @@ const updateFieldSchemata: (
       t("patient.form.errors.phoneNumbers"),
       areValidPhoneNumbers
     )
+    .test("phone-numbers", "dupe phone numbers", areUniquePhoneNumbers)
     .required(),
   email: yup.string().email(t("patient.form.errors.email")).nullable(),
   street: yup.string().required(t("patient.form.errors.street")),

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -68,12 +68,18 @@ export function phoneNumberIsValid(input: any) {
 }
 
 export function areUniquePhoneNumbers(phoneNumbers: any) {
-  const phoneNumbersSeen = new Set(
-    phoneNumbers.map((p: { number: string }) =>
-      phoneUtil.format(phoneUtil.parse(p.number), PhoneNumberFormat.E164)
-    )
-  );
-  return phoneNumbersSeen.size === phoneNumbers.length;
+  try {
+    const phoneNumbersSeen = new Set(
+      phoneNumbers.map((p: { number: string }) => {
+        const parsedNumber = phoneUtil.parse(p.number, "US");
+        return phoneUtil.format(parsedNumber, PhoneNumberFormat.E164);
+      })
+    );
+    return phoneNumbersSeen.size === phoneNumbers.length;
+  } catch (e) {
+    // parsing number can fail
+    return false;
+  }
 }
 
 export function areValidPhoneNumbers(phoneNumbers: any) {

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -152,7 +152,7 @@ const updateFieldSchemata: (
     )
     .test(
       "phone-numbers",
-      t("patient.form.errors.phoneNumbers"),
+      t("patient.form.errors.phoneNumbersDuplicate"),
       areUniquePhoneNumbers
     )
     .required(),

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -144,7 +144,11 @@ const updateFieldSchemata: (
       t("patient.form.errors.phoneNumbers"),
       areValidPhoneNumbers
     )
-    .test("phone-numbers", "dupe phone numbers", areUniquePhoneNumbers)
+    .test(
+      "phone-numbers",
+      t("patient.form.errors.phoneNumbers"),
+      areUniquePhoneNumbers
+    )
     .required(),
   email: yup.string().email(t("patient.form.errors.email")).nullable(),
   street: yup.string().required(t("patient.form.errors.street")),

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -165,6 +165,7 @@ export const en = {
             "Date of birth must be present, correctly formatted (MM/DD/YYYY), and in the past",
           telephone: "Phone number is missing or invalid",
           phoneNumbers: "Phone numbers are missing or invalid",
+          phoneNumbersDuplicate: "Duplicate phone number entered",
           email: "Email is missing or incorrectly formatted",
           street: "Street is missing",
           streetTwo: "Street 2 is incorrectly formatted",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -174,6 +174,7 @@ export const es: LanguageConfig = {
             "Se requiere fecha de nacimiento, formateada correctamente (MM/DD/AAAA) y en el pasado",
           telephone: "Falta el número de teléfono o no es válido",
           phoneNumbers: "Faltan los números de teléfono o no son válidos",
+          phoneNumbersDuplicate: "Número de teléfono duplicado ingresado",
           email: "Falta el correo electrónico o tiene un formato incorrecto",
           street: "Falta el nombre de la calle",
           streetTwo: "Calle 2 tiene un formato incorrecto",


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/2277

## Changes Proposed

- check for duplicate patient phone numbers on frontend and backend

## Additional Information

- Entering duplicates could cause multiple text messages to be sent to the same number
- Bug bash!

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
