### PR TITLE
Update PR template to add changeset tagging

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,7 @@
   - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
         (including re-granting permission to the no-PHI user if need be)
   - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
+  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
 - [ ] GraphQL schema changes are backward compatible with older version of the front-end
 
 ### Security


### PR DESCRIPTION
## Related Issue or Background Info

- Add a checkbox for Liquibase changeset `tag`s to enable the parameterized DB rollback changes added in #2177 
