### PR TITLE
Allow duplicate orgs in different states; remove unused endpoints

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -353,13 +353,4 @@ public class Translators {
     }
     throw IllegalGraphqlArgumentException.invalidInput(t, "organization type");
   }
-
-  public static String parseOrganizationTypeFromName(String t) {
-    for (Map.Entry<String, String> entry : ORGANIZATION_TYPES.entrySet()) {
-      if (entry.getValue().equals(t)) {
-        return entry.getKey();
-      }
-    }
-    throw IllegalGraphqlArgumentException.invalidInput(t, "organization type");
-  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -107,7 +107,7 @@ public class AccountRequestController {
     String organizationName = checkForDuplicateOrg(request.getName(), request.getState());
     String orgExternalId = createOrgExternalId(organizationName, request.getState());
     String organizationType = Translators.parseOrganizationType(request.getType());
-    return _os.createOrganization(organizationName, organizationType, orgExternalId); 
+    return _os.createOrganization(organizationName, organizationType, orgExternalId);
   }
 
   private String checkForDuplicateOrg(String organizationName, String state) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -92,7 +93,7 @@ public class AccountRequestController {
       // informing them of the error.
       throw new BadRequestException(
           "This email address is already associated with a SimpleReport user.");
-    } catch (BadRequestException e) {
+    } catch (BadRequestException | UnexpectedRollbackException e) {
       // The `BadRequestException` is thrown when an account is requested with an existing org
       // name. This happens quite frequently and is expected behavior of the current form
       throw new BadRequestException("This organization has already registered with SimpleReport.");
@@ -106,7 +107,7 @@ public class AccountRequestController {
     String organizationName = checkForDuplicateOrg(request.getName(), request.getState());
     String orgExternalId = createOrgExternalId(organizationName, request.getState());
     String organizationType = Translators.parseOrganizationType(request.getType());
-    return _os.createOrganization(organizationName, organizationType, orgExternalId);
+    return _os.createOrganization(organizationName, organizationType, orgExternalId); 
   }
 
   private String checkForDuplicateOrg(String organizationName, String state) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 /** Handles all user/organization management in Okta */
@@ -295,7 +296,7 @@ public class DemoOktaRepository implements OktaRepository {
   private class DuplicateUserError implements Error {
 
     public int getStatus() {
-      return 400;
+      return HttpStatus.BAD_REQUEST.value();
     }
 
     public String getCode() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -1,112 +1,46 @@
 package gov.cdc.usds.simplereport.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sendgrid.helpers.mail.Mail;
 import gov.cdc.usds.simplereport.api.accountrequest.AccountRequestController;
-import gov.cdc.usds.simplereport.api.accountrequest.errors.AccountRequestFailureException;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
-import gov.cdc.usds.simplereport.api.pxp.CurrentPatientContextHolder;
-import gov.cdc.usds.simplereport.config.TemplateConfiguration;
-import gov.cdc.usds.simplereport.config.WebConfiguration;
-import gov.cdc.usds.simplereport.config.authorization.TenantDataAuthenticationProvider;
-import gov.cdc.usds.simplereport.db.model.ApiUser;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
-import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
-import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
-import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
-import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
-import gov.cdc.usds.simplereport.service.AddressValidationService;
 import gov.cdc.usds.simplereport.service.ApiUserService;
-import gov.cdc.usds.simplereport.service.AuthorizationService;
-import gov.cdc.usds.simplereport.service.DeviceTypeService;
-import gov.cdc.usds.simplereport.service.OrganizationService;
-import gov.cdc.usds.simplereport.service.TenantDataAccessService;
 import gov.cdc.usds.simplereport.service.email.EmailProvider;
-import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
-import gov.cdc.usds.simplereport.service.model.DeviceSpecimenTypeHolder;
-import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
-import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.thymeleaf.spring5.SpringTemplateEngine;
 
-@WebMvcTest(
-    controllers = AccountRequestController.class,
-    includeFilters =
-        @Filter(
-            classes = {TemplateConfiguration.class},
-            type = FilterType.ASSIGNABLE_TYPE),
-    excludeFilters =
-        @Filter(
-            classes = {AuditLoggingAdvice.class, WebConfiguration.class},
-            type = FilterType.ASSIGNABLE_TYPE))
-class AccountRequestControllerTest {
-
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
+class AccountRequestControllerTest extends BaseFullStackTest {
   @Autowired private MockMvc _mockMvc;
+  @Autowired private AccountRequestController _controller;
 
-  @Autowired
-  @Qualifier("simpleReportTemplateEngine")
-  SpringTemplateEngine _templateEngine;
-
-  // Mocked dependencies of ApiUserService
-  @MockBean private ApiUserRepository apiUserRepository;
-  @MockBean private AuthorizationService authorizationService;
-  @MockBean private IdentitySupplier identitySupplier;
-  @MockBean private CurrentPatientContextHolder currentPatientContextHolder;
-  @MockBean private SmsWebhookContextHolder smsWebhookContextHolder;
-  @MockBean private TenantDataAccessService tenantDataAccessService;
-
-  @MockBean private OrganizationService orgService;
-  @MockBean private DeviceTypeService deviceTypeService;
-  @MockBean private AddressValidationService addressValidationService;
   @SpyBean private ApiUserService apiUserService;
-  @MockBean private CurrentAccountRequestContextHolder contextHolder;
-  @MockBean private CurrentTenantDataAccessContextHolder tenantDataAccessContextHolder;
-  @MockBean private TenantDataAuthenticationProvider tenantDataAuthProvider;
-
-  @MockBean private OktaRepository oktaRepository;
-
   @MockBean private EmailProvider mockSendGrid;
   @SpyBean private EmailService emailService;
 
@@ -114,12 +48,19 @@ class AccountRequestControllerTest {
   @Captor private ArgumentCaptor<Mail> mail;
   @Captor private ArgumentCaptor<String> externalIdCaptor;
   @Captor private ArgumentCaptor<PersonName> nameCaptor;
-  @Captor private ArgumentCaptor<StreetAddress> addressCaptor;
 
-  private static final String FAKE_ORG_EXTERNAL_ID_PREFIX = "RI-Day-Hayes-Trading-";
-  private static final String FAKE_ORG_EXTERNAL_ID =
-      FAKE_ORG_EXTERNAL_ID_PREFIX + "09e05f77-8765-48bb-adcb-96819af7aa32";
+  @BeforeEach
+  void clearDb() {
+    truncateDb();
+    _oktaRepo.reset();
+  }
 
+  @Test
+  void contextLoads() throws Exception {
+    assertThat(_controller).isNotNull();
+  }
+
+  // waitlist request tests
   @Test
   void waitlistIsOk() throws Exception {
     String requestBody =
@@ -152,6 +93,7 @@ class AccountRequestControllerTest {
   }
 
   @Test
+  @DisplayName("waitlist request fails without email")
   void waitlistValidatesInput() throws Exception {
     String requestBody =
         "{\"name\":\"Angela Chan\",\"phone\":\"+1 (157) 294-1842\",\"state\":\"Exercitation odit pr\",\"organization\":\"Lane Moss LLC\",\"referral\":\"Ea error voluptate v\"}";
@@ -167,98 +109,24 @@ class AccountRequestControllerTest {
     verifyNoInteractions(emailService);
   }
 
-  private static Stream<Arguments> getAccountRequestIsOkParameters() {
-    return Stream.of(
-        // using organization-type labels (old way)
-        Arguments.of(ResourceLinks.ACCOUNT_REQUEST, "Homeless Shelter"),
-        Arguments.of(
-            ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE_WITH_FACILITY, "Homeless Shelter"),
-        // using organization-type values (new way)
-        Arguments.of(ResourceLinks.ACCOUNT_REQUEST, "shelter"),
-        Arguments.of(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE_WITH_FACILITY, "shelter"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("getAccountRequestIsOkParameters")
-  void accountRequestIsOk(String resourceLink, String organizationType) throws Exception {
-    // also need to add default devices and other
+  // account request tests
+  @Test
+  void accountRequestSuccessful() throws Exception {
+    // given
     String requestBody =
-        String.format(
-            "{\"first-name\":\"Mary\",\"last-name\":\"Lopez\",\"email\":\"kyvuzoxy@mailinator.com\",\"work-phone-number\":\"+1 (969) 768-2863\",\"street-address1\":\"707 White Milton Extension\",\"street-address2\":\"Apt 3\",\"city\":\"Reprehenderit nostr\",\"state\":\"RI\",\"zip\":\"13046\",\"county\":\"Et consectetur sunt\",\"name\":\"Day Hayes Trading\",\"type\":\"%s\",\"facility-name\":\"Fiona Payne\",\"facility-phone-number\":\"800-888-8888\",\"clia-number\":\"474\",\"workflow\":\"Aut ipsum aute aute\",\"op-first-name\":\"Sawyer\",\"op-last-name\":\"Sears\",\"npi\":\"Quis sit eiusmod Nam\",\"op-phone-number\":\"+1 (583) 883-4172\",\"op-street-address1\":\"290 East Rocky Second Street\",\"op-street-address2\":\"UNAVAILABLE\",\"op-city\":\"Dicta cumque sit ip\",\"op-state\":\"AR\",\"op-zip\":\"43675\",\"op-county\":\"Asperiores illum in\",\"records-test-results\":\"No\",\"process-time\":\"15–30 minutes\",\"submitting-results-time\":\"Less than 30 minutes\",\"browsers\":\"Other\",\"testing-devices\":\"Abbott IDNow, BD Veritor, Cue, LumiraDX\",\"default-testing-device\":\"LumiraDX\",\"access-devices\":\"Smartphone\"}",
-            organizationType);
-
-    Organization organization = mock(Organization.class);
-    ApiUser apiUser = mock(ApiUser.class);
-    ApiUser acctRequestApiUser = mock(ApiUser.class);
-    DeviceType device1 = mock(DeviceType.class);
-    DeviceType device2 = mock(DeviceType.class);
-    DeviceType device3 = mock(DeviceType.class);
-    DeviceType device4 = mock(DeviceType.class);
-    UUID deviceUuid1 = UUID.randomUUID();
-    UUID deviceUuid2 = UUID.randomUUID();
-    UUID deviceUuid3 = UUID.randomUUID();
-    UUID deviceUuid4 = UUID.randomUUID();
-    UUID acctRequestApiUserUuid = UUID.randomUUID();
-    when(orgService.createOrganizationAndFacility(
-            any(),
-            any(),
-            startsWith(FAKE_ORG_EXTERNAL_ID_PREFIX),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any()))
-        .thenReturn(organization);
-    when(orgService.getOrganization(any())).thenReturn(organization);
-    when(organization.getExternalId()).thenReturn(FAKE_ORG_EXTERNAL_ID);
-    when(apiUserRepository.save(any())).thenReturn(apiUser);
-    when(apiUserRepository.findByLoginEmail("account-request-noreply@simplereport.gov"))
-        .thenReturn(Optional.of(acctRequestApiUser));
-    when(acctRequestApiUser.getInternalId()).thenReturn(acctRequestApiUserUuid);
-    when(contextHolder.isAccountRequest()).thenReturn(true);
-    when(device1.getName()).thenReturn("Abbott IDNow");
-    when(device1.getModel()).thenReturn("ID Now");
-    when(device1.getInternalId()).thenReturn(deviceUuid1);
-    when(device2.getName()).thenReturn("BD Veritor");
-    when(device2.getModel()).thenReturn("BD Veritor System for Rapid Detection of SARS-CoV-2*");
-    when(device2.getInternalId()).thenReturn(deviceUuid2);
-    when(device3.getName()).thenReturn("Cue");
-    when(device3.getModel()).thenReturn("CueTM COVID-19 Test*");
-    when(device3.getInternalId()).thenReturn(deviceUuid3);
-    when(device4.getName()).thenReturn("LumiraDX");
-    when(device4.getModel()).thenReturn("LumiraDx SARS-CoV-2 Ag Test*");
-    when(device4.getInternalId()).thenReturn(deviceUuid4);
-    when(deviceTypeService.fetchDeviceTypes())
-        .thenReturn(List.of(device1, device2, device3, device4));
-
-    DeviceSpecimenTypeHolder ds = mock(DeviceSpecimenTypeHolder.class);
-    when(deviceTypeService.getTypesForFacility(
-            eq(deviceUuid4.toString()),
-            eq(
-                List.of(
-                    deviceUuid1.toString(),
-                    deviceUuid2.toString(),
-                    deviceUuid3.toString(),
-                    deviceUuid4.toString()))))
-        .thenReturn(ds);
-
-    StreetAddress facilityAddress = mock(StreetAddress.class);
-    when(addressValidationService.getValidatedAddress(
-            "707 White Milton Extension",
-            "Apt 3",
-            "Reprehenderit nostr",
+        createAccountRequest(
+            "Day Hayes Trading",
             "RI",
-            "13046",
-            "facility"))
-        .thenReturn(facilityAddress);
+            "shelter",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
 
+    // when
     MockHttpServletRequestBuilder builder =
-        post(resourceLink)
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -266,67 +134,12 @@ class AccountRequestControllerTest {
 
     this._mockMvc.perform(builder).andExpect(status().isOk());
 
-    if (ResourceLinks.ACCOUNT_REQUEST.equals(resourceLink)) {
-      // v1 account request sends emails
+    // then
+    Optional<Organization> org = _orgService.getOrganizationByName("Day Hayes Trading");
+    assertThat(org).isPresent();
+    assertThat(org.get().getExternalId().startsWith("RI-Day-Hayes-Trading-"));
 
-      // mail 1: to us (contains formatted request data)
-      verify(emailService, times(1))
-          .send(
-              eq(List.of("support@simplereport.gov")),
-              eq("New account request"),
-              contentCaptor.capture());
-      assertThat(contentCaptor.getValue().getTemplateName()).isEqualTo("account-request");
-      assertThat(contentCaptor.getValue().toTemplateVariables()).containsEntry("firstName", "Mary");
-
-      // mail 2: to requester (simplereport new user email)
-      verify(emailService, times(1))
-          .sendWithProviderTemplate(
-              "kyvuzoxy@mailinator.com", EmailProviderTemplate.ACCOUNT_REQUEST);
-
-      verify(mockSendGrid, times(2)).send(mail.capture());
-      List<Mail> sentMails = mail.getAllValues();
-
-      // mail 1: to us (contains formatted request data)
-      assertThat(sentMails.get(0).getContent().get(0).getValue())
-          .contains(
-              "new SimpleReport account request",
-              "Mary",
-              "Lopez",
-              "kyvuzoxy@mailinator.com",
-              "Reprehenderit nostr");
-      assertNull(sentMails.get(0).getAttachments());
-      assertNull(sentMails.get(0).getTemplateId());
-
-      // mail 2: to requester (simplereport new user email)
-      assertThat(sentMails.get(1).getPersonalization().get(0).getTos().get(0).getEmail())
-          .isEqualTo("kyvuzoxy@mailinator.com");
-      assertNotNull(sentMails.get(1).getTemplateId());
-    } else {
-      // v2 account request does not send any emails
-      verify(emailService, times(0)).send(anyList(), anyString(), any());
-
-      verify(emailService, times(0)).sendWithProviderTemplate(anyString(), any());
-
-      verify(mockSendGrid, times(0)).send(any());
-    }
-
-    verify(deviceTypeService, times(1))
-        .getTypesForFacility(
-            deviceUuid4.toString(),
-            List.of(
-                deviceUuid1.toString(),
-                deviceUuid2.toString(),
-                deviceUuid3.toString(),
-                deviceUuid4.toString()));
-
-    verify(addressValidationService, times(1))
-        .getValidatedAddress(
-            "707 White Milton Extension",
-            "Apt 3",
-            "Reprehenderit nostr",
-            "RI",
-            "13046",
-            "facility");
+    assertThat(org.get().getIdentityVerified()).isFalse();
 
     verify(apiUserService, times(1))
         .createUser(
@@ -339,207 +152,178 @@ class AccountRequestControllerTest {
     assertNull(nameCaptor.getValue().getMiddleName());
     assertThat(nameCaptor.getValue().getLastName()).isEqualTo("Lopez");
     assertNull(nameCaptor.getValue().getSuffix());
-    assertThat(externalIdCaptor.getValue()).isEqualTo(FAKE_ORG_EXTERNAL_ID);
-
-    verify(orgService, times(1))
-        .createOrganizationAndFacility(
-            eq("Day Hayes Trading"),
-            eq("shelter"),
-            externalIdCaptor.capture(),
-            eq("Fiona Payne"),
-            eq("474"),
-            eq(facilityAddress),
-            eq("(800) 888-8888"),
-            eq(null),
-            eq(ds),
-            nameCaptor.capture(),
-            addressCaptor.capture(),
-            eq("(583) 883-4172"),
-            eq("Quis sit eiusmod Nam"));
-
-    assertThat(externalIdCaptor.getValue()).startsWith("RI-Day-Hayes-Trading-");
-    assertThat(nameCaptor.getValue().getFirstName()).isEqualTo("Sawyer");
-    assertNull(nameCaptor.getValue().getMiddleName());
-    assertThat(nameCaptor.getValue().getLastName()).isEqualTo("Sears");
-    assertNull(nameCaptor.getValue().getSuffix());
-    assertThat(addressCaptor.getValue().getStreetOne()).isEqualTo("290 East Rocky Second Street");
-    assertThat(addressCaptor.getValue().getStreetTwo()).isEqualTo("UNAVAILABLE");
-    assertThat(addressCaptor.getValue().getCity()).isEqualTo("Dicta cumque sit ip");
-    assertThat(addressCaptor.getValue().getState()).isEqualTo("AR");
-    assertThat(addressCaptor.getValue().getPostalCode()).isEqualTo("43675");
-    assertThat(addressCaptor.getValue().getCounty()).isEqualTo("Asperiores illum in");
-
-    // new user should be disabled in okta
-    verify(oktaRepository)
-        .createUser(any(IdentityAttributes.class), eq(organization), anySet(), anySet(), eq(false));
+    assertThat(externalIdCaptor.getValue()).contains("RI-Day-Hayes-Trading-");
   }
 
   @Test
-  @DisplayName("/account-request/organization-create-without-facility")
-  void organizationAccountRequestIsOk() throws Exception {
-    String resourceLink = ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE;
-    String requestBody =
-        "{\"firstName\": \"Mary\", \"lastName\": \"Lopez\", \"email\": \"kyvuzoxy@mailinator.com\", \"workPhoneNumber\": \"+1 (969) 768-2863\", \"state\": \"RI\", \"name\": \"Day Hayes Trading\", \"type\": \"Homeless Shelter\"}";
-
-    Organization organization = mock(Organization.class);
-    ApiUser apiUser = mock(ApiUser.class);
-    ApiUser acctRequestApiUser = mock(ApiUser.class);
-    UUID acctRequestApiUserUuid = UUID.randomUUID();
-    when(orgService.createOrganization(any(), any(), startsWith(FAKE_ORG_EXTERNAL_ID_PREFIX)))
-        .thenReturn(organization);
-    when(orgService.getOrganization(any())).thenReturn(organization);
-    when(organization.getExternalId()).thenReturn(FAKE_ORG_EXTERNAL_ID);
-    when(apiUserRepository.save(any())).thenReturn(apiUser);
-    when(apiUserRepository.findByLoginEmail("account-request-noreply@simplereport.gov"))
-        .thenReturn(Optional.of(acctRequestApiUser));
-    when(acctRequestApiUser.getInternalId()).thenReturn(acctRequestApiUserUuid);
-    when(contextHolder.isAccountRequest()).thenReturn(true);
-
-    MockHttpServletRequestBuilder builder =
-        post(resourceLink)
+  @DisplayName("Duplicate org in same state fails")
+  void duplicateOrgInSameState() throws Exception {
+    // given
+    String originalRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder originalBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
-            .content(requestBody);
+            .content(originalRequestBody);
+    this._mockMvc.perform(originalBuilder).andExpect(status().isOk());
 
-    this._mockMvc.perform(builder).andExpect(status().isOk());
+    // when
+    String duplicateRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Susie",
+            "",
+            "Smith",
+            "susie@example.com",
+            "760-858-9900");
 
-    // v2 account request does not send any emails
-    verify(emailService, times(0)).send(anyList(), anyString(), any());
-    verify(emailService, times(0)).sendWithProviderTemplate(anyString(), any());
-    verify(mockSendGrid, times(0)).send(any());
+    MockHttpServletRequestBuilder duplicateBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(duplicateRequestBody);
 
-    verify(apiUserService, times(1))
-        .createUser(
-            eq("kyvuzoxy@mailinator.com"),
-            nameCaptor.capture(),
-            externalIdCaptor.capture(),
-            eq(Role.ADMIN));
-
-    assertThat(nameCaptor.getValue().getFirstName()).isEqualTo("Mary");
-    assertNull(nameCaptor.getValue().getMiddleName());
-    assertThat(nameCaptor.getValue().getLastName()).isEqualTo("Lopez");
-    assertNull(nameCaptor.getValue().getSuffix());
-    assertThat(externalIdCaptor.getValue()).isEqualTo(FAKE_ORG_EXTERNAL_ID);
-
-    verify(orgService, times(1))
-        .createOrganization(eq("Day Hayes Trading"), eq("shelter"), externalIdCaptor.capture());
-
-    assertThat(externalIdCaptor.getValue()).startsWith("RI-Day-Hayes-Trading-");
-
-    // new user should be disabled in okta
-    verify(oktaRepository)
-        .createUser(any(IdentityAttributes.class), eq(organization), anySet(), anySet(), eq(false));
+    // then
+    MvcResult result = this._mockMvc.perform(duplicateBuilder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains("This organization has already registered with SimpleReport.");
   }
 
   @Test
-  @DisplayName("/account-request/without-facility-with-emails")
-  void accountRequestWithEmailsWithoutFacilityIsOk() throws Exception {
-    String resourceLink = ResourceLinks.ACCOUNT_REQUEST_WITHOUT_FACILITY_WITH_EMAILS;
-    String requestBody =
-        "{\"firstName\": \"Mary\", \"lastName\": \"Lopez\", \"email\": \"kyvuzoxy@mailinator.com\", \"workPhoneNumber\": \"+1 (969) 768-2863\", \"state\": \"RI\", \"name\": \"Day Hayes Trading\", \"type\": \"Homeless Shelter\"}";
+  @DisplayName("Duplicate org in different state succeeds but state is appended to name")
+  void duplicateOrgInDifferentState() throws Exception {
+    // given
+    String originalRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
 
-    Organization organization = mock(Organization.class);
-    ApiUser apiUser = mock(ApiUser.class);
-    ApiUser acctRequestApiUser = mock(ApiUser.class);
-    UUID acctRequestApiUserUuid = UUID.randomUUID();
-    when(orgService.createOrganization(any(), any(), startsWith(FAKE_ORG_EXTERNAL_ID_PREFIX)))
-        .thenReturn(organization);
-    when(orgService.getOrganization(any())).thenReturn(organization);
-    when(organization.getExternalId()).thenReturn(FAKE_ORG_EXTERNAL_ID);
-    when(apiUserRepository.save(any())).thenReturn(apiUser);
-    when(apiUserRepository.findByLoginEmail("account-request-noreply@simplereport.gov"))
-        .thenReturn(Optional.of(acctRequestApiUser));
-    when(acctRequestApiUser.getInternalId()).thenReturn(acctRequestApiUserUuid);
-    when(contextHolder.isAccountRequest()).thenReturn(true);
-
-    MockHttpServletRequestBuilder builder =
-        post(resourceLink)
+    MockHttpServletRequestBuilder originalBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
-            .content(requestBody);
+            .content(originalRequestBody);
 
-    MvcResult mvcResult = this._mockMvc.perform(builder).andExpect(status().isOk()).andReturn();
+    this._mockMvc.perform(originalBuilder).andExpect(status().isOk());
 
-    assertThat(mvcResult.getResponse().getContentAsString())
-        .contains("{\"orgExternalId\":\"" + FAKE_ORG_EXTERNAL_ID + "\"}");
+    // when
+    String duplicateRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "CA",
+            "k12",
+            "Susie",
+            "",
+            "Smith",
+            "susie@example.com",
+            "760-858-9900");
 
-    // v2 account request does not send any emails
-    verify(emailService, times(1)).send(anyList(), anyString(), any());
-    verify(emailService, times(1)).sendWithProviderTemplate(anyString(), any());
-    verify(mockSendGrid, times(2)).send(any());
+    MockHttpServletRequestBuilder duplicateBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(duplicateRequestBody);
 
-    verify(apiUserService, times(1))
-        .createUser(
-            eq("kyvuzoxy@mailinator.com"),
-            nameCaptor.capture(),
-            externalIdCaptor.capture(),
-            eq(Role.ADMIN));
+    this._mockMvc.perform(duplicateBuilder).andExpect(status().isOk());
 
-    assertThat(nameCaptor.getValue().getFirstName()).isEqualTo("Mary");
-    assertNull(nameCaptor.getValue().getMiddleName());
-    assertThat(nameCaptor.getValue().getLastName()).isEqualTo("Lopez");
-    assertNull(nameCaptor.getValue().getSuffix());
-    assertThat(externalIdCaptor.getValue()).isEqualTo(FAKE_ORG_EXTERNAL_ID);
+    // then
+    Optional<Organization> originalOrg = _orgService.getOrganizationByName("Central Schools");
+    assertThat(originalOrg).isPresent();
+    assertThat(originalOrg.get().getExternalId().startsWith("AZ-Central-Schools"));
 
-    verify(orgService, times(1))
-        .createOrganization(eq("Day Hayes Trading"), eq("shelter"), externalIdCaptor.capture());
-
-    assertThat(externalIdCaptor.getValue()).startsWith("RI-Day-Hayes-Trading-");
-
-    // new user should be disabled in okta
-    verify(oktaRepository)
-        .createUser(any(IdentityAttributes.class), eq(organization), anySet(), anySet(), eq(false));
+    Optional<Organization> duplicateOrg = _orgService.getOrganizationByName("Central Schools-CA");
+    assertThat(duplicateOrg).isPresent();
+    assertThat(duplicateOrg.get().getExternalId()).startsWith("CA-Central-Schools-CA-");
   }
 
-  @DisplayName("Account request should have valid input")
   @Test
-  void accountRequestValidatesInput() throws Exception {
-    String requestBody =
-        "{\"first-name\":\"Mary\",\"last-name\":\"Lopez\",\"work-phone-number\":\"+1 (969) 768-2863\",\"street-address1\":\"707 White Milton Extension\",\"apt-suite-other\":\"FL\",\"apt-floor-suite-no\":\"694\",\"city\":\"Reprehenderit nostr\",\"state\":\"RI\",\"zip\":\"13046\",\"county\":\"Et consectetur sunt\",\"name\":\"Day Hayes Trading\",\"type\":\"Homeless Shelter\",\"facility-name\":\"Fiona Payne\",\"facility-phone-number\":\"800-888-8888\",\"clia-number\":\"474\",\"workflow\":\"Aut ipsum aute aute\",\"op-first-name\":\"Sawyer\",\"op-last-name\":\"Sears\",\"npi\":\"Quis sit eiusmod Nam\",\"op-phone-number\":\"+1 (583) 883-4172\",\"op-street-address1\":\"290 East Rocky Second Street\",\"op-apt-suite-other\":\"UNAVAILABLE\",\"op-apt-floor-suite-no\":\"546\",\"op-city\":\"Dicta cumque sit ip\",\"op-state\":\"AR\",\"op-zip\":\"43675\",\"op-county\":\"Asperiores illum in\",\"records-test-results\":\"No\",\"process-time\":\"15–30 minutes\",\"submitting-results-time\":\"Less than 30 minutes\",\"browsers\":\"Other\",\"testing-devices\":\"Abbott IDNow, BD Veritor, LumiraDX\",\"default-testing-device\":\"LumiraDX\",\"access-devices\":\"Smartphone\"}";
-
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.ACCOUNT_REQUEST)
+  @DisplayName("Cannot create user with existing email address")
+  void duplicateUserFails() throws Exception {
+    // given
+    String originalRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder originalBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
-            .content(requestBody);
+            .content(originalRequestBody);
+    this._mockMvc.perform(originalBuilder).andExpect(status().isOk());
 
-    this._mockMvc.perform(builder).andExpect(status().isBadRequest());
-    verifyNoInteractions(emailService);
-    verifyNoInteractions(deviceTypeService);
-    verifyNoInteractions(addressValidationService);
-    verifyNoInteractions(orgService);
-    verifyNoInteractions(apiUserService);
+    // when
+    String duplicateRequestBody =
+        createAccountRequest(
+            "Different Org, Same User",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
+
+    MockHttpServletRequestBuilder duplicateBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(duplicateRequestBody);
+
+    // then
+    MvcResult result = this._mockMvc.perform(duplicateBuilder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains("This email address is already associated with a SimpleReport user.");
   }
 
-  @DisplayName("Account request should handle unregistered devices")
-  @Test
-  void accountRequestSubmittedDeviceNotRegistered() throws Exception {
-    String requestBody =
-        "{\"first-name\":\"Mary\",\"last-name\":\"Lopez\",\"email\":\"kyvuzoxy@mailinator.com\",\"work-phone-number\":\"+1 (969) 768-2863\",\"street-address1\":\"707 White Milton Extension\",\"street-address2\":\"Apt 3\",\"city\":\"Reprehenderit nostr\",\"state\":\"RI\",\"zip\":\"13046\",\"county\":\"Et consectetur sunt\",\"name\":\"Day Hayes Trading\",\"type\":\"Homeless Shelter\",\"facility-name\":\"Fiona Payne\",\"facility-phone-number\":\"800-888-8888\",\"clia-number\":\"474\",\"workflow\":\"Aut ipsum aute aute\",\"op-first-name\":\"Sawyer\",\"op-last-name\":\"Sears\",\"npi\":\"Quis sit eiusmod Nam\",\"op-phone-number\":\"+1 (583) 883-4172\",\"op-street-address1\":\"290 East Rocky Second Street\",\"op-street-address2\":\"UNAVAILABLE\",\"op-city\":\"Dicta cumque sit ip\",\"op-state\":\"AR\",\"op-zip\":\"43675\",\"op-county\":\"Asperiores illum in\",\"records-test-results\":\"No\",\"process-time\":\"15–30 minutes\",\"submitting-results-time\":\"Less than 30 minutes\",\"browsers\":\"Other\",\"testing-devices\":\"Invalid Device\",\"default-testing-device\":\"LumiraDX\",\"access-devices\":\"Smartphone\"}";
-
-    DeviceType device1 = mock(DeviceType.class);
-    UUID deviceUuid1 = UUID.randomUUID();
-    when(device1.getName()).thenReturn("Abbott IDNow");
-    when(device1.getModel()).thenReturn("ID Now");
-    when(device1.getInternalId()).thenReturn(deviceUuid1);
-    when(deviceTypeService.fetchDeviceTypes()).thenReturn(List.of(device1));
-
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.ACCOUNT_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(requestBody);
-
-    this._mockMvc
-        .perform(builder)
-        .andExpect(status().isInternalServerError())
-        .andExpect(
-            result ->
-                assertTrue(
-                    result.getResolvedException() instanceof AccountRequestFailureException));
+  private String createAccountRequest(
+      String orgName,
+      String state,
+      String orgType,
+      String firstName,
+      String middleName,
+      String lastName,
+      String workEmail,
+      String workPhone) {
+    JSONObject requestBody = new JSONObject();
+    requestBody.put("name", orgName);
+    requestBody.put("state", state);
+    requestBody.put("type", orgType);
+    requestBody.put("firstName", firstName);
+    requestBody.put("middleName", middleName);
+    requestBody.put("lastName", lastName);
+    requestBody.put("email", workEmail);
+    requestBody.put("workPhoneNumber", workPhone);
+    return requestBody.toString();
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -137,7 +137,7 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     // then
     Optional<Organization> org = _orgService.getOrganizationByName("Day Hayes Trading");
     assertThat(org).isPresent();
-    assertThat(org.get().getExternalId().startsWith("RI-Day-Hayes-Trading-"));
+    assertThat(org.get().getExternalId()).startsWith("RI-Day-Hayes-Trading-");
 
     assertThat(org.get().getIdentityVerified()).isFalse();
 
@@ -251,7 +251,7 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     // then
     Optional<Organization> originalOrg = _orgService.getOrganizationByName("Central Schools");
     assertThat(originalOrg).isPresent();
-    assertThat(originalOrg.get().getExternalId().startsWith("AZ-Central-Schools"));
+    assertThat(originalOrg.get().getExternalId()).startsWith("AZ-Central-Schools");
 
     Optional<Organization> duplicateOrg = _orgService.getOrganizationByName("Central Schools-CA");
     assertThat(duplicateOrg).isPresent();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -8,7 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import gov.cdc.usds.simplereport.config.authorization.UserPermission;
 import gov.cdc.usds.simplereport.db.model.ApiAuditEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.HttpRequestDetails;
+import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
 import gov.cdc.usds.simplereport.service.AuditService;
+import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.test_util.DbTruncator;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.util.Date;
@@ -38,6 +40,8 @@ public abstract class BaseFullStackTest {
   @Autowired private DbTruncator _truncator;
   @Autowired private AuditService _auditService;
   @Autowired protected TestDataFactory _dataFactory;
+  @Autowired protected OrganizationService _orgService;
+  @Autowired protected DemoOktaRepository _oktaRepo;
 
   protected Date _testStart;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -11,11 +11,6 @@ public final class ResourceLinks {
   public static final String ENTITY_NAME = "/pxp/register/entity-name";
 
   public static final String WAITLIST_REQUEST = "/account-request/waitlist";
-  public static final String ACCOUNT_REQUEST = "/account-request";
-  public static final String ACCOUNT_REQUEST_WITHOUT_FACILITY_WITH_EMAILS =
-      "/account-request/without-facility-with-emails";
-  public static final String ACCOUNT_REQUEST_ORGANIZATION_CREATE_WITH_FACILITY =
-      "/account-request/organization-create";
   public static final String ACCOUNT_REQUEST_ORGANIZATION_CREATE =
       "/account-request/organization-create-without-facility";
   public static final String USER_ACCOUNT_REQUEST = "/user-account";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
@@ -379,23 +379,6 @@ class TranslatorTest {
     assertEquals("[not-a-type] is not a valid organization type", caught.getMessage());
   }
 
-  @Test
-  void goodOrganizationTypeFromName() {
-    String type = Translators.parseOrganizationTypeFromName("Homeless Shelter");
-    assertEquals("shelter", type);
-  }
-
-  @Test
-  void badOrganizationTypeFromName() {
-    IllegalGraphqlArgumentException caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class,
-            () -> {
-              Translators.parseOrganizationTypeFromName("not-a-type");
-            });
-    assertEquals("[not-a-type] is not a valid organization type", caught.getMessage());
-  }
-
   static class GoodNameArgumentsProvider implements ArgumentsProvider {
 
     @Override


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2388 
- Adds new logic to the duplicate org check, so that organizations with the same name but different states can still register.

## Changes Proposed

- Remove unused endpoints from AccountRequestController and its test
- Add logic to allow orgs with the same name but different states to register (the "duplicate" org will be registered with the state appended to its org name)
- Changes AccountRequestControllerTest to extend BaseFullStack instead of mocking individual services. This was required as I wanted to accurately test duplicate orgs without mocking the responses
- Add new tests to AccountRequestControllerTest to check for duplicate orgs and duplicate users
- Add a new Error class and logic in DemoOktaRepository to catch duplicate users (which don't typically occur within the same org but rather across our entire Okta group)
- Updates BaseFullStackTest to grant access to OrganizationService and DemoOktaRepository, which are used for assertions in AccountRequestControllerTest

## Additional Information

Here's a sample workflow for duplicate orgs in different states:
- `Central Schools` registers successfully in AZ. They're created with the org name `Central Schools`.
- A different `Central Schools` tries to register in WA. They're created with the org name `Central Schools-WA`.

Adding the state to the org name in the case of duplicate orgs isn't great, because it'll show up for users in the app, but it was the only solution that will still allow orgs to register. The database has a rule that organization names must be unique, so contacting support wouldn't really help the user in this case.

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
