### PR TITLE
Fix bug preventing facility from being loaded from URL

### DIFF
--- a/frontend/src/app/facilitySelect/WithFacility.test.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.test.tsx
@@ -20,6 +20,11 @@ jest.mock("react-router-dom", () => ({
   }),
 }));
 
+jest.mock("../utils/url", () => ({
+  ...jest.requireActual("../utils/url"),
+  getFacilityIdFromUrl: () => "4",
+}));
+
 const mocks = [
   {
     request: {
@@ -166,6 +171,39 @@ describe("WithFacility", () => {
       it("should set the facility id search param", () => {
         expect(mockHistoryPush).toHaveBeenCalledWith({ search: "?facility=1" });
       });
+    });
+  });
+  describe("Facility ID from URL", () => {
+    beforeEach(() => {
+      store = mockStore({
+        dataLoaded: true,
+        organization: {
+          name: "Organization Name",
+        },
+        user: {
+          firstName: "Kim",
+          lastName: "Mendoza",
+          permissions: [],
+        },
+        facilities: [
+          { id: "1", name: "Facility 1" },
+          { id: "4", name: "Facility 4" },
+        ],
+      });
+      store.dispatch = jest.fn();
+      render(
+        <Provider store={store}>
+          <WithFacility>App</WithFacility>
+        </Provider>
+      );
+    });
+    it("sets facility in state", () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        updateFacility({
+          id: "4",
+          name: "Facility 4",
+        })
+      );
     });
   });
   describe("A new org", () => {

--- a/frontend/src/app/facilitySelect/WithFacility.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.tsx
@@ -60,17 +60,17 @@ const WithFacility: React.FC<Props> = ({ children }) => {
   useEffect(() => {
     // No action if facility in store and URL exist and are equal
     if (
-      facilityFromUrl &&
-      facilityInStore &&
-      facilityFromUrl === facilityInStore
+      facilityFromUrl?.id &&
+      facilityInStore?.id &&
+      facilityFromUrl.id === facilityInStore.id
     ) {
       return;
     }
 
     // If both exist but are different, URL selection is correct
     if (
-      facilityFromUrl &&
-      facilityInStore &&
+      facilityFromUrl?.id &&
+      facilityInStore?.id &&
       facilityFromUrl.id !== facilityInStore.id
     ) {
       setActiveFacility(facilityFromUrl);
@@ -78,13 +78,13 @@ const WithFacility: React.FC<Props> = ({ children }) => {
     }
 
     // If only in URL, set store value
-    if (facilityFromUrl && !facilityInStore) {
+    if (facilityFromUrl?.id && !facilityInStore) {
       setActiveFacility(facilityFromUrl);
       return;
     }
 
     // If only in store, set URL value
-    if (!facilityFromUrl && facilityInStore) {
+    if (!facilityFromUrl?.id && facilityInStore?.id) {
       setFacilityProp(facilityInStore.id);
       return;
     }


### PR DESCRIPTION
## Related Issue or Background Info

- Bug introduced by https://github.com/CDCgov/prime-simplereport/pull/2308

If you change facilities using the dropdown at the top of the screen, it doesn't work and you are prompted to reselect a facility.

https://user-images.githubusercontent.com/49658917/129776556-946bbd6e-1a56-4187-9a99-bd7831ae2c83.mov

## Changes Proposed

- Compare IDs rather than facility objects (which can be different references) in the `useEffect` hook of `WithFacility`

## Screenshots / Demos

Fixed behavior:

https://user-images.githubusercontent.com/49658917/129776715-e43f686c-b860-4424-bd1e-a4d2c1ac8e9e.mov

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
