### PR TITLE
Allow for tribalAffiliation to be null instead of assuming it is an array

### DIFF
--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -353,4 +353,29 @@ describe("EditPatient", () => {
       });
     });
   });
+  describe("tribal tribal Affiliation null", () => {
+    beforeEach(async () => {
+      const mocksWithNull = [...mocks];
+      (mocksWithNull[0].result.data.patient as any).tribalAffiliation = null;
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <MockedProvider mocks={mocksWithNull} addTypename={false}>
+              <EditPatient
+                facilityId={mockFacilityID}
+                patientId={mockPatientID}
+              />
+            </MockedProvider>
+          </Provider>
+        </MemoryRouter>
+      );
+    });
+    it("renders", async () => {
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Franecki, Eugenia", { exact: false })
+        ).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -194,7 +194,7 @@ const EditPatient = (props: Props) => {
               patient={{
                 ...data.patient,
                 tribalAffiliation:
-                  data.patient.tribalAffiliation[0] || undefined,
+                  data.patient.tribalAffiliation?.[0] || undefined,
                 phoneNumbers: data.patient.phoneNumbers.sort(function (
                   x: PhoneNumber,
                   y: PhoneNumber


### PR DESCRIPTION
## Related Issue or Background Info

- Issue that came in through support inbox https://usds.slack.com/archives/C024ZEUGWDV/p1629112963064700

## Changes Proposed

- Use optional chaining to access 0th element of tribal affiliation

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
