### PR TITLE
add patient_has_prior_tests to the test_event table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2909,3 +2909,19 @@ databaseChangeLog:
             columns:
               - column:
                   name: patient_id
+  - changeSet:
+      id: add-patient_has_prior_tests
+      author: zedd@skylight.digital
+      comment: This is to add patient_has_prior_tests test field to test event
+      changes:
+        - tagDatabase:
+            tag:  add-patient_has_prior_tests
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: patient_has_prior_tests
+                  type: boolean
+                  remarks: patient_has_prior_tests will track whether a patient has prior test events
+                  constraints:
+                    nullable: true


### PR DESCRIPTION
## Related Issue or Background Info

- part 2 fix for #2349 

## Changes Proposed

- add patient_has_prior_tests to the test_event table
- since the first_test will no be populated by the patient, we will use this field to track if we have previous test events

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
