### PR TITLE
Add ZIP validation to Experian PersonalDetailsForm

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -167,6 +167,21 @@ describe("PersonalDetailsForm", () => {
         ).toBeInTheDocument();
       });
     });
+    describe("On submitting an invalid zip code", () => {
+      beforeEach(async () => {
+        await act(async () => {
+          fillInText("ZIP code", "1234");
+        });
+        await act(async () => {
+          fireEvent.click(screen.getByText("Submit"));
+        });
+      });
+      it("shows an error", () => {
+        expect(
+          screen.getByText("A valid ZIP code is required")
+        ).toBeInTheDocument();
+      });
+    });
     describe("On submitting an incomplete form", () => {
       beforeEach(async () => {
         await act(async () => {

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -118,6 +118,9 @@ const experianStreetRegex = new RegExp(
   "m"
 );
 
+// this is the regex experian uses for zip validation
+const experianZipRegex = new RegExp("^([\\d]{5}([\\-]?[\\d]{4})?){1}$", "m");
+
 export const personalDetailsSchema: yup.SchemaOf<IdentityVerificationRequest> = yup
   .object()
   .shape({
@@ -154,6 +157,9 @@ export const personalDetailsSchema: yup.SchemaOf<IdentityVerificationRequest> = 
       }),
     city: yup.string().required("City is required"),
     state: yup.string().required("State is required"),
-    zip: yup.string().required("ZIP code is required"),
+    zip: yup
+      .string()
+      .matches(experianZipRegex, "A valid ZIP code is required")
+      .required("A valid ZIP code is required"),
     orgExternalId: yup.string().required("Organization ID is required"),
   });


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2383

## Changes Proposed

- Adds ZIP code validation to `PersonalDetailsForm` to match Experian's regex

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
