### PR TITLE
Display training site modal before facility selection

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -20,6 +20,7 @@ import { appPermissions } from "./permissions";
 import Settings from "./Settings/Settings";
 import { getAppInsights } from "./TelemetryService";
 import VersionEnforcer from "./VersionEnforcer";
+import { TrainingNotification } from "./commonComponents/TrainingNotification";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -92,6 +93,9 @@ const App = () => {
   return (
     <>
       <VersionEnforcer />
+      {process.env.REACT_APP_IS_TRAINING_SITE === "true" && (
+        <TrainingNotification />
+      )}
       <WithFacility>
         <Page>
           <Header />

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -19,7 +19,6 @@ import Button from "./Button/Button";
 import Dropdown from "./Dropdown";
 import useComponentVisible from "./ComponentVisible";
 import { LinkWithQuery } from "./LinkWithQuery";
-import { TrainingNotification } from "./TrainingNotification";
 import ChangeUser from "./ChangeUser";
 
 const Header: React.FC<{}> = () => {
@@ -100,9 +99,6 @@ const Header: React.FC<{}> = () => {
 
   return (
     <header className="usa-header usa-header--basic">
-      {process.env.REACT_APP_IS_TRAINING_SITE === "true" && (
-        <TrainingNotification />
-      )}
       <div className="usa-nav-container">
         <div className="usa-navbar">
           <div className="usa-logo" id="basic-logo">

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -4,7 +4,6 @@ import { MemoryRouter } from "react-router";
 import createMockStore from "redux-mock-store";
 import { useTrackEvent } from "@microsoft/applicationinsights-react-js";
 
-import { TRAINING_PURPOSES_ONLY } from "../TrainingNotification";
 import Header from "../Header";
 import "../../../i18n";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
@@ -52,26 +51,6 @@ describe("Header.tsx", () => {
     </MemoryRouter>
   );
 
-  const MODAL_TEXT = "Welcome to the SimpleReport";
-
-  it("displays the training header and modal and dismisses the modal", async () => {
-    process.env.REACT_APP_IS_TRAINING_SITE = "true";
-    render(<WrappedHeader />);
-    expect(await screen.findAllByText(TRAINING_PURPOSES_ONLY)).toHaveLength(2);
-    const trainingWelcome = await screen.findByText(MODAL_TEXT, {
-      exact: false,
-    });
-    expect(trainingWelcome).toBeInTheDocument();
-    await waitFor(() => {
-      fireEvent.click(screen.getByText("Got it", { exact: false }));
-    });
-    expect(trainingWelcome).not.toBeInTheDocument();
-  });
-  it("does not display training notifications outside the training environment", () => {
-    process.env.REACT_APP_IS_TRAINING_SITE = "false";
-    expect(screen.queryByText(TRAINING_PURPOSES_ONLY)).not.toBeInTheDocument();
-    expect(screen.queryByText(MODAL_TEXT)).not.toBeInTheDocument();
-  });
   it("displays the support link correctly", async () => {
     process.env.REACT_APP_IS_TRAINING_SITE = "false";
     render(<WrappedHeader />);


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2476 

## Changes Proposed

- Move `TrainingNotification` component higher up in the DOM so it appears before facility selection

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/9121162/132582268-77cf3e07-387d-4c8f-ac5a-8cc5e2312e6b.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
