### PR TITLE
Update prod Docker image dependencies

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM gradle:6.7.1-jdk11-hotspot AS build
+FROM gradle:6.9-jdk11-hotspot AS build
 WORKDIR /home/gradle/graphql-api
 COPY --chown=gradle:gradle ./.git ./.git
 WORKDIR /home/gradle/graphql-api/backend
@@ -20,7 +20,7 @@ COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
 
 RUN gradle --no-daemon assemble
 
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 EXPOSE 8080
 COPY --from=build /home/gradle/graphql-api/backend/build/libs/*.jar app.jar
 COPY --from=build  /home/gradle/graphql-api/backend/insights.jar insights.jar


### PR DESCRIPTION
## Related Issue or Background Info

#2178

## Changes Proposed

- Update base images in prod `Dockerfile`:
  - Update minor version of Gradle base image
  - Move from `openjdk` to `adoptopenjdk` - still OpenJDK, but updated much more often, and also with an up-to-date Alpine Java11 image

## Additional Information

- Java11 is the current LTS, so no updates to the major version at the moment. Java17 is the next LTS and should be out sometime in September.
