### PR TITLE
Add time to some ReportStream export fields

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -16,6 +16,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -119,12 +120,15 @@ public class TestEventExport {
     return value.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
   }
 
-  private String dateToHealthCareString(Optional<LocalDate> value) {
-    return dateToHealthCareString(value.orElse(null));
+  private String dateToHealthCareString(LocalDateTime value) {
+    if (value == null) {
+      return "";
+    }
+    return value.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
   }
 
-  private LocalDate convertToLocalDate(Date dateToConvert) {
-    return dateToConvert.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+  private LocalDateTime convertToLocalDateTime(Date dateToConvert) {
+    return dateToConvert.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
   }
 
   @JsonProperty("Patient_last_name")
@@ -154,7 +158,7 @@ public class TestEventExport {
 
   @JsonProperty("Patient_DOB")
   public String getPatientBirthDate() {
-    return dateToHealthCareString(patient.map(Person::getBirthDate));
+    return dateToHealthCareString(patient.map(Person::getBirthDate).orElse(null));
   }
 
   @JsonProperty("Patient_gender")
@@ -284,7 +288,7 @@ public class TestEventExport {
 
   @JsonProperty("Specimen_collection_date_time")
   public String getSpecimenCollectionDateTime() {
-    return dateToHealthCareString(convertToLocalDate(testEvent.getDateTested()));
+    return dateToHealthCareString(convertToLocalDateTime(testEvent.getDateTested()));
   }
 
   @JsonProperty("Ordering_provider_ID")
@@ -304,7 +308,7 @@ public class TestEventExport {
 
   @JsonProperty("Illness_onset_date")
   public String getSymptomOnsetDate() {
-    return dateToHealthCareString(survey.map(AskOnEntrySurvey::getSymptomOnsetDate));
+    return dateToHealthCareString(survey.map(AskOnEntrySurvey::getSymptomOnsetDate).orElse(null));
   }
 
   @JsonProperty("Testing_lab_name")
@@ -482,12 +486,14 @@ public class TestEventExport {
   @JsonProperty("Test_date")
   public String getTestDate() {
     return dateToHealthCareString(
-        Optional.ofNullable(testEvent.getDateTested()).map(this::convertToLocalDate));
+        Optional.ofNullable(testEvent.getDateTested())
+            .map(this::convertToLocalDateTime)
+            .orElse(null));
   }
 
   @JsonProperty("Date_result_released")
   public String getDateResultReleased() {
-    return dateToHealthCareString(LocalDate.now());
+    return dateToHealthCareString(LocalDateTime.now());
   }
 
   @JsonProperty("Order_test_date")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
@@ -93,7 +93,7 @@ class TestEventExportTest {
   }
 
   @Test
-  void someFieldsIncludeTime() throws Exception {
+  void certainDateFieldsIncludeTime() {
     Organization o = _dataFactory.createValidOrg();
     Facility f = _dataFactory.createValidFacility(o);
     Person p = _dataFactory.createFullPerson(o);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
@@ -91,4 +91,22 @@ class TestEventExportTest {
 
     assertEquals(o.getOrganizationType(), sut.getSiteOfCare());
   }
+
+  @Test
+  void someFieldsIncludeTime() throws Exception {
+    Organization o = _dataFactory.createValidOrg();
+    Facility f = _dataFactory.createValidFacility(o);
+    Person p = _dataFactory.createFullPerson(o);
+    TestEvent te = _dataFactory.createTestEvent(p, f);
+
+    TestEventExport sut = new TestEventExport(te);
+
+    var lengthWithoutTime = "yyyyMMdd".length();
+    var lengthWithTime = "yyyyMMddHHmmss".length();
+
+    assertEquals(lengthWithTime, sut.getSpecimenCollectionDateTime().length());
+    assertEquals(lengthWithTime, sut.getTestDate().length());
+    assertEquals(lengthWithTime, sut.getDateResultReleased().length());
+    assertEquals(lengthWithoutTime, sut.getPatientBirthDate().length());
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DataHubUploaderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DataHubUploaderServiceTest.java
@@ -73,7 +73,6 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
 
     // The data factory generates unique GUIDs for model instances shared by each test event,
     // so manually overwrite those values to match
-    var date = entry1.getDateResultReleased();
     var instrumentId1 = entry1.getInstrumentID();
     var patientId1 = entry1.getPatientId();
     var resultId1 = entry1.getResultID();
@@ -86,11 +85,11 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
     var serialized =
         "\"Corrected_result_ID\",\"Date_result_released\",\"Device_ID\",\"Employed_in_healthcare\",\"First_test\",\"Illness_onset_date\",\"Instrument_ID\",\"Order_test_date\",\"Ordered_test_code\",\"Ordering_facility_city\",\"Ordering_facility_county\",\"Ordering_facility_email\",\"Ordering_facility_name\",\"Ordering_facility_phone_number\",\"Ordering_facility_state\",\"Ordering_facility_street\",\"Ordering_facility_street_2\",\"Ordering_facility_zip_code\",\"Ordering_provider_ID\",\"Ordering_provider_city\",\"Ordering_provider_county\",\"Ordering_provider_first_name\",\"Ordering_provider_last_name\",\"Ordering_provider_phone_number\",\"Ordering_provider_state\",\"Ordering_provider_street\",\"Ordering_provider_street_2\",\"Ordering_provider_zip_code\",\"Organization_name\",\"Patient_DOB\",\"Patient_ID\",\"Patient_city\",\"Patient_county\",\"Patient_email\",\"Patient_ethnicity\",\"Patient_first_name\",\"Patient_gender\",\"Patient_last_name\",\"Patient_middle_name\",\"Patient_phone_number\",\"Patient_preferred_language\",\"Patient_race\",\"Patient_role\",\"Patient_state\",\"Patient_street\",\"Patient_street_2\",\"Patient_suffix\",\"Patient_tribal_affiliation\",\"Patient_zip_code\",\"Processing_mode_code\",\"Resident_congregate_setting\",\"Result_ID\",\"Site_of_care\",\"Specimen_collection_date_time\",\"Specimen_source_site_code\",\"Specimen_type_code\",\"Symptomatic_for_disease\",\"Test_date\",\"Test_result_code\",\"Test_result_status\",\"Testing_lab_CLIA\",\"Testing_lab_city\",\"Testing_lab_county\",\"Testing_lab_name\",\"Testing_lab_phone_number\",\"Testing_lab_state\",\"Testing_lab_street\",\"Testing_lab_street_2\",\"Testing_lab_zip_code\"\n"
             + "\"\",\""
-            + date
+            + entry1.getDateResultReleased()
             + "\",\"SFN\",\"N\",\"UNK\",\"\",\""
             + instrumentId1
             + "\",\""
-            + date
+            + entry1.getOrderTestDate()
             + "\",\"54321-BOOM\",\"Washington\",\"Washington\",\"facility@test.com\",\"Imaginary Site\",\"555-867-5309\",\"DC\",\"736 Jackson PI NW\",\"\",\"20503\",\"DOOOOOOM\",\"Washington\",\"Washington\",\"Doctor\",\"Doom\",\"800-555-1212\",\"DC\",\"736 Jackson PI NW\",\"\",\"20503\",\"The Mall\",\"18990510\",\""
             + patientId1
             + "\",\"Washington\",\"Washington\",\"\",\"N\",\"Fred\",\"M\",\"Astaire\",\"\",\"5168675309\",\"English\",\"2106-3\",\"RESIDENT\",\"DC\",\"736 Jackson PI NW\",\"\",\"\",\"\",\"20503\",\"P\",\"N\",\""
@@ -98,18 +97,18 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
             + "\",\""
             + siteOfCare1
             + "\",\""
-            + date
+            + entry1.getSpecimenCollectionDateTime()
             + "\",\"986543321\",\"000111222\",\"UNK\",\""
-            + date
+            + entry1.getTestDate()
             + "\",\"260415000\",\"F\",\"123456\",\"Washington\",\"Washington\",\"Imaginary Site\",\"555-867-5309\",\"DC\",\"736 Jackson PI NW\",\"\",\"20503\"\n"
             + "\""
             + te2.getPriorCorrectedTestEventId()
             + "\",\""
-            + date
+            + entry2.getDateResultReleased()
             + "\",\"SFN\",\"Y\",\"UNK\",\"\",\""
             + instrumentId2
             + "\",\""
-            + date
+            + entry2.getOrderTestDate()
             + "\",\"54321-BOOM\",\"Washington\",\"Washington\",\"facility@test.com\",\"Imaginary Site\",\"555-867-5309\",\"DC\",\"736 Jackson PI NW\",\"\",\"20503\",\"DOOOOOOM\",\"Washington\",\"Washington\",\"Doctor\",\"Doom\",\"800-555-1212\",\"DC\",\"736 Jackson PI NW\",\"\",\"20503\",\"The Mall\",\"18990510\",\""
             + patientId2
             + "\",\"Washington\",\"Washington\",\"\",\"N\",\"Fred\",\"M\",\"Astaire\",\"\",\"5168675309\",\"Spanish\",\"2106-3\",\"RESIDENT\",\"DC\",\"736 Jackson PI NW\",\"\",\"\",\"123\",\"20503\",\"P\",\"N\",\""
@@ -117,9 +116,9 @@ class DataHubUploaderServiceTest extends BaseServiceTest<DataHubUploaderService>
             + "\",\""
             + siteOfCare2
             + "\",\""
-            + date
+            + entry2.getSpecimenCollectionDateTime()
             + "\",\"986543321\",\"000111222\",\"UNK\",\""
-            + date
+            + entry2.getTestDate()
             + "\",\"260415000\",\"C\",\"123456\",\"Washington\",\"Washington\",\"Imaginary Site\",\"555-867-5309\",\"DC\",\"736 Jackson PI NW\",\"\",\"20503\"\n";
 
     try {


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2440

## Changes Proposed

- Update three fields to send LocalDateTime instead of LocalDate to ReportStream
- Add test

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
