### PR TITLE
Make the methods called in the constructor final

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -97,11 +97,11 @@ public class TestEvent extends BaseTestInfo {
     return getPatient().getInternalId();
   }
 
-  public Person getPatientData() {
+  public final Person getPatientData() {
     return patientData;
   }
 
-  public AskOnEntrySurvey getSurveyData() {
+  public final AskOnEntrySurvey getSurveyData() {
     return surveyData;
   }
 
@@ -113,11 +113,11 @@ public class TestEvent extends BaseTestInfo {
     }
   }
 
-  public Provider getProviderData() {
+  public final Provider getProviderData() {
     return providerData;
   }
 
-  public TestOrder getTestOrder() {
+  public final TestOrder getTestOrder() {
     return order;
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

- https://github.com/CDCgov/prime-simplereport/issues/2345

## Changes Proposed

- Make the methods called in the constructor final

## Additional Information

- This came out of a fortify scan

## Screenshots / Demos

## Checklist for Author and Reviewer
- [x] tests pass

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
