### PR TITLE
Adjust duplicate detection and findByName around existing dupes

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -111,7 +111,7 @@ public class AccountRequestController {
   }
 
   private String checkForDuplicateOrg(String organizationName, String state) {
-    List<Organization> potentialDuplicates = _os.getOrganizationByName(organizationName);
+    List<Organization> potentialDuplicates = _os.getOrganizationsByName(organizationName);
     if (potentialDuplicates.isEmpty()) {
       return organizationName;
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -20,5 +20,5 @@ public interface OrganizationRepository extends EternalAuditedEntityRepository<O
 
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY + " and UPPER(e.organizationName) = UPPER(:name)")
-  Optional<Organization> findByName(String name);
+  List<Organization> findAllByName(String name);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -138,7 +138,7 @@ public class OrganizationService {
                 "An organization with external_id=" + externalId + " does not exist"));
   }
 
-  public List<Organization> getOrganizationByName(String name) {
+  public List<Organization> getOrganizationsByName(String name) {
     return _repo.findAllByName(name);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -138,8 +138,8 @@ public class OrganizationService {
                 "An organization with external_id=" + externalId + " does not exist"));
   }
 
-  public Optional<Organization> getOrganizationByName(String name) {
-    return _repo.findByName(name);
+  public List<Organization> getOrganizationByName(String name) {
+    return _repo.findAllByName(name);
   }
 
   @AuthorizationConfiguration.RequireGlobalAdminUser

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -19,7 +19,6 @@ import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.email.EmailProvider;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import java.util.List;
-import java.util.Optional;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -135,11 +134,10 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     this._mockMvc.perform(builder).andExpect(status().isOk());
 
     // then
-    Optional<Organization> org = _orgService.getOrganizationByName("Day Hayes Trading");
-    assertThat(org).isPresent();
-    assertThat(org.get().getExternalId()).startsWith("RI-Day-Hayes-Trading-");
-
-    assertThat(org.get().getIdentityVerified()).isFalse();
+    List<Organization> org = _orgService.getOrganizationByName("Day Hayes Trading");
+    assertThat(org.size()).isEqualTo(1);
+    assertThat(org.get(0).getExternalId()).startsWith("RI-Day-Hayes-Trading-");
+    assertThat(org.get(0).getIdentityVerified()).isFalse();
 
     verify(apiUserService, times(1))
         .createUser(
@@ -297,13 +295,13 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     this._mockMvc.perform(duplicateBuilder).andExpect(status().isOk());
 
     // then
-    Optional<Organization> originalOrg = _orgService.getOrganizationByName("Central Schools");
-    assertThat(originalOrg).isPresent();
-    assertThat(originalOrg.get().getExternalId()).startsWith("AZ-Central-Schools");
+    List<Organization> originalOrg = _orgService.getOrganizationByName("Central Schools");
+    assertThat(originalOrg.size()).isEqualTo(1);
+    assertThat(originalOrg.get(0).getExternalId()).startsWith("AZ-Central-Schools");
 
-    Optional<Organization> duplicateOrg = _orgService.getOrganizationByName("Central Schools-CA");
-    assertThat(duplicateOrg).isPresent();
-    assertThat(duplicateOrg.get().getExternalId()).startsWith("CA-Central-Schools-CA-");
+    List<Organization> duplicateOrg = _orgService.getOrganizationByName("Central Schools-CA");
+    assertThat(duplicateOrg.size()).isEqualTo(1);
+    assertThat(duplicateOrg.get(0).getExternalId()).startsWith("CA-Central-Schools-CA-");
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -134,7 +134,7 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     this._mockMvc.perform(builder).andExpect(status().isOk());
 
     // then
-    List<Organization> org = _orgService.getOrganizationByName("Day Hayes Trading");
+    List<Organization> org = _orgService.getOrganizationsByName("Day Hayes Trading");
     assertThat(org.size()).isEqualTo(1);
     assertThat(org.get(0).getExternalId()).startsWith("RI-Day-Hayes-Trading-");
     assertThat(org.get(0).getIdentityVerified()).isFalse();
@@ -295,11 +295,11 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     this._mockMvc.perform(duplicateBuilder).andExpect(status().isOk());
 
     // then
-    List<Organization> originalOrg = _orgService.getOrganizationByName("Central Schools");
+    List<Organization> originalOrg = _orgService.getOrganizationsByName("Central Schools");
     assertThat(originalOrg.size()).isEqualTo(1);
     assertThat(originalOrg.get(0).getExternalId()).startsWith("AZ-Central-Schools");
 
-    List<Organization> duplicateOrg = _orgService.getOrganizationByName("Central Schools-CA");
+    List<Organization> duplicateOrg = _orgService.getOrganizationsByName("Central Schools-CA");
     assertThat(duplicateOrg.size()).isEqualTo(1);
     assertThat(duplicateOrg.get(0).getExternalId()).startsWith("CA-Central-Schools-CA-");
   }


### PR DESCRIPTION
## Related Issue or Background Info

- We've seen ~10 instances of AccountRequestFailureException in the last day because there are a number of org names that exist such that OrganizationRepository.findByName, which returns an `Optional<Organization>`, retrieves more than one result.
- This is happening because while there is a unique constraint on organization_name, the findByName query is case-insensitive, while the duplicate detection logic wasn't – so there are some collisions

## Changes Proposed

- Update OrganizationRepository.findByName to return List<Organization>
- Adjust calls downstream & the logic in AccountRequestController.checkForDuplicateOrg

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
