### PR TITLE
Revert container_name changes in docker-compose.yml

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
 RUN gradle --no-daemon classes testClasses assemble
 
 # db will be running in another container, for purposes of this local file
-ENV SPRING_DATASOURCE_URL=jdbc:postgresql://prime_sr_db:5432/simple_report
+ENV SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/simple_report
 
 ENTRYPOINT ["gradle", "--info", "--no-daemon"]
 CMD ["tasks"]

--- a/backend/Dockerfile.schemaspy
+++ b/backend/Dockerfile.schemaspy
@@ -4,7 +4,7 @@ WORKDIR /home/schemaspy
 RUN apk update && apk add graphviz curl
 RUN curl -H "Accept: application/zip" -L https://github.com/schemaspy/schemaspy/releases/download/v6.1.0/schemaspy-6.1.0.jar > schemaspy.jar
 RUN curl -H "Accept: application/zip" https://jdbc.postgresql.org/download/postgresql-42.2.18.jar > postgresql.jar
-RUN java -jar schemaspy.jar -debug -t pgsql -db simple_report -u postgres -p admin_password_for_local_dev_is_not_very_secure -host prime_sr_db:5432 -o output -s "simple_report" -dp postgresql.jar || true
+RUN java -jar schemaspy.jar -debug -t pgsql -db simple_report -u postgres -p admin_password_for_local_dev_is_not_very_secure -host db:5432 -o output -s "simple_report" -dp postgresql.jar || true
 
 FROM nginx:alpine
 EXPOSE 80

--- a/backend/docker-compose.db-rollback.yml
+++ b/backend/docker-compose.db-rollback.yml
@@ -6,10 +6,10 @@ services:
       dockerfile: backend/Dockerfile.db-rollback
       target: build
     image: simple-report-api-build
-    container_name: prime_sr_db_rollback
+    container_name: db_rollback
     environment:
       LIQUIBASE_ROLLBACK_TAG: ${LIQUIBASE_ROLLBACK_TAG:-}
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://prime_sr_db:5432/simple_report}
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://db:5432/simple_report}
     networks:
       - dev-net
 networks:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.5"
 services:
   db:
     image: postgres:12-alpine
-    container_name: prime_sr_db
     ports:
       - "${SR_DB_PORT:-5432}:${SR_DB_PORT:-5432}"
     environment:
@@ -27,7 +26,6 @@ services:
       context: ..
       dockerfile: backend/Dockerfile
     image: simple-report-api-build
-    container_name: prime_sr_api
     command: bootRun
     environment:
       SPRING_PROFILES_ACTIVE: dev,db-dockerized
@@ -44,7 +42,6 @@ services:
       context: .
       dockerfile: Dockerfile.schemaspy
       network: dev-net
-    container_name: prime_sr_schemaspy
     ports:
       - "${SR_SCHEMASPY_PORT:-8081}:80"
     environment:

--- a/backend/src/main/resources/application-db-dockerized.yaml
+++ b/backend/src/main/resources/application-db-dockerized.yaml
@@ -1,1 +1,1 @@
-spring.datasource.url: jdbc:postgresql://prime_sr_db:${SR_DB_PORT:5432}/simple_report
+spring.datasource.url: jdbc:postgresql://db:${SR_DB_PORT:5432}/simple_report


### PR DESCRIPTION
## Related Issue or Background Info

`container_names` were added to the `docker-compose.yml` file in #2177 to try to standardize container naming. This ended up breaking test DB containers due to a name conflict. This still seems like something to revisit but it's low priority and reverting it is the easiest option at the moment.

## Changes Proposed

- Revert aforementioned changes
