### PR TITLE
Allow trailing spaces in externalIDs

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -98,8 +98,12 @@ public class Translators {
     return value;
   }
 
-  public static String parseString(String value) {
-    return parseStringNoTrim(value).trim();
+  public static String parseString(String v) {
+    String value = parseStringNoTrim(v);
+    if (value == null) {
+      return null;
+    }
+    return value.trim();
   }
 
   public static UUID parseUUID(String uuid) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -87,7 +87,7 @@ public class Translators {
     }
   }
 
-  public static String parseString(String value) {
+  public static String parseStringNoTrim(String value) {
     if (value == null || "".equals(value)) {
       return null;
     }
@@ -95,7 +95,11 @@ public class Translators {
       throw new IllegalGraphqlArgumentException(
           "Value received exceeds field length limit of " + MAX_STRING_LENGTH + " characters");
     }
-    return value.trim();
+    return value;
+  }
+
+  public static String parseString(String value) {
+    return parseStringNoTrim(value).trim();
   }
 
   public static UUID parseUUID(String uuid) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -97,7 +97,7 @@ public class UserMutationResolver implements GraphQLMutationResolver {
   public User setCurrentUserTenantDataAccess(String organizationExternalID, String justification) {
     UserInfo user =
         _us.setCurrentUserTenantDataAccess(
-            Translators.parseString(organizationExternalID),
+            Translators.parseStringNoTrim(organizationExternalID),
             Translators.parseString(justification));
     return new User(user);
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -995,33 +995,36 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
   @Test
   void setCurrentUserTenantDataAccess_externalIdTrailingSpace_success() {
-    _dataFactory.createValidOrg("The Mall", "k12", "dc-with-trailing-space ", true);
+    TestUserIdentities.withUser(
+        TestUserIdentities.SITE_ADMIN_USER,
+        () -> {
+          useSuperUser();
+          _dataFactory.createValidOrg("The Mall", "k12", "dc-with-trailing-space ", true);
 
-    useSuperUser();
+          ObjectNode variables =
+              JsonNodeFactory.instance
+                  .objectNode()
+                  .put("organizationExternalId", "dc-with-trailing-space ")
+                  .put("justification", "This is my justification");
+          ObjectNode user =
+              (ObjectNode)
+                  runQuery(
+                          "set-current-user-tenant-data-access",
+                          "SetCurrentUserTenantDataAccessOp",
+                          variables,
+                          null)
+                      .get("setCurrentUserTenantDataAccess");
+          assertEquals("ruby@example.com", user.get("email").asText());
+          assertEquals(Role.ADMIN, Role.valueOf(user.get("role").asText()));
+          Set<UserPermission> allPermissions =
+              Arrays.stream(UserPermission.values()).collect(Collectors.toSet());
+          assertEquals(allPermissions, extractPermissionsFromUser(user));
+          assertLastAuditEntry("ruby@example.com", null, null);
 
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("organizationExternalId", "dc-with-trailing-space ")
-            .put("justification", "This is my justification");
-    ObjectNode user =
-        (ObjectNode)
-            runQuery(
-                    "set-current-user-tenant-data-access",
-                    "SetCurrentUserTenantDataAccessOp",
-                    variables,
-                    null)
-                .get("setCurrentUserTenantDataAccess");
-    assertEquals("ruby@example.com", user.get("email").asText());
-    assertEquals(Role.ADMIN, Role.valueOf(user.get("role").asText()));
-    Set<UserPermission> allPermissions =
-        Arrays.stream(UserPermission.values()).collect(Collectors.toSet());
-    assertEquals(allPermissions, extractPermissionsFromUser(user));
-    assertLastAuditEntry("ruby@example.com", null, null);
-
-    // run query using tenant data access
-    runQuery("current-user-query").get("whoami");
-    assertLastAuditEntry("ruby@example.com", "dc-with-trailing-space ", allPermissions);
+          // run query using tenant data access
+          runQuery("current-user-query").get("whoami");
+          assertLastAuditEntry("ruby@example.com", "dc-with-trailing-space ", allPermissions);
+        });
   }
 
   private List<ObjectNode> toList(ArrayNode arr) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -993,6 +993,37 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         ACCESS_ERROR);
   }
 
+  @Test
+  void setCurrentUserTenantDataAccess_externalIdTrailingSpace_success() {
+    _dataFactory.createValidOrg("The Mall", "k12", "dc-with-trailing-space ", true);
+
+    useSuperUser();
+
+    ObjectNode variables =
+        JsonNodeFactory.instance
+            .objectNode()
+            .put("organizationExternalId", "dc-with-trailing-space ")
+            .put("justification", "This is my justification");
+    ObjectNode user =
+        (ObjectNode)
+            runQuery(
+                    "set-current-user-tenant-data-access",
+                    "SetCurrentUserTenantDataAccessOp",
+                    variables,
+                    null)
+                .get("setCurrentUserTenantDataAccess");
+    assertEquals("ruby@example.com", user.get("email").asText());
+    assertEquals(Role.ADMIN, Role.valueOf(user.get("role").asText()));
+    Set<UserPermission> allPermissions =
+        Arrays.stream(UserPermission.values()).collect(Collectors.toSet());
+    assertEquals(allPermissions, extractPermissionsFromUser(user));
+    assertLastAuditEntry("ruby@example.com", null, null);
+
+    // run query using tenant data access
+    runQuery("current-user-query").get("whoami");
+    assertLastAuditEntry("ruby@example.com", "dc-with-trailing-space ", allPermissions);
+  }
+
   private List<ObjectNode> toList(ArrayNode arr) {
     List<ObjectNode> list = new ArrayList<>();
     for (int i = 0; i < arr.size(); i++) {


### PR DESCRIPTION
## Related Issue or Background Info

- support is unable to spoof accounts when the external ID has a trailing space. See: https://usds.slack.com/archives/C024ZEUGWDV/p1629339819142400

## Changes Proposed

- add a translator the doesn't call `trim()`

## Additional Information

- Calling `trim()` in `parseString()` is a side effect and not ideal (this bug is case in point) but I think it is desired in almost all user input and should be left as is
- externalIDs with spaces were created early days of the signup form when we were building them from the organizations name without trimming them. This might be something we can clean up if/when we add more granular permissions

## Screenshots / Demos

## Checklist for Author and Reviewer
- [ ] tests pass

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
