### PR TITLE
Remove CLIA validation on state selection

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
+++ b/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
@@ -113,7 +113,6 @@ const FacilityInformation: React.FC<Props> = ({
         onChange={onChange}
         onBlur={() => {
           validateField("state");
-          validateField("cliaNumber");
         }}
         validationStatus={errors.state ? "error" : undefined}
         errorMessage={errors.state}


### PR DESCRIPTION
## Related Issue or Background Info

Validating CLIA on state selection was leading to some weird interactions. Now that the CLIA input is after the state selection, we likely don't need the cross-validation. (It was only put in place because CLIA validation now takes the state as an input, so if the CLIA was entered before the state was selected the CLIA error would still persist.)

This is the old behavior:
![Settings _ SimpleReport (1)](https://user-images.githubusercontent.com/80282552/133332308-bb830ee4-fa63-4152-82ec-0a33fd3d47be.gif)


## Changes Proposed

- no longer validate CLIA numbers when the state changes


## Screenshots/Demos
![Settings _ SimpleReport (2)](https://user-images.githubusercontent.com/80282552/133333156-d0793665-6768-4add-b895-1bd1934ba92c.gif)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
