### PR TITLE
Correct language on "print test result" view for negative test case

### DIFF
--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -207,7 +207,7 @@ export const DetachedTestResultPrintModal = ({
             <h2>{t("testResult.note")}</h2>
             {data.testResult.result !== "POSITIVE" && (
               <>
-                <p>{t("testResult.notes.meaning")}</p>
+                <p>{t("testResult.notes.negative.p0")}</p>
                 <ul className="sr-multi-column">
                   <li>{t("testResult.notes.negative.symptoms.li2")}</li>
                   <li>{t("testResult.notes.negative.symptoms.li3")}</li>
@@ -219,6 +219,16 @@ export const DetachedTestResultPrintModal = ({
                   <li>{t("testResult.notes.negative.symptoms.li9")}</li>
                   <li>{t("testResult.notes.negative.symptoms.li10")}</li>
                 </ul>
+                <Trans
+                  t={t}
+                  parent="p"
+                  i18nKey="testResult.information"
+                  components={[
+                    <a href="https://www.cdc.gov/coronavirus/2019-ncov/if-you-are-sick/end-home-isolation.html">
+                      Centers for Disease Control and Prevention (CDC) website
+                    </a>,
+                  ]}
+                />
               </>
             )}
             {data.testResult.result === "POSITIVE" && (

--- a/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`TestResultPrintModal should render the test result print view 1`] = `
               Notes
             </h2>
             <p>
-              COVID-19 antigen tests can sometimes provid inaccurate or false results and follow up testing may be needed. Continue social distancing and wearing a mask. Contact your health care provider to determine if additional testing is needed especially if you experience any of these  symptoms.
+              Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
             </p>
             <ul
               class="sr-multi-column"
@@ -257,6 +257,15 @@ exports[`TestResultPrintModal should render the test result print view 1`] = `
                 Diarrhea
               </li>
             </ul>
+            <p>
+              For more information, please visit the 
+              <a
+                href="https://www.cdc.gov/coronavirus/2019-ncov/if-you-are-sick/end-home-isolation.html"
+              >
+                Centers for Disease Control and Prevention (CDC) website
+              </a>
+               or contact your local health department.
+            </p>
           </section>
         </main>
         <footer>


### PR DESCRIPTION
## Related Issue or Background Info

![image (1)](https://user-images.githubusercontent.com/27730981/133653869-037fb905-eaf8-4315-84be-75e99307247b.png)
* The above screenshot accurately captures the issue but (at least I'm pretty sure - @LGFranklin correct me if I'm wrong) prescribes the text for the _positive_ test case, which isn't what we want here

## Changes Proposed
- No longer refer to "antigen" in the test notes for negative results, as this is inaccurate and confusing

## Additional Information
* I treated the [Patient test result content v4](https://docs.google.com/document/d/1XBcBnS-kjXVbT44q7RN_6Nx9QmdFr-aNFj_IjaV3UhE/edit) as canonical when updating the text
    * @Rebecca-LM if this document is out-of-date in any way please let me know!

## Screenshots / Demos
### Before
#### English
<img width="527" alt="Screen Shot 2021-09-16 at 12 50 18 PM" src="https://user-images.githubusercontent.com/27730981/133654362-1e470375-8bc1-4058-8f73-e9e440ac3721.png">

#### Spanish
<img width="529" alt="Screen Shot 2021-09-16 at 12 54 02 PM" src="https://user-images.githubusercontent.com/27730981/133654383-22634cdf-affa-41cd-a8b9-df4b25678655.png">

### After
#### English
<img width="520" alt="Screen Shot 2021-09-16 at 1 01 00 PM" src="https://user-images.githubusercontent.com/27730981/133654498-aff260d6-e00b-4a44-a007-39491dce6b64.png">

#### Spanish
<img width="524" alt="Screen Shot 2021-09-16 at 12 53 42 PM" src="https://user-images.githubusercontent.com/27730981/133654414-5325fae8-81c6-48df-b88f-4ed82243704d.png">

## Checklist for Author and Reviewer
- [ ] @Rebecca-LM is the updated copy correct?
- [ ] @LGFranklin is this the correct outcome?

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
