### PR TITLE
add-patient button for no search results

### DIFF
--- a/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { MemoryRouter } from "react-router";
 import { Story, Meta } from "@storybook/react";
 
 import { TestResult } from "../QueueItem";
@@ -20,6 +22,10 @@ const patient = {
   },
 };
 
+const RouterWithFacility: React.FC = ({ children }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
 export default {
   title: "Search Results",
   component: SearchResults,
@@ -27,10 +33,14 @@ export default {
 } as Meta;
 
 const TestResultsTemplate = (): Story<TestResultsProps> => (args) => (
-  <SearchResults {...args} />
+  <RouterWithFacility>
+    <SearchResults {...args} />
+  </RouterWithFacility>
 );
 const QueueTemplate = (): Story<QueueProps> => (args) => (
-  <SearchResults {...args} />
+  <RouterWithFacility>
+    <SearchResults {...args} />
+  </RouterWithFacility>
 );
 
 export const NoResults = TestResultsTemplate();

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
@@ -1,0 +1,61 @@
+import { Story, Meta } from "@storybook/react";
+
+import { TestResult } from "../QueueItem";
+
+import SearchResults, { QueueProps, TestResultsProps } from "./SearchResults";
+
+const patient = {
+  internalId: "a123",
+  firstName: "George",
+  middleName: "",
+  lastName: "Washington",
+  birthDate: "1950-01-01",
+  isDeleted: false,
+  role: "somerole",
+  lastTest: {
+    dateAdded: "2020-01-01",
+    result: "NEGATIVE" as TestResult,
+    dateTested: "2020-01-01",
+    deviceTypeModel: "MegaTester2000",
+  },
+};
+
+export default {
+  title: "Search Results",
+  component: SearchResults,
+  argTypes: {},
+} as Meta;
+
+const TestResultsTemplate = (): Story<TestResultsProps> => (args) => (
+  <SearchResults {...args} />
+);
+const QueueTemplate = (): Story<QueueProps> => (args) => (
+  <SearchResults {...args} />
+);
+
+export const NoResults = TestResultsTemplate();
+NoResults.args = {
+  onPatientSelect: () => {},
+  page: "test-results",
+  loading: false,
+  patients: [],
+  shouldShowSuggestions: true,
+};
+
+export const WithResults = TestResultsTemplate();
+WithResults.args = {
+  onPatientSelect: () => {},
+  page: "test-results",
+  loading: false,
+  patients: [patient],
+  shouldShowSuggestions: true,
+};
+
+export const QueueResults = QueueTemplate();
+QueueResults.args = {
+  page: "queue",
+  loading: false,
+  patients: [patient],
+  patientsInQueue: [],
+  shouldShowSuggestions: true,
+};

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import userEvent from "@testing-library/user-event";
 
@@ -50,6 +51,13 @@ const patients: Patient[] = [
   },
 ];
 
+const mockFacilityID = "facility-id-101";
+const RouterWithFacility: React.FC = ({ children }) => (
+  <MemoryRouter initialEntries={[`/queue?facility=${mockFacilityID}`]}>
+    {children}
+  </MemoryRouter>
+);
+
 const mocks = [
   {
     request: {
@@ -79,14 +87,16 @@ describe("SearchResults", () => {
   describe("No Results", () => {
     it("should say 'No Results' for no matches", () => {
       const component = renderer.create(
-        <SearchResults
-          page="queue"
-          patients={[]}
-          patientsInQueue={[]}
-          onAddToQueue={jest.fn()}
-          shouldShowSuggestions={true}
-          loading={false}
-        />
+        <RouterWithFacility>
+          <SearchResults
+            page="queue"
+            patients={[]}
+            patientsInQueue={[]}
+            onAddToQueue={jest.fn()}
+            shouldShowSuggestions={true}
+            loading={false}
+          />
+        </RouterWithFacility>
       );
 
       expect(component.toJSON()).toMatchSnapshot();
@@ -94,34 +104,42 @@ describe("SearchResults", () => {
 
     it("should show add patient button", () => {
       render(
-        <SearchResults
-          page="queue"
-          patients={[]}
-          patientsInQueue={[]}
-          onAddToQueue={jest.fn()}
-          shouldShowSuggestions={true}
-          loading={false}
-        />
+        <RouterWithFacility>
+          <SearchResults
+            page="queue"
+            patients={[]}
+            patientsInQueue={[]}
+            onAddToQueue={jest.fn()}
+            shouldShowSuggestions={true}
+            loading={false}
+          />
+        </RouterWithFacility>
       );
 
       expect(screen.getByText("Add new patient")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Add new patient"));
+      act(() => {
+        userEvent.click(screen.getByText("Add new patient"));
+      });
       expect(
-        screen.getByText("Redirected to /add-patient")
+        screen.getByText(
+          `Redirected to /add-patient?facility=${mockFacilityID}`
+        )
       ).toBeInTheDocument();
     });
   });
 
   it("should show matching results", () => {
     const component = renderer.create(
-      <SearchResults
-        page="queue"
-        patients={patients}
-        patientsInQueue={[]}
-        onAddToQueue={jest.fn()}
-        shouldShowSuggestions={true}
-        loading={false}
-      />
+      <RouterWithFacility>
+        <SearchResults
+          page="queue"
+          patients={patients}
+          patientsInQueue={[]}
+          onAddToQueue={jest.fn()}
+          shouldShowSuggestions={true}
+          loading={false}
+        />
+      </RouterWithFacility>
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -130,14 +148,16 @@ describe("SearchResults", () => {
   it("links the non-duplicate patient", () => {
     const addToQueue = jest.fn();
     render(
-      <SearchResults
-        page="queue"
-        patients={patients}
-        patientsInQueue={["a123", "c789"]}
-        onAddToQueue={addToQueue}
-        shouldShowSuggestions={true}
-        loading={false}
-      />
+      <RouterWithFacility>
+        <SearchResults
+          page="queue"
+          patients={patients}
+          patientsInQueue={["a123", "c789"]}
+          onAddToQueue={addToQueue}
+          shouldShowSuggestions={true}
+          loading={false}
+        />
+      </RouterWithFacility>
     );
 
     expect(screen.getAllByText("Test in progress")).toHaveLength(2);
@@ -147,17 +167,19 @@ describe("SearchResults", () => {
   it("opens a modal for selected patient", async () => {
     const addToQueue = jest.fn();
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <SearchResults
-          page="queue"
-          patients={[]}
-          patientsInQueue={[]}
-          onAddToQueue={addToQueue}
-          shouldShowSuggestions={true}
-          loading={false}
-          selectedPatient={patients[0]}
-        />
-      </MockedProvider>
+      <RouterWithFacility>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <SearchResults
+            page="queue"
+            patients={[]}
+            patientsInQueue={[]}
+            onAddToQueue={addToQueue}
+            shouldShowSuggestions={true}
+            loading={false}
+            selectedPatient={patients[0]}
+          />
+        </MockedProvider>
+      </RouterWithFacility>
     );
 
     await waitFor(() => {

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
+import userEvent from "@testing-library/user-event";
 
 import { Patient } from "../../patients/ManagePatients";
-import { TestResult } from "../../testQueue/QueueItem";
+import { TestResult } from "../QueueItem";
 import { LAST_TEST_QUERY } from "../AoEForm/AoEModalForm";
 
 import SearchResults from "./SearchResults";
@@ -70,20 +71,45 @@ const mocks = [
   },
 ];
 
-describe("SearchResults", () => {
-  it("should say 'No Results' for no matches", () => {
-    const component = renderer.create(
-      <SearchResults
-        page="queue"
-        patients={[]}
-        patientsInQueue={[]}
-        onAddToQueue={jest.fn()}
-        shouldShowSuggestions={true}
-        loading={false}
-      />
-    );
+jest.mock("react-router-dom", () => ({
+  Redirect: (props: any) => `Redirected to ${props.to}`,
+}));
 
-    expect(component.toJSON()).toMatchSnapshot();
+describe("SearchResults", () => {
+  describe("No Results", () => {
+    it("should say 'No Results' for no matches", () => {
+      const component = renderer.create(
+        <SearchResults
+          page="queue"
+          patients={[]}
+          patientsInQueue={[]}
+          onAddToQueue={jest.fn()}
+          shouldShowSuggestions={true}
+          loading={false}
+        />
+      );
+
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    it("should show add patient button", () => {
+      render(
+        <SearchResults
+          page="queue"
+          patients={[]}
+          patientsInQueue={[]}
+          onAddToQueue={jest.fn()}
+          shouldShowSuggestions={true}
+          loading={false}
+        />
+      );
+
+      expect(screen.getByText("Add new patient")).toBeInTheDocument();
+      userEvent.click(screen.getByText("Add new patient"));
+      expect(
+        screen.getByText("Redirected to /add-patient")
+      ).toBeInTheDocument();
+    });
   });
 
   it("should show matching results", () => {

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import moment from "moment";
+import { Redirect } from "react-router-dom";
 
 import Button from "../../commonComponents/Button/Button";
 import AoEModalForm from "../AoEForm/AoEModalForm";
@@ -25,7 +26,7 @@ export interface QueueProps extends SearchResultsProps {
   patientsInQueue: string[];
 }
 
-interface TestResultsProps extends SearchResultsProps {
+export interface TestResultsProps extends SearchResultsProps {
   page: "test-results";
   onPatientSelect: (a: Patient) => void;
 }
@@ -41,6 +42,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
 
   const [dialogPatient, setDialogPatient] = useState<Patient | null>(null);
   const [canAddToQueue, setCanAddToQueue] = useState(false);
+  const [redirect, setRedirect] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (selectedPatient) {
@@ -48,6 +50,10 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       setCanAddToQueue(true);
     }
   }, [selectedPatient]);
+
+  if (redirect) {
+    return <Redirect to={redirect} />;
+  }
 
   const actionByPage = (patient: Patient) => {
     if (props.page === "queue") {
@@ -83,7 +89,25 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
   if (loading) {
     resultsContent = <p>Searching...</p>;
   } else if (patients.length === 0) {
-    resultsContent = <p>No results</p>;
+    resultsContent = (
+      <div
+        className={
+          "display-flex flex-column flex-align-center margin-x-7 margin-y-2"
+        }
+      >
+        <div className="margin-bottom-105">No results found.</div>
+        <div>
+          Check for spelling errors or
+          <Button
+            className="margin-left-1"
+            label="Add new patient"
+            onClick={() => {
+              setRedirect("/add-patient");
+            }}
+          />
+        </div>
+      </div>
+    );
   } else {
     resultsContent = (
       <table className="usa-table usa-table--borderless">

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import moment from "moment";
+import { useLocation } from "react-router";
 import { Redirect } from "react-router-dom";
 
 import Button from "../../commonComponents/Button/Button";
@@ -7,6 +8,7 @@ import AoEModalForm from "../AoEForm/AoEModalForm";
 import { displayFullName } from "../../utils";
 import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
+import { getFacilityIdFromUrl } from "../../utils/url";
 
 interface SearchResultsProps {
   patients: Patient[];
@@ -43,6 +45,8 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
   const [dialogPatient, setDialogPatient] = useState<Patient | null>(null);
   const [canAddToQueue, setCanAddToQueue] = useState(false);
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
+
+  const activeFacilityId = getFacilityIdFromUrl(useLocation());
 
   useEffect(() => {
     if (selectedPatient) {
@@ -102,7 +106,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
             className="margin-left-1"
             label="Add new patient"
             onClick={() => {
-              setRedirect("/add-patient");
+              setRedirect(`/add-patient?facility=${activeFacilityId}`);
             }}
           />
         </div>

--- a/frontend/src/app/testQueue/addToQueue/__snapshots__/SearchResults.test.tsx.snap
+++ b/frontend/src/app/testQueue/addToQueue/__snapshots__/SearchResults.test.tsx.snap
@@ -1,15 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SearchResults should say 'No Results' for no matches 1`] = `
+exports[`SearchResults No Results should say 'No Results' for no matches 1`] = `
 <div
   className="card-container shadow-3 results-dropdown"
 >
   <div
     className="usa-card__body results-dropdown__body"
   >
-    <p>
-      No results
-    </p>
+    <div
+      className="display-flex flex-column flex-align-center margin-x-7 margin-y-2"
+    >
+      <div
+        className="margin-bottom-105"
+      >
+        No results found.
+      </div>
+      <div>
+        Check for spelling errors or
+        <button
+          className="usa-button margin-left-1"
+          onClick={[Function]}
+          type="button"
+        >
+          Add new patient
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/src/app/utils/url.ts
+++ b/frontend/src/app/utils/url.ts
@@ -1,10 +1,18 @@
-const getParameterFromUrl = (param: string): string | null => {
-  const queryParams = new URLSearchParams(window.location.search);
+import { Location } from "history";
+
+const getParameterFromUrl = (
+  param: string,
+  location?: Location<unknown>
+): string | null => {
+  const queryParams = new URLSearchParams(
+    location ? location.search : window.location.search
+  );
   return queryParams.has(param) ? queryParams.get(param) : null;
 };
 
-export const getFacilityIdFromUrl = (): string | null =>
-  getParameterFromUrl("facility");
+export const getFacilityIdFromUrl = (
+  location?: Location<unknown>
+): string | null => getParameterFromUrl("facility", location);
 
 export const getPatientLinkIdFromUrl = (): string | null =>
   getParameterFromUrl("plid");


### PR DESCRIPTION
## Related Issue or Background Info

- resolves #2340 

## Changes Proposed

- add `Add new patient` link to no search results view

## Additional Information

## Screenshots / Demos
![image](https://user-images.githubusercontent.com/4952042/132387504-c398c06a-174b-4b92-80a0-bb962b8b946d.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
