### PR TITLE
Refactor facility selection to make the URL the source of truth

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -13,6 +13,7 @@ import { formatFullName } from "../utils/user";
 import siteLogo from "../../img/simplereport-logo-color.svg";
 import { hasPermission, appPermissions } from "../permissions";
 import { RootState } from "../store";
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 import Button from "./Button/Button";
 import Dropdown from "./Dropdown";
@@ -40,9 +41,9 @@ const Header: React.FC<{}> = () => {
   const facilities = useSelector(
     (state) => ((state as any).facilities as Facility[]) || []
   );
-  const facility = useSelector(
-    (state) => ((state as any).facility as Facility) || { id: "", name: "" }
-  );
+  const [selectedFacility, setSelectedFacility] = useSelectedFacility();
+  const facility = selectedFacility || { id: "", name: "" };
+
   const user = useSelector((state) => (state as any).user as User);
   const [menuVisible, setMenuVisible] = useState(false);
   const {
@@ -51,11 +52,11 @@ const Header: React.FC<{}> = () => {
     setIsComponentVisible: setStaffDetailsVisible,
   } = useComponentVisible(false);
 
-  const onFacilitySelect = (e: React.FormEvent<HTMLSelectElement>) => {
-    const id = (e.target as HTMLSelectElement).value;
-    window.location.href = `${
-      window.location.pathname
-    }?facility=${encodeURIComponent(id)}`;
+  const onFacilitySelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = facilities.find((f) => f.id === e.target.value);
+    if (selected) {
+      setSelectedFacility(selected);
+    }
   };
 
   const canViewSettings = hasPermission(

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -6,6 +6,7 @@ import { useTrackEvent } from "@microsoft/applicationinsights-react-js";
 
 import Header from "../Header";
 import "../../../i18n";
+import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
 
 const mockStore = createMockStore([]);
 
@@ -40,10 +41,11 @@ describe("Header.tsx", () => {
     process.env = OLD_ENV;
   });
 
-  const WrappedHeader: React.FC = () => (
+  const WrappedHeader: React.FC = ({ children }) => (
     <MemoryRouter>
       <Provider store={store}>
         <Header />
+        {children}
       </Provider>
     </MemoryRouter>
   );
@@ -88,4 +90,27 @@ describe("Header.tsx", () => {
       screen.queryByText("Login as", { exact: false })
     ).not.toBeInTheDocument();
   });
+  describe("Facility dropdown", () => {
+    it("Switches facilities", async () => {
+      render(
+        <WrappedHeader>
+          <FacilityViewer />
+        </WrappedHeader>
+      );
+      const dropdown = await screen.findAllByRole("option");
+      await waitFor(() => {
+        fireEvent.change(dropdown[1].closest("select")!, {
+          target: { value: "2" },
+        });
+      });
+      expect(
+        await screen.findByText("Facility 2 is selected")
+      ).toBeInTheDocument();
+    });
+  });
 });
+
+function FacilityViewer() {
+  const [selectedFacility] = useSelectedFacility();
+  return <>{selectedFacility?.name} is selected</>;
+}

--- a/frontend/src/app/facilitySelect/WithFacility.test.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.test.tsx
@@ -1,29 +1,24 @@
-import React from "react";
 import { Provider } from "react-redux";
 import renderer from "react-test-renderer";
 import configureStore from "redux-mock-store";
-import { act, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
+import { MemoryRouter as Router } from "react-router";
+import { I18nextProvider } from "react-i18next";
 
 import { appPermissions } from "../permissions";
-import { updateFacility } from "../store";
 import { GET_FACILITY_QUERY } from "../Settings/Facility/FacilityFormContainer";
+import i18n from "../../i18n";
 
 import WithFacility from "./WithFacility";
 
 const mockStore = configureStore([]);
-const mockHistoryPush = jest.fn();
-jest.mock("react-router-dom", () => ({
-  Prompt: (props: any) => <></>,
-  useHistory: () => ({
-    push: mockHistoryPush,
-  }),
-}));
-
-jest.mock("../utils/url", () => ({
-  ...jest.requireActual("../utils/url"),
-  getFacilityIdFromUrl: () => "4",
-}));
 
 const mocks = [
   {
@@ -50,9 +45,6 @@ const mocks = [
 describe("WithFacility", () => {
   let store: any;
   let component: any;
-  beforeEach(() => {
-    mockHistoryPush.mockClear();
-  });
 
   describe("With zero facilities", () => {
     beforeEach(() => {
@@ -70,9 +62,11 @@ describe("WithFacility", () => {
       });
       store.dispatch = jest.fn();
       component = renderer.create(
-        <Provider store={store}>
-          <WithFacility>App</WithFacility>
-        </Provider>
+        <Router>
+          <Provider store={store}>
+            <WithFacility>App</WithFacility>
+          </Provider>
+        </Router>
       );
     });
 
@@ -96,28 +90,17 @@ describe("WithFacility", () => {
         facilities: [{ id: "1", name: "Facility 1" }],
       });
       component = render(
-        <Provider store={store}>
-          <WithFacility>App</WithFacility>
-        </Provider>
+        <Router>
+          <Provider store={store}>
+            <WithFacility>App</WithFacility>
+          </Provider>
+        </Router>
       );
     });
 
-    it("should render with a value", () => {
-      expect(component.container.firstChild).toMatchSnapshot();
-    });
-    it("should select a facility once", () => {
-      expect(store.dispatch).toHaveBeenCalledTimes(1);
-    });
-    it("should select the first facility", () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        updateFacility({ id: "1", name: "Facility 1" })
-      );
-    });
-    it("should push history once", () => {
-      expect(mockHistoryPush).toHaveBeenCalledTimes(1);
-    });
-    it("should set the facility id search param", () => {
-      expect(mockHistoryPush).toHaveBeenCalledWith({ search: "?facility=1" });
+    it("should bypass the facility selection screen", async () => {
+      const renderedApp = await screen.findByText("App");
+      expect(renderedApp).toBeInTheDocument();
     });
   });
 
@@ -138,37 +121,29 @@ describe("WithFacility", () => {
           { id: "2", name: "Facility 2" },
         ],
       });
-      store.dispatch = jest.fn();
-      component = renderer.create(
-        <Provider store={store}>
-          <WithFacility>App</WithFacility>
-        </Provider>
+      component = render(
+        <Router>
+          <Provider store={store}>
+            <WithFacility>App</WithFacility>
+          </Provider>
+        </Router>
       );
     });
 
-    it("should render with a value", () => {
-      expect(component.toJSON()).toMatchSnapshot();
+    it("should show the facility selection screen", () => {
+      expect(component.container.firstChild).toMatchSnapshot();
     });
 
     describe("On facility select", () => {
-      beforeEach(() => {
-        renderer.act(() => {
-          component.root.findAllByType("button")[0].props.onClick();
+      beforeEach(async () => {
+        const options = await screen.findAllByRole("button");
+        await waitFor(() => {
+          fireEvent.click(options[0]);
         });
       });
-      it("should select a facility once", () => {
-        expect(store.dispatch).toHaveBeenCalledTimes(1);
-      });
-      it("should select the first facility", () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          updateFacility({ id: "1", name: "Facility 1" })
-        );
-      });
-      it("should push history once", () => {
-        expect(mockHistoryPush).toHaveBeenCalledTimes(1);
-      });
-      it("should set the facility id search param", () => {
-        expect(mockHistoryPush).toHaveBeenCalledWith({ search: "?facility=1" });
+      it("should show the app", async () => {
+        const renderedApp = await screen.findByText("App");
+        expect(renderedApp).toBeInTheDocument();
       });
     });
   });
@@ -186,23 +161,23 @@ describe("WithFacility", () => {
         },
         facilities: [
           { id: "1", name: "Facility 1" },
-          { id: "4", name: "Facility 4" },
+          { id: "2", name: "Facility 2" },
         ],
       });
-      store.dispatch = jest.fn();
       render(
-        <Provider store={store}>
-          <WithFacility>App</WithFacility>
-        </Provider>
+        <Router
+          initialEntries={[{ pathname: "/", search: "?facility=2" }]}
+          initialIndex={0}
+        >
+          <Provider store={store}>
+            <WithFacility>App</WithFacility>
+          </Provider>
+        </Router>
       );
     });
-    it("sets facility in state", () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        updateFacility({
-          id: "4",
-          name: "Facility 4",
-        })
-      );
+    it("loads facility directly from URL", async () => {
+      const renderedApp = await screen.findByText("App");
+      expect(renderedApp).toBeInTheDocument();
     });
   });
   describe("A new org", () => {
@@ -219,13 +194,16 @@ describe("WithFacility", () => {
         },
         facilities: [],
       });
-      store.dispatch = jest.fn();
       render(
-        <Provider store={store}>
-          <MockedProvider mocks={mocks} addTypename={false}>
-            <WithFacility>App</WithFacility>
-          </MockedProvider>
-        </Provider>
+        <I18nextProvider i18n={i18n}>
+          <Router>
+            <Provider store={store}>
+              <MockedProvider mocks={mocks} addTypename={false}>
+                <WithFacility>App</WithFacility>
+              </MockedProvider>
+            </Provider>
+          </Router>
+        </I18nextProvider>
       );
       await act(async () => {
         await screen.findAllByText("Welcome to SimpleReport", { exact: false });
@@ -234,7 +212,7 @@ describe("WithFacility", () => {
 
     it("should render the facility form", async () => {
       expect(
-        await screen.getByText("To get started, add a testing facility", {
+        await screen.findByText("To get started, add a testing facility", {
           exact: false,
         })
       ).toBeInTheDocument();

--- a/frontend/src/app/facilitySelect/WithFacility.test.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.test.tsx
@@ -95,7 +95,6 @@ describe("WithFacility", () => {
         },
         facilities: [{ id: "1", name: "Facility 1" }],
       });
-      store.dispatch = jest.fn();
       component = render(
         <Provider store={store}>
           <WithFacility>App</WithFacility>

--- a/frontend/src/app/facilitySelect/WithFacility.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.tsx
@@ -39,7 +39,6 @@ const WithFacility: React.FC<Props> = ({ children }) => {
 
     if (facilities.length === 1) {
       setSelectedFacility(facilities[0]);
-      return;
     }
   }, [facilities, selectedFacility, dataLoaded, setSelectedFacility]);
 

--- a/frontend/src/app/facilitySelect/__snapshots__/WithFacility.test.tsx.snap
+++ b/frontend/src/app/facilitySelect/__snapshots__/WithFacility.test.tsx.snap
@@ -1,63 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WithFacility With one facility should render with a value 1`] = `
-<p>
-  Loading facility information...
-</p>
-`;
-
-exports[`WithFacility With two facilities should render with a value 1`] = `
+exports[`WithFacility With two facilities should show the facility selection screen 1`] = `
 <main
-  className="prime-home"
+  class="prime-home"
   id="facility-select"
 >
   <div
-    className="grid-container"
+    class="grid-container"
   >
     <div
-      className="grid-row position-relative"
+      class="grid-row position-relative"
     >
       <div
-        className="prime-container card-container"
+        class="prime-container card-container"
       >
         <div
-          className="usa-card__header"
+          class="usa-card__header"
         >
           <div>
             <h2>
               SimpleReport
             </h2>
             <div
-              className="organization-name"
+              class="organization-name"
             >
               Organization Name
             </div>
           </div>
         </div>
         <div
-          className="usa-card__body"
+          class="usa-card__body"
         >
           <p
-            className="welcome"
+            class="welcome"
           >
             Welcome, 
             Kim Mendoza
           </p>
           <p
-            className="select-text"
+            class="select-text"
           >
             Please select the testing facility where you are working today.
           </p>
           <button
-            className="usa-button usa-button--outline"
-            onClick={[Function]}
+            class="usa-button usa-button--outline"
             type="button"
           >
             Facility 1
           </button>
           <button
-            className="usa-button usa-button--outline"
-            onClick={[Function]}
+            class="usa-button usa-button--outline"
             type="button"
           >
             Facility 2

--- a/frontend/src/app/facilitySelect/useSelectedFacility.ts
+++ b/frontend/src/app/facilitySelect/useSelectedFacility.ts
@@ -1,18 +1,24 @@
 import { useSelector } from "react-redux";
+import { useHistory } from "react-router";
 
 import { RootState } from "../store";
 import { getFacilityIdFromUrl } from "../utils/url";
 
 export const useSelectedFacility = () => {
+  const history = useHistory();
   const facility = getFacilityIdFromUrl();
   const selectedFacility = useSelector<RootState, Facility | undefined>(
     (state) => state.facilities.find((f) => f.id === facility)
   );
 
-  const setSelectedFacility = (facility: Facility) => {
-    window.location.href = `${
-      window.location.pathname
-    }?facility=${encodeURIComponent(facility.id)}`;
+  const setSelectedFacility = (selected: Facility) => {
+    if (facility) {
+      window.location.href = `${
+        window.location.pathname
+      }?facility=${encodeURIComponent(selected.id)}`;
+    } else {
+      history.push({ search: `?facility=${encodeURIComponent(selected.id)}` });
+    }
   };
 
   return [selectedFacility, setSelectedFacility] as const;

--- a/frontend/src/app/facilitySelect/useSelectedFacility.ts
+++ b/frontend/src/app/facilitySelect/useSelectedFacility.ts
@@ -1,18 +1,18 @@
 import { useSelector } from "react-redux";
-import { useHistory } from "react-router";
+import { useHistory, useLocation } from "react-router";
 
 import { RootState } from "../store";
-import { getFacilityIdFromUrl } from "../utils/url";
 
-export const useSelectedFacility = () => {
+export function useSelectedFacility() {
   const history = useHistory();
-  const facility = getFacilityIdFromUrl();
+  const facilityId = useQuery().get("facility");
+
   const selectedFacility = useSelector<RootState, Facility | undefined>(
-    (state) => state.facilities.find((f) => f.id === facility)
+    (state) => state.facilities.find((f) => f.id === facilityId)
   );
 
   const setSelectedFacility = (selected: Facility) => {
-    if (facility) {
+    if (facilityId) {
       window.location.href = `${
         window.location.pathname
       }?facility=${encodeURIComponent(selected.id)}`;
@@ -22,4 +22,8 @@ export const useSelectedFacility = () => {
   };
 
   return [selectedFacility, setSelectedFacility] as const;
-};
+}
+
+function useQuery() {
+  return new URLSearchParams(useLocation().search);
+}

--- a/frontend/src/app/facilitySelect/useSelectedFacility.ts
+++ b/frontend/src/app/facilitySelect/useSelectedFacility.ts
@@ -12,13 +12,7 @@ export function useSelectedFacility() {
   );
 
   const setSelectedFacility = (selected: Facility) => {
-    if (facilityId) {
-      window.location.href = `${
-        window.location.pathname
-      }?facility=${encodeURIComponent(selected.id)}`;
-    } else {
-      history.push({ search: `?facility=${encodeURIComponent(selected.id)}` });
-    }
+    history.push({ search: `?facility=${encodeURIComponent(selected.id)}` });
   };
 
   return [selectedFacility, setSelectedFacility] as const;

--- a/frontend/src/app/facilitySelect/useSelectedFacility.ts
+++ b/frontend/src/app/facilitySelect/useSelectedFacility.ts
@@ -1,0 +1,19 @@
+import { useSelector } from "react-redux";
+
+import { RootState } from "../store";
+import { getFacilityIdFromUrl } from "../utils/url";
+
+export const useSelectedFacility = () => {
+  const facility = getFacilityIdFromUrl();
+  const selectedFacility = useSelector<RootState, Facility | undefined>(
+    (state) => state.facilities.find((f) => f.id === facility)
+  );
+
+  const setSelectedFacility = (facility: Facility) => {
+    window.location.href = `${
+      window.location.pathname
+    }?facility=${encodeURIComponent(facility.id)}`;
+  };
+
+  return [selectedFacility, setSelectedFacility] as const;
+};

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -89,7 +89,7 @@ describe("AddPatient", () => {
     });
     it("shows a 'No facility selected' message", async () => {
       expect(
-        await screen.getByText("No facility selected", {
+        screen.getByText("No facility selected", {
           exact: false,
         })
       ).toBeInTheDocument();

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -13,7 +13,17 @@ import { MemoryRouter, Route } from "react-router";
 
 import AddPatient, { ADD_PATIENT } from "./AddPatient";
 
+const mockFacilityID = "b0d2041f-93c9-4192-b19a-dd99c0044a7e";
 const mockStore = configureStore([]);
+const store = mockStore({
+  facilities: [{ id: mockFacilityID, name: "123" }],
+});
+
+const RouterWithFacility: React.FC = ({ children }) => (
+  <MemoryRouter initialEntries={[`/add-patient?facility=${mockFacilityID}`]}>
+    {children}
+  </MemoryRouter>
+);
 
 jest.mock("../utils/smartyStreets", () => ({
   getBestSuggestion: jest.fn(),
@@ -60,11 +70,6 @@ describe("AddPatient", () => {
   afterEach(cleanup);
   describe("No facility selected", () => {
     beforeEach(() => {
-      const store = mockStore({
-        facility: {
-          id: "",
-        },
-      });
       render(
         <MemoryRouter>
           <Provider store={store}>
@@ -92,13 +97,6 @@ describe("AddPatient", () => {
   });
 
   describe("Facility selected", () => {
-    const mockFacilityID = "b0d2041f-93c9-4192-b19a-dd99c0044a7e";
-    const store = mockStore({
-      facility: {
-        id: mockFacilityID,
-      },
-      facilities: [{ id: mockFacilityID, name: "123" }],
-    });
     beforeEach(() => {
       const mocks = [
         {
@@ -183,17 +181,17 @@ describe("AddPatient", () => {
       render(
         <Provider store={store}>
           <MockedProvider mocks={mocks} addTypename={false}>
-            <MemoryRouter initialEntries={["/add-patient/"]}>
+            <RouterWithFacility>
               <Route component={AddPatient} path={"/add-patient/"} />
               <Route path={"/patients"} render={() => <p>Patients!</p>} />
-            </MemoryRouter>
+            </RouterWithFacility>
           </MockedProvider>
         </Provider>
       );
     });
     it("shows the form title", async () => {
       expect(
-        await screen.queryAllByText("Add New Person", { exact: false })[0]
+        screen.queryAllByText("Add New Person", { exact: false })[0]
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -117,7 +117,7 @@ const AddPatient = () => {
   >(ADD_PATIENT);
 
   const [activeFacility] = useSelectedFacility();
-  const activeFacilityId = activeFacility!.id;
+  const activeFacilityId = activeFacility?.id;
 
   const personPath = `/patients/?facility=${activeFacilityId}`;
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
@@ -126,7 +126,7 @@ const AddPatient = () => {
     return <Redirect to={redirect} />;
   }
 
-  if (activeFacilityId.length < 1) {
+  if (!activeFacilityId) {
     return <div>No facility selected</div>;
   }
 

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -115,8 +115,9 @@ const AddPatient = () => {
     AddPatientResponse,
     AddPatientParams
   >(ADD_PATIENT);
+
   const [activeFacility] = useSelectedFacility();
-  const activeFacilityId = activeFacility?.id || "";
+  const activeFacilityId = activeFacility!.id;
 
   const personPath = `/patients/?facility=${activeFacilityId}`;
   const [redirect, setRedirect] = useState<string | undefined>(undefined);

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { gql, useMutation } from "@apollo/client";
 import { toast } from "react-toastify";
 import { Redirect } from "react-router-dom";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
@@ -10,9 +9,9 @@ import { PATIENT_TERM_CAP } from "../../config/constants";
 import { showNotification } from "../utils";
 import Alert from "../commonComponents/Alert";
 import Button from "../commonComponents/Button/Button";
-import { RootState } from "../store";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { useDocumentTitle } from "../utils/hooks";
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 import PersonForm from "./Components/PersonForm";
 
@@ -116,9 +115,9 @@ const AddPatient = () => {
     AddPatientResponse,
     AddPatientParams
   >(ADD_PATIENT);
-  const activeFacilityId: string = useSelector<RootState, string>(
-    (state) => state.facility.id
-  );
+  const [activeFacility] = useSelectedFacility();
+  const activeFacilityId = activeFacility?.id || "";
+
   const personPath = `/patients/?facility=${activeFacilityId}`;
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
 

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -156,7 +156,6 @@ const AddPatient = () => {
       <div className={"grid-container margin-bottom-4"}>
         <PersonForm
           patient={EMPTY_PERSON}
-          activeFacilityId={activeFacilityId}
           savePerson={savePerson}
           getHeader={(_, onSave, formChanged) => (
             <div className="display-flex flex-justify">

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -74,7 +74,6 @@ const yesNoUnknownToBool = (
 interface Props {
   patient: Nullable<PersonFormData>;
   patientId?: string;
-  activeFacilityId: string;
   savePerson: (person: Nullable<PersonFormData>) => void;
   hideFacilitySelect?: boolean;
   getHeader?: (

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -13,6 +13,7 @@ import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router";
 
 import EditPatient, { GET_PATIENT } from "./EditPatient";
+import EditPatientContainer from "./EditPatientContainer";
 
 jest.mock("../commonComponents/ComboBox", () => () => <></>);
 const mockStore = configureStore([]);
@@ -376,6 +377,20 @@ describe("EditPatient", () => {
           screen.queryByText("Franecki, Eugenia", { exact: false })
         ).toBeInTheDocument();
       });
+    });
+  });
+  describe("EditPatientContainer", () => {
+    it("doesn't render if no facility is provided", async () => {
+      render(
+        <MemoryRouter>
+          <Provider store={configureStore()({ facilities: [] })}>
+            <EditPatientContainer patientId="5" />
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(
+        await screen.findByText("No facility selected", { exact: false })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -252,7 +252,6 @@ const EditPatient = (props: Props) => {
                     : data.patient.facility?.id,
               }}
               patientId={props.patientId}
-              activeFacilityId={props.facilityId}
               savePerson={savePerson}
               getHeader={(person, onSave, formChanged) => (
                 <div className="display-flex flex-justify">

--- a/frontend/src/app/patients/EditPatientContainer.tsx
+++ b/frontend/src/app/patients/EditPatientContainer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { useSelector } from "react-redux";
+
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 import EditPatient from "./EditPatient";
 
@@ -8,9 +9,9 @@ interface Props {
 }
 
 const EditPatientContainer: React.FC<Props> = ({ patientId }) => {
-  const activeFacilityId = useSelector(
-    (state) => (state as any).facility.id as string
-  );
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id || "";
+
   if (activeFacilityId.length < 1) {
     return <div>"No facility selected"</div>;
   }

--- a/frontend/src/app/patients/EditPatientContainer.tsx
+++ b/frontend/src/app/patients/EditPatientContainer.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const EditPatientContainer: React.FC<Props> = ({ patientId }) => {
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility?.id || "";
+  const activeFacilityId = facility!.id;
 
   if (activeFacilityId.length < 1) {
     return <div>"No facility selected"</div>;

--- a/frontend/src/app/patients/EditPatientContainer.tsx
+++ b/frontend/src/app/patients/EditPatientContainer.tsx
@@ -10,9 +10,9 @@ interface Props {
 
 const EditPatientContainer: React.FC<Props> = ({ patientId }) => {
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility!.id;
+  const activeFacilityId = facility?.id;
 
-  if (activeFacilityId.length < 1) {
+  if (!activeFacilityId) {
     return <div>"No facility selected"</div>;
   }
   return <EditPatient facilityId={activeFacilityId} patientId={patientId} />;

--- a/frontend/src/app/patients/ManagePatients.test.tsx
+++ b/frontend/src/app/patients/ManagePatients.test.tsx
@@ -5,12 +5,15 @@ import {
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import createMockStore from "redux-mock-store";
 
 import ManagePatients, {
   patientQuery,
   patientsCountQuery,
 } from "./ManagePatients";
+import ManagePatientsContainer from "./ManagePatientsContainer";
 
 const TestContainer: React.FC = ({ children }) => (
   <MemoryRouter>
@@ -58,6 +61,25 @@ describe("ManagePatients", () => {
     );
     expect(await screen.findByText(patients[1].lastName, { exact: false }));
     expect(await screen.findByText(patients[2].lastName, { exact: false }));
+  });
+  describe("ManagePatientsContainer", () => {
+    it("Doesn't render if no facility is selected", async () => {
+      render(
+        <MemoryRouter>
+          <Provider
+            store={createMockStore()({
+              facilities: [],
+              user: { isAdmin: false },
+            })}
+          >
+            <ManagePatientsContainer />
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(
+        await screen.findByText("No facility selected", { exact: false })
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/src/app/patients/ManagePatientsContainer.tsx
+++ b/frontend/src/app/patients/ManagePatientsContainer.tsx
@@ -10,7 +10,7 @@ import ManagePatients from "./ManagePatients";
 const ManagePatientsContainer = (props: { page?: number }) => {
   useDocumentTitle("People");
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility!.id || "";
+  const activeFacilityId = facility?.id || "";
   const user = useSelector<RootState, User>((state) => state.user);
   const isAdmin = useSelector<RootState, boolean>(
     (state) => state.user.isAdmin

--- a/frontend/src/app/patients/ManagePatientsContainer.tsx
+++ b/frontend/src/app/patients/ManagePatientsContainer.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { useSelector } from "react-redux";
 
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { hasPermission, appPermissions } from "../permissions";
 import { RootState } from "../store";
 import { useDocumentTitle } from "../utils/hooks";
@@ -9,9 +9,8 @@ import ManagePatients from "./ManagePatients";
 
 const ManagePatientsContainer = (props: { page?: number }) => {
   useDocumentTitle("People");
-  const activeFacilityId = useSelector(
-    (state) => (state as any).facility.id as string
-  );
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id || "";
   const user = useSelector<RootState, User>((state) => state.user);
   const isAdmin = useSelector<RootState, boolean>(
     (state) => state.user.isAdmin

--- a/frontend/src/app/patients/ManagePatientsContainer.tsx
+++ b/frontend/src/app/patients/ManagePatientsContainer.tsx
@@ -10,7 +10,7 @@ import ManagePatients from "./ManagePatients";
 const ManagePatientsContainer = (props: { page?: number }) => {
   useDocumentTitle("People");
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility?.id || "";
+  const activeFacilityId = facility!.id || "";
   const user = useSelector<RootState, User>((state) => state.user);
   const isAdmin = useSelector<RootState, boolean>(
     (state) => state.user.isAdmin

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -16,11 +16,7 @@ const initialState = {
   organization: {
     name: "",
   },
-  facilities: [],
-  facility: {
-    id: "",
-    name: "",
-  },
+  facilities: [] as Facility[],
   user: {
     id: "",
     firstName: "",
@@ -61,14 +57,6 @@ const reducers = (state = initialState, action: any) => {
         ...state,
         organization: {
           ...state.organization,
-          ...action.payload,
-        },
-      };
-    case UPDATE_FACILITY:
-      return {
-        ...state,
-        facility: {
-          ...state.facility,
           ...action.payload,
         },
       };

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -6,7 +6,6 @@ import { UserPermission } from "./permissions";
 
 const SET_INITIAL_STATE = "SET_INITIAL_STATE";
 const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
-const UPDATE_FACILITY = "UPDATE_FACILITY";
 const SET_PATIENT = "SET_PATIENT";
 
 // this should be the default value for a brand new org
@@ -83,13 +82,6 @@ export const updateOrganization = (organization: any) => {
   return {
     type: UPDATE_ORGANIZATION,
     payload: organization,
-  };
-};
-
-export const updateFacility = (facility: any) => {
-  return {
-    type: UPDATE_FACILITY,
-    payload: facility,
   };
 };
 

--- a/frontend/src/app/testQueue/TestQueueContainer.tsx
+++ b/frontend/src/app/testQueue/TestQueueContainer.tsx
@@ -6,7 +6,7 @@ import TestQueue from "./TestQueue";
 const TestQueueContainer = () => {
   useDocumentTitle("Conduct test");
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility?.id;
+  const activeFacilityId = facility!.id;
 
   return !activeFacilityId?.length ? (
     <div>"No facility selected"</div>

--- a/frontend/src/app/testQueue/TestQueueContainer.tsx
+++ b/frontend/src/app/testQueue/TestQueueContainer.tsx
@@ -6,9 +6,9 @@ import TestQueue from "./TestQueue";
 const TestQueueContainer = () => {
   useDocumentTitle("Conduct test");
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility!.id;
+  const activeFacilityId = facility?.id;
 
-  return !activeFacilityId?.length ? (
+  return !activeFacilityId ? (
     <div>"No facility selected"</div>
   ) : (
     <TestQueue activeFacilityId={activeFacilityId} />

--- a/frontend/src/app/testQueue/TestQueueContainer.tsx
+++ b/frontend/src/app/testQueue/TestQueueContainer.tsx
@@ -1,16 +1,14 @@
-import React from "react";
-import { useSelector } from "react-redux";
-
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { useDocumentTitle } from "../utils/hooks";
 
 import TestQueue from "./TestQueue";
 
 const TestQueueContainer = () => {
   useDocumentTitle("Conduct test");
-  const activeFacilityId = useSelector(
-    (state) => (state as any).facility.id as string
-  );
-  return !activeFacilityId.length ? (
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id;
+
+  return !activeFacilityId?.length ? (
     <div>"No facility selected"</div>
   ) : (
     <TestQueue activeFacilityId={activeFacilityId} />

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -35,6 +35,12 @@ jest.mock("@microsoft/applicationinsights-react-js", () => ({
   useTrackEvent: jest.fn(),
 }));
 
+const WithRouter: React.FC = ({ children }) => (
+  <MemoryRouter initialEntries={[{ search: "?facility=1" }]}>
+    {children}
+  </MemoryRouter>
+);
+
 // Data copied from Chrome network window
 const testResults = [
   {
@@ -718,14 +724,14 @@ const mocks = [
 describe("TestResultsList", () => {
   it("should render a list of tests", async () => {
     const { container, getByText } = render(
-      <MemoryRouter>
+      <WithRouter>
         <DetachedTestResultsList
           data={{ testResults }}
           page={1}
           entriesPerPage={20}
           totalEntries={testResults.length}
         />
-      </MemoryRouter>
+      </WithRouter>
     );
     expect(getByText("Test Results", { exact: false })).toBeInTheDocument();
     expect(getByText("Cragell, Barb Whitaker")).toBeInTheDocument();
@@ -733,13 +739,13 @@ describe("TestResultsList", () => {
   });
   it("should call appropriate gql endpoints for pagination", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
     expect(
       await screen.findByText("Test Results", { exact: false })
@@ -750,13 +756,13 @@ describe("TestResultsList", () => {
   });
   it("should be able to filter by patient", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
     expect(
       await screen.findByText("Test Results", { exact: false })
@@ -779,13 +785,13 @@ describe("TestResultsList", () => {
   });
   it("should be able to filter by result value", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
     expect(
       await screen.findByText("Test Results", { exact: false })
@@ -805,13 +811,13 @@ describe("TestResultsList", () => {
   });
   it("should be able to filter by role", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
     expect(
       await screen.findByText("Test Results", { exact: false })
@@ -831,13 +837,13 @@ describe("TestResultsList", () => {
   });
   it("should be able to filter by date", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
     expect(
       await screen.findByText("Test Results", { exact: false })
@@ -872,13 +878,13 @@ describe("TestResultsList", () => {
   });
   it("should be able to clear patient filter", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
 
     expect(
@@ -904,13 +910,13 @@ describe("TestResultsList", () => {
 
   it("should be able to clear date filters", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
 
     // Apply filter
@@ -952,13 +958,13 @@ describe("TestResultsList", () => {
 
   it("opens the test detail view", async () => {
     render(
-      <MemoryRouter>
+      <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <TestResultsList page={1} />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
     await screen.findByText("Test Results", { exact: false });
     const moreActions = within(screen.getByRole("table")).getAllByRole(

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -975,4 +975,19 @@ describe("TestResultsList", () => {
     fireEvent.click(viewDetails);
     expect(screen.queryAllByText("Test details").length).toBe(2);
   });
+
+  it("doesn't display anything if no facility is selected", async () => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <TestResultsList page={1} />
+          </MockedProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(
+      await screen.findByText("No facility selected", { exact: false })
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -580,7 +580,7 @@ const TestResultsList = (props: TestResultsListProps) => {
   useDocumentTitle("Results");
 
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility?.id || "";
+  const activeFacilityId = facility!.id;
 
   const [selectedPatientId, setSelectedPatientId] = useState<string>("");
   const [resultFilter, setResultFilter] = useState<string>("");

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -580,7 +580,7 @@ const TestResultsList = (props: TestResultsListProps) => {
   useDocumentTitle("Results");
 
   const [facility] = useSelectedFacility();
-  const activeFacilityId = facility!.id;
+  const activeFacilityId = facility?.id || "";
 
   const [selectedPatientId, setSelectedPatientId] = useState<string>("");
   const [resultFilter, setResultFilter] = useState<string>("");
@@ -650,7 +650,7 @@ const TestResultsList = (props: TestResultsListProps) => {
     fetchPolicy: "no-cache",
   });
 
-  if (activeFacilityId.length < 1) {
+  if (!activeFacilityId) {
     return <div>"No facility selected"</div>;
   }
 

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -10,7 +10,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useSelector } from "react-redux";
 import moment from "moment";
 import classnames from "classnames";
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
@@ -44,6 +43,7 @@ import { QUERY_PATIENT } from "../testQueue/addToQueue/AddToQueueSearch";
 import { Patient } from "../patients/ManagePatients";
 import SearchResults from "../testQueue/addToQueue/SearchResults";
 import Select from "../commonComponents/Select";
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 import TestResultPrintModal from "./TestResultPrintModal";
 import TestResultCorrectionModal from "./TestResultCorrectionModal";
@@ -579,9 +579,8 @@ type TestResultsListProps = Omit<Props, OmittedProps>;
 const TestResultsList = (props: TestResultsListProps) => {
   useDocumentTitle("Results");
 
-  const activeFacilityId = useSelector(
-    (state) => (state as any).facility.id as string
-  );
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id || "";
 
   const [selectedPatientId, setSelectedPatientId] = useState<string>("");
   const [resultFilter, setResultFilter] = useState<string>("");

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -550,7 +550,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   <a
                     aria-label="Page 1"
                     class="is-active"
-                    href="/results/1"
+                    href="/results/1?facility=1"
                   >
                     <span>
                       1

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -19,7 +19,6 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
       className="grid-container maxw-tablet padding-y-3"
     >
       <PersonForm
-        activeFacilityId=""
         patient={EMPTY_PERSON}
         savePerson={savePerson}
         getFooter={(onSave) => (

--- a/frontend/src/patientApp/timeOfTest/PatientFormContainer.tsx
+++ b/frontend/src/patientApp/timeOfTest/PatientFormContainer.tsx
@@ -17,7 +17,6 @@ const PatientFormContainer = () => {
   const history = useHistory();
   const [nextPage, setNextPage] = useState(false);
   const patient = useSelector((state: any) => state.patient);
-  const facility = useSelector((state: any) => state.facility);
 
   const dispatch = useDispatch();
 
@@ -91,7 +90,6 @@ const PatientFormContainer = () => {
               facilityId:
                 patient.facility === null ? null : patient.facility?.id,
             }}
-            activeFacilityId={facility.id}
             patientId={patient.internalId}
             hideFacilitySelect={true}
             savePerson={savePerson}


### PR DESCRIPTION
## Related Issue or Background Info

- We have been redundantly storing the selected facility in both our redux state and the URL. This has caused weird divergence issues.

## Changes Proposed

- Makes the URL the source of truth; removes selected facility entirely from state
- Abstracts the "selected facility" into a `useSelectedFacility` hook that both gets and sets the active facility in the URL.

## Additional Information

- We have discussed on a couple occasions that local storage might be a better location for this information than the URL bar, which is easy to accidentally overwrite both manually by the user and programmatically by developers. Making a `useSelectedFacility` hook means all of the logic resides in one place and our storage location should be relatively simple to change.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
