### PR TITLE
Clarify org vs individual work email for sign up

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -118,10 +118,10 @@ const PersonalDetailsForm = ({
   }
 
   const getFormElement = (
-    field: keyof IdentityVerificationRequest,
+    field: keyof IdentityVerificationRequest | `preheader${"1" | "2"}`,
     label: string,
     required: boolean,
-    preheader: string | null
+    hintText: string
   ) => {
     switch (field) {
       case "state":
@@ -164,10 +164,12 @@ const PersonalDetailsForm = ({
             required
           />
         );
+      case "preheader1":
+      case "preheader2":
+        return <p className="font-ui-sm text-bold margin-bottom-1">{label}</p>;
       default:
         return (
           <Input
-            className={preheader ? "margin-top-0" : ""}
             label={label}
             type={"text"}
             field={field}
@@ -178,6 +180,7 @@ const PersonalDetailsForm = ({
             validate={validateField}
             getValidationStatus={getValidationStatus}
             required={required}
+            hintText={hintText}
           />
         );
     }
@@ -211,7 +214,7 @@ const PersonalDetailsForm = ({
             >
               Experian
             </a>
-            . SimpleReport doesn’t access identity verification details.
+            . SimpleReport doesn’t access or keep identity verification details.
           </p>
           <p className="font-ui-2sm margin-bottom-0">
             Why we verify your identity
@@ -222,16 +225,11 @@ const PersonalDetailsForm = ({
           </p>
           <h3>{getPersonFullName()}</h3>
           {Object.entries(personalDetailsFields).map(
-            ([key, { label, required, preheader }]) => {
+            ([key, { label, required, hintText }]) => {
               const field = key as keyof IdentityVerificationRequest;
               return (
                 <div key={field}>
-                  {preheader && (
-                    <p className="font-ui-sm text-bold margin-bottom-1">
-                      {preheader}
-                    </p>
-                  )}
-                  {getFormElement(field, label, required, preheader)}
+                  {getFormElement(field, label, required, hintText)}
                 </div>
               );
             }

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -203,8 +203,8 @@ const PersonalDetailsForm = ({
           noLabels={true}
           segmentIndicatorOnBottom={true}
         />
-        <div className="margin-bottom-2">
-          <p className="font-ui-2xs text-base">
+        <div className="margin-bottom-2 organization-form">
+          <p className="margin-top-neg-2">
             To create your account, we’ll need information to verify your
             identity directly with{" "}
             <a
@@ -216,7 +216,7 @@ const PersonalDetailsForm = ({
             </a>
             . SimpleReport doesn’t access or keep identity verification details.
           </p>
-          <p className="font-ui-2sm margin-bottom-0">
+          <p className="font-ui-md margin-bottom-0">
             Why we verify your identity
           </p>
           <p className="font-ui-2xs text-base margin-top-1">

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -59,22 +59,24 @@ export const answersToArray = (answers: Answers): number[] =>
     .map((key) => parseInt(answers[key]));
 
 export const personalDetailsFields = [
-  ["dateOfBirth", "Date of birth", true, null],
-  ["email", "Email", true, "Personal contact information"],
-  ["phoneNumber", "Phone number", true, null],
-  ["streetAddress1", "Street address 1", true, "Home address"],
-  ["streetAddress2", "Street address 2", false, null],
-  ["city", "City", true, null],
-  ["state", "State", true, null],
-  ["zip", "ZIP code", true, null],
+  ["dateOfBirth", "Date of birth", true, ""],
+  ["preheader1", "Personal contact information", false, ""],
+  ["email", "Email", true, "Enter your non-work email address."],
+  ["phoneNumber", "Phone number", true, "Enter your non-work phone number."],
+  ["preheader2", "Home address", false, ""],
+  ["streetAddress1", "Street address 1", true, ""],
+  ["streetAddress2", "Street address 2", false, ""],
+  ["city", "City", true, ""],
+  ["state", "State", true, ""],
+  ["zip", "ZIP code", true, ""],
 ].reduce((fields, field) => {
   fields[field[0] as keyof IdentityVerificationRequest] = {
     label: field[1] as string,
     required: field[2] as boolean,
-    preheader: field[3] as string | null,
+    hintText: field[3] as string,
   };
   return fields;
-}, {} as { [key: string]: { label: string; required: boolean; preheader: string | null } });
+}, {} as { [key: string]: { label: string; required: boolean; hintText: string } });
 
 export const initPersonalDetails = (
   orgExternalId: string,

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -224,7 +224,7 @@ const OrganizationForm = () => {
             noLabels={true}
             segmentIndicatorOnBottom={true}
           />
-          <p className="usa-hint">
+          <p className="margin-top-neg-2 margin-bottom-4">
             Learn more about our{" "}
             <a href="https://simplereport.gov/getting-started/organizations-and-testing-facilities/onboard-your-organization/">
               sign up and identity verification process

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -134,7 +134,8 @@ const OrganizationForm = () => {
   const getFormElement = (
     field: keyof OrganizationCreateRequest,
     label: string | React.ReactNode,
-    required: boolean
+    required: boolean,
+    hintText: string
   ) => {
     switch (field) {
       case "state":
@@ -187,7 +188,9 @@ const OrganizationForm = () => {
               </label>
               <p className="usa-hint">
                 Only one person from an organization can be the administrator.
-                This person will submit information for identity verification.
+                This person will submit personal information for identity
+                verification. (SimpleReport doesn't access or keep personal
+                identity information.)
               </p>
             </>
           );
@@ -204,6 +207,7 @@ const OrganizationForm = () => {
             validate={validateField}
             getValidationStatus={getValidationStatus}
             required={required}
+            hintText={hintText}
           />
         );
     }
@@ -220,14 +224,23 @@ const OrganizationForm = () => {
             noLabels={true}
             segmentIndicatorOnBottom={true}
           />
+          <p className="usa-hint">
+            Learn more about our{" "}
+            <a href="https://simplereport.gov/getting-started/organizations-and-testing-facilities/onboard-your-organization/">
+              sign up and identity verification process
+            </a>
+            .
+          </p>
           {backendError ? backendError : null}
           {/* By mapping over organizationFields (found in utils.tsx), we reduce */}
           {/* duplication of input fields in JSX */}
           {Object.entries(organizationFields).map(
-            ([key, { label, required }]) => {
+            ([key, { label, required, hintText }]) => {
               const field = key as keyof OrganizationCreateRequest;
               return (
-                <div key={field}>{getFormElement(field, label, required)}</div>
+                <div key={field}>
+                  {getFormElement(field, label, required, hintText)}
+                </div>
               );
             }
           )}

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -46,22 +46,29 @@ export const organizationFields = [
       />
     </span>,
     true,
+    "",
   ],
-  ["state", "Organization state", true],
-  ["type", "Organization type", true],
-  ["banner", "Organization administrator", false],
-  ["firstName", "First name", true],
-  ["middleName", "Middle name", false],
-  ["lastName", "Last name", true],
-  ["email", "Work email", true],
-  ["workPhoneNumber", "Work phone number", true],
+  ["state", "Organization state", true, ""],
+  ["type", "Organization type", true, ""],
+  ["banner", "Organization administrator", false, ""],
+  ["firstName", "First name", true, ""],
+  ["middleName", "Middle name", false, ""],
+  ["lastName", "Last name", true, ""],
+  ["email", "Work email", true, "Enter your individual work email address."],
+  [
+    "workPhoneNumber",
+    "Work phone number",
+    true,
+    "Enter your direct work phone number.",
+  ],
 ].reduce((fields, field) => {
   fields[field[0] as keyof OrganizationCreateRequest] = {
     label: field[1] as string | React.ReactNode,
     required: field[2] as boolean,
+    hintText: field[3] as string,
   };
   return fields;
-}, {} as { [key: string]: { label: string | React.ReactNode; required: boolean } });
+}, {} as { [key: string]: { label: string | React.ReactNode; required: boolean; hintText: string } });
 
 export const initOrg = (): OrganizationCreateRequest => ({
   name: "",


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2379 
- Resolves #2387 

## Changes Proposed
**OrganizationForm changes**:

1. Add intro copy under "Sign up for SimpleReport" header: "Learn more about our [sign up and identity verification process](https://simplereport.gov/getting-started/organizations-and-testing-facilities/onboard-your-organization/)."
2. Modify helper text under “Organization administrator”:
“Only one person from an organization can be the administrator. This person will submit personal information for identity verification. (SimpleReport doesn't access or keep personal identity information.)”
3. Add helper text under “Work email”: "Enter your individual work email address."
4. Add helper text under “Work phone number”: "Enter your direct work phone number."

**PersonalDetailForm changes**:

1. Change line 2 of intro paragraph from "SimpleReport doesn’t access identity verification details." TO "SimpleReport doesn’t access or keep identity verification details."
2.Add helper text under “Email”: "Enter your non-work email address."
3. Add helper text under “Phone number”: "Enter your non-work phone number."
## Additional Information

- Changed the `xxxFields` objects in utils to include a `hintText`

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/9121162/131550203-4a0acf81-0f5e-4152-8e5c-d2a4f298a477.png)
![image](https://user-images.githubusercontent.com/9121162/131550219-55e17400-432c-4546-8f23-0d72bebdd948.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
