### PR TITLE
Update duplicate org errors

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -91,7 +91,7 @@ public class AccountRequestController {
       // This happens fairly frequently and is the expected behavior of the current form.
       // We rethrow this as a BadRequestException so that users get a toast on the frontend
       // informing them of the error.
-      System.out.println("Okta resource exception thrown: " + e);
+      LOG.info("Okta resource exception thrown: " + e);
       throw new BadRequestException(
           "This email address is already associated with a SimpleReport user.");
     } catch (BadRequestException | UnexpectedRollbackException e) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -91,6 +91,7 @@ public class AccountRequestController {
       // This happens fairly frequently and is the expected behavior of the current form.
       // We rethrow this as a BadRequestException so that users get a toast on the frontend
       // informing them of the error.
+      System.out.println("Okta resource exception thrown: " + e);
       throw new BadRequestException(
           "This email address is already associated with a SimpleReport user.");
     } catch (BadRequestException | UnexpectedRollbackException e) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -215,6 +216,19 @@ public class DemoOktaRepository implements OktaRepository {
   public String activateOrganizationWithSingleUser(Organization org) {
     activateOrganization(org);
     return "activationToken";
+  }
+
+  public String fetchAdminUserEmail(Organization org) {
+    Optional<Entry<String, OrganizationRoleClaims>> admin =
+        usernameOrgRolesMap.entrySet().stream()
+            .filter(e -> e.getValue().getGrantedRoles().contains(OrganizationRole.ADMIN))
+            .findFirst();
+    return admin
+        .map(
+            a -> {
+              return a.getKey();
+            })
+        .orElseThrow(() -> new IllegalStateException("Organization does not have an admin."));
   }
 
   public void createFacility(Facility facility) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -224,10 +224,7 @@ public class DemoOktaRepository implements OktaRepository {
             .filter(e -> e.getValue().getGrantedRoles().contains(OrganizationRole.ADMIN))
             .findFirst();
     return admin
-        .map(
-            a -> {
-              return a.getKey();
-            })
+        .map(Entry::getKey)
         .orElseThrow(() -> new IllegalStateException("Organization does not have an admin."));
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -471,6 +471,11 @@ public class LiveOktaRepository implements OktaRepository {
     return activateUser(user);
   }
 
+  public String fetchAdminUserEmail(Organization org) {
+    User user = getOrgAdminUsers(org).single();
+    return user.getProfile().getLogin();
+  }
+
   public void createFacility(Facility facility) {
     // Only create the facility group if the facility's organization has already been created
     String orgExternalId = facility.getOrganization().getExternalId();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -49,6 +49,8 @@ public interface OktaRepository {
 
   String activateOrganizationWithSingleUser(Organization org);
 
+  String fetchAdminUserEmail(Organization org);
+
   void createFacility(Facility facility);
 
   void deleteOrganization(Organization org);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -305,6 +305,55 @@ class AccountRequestControllerTest extends BaseFullStackTest {
   }
 
   @Test
+  @DisplayName("Duplicate org with admin re-signing up fails")
+  void duplicateOrgWithAdminFails() throws Exception {
+    // given
+    String originalRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "mlopez@mailinator.com",
+            "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder originalBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(originalRequestBody);
+    this._mockMvc.perform(originalBuilder).andExpect(status().isOk());
+
+    // when
+    String duplicateRequestBody =
+        createAccountRequest(
+            "Central Schools",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "mlopez@mailinator.com",
+            "+1 (969) 768-2863");
+
+    MockHttpServletRequestBuilder duplicateBuilder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(duplicateRequestBody);
+
+    // then
+    MvcResult result = this._mockMvc.perform(duplicateBuilder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains(
+            "Duplicate organization with admin user that has not completed identity verification.");
+  }
+
+  @Test
   @DisplayName("Cannot create user with existing email address")
   void duplicateUserFails() throws Exception {
     // given

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.idp.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -345,6 +346,26 @@ class DemoOktaRepositoryTest {
         new IdentityAttributes(AMOS.getUsername(), "First", "Middle", "Last", "Jr");
     assertThrows(
         IllegalGraphqlArgumentException.class, () -> _repo.reprovisionUser(identityAttributes));
+  }
+
+  @Test
+  void fetchAdminUserEmail_successful() {
+    _repo.createUser(AMOS, ABC, Set.of(ABC_1), Set.of(OrganizationRole.USER), true);
+    _repo.createUser(
+        BRAD,
+        ABC,
+        Set.of(ABC_2),
+        Set.of(OrganizationRole.ENTRY_ONLY, OrganizationRole.ALL_FACILITIES),
+        true);
+    _repo.createUser(CHARLES, ABC, Set.of(ABC_1, ABC_2), Set.of(), true);
+    _repo.createUser(
+        DIANE,
+        ABC,
+        Set.of(ABC_1, ABC_2),
+        Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ALL_FACILITIES, OrganizationRole.ADMIN),
+        true);
+
+    assertEquals(_repo.fetchAdminUserEmail(ABC), "dianek@gmail.com");
   }
 
   private static Facility getFacility(UUID uuid, Organization org) {

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -41,6 +41,18 @@ jest.mock("../SignUpApi", () => ({
         throw new Error(
           "This email address is already associated with a SimpleReport user."
         );
+      } else if (request.name === "DuplicateAdmin") {
+        throw new Error(
+          "Duplicate organization with admin user that has not completed identity verification."
+        );
+      } else if (request.name === "IdentityVerificationComplete") {
+        throw new Error(
+          "Duplicate organization with admin user who has completed identity verification."
+        );
+      } else if (request.name === "InternalError") {
+        throw new Error(
+          "An unknown error occured when creating this organization in Okta."
+        );
       } else {
         throw new Error("This is an error.");
       }
@@ -125,7 +137,7 @@ describe("OrganizationForm", () => {
 
     expect(
       screen.getByText(
-        "This organization has already registered with SimpleReport.",
+        "This organization already has a SimpleReport account. Please contact your organization administrator to request access.",
         { exact: false }
       )
     ).toBeInTheDocument();
@@ -147,6 +159,69 @@ describe("OrganizationForm", () => {
     expect(
       screen.getByText(
         "This email address is already registered with SimpleReport.",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("displays a duplicate org error and id verification link for an admin re-signing up", async () => {
+    fillIn(getOrgNameInput(), "DuplicateAdmin");
+    fillInDropDown(getOrgStateDropdown(), "TX");
+    fillInDropDown(getOrgTypeDropdown(), "Employer");
+    fillIn(getFirstNameInput(), "Greatest");
+    fillIn(getMiddleNameInput(), "OG");
+    fillIn(getLastNameInput(), "Ever");
+    fillIn(getEmailInput(), "admin@example.com");
+    fillIn(getPhoneInput(), "8008675309");
+    await act(async () => {
+      await getSubmitButton().click();
+    });
+
+    expect(
+      screen.getByText(
+        "Your organization is already registered with SimpleReport. To begin using it, schedule a time",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("displays a duplicate org error and instructions for admin user who has finished id verification", async () => {
+    fillIn(getOrgNameInput(), "IdentityVerificationComplete");
+    fillInDropDown(getOrgStateDropdown(), "TX");
+    fillInDropDown(getOrgTypeDropdown(), "Employer");
+    fillIn(getFirstNameInput(), "Greatest");
+    fillIn(getMiddleNameInput(), "OG");
+    fillIn(getLastNameInput(), "Ever");
+    fillIn(getEmailInput(), "admin@example.com");
+    fillIn(getPhoneInput(), "8008675309");
+    await act(async () => {
+      await getSubmitButton().click();
+    });
+
+    expect(
+      screen.getByText(
+        "Your organization is already registered with SimpleReport. Check your email for instructions on setting up your account.",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("displays a generic error message for Okta internal errors", async () => {
+    fillIn(getOrgNameInput(), "InternalError");
+    fillInDropDown(getOrgStateDropdown(), "TX");
+    fillInDropDown(getOrgTypeDropdown(), "Employer");
+    fillIn(getFirstNameInput(), "Greatest");
+    fillIn(getMiddleNameInput(), "OG");
+    fillIn(getLastNameInput(), "Ever");
+    fillIn(getEmailInput(), "admin@example.com");
+    fillIn(getPhoneInput(), "8008675309");
+    await act(async () => {
+      await getSubmitButton().click();
+    });
+
+    expect(
+      screen.getByText(
+        "An unexpected error occured. Please resubmit this form",
         { exact: false }
       )
     ).toBeInTheDocument();

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -147,16 +147,7 @@ export const organizationSchema: yup.SchemaOf<OrganizationCreateRequest> = yup
 
 export const organizationBackendErrors = (error: string): ReactElement => {
   switch (error) {
-    // Duplicate org; not admin user
-    case "Organization is a duplicate.":
-    case "This organization has already registered with SimpleReport.":
-      return (
-        <Alert type="error" title="Duplicate organization">
-          This organization already has a SimpleReport account. Please contact
-          your organization administrator to request access.
-        </Alert>
-      );
-    // Duplicate org; admin user has finised id verification
+    // Duplicate org. Admin user is attempting to resign up but has already completed identity verification.
     case "Duplicate organization with admin user who has completed identity verification.":
       return (
         <Alert type="error" title="Duplicate organization">
@@ -164,7 +155,7 @@ export const organizationBackendErrors = (error: string): ReactElement => {
           email for instructions on setting up your account.
         </Alert>
       );
-    // Duplicate org; admin user hasn't finished identity verification
+    // Duplicate org. Admin user is attempting to resign up and hasn't finished identity verification.
     case "Duplicate organization with admin user that has not completed identity verification.":
       return (
         <Alert type="error" title="Duplicate organization">
@@ -175,6 +166,15 @@ export const organizationBackendErrors = (error: string): ReactElement => {
           </a>{" "}
         </Alert>
       );
+    // Duplicate org. Non-admin user is attempting to reregister the organization.
+    case "This organization has already registered with SimpleReport.":
+      return (
+        <Alert type="error" title="Duplicate organization">
+          This organization already has a SimpleReport account. Please contact
+          your organization administrator to request access.
+        </Alert>
+      );
+    // Email already exists in SimpleReport (user is potentially already in another org.)
     case "This email address is already associated with a SimpleReport user.":
       return (
         <Alert type="error" title="Email already registered">
@@ -184,6 +184,7 @@ export const organizationBackendErrors = (error: string): ReactElement => {
           for help.
         </Alert>
       );
+    // Okta internal error.
     case "An unknown error occured when creating this organization in Okta.":
       return (
         <Alert type="error" title="Unexpected error">

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -147,13 +147,32 @@ export const organizationSchema: yup.SchemaOf<OrganizationCreateRequest> = yup
 
 export const organizationBackendErrors = (error: string): ReactElement => {
   switch (error) {
+    // Duplicate org; not admin user
+    case "Organization is a duplicate.":
     case "This organization has already registered with SimpleReport.":
       return (
         <Alert type="error" title="Duplicate organization">
-          This organization has already registered with SimpleReport. Please
-          contact your organization administrator or{" "}
-          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
-          for help.
+          This organization already has a SimpleReport account. Please contact
+          your organization administrator to request access.
+        </Alert>
+      );
+    // Duplicate org; admin user has finised id verification
+    case "Duplicate organization with admin user who has completed identity verification.":
+      return (
+        <Alert type="error" title="Duplicate organization">
+          Your organization is already registered with SimpleReport. Check your
+          email for instructions on setting up your account.
+        </Alert>
+      );
+    // Duplicate org; admin user hasn't finished identity verification
+    case "Duplicate organization with admin user that has not completed identity verification.":
+      return (
+        <Alert type="error" title="Duplicate organization">
+          Your organization is already registered with SimpleReport. To begin
+          using it, schedule a time to complete our{" "}
+          <a href="https://outlook.office365.com/owa/calendar/Helpdesk@HHSGOV.onmicrosoft.com/bookings/s/HOX7KgZruESJksIgC8qVxQ2">
+            online identity verification.
+          </a>{" "}
         </Alert>
       );
     case "This email address is already associated with a SimpleReport user.":
@@ -163,6 +182,14 @@ export const organizationBackendErrors = (error: string): ReactElement => {
           contact your organization administrator or{" "}
           <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
           for help.
+        </Alert>
+      );
+    case "An unknown error occured when creating this organization in Okta.":
+      return (
+        <Alert type="error" title="Unexpected error">
+          An unexpected error occured. Please resubmit this form, or contact{" "}
+          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
+          if the problem persists.
         </Alert>
       );
     default:


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #2549 

## Changes Proposed

- Add a check in the duplicate org logic to see if the user signing in is the admin, and change error message accordingly
- Also adds a new toast for unexpected Okta errors (this should catch the issue we saw yesterday, when a call to `.update()` failed)

## Screenshots / Demos
Admin tries to sign up again and has already finished identity verification:
![Screen Shot 2021-09-22 at 9 45 08 AM](https://user-images.githubusercontent.com/80282552/134400042-4a5c6276-3c6c-4d73-a323-b7c3540e8603.png)


Admin tries to sign up again but hasn't finished id verification:
![Screen Shot 2021-09-22 at 9 43 27 AM](https://user-images.githubusercontent.com/80282552/134399501-41130245-773f-4e03-b04f-1a494500f241.png)

Non-admin tries to create duplicate organization:
![Screen Shot 2021-09-22 at 9 44 33 AM](https://user-images.githubusercontent.com/80282552/134399803-8a164fe8-fae4-4f9b-9c92-0afe21caba7e.png)

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
