### PR TITLE
Scialli/registration dupes

### DIFF
--- a/frontend/src/app/commonComponents/Modal.tsx
+++ b/frontend/src/app/commonComponents/Modal.tsx
@@ -1,7 +1,31 @@
 import React from "react";
 import ReactModal from "react-modal";
+import classnames from "classnames";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import iconClose from "../../../node_modules/uswds/dist/img/usa-icons/close.svg";
+
+type ModalVariant = "warning";
+
+interface Props {
+  onClose: () => void;
+  showModal: boolean;
+  showClose?: boolean;
+  containerClassName?: string;
+  variant?: "warning";
+  title?: string;
+}
+interface SubComponents {
+  Header: typeof Header;
+  Footer: typeof Footer;
+}
+
+type IconDefinition = typeof faExclamationCircle;
+
+const variantIcons: Record<ModalVariant, IconDefinition> = {
+  warning: faExclamationCircle,
+};
 
 const Header: React.FC<{}> = ({ children }) => (
   <h3 className="modal__heading">{children}</h3>
@@ -10,20 +34,21 @@ const Footer: React.FC<{}> = ({ children }) => (
   <div className="modal__footer">{children}</div>
 );
 
-interface Props {
-  onClose: () => void;
-  showModal: boolean;
-}
-interface SubComponents {
-  Header: typeof Header;
-  Footer: typeof Footer;
-}
-
 const Modal: React.FC<Props> & SubComponents = ({
   onClose,
   showModal,
   children,
+  showClose = true,
+  containerClassName,
+  variant,
 }) => {
+  const containerClasses = classnames(
+    containerClassName,
+    "modal__container",
+    variant && "border-left-1 modal__variant",
+    variant === "warning" && "border-gold"
+  );
+
   return (
     <ReactModal
       portalClassName="modal--basic"
@@ -31,21 +56,33 @@ const Modal: React.FC<Props> & SubComponents = ({
       onRequestClose={onClose}
       style={{
         content: {
+          padding: 0,
           position: "initial",
+          borderRadius: 0,
+          border: 0,
         },
       }}
       overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
       ariaHideApp={process.env.NODE_ENV !== "test"}
     >
-      <div className="modal__container">
-        <button
-          className="modal__close-button"
-          style={{ cursor: "pointer" }}
-          onClick={() => onClose()}
-        >
-          <img className="modal__close-img" src={iconClose} alt="Close" />
-        </button>
-        <div className="modal__content">{children}</div>
+      <div className={containerClasses}>
+        {showClose && (
+          <button
+            className="modal__close-button"
+            style={{ cursor: "pointer" }}
+            onClick={() => onClose()}
+          >
+            <img className="modal__close-img" src={iconClose} alt="Close" />
+          </button>
+        )}
+        <div className="modal__content padding-205 grid-row">
+          {variant && (
+            <div className="grid-col flex-auto margin-right-2">
+              <FontAwesomeIcon icon={variantIcons[variant]} size="2x" />
+            </div>
+          )}
+          <div className="grid-col">{children}</div>
+        </div>
       </div>
     </ReactModal>
   );

--- a/frontend/src/app/commonComponents/Modal.tsx
+++ b/frontend/src/app/commonComponents/Modal.tsx
@@ -49,6 +49,13 @@ const Modal: React.FC<Props> & SubComponents = ({
     variant === "warning" && "border-gold"
   );
 
+  const variantStyles = variant
+    ? {
+        padding: 0,
+        borderRadius: 0,
+      }
+    : {};
+
   return (
     <ReactModal
       portalClassName="modal--basic"
@@ -56,10 +63,9 @@ const Modal: React.FC<Props> & SubComponents = ({
       onRequestClose={onClose}
       style={{
         content: {
-          padding: 0,
           position: "initial",
-          borderRadius: 0,
           border: 0,
+          ...variantStyles,
         },
       }}
       overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
@@ -75,7 +81,7 @@ const Modal: React.FC<Props> & SubComponents = ({
             <img className="modal__close-img" src={iconClose} alt="Close" />
           </button>
         )}
-        <div className="modal__content padding-205 grid-row">
+        <div className="modal__content grid-row">
           {variant && (
             <div className="grid-col flex-auto margin-right-2">
               <FontAwesomeIcon icon={variantIcons[variant]} size="2x" />

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -78,6 +78,7 @@ interface Props {
   patientId?: string;
   activeFacilityId: string;
   savePerson: (person: Nullable<PersonFormData>) => void;
+  onBlur?: (person: Nullable<PersonFormData>) => void;
   hideFacilitySelect?: boolean;
   getHeader?: (
     person: Nullable<PersonFormData>,
@@ -98,7 +99,7 @@ const PersonForm = (props: Props) => {
   >();
   const languages = getLanguages();
 
-  const { view = PersonFormView.APP } = props;
+  const { view = PersonFormView.APP, onBlur } = props;
 
   const { t } = useTranslation();
 
@@ -127,8 +128,9 @@ const PersonForm = (props: Props) => {
     [errors]
   );
 
-  const validateField = useCallback(
+  const onBlurField = useCallback(
     async (field: keyof PersonErrors) => {
+      onBlur?.(patient);
       try {
         await schema.validateAt(field, patient);
         clearError(field);
@@ -139,7 +141,7 @@ const PersonForm = (props: Props) => {
         }));
       }
     },
-    [patient, clearError, schema, getValidationError]
+    [patient, clearError, schema, getValidationError, onBlur]
   );
 
   // Make sure all existing errors are up-to-date (including translations)
@@ -157,7 +159,7 @@ const PersonForm = (props: Props) => {
         }
       }
     });
-  }, [validateField, errors, schema, patient, getValidationError]);
+  }, [errors, schema, patient, getValidationError]);
 
   const onPersonChange = <K extends keyof PersonFormData>(field: K) => (
     value: PersonFormData[K]
@@ -250,7 +252,7 @@ const PersonForm = (props: Props) => {
   const commonInputProps = {
     formObject: patient,
     onChange: onPersonChange,
-    validate: validateField,
+    validate: onBlurField,
     getValidationStatus: validationStatus,
     errors: errors,
   };
@@ -316,7 +318,7 @@ const PersonForm = (props: Props) => {
               facilityId={patient.facilityId}
               onChange={onPersonChange("facilityId")}
               validateField={() => {
-                validateField("facilityId");
+                onBlurField("facilityId");
               }}
               validationStatus={validationStatus}
               errors={errors}
@@ -419,7 +421,7 @@ const PersonForm = (props: Props) => {
                 defaultSelect
                 onChange={onPersonChange("state")}
                 onBlur={() => {
-                  validateField("state");
+                  onBlurField("state");
                 }}
                 validationStatus={validationStatus("state")}
                 errorMessage={errors.state}
@@ -488,7 +490,7 @@ const PersonForm = (props: Props) => {
             onPersonChange("residentCongregateSetting")(yesNoUnknownToBool(v))
           }
           onBlur={() => {
-            validateField("residentCongregateSetting");
+            onBlurField("residentCongregateSetting");
           }}
           validationStatus={validationStatus("residentCongregateSetting")}
           errorMessage={errors.residentCongregateSetting}
@@ -501,7 +503,7 @@ const PersonForm = (props: Props) => {
             onPersonChange("employedInHealthcare")(yesNoUnknownToBool(v))
           }
           onBlur={() => {
-            validateField("employedInHealthcare");
+            onBlurField("employedInHealthcare");
           }}
           validationStatus={validationStatus("employedInHealthcare")}
           errorMessage={errors.employedInHealthcare}

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -86,4 +86,14 @@ export class PxpApi {
   static selfRegister = async (person: SelfRegistrationData): Promise<void> => {
     return api.request("/register", person);
   };
+
+  static checkDuplicateRegistrant = async (person: {
+    firstName: string;
+    lastName: string;
+    birthDate: ISODate;
+    zipCode: string;
+    registrationLink: string;
+  }): Promise<{ unique: boolean }> => {
+    return api.request("/register/check-duplicate", person);
+  };
 }

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.stories.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.stories.tsx
@@ -1,0 +1,40 @@
+import { Story, Meta } from "@storybook/react";
+import { Provider } from "react-redux";
+import { MemoryRouter as Router } from "react-router-dom";
+import createMockStore from "redux-mock-store";
+
+import { getMocks } from "../../stories/storyMocks";
+
+import { SelfRegistration } from "./SelfRegistration";
+
+export default {
+  title: "App/Self-Registration",
+  component: SelfRegistration,
+  decorators: [
+    (Story) => (
+      <Provider store={createMockStore()({})}>
+        <Router initialEntries={["/register/shady-oaks"]}>
+          <Story />
+        </Router>
+      </Provider>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {},
+} as Meta;
+
+const Template: Story = (args) => <SelfRegistration {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};
+Default.parameters = {
+  msw: getMocks("getEntityName", "uniqueRegistration", "register"),
+};
+
+export const Duplicate = Template.bind({});
+Duplicate.args = {};
+Duplicate.parameters = {
+  msw: getMocks("getEntityName", "duplicateRegistration"),
+};

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
@@ -9,6 +9,8 @@ import { SelfRegistration } from "./SelfRegistration";
 
 const VALID_LINK = "foo-facility";
 
+const duplicatePersonFirstName = "Dupey";
+
 jest.mock("../PxpApiService", () => ({
   PxpApi: {
     getEntityName: (link: string) => {
@@ -22,6 +24,11 @@ jest.mock("../PxpApiService", () => ({
     },
     selfRegister: () => {
       return Promise.resolve();
+    },
+    checkDuplicateRegistrant: ({ firstName }: { firstName: string }) => {
+      return Promise.resolve({
+        unique: firstName === duplicatePersonFirstName ? false : true,
+      });
     },
   },
 }));
@@ -88,6 +95,47 @@ describe("SelfRegistration", () => {
     fireEvent.click(screen.getByText("Save changes"));
     expect(
       await screen.findByText("Registration complete")
+    ).toBeInTheDocument();
+  });
+
+  it("Handles duplicate registrant flow", async () => {
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter initialEntries={[`/register/${VALID_LINK}`]}>
+            <Route
+              exact
+              path="/register/:registrationLink"
+              component={SelfRegistration}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+    });
+    expect(screen.queryByText("Foo Facility")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("I agree"));
+    expect(screen.getByText("General information")).toBeInTheDocument();
+    Object.entries(filledForm).forEach(([field, value]) => {
+      fireEvent.change(screen.getByLabelText(field, { exact: false }), {
+        target: { value },
+      });
+    });
+    // Change firstName to duplicate value
+    const firstNameInput = await screen.findByLabelText("First name", {
+      exact: false,
+    });
+    fireEvent.change(firstNameInput, {
+      target: { value: duplicatePersonFirstName },
+    });
+    fireEvent.blur(firstNameInput);
+    // Duplicate modal shows
+    await screen.findByText("You already have a profile", { exact: false });
+    const exitButton = await screen.findByText("Exit sign up");
+    fireEvent.click(exitButton);
+    expect(
+      await screen.findByText("thanks for completing your patient profile", {
+        exact: false,
+      })
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -73,6 +73,19 @@ export const SelfRegistration = () => {
     }
   };
 
+  const onDuplicate = (
+    person: Pick<PersonFormData, "firstName" | "lastName">
+  ) => {
+    setStep(RegistrationStep.FINISHED);
+    setPersonName(
+      formatFullName({
+        firstName: person.firstName,
+        lastName: person.lastName,
+        middleName: "",
+      }) || ""
+    );
+  };
+
   return (
     <div className="bg-base-lightest minh-viewport">
       <div className="bg-white">
@@ -103,7 +116,12 @@ export const SelfRegistration = () => {
             />
           )}
           {step === RegistrationStep.FORM && (
-            <SelfRegistrationForm savePerson={savePerson} />
+            <SelfRegistrationForm
+              savePerson={savePerson}
+              onDuplicate={onDuplicate}
+              entityName={entityName}
+              registrationLink={registrationLink}
+            />
           )}
           {step === RegistrationStep.FINISHED && (
             <Confirmation personName={personName} entityName={entityName} />

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -1,3 +1,5 @@
+import moment from "moment";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "../../app/commonComponents/Button/Button";
@@ -10,8 +12,47 @@ type Props = {
   savePerson: (data: any) => void;
 };
 
+type IdentifyingData = {
+  firstName: string;
+  lastName: string;
+  zipCode: string;
+  birthDate: moment.Moment;
+};
+
 export const SelfRegistrationForm = ({ savePerson }: Props) => {
   const { t } = useTranslation();
+  const [identifyData, setIdentifyingData] = useState<
+    Nullable<IdentifyingData>
+  >({ firstName: null, lastName: null, zipCode: null, birthDate: null });
+
+  const onBlur = async ({
+    firstName,
+    lastName,
+    zipCode,
+    birthDate,
+  }: Nullable<PersonFormData>) => {
+    if (
+      firstName !== identifyData.firstName ||
+      lastName !== identifyData.lastName ||
+      zipCode !== identifyData.zipCode ||
+      !moment(birthDate).isSame(identifyData.birthDate)
+    ) {
+      setIdentifyingData({
+        firstName,
+        lastName,
+        zipCode,
+        birthDate: moment(birthDate),
+      });
+    }
+  };
+
+  useEffect(() => {
+    const { firstName, lastName, zipCode, birthDate } = identifyData;
+    if (!firstName || !lastName || !zipCode || !birthDate?.isValid()) {
+      return;
+    }
+    console.log("check for unique");
+  }, [identifyData]);
 
   return (
     <div
@@ -31,6 +72,7 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
           </Button>
         )}
         view={PersonFormView.SELF_REGISTRATION}
+        onBlur={onBlur}
       />
     </div>
   );

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "../../app/commonComponents/Button/Button";
+import Modal from "../../app/commonComponents/Modal";
 import { EMPTY_PERSON } from "../../app/patients/AddPatient";
 import PersonForm, {
   PersonFormView,
@@ -24,8 +25,9 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
   const [identifyData, setIdentifyingData] = useState<
     Nullable<IdentifyingData>
   >({ firstName: null, lastName: null, zipCode: null, birthDate: null });
+  const [isDuplicate, setIsDuplicate] = useState<boolean>(true);
 
-  const onBlur = async ({
+  const onBlur = ({
     firstName,
     lastName,
     zipCode,
@@ -48,10 +50,13 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
 
   useEffect(() => {
     const { firstName, lastName, zipCode, birthDate } = identifyData;
-    if (!firstName || !lastName || !zipCode || !birthDate?.isValid()) {
-      return;
+    async function checkForDuplicates() {
+      setIsDuplicate(true);
     }
-    console.log("check for unique");
+
+    if (firstName && lastName && zipCode && birthDate?.isValid()) {
+      checkForDuplicates();
+    }
   }, [identifyData]);
 
   return (
@@ -59,6 +64,7 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
       id="registration-container"
       className="grid-container maxw-tablet padding-y-3"
     >
+      <DuplicateModal showModal={!!isDuplicate} />
       <PersonForm
         activeFacilityId=""
         patient={EMPTY_PERSON}
@@ -75,5 +81,28 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
         onBlur={onBlur}
       />
     </div>
+  );
+};
+
+type DuplicateModalProps = {
+  showModal: boolean;
+};
+
+const DuplicateModal: React.FC<DuplicateModalProps> = ({ showModal }) => {
+  return (
+    <Modal
+      onClose={() => {}}
+      showModal={showModal}
+      showClose={false}
+      variant="warning"
+    >
+      <Modal.Header>You already have a profile at [Facility].</Modal.Header>
+      <p>
+        Our records show someone has registered with the same name, date of
+        birth, and ZIP code. Please check in with your testing site staff. You
+        do not need to register again.
+      </p>
+      <Button className="margin-right-auto">Exit sign up</Button>
+    </Modal>
   );
 };

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -8,9 +8,13 @@ import { EMPTY_PERSON } from "../../app/patients/AddPatient";
 import PersonForm, {
   PersonFormView,
 } from "../../app/patients/Components/PersonForm";
+import { PxpApi } from "../PxpApiService";
 
 type Props = {
   savePerson: (data: any) => void;
+  onDuplicate: (person: Pick<PersonFormData, "firstName" | "lastName">) => void;
+  entityName: string;
+  registrationLink: string;
 };
 
 type IdentifyingData = {
@@ -20,12 +24,17 @@ type IdentifyingData = {
   birthDate: moment.Moment;
 };
 
-export const SelfRegistrationForm = ({ savePerson }: Props) => {
+export const SelfRegistrationForm = ({
+  savePerson,
+  onDuplicate,
+  entityName,
+  registrationLink,
+}: Props) => {
   const { t } = useTranslation();
-  const [identifyData, setIdentifyingData] = useState<
+  const [identifyingData, setIdentifyingData] = useState<
     Nullable<IdentifyingData>
   >({ firstName: null, lastName: null, zipCode: null, birthDate: null });
-  const [isDuplicate, setIsDuplicate] = useState<boolean>(true);
+  const [isDuplicate, setIsDuplicate] = useState<boolean>();
 
   const onBlur = ({
     firstName,
@@ -34,10 +43,10 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
     birthDate,
   }: Nullable<PersonFormData>) => {
     if (
-      firstName !== identifyData.firstName ||
-      lastName !== identifyData.lastName ||
-      zipCode !== identifyData.zipCode ||
-      !moment(birthDate).isSame(identifyData.birthDate)
+      firstName !== identifyingData.firstName ||
+      lastName !== identifyingData.lastName ||
+      zipCode !== identifyingData.zipCode ||
+      !moment(birthDate).isSame(identifyingData.birthDate)
     ) {
       setIdentifyingData({
         firstName,
@@ -49,22 +58,43 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
   };
 
   useEffect(() => {
-    const { firstName, lastName, zipCode, birthDate } = identifyData;
-    async function checkForDuplicates() {
-      setIsDuplicate(true);
+    async function checkForDuplicates(data: IdentifyingData) {
+      const { firstName, lastName, zipCode } = data;
+      const birthDate = moment(data.birthDate).format("YYYY-MM-DD") as ISODate;
+      try {
+        const { unique } = await PxpApi.checkDuplicateRegistrant({
+          firstName,
+          lastName,
+          birthDate,
+          zipCode,
+          registrationLink,
+        });
+        setIsDuplicate(!unique);
+      } catch (e) {
+        // A failure to check duplicate shouldn't disrupt registration
+        console.error(e);
+      }
     }
 
+    const { firstName, lastName, zipCode, birthDate } = identifyingData;
     if (firstName && lastName && zipCode && birthDate?.isValid()) {
-      checkForDuplicates();
+      checkForDuplicates({ firstName, lastName, zipCode, birthDate });
     }
-  }, [identifyData]);
+  }, [identifyingData, registrationLink]);
 
   return (
     <div
       id="registration-container"
       className="grid-container maxw-tablet padding-y-3"
     >
-      <DuplicateModal showModal={!!isDuplicate} />
+      <DuplicateModal
+        showModal={!!isDuplicate}
+        onDuplicate={() => {
+          const { firstName, lastName } = identifyingData;
+          onDuplicate({ firstName: firstName || "", lastName: lastName || "" });
+        }}
+        entityName={entityName}
+      />
       <PersonForm
         activeFacilityId=""
         patient={EMPTY_PERSON}
@@ -86,9 +116,15 @@ export const SelfRegistrationForm = ({ savePerson }: Props) => {
 
 type DuplicateModalProps = {
   showModal: boolean;
+  onDuplicate: () => void;
+  entityName: string;
 };
 
-const DuplicateModal: React.FC<DuplicateModalProps> = ({ showModal }) => {
+const DuplicateModal: React.FC<DuplicateModalProps> = ({
+  showModal,
+  onDuplicate,
+  entityName,
+}) => {
   return (
     <Modal
       onClose={() => {}}
@@ -96,13 +132,21 @@ const DuplicateModal: React.FC<DuplicateModalProps> = ({ showModal }) => {
       showClose={false}
       variant="warning"
     >
-      <Modal.Header>You already have a profile at [Facility].</Modal.Header>
+      <Modal.Header>You already have a profile at {entityName}.</Modal.Header>
       <p>
         Our records show someone has registered with the same name, date of
         birth, and ZIP code. Please check in with your testing site staff. You
         do not need to register again.
       </p>
-      <Button className="margin-right-auto">Exit sign up</Button>
+      <Modal.Footer>
+        <Button
+          onClick={() => {
+            onDuplicate();
+          }}
+        >
+          Exit sign up
+        </Button>
+      </Modal.Footer>
     </Modal>
   );
 };

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -514,7 +514,23 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
 
   .modal__variant {
     h3 {
-      margin-top: 0;
+      margin: 0.3125rem 0 0 0;
+      font-size: 1.375rem;
+      line-height: 1.62rem;
+    }
+
+    .modal__content {
+      padding: 2rem 1.875rem;
+
+      p {
+        margin: 0.75rem 0 0 0;
+      }
+    }
+
+    .modal__footer {
+      display: flex;
+      justify-content: flex-start;
+      margin: 1.125rem 0 0 0;
     }
   }
 

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -512,6 +512,12 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
     margin-right: units(3);
   }
 
+  .modal__variant {
+    h3 {
+      margin-top: 0;
+    }
+  }
+
   .modal__footer {
     display: flex;
     justify-content: flex-end;

--- a/frontend/src/stories/storyMocks.tsx
+++ b/frontend/src/stories/storyMocks.tsx
@@ -91,6 +91,27 @@ const mocks = {
       );
     }
   ),
+  getEntityName: rest.get(
+    "http://localhost:8080/pxp/register/entity-name*",
+    (_, res, ctx) => {
+      return res(ctx.status(200), ctx.text("Shady Oaks"));
+    }
+  ),
+  duplicateRegistration: rest.post(
+    "http://localhost:8080/pxp/register/check-duplicate",
+    (_, rest, ctx) => {
+      return rest(ctx.status(200), ctx.json({ unique: false }));
+    }
+  ),
+  uniqueRegistration: rest.post(
+    "http://localhost:8080/pxp/register/check-duplicate",
+    (_, rest, ctx) => {
+      return rest(ctx.status(200), ctx.json({ unique: true }));
+    }
+  ),
+  register: rest.post("http://localhost:8080/pxp/register", (_, rest, ctx) => {
+    return rest(ctx.status(200));
+  }),
 };
 
 export const getMocks = (


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #1379

Delivering this is blocked on two things:
- [ ] Delivering the associated duplicate check API endpoint
- [ ] Translations for the duplicate warning modal

## Changes Proposed

- Adds a duplicate check UI
- Enhances the common modal component to account for variants. Currently, only the "warning" variant is developed

## Screenshots / Demos

The duplicate experience can be viewed in storybook here: https://60a556a7c807cc0039ec6786-vwzzccjotl.chromatic.com/?path=/story/app-self-registration--duplicate

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [n/a] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [n/a] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [n/a] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test` environment for verification
