### PR TITLE
fix results page redirect loop

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route } from "react-router-dom";
+import { BrowserRouter as Router, MemoryRouter, Route } from "react-router-dom";
 import { Provider } from "react-redux";
 import createMockStore, { MockStoreEnhanced } from "redux-mock-store";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
@@ -15,6 +15,12 @@ jest.mock("./VersionService", () => ({
     enforce: jest.fn(),
   },
 }));
+jest.mock("./testResults/CleanTestResultsList", () => {
+  return () => <p>CleanTestResultsList</p>;
+});
+jest.mock("./testResults/TestResultsList", () => {
+  return () => <p>TestResultsList</p>;
+});
 
 const mockStore = createMockStore([]);
 const mockDispatch = jest.fn();
@@ -222,5 +228,44 @@ describe("App", () => {
     renderApp(mockedStore, [WhoAmIQueryMock, facilityQueryMock]);
     expect(screen.queryByText(TRAINING_PURPOSES_ONLY)).not.toBeInTheDocument();
     expect(screen.queryByText(MODAL_TEXT)).not.toBeInTheDocument();
+  });
+  it("renders CleanTestResultsList when going to /results/", async () => {
+    const mockedStore = mockStore({ ...store, dataLoaded: true });
+
+    await render(
+      <Provider store={mockedStore}>
+        <MockedProvider mocks={[WhoAmIQueryMock]} addTypename={false}>
+          <MemoryRouter
+            initialEntries={[
+              `/results?facility=fec4de56-f4cc-4c61-b3d5-76869ca71296`,
+            ]}
+          >
+            <App />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
+    );
+
+    expect(await screen.findByText("CleanTestResultsList")).toBeInTheDocument();
+  });
+
+  it("renders TestResultsList when going to /results/page_number ", async () => {
+    const mockedStore = mockStore({ ...store, dataLoaded: true });
+
+    await render(
+      <Provider store={mockedStore}>
+        <MockedProvider mocks={[WhoAmIQueryMock]} addTypename={false}>
+          <MemoryRouter
+            initialEntries={[
+              `/results/1?facility=fec4de56-f4cc-4c61-b3d5-76869ca71296`,
+            ]}
+          >
+            <App />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
+    );
+
+    expect(await screen.findByText("TestResultsList")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -119,20 +119,18 @@ const App = () => {
               )}
             />
             <ProtectedRoute
-              path="/results/"
-              render={() => <CleanTestResultsList />}
-              requiredPermissions={appPermissions.results.canView}
-              userPermissions={data.whoami.permissions}
-              exact={true}
-            />
-            <ProtectedRoute
               path="/results/:page"
               render={({ match }: any) => {
                 return <TestResultsList pageNumber={match.params.page} />;
               }}
               requiredPermissions={appPermissions.results.canView}
               userPermissions={data.whoami.permissions}
-              exact={true}
+            />
+            <ProtectedRoute
+              path="/results/"
+              render={() => <CleanTestResultsList />}
+              requiredPermissions={appPermissions.results.canView}
+              userPermissions={data.whoami.permissions}
             />
             <ProtectedRoute
               path={`/patients/:page?`}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -8,7 +8,9 @@ import ProtectedRoute from "./commonComponents/ProtectedRoute";
 import Header from "./commonComponents/Header";
 import Page from "./commonComponents/Page/Page";
 import { setInitialState } from "./store";
-import TestResultsList from "./testResults/TestResultsList";
+import TestResultsList, {
+  CleanTestResultsList,
+} from "./testResults/TestResultsList";
 import TestQueueContainer from "./testQueue/TestQueueContainer";
 import ManagePatientsContainer from "./patients/ManagePatientsContainer";
 import EditPatientContainer from "./patients/EditPatientContainer";
@@ -118,12 +120,20 @@ const App = () => {
               )}
             />
             <ProtectedRoute
-              path="/results/:page?"
+              path="/results/"
+              render={() => <CleanTestResultsList />}
+              requiredPermissions={appPermissions.results.canView}
+              userPermissions={data.whoami.permissions}
+              exact={true}
+            />
+            <ProtectedRoute
+              path="/results/:page"
               render={({ match }: any) => {
                 return <TestResultsList pageNumber={match.params.page} />;
               }}
               requiredPermissions={appPermissions.results.canView}
               userPermissions={data.whoami.permissions}
+              exact={true}
             />
             <ProtectedRoute
               path={`/patients/:page?`}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -8,9 +8,8 @@ import ProtectedRoute from "./commonComponents/ProtectedRoute";
 import Header from "./commonComponents/Header";
 import Page from "./commonComponents/Page/Page";
 import { setInitialState } from "./store";
-import TestResultsList, {
-  CleanTestResultsList,
-} from "./testResults/TestResultsList";
+import TestResultsList from "./testResults/TestResultsList";
+import CleanTestResultsList from "./testResults/CleanTestResultsList";
 import TestQueueContainer from "./testQueue/TestQueueContainer";
 import ManagePatientsContainer from "./patients/ManagePatientsContainer";
 import EditPatientContainer from "./patients/EditPatientContainer";

--- a/frontend/src/app/commonComponents/ProtectedRoute.tsx
+++ b/frontend/src/app/commonComponents/ProtectedRoute.tsx
@@ -9,7 +9,6 @@ interface Props {
   path: string;
   component?: React.FC<any>;
   render?: any;
-  exact?: boolean;
 }
 const ProtectedRoute: React.FC<Props> = ({
   requiredPermissions,

--- a/frontend/src/app/commonComponents/ProtectedRoute.tsx
+++ b/frontend/src/app/commonComponents/ProtectedRoute.tsx
@@ -9,6 +9,7 @@ interface Props {
   path: string;
   component?: React.FC<any>;
   render?: any;
+  exact?: boolean;
 }
 const ProtectedRoute: React.FC<Props> = ({
   requiredPermissions,

--- a/frontend/src/app/testResults/CleanTestResultsList.test.tsx
+++ b/frontend/src/app/testResults/CleanTestResultsList.test.tsx
@@ -1,0 +1,54 @@
+import qs from "querystring";
+
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CleanTestResultsList from "./CleanTestResultsList";
+
+const mockStore = configureStore([]);
+const store = mockStore({
+  organization: {
+    name: "Organization Name",
+  },
+  user: {
+    firstName: "Kim",
+    lastName: "Mendoza",
+  },
+  facilities: [
+    { id: "1", name: "Facility 1" },
+    { id: "2", name: "Facility 2" },
+  ],
+  facility: { id: "1", name: "Facility 1" },
+});
+
+const mockPush = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useHistory: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("CleanTestResultsList", () => {
+  it("should redirect to page 1 of test results", async () => {
+    await render(
+      <MemoryRouter
+        initialEntries={[{ pathname: "/results/", search: "?facility=1" }]}
+      >
+        <Provider store={store}>
+          <CleanTestResultsList />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: "/results/1",
+        search: qs.stringify({
+          facility: 1,
+        }),
+      });
+    });
+  });
+});

--- a/frontend/src/app/testResults/CleanTestResultsList.tsx
+++ b/frontend/src/app/testResults/CleanTestResultsList.tsx
@@ -1,4 +1,4 @@
-// this component removes the filter search params from the url
+// this component removes all filter search params from the url
 import qs from "querystring";
 
 import { useHistory } from "react-router-dom";

--- a/frontend/src/app/testResults/CleanTestResultsList.tsx
+++ b/frontend/src/app/testResults/CleanTestResultsList.tsx
@@ -1,0 +1,26 @@
+// this component removes the filter search params from the url
+import qs from "querystring";
+
+import { useHistory } from "react-router-dom";
+import React from "react";
+
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
+
+const CleanTestResultsList = () => {
+  const history = useHistory();
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id || "";
+
+  if (activeFacilityId && history) {
+    history.push({
+      pathname: "/results/1",
+      search: qs.stringify({
+        facility: activeFacilityId,
+      }),
+    });
+  }
+
+  return <></>;
+};
+
+export default CleanTestResultsList;

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -698,20 +698,4 @@ const TestResultsList = (props: TestResultsListProps) => {
   );
 };
 
-// this component removes the filter search params from the url
-export const CleanTestResultsList = () => {
-  const history = useHistory();
-  const [facility] = useSelectedFacility();
-  const activeFacilityId = facility?.id || "";
-
-  history.push({
-    pathname: "/results/1",
-    search: qs.stringify({
-      facility: activeFacilityId,
-    }),
-  });
-
-  return <></>;
-};
-
 export default TestResultsList;

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -601,15 +601,6 @@ const TestResultsList = (props: TestResultsListProps) => {
   const role = getParameterFromUrl("role", history.location);
   const result = getParameterFromUrl("result", history.location);
 
-  useEffect(
-    () => () => {
-      history.replace({
-        search: qs.stringify({ facility: activeFacilityId }),
-      });
-    },
-    [history, activeFacilityId]
-  );
-
   const filterParams: FilterParams = {
     ...(patientId && { patientId: patientId }),
     ...(startDate && { startDate: startDate }),
@@ -705,6 +696,22 @@ const TestResultsList = (props: TestResultsListProps) => {
       refetch={refetch}
     />
   );
+};
+
+// this component removes the filter search params from the url
+export const CleanTestResultsList = () => {
+  const history = useHistory();
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id || "";
+
+  history.push({
+    pathname: "/results/1",
+    search: qs.stringify({
+      facility: activeFacilityId,
+    }),
+  });
+
+  return <></>;
 };
 
 export default TestResultsList;


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #2553

## Changes Proposed
- add a new route that removed the filter search params
- remove clearing search params when un-mounting test results component

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
