### PR TITLE
Replace empty line in Azure log query that gets passed through to Pagerduty

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -2,7 +2,7 @@ locals {
   env_title = title(var.env)
 
   // If skip_on_weekends true, only run the query on weekdays
-  skip_on_weekends = var.skip_on_weekends ? "| where dayofweek(now()) between (time(1) .. time(5))" : ""
+  skip_on_weekends = var.skip_on_weekends ? "| where dayofweek(now()) between (time(1) .. time(5))" : "| where true"
 }
 
 resource "azurerm_monitor_metric_alert" "cpu_util" {


### PR DESCRIPTION
## Related Issue or Background Info

Azure log queries return different results when there is an empty line.  For example:

```
requests

| where toint(resultCode) between (200 .. 299) and success == false and timestamp >= (datetime(2021-09-15T12:51:22.0000000Z) - 5m)
```

vs

```
requests
| where toint(resultCode) between (200 .. 299) and success == false and timestamp >= (datetime(2021-09-15T12:51:22.0000000Z) - 5m)
```

The second query returns the expected result where the first does not.

We're disabling some alerts on weekends with `skip_on_weekends` by adding a `where` clause to the query.  For alerts that aren't skipped on weekends, the value ends up being an empty string.  This results in the empty line in the query.

These queries get passed through to Pagerduty, so we end up with links in our incidents that contain queries that have to be edited and re-run in order to see the correct results.

## Changes Proposed

- Insert a clause that does not filter any results when not skipping weekends

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
