### PR TITLE
Make updates to manage users page

### DIFF
--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -260,7 +260,7 @@ describe("ManageUsers", () => {
       expect(getByLabelText("user", { exact: false })).toHaveAttribute(
         "disabled"
       );
-      expect(getByLabelText("Entry only", { exact: false })).toHaveAttribute(
+      expect(getByLabelText("Testing only", { exact: false })).toHaveAttribute(
         "disabled"
       );
       expect(container).toMatchSnapshot();

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -101,8 +101,10 @@ const UserDetail: React.FC<Props> = ({
       </div>
       <div className="user-content">
         <p className="text-base">
-          Admins have full access to conduct tests, manage results and profiles,
-          and manage settings and users
+          Admins have full access to SimpleReport. They can conduct tests,
+          manage test results and patient profiles, and also manage account
+          settings, users, and testing facilities. Standard and testing only
+          users have limited access for specific tasks, as described below.
         </p>
         <UserRoleSettingsForm
           activeUser={user}

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -100,7 +100,7 @@ const UserDetail: React.FC<Props> = ({
         ) : null}
       </div>
       <div className="user-content">
-        <h3 className="margin-bottom-0">User roles</h3>
+        <h3 className="margin-bottom-0 padding-top-1">User roles</h3>
         <p className="text-base">
           Admins have full access to SimpleReport. They can conduct tests,
           manage test results and patient profiles, and also manage account

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -100,6 +100,8 @@ const UserDetail: React.FC<Props> = ({
         ) : null}
       </div>
       <div className="user-content">
+      <h3 className="margin-bottom-0">User Roles
+      </h3>
         <p className="text-base">
           Admins have full access to SimpleReport. They can conduct tests,
           manage test results and patient profiles, and also manage account

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -100,8 +100,7 @@ const UserDetail: React.FC<Props> = ({
         ) : null}
       </div>
       <div className="user-content">
-      <h3 className="margin-bottom-0">User Roles
-      </h3>
+        <h3 className="margin-bottom-0">User roles</h3>
         <p className="text-base">
           Admins have full access to SimpleReport. They can conduct tests,
           manage test results and patient profiles, and also manage account

--- a/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
@@ -18,7 +18,8 @@ const ROLES: RoleButton[] = [
   },
   {
     value: "USER",
-    label: "Standard user (manage test results and patient profiles)",
+    label:
+      "Standard user (conduct tests, manage test results and patient profiles)",
   },
   {
     value: "ENTRY_ONLY",

--- a/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
@@ -14,11 +14,11 @@ interface RoleButton {
 const ROLES: RoleButton[] = [
   {
     value: "ADMIN",
-    label: "Admin (full permissions)",
+    label: "Admin (full access)",
   },
   {
     value: "USER",
-    label: "Standard user (manage results and profiles)",
+    label: "Standard user (manage test results and patient profiles)",
   },
   {
     value: "ENTRY_ONLY",

--- a/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
@@ -22,7 +22,7 @@ const ROLES: RoleButton[] = [
   },
   {
     value: "ENTRY_ONLY",
-    label: "Entry only (conduct tests)",
+    label: "Testing only (conduct tests)",
   },
 ];
 

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -48,12 +48,21 @@ const UsersSideNav: React.FC<Props> = ({
                     user.middleName,
                     user.lastName
                   )}
-                  {user.status !== "ACTIVE" && (
+                  {user.status === "SUSPENDED" && (
                     <span>
                       {" "}
                       <FontAwesomeIcon
                         icon={faCircle}
                         className={"prime-red-icon suspended-icon"}
+                      />
+                    </span>
+                  )}
+                  {user.status === "PROVISIONED" && (
+                    <span>
+                      {" "}
+                      <FontAwesomeIcon
+                        icon={faCircle}
+                        className={"prime-orange-icon suspended-icon"}
                       />
                     </span>
                   )}

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
             class="user-content"
           >
             <h3
-              class="margin-bottom-0"
+              class="margin-bottom-0 padding-top-1"
             >
               User roles
             </h3>
@@ -144,7 +144,7 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
                       class="usa-radio__label text-base"
                       for="4-val-ADMIN"
                     >
-                      Admin (full permissions)
+                      Admin (full access)
                     </label>
                   </div>
                   <div
@@ -164,7 +164,7 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
                       class="usa-radio__label text-base"
                       for="4-val-USER"
                     >
-                      Standard user (manage results and profiles)
+                      Standard user (manage test results and patient profiles)
                     </label>
                   </div>
                   <div
@@ -444,7 +444,7 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
             class="user-content"
           >
             <h3
-              class="margin-bottom-0"
+              class="margin-bottom-0 padding-top-1"
             >
               User roles
             </h3>
@@ -482,7 +482,7 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
                       class="usa-radio__label"
                       for="1-val-ADMIN"
                     >
-                      Admin (full permissions)
+                      Admin (full access)
                     </label>
                   </div>
                   <div
@@ -501,7 +501,7 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
                       class="usa-radio__label"
                       for="1-val-USER"
                     >
-                      Standard user (manage results and profiles)
+                      Standard user (manage test results and patient profiles)
                     </label>
                   </div>
                   <div

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
                       class="usa-radio__label text-base"
                       for="4-val-USER"
                     >
-                      Standard user (manage test results and patient profiles)
+                      Standard user (conduct tests, manage test results and patient profiles)
                     </label>
                   </div>
                   <div
@@ -501,7 +501,7 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
                       class="usa-radio__label"
                       for="1-val-USER"
                     >
-                      Standard user (manage test results and patient profiles)
+                      Standard user (conduct tests, manage test results and patient profiles)
                     </label>
                   </div>
                   <div

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
             <p
               class="text-base"
             >
-              Admins have full access to conduct tests, manage results and profiles, and manage settings and users
+              Admins have full access to SimpleReport. They can conduct tests, manage test results and patient profiles, and also manage account settings, users, and testing facilities. Standard and testing only users have limited access for specific tasks, as described below.
             </p>
             <div
               class="usa-form-group"
@@ -178,7 +178,7 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
                       class="usa-radio__label text-base"
                       for="4-val-ENTRY_ONLY"
                     >
-                      Entry only (conduct tests)
+                      Testing only (conduct tests)
                     </label>
                   </div>
                 </div>
@@ -441,7 +441,7 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
             <p
               class="text-base"
             >
-              Admins have full access to conduct tests, manage results and profiles, and manage settings and users
+              Admins have full access to SimpleReport. They can conduct tests, manage test results and patient profiles, and also manage account settings, users, and testing facilities. Standard and testing only users have limited access for specific tasks, as described below.
             </p>
             <div
               class="usa-form-group"
@@ -509,7 +509,7 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
                       class="usa-radio__label"
                       for="1-val-ENTRY_ONLY"
                     >
-                      Entry only (conduct tests)
+                      Testing only (conduct tests)
                     </label>
                   </div>
                 </div>

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -104,6 +104,11 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
           <div
             class="user-content"
           >
+            <h3
+              class="margin-bottom-0"
+            >
+              User roles
+            </h3>
             <p
               class="text-base"
             >
@@ -438,6 +443,11 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
           <div
             class="user-content"
           >
+            <h3
+              class="margin-bottom-0"
+            >
+              User roles
+            </h3>
             <p
               class="text-base"
             >

--- a/frontend/src/app/__snapshots__/App.test.tsx.snap
+++ b/frontend/src/app/__snapshots__/App.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`App Render main screen 1`] = `
                       <strong>
                         Role: 
                       </strong>
-                      Admin user
+                      Admin
                     </span>
                   </li>
                   <li
@@ -355,7 +355,7 @@ exports[`App Render main screen 1`] = `
                         <strong>
                           Role: 
                         </strong>
-                        Admin user
+                        Admin
                       </span>
                     </li>
                     <li

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -9,7 +9,7 @@ import {
 } from "@microsoft/applicationinsights-react-js";
 
 import { PATIENT_TERM_PLURAL_CAP } from "../../config/constants";
-import { formatFullName } from "../utils/user";
+import { formatFullName, formatRole } from "../utils/user";
 import siteLogo from "../../img/simplereport-logo-color.svg";
 import { hasPermission, appPermissions } from "../permissions";
 import { RootState } from "../store";
@@ -205,7 +205,7 @@ const Header: React.FC<{}> = () => {
                 <li className="usa-sidenav__item">
                   <span>
                     <strong>Role: </strong>
-                    {user.roleDescription}
+                    {formatRole(user.roleDescription)}
                   </span>
                 </li>
                 <li className="usa-sidenav__item">{facility.name}</li>
@@ -337,7 +337,7 @@ const Header: React.FC<{}> = () => {
                   <li className="usa-sidenav__item">
                     <span>
                       <strong>Role: </strong>
-                      {user.roleDescription}
+                      {formatRole(user.roleDescription)}
                     </span>
                   </li>
                   <li className="usa-sidenav__item">{facility.name}</li>

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -18,7 +18,7 @@ const store = mockStore({
   user: {
     firstName: "Kim",
     lastName: "Mendoza",
-    roleDescription: "Standard user"
+    roleDescription: "Standard user",
   },
   facilities: [
     { id: "1", name: "Facility 1" },

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -18,6 +18,7 @@ const store = mockStore({
   user: {
     firstName: "Kim",
     lastName: "Mendoza",
+    roleDescription: "Standard user"
   },
   facilities: [
     { id: "1", name: "Facility 1" },

--- a/frontend/src/app/utils/user.ts
+++ b/frontend/src/app/utils/user.ts
@@ -15,3 +15,16 @@ export const formatFullName = <T extends RequiredUserFields>(user: T) => {
   result += user.suffix ? `, ${user.suffix}` : "";
   return result;
 };
+
+export const formatRole = (role: String) => {
+  let result = "";
+  role = role.toLowerCase();
+  if (role.includes("admin")) {
+    result = "Admin";
+  } else if (role.includes("standard")) {
+    result = "Standard user";
+  } else {
+    result = "Testing only";
+  }
+  return result;
+};

--- a/frontend/src/app/utils/user.ts
+++ b/frontend/src/app/utils/user.ts
@@ -16,7 +16,7 @@ export const formatFullName = <T extends RequiredUserFields>(user: T) => {
   return result;
 };
 
-export const formatRole = (role: String) => {
+export const formatRole = (role: string) => {
   let result = "";
   role = role.toLowerCase();
   if (role.includes("admin")) {

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -328,6 +328,10 @@
   color: color($theme-color-secondary);
 }
 
+.prime-orange-icon {
+  color: orange;
+}
+
 // General group of related items on a form
 .sr-section {
   border: 1px solid #ccc;


### PR DESCRIPTION
## Related Issue or Background Info

- Partially fixes #2433 

## Changes Proposed

- change the icon to orange if a user's account is pending setup (was previously red)
- change "entry only" to "testing only" across the app
- updated the description of roles in the manage users page

## Additional Information

- haven't moved the emails from the sidebar yet because we don't have a clear place for them in the detail view. Will do that once we have a plan for the account management section

## Screenshots / Demos
![Screen Shot 2021-08-31 at 3 04 07 PM](https://user-images.githubusercontent.com/80282552/131582089-a8c84c74-a131-4570-8557-9f0f642a118a.png)
![Screen Shot 2021-08-31 at 3 04 12 PM](https://user-images.githubusercontent.com/80282552/131582102-8c25afc1-7faa-452a-9041-22f93c9efb47.png)

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify