### PR TITLE
Fix default device validation and state inconsistency

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -9,7 +9,7 @@ import { ValidateField } from "../FacilityForm";
 
 interface Props {
   deviceTypes: string[];
-  defaultDevice: string | null;
+  defaultDevice: string;
   updateDeviceTypes: (deviceTypes: string[]) => void;
   updateDefaultDevice: (defaultDevice: string) => void;
   deviceOptions: DeviceType[];

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -100,6 +100,7 @@ const ManageDevices: React.FC<Props> = ({
             <button
               className="usa-button--unstyled"
               onClick={() => onDeviceRemove(deviceId)}
+              aria-label="Delete device"
             >
               <FontAwesomeIcon icon={"trash"} className={"prime-red-icon"} />
             </button>

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -9,7 +9,7 @@ import { ValidateField } from "../FacilityForm";
 
 interface Props {
   deviceTypes: string[];
-  defaultDevice: string;
+  defaultDevice: string | null;
   updateDeviceTypes: (deviceTypes: string[]) => void;
   updateDefaultDevice: (defaultDevice: string) => void;
   deviceOptions: DeviceType[];
@@ -44,6 +44,10 @@ const ManageDevices: React.FC<Props> = ({
     const newDeviceTypes = Array.from(deviceTypes);
     newDeviceTypes.splice(newDeviceTypes.indexOf(id), 1);
     updateDeviceTypes(newDeviceTypes);
+    // Unset default device if ID matches
+    if (defaultDevice === id) {
+      updateDefaultDevice("");
+    }
   };
 
   // returns a list of deviceIds that have *not* been selected so far

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -134,7 +134,7 @@ const FacilityForm: React.FC<Props> = (props) => {
     AddressSuggestionConfig<AddressOptions>[]
   >([]);
 
-  const updateForm = (data: Facility) => {
+  const updateForm: typeof updateFormData = (data) => {
     updateFormData(data);
     updateFormChanged(true);
   };
@@ -151,16 +151,16 @@ const FacilityForm: React.FC<Props> = (props) => {
     });
   };
   const updateDeviceTypes = (deviceTypes: string[]) => {
-    updateForm({
+    updateForm((facility) => ({
       ...facility,
       deviceTypes,
-    });
+    }));
   };
   const updateDefaultDevice = (defaultDevice: string) => {
-    updateForm({
+    updateForm((facility) => ({
       ...facility,
       defaultDevice,
-    });
+    }));
   };
 
   const { errors, validateField, validateFacility } = useFacilityValidation(

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -97,7 +97,12 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
     .of(yup.string().required())
     .min(1, "There must be at least one device")
     .required("There must be at least one device"),
-  defaultDevice: yup.string().required("A default device must be selected"),
+  defaultDevice: yup.mixed().test(function (input) {
+    if (!input) {
+      return this.createError({ message: "A default device must be selected" });
+    }
+    return true;
+  }),
   orderingProvider: providerSchema.nullable(),
   phone: yup
     .string()

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -434,6 +434,33 @@ describe("FacilityForm", () => {
       });
     });
   });
+
+  describe("Device validation", () => {
+    it("warns about missing default device", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceOptions={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      // Delete default device
+      const deleteButtons = await screen.findAllByLabelText("Delete device");
+      await waitFor(() => {
+        fireEvent.click(deleteButtons[0]);
+      });
+      // Attempt save
+      const saveButtons = await screen.findAllByText("Save changes");
+      fireEvent.click(saveButtons[0]);
+      const warning = await screen.findByText(
+        "A default device must be selected",
+        { exact: false }
+      );
+      expect(warning).toBeInTheDocument();
+    });
+  });
 });
 
 async function validateAddress(


### PR DESCRIPTION
## Related Issue or Background Info

- User reports of not being able to save an initial facility https://usds.slack.com/archives/C024ZEUGWDV/p1629168889091000

## Changes Proposed

- Unsets the default device if that device is deleted from the list
- Better validation messages for missing default device

## Additional Information

- The one unfortunate part of this PR is setting the default device to an empty string instead of either `null` or `undefined`. This is to satisfy TypeScript. A more correct approach is probably to make a slightly different type for the Add Facility form, but that's more reworking than I think we want to do for a hotfix.

## Screenshots / Demos

![Default facility error](https://user-images.githubusercontent.com/49658917/129746144-3b1000e4-ebdd-41c5-84b4-fbc787b708d3.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
