### PR TITLE
catch BadRequestException

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -100,6 +100,10 @@ public class AccountRequestController {
         throw new BadRequestException(
             "An unknown error occured when creating this organization in Okta.");
       }
+    } catch (BadRequestException e) {
+      // Need to catch and re-throw these BadRequestExceptions or they get rethrown as
+      // AccountRequestFailureExceptions
+      throw e;
     } catch (UnexpectedRollbackException e) {
       // This `UnexpectedRollbackException` is thrown if a duplicate org somehow slips past our
       // checks and is attempted to be committed to the database.


### PR DESCRIPTION
## Related Issue or Background Info

- BadRequestExceptions that are (correctly!) thrown for duplicate organizations are being re-thrown as AccountRequestFailureExceptions and generating pages. This should fix that

## Changes Proposed

- catch and rethrow BadRequestException

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
