### PR TITLE
stop running testing db container after test run

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -212,5 +212,6 @@ test {
     systemProperty "test-db-port", testDbPort
     if (System.getenv("CI") == null) {
         dependsOn testDbStart
+        finalizedBy testDbStop
     }
 }


### PR DESCRIPTION
## Related Issue or Background Info

- Running backend tests leaves a postgres container running behind `simple-report-tests_db_1`

## Changes Proposed

- stop the postgres db container when tests conclude

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
