### PR TITLE
Reduce sensitivity of slow DB query alerts

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -210,7 +210,7 @@ ${local.skip_on_weekends}
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_time_window" {
   name                = "${var.env}-db-query-duration-over-time-window"
-  description         = "${local.env_title} >= 5 DB queries with durations >= 1s over time window"
+  description         = "10+ DB queries with durations over 1.25s in the past 5 minutes"
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
@@ -223,12 +223,12 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_t
   query = <<-QUERY
 dependencies
 ${local.skip_on_weekends}
-| where timestamp >= ago(5m) and name has "SQL:" and duration >= 1000
+| where timestamp >= ago(5m) and name has "SQL:" and duration > 1250
   QUERY
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 4
+    threshold = 10
   }
 
   action {


### PR DESCRIPTION
## Related Issue or Background Info

The "slow database query" alert fires too frequently for normal operation and does not typically produce actionable material. This patch lowers the sensitivity of this alert.

## Changes Proposed
  - Bump duration threshold from 1000ms to 1250 ms
  - Bump # of slow queries required to trigger the alert from 5 to 10
    over a 5 minute period

## Additional Information
- N/A

## Screenshots / Demos

## Checklist for Author and Reviewer
- [ ] Very much open for input for duration threshold/frequency values

### UI
- [ ] ~Any changes to the UI/UX are approved by design~
- [ ] ~Any new or updated content (e.g. error messages) are approved by design~

### Testing
- [ ] ~Includes a summary of what a code reviewer should verify~

### Changes are Backwards Compatible
- [ ] ~Database changes are submitted as a separate PR~
  - [ ] ~Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~
  - [ ] ~Any changes to tables that have custom no-PHI views are accompanied by changes to those views~
        ~(including re-granting permission to the no-PHI user if need be)~
  - [ ] ~Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`~
- [ ] ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
