### PR TITLE
Up the max reportstream upload size

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -61,7 +61,7 @@ simple-report:
     # these are overridden by application-dev, -prod, -test, etc
     upload-enabled: false
     upload-url: ""
-    max-csv-rows: 999
+    max-csv-rows: 5000
     api-key: ${DATAHUB_API_KEY:MISSING}
     secret-slack-notify-webhook-url: ${SECRET_SLACK_NOTIFY_WEBHOOK_URL:MISSING}
     upload-schedule: "0 0 11 * * *" # Daily at 11:00 AM Eastern Time


### PR DESCRIPTION
## Related Issue or Background Info

- We have started running into our max upload limit https://usds.slack.com/archives/C019PRYMR0Q/p1629720815107500

## Changes Proposed

- move the max upload from 999 to 5000

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
