### PR TITLE
add experian regex validation for street address

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -11,7 +11,6 @@ const fillInText = (label: string, text: string) => {
 };
 
 describe("PersonalDetailsForm", () => {
-
   beforeEach(() => {
     render(
       <PersonalDetailsForm
@@ -69,7 +68,7 @@ describe("PersonalDetailsForm", () => {
         ).toBeInTheDocument();
       });
     });
-    describe("On submitting an invalid street address", () => {
+    describe("On submitting an invalid street address 1", () => {
       beforeEach(async () => {
         await act(async () => {
           fillInText("Street address 1", "111 greendale dr,");
@@ -150,6 +149,21 @@ describe("PersonalDetailsForm", () => {
       it("shows an error", () => {
         expect(
           screen.getByText("A valid date of birth is required")
+        ).toBeInTheDocument();
+      });
+    });
+    describe("On submitting an invalid street address 2", () => {
+      beforeEach(async () => {
+        await act(async () => {
+          fillInText("Street address 2", "111 greendale dr,");
+        });
+        await act(async () => {
+          fireEvent.click(screen.getByText("Submit"));
+        });
+      });
+      it("shows an error", () => {
+        expect(
+          screen.getByText("A valid street address 2 is required")
         ).toBeInTheDocument();
       });
     });

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -4,7 +4,14 @@ import PersonalDetailsForm from "./PersonalDetailsForm";
 
 window.scrollTo = jest.fn();
 
+const fillInText = (label: string, text: string) => {
+  fireEvent.change(screen.getByLabelText(label, { exact: false }), {
+    target: { value: text },
+  });
+};
+
 describe("PersonalDetailsForm", () => {
+
   beforeEach(() => {
     render(
       <PersonalDetailsForm
@@ -16,7 +23,7 @@ describe("PersonalDetailsForm", () => {
     );
   });
 
-  it("displays the users full name", function () {
+  it("displays the users full name", () => {
     expect(screen.getByText("Bob Rob Bobberton")).toBeInTheDocument();
   });
 
@@ -26,9 +33,7 @@ describe("PersonalDetailsForm", () => {
 
   describe("Filling out the form", () => {
     beforeEach(() => {
-      fireEvent.change(screen.getByLabelText("Email *", { exact: false }), {
-        target: { value: "bob@bob.bob" },
-      });
+      fillInText("Email *", "bob@bob.bob");
     });
 
     it("enables the submit button", () => {
@@ -54,18 +59,28 @@ describe("PersonalDetailsForm", () => {
     describe("On submitting with an invalid phone number", () => {
       beforeEach(async () => {
         await act(async () => {
-          fireEvent.change(
-            screen.getByLabelText("Phone number", { exact: false }),
-            {
-              target: { value: "123" },
-            }
-          );
+          fillInText("Phone number", "123");
           fireEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
         expect(
           screen.getByText("A valid phone number is required")
+        ).toBeInTheDocument();
+      });
+    });
+    describe("On submitting an invalid street address", () => {
+      beforeEach(async () => {
+        await act(async () => {
+          fillInText("Street address 1", "111 greendale dr,");
+        });
+        await act(async () => {
+          fireEvent.click(screen.getByText("Submit"));
+        });
+      });
+      it("shows an error", () => {
+        expect(
+          screen.getByText("A valid street address is required")
         ).toBeInTheDocument();
       });
     });
@@ -141,9 +156,7 @@ describe("PersonalDetailsForm", () => {
     describe("On submitting an incomplete form", () => {
       beforeEach(async () => {
         await act(async () => {
-          fireEvent.change(screen.getByLabelText("Email", { exact: false }), {
-            target: { value: "bob@bob.bob" },
-          });
+          fillInText("Email", "bob@bob.bob");
           fireEvent.click(screen.getByText("Submit"));
         });
       });
@@ -161,30 +174,12 @@ describe("PersonalDetailsForm", () => {
       const dateButton = screen.getByText("15");
       expect(dateButton).toHaveClass("usa-date-picker__calendar__date");
       fireEvent.click(dateButton);
-      fireEvent.change(screen.getByLabelText("Email", { exact: false }), {
-        target: { value: "bob@bob.bob" },
-      });
-      fireEvent.change(
-        screen.getByLabelText("Phone number", { exact: false }),
-        {
-          target: { value: "530-867-5309" },
-        }
-      );
-      fireEvent.change(
-        screen.getByLabelText("Street address 1", { exact: false }),
-        {
-          target: { value: "123 Bob St" },
-        }
-      );
-      fireEvent.change(screen.getByLabelText("City", { exact: false }), {
-        target: { value: "Bobtown" },
-      });
-      fireEvent.change(screen.getByLabelText("State", { exact: false }), {
-        target: { value: "CA" },
-      });
-      fireEvent.change(screen.getByLabelText("ZIP code", { exact: false }), {
-        target: { value: "74783" },
-      });
+      fillInText("Email", "bob@bob.bob");
+      fillInText("Phone number", "530-867-5309");
+      fillInText("Street address 1", "123 Bob St");
+      fillInText("City", "Bobtown");
+      fillInText("State", "CA");
+      fillInText("ZIP code", "74783");
     });
 
     describe("On submit", () => {

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -144,7 +144,14 @@ export const personalDetailsSchema: yup.SchemaOf<IdentityVerificationRequest> = 
       .string()
       .matches(experianStreetRegex, "A valid street address is required")
       .required("A valid street address is required"),
-    streetAddress2: yup.string().nullable(),
+    streetAddress2: yup
+      .string()
+      .nullable()
+      .notRequired()
+      .matches(experianStreetRegex, {
+        message: "A valid street address 2 is required",
+        excludeEmptyString: true,
+      }),
     city: yup.string().required("City is required"),
     state: yup.string().required("State is required"),
     zip: yup.string().required("ZIP code is required"),

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -112,6 +112,12 @@ export const initPersonalDetailsErrors = (): Record<
   orgExternalId: "",
 });
 
+// this is the regex experian uses for street validation
+const experianStreetRegex = new RegExp(
+  "^([a-zA-Z0-9# \\-'$ / \\.]{1,60}){1}$",
+  "m"
+);
+
 export const personalDetailsSchema: yup.SchemaOf<IdentityVerificationRequest> = yup
   .object()
   .shape({
@@ -134,7 +140,10 @@ export const personalDetailsSchema: yup.SchemaOf<IdentityVerificationRequest> = 
         phoneNumberIsValid
       )
       .required(),
-    streetAddress1: yup.string().required("Street address is required"),
+    streetAddress1: yup
+      .string()
+      .matches(experianStreetRegex, "A valid street address is required")
+      .required("A valid street address is required"),
     streetAddress2: yup.string().nullable(),
     city: yup.string().required("City is required"),
     state: yup.string().required("State is required"),


### PR DESCRIPTION
## Related Issue or Background Info

- partial fix for #2383 

## Changes Proposed

- added regex street validation for experian form

## Additional Information

## Screenshots / Demos
![image](https://user-images.githubusercontent.com/4952042/131183365-5e24c53e-fc74-470d-9b02-8562d2fd9c9b.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
