### PR TITLE
Remove FetchType.LAZY hint on Facility.orderingProvider

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -31,7 +31,7 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
 
   @Column private String cliaNumber;
 
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  @ManyToOne(optional = false)
   @JoinColumn(name = "ordering_provider_id", nullable = false)
   private Provider orderingProvider;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiSmokeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiSmokeTest.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiSmokeTest extends BaseGraphqlTest {
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
@@ -10,7 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class DeviceManagementTest extends BaseGraphqlTest {
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class OrganizationFacilityTest extends BaseGraphqlTest {
 
   @Autowired private DeviceTypeService _deviceService;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientUploadTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientUploadTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class PatientUploadTest extends BaseGraphqlTest {
   public static final int PATIENT_PAGEOFFSET = 0;
   public static final int PATIENT_PAGESIZE = 1000;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -21,7 +21,9 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Autowired ApiUserRepository _apiUserRepo;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -23,7 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @WithMockUser(
     username = TestUserIdentities.SITE_ADMIN_USER,
     authorities = {Role.SITE_ADMIN, Role.DEFAULT_ORG_ADMIN})


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2460

## Changes Proposed

- Remove the FetchType.LAZY hint on Facility.orderingProvider

## Additional Information

- This will certainly lead to some N+1 queries, but when I add `Hibernate.initialize` in what I expected to be the appropriate place in the `TestEvent` constructor, it produces a SerializationException `could not serialize: Provider`.
- This isn't caught by the DataHubUploadService.serialize test because this issue occurs when the TestEvent is created, _not_ at time of serialization for upload.
- There are thousands of TestEvents in prod with null `provider_data` fields

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
