### PR TITLE
Remove Dynamics from AccountRequestController

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -25,7 +25,6 @@ import gov.cdc.usds.simplereport.service.AddressValidationService;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
-import gov.cdc.usds.simplereport.service.crm.CrmService;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.service.model.DeviceSpecimenTypeHolder;
@@ -64,7 +63,6 @@ public class AccountRequestController {
   private final ApiUserService _aus;
   private final EmailService _es;
   private final SendGridProperties sendGridProperties;
-  private final CrmService _crm;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   private static final Logger LOG = LoggerFactory.getLogger(AccountRequestController.class);
@@ -112,7 +110,6 @@ public class AccountRequestController {
       sendNewAccountRequestEmailToSrSupport(request.getEmail(), request);
       createAdminUser(
           request.getFirstName(), request.getLastName(), request.getEmail(), org.getExternalId());
-      _crm.submitAccountRequestData(request);
     } catch (ResourceException e) {
       // The `ResourceException` is thrown when an account is requested with an existing org
       // name. This happens quite frequently and is expected behavior of the current form
@@ -145,7 +142,6 @@ public class AccountRequestController {
       sendNewAccountRequestEmailToSrSupport(request.getEmail(), request);
       createAdminUser(
           request.getFirstName(), request.getLastName(), request.getEmail(), org.getExternalId());
-      _crm.submitOrganizationAccountRequestData(request);
     } catch (ResourceException | BadRequestException e) {
       // The `ResourceException` is thrown when an account is requested with an existing user email
       // address
@@ -172,7 +168,6 @@ public class AccountRequestController {
       Organization org = checkAccountRequestAndCreateOrgWithFacility(request);
       createAdminUser(
           request.getFirstName(), request.getLastName(), request.getEmail(), org.getExternalId());
-      _crm.submitAccountRequestData(request);
       return new AccountResponse(org.getExternalId());
     } catch (ResourceException | BadRequestException e) {
       // The `ResourceException` is thrown when an account is requested with an existing user email
@@ -196,7 +191,6 @@ public class AccountRequestController {
       Organization org = checkAccountRequestAndCreateOrg(request);
       createAdminUser(
           request.getFirstName(), request.getLastName(), request.getEmail(), org.getExternalId());
-      _crm.submitOrganizationAccountRequestData(request);
       return new AccountResponse(org.getExternalId());
     } catch (ResourceException e) {
       // The `ResourceException` is thrown when an account is requested with an existing org

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -372,9 +372,6 @@ class AccountRequestControllerTest {
     assertThat(addressCaptor.getValue().getPostalCode()).isEqualTo("43675");
     assertThat(addressCaptor.getValue().getCounty()).isEqualTo("Asperiores illum in");
 
-    // assertThat(accountRequestCaptor.getValue().getOrganizationName())
-    //     .isEqualTo("Day Hayes Trading");
-
     // new user should be disabled in okta
     verify(oktaRepository)
         .createUser(any(IdentityAttributes.class), eq(organization), anySet(), anySet(), eq(false));
@@ -414,9 +411,6 @@ class AccountRequestControllerTest {
     verify(emailService, times(0)).send(anyList(), anyString(), any());
     verify(emailService, times(0)).sendWithProviderTemplate(anyString(), any());
     verify(mockSendGrid, times(0)).send(any());
-
-    // assertThat(organizationAccountRequestCaptor.getValue().getOrganizationName())
-    //     .isEqualTo("Day Hayes Trading");
 
     verify(apiUserService, times(1))
         .createUser(
@@ -475,9 +469,6 @@ class AccountRequestControllerTest {
     verify(emailService, times(1)).send(anyList(), anyString(), any());
     verify(emailService, times(1)).sendWithProviderTemplate(anyString(), any());
     verify(mockSendGrid, times(2)).send(any());
-
-    // assertThat(organizationAccountRequestCaptor.getValue().getOrganizationName())
-    //     .isEqualTo("Day Hayes Trading");
 
     verify(apiUserService, times(1))
         .createUser(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -43,7 +43,6 @@ import gov.cdc.usds.simplereport.service.AuthorizationService;
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.TenantDataAccessService;
-import gov.cdc.usds.simplereport.service.crm.CrmService;
 import gov.cdc.usds.simplereport.service.email.EmailProvider;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
@@ -107,7 +106,6 @@ class AccountRequestControllerTest {
   @MockBean private CurrentTenantDataAccessContextHolder tenantDataAccessContextHolder;
   @MockBean private TenantDataAuthenticationProvider tenantDataAuthProvider;
 
-  @MockBean private CrmService crmService;
   @MockBean private OktaRepository oktaRepository;
 
   @MockBean private EmailProvider mockSendGrid;
@@ -374,10 +372,8 @@ class AccountRequestControllerTest {
     assertThat(addressCaptor.getValue().getPostalCode()).isEqualTo("43675");
     assertThat(addressCaptor.getValue().getCounty()).isEqualTo("Asperiores illum in");
 
-    // make sure we passed the data along to our CRM
-    verify(crmService, times(1)).submitAccountRequestData(accountRequestCaptor.capture());
-    assertThat(accountRequestCaptor.getValue().getOrganizationName())
-        .isEqualTo("Day Hayes Trading");
+    // assertThat(accountRequestCaptor.getValue().getOrganizationName())
+    //     .isEqualTo("Day Hayes Trading");
 
     // new user should be disabled in okta
     verify(oktaRepository)
@@ -419,10 +415,8 @@ class AccountRequestControllerTest {
     verify(emailService, times(0)).sendWithProviderTemplate(anyString(), any());
     verify(mockSendGrid, times(0)).send(any());
 
-    verify(crmService, times(1))
-        .submitOrganizationAccountRequestData(organizationAccountRequestCaptor.capture());
-    assertThat(organizationAccountRequestCaptor.getValue().getOrganizationName())
-        .isEqualTo("Day Hayes Trading");
+    // assertThat(organizationAccountRequestCaptor.getValue().getOrganizationName())
+    //     .isEqualTo("Day Hayes Trading");
 
     verify(apiUserService, times(1))
         .createUser(
@@ -482,10 +476,8 @@ class AccountRequestControllerTest {
     verify(emailService, times(1)).sendWithProviderTemplate(anyString(), any());
     verify(mockSendGrid, times(2)).send(any());
 
-    verify(crmService, times(1))
-        .submitOrganizationAccountRequestData(organizationAccountRequestCaptor.capture());
-    assertThat(organizationAccountRequestCaptor.getValue().getOrganizationName())
-        .isEqualTo("Day Hayes Trading");
+    // assertThat(organizationAccountRequestCaptor.getValue().getOrganizationName())
+    //     .isEqualTo("Day Hayes Trading");
 
     verify(apiUserService, times(1))
         .createUser(


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #2333 

## Changes Proposed

- Remove Dynamics from AccountRequestController methods and its test

## Additional Information

- There's a lot more Dynamics code that could be removed, but since we're potentially going to implement a different CRM for SimpleReport later I opted to keep it in place for now.

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- n/a Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
