### PR TITLE
Normalize org name and external id before creating organization

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -155,9 +155,20 @@ public class AccountRequestController {
   }
 
   private String createOrgExternalId(String organizationName, String state) {
-    return String.format(
-        "%s-%s-%s",
-        state, organizationName.replace(' ', '-').replace(':', '-'), UUID.randomUUID().toString());
+    organizationName =
+        organizationName
+            // remove all non-alpha-numeric
+            .replaceAll("[^-A-Za-z0-9 ]", "")
+            // spaces to hyphens
+            .replace(' ', '-')
+            // reduce repeated hyphens to one
+            .replaceAll("-+", "-")
+            // remove leading hyphens
+            .replaceAll("^-+", "");
+    if (organizationName.length() == 0) {
+      throw new BadRequestException("The organization name is invalid.");
+    }
+    return String.format("%s-%s-%s", state, organizationName, UUID.randomUUID());
   }
 
   private void createAdminUser(String firstName, String lastName, String email, String externalId) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -98,7 +98,7 @@ public class AccountRequestController {
             "This email address is already associated with a SimpleReport user.");
       } else {
         throw new BadRequestException(
-            "An unknown error occured when creating this organization in Okta.");
+            "An unknown error occurred when creating this organization in Okta.");
       }
     } catch (BadRequestException e) {
       // Need to catch and re-throw these BadRequestExceptions or they get rethrown as
@@ -116,14 +116,21 @@ public class AccountRequestController {
   }
 
   private Organization checkAccountRequestAndCreateOrg(OrganizationAccountRequest request) {
+    String parsedStateCode = Translators.parseState(request.getState());
     String organizationName =
-        checkForDuplicateOrg(request.getName(), request.getState(), request.getEmail());
-    String orgExternalId = createOrgExternalId(organizationName, request.getState());
+        checkForDuplicateOrg(request.getName(), parsedStateCode, request.getEmail());
+    String orgExternalId = createOrgExternalId(organizationName, parsedStateCode);
     String organizationType = Translators.parseOrganizationType(request.getType());
     return _os.createOrganization(organizationName, organizationType, orgExternalId);
   }
 
   private String checkForDuplicateOrg(String organizationName, String state, String email) {
+    organizationName = Translators.parseString(organizationName);
+    if (organizationName == null || "".equals(organizationName)) {
+      throw new BadRequestException("The organization name is empty.");
+    }
+    organizationName = organizationName.replaceAll("\\s{2,}", " ");
+
     List<Organization> potentialDuplicates = _os.getOrganizationsByName(organizationName);
     if (potentialDuplicates.isEmpty()) {
       return organizationName;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -45,6 +45,7 @@ class AccountRequestControllerTest extends BaseFullStackTest {
 
   @Captor private ArgumentCaptor<TemplateVariablesProvider> contentCaptor;
   @Captor private ArgumentCaptor<Mail> mail;
+  @Captor private ArgumentCaptor<String> orgNameCaptor;
   @Captor private ArgumentCaptor<String> externalIdCaptor;
   @Captor private ArgumentCaptor<PersonName> nameCaptor;
 
@@ -151,6 +152,51 @@ class AccountRequestControllerTest extends BaseFullStackTest {
     assertThat(nameCaptor.getValue().getLastName()).isEqualTo("Lopez");
     assertNull(nameCaptor.getValue().getSuffix());
     assertThat(externalIdCaptor.getValue()).contains("RI-Day-Hayes-Trading-");
+  }
+
+  @Test
+  void submitOrganizationAccountRequest_nameCleaning_success() throws Exception {
+    String requestBody =
+        createAccountRequest(
+            " Central   Schools  ",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+    this._mockMvc.perform(builder).andExpect(status().isOk());
+
+    verify(_orgService)
+        .createOrganization(orgNameCaptor.capture(), eq("k12"), externalIdCaptor.capture());
+
+    assertThat(orgNameCaptor.getValue()).isEqualTo("Central Schools");
+    assertThat(externalIdCaptor.getValue()).startsWith("AZ-Central-Schools-");
+  }
+
+  @Test
+  void submitOrganizationAccountRequest_emptyOrgName_failure() throws Exception {
+    String requestBody =
+        createAccountRequest(
+            " ", "AZ", "k12", "Mary", "", "Lopez", "kyvuzoxy@mailinator.com", "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    MvcResult result = this._mockMvc.perform(builder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains("The organization name is empty.");
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -23,6 +23,8 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -183,6 +185,7 @@ class AccountRequestControllerTest extends BaseFullStackTest {
 
   @Test
   void submitOrganizationAccountRequest_emptyOrgName_failure() throws Exception {
+    // failures when cleaning and checking organization name
     String requestBody =
         createAccountRequest(
             " ", "AZ", "k12", "Mary", "", "Lopez", "kyvuzoxy@mailinator.com", "+1 (969) 768-2863");
@@ -199,33 +202,13 @@ class AccountRequestControllerTest extends BaseFullStackTest {
         .contains("The organization name is empty.");
   }
 
-  @Test
-  void submitOrganizationAccountRequest_invalidOrgName_failure() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"% ^ #", "-", "  --- --- ---"})
+  void submitOrganizationAccountRequest_invalidOrgName_failure(String orgName) throws Exception {
+    // failures when cleaning and checking organization external id
     String requestBody =
         createAccountRequest(
-            "% ^ #",
-            "AZ", "k12", "Mary", "", "Lopez", "kyvuzoxy@mailinator.com", "+1 (969) 768-2863");
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(requestBody);
-
-    MvcResult result = this._mockMvc.perform(builder).andReturn();
-    assertThat(result.getResponse().getStatus()).isEqualTo(400);
-    assertThat(result.getResponse().getContentAsString())
-        .contains("The organization name is invalid.");
-  }
-
-  @Test
-  void submitOrganizationAccountRequest_hyphens_failure() throws Exception {
-    // hyphens are a special-special character since they are used for whitespace replacement and
-    // can also be added during org name cleaning (in the case of a name that exists in another
-    // state)
-    String requestBody =
-        createAccountRequest(
-            "  --- --- ---",
+            orgName,
             "AZ",
             "k12",
             "Mary",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/AccountRequestControllerTest.java
@@ -200,6 +200,53 @@ class AccountRequestControllerTest extends BaseFullStackTest {
   }
 
   @Test
+  void submitOrganizationAccountRequest_invalidOrgName_failure() throws Exception {
+    String requestBody =
+        createAccountRequest(
+            "% ^ #",
+            "AZ", "k12", "Mary", "", "Lopez", "kyvuzoxy@mailinator.com", "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    MvcResult result = this._mockMvc.perform(builder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains("The organization name is invalid.");
+  }
+
+  @Test
+  void submitOrganizationAccountRequest_hyphens_failure() throws Exception {
+    // hyphens are a special-special character since they are used for whitespace replacement and
+    // can also be added during org name cleaning (in the case of a name that exists in another
+    // state)
+    String requestBody =
+        createAccountRequest(
+            "  --- --- ---",
+            "AZ",
+            "k12",
+            "Mary",
+            "",
+            "Lopez",
+            "kyvuzoxy@mailinator.com",
+            "+1 (969) 768-2863");
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.ACCOUNT_REQUEST_ORGANIZATION_CREATE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    MvcResult result = this._mockMvc.perform(builder).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(400);
+    assertThat(result.getResponse().getContentAsString())
+        .contains("The organization name is invalid.");
+  }
+
+  @Test
   @DisplayName("Duplicate org in same state fails")
   void duplicateOrgInSameState() throws Exception {
     // given

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -40,7 +41,7 @@ public abstract class BaseFullStackTest {
   @Autowired private DbTruncator _truncator;
   @Autowired private AuditService _auditService;
   @Autowired protected TestDataFactory _dataFactory;
-  @Autowired protected OrganizationService _orgService;
+  @SpyBean protected OrganizationService _orgService;
   @Autowired protected DemoOktaRepository _oktaRepo;
 
   protected Date _testStart;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -62,7 +62,7 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
     List<Future<Map<Organization, Set<String>>>> futures = new ArrayList<>();
 
     ThreadPoolExecutor executor =
-        new ThreadPoolExecutor(2, 2, 1, TimeUnit.MINUTES, new ArrayBlockingQueue<>(2));
+        new ThreadPoolExecutor(n, n, 1, TimeUnit.MINUTES, new ArrayBlockingQueue<>(2));
 
     for (int i = 0; i < n; i++) {
       Future<Map<Organization, Set<String>>> future =

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -51,7 +51,7 @@ jest.mock("../SignUpApi", () => ({
         );
       } else if (request.name === "InternalError") {
         throw new Error(
-          "An unknown error occured when creating this organization in Okta."
+          "An unknown error occurred when creating this organization in Okta."
         );
       } else {
         throw new Error("This is an error.");
@@ -221,7 +221,7 @@ describe("OrganizationForm", () => {
 
     expect(
       screen.getByText(
-        "An unexpected error occured. Please resubmit this form",
+        "An unexpected error occurred. Please resubmit this form",
         { exact: false }
       )
     ).toBeInTheDocument();

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -147,6 +147,15 @@ export const organizationSchema: yup.SchemaOf<OrganizationCreateRequest> = yup
 
 export const organizationBackendErrors = (error: string): ReactElement => {
   switch (error) {
+    // Unusable org name.  Name probably doesn't contain any alphanumeric characters
+    case "The organization name is empty.":
+    case "The organization name is invalid.":
+      return (
+        <Alert type="error" title="Invalid organization name">
+          The organization name you entered is invalid. Please double check and
+          re-enter the organization name.
+        </Alert>
+      );
     // Duplicate org. Admin user is attempting to resign up but has already completed identity verification.
     case "Duplicate organization with admin user who has completed identity verification.":
       return (
@@ -185,10 +194,10 @@ export const organizationBackendErrors = (error: string): ReactElement => {
         </Alert>
       );
     // Okta internal error.
-    case "An unknown error occured when creating this organization in Okta.":
+    case "An unknown error occurred when creating this organization in Okta.":
       return (
         <Alert type="error" title="Unexpected error">
-          An unexpected error occured. Please resubmit this form, or contact{" "}
+          An unexpected error occurred. Please resubmit this form, or contact{" "}
           <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
           if the problem persists.
         </Alert>


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/2564

## Changes Proposed

- Normalize org name and external id before creating organization

## Additional Information

- This is just part of a continuing process to improve our detection and handling of duplicate organizations.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
