### PR TITLE
Test for missing provider in RS upload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -30,7 +30,7 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
 
   @Column private String cliaNumber;
 
-  @ManyToOne(optional = false)
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "ordering_provider_id", nullable = false)
   private Provider orderingProvider;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -30,7 +30,7 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
 
   @Column private String cliaNumber;
 
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  @ManyToOne(optional = false)
   @JoinColumn(name = "ordering_provider_id", nullable = false)
   private Provider orderingProvider;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -1,8 +1,7 @@
 package gov.cdc.usds.simplereport.api.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
@@ -19,6 +18,7 @@ import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
@@ -36,6 +36,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
   @Autowired private TestEventService _testEventService;
   @Autowired private OrganizationService _orgService;
   @MockBean private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   TestEventExport testEventExport;
 
@@ -45,6 +46,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
     Facility facility = _orgService.getFacilities(organization).get(0);
     Person patient = _dataFactory.createFullPerson(organization);
     _dataFactory.createTestOrder(patient, facility);
+    // create testEvent via the API to test the view layer hibernate session
     ObjectNode variables =
         JsonNodeFactory.instance
             .objectNode()
@@ -53,13 +55,101 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             .put("result", TestResult.NEGATIVE.toString())
             .put("dateTested", "2021-09-01T10:31:30.001Z");
     submitTestResult(variables, Optional.empty());
+    // getting the testEvent can be improve to use the same context as used by the uploader
     TestEvent testEvent = _testEventService.getLastTestResultsForPatient(patient);
     testEventExport = new TestEventExport(testEvent);
   }
 
   @Test
   void testEventSerialization() throws Exception {
-    assertEquals("Fred", testEventExport.getOrderingProviderFirstName());
+    JSONAssert.assertEquals(
+        "{"
+            + "\"Patient_last_name\":\"Astaire\","
+            + "\"Patient_first_name\":\"Fred\","
+            + "\"Patient_middle_name\":null,"
+            + "\"Patient_suffix\":null,"
+            + "\"Patient_race\":\"2106-3\","
+            + "\"Patient_DOB\":\"18990510\","
+            + "\"Patient_gender\":\"M\","
+            + "\"Patient_ethnicity\":\"N\","
+            + "\"Patient_street\":\"736 Jackson PI NW\","
+            + "\"Patient_street_2\":\"\","
+            + "\"Patient_city\":\"Washington\","
+            + "\"Patient_county\":\"Washington\","
+            + "\"Patient_state\":\"DC\","
+            + "\"Patient_zip_code\":\"20503\","
+            + "\"Patient_phone_number\":\"202-123-4567\","
+            + "\"Patient_email\":null,"
+            + "\"Patient_ID\":"
+            + testEventExport.getPatientId()
+            + ","
+            + "\"Patient_role\":\"RESIDENT\","
+            + "\"Patient_tribal_affiliation\":\"\","
+            + "\"Patient_preferred_language\":\"English\","
+            + "\"Employed_in_healthcare\":\"N\","
+            + "\"Resident_congregate_setting\":\"N\","
+            + "\"Result_ID\":"
+            + testEventExport.getResultID()
+            + ","
+            + "\"Corrected_result_ID\":\"\","
+            + "\"Test_result_status\":\"F\","
+            + "\"Test_result_code\":\"260415000\","
+            + "\"Specimen_collection_date_time\":\""
+            + testEventExport.getSpecimenCollectionDateTime()
+            + "\","
+            + "\"Ordering_provider_ID\":\"PEBBLES\","
+            + "\"First_test\":\"UNK\","
+            + "\"Symptomatic_for_disease\":\"UNK\","
+            + "\"Illness_onset_date\":\"\","
+            + "\"Testing_lab_name\":\"Injection Site\","
+            + "\"Testing_lab_CLIA\":\"000111222-3\","
+            + "\"Testing_lab_state\":null,"
+            + "\"Testing_lab_street\":\"2797 N Cerrada de Beto\","
+            + "\"Testing_lab_street_2\":\"\","
+            + "\"Testing_lab_zip_code\":null,"
+            + "\"Testing_lab_county\":null,"
+            + "\"Testing_lab_phone_number\":null,"
+            + "\"Testing_lab_city\":null,"
+            + "\"Processing_mode_code\":\"P\","
+            + "\"Ordering_facility_city\":null,"
+            + "\"Ordering_facility_county\":null,"
+            + "\"Ordering_facility_name\":\"Injection Site\","
+            + "\"Organization_name\":\"Dis Organization\","
+            + "\"Ordering_facility_phone_number\":null,"
+            + "\"Ordering_facility_email\":null,"
+            + "\"Ordering_facility_state\":null,"
+            + "\"Ordering_facility_street\":\"2797 N Cerrada de Beto\","
+            + "\"Ordering_facility_street_2\":\"\","
+            + "\"Ordering_facility_zip_code\":null,"
+            + "\"Ordering_provider_last_name\":\"Flintstone\","
+            + "\"Ordering_provider_first_name\":\"Fred\","
+            + "\"Ordering_provider_street\":\"123 Main Street\","
+            + "\"Ordering_provider_street_2\":\"\","
+            + "\"Ordering_provider_city\":\"Oz\","
+            + "\"Ordering_provider_state\":\"KS\","
+            + "\"Ordering_provider_zip_code\":null,"
+            + "\"Ordering_provider_county\":null,"
+            + "\"Ordering_provider_phone_number\":\"(202) 555-1212\","
+            + "\"Ordered_test_code\":\"54321-BOOM\","
+            + "\"Specimen_source_site_code\":\"986543321\","
+            + "\"Specimen_type_code\":\"000111222\","
+            + "\"Instrument_ID\":"
+            + testEventExport.getInstrumentID()
+            + ","
+            + "\"Device_ID\":\"SFN\","
+            + "\"Test_date\":\""
+            + testEventExport.getTestDate()
+            + "\","
+            + "\"Date_result_released\":\""
+            + testEventExport.getDateResultReleased()
+            + "\","
+            + "\"Order_test_date\":\""
+            + testEventExport.getOrderTestDate()
+            + "\","
+            + "\"Site_of_care\":\"university\""
+            + "}",
+        objectMapper.writeValueAsString(testEventExport),
+        false);
   }
 
   private JsonNode submitTestResult(ObjectNode variables, Optional<String> expectedError) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
+import gov.cdc.usds.simplereport.api.graphql.BaseGraphqlTest;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.service.OrganizationService;
+import gov.cdc.usds.simplereport.service.TestEventService;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+// added enable_lazy_load_no_trans=true because I couldn't figure out how to make the hibernate
+// session work within a test that also tests our API
+@TestPropertySource(
+    properties = {
+      "hibernate.query.interceptor.error-level=ERROR",
+      "spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true"
+    })
+@WithSimpleReportStandardUser
+class TestEventExportIntegrationTest extends BaseGraphqlTest {
+  @Autowired protected TestDataFactory _dataFactory;
+  @Autowired private TestEventService _testEventService;
+  @Autowired private OrganizationService _orgService;
+  @MockBean private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
+
+  TestEventExport testEventExport;
+
+  @BeforeEach
+  void initData() {
+    Organization organization = _orgService.getCurrentOrganizationNoCache();
+    Facility facility = _orgService.getFacilities(organization).get(0);
+    Person patient = _dataFactory.createFullPerson(organization);
+    _dataFactory.createTestOrder(patient, facility);
+    ObjectNode variables =
+        JsonNodeFactory.instance
+            .objectNode()
+            .put("deviceId", _dataFactory.getGenericDevice().getInternalId().toString())
+            .put("patientId", patient.getInternalId().toString())
+            .put("result", TestResult.NEGATIVE.toString())
+            .put("dateTested", "2021-09-01T10:31:30.001Z");
+    submitTestResult(variables, Optional.empty());
+    TestEvent testEvent = _testEventService.getLastTestResultsForPatient(patient);
+    testEventExport = new TestEventExport(testEvent);
+  }
+
+  @Test
+  void testEventSerialization() throws Exception {
+    assertEquals("Fred", testEventExport.getOrderingProviderFirstName());
+  }
+
+  private JsonNode submitTestResult(ObjectNode variables, Optional<String> expectedError) {
+    return runQuery("add-test-result-mutation", variables, expectedError.orElse(null));
+  }
+}


### PR DESCRIPTION
## Related Issue or Background Info
Test for this regression https://github.com/CDCgov/prime-simplereport/issues/2460

Regression was fixed in https://github.com/CDCgov/prime-simplereport/pull/2461

## Changes Proposed

- add a test to test the serialization of JSONB fields in the graphql context

## Additional Information

- getting the TestEvent for the test can be improved. Ideally this would mirror the uploader. I don't think it is currently worth the time modeling that until the queue based upload is implemented. This will hopefully remove the need for enable_lazy_load_no_trans
-   https://github.com/CDCgov/prime-simplereport/commit/2fb5bec827c2acb17379f2e6d6bfe794c5dcf6a1 illustrates the failing test, https://github.com/CDCgov/prime-simplereport/commit/166d2a44dc14cdd9ff18e1196f00ba698df0ab97 proves the hotfix works, and https://github.com/CDCgov/prime-simplereport/pull/2464/commits/d93d6c329edca0d074ffe9f98a00030a2b1a8f89 captures the entire upload as is

## Screenshots / Demos

## Checklist for Author and Reviewer
- [ ] test pass

### UI
- [n/a] Any changes to the UI/UX are approved by design 
- [n/a] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [n/a] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

## Cloud
- [n/a] DevOps team has been notified if PR requires ops support
- [n/a] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
