### PR TITLE
Reduce alert sensitivity

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -8,7 +8,6 @@ module "metric_alerts" {
   rg_name                        = data.azurerm_resource_group.rg.name
   tags                           = local.management_tags
   mem_threshold                  = 85
-  cpu_window_size                = 15
   http_response_time_aggregation = "Minimum"
   skip_on_weekends               = true
   disabled_alerts = [

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -55,7 +55,7 @@ variable "cpu_threshold" {
 }
 
 variable "cpu_window_size" {
-  default = 5
+  default = 15
 }
 
 variable "http_response_time_aggregation" {

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_monitor_metric_alert" "http_response_time" {
   resource_group_name = var.rg_name
   scopes              = [var.app_service_id]
   frequency           = "PT1M"
-  window_size         = "PT5M"
+  window_size         = "PT10M"
   severity            = var.severity
   enabled             = contains(var.disabled_alerts, "http_response_time") ? false : true
 

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -7,7 +7,6 @@ module "metric_alerts" {
   rg_name                        = data.azurerm_resource_group.rg.name
   tags                           = local.management_tags
   mem_threshold                  = 85
-  cpu_window_size                = 15
   http_response_time_aggregation = "Minimum"
   failed_http_2xx_threshold      = 14
   skip_on_weekends               = true


### PR DESCRIPTION
## Related Issue or Background Info

A [response time](https://prime-cdc.pagerduty.com/incidents/P1AOK3P) and a [cpu utilization](https://prime-cdc.pagerduty.com/incidents/P65KN9H) alert was created last night. The issues resolved it self. Still doing the investigation but I have been noticing these two alert seem to resolves themselves immediately after triggering

## Changes Proposed

- Increase the CPU window from 5 -> 15
- Increase the response time window from 5 -> 10

## Additional Information

- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
