### PR TITLE
Update validation to allow z clia for WA

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
+++ b/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
@@ -134,6 +134,7 @@ const FacilityInformation: React.FC<Props> = ({
         onChange={onChange}
         onBlur={() => {
           validateField("state");
+          validateField("cliaNumber");
         }}
         validationStatus={errors.state ? "error" : undefined}
         errorMessage={errors.state}

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -87,7 +87,7 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
           return false;
         }
 
-        return isValidCLIANumber(input);
+        return isValidCLIANumber(input, facility.parent.state);
       }
     ),
   street: yup.string().required("Facility street is missing"),

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -246,7 +246,7 @@ describe("FacilityForm", () => {
         });
 
         fireEvent.change(cliaInput, {
-          target: { value: "invalid-clia-number" },
+          target: { value: "12Z3456789" },
         });
         fireEvent.blur(cliaInput);
 
@@ -293,6 +293,47 @@ describe("FacilityForm", () => {
         });
         fireEvent.change(cliaInput, {
           target: { value: "invalid-clia-number" },
+        });
+        fireEvent.blur(cliaInput);
+
+        const saveButton = await screen.getAllByText("Save changes")[0];
+        fireEvent.click(saveButton);
+        await validateAddress(saveFacility);
+        expect(saveFacility).toBeCalledTimes(1);
+      });
+    });
+
+    describe("allows fake Z-CLIAs for permitted states", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(clia, "stateRequiresCLIANumberValidation")
+          .mockReturnValue(true);
+      });
+
+      afterEach(() => {
+        jest.spyOn(clia, "stateRequiresCLIANumberValidation").mockRestore();
+      });
+
+      it("allows Z-CLIA for Washington state only", async () => {
+        const washingtonFacility: Facility = validFacility;
+        washingtonFacility.state = "WA";
+
+        render(
+          <MemoryRouter>
+            <FacilityForm
+              facility={washingtonFacility}
+              deviceOptions={devices}
+              saveFacility={saveFacility}
+            />
+          </MemoryRouter>
+        );
+
+        const cliaInput = screen.getByLabelText("CLIA number", {
+          exact: false,
+        });
+
+        fireEvent.change(cliaInput, {
+          target: { value: "12Z3456789" },
         });
         fireEvent.blur(cliaInput);
 

--- a/frontend/src/app/utils/clia.ts
+++ b/frontend/src/app/utils/clia.ts
@@ -6,8 +6,13 @@ export function stateRequiresCLIANumberValidation(
   return !noCLIAValidationStates.includes(state);
 }
 
-export function isValidCLIANumber(input: string): boolean {
-  const cliaNumberValidator = /^\d{2}D\d{7}$/;
+export function isValidCLIANumber(input: string, state: string): boolean {
+  let cliaNumberValidator;
+  if (state === "WA") {
+    cliaNumberValidator = /^\d{2}[D, Z]\d{7}$/;
+  } else {
+    cliaNumberValidator = /^\d{2}D\d{7}$/;
+  }
 
   return cliaNumberValidator.test(input);
 }

--- a/frontend/src/app/utils/clia.ts
+++ b/frontend/src/app/utils/clia.ts
@@ -9,7 +9,7 @@ export function stateRequiresCLIANumberValidation(
 export function isValidCLIANumber(input: string, state: string): boolean {
   let cliaNumberValidator;
   if (state === "WA") {
-    cliaNumberValidator = /^\d{2}[D, Z]\d{7}$/;
+    cliaNumberValidator = /^\d{2}[DZ]\d{7}$/;
   } else {
     cliaNumberValidator = /^\d{2}D\d{7}$/;
   }


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #2489 

## Changes Proposed

- add validation for Washington state to permit 11Z1111111 formatted CLIAs, instead of D-formatted CLIAs
- The special Z logic only kicks in once the state has been selected. 

## Additional Information

https://skylight-hq.slack.com/archives/C019PRYMR0Q/p1630617973049300

## Screenshots / Demos

![Settings _ SimpleReport](https://user-images.githubusercontent.com/80282552/132038724-1553ceeb-d8f8-4a12-ad74-24b9287d40e7.gif)


## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
