### PR TITLE
center queue loading message and match background color

### DIFF
--- a/frontend/src/app/__snapshots__/App.test.tsx.snap
+++ b/frontend/src/app/__snapshots__/App.test.tsx.snap
@@ -416,6 +416,7 @@ exports[`App Render main screen 1`] = `
       </header>
       <main
         class="prime-home"
+        style="padding-top: 80px;"
       >
         <div
           class="grid-container"

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -131,7 +131,11 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     throw error;
   }
   if (loading) {
-    return <p>Loading patients...</p>;
+    return (
+      <main className="prime-home display-flex flex-justify-center">
+        Loading patients...
+      </main>
+    );
   }
 
   const facility = data.organization.testingFacility.find(

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -132,8 +132,14 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   }
   if (loading) {
     return (
-      <main className="prime-home display-flex flex-justify-center">
-        Loading patients...
+      <main
+        className="prime-home display-flex flex-justify-center"
+        style={{
+          fontSize: "22px",
+          paddingTop: "80px",
+        }}
+      >
+        Loading tests ...
       </main>
     );
   }

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`TestQueue should render the test queue 1`] = `
 <div>
   <main
     class="prime-home"
+    style="padding-top: 80px;"
   >
     <div
       class="grid-container"


### PR DESCRIPTION
## Related Issue or Background Info

- queue page loading screen is off to the side

## Changes Proposed

- center loading patients message
- match website background color

## Additional Information

## Screenshots / Demos
current behavior

https://user-images.githubusercontent.com/4952042/133451078-c0f5daf3-126b-4060-8699-83ccf5037201.mp4


proposed behavior


https://user-images.githubusercontent.com/4952042/133509432-4a07c417-9e6b-449e-ae37-92b6258433e4.mp4



## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
