### PR TITLE
Disable frontend error boundary alerts in demo/training

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -11,6 +11,9 @@ module "metric_alerts" {
   cpu_window_size                = 15
   http_response_time_aggregation = "Minimum"
   skip_on_weekends               = true
+  disabled_alerts = [
+    "frontend_error_boundary",
+  ]
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_demo_action_id

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -11,6 +11,9 @@ module "metric_alerts" {
   http_response_time_aggregation = "Minimum"
   failed_http_2xx_threshold      = 14
   skip_on_weekends               = true
+  disabled_alerts = [
+    "frontend_error_boundary",
+  ]
 
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_demo_action_id


### PR DESCRIPTION
## Related Issue or Background Info

The uncaught `PrimeErrorBoundary` alerts were disabled in all envs other than `demo` and `training`, but without source maps and addressing the underlying issues these alerts are also fairly unactionable.

## Changes Proposed

- Disable these alerts in `demo` and `training` until we fix the underlying issues.
