### PR TITLE
Don't raise an azure alert for duplicate usernames

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -202,6 +202,8 @@ public class AccountRequestController {
       // informing them of the error.
       throw new BadRequestException(
           "This email address is already associated with a SimpleReport user.");
+    } catch (BadRequestException e) {
+      throw e;
     } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
     }


### PR DESCRIPTION
## Related Issue or Background Info

- there have been [40 account request errors due to duplicate org names over the last 3 days](https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/source/Alerts.EmailLinks/scope/%7B%22resources%22%3A%5B%7B%22resourceId%22%3A%22%2Fsubscriptions%2F7d1e3999-6577-4cd5-b296-f518e5c8e677%2FresourceGroups%2Fprime-simple-report-prod%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fprime-simple-report-prod-insights%22%7D%5D%7D/q/eJylkMFKxDAQhu99ip89daGVNl7WhS54UPCgB9mTFwnJlGZtk5hJcAUf3rRF%2BgDOITP5mfnyTwJ9JuLIRfGDr4ECIZopC3LyOKHUMtIslKIRbd0catGe27vjbXsUh5tmjbc9aohhD2k1OClFzOg69HJkytiLMxYfxuoOxloKKAvkoKsiH42zvFz%2F%2FfxCWU9n4TwFOdPfn%2FS22rcnDJI59b25YnevlEs2vq5%2F8CjNmAI9%2FPna5Tkf3IVU3FxVm%2B%2FzTOsWaJWXNSPpZ4qD01mclqJCWNEvcppbbU7FLw%3D%3D/prettify/1/timespan/2021-08-21T19%3A26%3A28.0000000Z%2F2021-08-21T19%3A31%3A28.0000000Z). Each one one of these exceptions can create an unactionable alert

## Changes Proposed

- catch the `BadRequestException` that is raised in `checkForDuplicateOrg`

## Additional Information

- the account request has failed alert is triggered when `AccountRequestFailureException` is raised

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a ] DevOps team has been notified if PR requires ops support
- [n/a ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
