### PR TITLE
Allow org admins to initiate user password reset

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -79,8 +79,6 @@ public class UserMutationResolver implements GraphQLMutationResolver {
   }
 
   public User resetUserPassword(UUID id) {
-    System.out.println("made it to the mutation resolver!");
-    LOG.info("BOOYAH resetting user's password in UserMutationResolver");
     UserInfo user = _us.resetUserPassword(id);
     return new User(user);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -12,9 +12,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 @Component
 public class UserMutationResolver implements GraphQLMutationResolver {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -13,9 +13,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 public class UserMutationResolver implements GraphQLMutationResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UserMutationResolver.class);
 
   private final ApiUserService _us;
 
@@ -71,6 +75,13 @@ public class UserMutationResolver implements GraphQLMutationResolver {
     Set<UUID> facilitySet =
         facilities == null ? Set.of() : new HashSet<>(Arrays.asList(facilities));
     UserInfo user = _us.updateUserPrivileges(id, accessAllFacilities, facilitySet, role);
+    return new User(user);
+  }
+
+  public User resetUserPassword(UUID id) {
+    System.out.println("made it to the mutation resolver!");
+    LOG.info("BOOYAH resetting user's password in UserMutationResolver");
+    UserInfo user = _us.resetUserPassword(id);
     return new User(user);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -141,8 +141,6 @@ public class DemoOktaRepository implements OktaRepository {
   }
 
   public void resetUserPassword(String username) {
-    System.out.println("BOOYAH in demo reset password");
-    LOG.info("BOOYAH in demo resetting user password");
     if (!usernameOrgRolesMap.containsKey(username)) {
       throw new IllegalGraphqlArgumentException(
           "Cannot reset password for Okta user with unrecognized username");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -140,6 +140,15 @@ public class DemoOktaRepository implements OktaRepository {
     return Optional.of(newRoleClaims);
   }
 
+  public void resetUserPassword(String username) {
+    System.out.println("BOOYAH in demo reset password");
+    LOG.info("BOOYAH in demo resetting user password");
+    if (!usernameOrgRolesMap.containsKey(username)) {
+      throw new IllegalGraphqlArgumentException(
+          "Cannot reset password for Okta user with unrecognized username");
+    }
+  }
+
   public void setUserIsActive(String username, Boolean active) {
     if (active) {
       inactiveUsernames.remove(username);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -344,8 +344,6 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void resetUserPassword(String username) {
-    System.out.println("BOOYAH in live reset password");
-    LOG.info("BOOYAH in live resetting user password");
     UserList users = _client.listUsers(username, null, null, null, null);
     if (users.stream().count() == 0) {
       throw new IllegalGraphqlArgumentException(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -343,6 +343,18 @@ public class LiveOktaRepository implements OktaRepository {
     return getOrganizationRoleClaimsForUser(user);
   }
 
+  public void resetUserPassword(String username) {
+    System.out.println("BOOYAH in live reset password");
+    LOG.info("BOOYAH in live resetting user password");
+    UserList users = _client.listUsers(username, null, null, null, null);
+    if (users.stream().count() == 0) {
+      throw new IllegalGraphqlArgumentException(
+          "Cannot reset password for Okta user with unrecognized username");
+    }
+    User user = users.single();
+    user.resetPassword(true);
+  }
+
   public void setUserIsActive(String username, Boolean active) {
     UserList users = _client.listUsers(username, null, null, null, null);
     if (users.stream().count() == 0) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -30,6 +30,8 @@ public interface OktaRepository {
   Optional<OrganizationRoleClaims> updateUserPrivileges(
       String username, Organization org, Set<Facility> facilities, Set<OrganizationRole> roles);
 
+  void resetUserPassword(String username);
+
   void setUserIsActive(String username, Boolean active);
 
   void reactivateUser(String username);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -198,8 +198,6 @@ public class ApiUserService {
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUser
   public UserInfo resetUserPassword(UUID userId) {
-    System.out.println("wow, made it to the ApiUserService!");
-    LOG.info("BOOYAH in resetPassword ApiUserService");
     ApiUser apiUser = getApiUser(userId);
     String username = apiUser.getLoginEmail();
     _oktaRepo.resetUserPassword(username);
@@ -209,8 +207,7 @@ public class ApiUserService {
             .orElseThrow(MisconfiguredUserException::new);
     Organization org = _orgService.getOrganization(orgClaims.getOrganizationExternalId());
     OrganizationRoles orgRoles = _orgService.getOrganizationRoles(org, orgClaims);
-    UserInfo user = new UserInfo(apiUser, Optional.of(orgRoles), isAdmin(apiUser));
-    return user;
+    return new UserInfo(apiUser, Optional.of(orgRoles), isAdmin(apiUser));
   }
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUserNotSelf

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -348,6 +348,8 @@ type Mutation {
     facilities: [ID!]
     role: Role!
   ): User @requiredPermissions(allOf: ["MANAGE_USERS"])
+  resetUserPassword(id: ID!): User
+    @requiredPermissions(allOf: ["MANAGE_USERS"])
   setUserIsDeleted(id: ID!, deleted: Boolean!): User
     @requiredPermissions(allOf: ["MANAGE_USERS"])
   reactivateUser(id: ID!): User

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -527,8 +527,8 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode resetUserPasswordVariables = JsonNodeFactory.instance.objectNode().put("id", id);
     ObjectNode resp =
         runQuery("reset-user-password", "resetUserPassword", resetUserPasswordVariables, null);
-    ObjectNode updateUser = (ObjectNode) resp.get("updateUser");
-    assertEquals(USERNAMES.get(0), updateUser.get("email").asText());
+    ObjectNode resetUserPassword = (ObjectNode) resp.get("resetUserPassword");
+    assertEquals(USERNAMES.get(0), resetUserPassword.get("email").asText());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -516,6 +516,39 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   }
 
   @Test
+  void resetUserPassword_orgUser_success() {
+    useSuperUser();
+
+    ObjectNode addUser = runBoilerplateAddUser(Role.ADMIN);
+    String id = addUser.get("id").asText();
+
+    useOrgAdmin();
+
+    ObjectNode resetUserPasswordVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    ObjectNode resp =
+        runQuery("reset-user-password", "resetUserPassword", resetUserPasswordVariables, null);
+    ObjectNode updateUser = (ObjectNode) resp.get("updateUser");
+    assertEquals(USERNAMES.get(0), updateUser.get("email").asText());
+  }
+
+  @Test
+  void resetUserPassword_orgUser_failure() {
+    useSuperUser();
+
+    ObjectNode addUser = runBoilerplateAddUser(Role.ADMIN);
+    String id = addUser.get("id").asText();
+
+    useOrgUser();
+
+    ObjectNode resetUserPasswordVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    runQuery(
+        "reset-user-password",
+        "resetUserPassword",
+        resetUserPasswordVariables,
+        "Current user does not have permission to request [/resetUserPassword]");
+  }
+
+  @Test
   void updateUserPrivileges_orgAdmin_success() {
     useOrgAdmin();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 
 class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
+
   @Autowired ApiUserRepository _apiUserRepo;
   @Autowired OktaRepository _oktaRepo;
 
@@ -190,6 +191,19 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
                 _service.createUserInCurrentOrg("captain@pirate.com", personName, Role.USER, true));
 
     assertEquals("Unable to add user.", caught.getMessage());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void resetUserPassword_orgAdmin_success() {
+    initSampleData();
+
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+
+    UserInfo userInfo = _service.resetUserPassword(apiUser.getInternalId());
+
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
   }
 
   private void roleCheck(final UserInfo userInfo, final Set<OrganizationRole> expected) {

--- a/backend/src/test/resources/queries/reset-user-password
+++ b/backend/src/test/resources/queries/reset-user-password
@@ -1,0 +1,17 @@
+mutation resetUserPassword (
+    $id: ID!
+    ){
+  resetUserPassword(
+    id: $id
+  ) {
+      id
+      firstName,
+      lastName,
+      email,
+      organization {
+        name
+        externalId
+      }
+    }
+}
+

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -100,7 +100,9 @@ const ManageUsers: React.FC<Props> = ({
   );
   const [showInProgressModal, updateShowInProgressModal] = useState(false);
   const [showAddUserModal, updateShowAddUserModal] = useState(false);
-  const [showResetPasswordModal, updateShowResetPasswordModal] = useState(false);
+  const [showResetPasswordModal, updateShowResetPasswordModal] = useState(
+    false
+  );
   const [showDeleteUserModal, updateShowDeleteUserModal] = useState(false);
   const [showReactivateUserModal, updateShowReactivateUserModal] = useState(
     false

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -29,6 +29,7 @@ interface Props {
   allFacilities: UserFacilitySetting[];
   updateUserPrivileges: (variables: any) => Promise<any>;
   addUserToOrg: (variables: any) => Promise<any>;
+  resetUserPassword: (variables: any) => Promise<any>;
   deleteUser: (variables: any) => Promise<any>;
   reactivateUser: (variables: any) => Promise<any>;
   getUsers: () => Promise<any>;
@@ -76,6 +77,7 @@ const ManageUsers: React.FC<Props> = ({
   allFacilities,
   updateUserPrivileges,
   addUserToOrg,
+  resetUserPassword,
   deleteUser,
   reactivateUser,
   getUsers,
@@ -98,6 +100,7 @@ const ManageUsers: React.FC<Props> = ({
   );
   const [showInProgressModal, updateShowInProgressModal] = useState(false);
   const [showAddUserModal, updateShowAddUserModal] = useState(false);
+  const [showResetPasswordModal, updateShowResetPasswordModal] = useState(false);
   const [showDeleteUserModal, updateShowDeleteUserModal] = useState(false);
   const [showReactivateUserModal, updateShowReactivateUserModal] = useState(
     false
@@ -240,6 +243,28 @@ const ManageUsers: React.FC<Props> = ({
     }
   };
 
+  const handleResetUserPassword = async (userId: string) => {
+    try {
+      await resetUserPassword({
+        variables: {
+          id: userId,
+        },
+      });
+      const fullName = displayFullNameInOrder(
+        userWithPermissions?.firstName,
+        userWithPermissions?.middleName,
+        userWithPermissions?.lastName
+      );
+      updateShowResetPasswordModal(false);
+      showNotification(
+        toast,
+        <Alert type="success" title={`Password reset for ${fullName}`} />
+      );
+    } catch (e) {
+      setError(e);
+    }
+  };
+
   const handleDeleteUser = async (userId: string) => {
     try {
       await deleteUser({
@@ -375,6 +400,8 @@ const ManageUsers: React.FC<Props> = ({
               updateUser={updateUser}
               showReactivateUserModal={showReactivateUserModal}
               updateShowReactivateUserModal={updateShowReactivateUserModal}
+              showResetUserPasswordModal={showResetPasswordModal}
+              updateShowResetPasswordModal={updateShowResetPasswordModal}
               showDeleteUserModal={showDeleteUserModal}
               updateShowDeleteUserModal={updateShowDeleteUserModal}
               showInProgressModal={showInProgressModal}
@@ -382,6 +409,7 @@ const ManageUsers: React.FC<Props> = ({
               isUserEdited={isUserEdited}
               onContinueChangeActiveUser={onContinueChangeActiveUser}
               handleReactivateUser={handleReactivateUser}
+              handleResetUserPassword={handleResetUserPassword}
             />
           </div>
         </div>

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -91,6 +91,14 @@ const UPDATE_USER_PRIVILEGES = gql`
   }
 `;
 
+const RESET_USER_PASSWORD = gql`
+  mutation ResetUserPassword($id: ID!) {
+    resetUserPassword(id: $id) {
+      id
+    }
+  }
+`;
+
 const DELETE_USER = gql`
   mutation SetUserIsDeleted($id: ID!, $deleted: Boolean!) {
     setUserIsDeleted(id: $id, deleted: $deleted) {
@@ -160,6 +168,7 @@ const ManageUsersContainer: any = () => {
   const [deleteUser] = useMutation(DELETE_USER);
   const [reactivateUser] = useMutation(REACTIVATE_USER);
   const [addUserToOrg] = useMutation(ADD_USER_TO_ORG);
+  const [resetPassword] = useMutation(RESET_USER_PASSWORD);
 
   const { data, loading, error, refetch: getUsers } = useQuery<UserData, {}>(
     GET_USERS,
@@ -200,6 +209,7 @@ const ManageUsersContainer: any = () => {
       allFacilities={allFacilities}
       updateUserPrivileges={updateUserPrivileges}
       addUserToOrg={addUserToOrg}
+      resetUserPassword={resetPassword}
       deleteUser={deleteUser}
       reactivateUser={reactivateUser}
       getUsers={getUsers}

--- a/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
+++ b/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
@@ -36,7 +36,7 @@ const ResetUserPasswordModal: React.FC<Props> = ({
       <div className="border-0 card-container">
         <div className="display-flex flex-justify">
           <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
-            Reset user's password
+            Reset {displayFullName(user.firstName, user.middleName, user.lastName)}'s password
           </h1>
           <button onClick={onClose} className="close-button" aria-label="Close">
             <span className="fa-layers">
@@ -56,8 +56,7 @@ const ResetUserPasswordModal: React.FC<Props> = ({
           </p>
           <p>
             {" "}
-            Doing so will send them an email with a link to reset their
-            password.
+            Doing so will email this person a link to reset their password. The link will expire in 24 hours.
           </p>
         </div>
         <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">

--- a/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
+++ b/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
@@ -36,7 +36,9 @@ const ResetUserPasswordModal: React.FC<Props> = ({
       <div className="border-0 card-container">
         <div className="display-flex flex-justify">
           <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
-            Reset {displayFullName(user.firstName, user.middleName, user.lastName)}'s password
+            Reset{" "}
+            {displayFullName(user.firstName, user.middleName, user.lastName)}'s
+            password
           </h1>
           <button onClick={onClose} className="close-button" aria-label="Close">
             <span className="fa-layers">
@@ -56,7 +58,8 @@ const ResetUserPasswordModal: React.FC<Props> = ({
           </p>
           <p>
             {" "}
-            Doing so will email this person a link to reset their password. The link will expire in 24 hours.
+            Doing so will email this person a link to reset their password. The
+            link will expire in 24 hours.
           </p>
         </div>
         <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">

--- a/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
+++ b/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
@@ -9,67 +9,75 @@ import { SettingsUser } from "./ManageUsersContainer";
 import "./ManageUsers.scss";
 
 interface Props {
-    onClose: () => void;
-    onResetPassword: (userId: string) => void;
-    user: SettingsUser;
+  onClose: () => void;
+  onResetPassword: (userId: string) => void;
+  user: SettingsUser;
 }
 
-const ResetUserPasswordModal: React.FC<Props> = ({ onClose, onResetPassword, user }) => {
-    return (
-      <Modal
-        isOpen={true}
-        style={{
-          content: {
-            maxHeight: "90vh",
-            width: "40em",
-            position: "initial",
-          },
-        }}
-        overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
-        contentLabel="Unsaved changes to current user"
-        ariaHideApp={process.env.NODE_ENV !== "test"}
-      >
-        <div className="border-0 card-container">
-          <div className="display-flex flex-justify">
-            <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
-              Reset user's password
-            </h1>
-            <button onClick={onClose} className="close-button" aria-label="Close">
-              <span className="fa-layers">
-                <FontAwesomeIcon icon={"circle"} size="2x" inverse />
-                <FontAwesomeIcon icon={"times-circle"} size="2x" />
-              </span>
-            </button>
-          </div>
-          <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
-          <div className="grid-row grid-gap">
-            <p>
-              Are you sure you want to reset the password for{" "}
-              <strong>
-                {displayFullName(user.firstName, user.middleName, user.lastName)}
-              </strong>
-              ?
-            </p>
-            <p> Doing so will send them an email with a link to reset their password.</p>
-          </div>
-          <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
-            <div className="display-flex flex-justify-end">
-              <Button
-                className="margin-right-2"
-                onClick={onClose}
-                variant="unstyled"
-                label="No, go back"
-              />
-              <Button
-                className="margin-right-205"
-                onClick={() => onResetPassword(user.id)}
-                label="Yes, I'm sure"
-              />
-            </div>
+const ResetUserPasswordModal: React.FC<Props> = ({
+  onClose,
+  onResetPassword,
+  user,
+}) => {
+  return (
+    <Modal
+      isOpen={true}
+      style={{
+        content: {
+          maxHeight: "90vh",
+          width: "40em",
+          position: "initial",
+        },
+      }}
+      overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
+      contentLabel="Unsaved changes to current user"
+      ariaHideApp={process.env.NODE_ENV !== "test"}
+    >
+      <div className="border-0 card-container">
+        <div className="display-flex flex-justify">
+          <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
+            Reset user's password
+          </h1>
+          <button onClick={onClose} className="close-button" aria-label="Close">
+            <span className="fa-layers">
+              <FontAwesomeIcon icon={"circle"} size="2x" inverse />
+              <FontAwesomeIcon icon={"times-circle"} size="2x" />
+            </span>
+          </button>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
+        <div className="grid-row grid-gap">
+          <p>
+            Are you sure you want to reset the password for{" "}
+            <strong>
+              {displayFullName(user.firstName, user.middleName, user.lastName)}
+            </strong>
+            ?
+          </p>
+          <p>
+            {" "}
+            Doing so will send them an email with a link to reset their
+            password.
+          </p>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
+          <div className="display-flex flex-justify-end">
+            <Button
+              className="margin-right-2"
+              onClick={onClose}
+              variant="unstyled"
+              label="No, go back"
+            />
+            <Button
+              className="margin-right-205"
+              onClick={() => onResetPassword(user.id)}
+              label="Yes, I'm sure"
+            />
           </div>
         </div>
-      </Modal>
-    );
-  };
-  
-  export default ResetUserPasswordModal;
+      </div>
+    </Modal>
+  );
+};
+
+export default ResetUserPasswordModal;

--- a/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
+++ b/frontend/src/app/Settings/Users/ResetUserPasswordModal.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import Modal from "react-modal";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import Button from "../../commonComponents/Button/Button";
+import { displayFullName } from "../../utils";
+
+import { SettingsUser } from "./ManageUsersContainer";
+import "./ManageUsers.scss";
+
+interface Props {
+    onClose: () => void;
+    onResetPassword: (userId: string) => void;
+    user: SettingsUser;
+}
+
+const ResetUserPasswordModal: React.FC<Props> = ({ onClose, onResetPassword, user }) => {
+    return (
+      <Modal
+        isOpen={true}
+        style={{
+          content: {
+            maxHeight: "90vh",
+            width: "40em",
+            position: "initial",
+          },
+        }}
+        overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
+        contentLabel="Unsaved changes to current user"
+        ariaHideApp={process.env.NODE_ENV !== "test"}
+      >
+        <div className="border-0 card-container">
+          <div className="display-flex flex-justify">
+            <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
+              Reset user's password
+            </h1>
+            <button onClick={onClose} className="close-button" aria-label="Close">
+              <span className="fa-layers">
+                <FontAwesomeIcon icon={"circle"} size="2x" inverse />
+                <FontAwesomeIcon icon={"times-circle"} size="2x" />
+              </span>
+            </button>
+          </div>
+          <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
+          <div className="grid-row grid-gap">
+            <p>
+              Are you sure you want to reset the password for{" "}
+              <strong>
+                {displayFullName(user.firstName, user.middleName, user.lastName)}
+              </strong>
+              ?
+            </p>
+            <p> Doing so will send them an email with a link to reset their password.</p>
+          </div>
+          <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
+            <div className="display-flex flex-justify-end">
+              <Button
+                className="margin-right-2"
+                onClick={onClose}
+                variant="unstyled"
+                label="No, go back"
+              />
+              <Button
+                className="margin-right-205"
+                onClick={() => onResetPassword(user.id)}
+                label="Yes, I'm sure"
+              />
+            </div>
+          </div>
+        </div>
+      </Modal>
+    );
+  };
+  
+  export default ResetUserPasswordModal;

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -12,6 +12,7 @@ import DeleteUserModal from "./DeleteUserModal";
 import UserFacilitiesSettingsForm from "./UserFacilitiesSettingsForm";
 import UserRoleSettingsForm from "./UserRoleSettingsForm";
 import ReactivateUserModal from "./ReactivateUserModal";
+import ResetUserPasswordModal from "./ResetUserPasswordModal";
 import "./ManageUsers.scss";
 
 interface Props {
@@ -24,6 +25,8 @@ interface Props {
   updateUser: UpdateUser;
   showReactivateUserModal: boolean;
   updateShowReactivateUserModal: (showReactivateUserModal: boolean) => void;
+  showResetUserPasswordModal: boolean;
+  updateShowResetPasswordModal: (showResetPasswordModal: boolean) => void;
   showDeleteUserModal: boolean;
   updateShowDeleteUserModal: (showDeleteUserModal: boolean) => void;
   showInProgressModal: boolean;
@@ -31,6 +34,7 @@ interface Props {
   isUserEdited: boolean;
   onContinueChangeActiveUser: () => void;
   handleReactivateUser: (userId: string) => void;
+  handleResetUserPassword: (userId: string) => void;
 }
 const roles: Role[] = ["ADMIN", "ENTRY_ONLY", "USER"];
 
@@ -44,6 +48,8 @@ const UserDetail: React.FC<Props> = ({
   handleDeleteUser,
   showReactivateUserModal,
   updateShowReactivateUserModal,
+  showResetUserPasswordModal,
+  updateShowResetPasswordModal,
   showDeleteUserModal,
   updateShowDeleteUserModal,
   showInProgressModal,
@@ -51,6 +57,7 @@ const UserDetail: React.FC<Props> = ({
   isUserEdited,
   onContinueChangeActiveUser,
   handleReactivateUser,
+  handleResetUserPassword,
 }) => {
   return (
     <div className="tablet:grid-col padding-left-2">
@@ -153,6 +160,13 @@ const UserDetail: React.FC<Props> = ({
           onReactivateUser={handleReactivateUser}
         />
       ) : null}
+        {showResetUserPasswordModal ? (
+            <ResetUserPasswordModal
+                user={user}
+                onClose={() => updateShowResetPasswordModal(false)}
+                onResetPassword={handleResetUserPassword}
+            />
+        ) : null}
     </div>
   );
 };

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -84,6 +84,16 @@ const UserDetail: React.FC<Props> = ({
             disabled={isUpdating}
           />
         ) : null}
+        {process.env.REACT_APP_EDIT_USER_ROLE === "true" && user.status !== "SUSPENDED" &&
+        user?.id !== loggedInUser.id  ? (
+            <Button
+                variant="outline"
+                className="margin-left-auto margin-bottom-1"
+                onClick={() => updateShowResetPasswordModal(true)}
+                label={"Reset password"}
+                disabled={isUpdating}
+            />
+        ) : null}
       </div>
       <div className="user-content">
         <p className="text-base">

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -84,15 +84,16 @@ const UserDetail: React.FC<Props> = ({
             disabled={isUpdating}
           />
         ) : null}
-        {process.env.REACT_APP_EDIT_USER_ROLE === "true" && user.status !== "SUSPENDED" &&
-        user?.id !== loggedInUser.id  ? (
-            <Button
-                variant="outline"
-                className="margin-left-auto margin-bottom-1"
-                onClick={() => updateShowResetPasswordModal(true)}
-                label={"Reset password"}
-                disabled={isUpdating}
-            />
+        {process.env.REACT_APP_EDIT_USER_ROLE === "true" &&
+        user.status !== "SUSPENDED" &&
+        user?.id !== loggedInUser.id ? (
+          <Button
+            variant="outline"
+            className="margin-left-auto margin-bottom-1"
+            onClick={() => updateShowResetPasswordModal(true)}
+            label={"Reset password"}
+            disabled={isUpdating}
+          />
         ) : null}
       </div>
       <div className="user-content">
@@ -170,13 +171,13 @@ const UserDetail: React.FC<Props> = ({
           onReactivateUser={handleReactivateUser}
         />
       ) : null}
-        {showResetUserPasswordModal ? (
-            <ResetUserPasswordModal
-                user={user}
-                onClose={() => updateShowResetPasswordModal(false)}
-                onResetPassword={handleResetUserPassword}
-            />
-        ) : null}
+      {showResetUserPasswordModal ? (
+        <ResetUserPasswordModal
+          user={user}
+          onClose={() => updateShowResetPasswordModal(false)}
+          onResetPassword={handleResetUserPassword}
+        />
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -410,6 +410,12 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
             >
               John Arthur
             </h2>
+            <button
+              class="usa-button usa-button--outline margin-left-auto margin-bottom-1"
+              type="button"
+            >
+              Reset password
+            </button>
           </div>
           <div
             class="user-content"


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/1930

## Changes Proposed

- Add reset password button to org user management
- Add graphql mutation to send reset password email (through Okta)

## Additional Information

- A lot of support requests are made asking for password resets.  This will allow org admins to initiate the process for their users.

## Screenshots / Demos

## Checklist for Author and Reviewer

The frontend changes are visible on the user management page (`https://[env].simplereport.gov/app/settings`)



### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
