### PR TITLE
fix crash when adding invalid facility to a user

### DIFF
--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -235,6 +235,7 @@ describe("ManageUsers", () => {
               deleteUser={deleteUser}
               getUsers={getUsers}
               reactivateUser={reactivateUser}
+              resetUserPassword={() => Promise.resolve()}
             />
           </TestContainer>
         );
@@ -419,6 +420,7 @@ describe("ManageUsers", () => {
               deleteUser={deleteUser}
               getUsers={getUsers}
               reactivateUser={reactivateUser}
+              resetUserPassword={() => Promise.resolve()}
             />
           </TestContainer>
         );
@@ -473,6 +475,7 @@ describe("ManageUsers", () => {
               deleteUser={deleteUser}
               getUsers={getUsers}
               reactivateUser={reactivateUser}
+              resetUserPassword={() => Promise.resolve()}
             />
           </TestContainer>
         );
@@ -565,6 +568,7 @@ describe("ManageUsers", () => {
                 deleteUser={deleteUser}
                 getUsers={getUsers}
                 reactivateUser={reactivateUser}
+                resetUserPassword={() => Promise.resolve()}
               />
             </MockedProvider>
           </Provider>

--- a/frontend/src/app/Settings/Users/UserFacilitiesSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserFacilitiesSettingsForm.tsx
@@ -228,7 +228,7 @@ const UserFacilitiesSettingsForm: React.FC<Props> = ({
           <Button
             className="height-5 margin-left-2"
             variant="outline"
-            disabled={hasAllFacilityAccess}
+            disabled={hasAllFacilityAccess || !selectedFacility}
             onClick={(e) => {
               e.preventDefault();
               const facility = facilityLookup[selectedFacility];

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -593,7 +593,8 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
                 </div>
               </div>
               <button
-                class="usa-button usa-button--outline height-5 margin-left-2"
+                class="usa-button usa-button--outline usa-button-disabled height-5 margin-left-2"
+                disabled=""
                 type="button"
               >
                 Add


### PR DESCRIPTION
## Related Issue or Background Info

- resolves https://github.com/CDCgov/prime-simplereport/issues/2239

## Changes Proposed

- disable the add button when no facility is selected

## Additional Information


## Screenshots / Demos
disabled when no facility is selected
![image](https://user-images.githubusercontent.com/4952042/129750989-64b1dbf9-8509-42c4-8c07-aab81b0c8e5a.png)
enabled when you select a valid facility
![image](https://user-images.githubusercontent.com/4952042/129751046-6258d37c-59fe-45cf-99ba-f0798013bcc4.png)



## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
