### PR TITLE
Tweak TF PagerDuty config to match console

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -16,7 +16,7 @@ module "metric_alerts" {
   ]
 
   action_group_ids = [
-    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+    data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
 
 }

--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -21,7 +21,7 @@ module "metric_alerts" {
   ]
 
   action_group_ids = [
-    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+    data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
 
 }

--- a/ops/global/_output.tf
+++ b/ops/global/_output.tf
@@ -11,8 +11,8 @@ output "acr_simeplereport_admin_password" {
   sensitive = true
 }
 
-output "pagerduty_demo_action_id" {
-  value = module.pagerduty_demo.monitor_group_id
+output "pagerduty_non_prod_action_id" {
+  value = module.pagerduty_non_prod.monitor_group_id
 }
 
 output "pagerduty_prod_action_id" {

--- a/ops/global/main.tf
+++ b/ops/global/main.tf
@@ -49,10 +49,10 @@ module "insights" {
   tags          = local.management_tags
 }
 
-module "pagerduty_demo" {
+module "pagerduty_non_prod" {
   source                  = "../services/pagerduty"
   resource_group_name     = data.azurerm_resource_group.rg.name
-  pagerduty_service_name  = "SimpleReport - Demo"
+  pagerduty_service_name  = "SimpleReport - Non-Prod"
   action_group_short_name = "SR-NonProd"
 }
 

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -21,7 +21,7 @@ module "metric_alerts" {
   ]
 
   action_group_ids = [
-    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+    data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
 
 

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -16,6 +16,6 @@ module "metric_alerts" {
   ]
 
   action_group_ids = [
-    data.terraform_remote_state.global.outputs.pagerduty_demo_action_id
+    data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
 }


### PR DESCRIPTION
## Related Issue or Background Info

#1964 

We want TF config to be the source of truth for our infrastructure, and the existing state doesn't match up with what's in the console.

## Changes Proposed

* Rename `demo` to `non_prod` in PagerDuty-related TF config

## Additional Information

- This changes an output variable name, so this will break without a manual deploy of `global` _before_ merging.