### PR TITLE
Add waitlist form to state error

### DIFF
--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -94,8 +94,9 @@ const getStateErrorMessage = (param: any) =>
       SimpleReport isn't available yet in your state. For more information, view{" "}
       <a href="https://simplereport.gov/using-simplereport/manage-facility-info/find-supported-jurisdictions">
         supported jurisdictions
-      </a>
-      .
+      </a>{" "}
+      or sign up for our{" "}
+      <a href="https://simplereport.gov/waitlist">waitlist</a>.
     </>
   ) : (
     "Organization state is required"


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2118 

## Changes Proposed

- This adds the waitlist link to the state error in the organization signup form, so that when users select an unsupported state they can fill out the waitlist instead.

## Additional Information

- This change still keeps the supported jurisdiction link in place, is that the desired behavior?

## Screenshots / Demos
Before:
![Screen Shot 2021-08-24 at 3 36 05 PM](https://user-images.githubusercontent.com/80282552/130699978-0a9cfa9b-4188-4bce-aab4-222932d9b8bb.png)

After:
![Screen Shot 2021-08-24 at 3 45 52 PM](https://user-images.githubusercontent.com/80282552/130699983-96596d29-46c3-4d6b-8416-e456c96701b8.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
