### PR TITLE
Add Consent page to Experian flow

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/Consent.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.stories.tsx
@@ -1,0 +1,23 @@
+import { Story, Meta } from "@storybook/react";
+import { MemoryRouter } from "react-router";
+
+import Consent from "./Consent";
+
+export default {
+  title: "App/Identity Verification/Step 1: Consent",
+  component: Consent,
+  argTypes: {},
+} as Meta;
+
+const Template: Story = (args) => (
+  <MemoryRouter
+    initialEntries={[
+      { pathname: "/identity-verification", search: "?orgExternalId=foo" },
+    ]}
+  >
+    <Consent {...args} />
+  </MemoryRouter>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/frontend/src/app/signUp/IdentityVerification/Consent.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import Consent from "./Consent";
+
+describe("Consent", () => {
+  beforeEach(() => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: "/identity-verification", search: "?orgExternalId=foo" },
+        ]}
+      >
+        <Consent />
+      </MemoryRouter>
+    );
+  });
+  it("initializes with the submit button enabled", () => {
+    expect(screen.getByText("I agree")).not.toHaveAttribute("disabled");
+  });
+  it("initializes to an error page if no org id is passed", () => {
+    render(
+      <MemoryRouter>
+        <Consent />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByText("We weren't able to find your affiliated organization", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/signUp/IdentityVerification/Consent.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.tsx
@@ -4,14 +4,12 @@ import { Card } from "../../commonComponents/Card/Card";
 import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
 import Button from "../../commonComponents/Button/Button";
 import { useSearchParam } from "../../utils/url";
-import Checkboxes from "../../commonComponents/Checkboxes";
 
 import PersonalDetailsForm from "./PersonalDetailsForm";
 
 const Consent = () => {
   // Get organization ID from URL
   const orgExternalId = useSearchParam("orgExternalId");
-  const [consentGiven, setConsentGiven] = useState<boolean>(false);
   const [submitted, setSubmitted] = useState(false);
 
   if (orgExternalId === null) {
@@ -32,7 +30,7 @@ const Consent = () => {
 
   return (
     <CardBackground>
-      <Card logo bodyKicker="Consent to Identify Verification">
+      <Card logo bodyKicker="Identity verification consent">
         <div className="margin-bottom-2">
           <p className="font-ui-2xs text-base">
             To create your account, you’ll need to consent to identity
@@ -40,10 +38,10 @@ const Consent = () => {
             <a href="https://www.experian.com/decision-analytics/identity-proofing">
               Experian
             </a>
-            . SimpleReport doesn’t access identity verification details.
+            . SimpleReport doesn’t access your identity verification details.
           </p>
           <p className="font-ui-2xs text-base margin-top-0">
-            You understand that by clicking on the I AGREE button immediately
+            You understand that by clicking on the "I agree" button immediately
             following this notice, you are providing ‘written instructions’ to
             SimpleReport under the Fair Credit Reporting Act authorizing
             SimpleReport to obtain information from your personal credit profile
@@ -59,30 +57,14 @@ const Consent = () => {
             applicable, this information may also be shared by us with other
             companies to support your transactions and for fraud avoidance
             purposes. You can see a more detailed list of information
-            potentially disclosed and how we use your data in our Privacy
-            Policy.
+            potentially disclosed and how we use your data in our{" "}
+            <a href="https://www.cdc.gov/other/privacy.html">privacy policy</a>.
           </p>
-          <div className="display-flex flex-column flex-align-center">
-            <Checkboxes
-              className="margin-top-neg-3"
-              onChange={(e) => setConsentGiven(e.target.checked)}
-              name="consent_given"
-              legend=""
-              boxes={[
-                {
-                  value: "1",
-                  label: "I AGREE",
-                  checked: consentGiven,
-                },
-              ]}
-            />
-          </div>
         </div>
         <Button
           className="width-full"
-          disabled={!consentGiven}
           onClick={() => setSubmitted(true)}
-          label={"Submit"}
+          label={"I agree"}
         />
       </Card>
     </CardBackground>

--- a/frontend/src/app/signUp/IdentityVerification/Consent.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.tsx
@@ -33,7 +33,7 @@ const Consent = () => {
       <Card logo bodyKicker="Identity verification consent">
         <div className="margin-bottom-2">
           <p className="font-ui-2xs text-base">
-            To create your account, you’ll need to consent to identity
+            To create an account, you’ll need to consent to identity
             verification by{" "}
             <a href="https://www.experian.com/decision-analytics/identity-proofing">
               Experian
@@ -43,15 +43,15 @@ const Consent = () => {
           <p className="font-ui-2xs text-base margin-top-0">
             You understand that by clicking on the "I agree" button immediately
             following this notice, you are providing ‘written instructions’ to
-            SimpleReport under the Fair Credit Reporting Act authorizing
+            SimpleReport under the Fair Credit Reporting Act, authorizing
             SimpleReport to obtain information from your personal credit profile
             or other information from Experian. You authorize SimpleReport to
             obtain such information solely to verify your identity to avoid
             fraudulent transactions in your name.
           </p>
-          <p className="font-ui-2xs text-base margin-top-0 margin-bottom-neg-2">
+          <p className="font-ui-2xs text-base margin-top-0">
             You authorize your wireless operator to disclose to us details of
-            your account, subscriber, billing and device, if available, to
+            your account, subscriber, billing, and device, if available, to
             support verification of identity, fraud avoidance in support of and
             for the duration of your business relationship with us. Where
             applicable, this information may also be shared by us with other

--- a/frontend/src/app/signUp/IdentityVerification/Consent.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+
+import { Card } from "../../commonComponents/Card/Card";
+import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
+import Button from "../../commonComponents/Button/Button";
+import { useSearchParam } from "../../utils/url";
+import Checkboxes from "../../commonComponents/Checkboxes";
+
+import PersonalDetailsForm from "./PersonalDetailsForm";
+
+const Consent = () => {
+  // Get organization ID from URL
+  const orgExternalId = useSearchParam("orgExternalId");
+  const [consentGiven, setConsentGiven] = useState<boolean>(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  if (orgExternalId === null) {
+    return (
+      <CardBackground>
+        <Card logo bodyKicker={"Invalid request"} bodyKickerCentered={true}>
+          <p className="text-center">
+            We weren't able to find your affiliated organization
+          </p>
+        </Card>
+      </CardBackground>
+    );
+  }
+
+  if (submitted) {
+    return <PersonalDetailsForm orgExternalId={orgExternalId} />;
+  }
+
+  return (
+    <CardBackground>
+      <Card logo bodyKicker="Consent to Identify Verification">
+        <div className="margin-bottom-2">
+          <p className="font-ui-2xs text-base">
+            To create your account, you’ll need to consent to identity
+            verification by{" "}
+            <a href="https://www.experian.com/decision-analytics/identity-proofing">
+              Experian
+            </a>
+            . SimpleReport doesn’t access identity verification details.
+          </p>
+          <p className="font-ui-2xs text-base margin-top-0">
+            You understand that by clicking on the I AGREE button immediately
+            following this notice, you are providing ‘written instructions’ to
+            SimpleReport under the Fair Credit Reporting Act authorizing
+            SimpleReport to obtain information from your personal credit profile
+            or other information from Experian. You authorize SimpleReport to
+            obtain such information solely to verify your identity to avoid
+            fraudulent transactions in your name.
+          </p>
+          <p className="font-ui-2xs text-base margin-top-0 margin-bottom-neg-2">
+            You authorize your wireless operator to disclose to us details of
+            your account, subscriber, billing and device, if available, to
+            support verification of identity, fraud avoidance in support of and
+            for the duration of your business relationship with us. Where
+            applicable, this information may also be shared by us with other
+            companies to support your transactions and for fraud avoidance
+            purposes. You can see a more detailed list of information
+            potentially disclosed and how we use your data in our Privacy
+            Policy.
+          </p>
+          <div className="display-flex flex-column flex-align-center">
+            <Checkboxes
+              className="margin-top-neg-3"
+              onChange={(e) => setConsentGiven(e.target.checked)}
+              name="consent_given"
+              legend=""
+              boxes={[
+                {
+                  value: "1",
+                  label: "I AGREE",
+                  checked: consentGiven,
+                },
+              ]}
+            />
+          </div>
+        </div>
+        <Button
+          className="width-full"
+          disabled={!consentGiven}
+          onClick={() => setSubmitted(true)}
+          label={"Submit"}
+        />
+      </Card>
+    </CardBackground>
+  );
+};
+
+export default Consent;

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.stories.tsx
@@ -1,23 +1,19 @@
 import { Story, Meta } from "@storybook/react";
-import { MemoryRouter } from "react-router";
 
 import PersonalDetailsForm from "./PersonalDetailsForm";
 
 export default {
-  title: "App/Identity Verification/Step 1: Personal Details",
+  title: "App/Identity Verification/Step 2: Personal Details",
   component: PersonalDetailsForm,
   argTypes: {},
+  args: {
+    orgExternalId: "foo",
+  },
 } as Meta;
 
-const Template: Story = (args) => (
-  <MemoryRouter
-    initialEntries={[
-      { pathname: "/identity-verification", search: "?orgExternalId=foo" },
-    ]}
-  >
-    <PersonalDetailsForm {...args} />
-  </MemoryRouter>
-);
+type Props = React.ComponentProps<typeof PersonalDetailsForm>;
+
+const Template: Story<Props> = (args) => <PersonalDetailsForm {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -11,24 +11,12 @@ describe("PersonalDetailsForm", () => {
           { pathname: "/identity-verification", search: "?orgExternalId=foo" },
         ]}
       >
-        <PersonalDetailsForm />
+        <PersonalDetailsForm orgExternalId="foo" />
       </MemoryRouter>
     );
   });
   it("initializes with the submit button disabled", () => {
     expect(screen.getByText("Submit")).toHaveAttribute("disabled");
-  });
-  it("initializes to an error page if no org id is passed", () => {
-    render(
-      <MemoryRouter>
-        <PersonalDetailsForm />
-      </MemoryRouter>
-    );
-    expect(
-      screen.getByText("We weren't able to find your affiliated organization", {
-        exact: false,
-      })
-    ).toBeInTheDocument();
   });
   describe("Filling out the form", () => {
     beforeEach(() => {

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -12,7 +12,6 @@ import { isFormValid, isFieldValid } from "../../utils/yupHelpers";
 import Input from "../../commonComponents/Input";
 import { stateCodes } from "../../../config/constants";
 import Select from "../../commonComponents/Select";
-import { useSearchParam } from "../../utils/url";
 
 import {
   initPersonalDetails,
@@ -27,9 +26,11 @@ type PersonalDetailsFormErrors = Record<
   string
 >;
 
-const PersonalDetailsForm = () => {
-  // Get organization ID from URL
-  const orgExternalId = useSearchParam("orgExternalId");
+interface Props {
+  orgExternalId: string;
+}
+
+const PersonalDetailsForm = ({ orgExternalId }: Props) => {
   const [
     personalDetails,
     setPersonalDetails,

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.stories.tsx
@@ -5,7 +5,7 @@ import { getMocks } from "../../../stories/storyMocks";
 import QuestionsFormContainer from "./QuestionsFormContainer";
 
 export default {
-  title: "App/Identity Verification/Step 2: Identity verification questions",
+  title: "App/Identity Verification/Step 3: Identity verification questions",
   component: QuestionsFormContainer,
   parameters: {
     msw: getMocks("getQuestions"),

--- a/frontend/src/app/signUp/IdentityVerification/Success.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Success.stories.tsx
@@ -3,7 +3,7 @@ import { Story, Meta } from "@storybook/react";
 import Success from "./Success";
 
 export default {
-  title: "App/Identity Verification/Step 3: Success",
+  title: "App/Identity Verification/Step 4: Success",
   component: Success,
   argTypes: {},
   args: {

--- a/frontend/src/app/signUp/SignUpApp.test.tsx
+++ b/frontend/src/app/signUp/SignUpApp.test.tsx
@@ -13,7 +13,11 @@ describe("SignUpApp", () => {
     ));
 
     render(
-      <MemoryRouter initialEntries={["/identity-verification"]}>
+      <MemoryRouter
+        initialEntries={[
+          { pathname: "/identity-verification", search: "?orgExternalId=foo" },
+        ]}
+      >
         <SignUpApp
           match={{ path: "" } as any}
           location={{} as any}
@@ -23,6 +27,8 @@ describe("SignUpApp", () => {
     );
   });
   it("renders", () => {
-    expect(screen.getByText("personal details form")).toBeInTheDocument();
+    expect(
+      screen.getByText("Identity verification consent")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/signUp/SignUpApp.tsx
+++ b/frontend/src/app/signUp/SignUpApp.tsx
@@ -3,7 +3,7 @@ import { Route, RouteComponentProps } from "react-router-dom";
 import PrimeErrorBoundary from "../PrimeErrorBoundary";
 import Page from "../commonComponents/Page/Page";
 
-import PersonalDetailsForm from "./IdentityVerification/PersonalDetailsForm";
+import Consent from "./IdentityVerification/Consent";
 
 const SignUpApp: React.FC<RouteComponentProps> = ({ match: { path } }) => {
   return (
@@ -12,7 +12,7 @@ const SignUpApp: React.FC<RouteComponentProps> = ({ match: { path } }) => {
         <Route
           path={`${path}/identity-verification`}
           exact
-          component={PersonalDetailsForm}
+          component={Consent}
         />
       </Page>
     </PrimeErrorBoundary>


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2278

## Changes Proposed

- Adds `Consent` component with required consent language from Experian
- Flow starts with this new component, requires checking "I AGREE" checkbox before continuing

## Additional Information

- this is a quick pass, open to design changes

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/9121162/129611862-4279496c-c903-4382-a956-a17577bb6a03.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
