### PR TITLE
Fix n+1 queries on Text Messages

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TextMessageSent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TextMessageSent.java
@@ -2,12 +2,13 @@ package gov.cdc.usds.simplereport.db.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 @Entity
 public class TextMessageSent extends AuditedEntity {
-  @ManyToOne
+  @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "patient_link_internal_id")
   private PatientLink patientLink;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TextMessageStatus.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TextMessageStatus.java
@@ -2,12 +2,13 @@ package gov.cdc.usds.simplereport.db.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 @Entity
 public class TextMessageStatus extends AuditedEntity {
-  @ManyToOne
+  @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "text_message_sent_internal_id")
   private TextMessageSent textMessageSent;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusServiceTest.java
@@ -18,9 +18,7 @@ import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class TextMessageStatusServiceTest extends BaseServiceTest<TextMessageStatusService> {
 
   @Autowired TextMessageStatusService _service;


### PR DESCRIPTION
## Related Issue or Background Info

- One step closer to fixing https://github.com/CDCgov/prime-simplereport/issues/2374 

## Changes Proposed

- add optional and fetchType lazy flad to `TextMessageStatus` and TextMessageStent

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
