### PR TITLE
Add disableTimer flag to QuestionsForm to prevent Chromatic diffs

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.stories.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.stories.tsx
@@ -18,6 +18,7 @@ export default {
   args: {
     personalDetails,
     orgExternalId: "foo",
+    disableTimer: true,
   },
 } as Meta;
 

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
@@ -61,7 +61,7 @@ const QuestionsForm: React.FC<Props> = ({
     return () => {
       isCounting = false;
     };
-  }, [timeLeft, onFail]);
+  }, [timeLeft, onFail, disableTimer]);
 
   const schema = buildSchema(questionSet);
 

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
@@ -24,6 +24,7 @@ interface Props {
   onSubmit: (answers: Answers) => void;
   onFail: () => void;
   timeToComplete?: number;
+  disableTimer?: boolean;
 }
 
 type QuestionFormErrors = Record<keyof Answers, string>;
@@ -34,6 +35,7 @@ const QuestionsForm: React.FC<Props> = ({
   onSubmit,
   onFail,
   timeToComplete,
+  disableTimer,
 }) => {
   const [answers, setAnswers] = useState<Nullable<Answers>>(
     initAnswers(questionSet)
@@ -52,7 +54,7 @@ const QuestionsForm: React.FC<Props> = ({
       onFail();
     }
     setTimeout(() => {
-      if (isCounting) {
+      if (isCounting && !disableTimer) {
         setTimeLeft(timeLeft - 1);
       }
     }, 1000);

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsFormContainer.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsFormContainer.tsx
@@ -13,6 +13,7 @@ interface Props {
   personalDetails: IdentityVerificationRequest;
   orgExternalId: string;
   timeToComplete?: number;
+  disableTimer?: boolean;
 }
 
 // Experian doesn't accept names with accents, so we allow users to input them
@@ -38,6 +39,7 @@ const QuestionsFormContainer = ({
   personalDetails,
   orgExternalId,
   timeToComplete,
+  disableTimer,
 }: Props) => {
   const [loading, setLoading] = useState(true);
   const [identificationVerified, setIdentificationVerified] = useState<
@@ -102,6 +104,7 @@ const QuestionsFormContainer = ({
         onSubmit={onSubmit}
         onFail={() => onSubmit({})}
         timeToComplete={timeToComplete}
+        disableTimer={disableTimer}
       />
     );
   }


### PR DESCRIPTION
## Related Issue or Background Info

- Chromatic keeps showing diffs between 5:00 and 4:59 depending on how long it takes to make a snapshot. This should prevent that

## Changes Proposed

- Add a `disableTimer` boolean flag that is only used in the story for `QuestionsForm`

## Screenshots / Demos

https://user-images.githubusercontent.com/9121162/132913895-0368c5a0-e72e-4d6e-82cb-d5cd5ee2eb5e.mp4



## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
