### PR TITLE
type get patient response

### DIFF
--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -50,6 +50,44 @@ export const GET_PATIENT = gql`
   }
 `;
 
+interface GetPatientParams {
+  id: string;
+}
+
+interface GetPatientResponse {
+  patient: {
+    firstName: string;
+    middleName: string | null;
+    lastName: string;
+    birthDate: string;
+    street: string;
+    streetTwo: string | null;
+    city: string | null;
+    state: string;
+    zipCode: string;
+    telephone: string;
+    phoneNumbers: {
+      type: string;
+      number: string;
+    }[];
+    role: Role | null;
+    lookupId: string | null;
+    email: string | null;
+    county: string | null;
+    race: Race | null;
+    ethnicity: Ethnicity | null;
+    tribalAffiliation: (TribalAffiliation | null)[] | null;
+    gender: Gender | null;
+    residentCongregateSetting: boolean | null;
+    employedInHealthcare: boolean | null;
+    preferredLanguage: Language | null;
+    facility: {
+      id: string;
+    } | null;
+    testResultDelivery: TestResultDeliveryPreference | null;
+  };
+}
+
 const UPDATE_PATIENT = gql`
   mutation UpdatePatient(
     $facilityId: ID
@@ -128,7 +166,10 @@ const EditPatient = (props: Props) => {
 
   const { t } = useTranslation();
 
-  const { data, loading, error } = useQuery(GET_PATIENT, {
+  const { data, loading, error } = useQuery<
+    GetPatientResponse,
+    GetPatientParams
+  >(GET_PATIENT, {
     variables: { id: props.patientId || "" },
     fetchPolicy: "no-cache",
   });
@@ -146,7 +187,7 @@ const EditPatient = (props: Props) => {
   if (loading) {
     return <p>Loading...</p>;
   }
-  if (error) {
+  if (error || data == undefined) {
     return <p>error loading patient with id {props.patientId}...</p>;
   }
 

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -187,7 +187,7 @@ const EditPatient = (props: Props) => {
   if (loading) {
     return <p>Loading...</p>;
   }
-  if (error || data == undefined) {
+  if (error || data === undefined) {
     return <p>error loading patient with id {props.patientId}...</p>;
   }
 

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -66,10 +66,7 @@ interface GetPatientResponse {
     state: string;
     zipCode: string;
     telephone: string;
-    phoneNumbers: {
-      type: string;
-      number: string;
-    }[];
+    phoneNumbers: PhoneNumber[];
     role: Role | null;
     lookupId: string | null;
     email: string | null;


### PR DESCRIPTION
## Related Issue or Background Info

- Attempt to prevent the likely hood of API response data bugs like https://usds.slack.com/archives/C024ZEUGWDV/p1629112963064700
- Bug was fixed in https://github.com/CDCgov/prime-simplereport/pull/2319

## Changes Proposed

- type patient detail response

## Additional Information

- This is still making some assumptions about the data format. For one The API is not guaranteed to return gender/race/ethnicity/etc. in the correct format 
  - note this is an issue and is tracked in https://github.com/CDCgov/prime-simplereport/issues/2164

## Screenshots / Demos

## Checklist for Author and Reviewer
- [x] ensure the edit person from still loads and submits
   - [x] with minimal data
   - [x] with all fields filled out  

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
