### PR TITLE
better experian street address 2 error message

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -136,7 +136,7 @@ describe("PersonalDetailsForm", () => {
       });
       it("shows an error", () => {
         expect(
-          screen.getByText("A valid street address 2 is required")
+          screen.getByText("Street 2 contains invalid symbols")
         ).toBeInTheDocument();
       });
     });

--- a/frontend/src/app/signUp/IdentityVerification/utils.ts
+++ b/frontend/src/app/signUp/IdentityVerification/utils.ts
@@ -155,7 +155,7 @@ export const personalDetailsSchema: yup.SchemaOf<IdentityVerificationRequest> = 
       .nullable()
       .notRequired()
       .matches(experianStreetRegex, {
-        message: "A valid street address 2 is required",
+        message: "Street 2 contains invalid symbols",
         excludeEmptyString: true,
       }),
     city: yup.string().required("City is required"),


### PR DESCRIPTION
## Related Issue or Background Info

- related to #2383
- changes error message per feedback from @Rebecca-LM 

## Changes Proposed

- change street address 2 error message to `Street 2 contains invalid symbols`

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
