### PR TITLE
Update admin user email logic to account for multiple admins in duplicate orgs

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -218,14 +218,12 @@ public class DemoOktaRepository implements OktaRepository {
     return "activationToken";
   }
 
-  public String fetchAdminUserEmail(Organization org) {
-    Optional<Entry<String, OrganizationRoleClaims>> admin =
+  public List<String> fetchAdminUserEmail(Organization org) {
+    Set<Entry<String, OrganizationRoleClaims>> admins =
         usernameOrgRolesMap.entrySet().stream()
             .filter(e -> e.getValue().getGrantedRoles().contains(OrganizationRole.ADMIN))
-            .findFirst();
-    return admin
-        .map(Entry::getKey)
-        .orElseThrow(() -> new IllegalStateException("Organization does not have an admin."));
+            .collect(Collectors.toSet());
+    return admins.stream().map(Entry::getKey).collect(Collectors.toList());
   }
 
   public void createFacility(Facility facility) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -471,9 +471,9 @@ public class LiveOktaRepository implements OktaRepository {
     return activateUser(user);
   }
 
-  public String fetchAdminUserEmail(Organization org) {
-    User user = getOrgAdminUsers(org).single();
-    return user.getProfile().getLogin();
+  public List<String> fetchAdminUserEmail(Organization org) {
+    UserList admins = getOrgAdminUsers(org);
+    return admins.stream().map(u -> u.getProfile().getLogin()).collect(Collectors.toList());
   }
 
   public void createFacility(Facility facility) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -6,6 +6,7 @@ import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -49,7 +50,7 @@ public interface OktaRepository {
 
   String activateOrganizationWithSingleUser(Organization org);
 
-  String fetchAdminUserEmail(Organization org);
+  List<String> fetchAdminUserEmail(Organization org);
 
   void createFacility(Facility facility);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -1,10 +1,9 @@
 package gov.cdc.usds.simplereport.idp.repository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -366,7 +365,7 @@ class DemoOktaRepositoryTest {
         Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ALL_FACILITIES, OrganizationRole.ADMIN),
         true);
 
-    assertThat(_repo.fetchAdminUserEmail(ABC).contains("dianek@gmail.com"));
+    assertThat(_repo.fetchAdminUserEmail(ABC)).contains("dianek@gmail.com");
   }
 
   private static Facility getFacility(UUID uuid, Organization org) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -365,7 +366,7 @@ class DemoOktaRepositoryTest {
         Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ALL_FACILITIES, OrganizationRole.ADMIN),
         true);
 
-    assertEquals(_repo.fetchAdminUserEmail(ABC), "dianek@gmail.com");
+    assertThat(_repo.fetchAdminUserEmail(ABC).contains("dianek@gmail.com"));
   }
 
   private static Facility getFacility(UUID uuid, Organization org) {


### PR DESCRIPTION
## Related Issue or Background Info

- https://prime-cdc.pagerduty.com/incidents/PUW5WSC

Part of the duplicate org changes I made yesterday included logic to check if the email was associated with an admin, so the toast could be more specific about next steps. I assumed there would only be a single admin in the org at this point, but turns out that was not a correct assumption. If someone tried to re-register an organization that already had multiple admins, an IllegalStateException was thrown by Okta (because we were expecting a single user and got a list of them instead.) This updates OktaRepository and associated files to expect a list of usernames, rather than a single one.

## Changes Proposed

- update OktaRepository to expect a list of usernames
- update AccountRequestController to look for a match within the list

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- n/a Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
