### PR TITLE
Add IncorrectResultSizeDataAccessException to AccountRequestController

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -27,6 +27,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -93,9 +94,17 @@ public class AccountRequestController {
       // informing them of the error.
       throw new BadRequestException(
           "This email address is already associated with a SimpleReport user.");
-    } catch (BadRequestException | UnexpectedRollbackException e) {
+    } catch (BadRequestException
+        | UnexpectedRollbackException
+        | IncorrectResultSizeDataAccessException e) {
       // The `BadRequestException` is thrown when an account is requested with an existing org
-      // name. This happens quite frequently and is expected behavior of the current form
+      // name. This happens quite frequently and is expected behavior of the current form.
+      // The UnexpectedRollback and IncorrectResultSizeDataAcccess exceptions are variations on the
+      // same issue.
+      // IncorrectResultSize happens with orgs that already have multiple duplicates in different
+      // cases.
+      // UnexpectedRollback is the catchall for attempting to write an org to the db that is already
+      // there.
       throw new BadRequestException("This organization has already registered with SimpleReport.");
     } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);


### PR DESCRIPTION
## Related Issue or Background Info

- There was a page thrown this morning that was a slightly different flavor of duplicate org exception. With the [casing check added](https://github.com/CDCgov/prime-simplereport/pull/2467), the query sometimes returns multiple entities from the database. This catches that exception and rethrows it as BadRequestException, since it's just another duplicate org issue.

## Changes Proposed

- Catch IncorrectResultSizeDataAccessException when creating new orgs

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
