### PR TITLE
Use advisory lock to limit email reminders task to one api instance

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -40,6 +40,14 @@ public class ReminderService {
    * were created and did not complete id verification
    */
   public Map<Organization, Set<String>> sendAccountReminderEmails() {
+    // take the advisory lock for this process. auto released after transaction
+    if (_orgRepo.tryOrgReminderLock()) {
+      LOG.info("Reminder lock obtained: commencing email sending");
+    } else {
+      LOG.info("Reminders locked out by mutex: aborting");
+      return new HashMap<>();
+    }
+
     TimeZone tz = TimeZone.getTimeZone("America/New_York");
     LocalDate now = LocalDate.now(tz.toZoneId());
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -93,6 +93,7 @@ public class ReminderService {
       Thread.sleep(1L);
     } catch (InterruptedException e) {
       LOG.debug("sendAccountReminderEmails: sleep interrupted");
+      Thread.currentThread().interrupt();
     }
 
     return orgReminderMap;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -88,6 +88,13 @@ public class ReminderService {
       orgReminderMap.put(org, emailsInOrg);
     }
 
+    try {
+      // hold the lock a little extra so other instances have a chance to fail to acquire it
+      Thread.sleep(1L);
+    } catch (InterruptedException e) {
+      LOG.debug("sendAccountReminderEmails: sleep interrupted");
+    }
+
     return orgReminderMap;
   }
 


### PR DESCRIPTION
## Related Issue or Background Info

Org reminder emails are being sent multiple times.  This is because the scheduled task is running on each of the api instances (currently 3).

## Changes Proposed

- Use a lock so only 1 instance will send the reminder emails

## Additional Information

- This is implemented similar to the way it is done with DataHubUploaderService/DataHubUploadRepository

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
