### PR TITLE
Return success boolean from resendToReportStream

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
@@ -17,7 +17,6 @@ public class TestResultMutationResolver implements GraphQLMutationResolver {
      * NOTE: This when the DataHubUploaderService is decommissioned, this will need to be replaced with some logic like:
      * TestEventRepository.findAllByInternalIdIn(testEventIds).forEach(testEvent -> TestEventReportingService.report(testEvent))
      */
-    _dataHubUploaderService.dataHubUploaderTask(testEventIds);
-    return true;
+    return _dataHubUploaderService.dataHubUploaderTask(testEventIds);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubUploaderService.java
@@ -186,8 +186,8 @@ public class DataHubUploaderService {
   }
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
-  public void dataHubUploaderTask(List<UUID> testEventIds) {
-    uploaderTask(
+  public boolean dataHubUploaderTask(List<UUID> testEventIds) {
+    return uploaderTask(
         () -> {
           try {
             return createTestEventCSV(_testReportEventsRepo.findAllByInternalIdIn(testEventIds));
@@ -227,12 +227,12 @@ public class DataHubUploaderService {
     uploaderTask(testEventSupplier, true);
   }
 
-  private void uploaderTask(Supplier<List<TestEvent>> testEventSupplier, boolean withTracking) {
+  private boolean uploaderTask(Supplier<List<TestEvent>> testEventSupplier, boolean withTracking) {
     // sanity check everything is configured correctly (dev likely will not be)
     if (!_config.getUploadEnabled()) {
       LOG.warn(
           "DataHubUploaderTask not running because simple-report.data-hub.uploadEnabled is false");
-      return;
+      return false;
     }
 
     if (_dataHubUploadRepo
@@ -241,7 +241,7 @@ public class DataHubUploaderService {
       LOG.info("Data hub upload lock obtained: commencing upload processing.");
     } else {
       LOG.info("Data hub upload locked out by mutex: aborting");
-      return;
+      return false;
     }
 
     this.init();
@@ -255,7 +255,7 @@ public class DataHubUploaderService {
     }
     if (!msgs.isEmpty()) {
       _slack.sendSlackChannelMessage("DataHubUploader not run", msgs, true);
-      return;
+      return false;
     }
 
     // The start date is the last end date. Can be null for empty database.
@@ -263,7 +263,7 @@ public class DataHubUploaderService {
     if (lastTimestamp == null) {
       // this happens if EVERYTHING in the db would be matched.
       LOG.error("No earliest_recorded_timestamp found. EVERYTHING would be matched and sent");
-      return;
+      return false;
     }
 
     Optional<DataHubUpload> tracking =
@@ -287,6 +287,7 @@ public class DataHubUploaderService {
       _testEventReportingService.markTestEventsAsReported(new HashSet<>(eventsReported));
     } catch (RestClientException | UnexpectedIOException err) {
       tracking.ifPresent(upload -> _trackingService.markFailed(upload, _resultJson, err));
+      return false;
     }
 
     tracking.ifPresent(
@@ -308,5 +309,6 @@ public class DataHubUploaderService {
 
     // should this sleep for some period of time? If no rows match it may be really fast
     // and other server instances not overlap and get blocked by tryUploadLock() otherwise.
+    return true;
   }
 }


### PR DESCRIPTION
## Related Issue or Background Info

- When redriving records to ReportStream, the GraphQL endpoint previously returned `true` in all circumstances. It will now return `false` on failure to upload.

## Changes Proposed

- Flip around a couple method signatures from void -> boolean and return appropriately

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
