### PR TITLE
Change OrganizationForm to display backend errors as Alert at top of form

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -202,6 +202,10 @@ public class AccountRequestController {
       // informing them of the error.
       throw new BadRequestException(
           "This email address is already associated with a SimpleReport user.");
+    } catch (BadRequestException e) {
+      // The `BadRequestException` is thrown when an account is requested with an existing org
+      // name. This happens quite frequently and is expected behavior of the current form
+      throw new BadRequestException("This organization has already registered with SimpleReport.");
     } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
     }

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -71,6 +71,27 @@ describe("OrganizationForm", () => {
     expect(getSubmitButton()).toHaveAttribute("disabled");
   });
 
+  it("displays form errors when submitting invalid input", async () => {
+    fillInDropDown(getOrgStateDropdown(), "AK");
+    await act(async () => {
+      await getSubmitButton().click();
+    });
+
+    expect(
+      screen.getByText("Organization name is required")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Organization type is required")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("SimpleReport isn't available yet in your state.", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+  });
+
   it("redirects to identity verification when submitting valid input", async () => {
     fillIn(getOrgNameInput(), "Drake");
     fillInDropDown(getOrgStateDropdown(), "TX");

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -31,7 +31,12 @@ const fillInDropDown = (input: any, text: string) =>
   });
 
 jest.mock("../SignUpApi", () => ({
-  SignUpApi: { createOrganization: jest.fn() },
+  SignUpApi: {
+    createOrganization: jest.fn((request: OrganizationCreateRequest) => {
+      console.log("createOrganization", request);
+      return { orgExternalId: "foo" };
+    }),
+  },
 }));
 
 describe("OrganizationForm", () => {

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -82,7 +82,8 @@ const OrganizationForm = () => {
         const res = await SignUpApi.createOrganization(organization);
         setOrgExternalId(res.orgExternalId);
       } catch (error) {
-        setBackendError(organizationBackendErrors(error));
+        const message = error.message || error;
+        setBackendError(organizationBackendErrors(message));
         setLoading(false);
         window.scrollTo(0, 0);
         return;

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ReactElement, useState } from "react";
 import { toast } from "react-toastify";
 import { Redirect } from "react-router";
 
@@ -22,6 +22,7 @@ import {
   organizationFields,
   OrganizationTypeEnum,
   organizationSchema as schema,
+  organizationBackendErrors,
 } from "./utils";
 
 import "./OrganizationForm.scss";
@@ -48,6 +49,7 @@ const OrganizationForm = () => {
     initOrg()
   );
   const [errors, setErrors] = useState<OrganizationFormErrors>(initOrgErrors());
+  const [backendError, setBackendError] = useState<ReactElement>();
 
   const [loading, setLoading] = useState(false);
   const [formChanged, setFormChanged] = useState(false);
@@ -80,10 +82,7 @@ const OrganizationForm = () => {
         const res = await SignUpApi.createOrganization(organization);
         setOrgExternalId(res.orgExternalId);
       } catch (error) {
-        const alert = (
-          <Alert type="error" title="Submission Error" body={error} />
-        );
-        showNotification(toast, alert);
+        setBackendError(organizationBackendErrors(error));
         setLoading(false);
         return;
       }
@@ -208,6 +207,7 @@ const OrganizationForm = () => {
       <Card logo>
         <div className="margin-bottom-2 organization-form">
           <h2>Sign up for SimpleReport</h2>
+          {backendError ? backendError : null}
           {/* By mapping over organizationFields (found in utils.tsx), we reduce */}
           {/* duplication of input fields in JSX */}
           {Object.entries(organizationFields).map(

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -84,6 +84,7 @@ const OrganizationForm = () => {
       } catch (error) {
         setBackendError(organizationBackendErrors(error));
         setLoading(false);
+        window.scrollTo(0, 0);
         return;
       }
       setErrors(initOrgErrors());
@@ -97,6 +98,7 @@ const OrganizationForm = () => {
         body="Please check the form to make sure you complete all of the required fields."
       />
     );
+    window.scrollTo(0, 0);
     showNotification(toast, alert);
     setLoading(false);
   };

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -1,8 +1,10 @@
 import * as yup from "yup";
+import { ReactElement } from "react";
 
 import { TextWithTooltip } from "../../commonComponents/TextWithTooltip";
 import { phoneNumberIsValid } from "../../patients/personSchema";
 import { liveJurisdictions } from "../../../config/constants";
+import Alert from "../../commonComponents/Alert";
 
 import { OrganizationCreateRequest } from "./OrganizationForm";
 
@@ -123,3 +125,34 @@ export const organizationSchema: yup.SchemaOf<OrganizationCreateRequest> = yup
       .test("", "A valid phone number is required", phoneNumberIsValid)
       .required(),
   });
+
+export const organizationBackendErrors = (error: string): ReactElement => {
+  switch (error) {
+    case "This organization has already registered with SimpleReport.":
+      return (
+        <Alert type="error" title="Duplicate organization">
+          This organization has already registered with SimpleReport. Please
+          contact your organization administrator or{" "}
+          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
+          for help.
+        </Alert>
+      );
+    case "This email address is already associated with a SimpleReport user.":
+      return (
+        <Alert type="error" title="Email already registered">
+          This email address is already registered with SimpleReport. Please
+          contact your organization administrator or{" "}
+          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
+          for help.
+        </Alert>
+      );
+    default:
+      return (
+        <Alert type="error" title="Submission error">
+          {error} Please contact your organization administrator or{" "}
+          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
+          for help.
+        </Alert>
+      );
+  }
+};


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2119

## Changes Proposed

- Instead of showing backend errors as toasts, add an `Alert` component at the top of the form
- Include a link to email support in that `Alert`


## Screenshots / Demos

![image](https://user-images.githubusercontent.com/9121162/130516851-fc1bd756-3b0b-4083-9508-30565ef2249b.png)  
  
![image](https://user-images.githubusercontent.com/9121162/130517075-56382371-22fe-4c1e-9f56-9277039937f4.png)


## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
