### PR TITLE
Make sure workflows can access OKTA_API_KEY

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -39,6 +39,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -37,6 +37,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -34,6 +34,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -39,6 +39,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -39,6 +39,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -35,6 +35,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -39,6 +39,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_KEY: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
## Related Issue or Background Info

Bugfix for #2205 - `OKTA_API_KEY` is preset in GH secrets but needs to be explicitly made an env var.