### PR TITLE
Add link to app homepage on error boundary

### DIFF
--- a/frontend/src/app/commonComponents/ErrorPage.tsx
+++ b/frontend/src/app/commonComponents/ErrorPage.tsx
@@ -7,11 +7,13 @@ const ErrorPage = () => {
       <USAGovBanner />
       <header className="border-bottom border-base-lighter padding-y-1">
         <div className="grid-container">
-          <img
-            className="maxh-4"
-            src={siteLogo}
-            alt="{process.env.REACT_APP_TITLE}"
-          />
+          <a href={process.env.PUBLIC_URL || "/"}>
+            <img
+              className="maxh-4"
+              src={siteLogo}
+              alt={process.env.REACT_APP_TITLE}
+            />
+          </a>
         </div>
       </header>
       <main className="usa-section">

--- a/frontend/src/app/commonComponents/__test__/__snapshots__/ErrorPage.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__test__/__snapshots__/ErrorPage.test.tsx.snap
@@ -59,11 +59,15 @@ exports[`ErrorPage displays the correct error message 1`] = `
     <div
       class="grid-container"
     >
-      <img
-        alt="{process.env.REACT_APP_TITLE}"
-        class="maxh-4"
-        src="simplereport-logo-color.svg"
-      />
+      <a
+        href="/"
+      >
+        <img
+          alt="SimpleReport"
+          class="maxh-4"
+          src="simplereport-logo-color.svg"
+        />
+      </a>
     </div>
   </header>
   <main


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2516 

## Changes Proposed

- Turns the logo at the top of `ErrorPage` into a link to the root path of the app

## Screenshots / Demos

https://user-images.githubusercontent.com/9121162/132909527-70001faf-6818-4c5e-b14e-cf5b5f8ceb80.mp4



## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
