### PR TITLE
Update ReportStream schedule

### DIFF
--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -4,7 +4,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as test
-    upload-schedule: "30 * * * *" # hourly on the :30 to differentiate from test, which sends on the :00
+    upload-schedule: "0 30 * * * *" # hourly on the :30 to differentiate from test, which sends on the :00
   patient-link-url: https://dev.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://dev.simplereport.gov/api/pxp/callback
   sendgrid:

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -4,7 +4,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as test
-    upload-schedule: "0 30 5-21/2 * * *" # hourly on the :30 to differentiate from test, which sends on the :00
+    upload-schedule: "30 * * * *" # hourly on the :30 to differentiate from test, which sends on the :00
   patient-link-url: https://dev.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://dev.simplereport.gov/api/pxp/callback
   sendgrid:

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   data-hub:
     upload-enabled: true
-    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems&verbose=true" # same destination as test
+    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as test
     upload-schedule: "30 * * * *" # hourly on the :30 to differentiate from test, which sends on the :00
   patient-link-url: https://dev.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://dev.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   data-hub:
     upload-enabled: true
-    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as test
+    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems&verbose=true" # same destination as test
     upload-schedule: "30 * * * *" # hourly on the :30 to differentiate from test, which sends on the :00
   patient-link-url: https://dev.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://dev.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   data-hub:
     upload-enabled: true
-    upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems&verbose=true"
+    upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems"
     upload-schedule: "5,20,35,50 * * * *"
   patient-link-url: https://simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   data-hub:
     upload-enabled: true
-    upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems"
+    upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems&verbose=true"
     upload-schedule: "5,20,35,50 * * * *"
   patient-link-url: https://simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -4,7 +4,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems"
-    upload-schedule: "0 0 5-21/2 * * *"
+    upload-schedule: "5,20,35,50 * * * *"
   patient-link-url: https://simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://simplereport.gov/api/pxp/callback
   id-verification-reminders:

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -4,7 +4,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://prime-data-hub-prod.azurefd.net/api/reports?option=SkipInvalidItems"
-    upload-schedule: "5,20,35,50 * * * *"
+    upload-schedule: "0 5,20,35,50 * * * *"
   patient-link-url: https://simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://simplereport.gov/api/pxp/callback
   id-verification-reminders:

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   data-hub:
     upload-enabled: true
-    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as dev
+    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems&verbose=true" # same destination as dev
     upload-schedule: "0 * * * *" # hourly on the :00 to differentiate from dev, which sends on the :30
   patient-link-url: https://test.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://test.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   data-hub:
     upload-enabled: true
-    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems&verbose=true" # same destination as dev
+    upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as dev
     upload-schedule: "0 * * * *" # hourly on the :00 to differentiate from dev, which sends on the :30
   patient-link-url: https://test.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://test.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -4,7 +4,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as dev
-    upload-schedule: "0 * * * *" # hourly on the :00 to differentiate from dev, which sends on the :30
+    upload-schedule: "0 0 * * * *" # hourly on the :00 to differentiate from dev, which sends on the :30
   patient-link-url: https://test.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://test.simplereport.gov/api/pxp/callback
   sendgrid:

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -4,7 +4,7 @@ simple-report:
   data-hub:
     upload-enabled: true
     upload-url: "https://staging.prime.cdc.gov/api/reports?option=SkipInvalidItems" # same destination as dev
-    upload-schedule: "0 0 5-21/2 * * *" # hourly on the :00 to differentiate from dev, which sends on the :30
+    upload-schedule: "0 * * * *" # hourly on the :00 to differentiate from dev, which sends on the :30
   patient-link-url: https://test.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://test.simplereport.gov/api/pxp/callback
   sendgrid:


### PR DESCRIPTION
## Related Issue or Background Info

- Per convo w/ ReportStream, we will now send to prod on the :05, :20, :35, and :50 minutes
- Send at all hours, instead of only during business hours as we used to
- In dev & test we will send to staging hourly on the :30 and :00, respectively

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
