### PR TITLE
Use generated queries in manage users

### DIFF
--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -111,7 +111,7 @@ type ApiUser {
 }
 
 type ApiUserWithStatus {
-  id: ID
+  id: ID!
   name: NameInfo!
   firstName: String
   middleName: String
@@ -287,7 +287,7 @@ type Query {
   topLevelDashboardMetrics(facilityId: ID, startDate: DateTime!, endDate: DateTime!): TopLevelDashboardMetrics
     @requiredPermissions(allOf: ["EDIT_ORGANIZATION"])
   users: [ApiUser] @requiredPermissions(allOf: ["MANAGE_USERS"])
-  usersWithStatus: [ApiUserWithStatus] @requiredPermissions(allOf: ["MANAGE_USERS"])
+  usersWithStatus: [ApiUserWithStatus!] @requiredPermissions(allOf: ["MANAGE_USERS"])
   user(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   whoami: User!
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -17,8 +17,8 @@ type Organization {
 }
 
 type Facility {
-  id: ID
-  name: String
+  id: ID!
+  name: String!
   cliaNumber: String
   address: AddressInfo
   street: String
@@ -81,8 +81,8 @@ input PhoneNumberInput {
 
 # Note: the login username is the user's email
 type User {
-  id: ID
-  name: NameInfo
+  id: ID!
+  name: NameInfo!
   firstName: String
   middleName: String
   lastName: String!

--- a/frontend/src/app/Settings/Users/CreateUserForm.tsx
+++ b/frontend/src/app/Settings/Users/CreateUserForm.tsx
@@ -70,7 +70,7 @@ const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit, isUpdating }) => {
     !newUser.lastName ||
     !newUser.email ||
     !(newUser as SettingsUser).organization?.testingFacility ||
-    (newUser as SettingsUser).organization.testingFacility.length === 0;
+    (newUser as SettingsUser)?.organization?.testingFacility.length === 0;
 
   const onSave = async () => {
     setSaving(true);

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -7,8 +7,9 @@ import configureStore from "redux-mock-store";
 import { displayFullName } from "../../utils";
 
 import ManageUsers, { SettingsUsers } from "./ManageUsers";
-import { GET_USER } from "./ManageUsersContainer";
+
 import "../../../i18n";
+import { GetUserDocument } from "../../../generated/graphql";
 
 const organization = { testingFacility: [{ id: "a1", name: "Foo Org" }] };
 const allFacilities = [
@@ -90,7 +91,7 @@ const suspendedUsers: SettingsUsers[keyof SettingsUsers][] = [
 const mocks = [
   {
     request: {
-      query: GET_USER,
+      query: GetUserDocument,
       variables: {
         id: "a123",
       },
@@ -113,7 +114,7 @@ const mocks = [
   },
   {
     request: {
-      query: GET_USER,
+      query: GetUserDocument,
       variables: {
         id: "b1",
       },
@@ -136,7 +137,7 @@ const mocks = [
   },
   {
     request: {
-      query: GET_USER,
+      query: GetUserDocument,
       variables: {
         id: "b234",
       },
@@ -505,7 +506,7 @@ describe("ManageUsers", () => {
     const updatedMocks = [
       {
         request: {
-          query: GET_USER,
+          query: GetUserDocument,
           variables: {
             id: "a123",
           },
@@ -533,7 +534,7 @@ describe("ManageUsers", () => {
       },
       {
         request: {
-          query: GET_USER,
+          query: GetUserDocument,
           variables: {
             id: "b1",
           },

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -5,11 +5,11 @@ import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { displayFullName } from "../../utils";
+import { GetUserDocument } from "../../../generated/graphql";
 
 import ManageUsers, { SettingsUsers } from "./ManageUsers";
 
 import "../../../i18n";
-import { GetUserDocument } from "../../../generated/graphql";
 
 const organization = { testingFacility: [{ id: "a1", name: "Foo Org" }] };
 const allFacilities = [

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -5,6 +5,7 @@ import Alert from "../../commonComponents/Alert";
 import Button from "../../commonComponents/Button/Button";
 import { showNotification, displayFullName } from "../../utils";
 import reload from "../../utils/reload";
+import { UserPermission } from "../../../generated/graphql";
 
 import CreateUserModal from "./CreateUserModal";
 import UsersSideNav from "./UsersSideNav";
@@ -168,7 +169,7 @@ const ManageUsers: React.FC<Props> = ({
           ({ id }) => id
         ),
         accessAllFacilities: userWithPermissions?.permissions.includes(
-          "ACCESS_ALL_FACILITIES"
+          UserPermission.AccessAllFacilities
         ),
       },
     })
@@ -217,7 +218,7 @@ const ManageUsers: React.FC<Props> = ({
           role: role,
           facilities: organization?.testingFacility.map(({ id }) => id) || [],
           accessAllFacilities:
-            permissions?.includes("ACCESS_ALL_FACILITIES") || false,
+            permissions?.includes(UserPermission.AccessAllFacilities) || false,
         },
       });
 

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from "react";
-import { useLazyQuery } from "@apollo/client";
+import { ApolloQueryResult } from "@apollo/client";
 
 import Alert from "../../commonComponents/Alert";
 import Button from "../../commonComponents/Button/Button";
 import { showNotification, displayFullName } from "../../utils";
 import reload from "../../utils/reload";
-import { UserPermission } from "../../../generated/graphql";
+import {
+  UserPermission,
+  useGetUserLazyQuery,
+  GetUsersAndStatusQuery,
+} from "../../../generated/graphql";
 
 import CreateUserModal from "./CreateUserModal";
 import UsersSideNav from "./UsersSideNav";
@@ -14,8 +18,6 @@ import {
   SettingsUser,
   LimitedUser,
   UserFacilitySetting,
-  SingleUserData,
-  GET_USER,
 } from "./ManageUsersContainer";
 import "./ManageUsers.scss";
 
@@ -28,7 +30,7 @@ interface Props {
   resetUserPassword: (variables: any) => Promise<any>;
   deleteUser: (variables: any) => Promise<any>;
   reactivateUser: (variables: any) => Promise<any>;
-  getUsers: () => Promise<any>;
+  getUsers: () => Promise<ApolloQueryResult<GetUsersAndStatusQuery>>;
 }
 
 export type LimitedUsers = { [id: string]: LimitedUser };
@@ -82,15 +84,12 @@ const ManageUsers: React.FC<Props> = ({
   const [
     userWithPermissions,
     updateUserWithPermissions,
-  ] = useState<SettingsUser>();
-  const [queryUserWithPermissions] = useLazyQuery<SingleUserData, {}>(
-    GET_USER,
-    {
-      variables: { id: activeUser ? activeUser.id : loggedInUser.id },
-      fetchPolicy: "no-cache",
-      onCompleted: (data) => updateUserWithPermissions(data.user),
-    }
-  );
+  ] = useState<SettingsUser | null>();
+  const [queryUserWithPermissions] = useGetUserLazyQuery({
+    variables: { id: activeUser ? activeUser.id : loggedInUser.id },
+    fetchPolicy: "no-cache",
+    onCompleted: (data) => updateUserWithPermissions(data.user),
+  });
   const [nextActiveUserId, updateNextActiveUserId] = useState<string | null>(
     null
   );
@@ -165,7 +164,7 @@ const ManageUsers: React.FC<Props> = ({
       variables: {
         id: userWithPermissions?.id,
         role: userWithPermissions?.role,
-        facilities: userWithPermissions?.organization.testingFacility.map(
+        facilities: userWithPermissions?.organization?.testingFacility.map(
           ({ id }) => id
         ),
         accessAllFacilities: userWithPermissions?.permissions.includes(

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { gql, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 
@@ -107,7 +106,7 @@ export interface UserFacilitySetting {
   name: string;
 }
 
-const ManageUsersContainer: any = () => {
+const ManageUsersContainer = () => {
   const loggedInUser = useSelector<RootState, User>((state) => state.user);
   const allFacilities = useSelector<RootState, UserFacilitySetting[]>(
     (state) => state.facilities

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 
-import { UserRole, Role } from "../../permissions";
-import { UserPermission } from "../../../generated/graphql";
+import { Role } from "../../permissions";
+import { Maybe, UserPermission } from "../../../generated/graphql";
 
 import ManageUsers from "./ManageUsers";
 
@@ -20,52 +20,30 @@ const GET_USERS_WITH_STATUS = gql`
   }
 `;
 
-export const GET_USER = gql`
-  query GetUser($id: ID!) {
-    user(id: $id) {
-      id
-      firstName
-      middleName
-      lastName
-      roleDescription
-      role
-      permissions
-      email
-      status
-      organization {
-        testingFacility {
-          id
-          name
-        }
-      }
-    }
-  }
-`;
-
 // structure for `getUser` query
 export interface SettingsUser {
   id: string;
-  firstName: string;
-  middleName: string;
+  firstName?: Maybe<string>;
+  middleName?: Maybe<string>;
   lastName: string;
-  roleDescription: UserRole;
-  role: Role;
+  roleDescription: string;
+  role?: Maybe<Role>;
   permissions: UserPermission[];
   email: string;
-  status: string;
-  organization: {
+  status?: Maybe<string>;
+  organization?: Maybe<{
     testingFacility: UserFacilitySetting[];
-  };
+  }>;
 }
 
 // structure for `getUsersWithStatus` query
 export interface LimitedUser {
   id: string;
-  firstName: string;
-  middleName: string;
+  firstName?: string;
+  middleName?: string;
   lastName: string;
   email: string;
-  status: string;
+  status?: string;
 }
 
 interface UserData {
@@ -156,13 +134,6 @@ interface FacilityData {
 export interface UserFacilitySetting {
   id: string;
   name: string;
-}
-
-export interface NewUserInvite {
-  firstName: string;
-  lastName: string;
-  email: string;
-  role: UserRole | string | undefined; // TODO: clean this up or delete it if we are not supporting this feature
 }
 
 const ManageUsersContainer: any = () => {

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { gql, useQuery, useMutation } from "@apollo/client";
+import { gql, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 
+import { RootState } from "../../store";
 import { Role } from "../../permissions";
 import {
   Maybe,
@@ -101,30 +102,16 @@ const ADD_USER_TO_ORG = gql`
   }
 `;
 
-const GET_FACILITIES = gql`
-  query GetFacilitiesForManageUsers {
-    organization {
-      testingFacility {
-        id
-        name
-      }
-    }
-  }
-`;
-
-interface FacilityData {
-  organization: {
-    testingFacility: UserFacilitySetting[];
-  };
-}
-
 export interface UserFacilitySetting {
   id: string;
   name: string;
 }
 
 const ManageUsersContainer: any = () => {
-  const loggedInUser = useSelector((state) => (state as any).user as User);
+  const loggedInUser = useSelector<RootState, User>((state) => state.user);
+  const allFacilities = useSelector<RootState, UserFacilitySetting[]>(
+    (state) => state.facilities
+  );
   const [updateUserPrivileges] = useMutation(UPDATE_USER_PRIVILEGES);
   const [deleteUser] = useMutation(DELETE_USER);
   const [reactivateUser] = useMutation(REACTIVATE_USER);
@@ -138,32 +125,17 @@ const ManageUsersContainer: any = () => {
     refetch: getUsers,
   } = useGetUsersAndStatusQuery({ fetchPolicy: "no-cache" });
 
-  const {
-    data: dataFacilities,
-    loading: loadingFacilities,
-    error: errorFacilities,
-  } = useQuery<FacilityData, {}>(GET_FACILITIES, {
-    fetchPolicy: "no-cache",
-  });
-
-  if (loading || loadingFacilities) {
+  if (loading) {
     return <p> Loading... </p>;
   }
 
-  if (error || errorFacilities) {
-    throw error || errorFacilities;
+  if (error) {
+    throw error;
   }
 
   if (data === undefined) {
     return <p>Error: Users not found</p>;
   }
-
-  if (dataFacilities === undefined) {
-    return <p>Error: Facilities not found</p>;
-  }
-
-  const allFacilities = dataFacilities.organization
-    .testingFacility as UserFacilitySetting[];
 
   return (
     <ManageUsers

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -3,22 +3,13 @@ import { gql, useQuery, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 
 import { Role } from "../../permissions";
-import { Maybe, UserPermission } from "../../../generated/graphql";
+import {
+  Maybe,
+  useGetUsersAndStatusQuery,
+  UserPermission,
+} from "../../../generated/graphql";
 
 import ManageUsers from "./ManageUsers";
-
-const GET_USERS_WITH_STATUS = gql`
-  query GetUsersAndStatus {
-    usersWithStatus {
-      id
-      firstName
-      middleName
-      lastName
-      email
-      status
-    }
-  }
-`;
 
 // structure for `getUser` query
 export interface SettingsUser {
@@ -39,15 +30,11 @@ export interface SettingsUser {
 // structure for `getUsersWithStatus` query
 export interface LimitedUser {
   id: string;
-  firstName?: string;
-  middleName?: string;
+  firstName?: Maybe<string>;
+  middleName?: Maybe<string>;
   lastName: string;
   email: string;
-  status?: string;
-}
-
-interface UserData {
-  usersWithStatus: LimitedUser[];
+  status?: Maybe<string>;
 }
 
 export interface SingleUserData {
@@ -144,10 +131,12 @@ const ManageUsersContainer: any = () => {
   const [addUserToOrg] = useMutation(ADD_USER_TO_ORG);
   const [resetPassword] = useMutation(RESET_USER_PASSWORD);
 
-  const { data, loading, error, refetch: getUsers } = useQuery<UserData, {}>(
-    GET_USERS_WITH_STATUS,
-    { fetchPolicy: "no-cache" }
-  );
+  const {
+    data,
+    loading,
+    error,
+    refetch: getUsers,
+  } = useGetUsersAndStatusQuery({ fetchPolicy: "no-cache" });
 
   const {
     data: dataFacilities,
@@ -178,7 +167,7 @@ const ManageUsersContainer: any = () => {
 
   return (
     <ManageUsers
-      users={data.usersWithStatus}
+      users={data.usersWithStatus || []}
       loggedInUser={loggedInUser}
       allFacilities={allFacilities}
       updateUserPrivileges={updateUserPrivileges}

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 
-import { UserRole, UserPermission, Role } from "../../permissions";
+import { UserRole, Role } from "../../permissions";
+import { UserPermission } from "../../../generated/graphql";
 
 import ManageUsers from "./ManageUsers";
 

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -133,8 +133,9 @@ const UserDetail: React.FC<Props> = ({
           onClick={() => handleUpdateUser()}
           label={isUpdating ? "Saving..." : "Save changes"}
           disabled={
+            !user.role ||
             !roles.includes(user.role) ||
-            user.organization.testingFacility.length === 0 ||
+            user?.organization?.testingFacility.length === 0 ||
             !isUserEdited ||
             !["Admin user", "Admin user (SU)"].includes(
               loggedInUser.roleDescription

--- a/frontend/src/app/Settings/Users/UserFacilitiesSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserFacilitiesSettingsForm.tsx
@@ -6,6 +6,7 @@ import classnames from "classnames";
 import Checkboxes from "../../commonComponents/Checkboxes";
 import Dropdown from "../../commonComponents/Dropdown";
 import Button from "../../commonComponents/Button/Button";
+import { UserPermission } from "../../../generated/graphql";
 
 import { UpdateUser } from "./ManageUsers";
 import { SettingsUser, UserFacilitySetting } from "./ManageUsersContainer";
@@ -15,7 +16,8 @@ import "./ManageUsers.scss";
 type FacilityLookup = Record<string, UserFacilitySetting>;
 
 const getHasAllFacilityAccess = (user: Partial<SettingsUser>) =>
-  user.role === "ADMIN" || user.permissions?.includes("ACCESS_ALL_FACILITIES");
+  user.role === "ADMIN" ||
+  user.permissions?.includes(UserPermission.AccessAllFacilities);
 
 const alphabeticalFacilitySort = (
   a: UserFacilitySetting,
@@ -158,7 +160,7 @@ const UserFacilitiesSettingsForm: React.FC<Props> = ({
           if (e.target.checked) {
             onUpdateUser("permissions", [
               ...(activeUser.permissions || []),
-              "ACCESS_ALL_FACILITIES",
+              UserPermission.AccessAllFacilities,
             ]);
           } else {
             onUpdateUser(

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsers.test.tsx.snap
@@ -92,7 +92,9 @@ exports[`ManageUsers regular list of users disables logged-in user's settings 1`
               <div>
                 <span
                   class="top-user-status"
-                />
+                >
+                  Unknown
+                </span>
               </div>
             </div>
             <span
@@ -430,7 +432,9 @@ exports[`ManageUsers regular list of users displays the list of users and defaul
               <div>
                 <span
                   class="top-user-status"
-                />
+                >
+                  Unknown
+                </span>
               </div>
             </div>
             <button

--- a/frontend/src/app/Settings/Users/operations.graphql
+++ b/frontend/src/app/Settings/Users/operations.graphql
@@ -1,0 +1,19 @@
+query GetUser($id: ID!) {
+  user(id: $id) {
+    id
+    firstName
+    middleName
+    lastName
+    roleDescription
+    role
+    permissions
+    email
+    status
+    organization {
+      testingFacility {
+        id
+        name
+      }
+    }
+  }
+}

--- a/frontend/src/app/Settings/Users/operations.graphql
+++ b/frontend/src/app/Settings/Users/operations.graphql
@@ -17,3 +17,14 @@ query GetUser($id: ID!) {
     }
   }
 }
+
+query GetUsersAndStatus {
+  usersWithStatus {
+    id
+    firstName
+    middleName
+    lastName
+    email
+    status
+  }
+}

--- a/frontend/src/app/commonComponents/ProtectedRoute.tsx
+++ b/frontend/src/app/commonComponents/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Redirect, Route } from "react-router-dom";
 
-import { UserPermission } from "../permissions";
+import { UserPermission } from "../../generated/graphql";
 
 interface Props {
   requiredPermissions: UserPermission[];

--- a/frontend/src/app/permissions.tsx
+++ b/frontend/src/app/permissions.tsx
@@ -1,7 +1,5 @@
 import { UserPermission } from "../generated/graphql";
 
-export type UserRole = "admin" | "user" | "entry-only";
-
 // this is what the server sends back in the user.roleDescription field. It is used as the display value (most of the time)
 export type RoleDescription =
   | "Admin user"

--- a/frontend/src/app/permissions.tsx
+++ b/frontend/src/app/permissions.tsx
@@ -1,15 +1,4 @@
-export type UserPermission =
-  | "READ_PATIENT_LIST"
-  | "READ_RESULT_LIST"
-  | "EDIT_PATIENT"
-  | "ARCHIVE_PATIENT"
-  | "EDIT_FACILITY"
-  | "EDIT_ORGANIZATION"
-  | "START_TEST"
-  | "UPDATE_TEST"
-  | "SUBMIT_TEST"
-  | "SEARCH_PATIENTS"
-  | "ACCESS_ALL_FACILITIES";
+import { UserPermission } from "../generated/graphql";
 
 export type UserRole = "admin" | "user" | "entry-only";
 
@@ -51,55 +40,33 @@ const hasPermission = (
   );
 };
 
-interface AppPermissions {
-  settings: {
-    canView: UserPermission[];
-    canEditFacility: UserPermission[];
-    canEditOrganization: UserPermission[];
-  };
-  people: {
-    canView: UserPermission[];
-    canEdit: UserPermission[];
-    canDelete: UserPermission[];
-  };
-  results: {
-    canView: UserPermission[];
-  };
-  tests: {
-    canView: UserPermission[];
-    canSearch: UserPermission[];
-    canStart: UserPermission[];
-    canUpdate: UserPermission[];
-    canSubmit: UserPermission[];
-  };
-}
-
 /*
     Maps a user functionality to the required list of professions
     - a user functionality could be a link that needs to be disabled, a button that needs to be hidden, a query that needs to be rejected, etc
         - a single UX functionality may need gating at multiple parts in the app
     - permissions are defined in the backend and returned in the whoami query
 */
-const appPermissions: AppPermissions = {
+const appPermissions = {
   settings: {
-    canView: ["EDIT_ORGANIZATION", "EDIT_FACILITY"],
-    canEditFacility: ["EDIT_FACILITY"], // TODO: not used
-    canEditOrganization: ["EDIT_ORGANIZATION"], // TODO: not used
+    canView: [UserPermission.EditOrganization, UserPermission.EditFacility],
   },
   people: {
-    canView: ["READ_PATIENT_LIST"],
-    canEdit: ["EDIT_PATIENT"],
-    canDelete: ["ARCHIVE_PATIENT"],
+    canView: [UserPermission.ReadPatientList],
+    canEdit: [UserPermission.EditPatient],
+    canDelete: [UserPermission.ArchivePatient],
   },
   results: {
-    canView: ["READ_RESULT_LIST"],
+    canView: [UserPermission.ReadResultList],
   },
   tests: {
-    canView: ["START_TEST", "UPDATE_TEST", "SUBMIT_TEST"],
-    canSearch: ["SEARCH_PATIENTS"], // TODO: not used
-    canStart: ["START_TEST"],
-    canUpdate: ["UPDATE_TEST"],
-    canSubmit: ["SUBMIT_TEST"],
+    canView: [
+      UserPermission.StartTest,
+      UserPermission.UpdateTest,
+      UserPermission.SubmitTest,
+    ],
+    canStart: [UserPermission.StartTest],
+    canUpdate: [UserPermission.UpdateTest],
+    canSubmit: [UserPermission.SubmitTest],
   },
 };
 

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,8 +1,7 @@
 import { createStore } from "redux";
 
 import { COVID_RESULTS } from "../app/constants";
-
-import { UserPermission } from "./permissions";
+import { UserPermission } from "../generated/graphql";
 
 const SET_INITIAL_STATE = "SET_INITIAL_STATE";
 const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";

--- a/frontend/src/app/utils/text.ts
+++ b/frontend/src/app/utils/text.ts
@@ -92,14 +92,15 @@ export function formatPhoneNumber(str: string) {
   return null;
 }
 
-export function formatUserStatus(status: string) {
-  let userFriendlyStatus;
-  if (status === "SUSPENDED") {
-    userFriendlyStatus = "Account deactivated";
-  } else if (status === "PROVISIONED") {
-    userFriendlyStatus = "Pending account set up";
-  } else {
-    userFriendlyStatus = capitalizeText(status);
+export function formatUserStatus(status?: string | null) {
+  if (!status) {
+    return "Unknown";
   }
-  return userFriendlyStatus;
+  if (status === "SUSPENDED") {
+    return "Account deactivated";
+  } else if (status === "PROVISIONED") {
+    return "Pending account set up";
+  } else {
+    return capitalizeText(status);
+  }
 }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -83,8 +83,8 @@ export type Facility = {
   defaultDeviceType?: Maybe<DeviceType>;
   deviceTypes?: Maybe<Array<Maybe<DeviceType>>>;
   email?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["ID"]>;
-  name?: Maybe<Scalars["String"]>;
+  id: Scalars["ID"];
+  name: Scalars["String"];
   orderingProvider?: Maybe<Provider>;
   patientSelfRegistrationLink?: Maybe<Scalars["String"]>;
   phone?: Maybe<Scalars["String"]>;
@@ -744,11 +744,11 @@ export type User = {
   __typename?: "User";
   email: Scalars["String"];
   firstName?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["ID"]>;
+  id: Scalars["ID"];
   isAdmin?: Maybe<Scalars["Boolean"]>;
   lastName: Scalars["String"];
   middleName?: Maybe<Scalars["String"]>;
-  name?: Maybe<NameInfo>;
+  name: NameInfo;
   organization?: Maybe<Organization>;
   permissions: Array<UserPermission>;
   role?: Maybe<Role>;
@@ -781,7 +781,7 @@ export type WhoAmIQuery = {
   __typename?: "Query";
   whoami: {
     __typename?: "User";
-    id?: Maybe<string>;
+    id: string;
     firstName?: Maybe<string>;
     middleName?: Maybe<string>;
     lastName: string;
@@ -795,8 +795,8 @@ export type WhoAmIQuery = {
       name: string;
       testingFacility: Array<{
         __typename?: "Facility";
-        id?: Maybe<string>;
-        name?: Maybe<string>;
+        id: string;
+        name: string;
       }>;
     }>;
   };
@@ -811,9 +811,9 @@ export type GetFacilitiesQuery = {
     internalId: string;
     testingFacility: Array<{
       __typename?: "Facility";
-      id?: Maybe<string>;
+      id: string;
       cliaNumber?: Maybe<string>;
-      name?: Maybe<string>;
+      name: string;
       street?: Maybe<string>;
       streetTwo?: Maybe<string>;
       city?: Maybe<string>;
@@ -926,9 +926,9 @@ export type GetManagedFacilitiesQuery = {
     __typename?: "Organization";
     testingFacility: Array<{
       __typename?: "Facility";
-      id?: Maybe<string>;
+      id: string;
       cliaNumber?: Maybe<string>;
-      name?: Maybe<string>;
+      name: string;
       street?: Maybe<string>;
       streetTwo?: Maybe<string>;
       city?: Maybe<string>;
@@ -1004,7 +1004,7 @@ export type AllSelfRegistrationLinksQuery = {
       patientSelfRegistrationLink?: Maybe<string>;
       facilities: Array<{
         __typename?: "Facility";
-        name?: Maybe<string>;
+        name: string;
         patientSelfRegistrationLink?: Maybe<string>;
       }>;
     }>;
@@ -1030,34 +1030,6 @@ export type GetUsersAndStatusQuery = {
   >;
 };
 
-export type GetUserQueryVariables = Exact<{
-  id: Scalars["ID"];
-}>;
-
-export type GetUserQuery = {
-  __typename?: "Query";
-  user?: Maybe<{
-    __typename?: "User";
-    id?: Maybe<string>;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName: string;
-    roleDescription: string;
-    role?: Maybe<Role>;
-    permissions: Array<UserPermission>;
-    email: string;
-    status?: Maybe<string>;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      testingFacility: Array<{
-        __typename?: "Facility";
-        id?: Maybe<string>;
-        name?: Maybe<string>;
-      }>;
-    }>;
-  }>;
-};
-
 export type UpdateUserPrivilegesMutationVariables = Exact<{
   id: Scalars["ID"];
   role: Role;
@@ -1067,7 +1039,7 @@ export type UpdateUserPrivilegesMutationVariables = Exact<{
 
 export type UpdateUserPrivilegesMutation = {
   __typename?: "Mutation";
-  updateUserPrivileges?: Maybe<{ __typename?: "User"; id?: Maybe<string> }>;
+  updateUserPrivileges?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
 export type ResetUserPasswordMutationVariables = Exact<{
@@ -1076,7 +1048,7 @@ export type ResetUserPasswordMutationVariables = Exact<{
 
 export type ResetUserPasswordMutation = {
   __typename?: "Mutation";
-  resetUserPassword?: Maybe<{ __typename?: "User"; id?: Maybe<string> }>;
+  resetUserPassword?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
 export type SetUserIsDeletedMutationVariables = Exact<{
@@ -1086,7 +1058,7 @@ export type SetUserIsDeletedMutationVariables = Exact<{
 
 export type SetUserIsDeletedMutation = {
   __typename?: "Mutation";
-  setUserIsDeleted?: Maybe<{ __typename?: "User"; id?: Maybe<string> }>;
+  setUserIsDeleted?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
 export type ReactivateUserMutationVariables = Exact<{
@@ -1095,7 +1067,7 @@ export type ReactivateUserMutationVariables = Exact<{
 
 export type ReactivateUserMutation = {
   __typename?: "Mutation";
-  reactivateUser?: Maybe<{ __typename?: "User"; id?: Maybe<string> }>;
+  reactivateUser?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
 export type AddUserToCurrentOrgMutationVariables = Exact<{
@@ -1107,7 +1079,7 @@ export type AddUserToCurrentOrgMutationVariables = Exact<{
 
 export type AddUserToCurrentOrgMutation = {
   __typename?: "Mutation";
-  addUserToCurrentOrg?: Maybe<{ __typename?: "User"; id?: Maybe<string> }>;
+  addUserToCurrentOrg?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
 export type GetFacilitiesForManageUsersQueryVariables = Exact<{
@@ -1120,8 +1092,36 @@ export type GetFacilitiesForManageUsersQuery = {
     __typename?: "Organization";
     testingFacility: Array<{
       __typename?: "Facility";
-      id?: Maybe<string>;
-      name?: Maybe<string>;
+      id: string;
+      name: string;
+    }>;
+  }>;
+};
+
+export type GetUserQueryVariables = Exact<{
+  id: Scalars["ID"];
+}>;
+
+export type GetUserQuery = {
+  __typename?: "Query";
+  user?: Maybe<{
+    __typename?: "User";
+    id: string;
+    firstName?: Maybe<string>;
+    middleName?: Maybe<string>;
+    lastName: string;
+    roleDescription: string;
+    role?: Maybe<Role>;
+    permissions: Array<UserPermission>;
+    email: string;
+    status?: Maybe<string>;
+    organization?: Maybe<{
+      __typename?: "Organization";
+      testingFacility: Array<{
+        __typename?: "Facility";
+        id: string;
+        name: string;
+      }>;
     }>;
   }>;
 };
@@ -1138,7 +1138,7 @@ export type AddUserMutationVariables = Exact<{
 
 export type AddUserMutation = {
   __typename?: "Mutation";
-  addUser?: Maybe<{ __typename?: "User"; id?: Maybe<string> }>;
+  addUser?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
 export type CreateDeviceTypeMutationVariables = Exact<{
@@ -1189,7 +1189,7 @@ export type SetCurrentUserTenantDataAccessOpMutation = {
   __typename?: "Mutation";
   setCurrentUserTenantDataAccess?: Maybe<{
     __typename?: "User";
-    id?: Maybe<string>;
+    id: string;
     email: string;
     permissions: Array<UserPermission>;
     role?: Maybe<Role>;
@@ -1246,7 +1246,7 @@ export type AddPatientMutation = {
   addPatient?: Maybe<{
     __typename?: "Patient";
     internalId?: Maybe<string>;
-    facility?: Maybe<{ __typename?: "Facility"; id?: Maybe<string> }>;
+    facility?: Maybe<{ __typename?: "Facility"; id: string }>;
   }>;
 };
 
@@ -1302,7 +1302,7 @@ export type GetPatientDetailsQuery = {
         }>
       >
     >;
-    facility?: Maybe<{ __typename?: "Facility"; id?: Maybe<string> }>;
+    facility?: Maybe<{ __typename?: "Facility"; id: string }>;
   }>;
 };
 
@@ -1488,7 +1488,7 @@ export type GetFacilityQueueQuery = {
     __typename?: "Organization";
     testingFacility: Array<{
       __typename?: "Facility";
-      id?: Maybe<string>;
+      id: string;
       deviceTypes?: Maybe<
         Array<
           Maybe<{
@@ -1691,7 +1691,7 @@ export type GetTestResultForPrintQuery = {
     }>;
     facility?: Maybe<{
       __typename?: "Facility";
-      name?: Maybe<string>;
+      name: string;
       cliaNumber?: Maybe<string>;
       phone?: Maybe<string>;
       street?: Maybe<string>;
@@ -2535,68 +2535,6 @@ export type GetUsersAndStatusQueryResult = Apollo.QueryResult<
   GetUsersAndStatusQuery,
   GetUsersAndStatusQueryVariables
 >;
-export const GetUserDocument = gql`
-  query GetUser($id: ID!) {
-    user(id: $id) {
-      id
-      firstName
-      middleName
-      lastName
-      roleDescription
-      role
-      permissions
-      email
-      status
-      organization {
-        testingFacility {
-          id
-          name
-        }
-      }
-    }
-  }
-`;
-
-/**
- * __useGetUserQuery__
- *
- * To run a query within a React component, call `useGetUserQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetUserQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetUserQuery(
-  baseOptions: Apollo.QueryHookOptions<GetUserQuery, GetUserQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetUserQuery, GetUserQueryVariables>(
-    GetUserDocument,
-    options
-  );
-}
-export function useGetUserLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<GetUserQuery, GetUserQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<GetUserQuery, GetUserQueryVariables>(
-    GetUserDocument,
-    options
-  );
-}
-export type GetUserQueryHookResult = ReturnType<typeof useGetUserQuery>;
-export type GetUserLazyQueryHookResult = ReturnType<typeof useGetUserLazyQuery>;
-export type GetUserQueryResult = Apollo.QueryResult<
-  GetUserQuery,
-  GetUserQueryVariables
->;
 export const UpdateUserPrivilegesDocument = gql`
   mutation UpdateUserPrivileges(
     $id: ID!
@@ -2928,6 +2866,68 @@ export type GetFacilitiesForManageUsersLazyQueryHookResult = ReturnType<
 export type GetFacilitiesForManageUsersQueryResult = Apollo.QueryResult<
   GetFacilitiesForManageUsersQuery,
   GetFacilitiesForManageUsersQueryVariables
+>;
+export const GetUserDocument = gql`
+  query GetUser($id: ID!) {
+    user(id: $id) {
+      id
+      firstName
+      middleName
+      lastName
+      roleDescription
+      role
+      permissions
+      email
+      status
+      organization {
+        testingFacility {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetUserQuery__
+ *
+ * To run a query within a React component, call `useGetUserQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetUserQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetUserQuery(
+  baseOptions: Apollo.QueryHookOptions<GetUserQuery, GetUserQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetUserQuery, GetUserQueryVariables>(
+    GetUserDocument,
+    options
+  );
+}
+export function useGetUserLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetUserQuery, GetUserQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetUserQuery, GetUserQueryVariables>(
+    GetUserDocument,
+    options
+  );
+}
+export type GetUserQueryHookResult = ReturnType<typeof useGetUserQuery>;
+export type GetUserLazyQueryHookResult = ReturnType<typeof useGetUserLazyQuery>;
+export type GetUserQueryResult = Apollo.QueryResult<
+  GetUserQuery,
+  GetUserQueryVariables
 >;
 export const AddUserDocument = gql`
   mutation AddUser(

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1063,22 +1063,6 @@ export type AddUserToCurrentOrgMutation = {
   addUserToCurrentOrg?: Maybe<{ __typename?: "User"; id: string }>;
 };
 
-export type GetFacilitiesForManageUsersQueryVariables = Exact<{
-  [key: string]: never;
-}>;
-
-export type GetFacilitiesForManageUsersQuery = {
-  __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    testingFacility: Array<{
-      __typename?: "Facility";
-      id: string;
-      name: string;
-    }>;
-  }>;
-};
-
 export type GetUserQueryVariables = Exact<{
   id: Scalars["ID"];
 }>;
@@ -2742,66 +2726,6 @@ export type AddUserToCurrentOrgMutationResult = Apollo.MutationResult<AddUserToC
 export type AddUserToCurrentOrgMutationOptions = Apollo.BaseMutationOptions<
   AddUserToCurrentOrgMutation,
   AddUserToCurrentOrgMutationVariables
->;
-export const GetFacilitiesForManageUsersDocument = gql`
-  query GetFacilitiesForManageUsers {
-    organization {
-      testingFacility {
-        id
-        name
-      }
-    }
-  }
-`;
-
-/**
- * __useGetFacilitiesForManageUsersQuery__
- *
- * To run a query within a React component, call `useGetFacilitiesForManageUsersQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFacilitiesForManageUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFacilitiesForManageUsersQuery({
- *   variables: {
- *   },
- * });
- */
-export function useGetFacilitiesForManageUsersQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetFacilitiesForManageUsersQuery,
-    GetFacilitiesForManageUsersQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetFacilitiesForManageUsersQuery,
-    GetFacilitiesForManageUsersQueryVariables
-  >(GetFacilitiesForManageUsersDocument, options);
-}
-export function useGetFacilitiesForManageUsersLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFacilitiesForManageUsersQuery,
-    GetFacilitiesForManageUsersQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetFacilitiesForManageUsersQuery,
-    GetFacilitiesForManageUsersQueryVariables
-  >(GetFacilitiesForManageUsersDocument, options);
-}
-export type GetFacilitiesForManageUsersQueryHookResult = ReturnType<
-  typeof useGetFacilitiesForManageUsersQuery
->;
-export type GetFacilitiesForManageUsersLazyQueryHookResult = ReturnType<
-  typeof useGetFacilitiesForManageUsersLazyQuery
->;
-export type GetFacilitiesForManageUsersQueryResult = Apollo.QueryResult<
-  GetFacilitiesForManageUsersQuery,
-  GetFacilitiesForManageUsersQueryVariables
 >;
 export const GetUserDocument = gql`
   query GetUser($id: ID!) {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -55,7 +55,7 @@ export type ApiUserWithStatus = {
   __typename?: "ApiUserWithStatus";
   email: Scalars["String"];
   firstName?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["ID"]>;
+  id: Scalars["ID"];
   lastName: Scalars["String"];
   middleName?: Maybe<Scalars["String"]>;
   name: NameInfo;
@@ -583,7 +583,7 @@ export type Query = {
   topLevelDashboardMetrics?: Maybe<TopLevelDashboardMetrics>;
   user?: Maybe<User>;
   users?: Maybe<Array<Maybe<ApiUser>>>;
-  usersWithStatus?: Maybe<Array<Maybe<ApiUserWithStatus>>>;
+  usersWithStatus?: Maybe<Array<ApiUserWithStatus>>;
   whoami: User;
 };
 
@@ -1011,25 +1011,6 @@ export type AllSelfRegistrationLinksQuery = {
   };
 };
 
-export type GetUsersAndStatusQueryVariables = Exact<{ [key: string]: never }>;
-
-export type GetUsersAndStatusQuery = {
-  __typename?: "Query";
-  usersWithStatus?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "ApiUserWithStatus";
-        id?: Maybe<string>;
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName: string;
-        email: string;
-        status?: Maybe<string>;
-      }>
-    >
-  >;
-};
-
 export type UpdateUserPrivilegesMutationVariables = Exact<{
   id: Scalars["ID"];
   role: Role;
@@ -1124,6 +1105,23 @@ export type GetUserQuery = {
       }>;
     }>;
   }>;
+};
+
+export type GetUsersAndStatusQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetUsersAndStatusQuery = {
+  __typename?: "Query";
+  usersWithStatus?: Maybe<
+    Array<{
+      __typename?: "ApiUserWithStatus";
+      id: string;
+      firstName?: Maybe<string>;
+      middleName?: Maybe<string>;
+      lastName: string;
+      email: string;
+      status?: Maybe<string>;
+    }>
+  >;
 };
 
 export type AddUserMutationVariables = Exact<{
@@ -2473,68 +2471,6 @@ export type AllSelfRegistrationLinksQueryResult = Apollo.QueryResult<
   AllSelfRegistrationLinksQuery,
   AllSelfRegistrationLinksQueryVariables
 >;
-export const GetUsersAndStatusDocument = gql`
-  query GetUsersAndStatus {
-    usersWithStatus {
-      id
-      firstName
-      middleName
-      lastName
-      email
-      status
-    }
-  }
-`;
-
-/**
- * __useGetUsersAndStatusQuery__
- *
- * To run a query within a React component, call `useGetUsersAndStatusQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUsersAndStatusQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetUsersAndStatusQuery({
- *   variables: {
- *   },
- * });
- */
-export function useGetUsersAndStatusQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >(GetUsersAndStatusDocument, options);
-}
-export function useGetUsersAndStatusLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >(GetUsersAndStatusDocument, options);
-}
-export type GetUsersAndStatusQueryHookResult = ReturnType<
-  typeof useGetUsersAndStatusQuery
->;
-export type GetUsersAndStatusLazyQueryHookResult = ReturnType<
-  typeof useGetUsersAndStatusLazyQuery
->;
-export type GetUsersAndStatusQueryResult = Apollo.QueryResult<
-  GetUsersAndStatusQuery,
-  GetUsersAndStatusQueryVariables
->;
 export const UpdateUserPrivilegesDocument = gql`
   mutation UpdateUserPrivileges(
     $id: ID!
@@ -2928,6 +2864,68 @@ export type GetUserLazyQueryHookResult = ReturnType<typeof useGetUserLazyQuery>;
 export type GetUserQueryResult = Apollo.QueryResult<
   GetUserQuery,
   GetUserQueryVariables
+>;
+export const GetUsersAndStatusDocument = gql`
+  query GetUsersAndStatus {
+    usersWithStatus {
+      id
+      firstName
+      middleName
+      lastName
+      email
+      status
+    }
+  }
+`;
+
+/**
+ * __useGetUsersAndStatusQuery__
+ *
+ * To run a query within a React component, call `useGetUsersAndStatusQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetUsersAndStatusQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetUsersAndStatusQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetUsersAndStatusQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetUsersAndStatusQuery,
+    GetUsersAndStatusQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetUsersAndStatusQuery,
+    GetUsersAndStatusQueryVariables
+  >(GetUsersAndStatusDocument, options);
+}
+export function useGetUsersAndStatusLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetUsersAndStatusQuery,
+    GetUsersAndStatusQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetUsersAndStatusQuery,
+    GetUsersAndStatusQueryVariables
+  >(GetUsersAndStatusDocument, options);
+}
+export type GetUsersAndStatusQueryHookResult = ReturnType<
+  typeof useGetUsersAndStatusQuery
+>;
+export type GetUsersAndStatusLazyQueryHookResult = ReturnType<
+  typeof useGetUsersAndStatusLazyQuery
+>;
+export type GetUsersAndStatusQueryResult = Apollo.QueryResult<
+  GetUsersAndStatusQuery,
+  GetUsersAndStatusQueryVariables
 >;
 export const AddUserDocument = gql`
   mutation AddUser(


### PR DESCRIPTION
## Related Issue or Background Info

- Continuing refactor work to use a strongly typed API via types generated from our schema definition

## Changes Proposed

- Update schema to add not nullable where applicable
- Convert getUser query to the geneated functions a
- Update local types to better match our API schema
- Remove API call to get Facilities and get them from state
- Added typing for getting the user form the state

## Additional Information

- Held off on updating the mutations to reduce individual PR size

## Screenshots / Demos

## Checklist for Author and Reviewer
- [x] Manage user page renders
- [x] Changing a user renders the user
- [x] Updating a user's role enables the save button

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
