### PR TITLE
hardcode print modal dates in storybook to avoid constant change in chromatic

### DIFF
--- a/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
@@ -17,7 +17,7 @@ export default {
 } as Meta;
 
 const testResult = {
-  dateTested: new Date(),
+  dateTested: new Date("2021-08-20"),
   result: "NEGATIVE",
   correctionStatus: null,
   deviceType: {
@@ -55,6 +55,7 @@ const defaultProps: TestResultPrintModalProps = {
   data: { testResult } as any,
   testResultId: uniqueId(),
   closeModal: () => {},
+  hardcodedPrintDate: "8/24/2021, 9:44:25 AM",
 };
 
 const Template: Story<TestResultPrintModalProps> = (args) => {

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -58,12 +58,14 @@ export interface TestResultPrintModalProps {
   data: any; // testQuery result
   testResultId: string | undefined;
   closeModal: () => void;
+  hardcodedPrintDate?: string;
 }
 
 export const DetachedTestResultPrintModal = ({
   testResultId,
   data,
   closeModal,
+  hardcodedPrintDate,
 }: TestResultPrintModalProps) => {
   const { t } = useTranslation();
 
@@ -263,7 +265,8 @@ export const DetachedTestResultPrintModal = ({
         </main>
         <footer>
           <p>
-            {t("testResult.printed")} {new Date().toLocaleString()}
+            {t("testResult.printed")}{" "}
+            {hardcodedPrintDate || new Date().toLocaleString()}
           </p>
         </footer>
       </div>


### PR DESCRIPTION
…

## Related Issue or Background Info

- print modal storybook has dynamically generated dates causing it to change constantly

## Changes Proposed

- hard-code dates for the print modal storybook

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
