### PR TITLE
Update contact information copy and allow for results to be texted to minors

### DIFF
--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -89,7 +89,10 @@ const testResultDeliveryPreferenceValues = (
   label: string;
 }[] => {
   return [
-    { label: i18n.t("constants.yesNoUnk.YES"), value: "SMS" },
+    {
+      label: i18n.t("patient.form.contact.receiveTextMessageResults"),
+      value: "SMS",
+    },
     { label: i18n.t("constants.yesNoUnk.NO"), value: "NONE" },
   ];
 };

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -220,7 +220,7 @@ describe("AddPatient", () => {
             "Would you like to receive your results via text message": {
               label: "Yes",
               value: "SMS",
-              exact: true,
+              exact: false,
             },
           }
         );

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -227,7 +227,6 @@ const ManagePhoneNumbers: React.FC<Props> = ({
         <RadioGroup
           legend={t("patient.form.contact.testResultDelivery")}
           name="testResultDelivery"
-          hintText={t("patient.form.contact.testResultDeliveryHint")}
           buttons={TEST_RESULT_DELIVERY_PREFERENCE_VALUES}
           onChange={updateTestResultDelivery}
           selectedRadio={testResultDelivery}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -359,6 +359,9 @@ const PersonForm = (props: Props) => {
         </div>
       </FormGroup>
       <FormGroup title={t("patient.form.contact.heading")}>
+        <p className="usa-hint maxw-prose">
+          {t("patient.form.contact.helpText")}
+        </p>
         <ManagePhoneNumbers
           phoneNumbers={patient.phoneNumbers || []}
           testResultDelivery={patient.testResultDelivery}

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -303,6 +303,11 @@ Object {
                   >
                     Contact information
                   </legend>
+                  <p
+                    class="usa-hint maxw-prose"
+                  >
+                    You're responsible for entering the correct contact information, following applicable federal and state laws.
+                  </p>
                   <div
                     class="usa-form"
                   >
@@ -430,11 +435,6 @@ Object {
                         >
                           Would you like to receive your results via text message?
                         </legend>
-                        <span
-                          class="usa-hint"
-                        >
-                          We'll text all mobile numbers on file
-                        </span>
                         <div
                           class=""
                         >
@@ -453,7 +453,7 @@ Object {
                               class="usa-radio__label"
                               for="53-val-SMS"
                             >
-                              Yes
+                              Yes, text all mobile numbers on file.
                             </label>
                           </div>
                           <div
@@ -1772,6 +1772,11 @@ Object {
                 >
                   Contact information
                 </legend>
+                <p
+                  class="usa-hint maxw-prose"
+                >
+                  You're responsible for entering the correct contact information, following applicable federal and state laws.
+                </p>
                 <div
                   class="usa-form"
                 >
@@ -1899,11 +1904,6 @@ Object {
                       >
                         Would you like to receive your results via text message?
                       </legend>
-                      <span
-                        class="usa-hint"
-                      >
-                        We'll text all mobile numbers on file
-                      </span>
                       <div
                         class=""
                       >
@@ -1922,7 +1922,7 @@ Object {
                             class="usa-radio__label"
                             for="53-val-SMS"
                           >
-                            Yes
+                            Yes, text all mobile numbers on file.
                           </label>
                         </div>
                         <div

--- a/frontend/src/app/testQueue/AoEForm/AoEForm.test.tsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEForm.test.tsx
@@ -200,7 +200,7 @@ describe("AoEForm", () => {
       );
       const smsDeliveryRadio = screen.getByRole("radio", {
         name:
-          "Yes (There are no mobile phone numbers listed in your patient profile.)",
+          "Yes, text all mobile numbers on file. (There are no mobile phone numbers listed in your patient profile.)",
       });
 
       expect(smsDeliveryRadio).toBeInTheDocument();

--- a/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import classnames from "classnames";
-import moment from "moment";
 
 import {
   globalSymptomDefinitions,
@@ -137,8 +136,6 @@ const AoEForm: React.FC<Props> = ({
     patient.testResultDelivery
   );
 
-  const patientIsOver18 = moment().diff(patient.birthDate, "years") >= 18;
-
   // form validation
   const [symptomError, setSymptomError] = useState<string | undefined>();
   const [symptomOnsetError, setSymptomOnsetError] = useState<
@@ -183,7 +180,7 @@ const AoEForm: React.FC<Props> = ({
     {
       label: (
         <>
-          Yes
+          Yes, text all mobile numbers on file.
           <span className="usa-checkbox__label-description">
             <p>
               {phoneNumbers.length > 0 ? (
@@ -293,23 +290,21 @@ const AoEForm: React.FC<Props> = ({
         ref={formRef}
       >
         <RequiredMessage />
-        {patientIsOver18 && (
-          <FormGroup title="Results">
-            <div className="prime-formgroup__wrapper">
-              <RadioGroup
-                legend="Would you like to receive your results via text message?"
-                name="testResultDelivery"
-                onChange={setTestResultDelivery}
-                buttons={getTestResultDeliveryPreferences(patientMobileNumbers)}
-                selectedRadio={
-                  patientMobileNumbers.length === 0
-                    ? "NONE"
-                    : testResultDelivery
-                }
-              />
-            </div>
-          </FormGroup>
-        )}
+        <FormGroup title="Results">
+          <div className="prime-formgroup__wrapper">
+            <RadioGroup
+              legend="Would you like to receive a copy of your results via text message?"
+              hintText="You’re responsible for entering the correct contact information, following applicable federal and state laws."
+              wrapperClassName="margin-top-0"
+              name="testResultDelivery"
+              onChange={setTestResultDelivery}
+              buttons={getTestResultDeliveryPreferences(patientMobileNumbers)}
+              selectedRadio={
+                patientMobileNumbers.length === 0 ? "NONE" : testResultDelivery
+              }
+            />
+          </div>
+        </FormGroup>
         <FormGroup title="Symptoms">
           <SymptomInputs
             noSymptoms={noSymptoms}

--- a/frontend/src/app/testQueue/AoEForm/__snapshots__/AoEForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/AoEForm/__snapshots__/AoEForm.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`AoEForm renders correctly 1`] = `
         class="prime-formgroup__wrapper"
       >
         <div
-          className="usa-form-group margin-top-0"
+          class="usa-form-group margin-top-0"
         >
           <fieldset
             class="usa-fieldset prime-radios"
@@ -43,7 +43,7 @@ exports[`AoEForm renders correctly 1`] = `
               Would you like to receive a copy of your results via text message?
             </legend>
             <span
-              className="usa-hint"
+              class="usa-hint"
             >
               You’re responsible for entering the correct contact information, following applicable federal and state laws.
             </span>
@@ -57,15 +57,14 @@ exports[`AoEForm renders correctly 1`] = `
                   checked=""
                   class="usa-radio__input"
                   data-required="false"
-                  disabled={false}
                   id="8-val-SMS"
                   name="testResultDelivery"
                   type="radio"
                   value="SMS"
                 />
                 <label
-                  className="usa-radio__label"
-                  htmlFor="8-val-SMS"
+                  class="usa-radio__label"
+                  for="8-val-SMS"
                 >
                   Yes, text all mobile numbers on file.
                   <span
@@ -94,15 +93,14 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   class="usa-radio__input"
                   data-required="false"
-                  disabled={false}
                   id="8-val-NONE"
                   name="testResultDelivery"
                   type="radio"
                   value="NONE"
                 />
                 <label
-                  className="usa-radio__label"
-                  htmlFor="8-val-NONE"
+                  class="usa-radio__label"
+                  for="8-val-NONE"
                 >
                   No
                 </label>
@@ -152,16 +150,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="9-val-0"
                   name="no_symptoms"
                   type="checkbox"
                   value="no"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="9-val-0"
+                  class="usa-checkbox__label"
+                  for="9-val-0"
                 >
                   No Symptoms
                 </label>
@@ -190,16 +187,16 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={true}
-                  className="usa-checkbox__input"
+                  checked=""
+                  class="usa-checkbox__input"
                   id="10-val-0"
                   name="symptom_list"
                   type="checkbox"
                   value="426000000"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-0"
+                  class="usa-checkbox__label"
+                  for="10-val-0"
                 >
                   Fever over 100.4F
                 </label>
@@ -208,16 +205,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-1"
                   name="symptom_list"
                   type="checkbox"
                   value="103001002"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-1"
+                  class="usa-checkbox__label"
+                  for="10-val-1"
                 >
                   Feeling feverish
                 </label>
@@ -226,16 +222,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-2"
                   name="symptom_list"
                   type="checkbox"
                   value="43724002"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-2"
+                  class="usa-checkbox__label"
+                  for="10-val-2"
                 >
                   Chills
                 </label>
@@ -244,16 +239,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-3"
                   name="symptom_list"
                   type="checkbox"
                   value="49727002"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-3"
+                  class="usa-checkbox__label"
+                  for="10-val-3"
                 >
                   Cough
                 </label>
@@ -262,16 +256,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-4"
                   name="symptom_list"
                   type="checkbox"
                   value="267036007"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-4"
+                  class="usa-checkbox__label"
+                  for="10-val-4"
                 >
                   Shortness of breath
                 </label>
@@ -280,16 +273,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-5"
                   name="symptom_list"
                   type="checkbox"
                   value="230145002"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-5"
+                  class="usa-checkbox__label"
+                  for="10-val-5"
                 >
                   Difficulty breathing
                 </label>
@@ -298,16 +290,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-6"
                   name="symptom_list"
                   type="checkbox"
                   value="84229001"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-6"
+                  class="usa-checkbox__label"
+                  for="10-val-6"
                 >
                   Fatigue
                 </label>
@@ -316,16 +307,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-7"
                   name="symptom_list"
                   type="checkbox"
                   value="68962001"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-7"
+                  class="usa-checkbox__label"
+                  for="10-val-7"
                 >
                   Muscle or body aches
                 </label>
@@ -334,16 +324,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-8"
                   name="symptom_list"
                   type="checkbox"
                   value="25064002"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-8"
+                  class="usa-checkbox__label"
+                  for="10-val-8"
                 >
                   Headache
                 </label>
@@ -352,16 +341,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-9"
                   name="symptom_list"
                   type="checkbox"
                   value="36955009"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-9"
+                  class="usa-checkbox__label"
+                  for="10-val-9"
                 >
                   New loss of taste
                 </label>
@@ -370,16 +358,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-10"
                   name="symptom_list"
                   type="checkbox"
                   value="44169009"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-10"
+                  class="usa-checkbox__label"
+                  for="10-val-10"
                 >
                   New loss of smell
                 </label>
@@ -388,16 +375,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-11"
                   name="symptom_list"
                   type="checkbox"
                   value="162397003"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-11"
+                  class="usa-checkbox__label"
+                  for="10-val-11"
                 >
                   Sore throat
                 </label>
@@ -406,16 +392,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-12"
                   name="symptom_list"
                   type="checkbox"
                   value="68235000"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-12"
+                  class="usa-checkbox__label"
+                  for="10-val-12"
                 >
                   Nasal congestion
                 </label>
@@ -424,16 +409,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-13"
                   name="symptom_list"
                   type="checkbox"
                   value="64531003"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-13"
+                  class="usa-checkbox__label"
+                  for="10-val-13"
                 >
                   Runny nose
                 </label>
@@ -442,16 +426,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-14"
                   name="symptom_list"
                   type="checkbox"
                   value="422587007"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-14"
+                  class="usa-checkbox__label"
+                  for="10-val-14"
                 >
                   Nausea
                 </label>
@@ -460,16 +443,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-15"
                   name="symptom_list"
                   type="checkbox"
                   value="422400008"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-15"
+                  class="usa-checkbox__label"
+                  for="10-val-15"
                 >
                   Vomiting
                 </label>
@@ -478,16 +460,15 @@ exports[`AoEForm renders correctly 1`] = `
                 class="usa-checkbox"
               >
                 <input
-                  checked={false}
-                  className="usa-checkbox__input"
+                  class="usa-checkbox__input"
                   id="10-val-16"
                   name="symptom_list"
                   type="checkbox"
                   value="62315008"
                 />
                 <label
-                  className="usa-checkbox__label"
-                  htmlFor="10-val-16"
+                  class="usa-checkbox__label"
+                  for="10-val-16"
                 >
                   Diarrhea
                 </label>
@@ -625,15 +606,14 @@ exports[`AoEForm renders correctly 1`] = `
                   checked=""
                   class="usa-radio__input"
                   data-required="false"
-                  disabled={false}
                   id="11-val-yes"
                   name="most_recent_flag"
                   type="radio"
                   value="yes"
                 />
                 <label
-                  className="usa-radio__label"
-                  htmlFor="11-val-yes"
+                  class="usa-radio__label"
+                  for="11-val-yes"
                 >
                   Yes
                 </label>
@@ -644,15 +624,14 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   class="usa-radio__input"
                   data-required="false"
-                  disabled={false}
                   id="11-val-no"
                   name="most_recent_flag"
                   type="radio"
                   value="no"
                 />
                 <label
-                  className="usa-radio__label"
-                  htmlFor="11-val-no"
+                  class="usa-radio__label"
+                  for="11-val-no"
                 >
                   No
                 </label>

--- a/frontend/src/app/testQueue/AoEForm/__snapshots__/AoEForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/AoEForm/__snapshots__/AoEForm.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`AoEForm renders correctly 1`] = `
         className="prime-formgroup__wrapper"
       >
         <div
-          className="usa-form-group"
+          className="usa-form-group margin-top-0"
         >
           <fieldset
             className="usa-fieldset prime-radios"
@@ -41,8 +41,13 @@ exports[`AoEForm renders correctly 1`] = `
             <legend
               className="usa-legend"
             >
-              Would you like to receive your results via text message?
+              Would you like to receive a copy of your results via text message?
             </legend>
+            <span
+              className="usa-hint"
+            >
+              You’re responsible for entering the correct contact information, following applicable federal and state laws.
+            </span>
             <div
               className=""
             >
@@ -54,7 +59,7 @@ exports[`AoEForm renders correctly 1`] = `
                   className="usa-radio__input"
                   data-required="false"
                   disabled={false}
-                  id="7-val-SMS"
+                  id="8-val-SMS"
                   name="testResultDelivery"
                   onChange={[Function]}
                   type="radio"
@@ -62,9 +67,9 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-radio__label"
-                  htmlFor="7-val-SMS"
+                  htmlFor="8-val-SMS"
                 >
-                  Yes
+                  Yes, text all mobile numbers on file.
                   <span
                     className="usa-checkbox__label-description"
                   >
@@ -93,7 +98,7 @@ exports[`AoEForm renders correctly 1`] = `
                   className="usa-radio__input"
                   data-required="false"
                   disabled={false}
-                  id="7-val-NONE"
+                  id="8-val-NONE"
                   name="testResultDelivery"
                   onChange={[Function]}
                   type="radio"
@@ -101,7 +106,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-radio__label"
-                  htmlFor="7-val-NONE"
+                  htmlFor="8-val-NONE"
                 >
                   No
                 </label>
@@ -153,7 +158,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="8-val-0"
+                  id="9-val-0"
                   name="no_symptoms"
                   onChange={[Function]}
                   type="checkbox"
@@ -161,7 +166,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="8-val-0"
+                  htmlFor="9-val-0"
                 >
                   No Symptoms
                 </label>
@@ -192,7 +197,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={true}
                   className="usa-checkbox__input"
-                  id="9-val-0"
+                  id="10-val-0"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -200,7 +205,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-0"
+                  htmlFor="10-val-0"
                 >
                   Fever over 100.4F
                 </label>
@@ -211,7 +216,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-1"
+                  id="10-val-1"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -219,7 +224,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-1"
+                  htmlFor="10-val-1"
                 >
                   Feeling feverish
                 </label>
@@ -230,7 +235,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-2"
+                  id="10-val-2"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -238,7 +243,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-2"
+                  htmlFor="10-val-2"
                 >
                   Chills
                 </label>
@@ -249,7 +254,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-3"
+                  id="10-val-3"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -257,7 +262,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-3"
+                  htmlFor="10-val-3"
                 >
                   Cough
                 </label>
@@ -268,7 +273,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-4"
+                  id="10-val-4"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -276,7 +281,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-4"
+                  htmlFor="10-val-4"
                 >
                   Shortness of breath
                 </label>
@@ -287,7 +292,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-5"
+                  id="10-val-5"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -295,7 +300,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-5"
+                  htmlFor="10-val-5"
                 >
                   Difficulty breathing
                 </label>
@@ -306,7 +311,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-6"
+                  id="10-val-6"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -314,7 +319,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-6"
+                  htmlFor="10-val-6"
                 >
                   Fatigue
                 </label>
@@ -325,7 +330,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-7"
+                  id="10-val-7"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -333,7 +338,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-7"
+                  htmlFor="10-val-7"
                 >
                   Muscle or body aches
                 </label>
@@ -344,7 +349,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-8"
+                  id="10-val-8"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -352,7 +357,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-8"
+                  htmlFor="10-val-8"
                 >
                   Headache
                 </label>
@@ -363,7 +368,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-9"
+                  id="10-val-9"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -371,7 +376,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-9"
+                  htmlFor="10-val-9"
                 >
                   New loss of taste
                 </label>
@@ -382,7 +387,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-10"
+                  id="10-val-10"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -390,7 +395,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-10"
+                  htmlFor="10-val-10"
                 >
                   New loss of smell
                 </label>
@@ -401,7 +406,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-11"
+                  id="10-val-11"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -409,7 +414,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-11"
+                  htmlFor="10-val-11"
                 >
                   Sore throat
                 </label>
@@ -420,7 +425,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-12"
+                  id="10-val-12"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -428,7 +433,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-12"
+                  htmlFor="10-val-12"
                 >
                   Nasal congestion
                 </label>
@@ -439,7 +444,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-13"
+                  id="10-val-13"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -447,7 +452,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-13"
+                  htmlFor="10-val-13"
                 >
                   Runny nose
                 </label>
@@ -458,7 +463,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-14"
+                  id="10-val-14"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -466,7 +471,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-14"
+                  htmlFor="10-val-14"
                 >
                   Nausea
                 </label>
@@ -477,7 +482,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-15"
+                  id="10-val-15"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -485,7 +490,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-15"
+                  htmlFor="10-val-15"
                 >
                   Vomiting
                 </label>
@@ -496,7 +501,7 @@ exports[`AoEForm renders correctly 1`] = `
                 <input
                   checked={false}
                   className="usa-checkbox__input"
-                  id="9-val-16"
+                  id="10-val-16"
                   name="symptom_list"
                   onChange={[Function]}
                   type="checkbox"
@@ -504,7 +509,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-checkbox__label"
-                  htmlFor="9-val-16"
+                  htmlFor="10-val-16"
                 >
                   Diarrhea
                 </label>
@@ -659,7 +664,7 @@ exports[`AoEForm renders correctly 1`] = `
                   className="usa-radio__input"
                   data-required="false"
                   disabled={false}
-                  id="10-val-yes"
+                  id="11-val-yes"
                   name="most_recent_flag"
                   onChange={[Function]}
                   type="radio"
@@ -667,7 +672,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-radio__label"
-                  htmlFor="10-val-yes"
+                  htmlFor="11-val-yes"
                 >
                   Yes
                 </label>
@@ -680,7 +685,7 @@ exports[`AoEForm renders correctly 1`] = `
                   className="usa-radio__input"
                   data-required="false"
                   disabled={false}
-                  id="10-val-no"
+                  id="11-val-no"
                   name="most_recent_flag"
                   onChange={[Function]}
                   type="radio"
@@ -688,7 +693,7 @@ exports[`AoEForm renders correctly 1`] = `
                 />
                 <label
                   className="usa-radio__label"
-                  htmlFor="10-val-no"
+                  htmlFor="11-val-no"
                 >
                   No
                 </label>

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -116,13 +116,15 @@ export const en = {
         },
         contact: {
           heading: "Contact information",
+          helpText:
+            "You're responsible for entering the correct contact information, following applicable federal and state laws.",
           primaryPhoneNumber: "Primary phone number",
           additionalPhoneNumber: "Additional phone number",
+          receiveTextMessageResults: "Yes, text all mobile numbers on file.",
           phoneType: "Phone type",
           addNumber: "Add another number",
           testResultDelivery:
             "Would you like to receive your results via text message?",
-          testResultDeliveryHint: "We'll text all mobile numbers on file",
           email: "Email address",
           street1: "Street address 1",
           street2: "Street address 2",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -123,14 +123,14 @@ export const es: LanguageConfig = {
         },
         contact: {
           heading: "Información de contacto",
+          helpText: "MISSING",
           primaryPhoneNumber: "Número de teléfono principal",
           additionalPhoneNumber: "Número de teléfono adicional",
+          receiveTextMessageResults: "MISSING",
           phoneType: "Tipo de teléfono",
           addNumber: "Agregar otro número",
           testResultDelivery:
             "¿Le gustaría recibir sus resultados por mensaje de texto?",
-          testResultDeliveryHint:
-            "Enviaremos un mensaje de texto a todos los números de teléfono móviles registrados",
           email: "Dirección de correo electrónico",
           street1: "Dirección 1",
           street2: "Dirección 2",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -123,10 +123,12 @@ export const es: LanguageConfig = {
         },
         contact: {
           heading: "Información de contacto",
-          helpText: "MISSING",
+          helpText:
+            "Usted es responsable de ingresar la información de contacto correcta, siguiendo las leyes federales y estatales aplicables.",
           primaryPhoneNumber: "Número de teléfono principal",
           additionalPhoneNumber: "Número de teléfono adicional",
-          receiveTextMessageResults: "MISSING",
+          receiveTextMessageResults:
+            "Sí, envíe un mensaje de texto a todos los números registrados de teléfonos móviles.",
           phoneType: "Tipo de teléfono",
           addNumber: "Agregar otro número",
           testResultDelivery:

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/AoEPatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/AoEPatientFormContainer.test.tsx.snap
@@ -107,6 +107,94 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
           <legend
             className="prime-formgroup-heading usa-legend"
           >
+            Results
+          </legend>
+          <div
+            className="prime-formgroup__wrapper"
+          >
+            <div
+              className="usa-form-group margin-top-0"
+            >
+              <fieldset
+                className="usa-fieldset prime-radios"
+              >
+                <legend
+                  className="usa-legend"
+                >
+                  Would you like to receive a copy of your results via text message?
+                </legend>
+                <span
+                  className="usa-hint"
+                >
+                  You’re responsible for entering the correct contact information, following applicable federal and state laws.
+                </span>
+                <div
+                  className=""
+                >
+                  <div
+                    className="usa-radio"
+                  >
+                    <input
+                      checked={false}
+                      className="usa-radio__input"
+                      data-required="false"
+                      disabled={true}
+                      id="1-val-SMS"
+                      name="testResultDelivery"
+                      onChange={[Function]}
+                      type="radio"
+                      value="SMS"
+                    />
+                    <label
+                      className="usa-radio__label text-base"
+                      htmlFor="1-val-SMS"
+                    >
+                      Yes, text all mobile numbers on file.
+                      <span
+                        className="usa-checkbox__label-description"
+                      >
+                        <p>
+                          (There are no mobile phone numbers listed in your patient profile.)
+                        </p>
+                      </span>
+                    </label>
+                  </div>
+                  <div
+                    className="usa-radio"
+                  >
+                    <input
+                      checked={true}
+                      className="usa-radio__input"
+                      data-required="false"
+                      disabled={false}
+                      id="1-val-NONE"
+                      name="testResultDelivery"
+                      onChange={[Function]}
+                      type="radio"
+                      value="NONE"
+                    />
+                    <label
+                      className="usa-radio__label"
+                      htmlFor="1-val-NONE"
+                    >
+                      No
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        className="prime-formgroup"
+      >
+        <fieldset
+          className="usa-fieldset"
+        >
+          <legend
+            className="prime-formgroup-heading usa-legend"
+          >
             Symptoms
           </legend>
           <div
@@ -139,7 +227,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="1-val-0"
+                      id="2-val-0"
                       name="no_symptoms"
                       onChange={[Function]}
                       type="checkbox"
@@ -147,7 +235,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="1-val-0"
+                      htmlFor="2-val-0"
                     >
                       No Symptoms
                     </label>
@@ -178,7 +266,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-0"
+                      id="3-val-0"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -186,7 +274,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-0"
+                      htmlFor="3-val-0"
                     >
                       Fever over 100.4F
                     </label>
@@ -197,7 +285,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-1"
+                      id="3-val-1"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -205,7 +293,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-1"
+                      htmlFor="3-val-1"
                     >
                       Feeling feverish
                     </label>
@@ -216,7 +304,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-2"
+                      id="3-val-2"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -224,7 +312,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-2"
+                      htmlFor="3-val-2"
                     >
                       Chills
                     </label>
@@ -235,7 +323,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-3"
+                      id="3-val-3"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -243,7 +331,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-3"
+                      htmlFor="3-val-3"
                     >
                       Cough
                     </label>
@@ -254,7 +342,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-4"
+                      id="3-val-4"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -262,7 +350,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-4"
+                      htmlFor="3-val-4"
                     >
                       Shortness of breath
                     </label>
@@ -273,7 +361,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-5"
+                      id="3-val-5"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -281,7 +369,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-5"
+                      htmlFor="3-val-5"
                     >
                       Difficulty breathing
                     </label>
@@ -292,7 +380,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-6"
+                      id="3-val-6"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -300,7 +388,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-6"
+                      htmlFor="3-val-6"
                     >
                       Fatigue
                     </label>
@@ -311,7 +399,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-7"
+                      id="3-val-7"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -319,7 +407,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-7"
+                      htmlFor="3-val-7"
                     >
                       Muscle or body aches
                     </label>
@@ -330,7 +418,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-8"
+                      id="3-val-8"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -338,7 +426,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-8"
+                      htmlFor="3-val-8"
                     >
                       Headache
                     </label>
@@ -349,7 +437,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-9"
+                      id="3-val-9"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -357,7 +445,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-9"
+                      htmlFor="3-val-9"
                     >
                       New loss of taste
                     </label>
@@ -368,7 +456,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-10"
+                      id="3-val-10"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -376,7 +464,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-10"
+                      htmlFor="3-val-10"
                     >
                       New loss of smell
                     </label>
@@ -387,7 +475,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-11"
+                      id="3-val-11"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -395,7 +483,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-11"
+                      htmlFor="3-val-11"
                     >
                       Sore throat
                     </label>
@@ -406,7 +494,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-12"
+                      id="3-val-12"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -414,7 +502,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-12"
+                      htmlFor="3-val-12"
                     >
                       Nasal congestion
                     </label>
@@ -425,7 +513,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-13"
+                      id="3-val-13"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -433,7 +521,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-13"
+                      htmlFor="3-val-13"
                     >
                       Runny nose
                     </label>
@@ -444,7 +532,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-14"
+                      id="3-val-14"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -452,7 +540,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-14"
+                      htmlFor="3-val-14"
                     >
                       Nausea
                     </label>
@@ -463,7 +551,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-15"
+                      id="3-val-15"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -471,7 +559,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-15"
+                      htmlFor="3-val-15"
                     >
                       Vomiting
                     </label>
@@ -482,7 +570,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     <input
                       checked={false}
                       className="usa-checkbox__input"
-                      id="2-val-16"
+                      id="3-val-16"
                       name="symptom_list"
                       onChange={[Function]}
                       type="checkbox"
@@ -490,7 +578,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-checkbox__label"
-                      htmlFor="2-val-16"
+                      htmlFor="3-val-16"
                     >
                       Diarrhea
                     </label>
@@ -630,7 +718,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                       className="usa-radio__input"
                       data-required="false"
                       disabled={false}
-                      id="3-val-YES"
+                      id="4-val-YES"
                       name="prior_test_flag"
                       onChange={[Function]}
                       type="radio"
@@ -638,7 +726,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-radio__label"
-                      htmlFor="3-val-YES"
+                      htmlFor="4-val-YES"
                     >
                       Yes
                     </label>
@@ -651,7 +739,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                       className="usa-radio__input"
                       data-required="false"
                       disabled={false}
-                      id="3-val-NO"
+                      id="4-val-NO"
                       name="prior_test_flag"
                       onChange={[Function]}
                       type="radio"
@@ -659,7 +747,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     />
                     <label
                       className="usa-radio__label"
-                      htmlFor="3-val-NO"
+                      htmlFor="4-val-NO"
                     >
                       No
                     </label>
@@ -703,7 +791,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     className="usa-radio__input"
                     data-required="false"
                     disabled={false}
-                    id="4-val-77386006"
+                    id="5-val-77386006"
                     name="pregnancy"
                     onChange={[Function]}
                     type="radio"
@@ -711,7 +799,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                   />
                   <label
                     className="usa-radio__label"
-                    htmlFor="4-val-77386006"
+                    htmlFor="5-val-77386006"
                   >
                     Yes
                   </label>
@@ -724,7 +812,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     className="usa-radio__input"
                     data-required="false"
                     disabled={false}
-                    id="4-val-60001007"
+                    id="5-val-60001007"
                     name="pregnancy"
                     onChange={[Function]}
                     type="radio"
@@ -732,7 +820,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                   />
                   <label
                     className="usa-radio__label"
-                    htmlFor="4-val-60001007"
+                    htmlFor="5-val-60001007"
                   >
                     No
                   </label>
@@ -745,7 +833,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                     className="usa-radio__input"
                     data-required="false"
                     disabled={false}
-                    id="4-val-261665006"
+                    id="5-val-261665006"
                     name="pregnancy"
                     onChange={[Function]}
                     type="radio"
@@ -753,7 +841,7 @@ exports[`AoEPatientFormContainer snapshot 1`] = `
                   />
                   <label
                     className="usa-radio__label"
-                    htmlFor="4-val-261665006"
+                    htmlFor="5-val-261665006"
                   >
                     Prefer not to answer
                   </label>

--- a/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
+++ b/frontend/src/patientApp/timeOfTest/__snapshots__/PatientFormContainer.test.tsx.snap
@@ -276,6 +276,11 @@ exports[`PatientFormContainer snapshot 1`] = `
             >
               Contact information
             </legend>
+            <p
+              className="usa-hint maxw-prose"
+            >
+              You're responsible for entering the correct contact information, following applicable federal and state laws.
+            </p>
             <div
               className="usa-form"
             >


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #2086

## Changes Proposed

- Removes restriction on seeing the option to text results to minors
- Updates copy in both English and Spanish surrounding contact information and texting results

## Additional Information

- Tested in the `test` environment to confirm results could be texted

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
