### PR TITLE
Add NJ to list of supported states

### DIFF
--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -19,6 +19,7 @@ export const liveJurisdictions = [
   "MS",
   "MT",
   "ND",
+  "NJ",
   "NM",
   "OH",
   "PA",


### PR DESCRIPTION
## Related Issue or Background Info

- NJ is now live with ReportStream, should be added to SimpleReport

## Additional Information

https://skylight-hq.slack.com/archives/C019PRYMR0Q/p1631032121083800
