### PR TITLE
Throw more specific toast for Okta account duplication error on signup

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -197,7 +197,7 @@ public class AccountRequestController {
     } catch (ResourceException e) {
       // The `ResourceException` is thrown when an account is requested with an existing org
       // name. This happens quite frequently and is expected behavior of the current form
-      throw e;
+      throw new BadRequestException("This email address is already associated with a SimpleReport user.");
     } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -195,9 +195,13 @@ public class AccountRequestController {
           request.getFirstName(), request.getLastName(), request.getEmail(), org.getExternalId());
       return new AccountResponse(org.getExternalId());
     } catch (ResourceException e) {
-      // The `ResourceException` is thrown when an account is requested with an existing org
-      // name. This happens quite frequently and is expected behavior of the current form
-      throw new BadRequestException("This email address is already associated with a SimpleReport user.");
+      // The `ResourceException` is thrown when a user requests an account with an email address
+      // that's already in Okta.
+      // This happens fairly frequently and is the expected behavior of the current form.
+      // We rethrow this as a BadRequestException so that users get at toast on the frontend
+      // informing them of the error.
+      throw new BadRequestException(
+          "This email address is already associated with a SimpleReport user.");
     } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
     }


### PR DESCRIPTION
## Related Issue or Background Info

When a user signs up for SimpleReport with an email that's already taken, Okta throws a `ResourceException`: 

> com.okta.sdk.resource.ResourceException: HTTP 400, Okta E0000001 (Api validation failed: login - login: An object with this field already exists in the current organization), ErrorId oaeFyjjt3WJSu60KdrIsT93cA

This was showing on the frontend as a generic 500 error, giving the user a toast with the timestamp but not much further detail. This change rethrows the `ResourceException` as a `BadRequestException`, which changes the toast that appears on the frontend.

## Changes Proposed

- rethrow `ResourceException` as `BadRequestException`

## Additional Information

This is a fairly common issue, it's already happened 4 times today. My hope is that it'll be less common moving forward now that the signup form has frontend validation. (My theory on the flow here is that users submit the form once with some invalid fields, like a blank phone number, so their Okta account is created but they still see an error submitting the form. Then when they fix the phone number, Okta throws an error because their account has already been created.)

I only changed this for the only endpoint that's currently in use. I plan to remove the obsolete endpoints in a followup PR.

## Screenshots / Demos

<img width="601" alt="Screen Shot 2021-08-19 at 2 16 36 PM" src="https://user-images.githubusercontent.com/80282552/130146225-e558e1bb-929c-4ece-835b-2187ec6144f4.png">

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- n/a Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
