### PR TITLE
add patient_id index to test_event

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2899,3 +2899,13 @@ databaseChangeLog:
             columns:
               - column:
                   name: person_internal_id
+  - changeSet:
+      id: add-index-test_event-patient_id
+      author: zedd@skylight.digital
+      changes:
+        - createIndex:
+            tableName: test_event
+            indexName: ix__test_event__patient_id
+            columns:
+              - column:
+                  name: patient_id


### PR DESCRIPTION
## Related Issue or Background Info

- addresses #2487 
## Changes Proposed

- add `patient_id` index in `test_event` to speed up the `findLastTestsByPatient` query

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
