### PR TITLE
Parameterized DB rollbacks

### DIFF
--- a/.github/workflows/rollbackDB.yml
+++ b/.github/workflows/rollbackDB.yml
@@ -1,0 +1,66 @@
+name: Rollback DB
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The Liquibase tag to roll back to'
+        required: true
+      environment:
+        description: 'The environment of the DB that should be rolled back'
+        required: true
+
+concurrency:
+  group: db-rollback
+
+env:
+  DEPLOY_ENV: ${{ github.event.inputs.environment }}
+  LIQUIBASE_ROLLBACK_TAG: ${{ github.event.inputs.tag }}
+  DOCKER_COMPOSE_FILE: docker-compose.db-rollback.yml
+  GIT_SHA: rollback
+jobs:
+  build-rollback-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ACR
+        run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
+      - name: Delete previous rollback image
+        run: az acr repository delete --name simplereportacr --image api/simple-report-api-build:rollback -y
+      - name: Build and push Docker images
+        run: ./build_and_push.sh
+  rollback-to-tag:
+    runs-on: ubuntu-latest
+    needs: build-rollback-image
+    defaults:
+      run:
+        working-directory: ./ops
+    env:
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.15.1
+      - name: Terraform init
+        run: make init-${{ env.DEPLOY_ENV }}
+      - name: Launch DB Rollback Container Instance
+        run: terraform -chdir=$DEPLOY_ENV apply -var acr_image_tag=dummy -var liquibase_rollback_tag=$LIQUIBASE_ROLLBACK_TAG -target module.db_rollback[0] --auto-approve
+      - name: Display logs
+        if: always()
+        run: az container logs --follow -g prime-simple-report-$DEPLOY_ENV --name simple-report-$DEPLOY_ENV-db-rollback

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
 RUN gradle --no-daemon classes testClasses assemble
 
 # db will be running in another container, for purposes of this local file
-ENV SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/simple_report
+ENV SPRING_DATASOURCE_URL=jdbc:postgresql://prime_sr_db:5432/simple_report
 
 ENTRYPOINT ["gradle", "--info", "--no-daemon"]
 CMD ["tasks"]

--- a/backend/Dockerfile.db-rollback
+++ b/backend/Dockerfile.db-rollback
@@ -1,0 +1,15 @@
+FROM gradle:6.9.1-jdk11-hotspot AS build
+
+WORKDIR /home/gradle/graphql-api
+COPY --chown=gradle:gradle ./.git ./.git
+
+WORKDIR /home/gradle/graphql-api/backend
+COPY --chown=gradle:gradle backend/gradle ./gradle
+COPY --chown=gradle:gradle backend/*.gradle ./
+COPY --chown=gradle:gradle ./backend/config ./config
+COPY --chown=gradle:gradle ./backend/src ./src
+COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
+COPY --chown=gradle:gradle ./backend/db_rollback_to_tag.sh ./db_rollback_to_tag.sh
+
+# Indefinite keep-alive
+ENTRYPOINT ["./db_rollback_to_tag.sh"]

--- a/backend/Dockerfile.schemaspy
+++ b/backend/Dockerfile.schemaspy
@@ -4,7 +4,7 @@ WORKDIR /home/schemaspy
 RUN apk update && apk add graphviz curl
 RUN curl -H "Accept: application/zip" -L https://github.com/schemaspy/schemaspy/releases/download/v6.1.0/schemaspy-6.1.0.jar > schemaspy.jar
 RUN curl -H "Accept: application/zip" https://jdbc.postgresql.org/download/postgresql-42.2.18.jar > postgresql.jar
-RUN java -jar schemaspy.jar -debug -t pgsql -db simple_report -u postgres -p admin_password_for_local_dev_is_not_very_secure -host db:5432 -o output -s "simple_report" -dp postgresql.jar || true
+RUN java -jar schemaspy.jar -debug -t pgsql -db simple_report -u postgres -p admin_password_for_local_dev_is_not_very_secure -host prime_sr_db:5432 -o output -s "simple_report" -dp postgresql.jar || true
 
 FROM nginx:alpine
 EXPOSE 80

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -154,15 +154,20 @@ jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
 }
 
+// Prefer SPRING_DATASOURCE_URL if provided
+def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://127.0.0.1:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
+// If SPRING_DATASOURCE_URL is provided, assume target DB is non-local and schema is "public"
+def defaultSchema = System.getenv("SPRING_DATASOURCE_URL") ? "public" : "simple_report"
+
 liquibase {
     activities {
         main {
             driver "org.postgresql.Driver"
             changeLogFile "/db/changelog/db.changelog-master.yaml"
-            url "jdbc:postgresql://127.0.0.1:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
+            url dbConnectionString
             username "postgres"
             password "admin_password_for_local_dev_is_not_very_secure"
-            defaultSchemaName "simple_report"
+            defaultSchemaName defaultSchema
             classpath "src/main/resources"
             // this shadows application.yaml: should probably be in a shared properties file
             changeLogParameters noPhiUsername: "simple_report_no_phi"

--- a/backend/build_and_push.sh
+++ b/backend/build_and_push.sh
@@ -2,7 +2,7 @@
 #
 # ./build_and_push.sh
 
-GIT_SHA=$(git rev-parse --short HEAD)
+GIT_SHA=${GIT_SHA:-$(git rev-parse --short HEAD)}
 ACR_TAG="simplereportacr.azurecr.io/api/simple-report-api-build:$GIT_SHA"
 
 export DOCKER_CLI_EXPERIMENTAL=enabled # to get "manifest inspect"
@@ -13,7 +13,7 @@ if docker manifest inspect $ACR_TAG > /dev/null 2>&1; then
 fi
 
 echo "Building backend images"
-docker-compose -f docker-compose.prod.yml build
+docker-compose -f ${DOCKER_COMPOSE_FILE:-docker-compose.prod.yml} build
 
 docker tag "simple-report-api-build:latest" $ACR_TAG
 echo "Tagged $ACR_TAG"

--- a/backend/db_rollback_to_tag.sh
+++ b/backend/db_rollback_to_tag.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ -n $LIQUIBASE_ROLLBACK_TAG ]];
+    then
+        echo "***************************************************************"
+        echo "Rollback tag provided! Rolling back to: $LIQUIBASE_ROLLBACK_TAG"
+        echo "***************************************************************"
+
+        # Roll back to the provided tag
+        gradle liquibaseRollback -PliquibaseCommandValue="$LIQUIBASE_ROLLBACK_TAG"
+    else
+        echo "*******************************************"
+        echo "No rollback tag provided! Taking no action."
+        echo "*******************************************"
+fi

--- a/backend/docker-compose.db-rollback.yml
+++ b/backend/docker-compose.db-rollback.yml
@@ -1,0 +1,17 @@
+version: "3.2"
+services:
+  rollback:
+    build:
+      context: ..
+      dockerfile: backend/Dockerfile.db-rollback
+      target: build
+    image: simple-report-api-build
+    container_name: prime_sr_db_rollback
+    environment:
+      LIQUIBASE_ROLLBACK_TAG: ${LIQUIBASE_ROLLBACK_TAG:-}
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://prime_sr_db:5432/simple_report}
+    networks:
+      - dev-net
+networks:
+  dev-net:
+    name: dev-net

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.5"
 services:
   db:
     image: postgres:12-alpine
+    container_name: prime_sr_db
     ports:
       - "${SR_DB_PORT:-5432}:${SR_DB_PORT:-5432}"
     environment:
@@ -26,6 +27,7 @@ services:
       context: ..
       dockerfile: backend/Dockerfile
     image: simple-report-api-build
+    container_name: prime_sr_api
     command: bootRun
     environment:
       SPRING_PROFILES_ACTIVE: dev,db-dockerized
@@ -42,6 +44,7 @@ services:
       context: .
       dockerfile: Dockerfile.schemaspy
       network: dev-net
+    container_name: prime_sr_schemaspy
     ports:
       - "${SR_SCHEMASPY_PORT:-8081}:80"
     environment:

--- a/backend/src/main/resources/application-db-dockerized.yaml
+++ b/backend/src/main/resources/application-db-dockerized.yaml
@@ -1,1 +1,1 @@
-spring.datasource.url: jdbc:postgresql://db:${SR_DB_PORT:5432}/simple_report
+spring.datasource.url: jdbc:postgresql://prime_sr_db:${SR_DB_PORT:5432}/simple_report

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -43,12 +43,12 @@ api.tfvars: /dev/null
 	echo "deploy_actor=\"$(GITHUB_ACTOR)\"" >> $@;
 
 init-%: .valid-env-%
-	terraform -chdir=$* init
 	terraform -chdir=$*/persistent init
+	terraform -chdir=$* init
 
 deploy-%: .valid-env-% api.tfvars
-	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars
 	terraform -chdir=$*/persistent apply -auto-approve
+	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars
 
 promote-%: .be-logged-in .valid-env-%
 	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)

--- a/ops/demo/_var.tf
+++ b/ops/demo/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/demo/container_instances.tf
+++ b/ops/demo/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_demo.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_db_jdbc.value
+}

--- a/ops/demo/persistent/_output.tf
+++ b/ops/demo/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}

--- a/ops/dev/_var.tf
+++ b/ops/dev/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/dev/container_instances.tf
+++ b/ops/dev/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_dev.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_dev_db_jdbc.value
+}

--- a/ops/dev/persistent/_output.tf
+++ b/ops/dev/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}

--- a/ops/pentest/_var.tf
+++ b/ops/pentest/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/pentest/container_instances.tf
+++ b/ops/pentest/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_pentest.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_db_jdbc.value
+}

--- a/ops/pentest/persistent/_output.tf
+++ b/ops/pentest/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}

--- a/ops/prod/_var.tf
+++ b/ops/prod/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/prod/container_instances.tf
+++ b/ops/prod/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_prod.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_db_jdbc.value
+}

--- a/ops/prod/persistent/_output.tf
+++ b/ops/prod/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}

--- a/ops/services/container_instances/db_rollback/_var.tf
+++ b/ops/services/container_instances/db_rollback/_var.tf
@@ -1,0 +1,25 @@
+variable "env" {}
+variable "name" {}
+variable "resource_group_name" {}
+variable "resource_group_location" {}
+
+variable "network_profile_id" {}
+
+# ACR info
+variable "acr_username" {
+  default = "simplereportacr"
+}
+
+variable "acr_password" {
+  sensitive = true
+}
+
+variable "acr_server" {
+  default = "simplereportacr.azurecr.io"
+}
+
+# Rollback info
+
+variable "rollback_tag" {}
+
+variable "spring_datasource_url" {}

--- a/ops/services/container_instances/db_rollback/db_rollback.tf
+++ b/ops/services/container_instances/db_rollback/db_rollback.tf
@@ -1,0 +1,37 @@
+resource "azurerm_container_group" "db_rollback" {
+  name                = "${var.name}-${var.env}-db-rollback"
+  location            = var.resource_group_location
+  resource_group_name = var.resource_group_name
+  ip_address_type     = "Private"
+  os_type             = "Linux"
+  restart_policy      = "Never"
+  network_profile_id  = var.network_profile_id
+
+  image_registry_credential {
+    username = var.acr_username
+    password = var.acr_password
+    server   = var.acr_server
+
+  }
+
+  container {
+    name   = "${var.name}-${var.env}-db-rollback"
+    image  = "${var.acr_server}/api/simple-report-api-build:rollback"
+    cpu    = "1"
+    memory = "1.5"
+
+    // Not a real port but *a* port is required, so expose a port the container hopefully doesn't respond to
+    ports {
+      port     = 1234
+      protocol = "TCP"
+    }
+
+    environment_variables = {
+      LIQUIBASE_ROLLBACK_TAG = var.rollback_tag
+    }
+
+    secure_environment_variables = {
+      SPRING_DATASOURCE_URL = var.spring_datasource_url
+    }
+  }
+}

--- a/ops/services/virtual_network/_output.tf
+++ b/ops/services/virtual_network/_output.tf
@@ -17,3 +17,7 @@ output "private_dns_zone_id" {
 output "network" {
   value = azurerm_virtual_network.vn
 }
+
+output "network_profile_id" {
+  value = azurerm_network_profile.container_instances.id
+}

--- a/ops/services/virtual_network/main.tf
+++ b/ops/services/virtual_network/main.tf
@@ -60,3 +60,36 @@ resource "azurerm_private_dns_zone" "default" {
   name                = "privatelink.postgres.database.azure.com"
   resource_group_name = var.resource_group_name
 }
+
+# Subnet + network profile for Azure Container Instances
+
+resource "azurerm_subnet" "container_instances" {
+  name                 = "${var.env}-azure-container-instances"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = "simple-report-test-network"
+  address_prefixes     = ["10.3.101.0/24"]
+
+  delegation {
+    name = "${var.env}-container-instances"
+
+    service_delegation {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_network_profile" "container_instances" {
+  name                = "${var.env}-azure-container-instances"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  container_network_interface {
+    name = "${var.env}-container-instances"
+
+    ip_configuration {
+      name      = "${var.env}-container-instances"
+      subnet_id = azurerm_subnet.container_instances.id
+    }
+  }
+}

--- a/ops/stg/_var.tf
+++ b/ops/stg/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/stg/container_instances.tf
+++ b/ops/stg/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_stg.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_db_jdbc.value
+}

--- a/ops/stg/persistent/_output.tf
+++ b/ops/stg/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}

--- a/ops/test/_var.tf
+++ b/ops/test/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/test/container_instances.tf
+++ b/ops/test/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_test.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_db_jdbc.value
+}

--- a/ops/test/persistent/_output.tf
+++ b/ops/test/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}

--- a/ops/training/_var.tf
+++ b/ops/training/_var.tf
@@ -32,3 +32,9 @@ variable "deploy_actor" {
   type        = string
   default     = ""
 }
+
+variable "liquibase_rollback_tag" {
+  description = "If defined, attempt to roll DB back to this tag"
+  type        = string
+  default     = null
+}

--- a/ops/training/container_instances.tf
+++ b/ops/training/container_instances.tf
@@ -1,0 +1,14 @@
+module "db_rollback" {
+  # Only create this resource if we're actually doing a rollback
+  count = var.liquibase_rollback_tag == null ? 0 : 1
+
+  source                  = "../services/container_instances/db_rollback"
+  name                    = local.name
+  env                     = local.env
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  resource_group_location = data.azurerm_resource_group.rg.location
+  network_profile_id      = data.terraform_remote_state.persistent_training.outputs.network_profile_id
+  acr_password            = data.terraform_remote_state.global.outputs.acr_simeplereport_admin_password
+  rollback_tag            = var.liquibase_rollback_tag
+  spring_datasource_url   = data.azurerm_key_vault_secret.sr_db_jdbc.value
+}

--- a/ops/training/persistent/_output.tf
+++ b/ops/training/persistent/_output.tf
@@ -26,3 +26,7 @@ output "postgres_server_name" {
 output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
+
+output "network_profile_id" {
+  value = module.vnet.network_profile_id
+}


### PR DESCRIPTION
## Related Issue or Background Info

#2177 

We want to be able to roll a cloud DB back to a given tag if necessary.

## Changes Proposed

- Add a subnet, network profile, and container group to enable Azure Container Instances (run arbitrary containers without underlying infrastructure). We can use these to run one-off tasks, such as a container that runs `gradle` to do a rollback and then exits.
- Parameterize `build_and_push.sh` and `build.gradle` to assist in building/pushing the `Dockerfile.db-rollback` image
- Add a `Rollback DB` workflow that takes a tag and environment argument

## Additional Information

- After _many_ dead ends due to Azure or network restrictions, I think this is a reasonable way to run DB rollbacks specifically, and temporary or finite commands inside the virtual network generally.
