### PR TITLE
Make sure duplicate org check is case insensitive

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -18,6 +18,7 @@ public interface OrganizationRepository extends EternalAuditedEntityRepository<O
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.identityVerified = :identityVerified")
   List<Organization> findAllByIdentityVerified(boolean identityVerified);
 
-  @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.organizationName = :name")
+  @Query(
+      EternalAuditedEntityRepository.BASE_QUERY + " and UPPER(e.organizationName) = UPPER(:name)")
   Optional<Organization> findByName(String name);
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -205,7 +205,7 @@ class AccountRequestControllerTest extends BaseFullStackTest {
 
   @Test
   @DisplayName("Duplicate org in same state with different letter casing fails")
-  void duplicateOrgInSameState() throws Exception {
+  void duplicateOrgInSameStateDifferentCasing() throws Exception {
     // given
     String originalRequestBody =
         createAccountRequest(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -204,6 +204,54 @@ class AccountRequestControllerTest extends BaseFullStackTest {
   }
 
   @Test
+  @DisplayName("Duplicate org in same state with different letter casing fails")
+  void duplicateOrgInSameState() throws Exception {
+    // given
+    String originalRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder originalBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(originalRequestBody);
+    this._mockMvc.perform(originalBuilder).andExpect(status().isOk());
+
+    // when
+    String duplicateRequestBody =
+        createAccountRequest(
+            "CENTRAL SCHOOLS",
+            "AZ",
+            "k12",
+            "Susie",
+            "",
+            "Smith",
+            "susie@example.com",
+            "760-858-9900");
+
+    MockHttpServletRequestBuilder duplicateBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(duplicateRequestBody);
+
+    // then
+    MvcResult result = this._mockMvc.perform(duplicateBuilder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains("This organization has already registered with SimpleReport.");
+  }
+
+  @Test
   @DisplayName("Duplicate org in different state succeeds but state is appended to name")
   void duplicateOrgInDifferentState() throws Exception {
     // given


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves issue noted [in this Slack thread](https://skylight-hq.slack.com/archives/C01T5NC1WMN/p1630529173015600) where it is possible to create duplicate orgs with different letter casing

## Changes Proposed

- Make org lookup method in repo case insensitive

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
