### PR TITLE
Add link to find CLIA in facility form

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
+++ b/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
@@ -44,6 +44,9 @@ const FacilityInformation: React.FC<Props> = ({
       />
       <TextInput
         label="CLIA number"
+        hintText={
+          <a href="https://www.cdc.gov/clia/LabSearch.html#">Find my CLIA</a>
+        }
         name="cliaNumber"
         value={facility.cliaNumber}
         required

--- a/frontend/src/app/commonComponents/TextInput.tsx
+++ b/frontend/src/app/commonComponents/TextInput.tsx
@@ -34,7 +34,7 @@ interface Props {
   pattern?: string;
   inputMode?: string;
   ariaDescribedBy?: string;
-  hintText?: string;
+  hintText?: string | React.ReactNode;
   inputRef?: React.RefObject<HTMLInputElement>;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   format?: string;


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #2372 

## Changes Proposed

- add hint text to the facility label showing a "Find my CLIA" link

## Screenshots / Demos
![Screen Shot 2021-08-24 at 9 05 32 AM](https://user-images.githubusercontent.com/80282552/130652135-053def91-85f6-4bc0-9117-98eee8a235da.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
