### PR TITLE
Remove some Experian logging

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
@@ -117,9 +117,8 @@ public class LiveExperianService
               _experianProperties.getPreciseidClientReferenceId(),
               userData);
 
-      LOG.info("EXPERIAN_QUESTION_REQUEST_SUBMITTED: {}", initialRequestBody);
+      LOG.info("EXPERIAN_QUESTION_REQUEST_SUBMITTED");
       ObjectNode responseEntity = submitExperianRequest(initialRequestBody);
-      LOG.info("EXPERIAN_QUESTION_RESPONSE: {}", responseEntity);
 
       // KIQ response may a kbaresultCode that indicates failure, this seems to only be present
       // in unsuccessful requests to get questions (consumer not found, deceased, etc.)
@@ -149,9 +148,8 @@ public class LiveExperianService
               _experianProperties.getPreciseidTenantId(),
               _experianProperties.getPreciseidClientReferenceId(),
               answersRequest);
-      LOG.info("EXPERIAN_ANSWER_REQUEST_SUBMITTED: {}", finalRequestBody);
+      LOG.info("EXPERIAN_ANSWER_REQUEST_SUBMITTED");
       ObjectNode responseEntity = submitExperianRequest(finalRequestBody);
-      LOG.info("EXPERIAN_ANSWER_RESPONSE: {}", responseEntity);
 
       // look for errors in KIQ response ("CrossCore - PreciseId (Option 24).pdf" page 79)
       int kbaResultCode = findNodeInResponse(responseEntity, KBA_RESULT_CODE_PATH).asInt();
@@ -175,7 +173,7 @@ public class LiveExperianService
 
       // Generate a searchable log message so we can monitor decisions from Experian
       String requestData = _objectMapper.writeValueAsString(answersRequest);
-      LOG.info("EXPERIAN_DECISION ({}): {}, {}", passed, responseEntity, requestData);
+      LOG.info("EXPERIAN_DECISION ({}): {}", passed, requestData);
 
       return new IdentityVerificationAnswersResponse(passed);
     } catch (RestClientException | JsonProcessingException e) {
@@ -202,7 +200,6 @@ public class LiveExperianService
     final JsonNode fetchedNode = responseEntity.at(path);
     if (fetchedNode.isMissingNode()) {
       LOG.error("EXPERIAN_NULL_NODE: {}", path);
-      LOG.error("EXPERIAN_NULL_NODE_RESPONSE: {}", responseEntity);
       throw new ExperianNullNodeException("Could not find data in response from Experian");
     }
     return fetchedNode;


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2631 

## Changes Proposed

- remove any sensitive data from logs, only logging when a request or response is made

## Additional Information

This additional logging was added at the beginning of our Experian integration because we were seeing mysterious errors that needed to be debugged. Now that Experian has been working successfully for a few weeks and we have a method in place to catch abandoned users, we don't need the full logs anymore.

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- n/a Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
