### PR TITLE
Remove self-registration <NewFeatureTag>

### DIFF
--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.tsx
@@ -2,8 +2,6 @@ import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEffect, useMemo, useState } from "react";
 
-import { NewFeatureTag } from "../commonComponents/NewFeatureTag";
-
 import "./ManageSelfRegistrationLinks.scss";
 
 type FacilitySlug = { name: string; slug: string };
@@ -51,10 +49,6 @@ export const ManageSelfRegistrationLinks = ({
         <div className="usa-card__header">
           <h2 className="display-flex flex-row flex-align-center">
             <span>Patient self-registration</span>
-            <NewFeatureTag
-              feature="selfRegistration"
-              className="margin-left-1 padding-y-05"
-            />
           </h2>
         </div>
         <div className="usa-card__body maxw-prose padding-y-3">

--- a/frontend/src/app/Settings/SettingsNav.tsx
+++ b/frontend/src/app/Settings/SettingsNav.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
-import { NewFeatureTag } from "../commonComponents/NewFeatureTag";
 
 const SettingsNav = () => {
   return (
@@ -33,8 +32,7 @@ const SettingsNav = () => {
             to={`/settings/self-registration`}
             activeClassName="active"
           >
-            Patient self-registration{" "}
-            <NewFeatureTag feature="selfRegistration" />
+            Patient self-registration
           </LinkWithQuery>
         </li>
       </ul>

--- a/frontend/src/app/Settings/__snapshots__/SettingsNav.test.tsx.snap
+++ b/frontend/src/app/Settings/__snapshots__/SettingsNav.test.tsx.snap
@@ -43,13 +43,6 @@ exports[`SettingsNav displays the nav order correctly and defaults to 'Manage Us
           href="/settings/self-registration"
         >
           Patient self-registration
-           
-          <span
-            class="usa-tag bg-black"
-            data-testid="tag"
-          >
-            New
-          </span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Related Issue or Background Info

- The NewFeatureTag expires on 8/20, and it's breaking snapshot tests in CI

## Changes Proposed

- Remove the NewFeatureTag from Patient self-registration tabs. Note: it's already gone for users, bc it expired

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
