### PR TITLE
Update OrganizationService.getFacilityInCurrentOrg to use cached values

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -168,9 +168,12 @@ public class OrganizationService {
   }
 
   public Facility getFacilityInCurrentOrg(UUID facilityId) {
-    Organization org = getCurrentOrganization();
-    return _facilityRepo
-        .findByOrganizationAndInternalId(org, facilityId)
+    return getCurrentOrganizationRoles()
+        .orElseThrow(MisconfiguredUserException::new)
+        .getFacilities()
+        .stream()
+        .filter(f -> f.getInternalId().equals(facilityId))
+        .findAny()
         .orElseThrow(() -> new IllegalGraphqlArgumentException("facility could not be found"));
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

- `OrganizationService.getFacilityInCurrentOrg` makes a discrete database query for values that are already cached in the request context

## Changes Proposed

- Rewrite this method to use the cache via `getCurrentOrganizationRoles()`

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
