### PR TITLE
Move CLIA after state on facility form and update error message

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
+++ b/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
@@ -43,27 +43,6 @@ const FacilityInformation: React.FC<Props> = ({
         errorMessage={errors.name}
       />
       <TextInput
-        label="CLIA number"
-        hintText={
-          <a
-            href="https://www.cdc.gov/clia/LabSearch.html#"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Find my CLIA
-          </a>
-        }
-        name="cliaNumber"
-        value={facility.cliaNumber}
-        required
-        onChange={onChange}
-        onBlur={() => {
-          validateField("cliaNumber");
-        }}
-        validationStatus={errors.cliaNumber ? "error" : undefined}
-        errorMessage={errors.cliaNumber}
-      />
-      <TextInput
         label="Phone number"
         name="phone"
         value={facility.phone}
@@ -140,6 +119,27 @@ const FacilityInformation: React.FC<Props> = ({
         errorMessage={errors.state}
         selectClassName="usa-input--medium"
         data-testid="facility-state-dropdown"
+      />
+      <TextInput
+        label="CLIA number"
+        hintText={
+          <a
+            href="https://www.cdc.gov/clia/LabSearch.html#"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Find my CLIA
+          </a>
+        }
+        name="cliaNumber"
+        value={facility.cliaNumber}
+        required
+        onChange={onChange}
+        onBlur={() => {
+          validateField("cliaNumber");
+        }}
+        validationStatus={errors.cliaNumber ? "error" : undefined}
+        errorMessage={errors.cliaNumber}
       />
     </div>
   );

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -78,7 +78,7 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
     .test(
       "facility-clia",
       ({ value }) => {
-        if (value[2] === "Z") {
+        if (value[2] === "Z" && value.length === 10) {
           return "Special Z CLIAs are only valid in WA";
         }
         return "CLIA number should be 10 characters (##D#######)";

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -77,7 +77,12 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
     .required("CLIA number should be 10 characters (##D#######)")
     .test(
       "facility-clia",
-      "CLIA number should be 10 characters (##D#######)",
+      ({ value }) => {
+        if (value[2] === "Z") {
+          return "Special Z CLIAs are only valid in WA";
+        }
+        return "CLIA number should be 10 characters (##D#######)";
+      },
       (input, facility) => {
         if (!stateRequiresCLIANumberValidation(facility.parent.state)) {
           return true;

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -246,7 +246,7 @@ describe("FacilityForm", () => {
         });
 
         fireEvent.change(cliaInput, {
-          target: { value: "12Z3456789" },
+          target: { value: "12F3456789" },
         });
         fireEvent.blur(cliaInput);
 
@@ -341,6 +341,42 @@ describe("FacilityForm", () => {
         fireEvent.click(saveButton);
         await validateAddress(saveFacility);
         expect(saveFacility).toBeCalledTimes(1);
+      });
+      it("doesn't allow a Z-CLIA for a non-Washington state", async () => {
+        const californiaFacility: Facility = validFacility;
+        californiaFacility.state = "CA";
+        render(
+          <MemoryRouter>
+            <FacilityForm
+              facility={californiaFacility}
+              deviceOptions={devices}
+              saveFacility={saveFacility}
+            />
+          </MemoryRouter>
+        );
+
+        const cliaInput = screen.getByLabelText("CLIA number", {
+          exact: false,
+        });
+
+        fireEvent.change(cliaInput, {
+          target: { value: "12Z3456789" },
+        });
+        fireEvent.blur(cliaInput);
+
+        const expectedError = "Special Z CLIAs are only valid in WA";
+
+        expect(
+          await screen.findByText(expectedError, {
+            exact: false,
+          })
+        ).toBeInTheDocument();
+
+        const saveButton = screen.getAllByText("Save changes")[0];
+        await waitFor(async () => {
+          fireEvent.click(saveButton);
+        });
+        expect(saveFacility).toBeCalledTimes(0);
       });
     });
   });


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2497
- Resolves #2521 

## Changes Proposed

- Move CLIA field after state so that users enter state before CLIA
- Update yup schema to customize error message based on state

## Screenshots / Demos

https://user-images.githubusercontent.com/9121162/132772627-3cd6d5ba-97e3-491c-98cf-5c74696e6152.mp4

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
