### PR TITLE
pre-fill Experian personal details page with person name

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/Consent.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.stories.tsx
@@ -12,7 +12,14 @@ export default {
 const Template: Story = (args) => (
   <MemoryRouter
     initialEntries={[
-      { pathname: "/identity-verification", search: "?orgExternalId=foo" },
+      {
+        pathname: "/identity-verification",
+        state: {
+          firstName: "Harry",
+          lastName: "Potter",
+          orgExternalId: "Hogwarts",
+        },
+      },
     ]}
   >
     <Consent {...args} />

--- a/frontend/src/app/signUp/IdentityVerification/Consent.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.test.tsx
@@ -3,12 +3,23 @@ import { MemoryRouter } from "react-router";
 
 import Consent from "./Consent";
 
+jest.mock("react-router-dom", () => ({
+  Redirect: (props: any) => `Redirected to ${props.to.pathname}`,
+}));
+
 describe("Consent", () => {
   beforeEach(() => {
     render(
       <MemoryRouter
         initialEntries={[
-          { pathname: "/identity-verification", search: "?orgExternalId=foo" },
+          {
+            pathname: "/identity-verification",
+            state: {
+              firstName: "Harry",
+              lastName: "Potter",
+              orgExternalId: "Hogwarts",
+            },
+          },
         ]}
       >
         <Consent />
@@ -18,16 +29,14 @@ describe("Consent", () => {
   it("initializes with the submit button enabled", () => {
     expect(screen.getByText("I agree")).not.toHaveAttribute("disabled");
   });
-  it("initializes to an error page if no org id is passed", () => {
+
+  it("redirects to sign-up page when it doesnt get org id and user info", () => {
     render(
       <MemoryRouter>
         <Consent />
       </MemoryRouter>
     );
-    expect(
-      screen.getByText("We weren't able to find your affiliated organization", {
-        exact: false,
-      })
-    ).toBeInTheDocument();
+
+    expect(screen.getByText("Redirected to /sign-up")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/signUp/IdentityVerification/Consent.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.tsx
@@ -1,31 +1,34 @@
 import { useState } from "react";
+import { useLocation } from "react-router";
+import { Redirect } from "react-router-dom";
 
 import { Card } from "../../commonComponents/Card/Card";
 import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
 import Button from "../../commonComponents/Button/Button";
-import { useSearchParam } from "../../utils/url";
 
-import PersonalDetailsForm from "./PersonalDetailsForm";
+import PersonalDetailsForm, {
+  PersonalDetailsFormProps,
+} from "./PersonalDetailsForm";
 
 const Consent = () => {
-  // Get organization ID from URL
-  const orgExternalId = useSearchParam("orgExternalId");
+  // Get person name & org id from route state
+  const { orgExternalId, firstName, middleName, lastName } =
+    useLocation<PersonalDetailsFormProps>().state || {};
   const [submitted, setSubmitted] = useState(false);
 
-  if (orgExternalId === null) {
-    return (
-      <CardBackground>
-        <Card logo bodyKicker={"Invalid request"} bodyKickerCentered={true}>
-          <p className="text-center">
-            We weren't able to find your affiliated organization
-          </p>
-        </Card>
-      </CardBackground>
-    );
+  if (!orgExternalId || !firstName || !lastName) {
+    return <Redirect to={{ pathname: "/sign-up" }} />;
   }
 
   if (submitted) {
-    return <PersonalDetailsForm orgExternalId={orgExternalId} />;
+    return (
+      <PersonalDetailsForm
+        orgExternalId={orgExternalId}
+        firstName={firstName}
+        middleName={middleName}
+        lastName={lastName}
+      />
+    );
   }
 
   return (

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.stories.tsx
@@ -1,14 +1,19 @@
 import { Story, Meta } from "@storybook/react";
 
-import PersonalDetailsForm from "./PersonalDetailsForm";
+import PersonalDetailsForm, {
+  PersonalDetailsFormProps,
+} from "./PersonalDetailsForm";
 
 export default {
   title: "App/Identity Verification/Step 2: Personal Details",
   component: PersonalDetailsForm,
   argTypes: {},
   args: {
-    orgExternalId: "foo",
-  },
+    firstName: "Harry",
+    middleName: "James",
+    lastName: "Potter",
+    orgExternalId: "Hogwarts",
+  } as PersonalDetailsFormProps,
 } as Meta;
 
 type Props = React.ComponentProps<typeof PersonalDetailsForm>;

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -1,68 +1,73 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
 
 import PersonalDetailsForm from "./PersonalDetailsForm";
 
 describe("PersonalDetailsForm", () => {
   beforeEach(() => {
     render(
-      <MemoryRouter
-        initialEntries={[
-          { pathname: "/identity-verification", search: "?orgExternalId=foo" },
-        ]}
-      >
-        <PersonalDetailsForm orgExternalId="foo" />
-      </MemoryRouter>
+      <PersonalDetailsForm
+        orgExternalId="foo"
+        firstName={"Bob"}
+        middleName={"Rob"}
+        lastName={"Bobberton"}
+      />
     );
   });
+
+  it("displays the users full name", function () {
+    expect(screen.getByText("Bob Rob Bobberton")).toBeInTheDocument();
+  });
+
   it("initializes with the submit button disabled", () => {
     expect(screen.getByText("Submit")).toHaveAttribute("disabled");
   });
+
   describe("Filling out the form", () => {
     beforeEach(() => {
-      fireEvent.change(screen.getByLabelText("First name", { exact: false }), {
-        target: { value: "Bob" },
+      fireEvent.change(screen.getByLabelText("Email *", { exact: false }), {
+        target: { value: "bob@bob.bob" },
       });
     });
+
     it("enables the submit button", () => {
       expect(screen.getByText("Submit")).not.toHaveAttribute("disabled");
     });
     describe("focusing and not adding a value", () => {
       beforeEach(async () => {
         await act(async () => {
-          await screen.getByLabelText("Last name", { exact: false }).focus();
-          await screen.getByText("Submit", { exact: false }).focus();
+          await screen
+            .getByLabelText("Phone number *", { exact: false })
+            .focus();
+          await screen
+            .getByLabelText("Street address 1", { exact: false })
+            .focus();
         });
       });
       it("shows a single error", () => {
-        expect(screen.queryAllByText("Last name is required").length).toBe(1);
+        expect(
+          screen.getByText("Phone number is required")
+        ).toBeInTheDocument();
       });
     });
     describe("On submit", () => {
       beforeEach(async () => {
         await act(async () => {
-          await fireEvent.click(
-            screen.queryAllByText("Submit", {
-              exact: false,
-            })[0]
-          );
+          fireEvent.change(screen.getByLabelText("Email", { exact: false }), {
+            target: { value: "bob@bob.bob" },
+          });
+          fireEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
         expect(
           screen.queryAllByText("is required", { exact: false }).length
-        ).toBe(7);
+        ).toBe(5);
       });
     });
   });
+
   describe("Completed form", () => {
     beforeEach(() => {
-      fireEvent.change(screen.getByLabelText("First name", { exact: false }), {
-        target: { value: "Bob" },
-      });
-      fireEvent.change(screen.getByLabelText("Last name", { exact: false }), {
-        target: { value: "Bobberton" },
-      });
       fireEvent.click(screen.getByTestId("date-picker-button"));
       const dateButton = screen.getByText("15");
       expect(dateButton).toHaveClass("usa-date-picker__calendar__date");
@@ -88,9 +93,6 @@ describe("PersonalDetailsForm", () => {
       fireEvent.change(screen.getByLabelText("State", { exact: false }), {
         target: { value: "CA" },
       });
-      fireEvent.change(screen.getByLabelText("First name", { exact: false }), {
-        target: { value: "Bob" },
-      });
       fireEvent.change(screen.getByLabelText("ZIP code", { exact: false }), {
         target: { value: "74783" },
       });
@@ -99,11 +101,7 @@ describe("PersonalDetailsForm", () => {
     describe("On submit", () => {
       beforeEach(async () => {
         await act(async () => {
-          await fireEvent.click(
-            screen.queryAllByText("Submit", {
-              exact: false,
-            })[0]
-          );
+          fireEvent.click(screen.getByText("Submit"));
         });
       });
       it("does not shows an error", () => {

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -26,16 +26,24 @@ type PersonalDetailsFormErrors = Record<
   string
 >;
 
-interface Props {
+export type PersonalDetailsFormProps = {
   orgExternalId: string;
-}
+  firstName: string;
+  middleName: string;
+  lastName: string;
+};
 
-const PersonalDetailsForm = ({ orgExternalId }: Props) => {
+const PersonalDetailsForm = ({
+  orgExternalId,
+  firstName,
+  middleName,
+  lastName,
+}: PersonalDetailsFormProps) => {
   const [
     personalDetails,
     setPersonalDetails,
   ] = useState<IdentityVerificationRequest>(
-    initPersonalDetails(orgExternalId || "")
+    initPersonalDetails(orgExternalId, firstName, middleName, lastName)
   );
   const [errors, setErrors] = useState<PersonalDetailsFormErrors>(
     initPersonalDetailsErrors()
@@ -174,25 +182,30 @@ const PersonalDetailsForm = ({ orgExternalId }: Props) => {
     }
   };
 
+  const getPersonFullName = () =>
+    [
+      personalDetails.firstName,
+      personalDetails.middleName,
+      personalDetails.lastName,
+    ].join(" ");
+
   return (
     <CardBackground>
       <Card logo bodyKicker="Enter personal details">
         <div className="margin-bottom-2">
           <p className="font-ui-2xs text-base">
-            To create your account, you’ll need to reenter information and
-            answer a few questions to verify your identity directly with{" "}
-            <a href="https://www.experian.com/decision-analytics/identity-proofing">
-              Experian
-            </a>
-            . SimpleReport doesn’t access identity verification details.
+            To create your account, we’ll need information to verify your
+            identity directly with Experian. SimpleReport doesn’t access
+            identity verification details.
           </p>
           <p className="font-ui-2sm margin-bottom-0">
             Why we verify your identity
           </p>
-          <p className="font-ui-2xs text-base margin-top-0">
+          <p className="font-ui-2xs text-base margin-top-1">
             Identity verification helps protect organizations working with
             personal health information.
           </p>
+          <h3>{getPersonFullName()}</h3>
           {Object.entries(personalDetailsFields).map(
             ([key, { label, required, preheader }]) => {
               const field = key as keyof IdentityVerificationRequest;

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -34,9 +34,6 @@ export const answersToArray = (answers: Answers): number[] =>
     .map((key) => parseInt(answers[key]));
 
 export const personalDetailsFields = [
-  ["firstName", "First name", true, "Legal name"],
-  ["middleName", "Middle name", false, null],
-  ["lastName", "Last name", true, null],
   ["dateOfBirth", "Date of birth", true, null],
   ["email", "Email", true, "Personal contact information"],
   ["phoneNumber", "Phone number", true, null],
@@ -55,10 +52,14 @@ export const personalDetailsFields = [
 }, {} as { [key: string]: { label: string; required: boolean; preheader: string | null } });
 
 export const initPersonalDetails = (
-  orgExternalId = ""
+  orgExternalId: string,
+  firstName: string,
+  middleName: string,
+  lastName: string
 ): IdentityVerificationRequest => ({
-  firstName: "",
-  lastName: "",
+  firstName,
+  middleName,
+  lastName,
   dateOfBirth: "",
   email: "",
   phoneNumber: "",

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -3,7 +3,9 @@ import userEvent from "@testing-library/user-event";
 
 import { SignUpApi } from "../SignUpApi";
 
-import OrganizationForm from "./OrganizationForm";
+import OrganizationForm, {
+  OrganizationCreateRequest,
+} from "./OrganizationForm";
 
 const getOrgNameInput = () =>
   screen.getByRole("textbox", {
@@ -54,6 +56,7 @@ describe("OrganizationForm", () => {
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
     fillIn(getFirstNameInput(), "Greatest");
+    fillIn(getMiddleNameInput(), "OG");
     fillIn(getLastNameInput(), "Ever");
     fillIn(getEmailInput(), "ever@greatest.com");
     fillIn(getPhoneInput(), "8008675309");
@@ -61,6 +64,15 @@ describe("OrganizationForm", () => {
       await getSubmitButton().click();
     });
 
-    expect(SignUpApi.createOrganization).toHaveBeenCalled();
+    expect(SignUpApi.createOrganization).toHaveBeenCalledWith({
+      name: "Drake",
+      type: "employer",
+      state: "TX",
+      firstName: "Greatest",
+      middleName: "OG",
+      lastName: "Ever",
+      email: "ever@greatest.com",
+      workPhoneNumber: "8008675309",
+    } as OrganizationCreateRequest);
   });
 });

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -14,6 +14,7 @@ import Select from "../../commonComponents/Select";
 import { TextWithTooltip } from "../../commonComponents/TextWithTooltip";
 import { SignUpApi } from "../SignUpApi";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
+import { PersonalDetailsFormProps } from "../IdentityVerification/PersonalDetailsForm";
 
 import {
   initOrg,
@@ -106,7 +107,12 @@ const OrganizationForm = () => {
       <Redirect
         to={{
           pathname: "/sign-up/identity-verification",
-          search: `?orgExternalId=${orgExternalId}`,
+          state: {
+            orgExternalId: orgExternalId,
+            firstName: organization.firstName,
+            middleName: organization.middleName,
+            lastName: organization.lastName,
+          } as PersonalDetailsFormProps,
         }}
       />
     );
@@ -175,7 +181,7 @@ const OrganizationForm = () => {
               </label>
               <p className="usa-hint">
                 Only one person from an organization can be the administrator.
-                This person will submit information for identity verifcation.
+                This person will submit information for identity verification.
               </p>
             </>
           );
@@ -215,7 +221,10 @@ const OrganizationForm = () => {
         </div>
         <p>
           By submitting this form, you agree to our{" "}
-          <a href="/terms-of-service">terms of service</a>.
+          <a href="/terms-of-service" target="_blank" rel="noopener noreferrer">
+            terms of service
+          </a>
+          .
         </p>
         <Button
           className="width-full margin-top-2 submit-button"

--- a/frontend/src/app/signUp/SignUpApp.test.tsx
+++ b/frontend/src/app/signUp/SignUpApp.test.tsx
@@ -2,22 +2,11 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import SignUpApp from "./SignUpApp";
-import PersonalDetailsForm from "./IdentityVerification/PersonalDetailsForm";
-
-jest.mock("./IdentityVerification/PersonalDetailsForm");
 
 describe("SignUpApp", () => {
   beforeEach(() => {
-    (PersonalDetailsForm as any).mockImplementation(() => (
-      <div>personal details form</div>
-    ));
-
     render(
-      <MemoryRouter
-        initialEntries={[
-          { pathname: "/identity-verification", search: "?orgExternalId=foo" },
-        ]}
-      >
+      <MemoryRouter>
         <SignUpApp
           match={{ path: "" } as any}
           location={{} as any}
@@ -27,8 +16,6 @@ describe("SignUpApp", () => {
     );
   });
   it("renders", () => {
-    expect(
-      screen.getByText("Identity verification consent")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Sign up for SimpleReport")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/testResults/TestResultPrintModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.test.tsx
@@ -5,7 +5,7 @@ import ReactDOM from "react-dom";
 import { DetachedTestResultPrintModal } from "./TestResultPrintModal";
 
 const testResult = {
-  dateTested: new Date(),
+  dateTested: new Date("2021-08-20"),
   result: "NEGATIVE",
   correctionStatus: null,
   deviceType: {


### PR DESCRIPTION
## Related Issue or Background Info

- resolves https://github.com/CDCgov/prime-simplereport/issues/2046

## Changes Proposed

- pre-fill Experian personal details page with person first name, last name, and middle name if they provide it
- moved the org id from the url (search params) to the router state
- redirect to `signup page` from` verification page` if `org id`,  `last name`, or` first name` is not provided
- fixed `verification` typo in signup form
- terms of service will now open in a new tab

## Additional Information

## Screenshots / Demos
![image](https://user-images.githubusercontent.com/4952042/130472661-3dbe0238-1891-4b2d-9f55-d7b6c639b505.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
