### PR TITLE
Log an error on an n+1 query

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -123,3 +123,6 @@ twilio:
 logging:
   pattern:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
+spring-hibernate-query-utils:
+  n-plus-one-queries-detection:
+    error-level: ERROR

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -123,6 +123,4 @@ twilio:
 logging:
   pattern:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
-spring-hibernate-query-utils:
-  n-plus-one-queries-detection:
-    error-level: ERROR
+hibernate.query.interceptor.error-level: ERROR

--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -6,7 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = {"spring-hibernate-query-utils.n-plus-one-queries-detection.error-level=ERROR"})
+    properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
 public class SimpleReportApplicationTests {
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {"spring-hibernate-query-utils.n-plus-one-queries-detection.error-level=ERROR"})
 public class SimpleReportApplicationTests {
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = {"spring-hibernate-query-utils.n-plus-one-queries-detection.error-level=ERROR"})
+    properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
 @AutoConfigureMockMvc
 public abstract class BaseFullStackTest {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -28,7 +28,9 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * Base class for all tests that simulate fully-integrated API requests by either patients or
  * providers.
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {"spring-hibernate-query-utils.n-plus-one-queries-detection.error-level=ERROR"})
 @AutoConfigureMockMvc
 public abstract class BaseFullStackTest {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiSmokeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiSmokeTest.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiSmokeTest extends BaseGraphqlTest {
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -39,7 +39,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiUserManagementTest extends BaseGraphqlTest {
 
   private static final String NO_USER_ERROR = "Cannot find user.";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -43,6 +43,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Tests around edges of audit logging.
@@ -55,6 +56,7 @@ import org.springframework.http.ResponseEntity;
  * Since MockMvc does not wrap error handling, this uses TestRestTemplate for PXP requests (this is
  * in any case what the graphql tests use, so there is no additional cost).
  */
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class AuditLoggingFailuresTest extends BaseGraphqlTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuditLoggingFailuresTest.class);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -25,9 +25,11 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class AuditLoggingTest extends BaseGraphqlTest {
 
   @Autowired private MockMvc _mockMvc;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
@@ -10,7 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class DeviceManagementTest extends BaseGraphqlTest {
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class OrganizationFacilityTest extends BaseGraphqlTest {
 
   @Autowired private DeviceTypeService _deviceService;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 /** Tests for adding and fetching patients through the API */
 class PatientManagementTest extends BaseGraphqlTest {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientUploadTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientUploadTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class PatientUploadTest extends BaseGraphqlTest {
   public static final int PATIENT_PAGEOFFSET = 0;
   public static final int PATIENT_PAGESIZE = 1000;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @WithSimpleReportStandardUser // this is ridiculously sneaky
 class QueueManagementTest extends BaseGraphqlTest {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @WithSimpleReportStandardUser // hackedy hack
 class TestResultTest extends BaseGraphqlTest {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -32,11 +32,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class PatientExperienceControllerTest extends BaseFullStackTest {
 
   @Autowired private MockMvc _mockMvc;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientSelfRegistrationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientSelfRegistrationControllerTest.java
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class PatientSelfRegistrationControllerTest extends BaseFullStackTest {
   @Autowired private MockMvc _mockMvc;
   @Autowired private PatientSelfRegistrationController _controller;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/SmsCallbackControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/SmsCallbackControllerTest.java
@@ -30,9 +30,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class SmsCallbackControllerTest extends BaseFullStackTest {
 
   @Autowired private MockMvc _mockMvc;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -19,7 +19,9 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Autowired ApiUserRepository _apiUserRepo;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingServiceTest.java
@@ -23,8 +23,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
+import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @SuppressWarnings("unchecked")
 class AzureStorageQueueTestEventReportingServiceTest
     extends BaseServiceTest<TestEventReportingService> {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -35,6 +35,7 @@ import org.springframework.security.access.AccessDeniedException;
     properties = {
       "spring.main.web-application-type=NONE",
       "simple-report.authorization.role-prefix=" + TestUserIdentities.TEST_ROLE_PREFIX,
+      "spring-hibernate-query-utils.n-plus-one-queries-detection.error-level=ERROR"
     })
 @Import(SliceTestConfiguration.class)
 @WithSimpleReportStandardUser

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -35,7 +35,7 @@ import org.springframework.security.access.AccessDeniedException;
     properties = {
       "spring.main.web-application-type=NONE",
       "simple-report.authorization.role-prefix=" + TestUserIdentities.TEST_ROLE_PREFIX,
-      "spring-hibernate-query-utils.n-plus-one-queries-detection.error-level=ERROR"
+      "hibernate.query.interceptor.error-level=EXCEPTION"
     })
 @Import(SliceTestConfiguration.class)
 @WithSimpleReportStandardUser

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DataHubUploaderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DataHubUploaderServiceTest.java
@@ -20,7 +20,9 @@ import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService> {
   @Autowired private TestDataFactory _dataFactory;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Autowired private TestDataFactory _dataFactory;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @SuppressWarnings("checkstyle:MagicNumber")
 class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
   @Autowired private OrganizationService _organizationService;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkServiceTest.java
@@ -20,7 +20,9 @@ import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class PatientSelfRegistrationLinkServiceTest
     extends BaseServiceTest<PatientSelfRegistrationLinkService> {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @SuppressWarnings("checkstyle:MagicNumber")
 class PersonServiceTest extends BaseServiceTest<PersonService> {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -49,7 +49,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @SuppressWarnings("checkstyle:MagicNumber")
 class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -23,10 +23,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 
 @WithMockUser(
     username = TestUserIdentities.SITE_ADMIN_USER,
     authorities = {Role.SITE_ADMIN, Role.DEFAULT_ORG_ADMIN})
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class UploadServiceTest extends BaseServiceTest<UploadService> {
   public static final int PATIENT_PAGEOFFSET = 0;
   public static final int PATIENT_PAGESIZE = 1000;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/SmsServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/SmsServiceTest.java
@@ -40,7 +40,9 @@ import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class SmsServiceTest extends BaseServiceTest<SmsService> {
   @MockBean SmsProviderWrapper mockTwilio;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusServiceTest.java
@@ -18,7 +18,9 @@ import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class TextMessageStatusServiceTest extends BaseServiceTest<TextMessageStatusService> {
 
   @Autowired TextMessageStatusService _service;


### PR DESCRIPTION
## Related Issue or Background Info

We are currently reactive to n+1 queries when they start being a problem in production. Given our current growth it would be good to get a handle on this problem

## Changes Proposed

- Have base test classes throw exceptions when a n+1 query is found
- Overide property so existing n+! issues are logged as Errors

## Additional Information

- logs can be found by searching file in `backend/build/test-results/test` for `HibernateQueryInterceptor`. There are currently 1603 results in 24 files
- https://github.com/yannbriancon/spring-hibernate-query-utils

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
