### PR TITLE
Import toast in utils instead of importing it

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from "react";
-import { toast } from "react-toastify";
 import { Prompt } from "react-router-dom";
 
 import iconSprite from "../../../../node_modules/uswds/dist/img/sprite.svg";
@@ -90,7 +89,7 @@ export const useFacilityValidation = (facility: Facility) => {
           body="Please check the form to make sure you complete all of the required fields."
         />
       );
-      showNotification(toast, alert);
+      showNotification(alert);
       return "error";
     }
   };

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { gql, useQuery, useMutation } from "@apollo/client";
-import { toast } from "react-toastify";
 import {
   useAppInsightsContext,
   useTrackEvent,
@@ -236,7 +235,7 @@ const FacilityFormContainer: any = (props: Props) => {
         body="The settings for the facility have been updated"
       />
     );
-    showNotification(toast, alert);
+    showNotification(alert);
     updateSaveSuccess(true);
   };
 

--- a/frontend/src/app/Settings/ManageOrganization.tsx
+++ b/frontend/src/app/Settings/ManageOrganization.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { toast } from "react-toastify";
 
 import TextInput from "../commonComponents/TextInput";
 import Button from "../commonComponents/Button/Button";
@@ -60,7 +59,6 @@ const ManageOrganization: React.FC<Props> = (props) => {
       props.onSave(organization);
     } else {
       showNotification(
-        toast,
         <Alert
           type="error"
           title="Information missing"

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -1,7 +1,6 @@
 import React, { ComponentProps } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { gql, useQuery, useMutation } from "@apollo/client";
-import { toast } from "react-toastify";
 import {
   useAppInsightsContext,
   useTrackEvent,
@@ -94,7 +93,7 @@ const ManageOrganizationContainer: any = () => {
       alertProps.body =
         "There was an eroror updating the organization settings";
     }
-    showNotification(toast, <Alert {...alertProps} />);
+    showNotification(<Alert {...alertProps} />);
   };
 
   return (

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { toast } from "react-toastify";
 import { useLazyQuery } from "@apollo/client";
 
 import Alert from "../../commonComponents/Alert";
@@ -183,7 +182,6 @@ const ManageUsers: React.FC<Props> = ({
         );
         setIsUpdating(false);
         showNotification(
-          toast,
           <Alert
             type="success"
             title="Changes Saved"
@@ -226,7 +224,6 @@ const ManageUsers: React.FC<Props> = ({
       await getUsers();
       const fullName = displayFullName(firstName, "", lastName);
       showNotification(
-        toast,
         <Alert
           type="success"
           title={`Invitation sent to ${fullName}`}
@@ -255,7 +252,6 @@ const ManageUsers: React.FC<Props> = ({
       );
       updateShowResetPasswordModal(false);
       showNotification(
-        toast,
         <Alert type="success" title={`Password reset for ${fullName}`} />
       );
     } catch (e) {
@@ -279,7 +275,6 @@ const ManageUsers: React.FC<Props> = ({
       updateShowDeleteUserModal(false);
       setDeletedUserId(userId);
       showNotification(
-        toast,
         <Alert type="success" title={`User account removed for ${fullName}`} />
       );
       await getUsers();
@@ -303,7 +298,6 @@ const ManageUsers: React.FC<Props> = ({
       updateShowReactivateUserModal(false);
       reload();
       showNotification(
-        toast,
         <Alert type="success" title={`${fullName} has been reactivated.`} />
       );
     } catch (e) {

--- a/frontend/src/app/admin/DeviceType/DeviceTypeFormContainer.tsx
+++ b/frontend/src/app/admin/DeviceType/DeviceTypeFormContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { gql, useMutation } from "@apollo/client";
-import { toast } from "react-toastify";
 import { Redirect } from "react-router-dom";
 
 import Alert from "../../commonComponents/Alert";
@@ -51,7 +50,7 @@ const DeviceTypeFormContainer: any = () => {
           body="The device has been created"
         />
       );
-      showNotification(toast, alert);
+      showNotification(alert);
       setSubmitted(true);
     });
   };

--- a/frontend/src/app/admin/Organization/AddOrganizationAdminFormContainer.tsx
+++ b/frontend/src/app/admin/Organization/AddOrganizationAdminFormContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { toast } from "react-toastify";
 import {
   useAppInsightsContext,
   useTrackEvent,
@@ -114,7 +113,7 @@ const AddOrganizationAdminFormContainer: any = () => {
           body="The organization admin has been added"
         />
       );
-      showNotification(toast, alert);
+      showNotification(alert);
       setSubmitted(true);
     });
   };

--- a/frontend/src/app/admin/Organization/FacilityAdmin.tsx
+++ b/frontend/src/app/admin/Organization/FacilityAdmin.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from "react";
-import { toast } from "react-toastify";
 
 import Alert from "../../commonComponents/Alert";
 import Input from "../../commonComponents/Input";
@@ -61,7 +60,7 @@ export const useFacilityAdminValidation = (admin: FacilityAdmin) => {
           body="Please check the form to make sure you complete all of the required fields."
         />
       );
-      showNotification(toast, alert);
+      showNotification(alert);
       return "error";
     }
   };

--- a/frontend/src/app/admin/Organization/OrganizationDropDown.tsx
+++ b/frontend/src/app/admin/Organization/OrganizationDropDown.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { toast } from "react-toastify";
 
 import Alert from "../../commonComponents/Alert";
 import { showNotification } from "../../utils";
@@ -27,7 +26,7 @@ export const useOrganizationDropDownValidation = (
           body="Please select an organization."
         />
       );
-      showNotification(toast, alert);
+      showNotification(alert);
       return "error";
     }
 

--- a/frontend/src/app/admin/Organization/PendingOrganizationsList.tsx
+++ b/frontend/src/app/admin/Organization/PendingOrganizationsList.tsx
@@ -1,7 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
 import React, { useState } from "react";
 import classnames from "classnames";
-import { toast } from "react-toastify";
 
 import {
   InjectedQueryWrapperProps,
@@ -120,7 +119,7 @@ export const DetachedPendingOrganizationsList: any = ({
             body=""
           />
         );
-        showNotification(toast, alert);
+        showNotification(alert);
       })
       .finally(refetch);
   };

--- a/frontend/src/app/admin/Organization/TenantDataAccessFormContainer.tsx
+++ b/frontend/src/app/admin/Organization/TenantDataAccessFormContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { toast } from "react-toastify";
 import {
   useAppInsightsContext,
   useTrackEvent,
@@ -88,7 +87,7 @@ const TenantDataAccessFormContainer: any = () => {
           body="You now have access to tenant data for the requested organization."
         />
       );
-      showNotification(toast, alert);
+      showNotification(alert);
       setSubmitted(true);
 
       // reload the page, in the future, this should just update state where appropriate

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { gql, useLazyQuery, useMutation } from "@apollo/client";
-import { toast } from "react-toastify";
 import { Redirect } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import moment from "moment";
@@ -250,7 +249,6 @@ const AddPatient = () => {
       },
     });
     showNotification(
-      toast,
       <Alert
         type="success"
         title={`${PATIENT_TERM_CAP} record created`}

--- a/frontend/src/app/patients/ArchivePersonModal.tsx
+++ b/frontend/src/app/patients/ArchivePersonModal.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
-import { toast } from "react-toastify";
 
 import Button from "../commonComponents/Button/Button";
 import { displayFullName, showNotification } from "../utils";
@@ -43,7 +42,7 @@ const ArchivePersonModal = ({ person, closeModal }: Props) => {
     })
       .then(() => {
         const alert = <Alert type="success" title="Record archived" body="" />;
-        showNotification(toast, alert);
+        showNotification(alert);
       })
       .finally(() => {
         closeModal();

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState, useEffect } from "react";
 import { Prompt } from "react-router-dom";
-import { toast } from "react-toastify";
 import { SchemaOf } from "yup";
 import { useTranslation } from "react-i18next";
 
@@ -234,7 +233,7 @@ const PersonForm = (props: Props) => {
           document.getElementsByName(name)[0]?.focus();
           focusedOnError = true;
         }
-        showError(toast, t("patient.form.errors.validationMsg"), error);
+        showError(t("patient.form.errors.validationMsg"), error);
       });
       return;
     }

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { toast } from "react-toastify";
 import { Redirect } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
@@ -209,7 +208,6 @@ const EditPatient = (props: Props) => {
       },
     });
     showNotification(
-      toast,
       <Alert
         type="success"
         title={`${PATIENT_TERM_CAP} record saved`}

--- a/frontend/src/app/patients/PatientUpload.tsx
+++ b/frontend/src/app/patients/PatientUpload.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { gql, useMutation } from "@apollo/client";
-import { toast } from "react-toastify";
 
 import { showError, showNotification } from "../utils";
 import Alert from "../commonComponents/Alert";
@@ -23,12 +22,11 @@ const PatientUpload = ({ onSuccess }: Props) => {
   }: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = files;
     if (fileList === null) {
-      showError(toast, "Error", "File not found");
+      showError("Error", "File not found");
       return;
     }
     upload({ variables: { patientList: fileList[0] } }).then((response) => {
       showNotification(
-        toast,
         <Alert
           type="success"
           title={`Patients uploaded`}

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { toast } from "react-toastify";
 import moment from "moment";
 
 import { Card } from "../../commonComponents/Card/Card";
@@ -92,7 +91,7 @@ const PersonalDetailsForm = ({
         body="Please check the form to make sure you complete all of the required fields."
       />
     );
-    showNotification(toast, alert);
+    showNotification(alert);
     setSaving(false);
   };
 

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { toast } from "react-toastify";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStopwatch } from "@fortawesome/free-solid-svg-icons";
 
@@ -94,7 +93,7 @@ const QuestionsForm: React.FC<Props> = ({
         body="Please check the form to make sure you complete all of the required fields."
       />
     );
-    showNotification(toast, alert);
+    showNotification(alert);
   };
 
   return (

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -1,5 +1,4 @@
 import { ReactElement, useState } from "react";
-import { toast } from "react-toastify";
 import { Redirect } from "react-router";
 
 import { Card } from "../../commonComponents/Card/Card";
@@ -104,7 +103,7 @@ const OrganizationForm = () => {
       />
     );
     window.scrollTo(0, 0);
-    showNotification(toast, alert);
+    showNotification(alert);
     setLoading(false);
   };
 

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { toast } from "react-toastify";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
 import {
@@ -311,11 +310,11 @@ const QueueItem = ({
           body="The phone number provided may not be valid or may not be able to accept text messages"
         />
       );
-      showNotification(toast, deliveryFailureAlert);
+      showNotification(deliveryFailureAlert);
     }
 
     let alert = <Alert type="success" title={title} body={body} />;
-    showNotification(toast, alert);
+    showNotification(alert);
   };
 
   const onTestResultSubmit = async (forceSubmit: boolean = false) => {

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
-import { toast } from "react-toastify";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import { showError } from "../utils";
@@ -143,7 +142,6 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   }
   if (facility.deviceTypes.length === 0) {
     showError(
-      toast,
       "This facility does not have any testing devices. Go into Settings -> Manage facilities and add a device."
     );
   }

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -5,7 +5,6 @@ import React, {
   useMemo,
   useCallback,
 } from "react";
-import { toast } from "react-toastify";
 import { gql, useMutation, useLazyQuery, useQuery } from "@apollo/client";
 import {
   useAppInsightsContext,
@@ -269,7 +268,7 @@ const AddToQueueSearchBox = ({
           ),
         };
         const alert = <Alert type={type} title={title} body={body} />;
-        showNotification(toast, alert);
+        showNotification(alert);
         refetchQueue();
         if (createOrUpdate === "create") {
           return res.data.addPatientToQueue;

--- a/frontend/src/app/testResults/TestResultCorrectionModal.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
-import { toast } from "react-toastify";
 
 import Button from "../commonComponents/Button/Button";
 import { displayFullName, showNotification } from "../utils";
@@ -64,7 +63,7 @@ export const DetachedTestResultCorrectionModal = ({
         const alert = (
           <Alert type="success" title="Result marked as error" body="" />
         );
-        showNotification(toast, alert);
+        showNotification(alert);
       })
       .finally(() => {
         closeModal();

--- a/frontend/src/app/utils/index.tsx
+++ b/frontend/src/app/utils/index.tsx
@@ -1,8 +1,6 @@
-import { toast as t } from "react-toastify";
+import { toast } from "react-toastify";
 
 import Alert from "../commonComponents/Alert";
-
-type Toast = typeof t;
 
 export const displayFullName = (
   first: string | null | undefined,
@@ -25,7 +23,7 @@ export const isEmptyString = (input = "") => {
   return Boolean(input.trim().length === 0);
 };
 
-export const showNotification = (toast: Toast, children: JSX.Element) => {
+export const showNotification = (children: JSX.Element) => {
   try {
     // id will de-dup. just use whole message as id
     const toastId = JSON.stringify(children.props).substr(0, 512);
@@ -37,10 +35,9 @@ export const showNotification = (toast: Toast, children: JSX.Element) => {
 };
 
 export const showError = (
-  toast: Toast,
   message = "Please check for missing data or typos.",
   title = "Problems saving data to server"
 ) => {
   const err_msg = message.substr(0, 512);
-  showNotification(toast, <Alert type="error" title={title} body={err_msg} />);
+  showNotification(<Alert type="error" title={title} body={err_msg} />);
 };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,7 +12,6 @@ import { Switch, Route, BrowserRouter as Router } from "react-router-dom";
 import { createUploadLink } from "apollo-upload-client";
 import { ErrorResponse, onError } from "@apollo/client/link/error";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
-import { toast } from "react-toastify";
 import Modal from "react-modal";
 
 import App from "./app/App";
@@ -79,11 +78,7 @@ const logoutLink = onError(({ networkError, graphQLErrors }: ErrorResponse) => {
       if (appInsights instanceof ApplicationInsights) {
         appInsights.trackException({ error: networkError });
       }
-      showError(
-        toast,
-        "Please check for errors and try again",
-        networkError.message
-      );
+      showError("Please check for errors and try again", networkError.message);
     }
   }
   if (graphQLErrors) {
@@ -93,11 +88,7 @@ const logoutLink = onError(({ networkError, graphQLErrors }: ErrorResponse) => {
       );
       return message;
     });
-    showError(
-      toast,
-      "Please check for errors and try again",
-      messages.join(" ")
-    );
+    showError("Please check for errors and try again", messages.join(" "));
     console.error("graphql error", graphQLErrors);
   }
 });

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router";
-import { toast, ToastContainer } from "react-toastify";
+import { ToastContainer } from "react-toastify";
 import moment from "moment";
 import "react-toastify/dist/ReactToastify.css";
 import { useTranslation } from "react-i18next";
@@ -66,7 +66,6 @@ export const SelfRegistration = () => {
       setStep(RegistrationStep.FINISHED);
     } catch (e) {
       showError(
-        toast,
         t("selfRegistration.form.error.heading"),
         t("selfRegistration.form.error.text")
       );

--- a/frontend/src/patientApp/timeOfTest/AoEPatientFormContainer.tsx
+++ b/frontend/src/patientApp/timeOfTest/AoEPatientFormContainer.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Redirect } from "react-router-dom";
 import { connect, useSelector } from "react-redux";
-import { toast } from "react-toastify";
 
 import AoEForm from "../../app/testQueue/AoEForm/AoEForm";
 import { showError } from "../../app/utils";
@@ -28,7 +27,7 @@ const AoEPatientFormContainer: React.FC<Props> = ({ page }: Props) => {
       await PxpApi.submitQuestions(plid as string, patient.birthDate, data);
       setNextPage(true);
     } catch (e) {
-      showError(toast, "There was an error submitting your responses");
+      showError("There was an error submitting your responses");
       return;
     }
   };

--- a/frontend/src/patientApp/timeOfTest/PatientFormContainer.tsx
+++ b/frontend/src/patientApp/timeOfTest/PatientFormContainer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { connect, useSelector, useDispatch } from "react-redux";
 import { Redirect, useHistory } from "react-router-dom";
-import { toast } from "react-toastify";
 
 import { setPatient as reduxSetPatient } from "../../app/store";
 import { PxpApi } from "../../patientApp/PxpApiService";
@@ -67,7 +66,6 @@ const PatientFormContainer = () => {
       }
     );
     showNotification(
-      toast,
       <Alert type="success" title={`Your profile changes have been saved`} />
     );
 


### PR DESCRIPTION
## Related Issue or Background Info

- https://github.com/CDCgov/prime-simplereport/pull/2542#discussion_r707677518

## Changes Proposed

- import toast in the until functions that use it

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
