### PR TITLE
Update frontend security question validation to match Okta limits

### DIFF
--- a/frontend/src/app/accountCreation/SecurityQuestion/SecurityQuestion.tsx
+++ b/frontend/src/app/accountCreation/SecurityQuestion/SecurityQuestion.tsx
@@ -40,8 +40,8 @@ export const SecurityQuestion = () => {
     if (securityAnswer.length < 4) {
       error = "Answer must be at least 4 characters";
     }
-    if (securityAnswer.length > 256) {
-      error = "Answer must be less than 256 characters";
+    if (securityAnswer.length >= 100) {
+      error = "Answer must be less than 100 characters";
     }
     setSecurityAnswerError(error);
     return error === "";

--- a/frontend/src/app/signUp/IdentityVerification/Consent.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import Consent from "./Consent";


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2236 

## Changes Proposed

- Update frontend security question validation to 100 characters to match the backend

## Additional Information

I also updated a new test that had some linter issues

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- n/a Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
