### PR TITLE
Tim best/db logging

### DIFF
--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -45,3 +45,17 @@ resource "azurerm_postgresql_configuration" "log_autovacuum_min_duration" {
   server_name         = azurerm_postgresql_server.db.name
   value               = 0
 }
+
+resource "azurerm_postgresql_configuration" "pg_qs_query_capture_mode" {
+  name                = "pg_qs.query_capture_mode"
+  resource_group_name = var.rg_name
+  server_name         = azurerm_postgresql_server.db.name
+  value               = "TOP"
+}
+
+resource "azurerm_postgresql_configuration" "pgms_wait_sampling_query_capture_mode" {
+  name                = "pgms_wait_sampling.query_capture_mode"
+  resource_group_name = var.rg_name
+  server_name         = azurerm_postgresql_server.db.name
+  value               = "ALL"
+}

--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -43,7 +43,7 @@ resource "azurerm_postgresql_configuration" "log_autovacuum_min_duration" {
   name                = "log_autovacuum_min_duration"
   resource_group_name = var.rg_name
   server_name         = azurerm_postgresql_server.db.name
-  value               = 0
+  value               = 250
 }
 
 resource "azurerm_postgresql_configuration" "pg_qs_query_capture_mode" {

--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -38,3 +38,10 @@ resource "azurerm_postgresql_database" "simple_report" {
   resource_group_name = var.rg_name
   server_name         = azurerm_postgresql_server.db.name
 }
+
+resource "azurerm_postgresql_configuration" "log_autovacuum_min_duration" {
+  name                = "log_autovacuum_min_duration"
+  resource_group_name = var.rg_name
+  server_name         = azurerm_postgresql_server.db.name
+  value               = 0
+}


### PR DESCRIPTION
## Related Issue or Background Info

- We have gotten a number of alerts on slow DB queries since setting up the alert. Digging into it there seems to be some correlation with the I/O spikes at 3:15PM every day. My first thought was that this might be a vacuum running. Looking at the logs I found that we don't currently log when a vacuum runs.
- While poking around I also found configs we can change to start leveraging Azure's Query Performance Insight features 

## Changes Proposed

- log auto vacuum
- turn on `query_capture_mode`

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.db.azurerm_postgresql_configuration.log_autovacuum_min_duration will be created
  + resource "azurerm_postgresql_configuration" "log_autovacuum_min_duration" {
      + id                  = (known after apply)
      + name                = "log_autovacuum_min_duration"
      + resource_group_name = "prime-simple-report-dev"
      + server_name         = "simple-report-dev-db"
      + value               = "0"
    }

  # module.db.azurerm_postgresql_configuration.pg_qs_query_capture_mode will be created
  + resource "azurerm_postgresql_configuration" "pg_qs_query_capture_mode" {
      + id                  = (known after apply)
      + name                = "pg_qs.query_capture_mode"
      + resource_group_name = "prime-simple-report-dev"
      + server_name         = "simple-report-dev-db"
      + value               = "TOP"
    }

  # module.db.azurerm_postgresql_configuration.pgms_wait_sampling_query_capture_mode will be created
  + resource "azurerm_postgresql_configuration" "pgms_wait_sampling_query_capture_mode" {
      + id                  = (known after apply)
      + name                = "pgms_wait_sampling.query_capture_mode"
      + resource_group_name = "prime-simple-report-dev"
      + server_name         = "simple-report-dev-db"
      + value               = "ALL"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

```

## Additional Information

- https://www.postgresql.org/docs/9.5/runtime-config-autovacuum.html

## Screenshots / Demos
![Screen Shot 2021-08-27 at 11 20 46 AM](https://user-images.githubusercontent.com/53869143/131153323-c87e9e11-0ef3-4a82-b5b0-1e7a28b82737.png)
![Screen Shot 2021-08-27 at 11 21 34 AM](https://user-images.githubusercontent.com/53869143/131153328-e51da5ad-41b8-40aa-85a0-f9c2692a6299.png)
![Screen Shot 2021-08-27 at 11 38 47 AM](https://user-images.githubusercontent.com/53869143/131153330-3724d8ee-1a3a-4b0d-b7a3-2aa9e47a12af.png)
![Screen Shot 2021-08-27 at 11 38 54 AM](https://user-images.githubusercontent.com/53869143/131153332-2df8e6d5-e71f-46d8-aab7-29af5a2ff7c3.png)

## Checklist for Author and Reviewer
- [x] queries logged do not contain PII
- [x] works in a lower env
- [x] provide terraform plan for review

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
