### PR TITLE
Change sign up form endpoint

### DIFF
--- a/frontend/src/app/signUp/SignUpApi.test.ts
+++ b/frontend/src/app/signUp/SignUpApi.test.ts
@@ -78,7 +78,7 @@ describe("SignUpApi", () => {
     });
     it("calls fetch with the correct data", () => {
       expect(fetch).toHaveBeenCalledWith(
-        "http://localhost:8080/account-request/without-facility-with-emails",
+        "http://localhost:8080/account-request/organization-create-without-facility",
         {
           body:
             '{"firstName":"Laslo","lastName":"Dickens","email":"laslo@shadow.corp","name":"Shadow","type":"treatment_center","state":"NY","workPhoneNumber":"665-452-5484"}',

--- a/frontend/src/app/signUp/SignUpApi.ts
+++ b/frontend/src/app/signUp/SignUpApi.ts
@@ -23,7 +23,7 @@ export class SignUpApi {
     request: OrganizationCreateRequest
   ): Promise<OrganizationCreateResponse> {
     return api.request(
-      "/account-request/without-facility-with-emails",
+      "/account-request/organization-create-without-facility",
       request
     );
   }


### PR DESCRIPTION
Quick add-on to #2346 to change the endpoint to the one that doesn't send an email to support notifiying them that a new account was requested