### PR TITLE
Add MaintenanceBanner component and workflow

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -30,5 +30,5 @@ jobs:
         shell: bash
         run: |
           echo '{"active": true, "message": "Our engineers are actively working to fix the issue."}' > maintenance.json
-          az storage blob upload -f maintenance.json -c '$web' \
+          az storage blob upload -f maintenance.json -n maintenance.json -c '$web' \
             --account-name simplereport${{ matrix.deploy-env }}app

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,15 +1,18 @@
 name: Maintenance Mode
 
 on:
-  workflow_dispatch:
-    inputs:
-      active:
-        description: "Active outage? (true/false)"
-        required: true
-        default: "true"
-      message:
-        description: "Message to display"
-        required: true
+  push:
+    branches:
+      - nick/2315-maintenance-banner
+  # workflow_dispatch:
+  #   inputs:
+  #     active:
+  #       description: "Active outage? (true/false)"
+  #       required: true
+  #       default: "true"
+  #     message:
+  #       description: "Message to display"
+  #       required: true
 
 jobs:
   pushMaintenanceBlob:
@@ -17,7 +20,8 @@ jobs:
     strategy:
       matrix:
         deploy-env:
-          ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
+          ["dev"]
+          # ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
     steps:
       - uses: azure/login@v1
         with:
@@ -25,6 +29,6 @@ jobs:
       - name: Push maintenance.json
         shell: bash
         run: |
-          echo '{"active": ${{ inputs.active }}, "message": "${{ inputs.message }}"}' > maintenance.json
+          echo '{"active": true, "message": "Our engineers are actively working to fix the issue."}' > maintenance.json
           az storage blob upload -f maintenance.json -c '$web' \
             --account-name simplereport${{ matrix.deploy-env }}app

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,30 @@
+name: Maintenance Mode
+
+on:
+  workflow_dispatch:
+    inputs:
+      active:
+        description: "Active outage? (true/false)"
+        required: true
+        default: "true"
+      message:
+        description: "Message to display"
+        required: true
+
+jobs:
+  pushMaintenanceBlob:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        deploy-env:
+          ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
+    steps:
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Push maintenance.json
+        shell: bash
+        run: |
+          echo '{"active": ${{ inputs.active }}, "message": "${{ inputs.message }}"}' > maintenance.json
+          az storage blob upload -f maintenance.json -c '$web' \
+            --account-name simplereport${{ matrix.deploy-env }}app

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       matrix:
         deploy-env:
-          ["dev"]
-          # ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
+          ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
     steps:
       - uses: azure/login@v1
         with:
@@ -29,6 +28,6 @@ jobs:
       - name: Push maintenance.json
         shell: bash
         run: |
-          echo '{"active": true, "message": "Our engineers are actively working to fix the issue."}' > maintenance.json
+          echo '{"active": false, "message": ""}' > maintenance.json
           az storage blob upload -f maintenance.json -n maintenance.json -c '$web' \
             --account-name simplereport${{ matrix.deploy-env }}app

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -10,6 +10,7 @@ on:
       message:
         description: "Message to display"
         required: true
+        default: "We're working on getting this fixed as soon as possible."
 
 jobs:
   pushMaintenanceBlob:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,18 +1,15 @@
 name: Maintenance Mode
 
 on:
-  push:
-    branches:
-      - nick/2315-maintenance-banner
-  # workflow_dispatch:
-  #   inputs:
-  #     active:
-  #       description: "Active outage? (true/false)"
-  #       required: true
-  #       default: "true"
-  #     message:
-  #       description: "Message to display"
-  #       required: true
+  workflow_dispatch:
+    inputs:
+      active:
+        description: "Active outage? (true/false)"
+        required: true
+        default: "true"
+      message:
+        description: "Message to display"
+        required: true
 
 jobs:
   pushMaintenanceBlob:
@@ -28,6 +25,6 @@ jobs:
       - name: Push maintenance.json
         shell: bash
         run: |
-          echo '{"active": false, "message": ""}' > maintenance.json
+          echo '{"active": ${{ inputs.active }}, "message": "${{ inputs.message }}"}' > maintenance.json
           az storage blob upload -f maintenance.json -n maintenance.json -c '$web' \
             --account-name simplereport${{ matrix.deploy-env }}app

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -21,6 +21,7 @@ import Settings from "./Settings/Settings";
 import { getAppInsights } from "./TelemetryService";
 import VersionEnforcer from "./VersionEnforcer";
 import { TrainingNotification } from "./commonComponents/TrainingNotification";
+import { MaintenanceBanner } from "./commonComponents/MaintenanceBanner";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -93,6 +94,7 @@ const App = () => {
   return (
     <>
       <VersionEnforcer />
+      <MaintenanceBanner />
       {process.env.REACT_APP_IS_TRAINING_SITE === "true" && (
         <TrainingNotification />
       )}

--- a/frontend/src/app/commonComponents/Alert.tsx
+++ b/frontend/src/app/commonComponents/Alert.tsx
@@ -19,7 +19,7 @@ import classnames from "classnames";
  * @param {string} role  ARIA role type
  */
 
-export type AlertType = "info" | "success" | "warning" | "error";
+export type AlertType = "info" | "success" | "warning" | "error" | "emergency";
 export interface AlertContent {
   type: AlertType;
   title: string;

--- a/frontend/src/app/commonComponents/MaintenanceBanner.tsx
+++ b/frontend/src/app/commonComponents/MaintenanceBanner.tsx
@@ -4,12 +4,13 @@ import Alert from "./Alert";
 
 interface MaintenanceMode {
   active: boolean;
-  message?: string;
+  message: string;
 }
 
 export const MaintenanceBanner: React.FC = () => {
   const [maintenanceMode, setMaintenanceMode] = useState<MaintenanceMode>({
     active: false,
+    message: "",
   });
   useEffect(() => {
     const getMaintenanceMode = async () => {
@@ -30,7 +31,7 @@ export const MaintenanceBanner: React.FC = () => {
         <div className="usa-site-alert usa-site-alert--emergency usa-site-alert--no-heading border-top border-base-lighter">
           <Alert type="emergency" role="alert">
             <strong>SimpleReport is currently experiencing an outage.</strong>{" "}
-            {maintenanceMode?.message}
+            {maintenanceMode.message}
           </Alert>
         </div>
       ) : null}

--- a/frontend/src/app/commonComponents/MaintenanceBanner.tsx
+++ b/frontend/src/app/commonComponents/MaintenanceBanner.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import Alert from "./Alert";
+
+interface MaintenanceMode {
+  active: boolean;
+  message?: string;
+}
+
+export const MaintenanceBanner: React.FC = () => {
+  const [maintenanceMode, setMaintenanceMode] = useState<MaintenanceMode>({
+    active: false,
+  });
+  useEffect(() => {
+    const getMaintenanceMode = async () => {
+      const maintenance = await fetch("/maintenance.json");
+      const maintenanceJSON = await maintenance.json();
+      setMaintenanceMode(maintenanceJSON);
+    };
+    getMaintenanceMode();
+  }, []);
+
+  return (
+    <>
+      {maintenanceMode.active ? (
+        <div className="usa-site-alert usa-site-alert--emergency usa-site-alert--no-heading border-top border-base-lighter">
+          <Alert type="emergency" role="alert">
+            <strong>SimpleReport is currently experiencing an outage.</strong>{" "}
+            {maintenanceMode?.message}
+          </Alert>
+        </div>
+      ) : null}
+    </>
+  );
+};

--- a/frontend/src/app/commonComponents/MaintenanceBanner.tsx
+++ b/frontend/src/app/commonComponents/MaintenanceBanner.tsx
@@ -14,8 +14,12 @@ export const MaintenanceBanner: React.FC = () => {
   useEffect(() => {
     const getMaintenanceMode = async () => {
       const maintenance = await fetch("/maintenance.json");
-      const maintenanceJSON = await maintenance.json();
-      setMaintenanceMode(maintenanceJSON);
+      try {
+        const maintenanceJSON = await maintenance.json();
+        setMaintenanceMode(maintenanceJSON);
+      } catch (e) {
+        console.error(e);
+      }
     };
     getMaintenanceMode();
   }, []);

--- a/ops/demo/main.tf
+++ b/ops/demo/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 module "app_gateway" {

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 

--- a/ops/training/main.tf
+++ b/ops/training/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
       transforms   = ["Lowercase"]
     }
   }
+
+  delivery_rule {
+    name  = "bypassMaintenanceJsonCache"
+    order = 2
+
+    cache_expiration_action {
+      behavior = "BypassCache"
+    }
+
+    url_file_name_condition {
+      operator     = "Equal"
+      match_values = ["maintenance.json"]
+      transforms   = ["Lowercase"]
+    }
+  }
 }
 
 


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2315 

## Changes Proposed

- Adds a `MaintenanceBanner` component which fetches `/maintenance.json` and displays the included message if there is an active outage
- Adds a GitHub workflow that allows us to push a new `maintenance.json` storage blob to Azure in all environments. The workflow takes two inputs: whether there is an active outage (true/false) and an optional message to include in the banner

## Additional Information

- Still need to test the workflow to see if it actually works... not sure if I need to do something with the CDN after uploading the blob?
- Need an accompanying PR for the static site to fetch `/maintenance.json` and display the same banner
- Probably need to tweak the content
- Assigned everyone to review just for awareness

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/9121162/133167197-47e9404d-977a-4f7c-b27f-1dcfee94ab25.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
