### PR TITLE
[2199] Front end docker for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ start-backend:
 	cd backend;\
 	docker-compose --env-file .env.development up -d db && \
 	SR_DB_PORT=5433 ./gradlew bootRun --args='--spring.profiles.active=dev';
-
 start-frontend:
 	cd frontend;\
-	bash -l -c 'nvm use && yarn start';
+	yarn install && docker-compose up;
 

--- a/README.md
+++ b/README.md
@@ -294,12 +294,9 @@ These can also be set by environment variable if desired.
 The front end is a React app. The app uses [Apollo](https://www.apollographql.com/) to manage the graphql API. For styling the app leverages the [U.S. Web Design System (USWDS)](https://designsystem.digital.gov/)
 
 ### Frontend-Setup
-
-1. Install [nvm](https://github.com/nvm-sh/nvm)
 1. (optional) Install react developer tools extensions
 1. Install [yarn](https://classic.yarnpkg.com/en/docs/install)
-1. `cd frontend && nvm use && yarn install`
-1. `yarn start`
+1. `cd frontend && yarn install && docker-compose up`
 1. view site at http://localhost:3000
    - Note: frontend need the backend to be running to work
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,17 +1,10 @@
-# Dockerfile for local development
-FROM node:14-alpine
+ARG NODE_VER
+ARG NODE_ENV
 
-RUN apk add g++ make python
+FROM node:${NODE_VER}-alpine
+ENV NODE_ENV=${NODE_ENV}
 
-# create directory on container
-WORKDIR /frontend/app 
+WORKDIR /frontend
+CMD ["yarn", "soft-start"]
 
-ENV PATH /app/node_modules/.bin:$PATH
-
-COPY package.json /frontend/app
-
-RUN yarn
-
-COPY . /frontend/app
-
-CMD ["yarn", "start"]
+EXPOSE 3000

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.5"
+services:
+  frontend:
+    build:
+      context: ./
+      dockerfile: Dockerfile.dev
+      args: 
+        NODE_VER: 14
+        NODE_ENV: development
+    volumes:
+      - ./:/frontend/
+      - ../backend/src/main/resources/graphql:/backend/src/main/resources/graphql
+    ports:
+      - "3000:3000"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
   "scripts": {
     "prestart": "rm -rf .eslintcache && yarn",
     "start": "REACT_APP_CURRENT_COMMIT=$(git rev-parse HEAD) npm-run-all -p watch-css start-js",
+    "soft-start": "REACT_APP_CURRENT_COMMIT=$(git rev-parse HEAD) npm-run-all -p watch-css start-js",
     "start-js": "craco start",
     "prebuild": "yarn compile-scss",
     "build": "INLINE_RUNTIME_CHUNK=false REACT_APP_CURRENT_COMMIT=$(git rev-parse HEAD) craco build",


### PR DESCRIPTION
## Related Issue or Background Info

- [Dockerize FE](https://app.zenhub.com/workspaces/simplereport-devops-61127bc8b61cae0013456681/issues/cdcgov/prime-simplereport/2199)

The existing docker experience was practically unusable for local development, it took >10 minutes to build the container, yarn install took > 10 minutes, and it featured no hot reloading. This PR addresses those usability concerns and makes a dockerized front-end the default for local development via the make script.

## Changes Proposed

- Volume mount front-end to docker
- Volume mount necessary back-end files.
- Adds an additional `yarn soft-start` which doesn't delete installed yarn packages, reducing start up time. This soft start is the default.

## Additional Information

- The development of this was made with usability for local development in mind, which has the drawback of this not being a stand alone container. 
- Yarn packages are installed on the host machine and not in the container to reduce start-up time. 
- This change may be a shift for a lot of people who prefer to start the front-end outside of a docker container, while that is still possible, my goal is to support docker based development.


## Screenshots / Demos

New vs Old Image Size

<img width="497" alt="Screen Shot 2021-08-20 at 8 51 41 AM" src="https://user-images.githubusercontent.com/28940414/130515526-5392ab31-b6f2-4b80-ae4f-677ac99549a6.png">


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
