### PR TITLE
Actually fix ReminderService

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -18,8 +18,10 @@ import java.util.TimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class ReminderService {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReminderService.class);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -9,8 +10,15 @@ import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -31,6 +39,63 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
   void sendAccountReminderEmails_sendEmails_success() throws SQLException {
     String email = "fake@example.org";
     Organization unverifiedOrg = _dataFactory.createUnverifiedOrg();
+    initAndBackdateUnverifiedOrg(unverifiedOrg, email);
+
+    Map<Organization, Set<String>> orgEmailsSentMap = _service.sendAccountReminderEmails();
+    assertEquals(1, orgEmailsSentMap.keySet().size());
+
+    Organization remindedOrg = orgEmailsSentMap.keySet().iterator().next();
+    assertEquals(unverifiedOrg.getExternalId(), remindedOrg.getExternalId());
+
+    Set<String> remindedEmails = orgEmailsSentMap.get(remindedOrg);
+    assertEquals(Set.of(email), remindedEmails);
+  }
+
+  @Test
+  void sendAccountReminderEmails_concurrencyLock_success()
+      throws InterruptedException, ExecutionException, SQLException {
+    String email = "fake@example.org";
+    Organization unverifiedOrg = _dataFactory.createUnverifiedOrg();
+    initAndBackdateUnverifiedOrg(unverifiedOrg, email);
+
+    int n = 3;
+    List<Future<Map<Organization, Set<String>>>> futures = new ArrayList<>();
+
+    ThreadPoolExecutor executor =
+        new ThreadPoolExecutor(2, 2, 1, TimeUnit.MINUTES, new ArrayBlockingQueue<>(2));
+
+    for (int i = 0; i < n; i++) {
+      Future<Map<Organization, Set<String>>> future =
+          executor.submit(() -> _service.sendAccountReminderEmails());
+      futures.add(future);
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(1, TimeUnit.MINUTES);
+
+    assertEquals(n, futures.size());
+
+    Map<Organization, Set<String>> successResult = null;
+    int emptyResultCount = 0;
+
+    for (Future<Map<Organization, Set<String>>> resultFuture : futures) {
+      Map<Organization, Set<String>> result = resultFuture.get();
+      if (result.keySet().size() > 0) {
+        successResult = result;
+      } else {
+        emptyResultCount++;
+      }
+    }
+
+    // expect:
+    //   * 1 result with 1 key (the one that got the lock)
+    assertNotNull(successResult);
+    assertEquals(1, successResult.keySet().size());
+    //   * n-1 results with empty key set
+    assertEquals(n - 1, emptyResultCount);
+  }
+
+  void initAndBackdateUnverifiedOrg(Organization unverifiedOrg, String email) throws SQLException {
     backdateOrgCreatedAt(unverifiedOrg);
 
     // another unverified org, too new to be reminded
@@ -44,15 +109,6 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
         Set.of(),
         Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ADMIN),
         true);
-
-    Map<Organization, Set<String>> orgEmailsSentMap = _service.sendAccountReminderEmails();
-    assertEquals(1, orgEmailsSentMap.keySet().size());
-
-    Organization remindedOrg = orgEmailsSentMap.keySet().iterator().next();
-    assertEquals(unverifiedOrg.getExternalId(), remindedOrg.getExternalId());
-
-    Set<String> remindedEmails = orgEmailsSentMap.get(remindedOrg);
-    assertEquals(Set.of(email), remindedEmails);
   }
 
   @Transactional


### PR DESCRIPTION
## Related Issue or Background Info

The first attempt to prevent multiple reminder emails from being sent (https://github.com/CDCgov/prime-simplereport/pull/2641) was not successful.  This builds on the previous PR and adds a test to ensure use of the lock works.

## Changes Proposed

- Make ReminderService transactional
- Add test

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
