### PR TITLE
Add index on person(organization_id, facility_id, is_deleted)

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2870,7 +2870,7 @@ databaseChangeLog:
       author: adam@skylight.digital
       changes:
         - createIndex:
-            tableName: test_event
+            tableName: person
             indexName: ix__person__organization_id-facility_id-is_deleted
             columns:
               - column:

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2865,3 +2865,17 @@ databaseChangeLog:
                   test_result_delivery = person.test_result_delivery_preference
               FROM ${database.defaultSchemaName}.person
               WHERE patient_preferences.internal_id = person.internal_id;
+  - changeSet:
+      id: add-index-person-org-facility-deleted
+      author: adam@skylight.digital
+      changes:
+        - createIndex:
+            tableName: test_event
+            indexName: ix__person__organization_id-facility_id-is_deleted
+            columns:
+              - column:
+                  name: organization_id
+              - column:
+                  name: facility_id
+              - column:
+                  name: is_deleted


### PR DESCRIPTION
## Related Issue or Background Info

This should improve the performance of the `COUNT()` query that's made as part of paginating GetPatientsByFacility.

#### Query:
```
    select
        count(person0_.internal_id) as col_0_0_ 
    from
        simple_report.person person0_ 
    where
        (
            person0_.facility_id is null 
            or person0_.facility_id=?
        ) 
        and person0_.is_deleted=? 
        and person0_.organization_id=?
```

#### Old query plan: 
```
Aggregate  (cost=11.65..11.66 rows=1 width=8) (actual time=0.019..0.019 rows=1 loops=1)
  ->  Seq Scan on person person0_  (cost=0.00..11.65 rows=1 width=16) (actual time=0.015..0.016 rows=3 loops=1)
        Filter: ((NOT is_deleted) AND ((facility_id IS NULL) OR (facility_id = '6d3cc66f-2170-41cc-be87-b17f41771b9c'::uuid)) AND (organization_id = 'cb59cfca-4561-4527-9a19-1ed4b1120269'::uuid))
```

#### New query plan:
```
Aggregate  (cost=2.50..2.51 rows=1 width=8) (actual time=0.902..0.903 rows=1 loops=1)
  ->  Index Scan using person_facility_org on person person0_  (cost=0.27..2.50 rows=1 width=16) (actual time=0.898..0.898 rows=0 loops=1)
        Index Cond: ((organization_id = 'cb59cfca-4561-4527-9a19-1ed4b1120269'::uuid) AND (is_deleted = false))
        Filter: ((NOT is_deleted) AND ((facility_id IS NULL) OR (facility_id = '6d3cc66f-2170-41cc-be87-b17f41771b9c'::uuid)))
```

## Changes Proposed

- Add an index on `person(organization_id, facility_id, is_deleted)`

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
