### PR TITLE
Increase patient link expiry to 3 days

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLink.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLink.java
@@ -11,7 +11,7 @@ import javax.persistence.ManyToOne;
 
 @Entity
 public class PatientLink extends EternalAuditedEntity {
-  private static final int SHELF_LIFE_DAYS = 3;
+  private static final int SHELF_LIFE = 3;
 
   @ManyToOne(optional = false)
   @JoinColumn(name = "test_order_id", nullable = false)
@@ -35,7 +35,7 @@ public class PatientLink extends EternalAuditedEntity {
 
   public Date getExpiresAt() {
     if (expiresAt == null) {
-      return Date.from(getCreatedAt().toInstant().plus(Duration.ofDays(SHELF_LIFE_DAYS)));
+      return Date.from(getCreatedAt().toInstant().plus(Duration.ofDays(SHELF_LIFE)));
     }
     return expiresAt;
   }
@@ -49,6 +49,6 @@ public class PatientLink extends EternalAuditedEntity {
   }
 
   public void refresh() {
-    expiresAt = Date.from(Instant.now().plus(Duration.ofDays(SHELF_LIFE_DAYS)));
+    expiresAt = Date.from(Instant.now().plus(Duration.ofDays(SHELF_LIFE)));
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLink.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLink.java
@@ -11,6 +11,8 @@ import javax.persistence.ManyToOne;
 
 @Entity
 public class PatientLink extends EternalAuditedEntity {
+  private static final int SHELF_LIFE_DAYS = 3;
+
   @ManyToOne(optional = false)
   @JoinColumn(name = "test_order_id", nullable = false)
   private TestOrder testOrder;
@@ -33,7 +35,7 @@ public class PatientLink extends EternalAuditedEntity {
 
   public Date getExpiresAt() {
     if (expiresAt == null) {
-      return Date.from(getCreatedAt().toInstant().plus(Duration.ofDays(1)));
+      return Date.from(getCreatedAt().toInstant().plus(Duration.ofDays(SHELF_LIFE_DAYS)));
     }
     return expiresAt;
   }
@@ -47,6 +49,6 @@ public class PatientLink extends EternalAuditedEntity {
   }
 
   public void refresh() {
-    expiresAt = Date.from(Instant.now().plus(Duration.ofDays(1)));
+    expiresAt = Date.from(Instant.now().plus(Duration.ofDays(SHELF_LIFE_DAYS)));
   }
 }


### PR DESCRIPTION
## Related Issue or Background Info

- Per slack convo in ops/support channel, this is an experiment to see if it reduces support requests & expiry failures

## Changes Proposed

- Increase patient link expiry to 3 days

## Additional Information

- We can measure results by % of 410 responses on /pxp/verify against total traffic 

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
