### PR TITLE
fireEvent -> userEvent

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -2,7 +2,8 @@ import { BrowserRouter as Router, MemoryRouter, Route } from "react-router-dom";
 import { Provider } from "react-redux";
 import createMockStore, { MockStoreEnhanced } from "redux-mock-store";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import App, { WHOAMI_QUERY } from "./App";
 import { queueQuery } from "./testQueue/TestQueue";
@@ -218,7 +219,7 @@ describe("App", () => {
     });
     expect(trainingWelcome).toBeInTheDocument();
     await waitFor(() => {
-      fireEvent.click(screen.getByText("Got it", { exact: false }));
+      userEvent.click(screen.getByText("Got it", { exact: false }));
     });
     expect(trainingWelcome).not.toBeInTheDocument();
   });

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
@@ -180,7 +181,7 @@ describe("FacilityFormContainer", () => {
   it("redirects on successful save", async () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
-      await fireEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(await screen.findByText("Redirected")).toBeDefined();
     });

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 
 import * as clia from "../utils/clia";
@@ -108,11 +109,11 @@ describe("FacilityForm", () => {
       </MemoryRouter>
     );
     const saveButton = await screen.getAllByText("Save changes")[0];
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("Testing facility name", { exact: false }),
-      { target: { value: "Bar Facility" } }
+      "Bar Facility"
     );
-    fireEvent.click(saveButton);
+    userEvent.click(saveButton);
     await validateAddress(saveFacility);
   });
   it("provides validation feedback during form completion", async () => {
@@ -128,8 +129,8 @@ describe("FacilityForm", () => {
     const facilityNameInput = screen.getByLabelText("Testing facility name", {
       exact: false,
     });
-    fireEvent.change(facilityNameInput, { target: { value: "" } });
-    fireEvent.blur(facilityNameInput);
+    userEvent.clear(facilityNameInput);
+    userEvent.tab();
     const warning = await screen.findByText("Facility name is missing");
     expect(warning).toBeInTheDocument();
   });
@@ -148,10 +149,8 @@ describe("FacilityForm", () => {
       exact: false,
     });
     await waitFor(() => {
-      fireEvent.change(facilityNameInput, { target: { value: "" } });
-    });
-    await waitFor(async () => {
-      fireEvent.click(saveButton);
+      userEvent.clear(facilityNameInput);
+      userEvent.click(saveButton);
     });
     expect(saveFacility).toBeCalledTimes(0);
   });
@@ -169,8 +168,8 @@ describe("FacilityForm", () => {
     const emailInput = screen.getByLabelText("Email", {
       exact: false,
     });
-    fireEvent.change(emailInput, { target: { value: "123-456-7890" } });
-    fireEvent.blur(emailInput);
+    userEvent.type(emailInput, "123-456-7890");
+    userEvent.tab();
 
     expect(
       await screen.findByText("Email is incorrectly formatted", {
@@ -179,15 +178,13 @@ describe("FacilityForm", () => {
     ).toBeInTheDocument();
 
     await waitFor(async () => {
-      fireEvent.click(saveButton);
+      userEvent.click(saveButton);
     });
     expect(saveFacility).toBeCalledTimes(0);
 
-    fireEvent.change(emailInput, {
-      target: { value: "foofacility@example.com" },
-    });
+    userEvent.type(emailInput, "foofacility@example.com");
     await waitFor(async () => {
-      fireEvent.click(saveButton);
+      userEvent.click(saveButton);
     });
     await validateAddress(saveFacility);
   });
@@ -202,12 +199,8 @@ describe("FacilityForm", () => {
       </MemoryRouter>
     );
     const stateDropdownElement = screen.getByTestId("facility-state-dropdown");
-    fireEvent.change(stateDropdownElement, { target: { selectedValue: "PW" } });
-    fireEvent.change(stateDropdownElement, { target: { value: "PW" } });
-    await waitFor(async () => {
-      fireEvent.blur(stateDropdownElement);
-    });
-
+    userEvent.selectOptions(stateDropdownElement, "PW");
+    userEvent.tab();
     // There's a line break between these two statements, so they have to be separated
     const warning = await screen.findByText(
       "SimpleReport isn’t currently supported in",
@@ -245,10 +238,8 @@ describe("FacilityForm", () => {
           exact: false,
         });
 
-        fireEvent.change(cliaInput, {
-          target: { value: "12F3456789" },
-        });
-        fireEvent.blur(cliaInput);
+        userEvent.type(cliaInput, "12F3456789");
+        userEvent.tab();
 
         const expectedError = "CLIA number should be 10 characters";
 
@@ -260,7 +251,7 @@ describe("FacilityForm", () => {
 
         const saveButton = screen.getAllByText("Save changes")[0];
         await waitFor(async () => {
-          fireEvent.click(saveButton);
+          userEvent.click(saveButton);
         });
         expect(saveFacility).toBeCalledTimes(0);
       });
@@ -291,13 +282,11 @@ describe("FacilityForm", () => {
         const cliaInput = screen.getByLabelText("CLIA number", {
           exact: false,
         });
-        fireEvent.change(cliaInput, {
-          target: { value: "invalid-clia-number" },
-        });
-        fireEvent.blur(cliaInput);
+        userEvent.type(cliaInput, "invalid-clia-number");
+        userEvent.tab();
 
         const saveButton = await screen.getAllByText("Save changes")[0];
-        fireEvent.click(saveButton);
+        userEvent.click(saveButton);
         await validateAddress(saveFacility);
         expect(saveFacility).toBeCalledTimes(1);
       });
@@ -332,13 +321,12 @@ describe("FacilityForm", () => {
           exact: false,
         });
 
-        fireEvent.change(cliaInput, {
-          target: { value: "12Z3456789" },
-        });
-        fireEvent.blur(cliaInput);
+        userEvent.clear(cliaInput);
+        userEvent.type(cliaInput, "12Z3456789");
+        userEvent.tab();
 
         const saveButton = await screen.getAllByText("Save changes")[0];
-        fireEvent.click(saveButton);
+        userEvent.click(saveButton);
         await validateAddress(saveFacility);
         expect(saveFacility).toBeCalledTimes(1);
       });
@@ -359,10 +347,9 @@ describe("FacilityForm", () => {
           exact: false,
         });
 
-        fireEvent.change(cliaInput, {
-          target: { value: "12Z3456789" },
-        });
-        fireEvent.blur(cliaInput);
+        userEvent.clear(cliaInput);
+        userEvent.type(cliaInput, "12Z3456789");
+        userEvent.tab();
 
         const expectedError = "Special Z CLIAs are only valid in WA";
 
@@ -374,7 +361,7 @@ describe("FacilityForm", () => {
 
         const saveButton = screen.getAllByText("Save changes")[0];
         await waitFor(async () => {
-          fireEvent.click(saveButton);
+          userEvent.click(saveButton);
         });
         expect(saveFacility).toBeCalledTimes(0);
       });
@@ -409,10 +396,8 @@ describe("FacilityForm", () => {
           exact: false,
         });
 
-        fireEvent.change(npiInput, {
-          target: { value: null },
-        });
-        fireEvent.blur(npiInput);
+        userEvent.clear(npiInput);
+        userEvent.tab();
 
         const expectedError = "Ordering provider NPI is incorrectly formatted";
 
@@ -426,7 +411,7 @@ describe("FacilityForm", () => {
 
         const saveButton = screen.getAllByText("Save changes")[0];
         await waitFor(async () => {
-          fireEvent.click(saveButton);
+          userEvent.click(saveButton);
         });
         expect(saveFacility).toBeCalledTimes(0);
       });
@@ -458,16 +443,14 @@ describe("FacilityForm", () => {
         const npiInput = screen.getByLabelText("NPI", {
           exact: false,
         });
-        fireEvent.change(npiInput, {
-          target: { value: null },
-        });
-        fireEvent.blur(npiInput);
+        userEvent.clear(npiInput);
+        userEvent.tab();
 
         // The spy function was called at least once
         expect(spy.mock.calls.length).toBeGreaterThan(0);
 
         const saveButton = await screen.getAllByText("Save changes")[0];
-        fireEvent.click(saveButton);
+        userEvent.click(saveButton);
         await validateAddress(saveFacility);
         expect(saveFacility).toBeCalledTimes(1);
       });
@@ -494,11 +477,12 @@ describe("FacilityForm", () => {
         </MemoryRouter>
       );
       const saveButton = screen.getAllByText("Save changes")[0];
-      fireEvent.change(
-        screen.getByLabelText("Testing facility name", { exact: false }),
-        { target: { value: "La Croix Facility" } }
-      );
-      fireEvent.click(saveButton);
+      const facilityName = screen.getByLabelText("Testing facility name", {
+        exact: false,
+      });
+      userEvent.clear(facilityName);
+      userEvent.type(facilityName, "La Croix Facility");
+      userEvent.click(saveButton);
       await validateAddress(saveFacility, "suggested address");
       expect(saveFacility).toBeCalledWith({
         ...validFacility,
@@ -526,11 +510,11 @@ describe("FacilityForm", () => {
       // Delete default device
       const deleteButtons = await screen.findAllByLabelText("Delete device");
       await waitFor(() => {
-        fireEvent.click(deleteButtons[0]);
+        userEvent.click(deleteButtons[0]);
       });
       // Attempt save
       const saveButtons = await screen.findAllByText("Save changes");
-      fireEvent.click(saveButtons[0]);
+      userEvent.click(saveButtons[0]);
       const warning = await screen.findByText(
         "A default device must be selected",
         { exact: false }
@@ -546,9 +530,9 @@ async function validateAddress(
 ) {
   await screen.findByText("Address validation");
   const radios = screen.getAllByLabelText(selection, { exact: false });
-  radios.forEach(fireEvent.click);
+  radios.forEach((r) => userEvent.click(r));
   const button = screen.getAllByText("Save changes")[2];
   expect(button).not.toBeDisabled();
-  fireEvent.click(button);
+  userEvent.click(button);
   expect(saveFacility).toBeCalledTimes(1);
 }

--- a/frontend/src/app/Settings/ManageOrganization.test.tsx
+++ b/frontend/src/app/Settings/ManageOrganization.test.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { DeepPartial } from "redux";
 import configureStore from "redux-mock-store";
@@ -48,11 +49,11 @@ describe("ManageOrganization", () => {
     });
     const saveButton = screen.getByText("Save settings");
     expect(orgNameInput).not.toBeDisabled();
-    fireEvent.change(orgNameInput, { target: { value: "Penny Lane" } });
-    fireEvent.change(orgTypeInput, { target: { value: "other" } });
+    userEvent.type(orgNameInput, "Penny Lane");
+    userEvent.selectOptions(orgTypeInput, "other");
     expect(saveButton).not.toBeDisabled();
     await waitFor(() => {
-      fireEvent.click(saveButton);
+      userEvent.click(saveButton);
     });
   });
 
@@ -69,10 +70,10 @@ describe("ManageOrganization", () => {
       exact: false,
     });
     const saveButton = screen.getByText("Save settings");
-    fireEvent.change(orgTypeInput, { target: { value: "hospice" } });
+    userEvent.selectOptions(orgTypeInput, "hospice");
     expect(saveButton).not.toBeDisabled();
     await waitFor(() => {
-      fireEvent.click(saveButton);
+      userEvent.click(saveButton);
     });
   });
 });

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinks.test.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinks.test.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import {
   ManageSelfRegistrationLinksContainer,
@@ -63,7 +64,7 @@ describe("ManageSelfRegistrationLinks", () => {
     const orgUrl = `${process.env.REACT_APP_BASE_URL}/register/${expectedOrgSlug}`;
     const [orgBtn] = screen.getAllByRole("button");
     await waitFor(() => {
-      fireEvent.click(orgBtn);
+      userEvent.click(orgBtn);
     });
     expect(navigator.clipboard.writeText).toBeCalledWith(orgUrl);
   });
@@ -72,7 +73,7 @@ describe("ManageSelfRegistrationLinks", () => {
     const facilityUrl = `${process.env.REACT_APP_BASE_URL}/register/${expectedFacilitySlug}`;
     const btns = screen.getAllByRole("button");
     await waitFor(() => {
-      fireEvent.click(btns[2]);
+      userEvent.click(btns[2]);
     });
     expect(navigator.clipboard.writeText).toBeCalledWith(facilityUrl);
   });

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { render, fireEvent, waitFor, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -253,7 +254,7 @@ describe("ManageUsers", () => {
     });
 
     it("disables logged-in user's settings", async () => {
-      fireEvent.click(getByText(displayFullName("Bob", "", "Bobberoo")));
+      userEvent.click(getByText(displayFullName("Bob", "", "Bobberoo")));
       await findByText("YOU");
       expect(getByLabelText("admin", { exact: false })).toHaveAttribute(
         "disabled"
@@ -275,7 +276,7 @@ describe("ManageUsers", () => {
         role: "USER",
       };
 
-      fireEvent.click(getByText("New User", { exact: false }));
+      userEvent.click(getByText("New User", { exact: false }));
       const [first, last, email] = await findAllByRole("textbox");
       const select = getByLabelText("Access level", { exact: false });
       fireEvent.change(first, inputValue(newUser.firstName));
@@ -284,10 +285,10 @@ describe("ManageUsers", () => {
       fireEvent.change(select, inputValue(newUser.role));
       const sendButton = getByText("Send invite");
       await waitFor(() => {
-        fireEvent.click(screen.getAllByRole("checkbox")[1]);
+        userEvent.click(screen.getAllByRole("checkbox")[1]);
         expect(sendButton).not.toBeDisabled();
       });
-      fireEvent.click(sendButton);
+      userEvent.click(sendButton);
       await waitFor(() => expect(addUserToOrg).toBeCalled());
       expect(addUserToOrg).toBeCalledWith({ variables: newUser });
       expect(updateUserPrivileges).toBeCalledWith({
@@ -308,7 +309,7 @@ describe("ManageUsers", () => {
         role: "USER",
       };
 
-      fireEvent.click(getByText("New User", { exact: false }));
+      userEvent.click(getByText("New User", { exact: false }));
       const [first, last, email] = await findAllByRole("textbox");
       const select = getByLabelText("Access level", { exact: false });
       fireEvent.change(first, inputValue(newUser.firstName));
@@ -317,10 +318,10 @@ describe("ManageUsers", () => {
       fireEvent.change(select, inputValue(newUser.role));
       const sendButton = getByText("Send invite");
       await waitFor(() => {
-        fireEvent.click(screen.getAllByRole("checkbox")[1]);
+        userEvent.click(screen.getAllByRole("checkbox")[1]);
         expect(sendButton).not.toBeDisabled();
       });
-      fireEvent.click(sendButton);
+      userEvent.click(sendButton);
       await waitFor(() => expect(addUserToOrg).not.toBeCalled());
       expect(
         screen.queryAllByText("Email must be a valid email address").length
@@ -334,15 +335,15 @@ describe("ManageUsers", () => {
         email: "jane@smith.co",
       };
 
-      fireEvent.click(getByText("New User", { exact: false }));
+      userEvent.click(getByText("New User", { exact: false }));
       const [first, last, email] = await findAllByRole("textbox");
       fireEvent.change(first, inputValue(newUser.firstName));
       fireEvent.change(last, inputValue(newUser.lastName));
       fireEvent.change(email, inputValue(newUser.email));
-      fireEvent.click(screen.getAllByRole("checkbox")[1]);
+      userEvent.click(screen.getAllByRole("checkbox")[1]);
       const sendButton = getByText("Send invite");
       await waitFor(() => expect(sendButton).not.toBeDisabled());
-      fireEvent.click(sendButton);
+      userEvent.click(sendButton);
       await waitFor(() => expect(addUserToOrg).toBeCalled());
       expect(addUserToOrg).toBeCalledWith({
         variables: { ...newUser, role: "USER" },
@@ -351,9 +352,9 @@ describe("ManageUsers", () => {
 
     it("deletes a user", async () => {
       const removeButton = await findByText("Remove", { exact: false });
-      fireEvent.click(removeButton);
+      userEvent.click(removeButton);
       const sureButton = await findByText("Yes", { exact: false });
-      fireEvent.click(sureButton);
+      userEvent.click(sureButton);
       await waitFor(() => expect(deleteUser).toBeCalled());
       expect(deleteUser).toBeCalledWith({
         variables: { deleted: true, id: users[0].id },
@@ -362,10 +363,10 @@ describe("ManageUsers", () => {
 
     it("updates someone from user to admin", async () => {
       const [adminOption] = await findAllByRole("radio");
-      fireEvent.click(adminOption);
+      userEvent.click(adminOption);
       const button = await findByText("Save", { exact: false });
       await waitFor(() => expect(button).not.toHaveAttribute("disabled"));
-      fireEvent.click(button);
+      userEvent.click(button);
       await waitFor(() => expect(updateUserPrivileges).toBeCalled());
       expect(updateUserPrivileges).toBeCalledWith({
         variables: {
@@ -384,11 +385,11 @@ describe("ManageUsers", () => {
         fireEvent.change(facilitySelect, { target: { value: "a1" } });
         expect(addButton).not.toBeDisabled();
       });
-      fireEvent.click(addButton);
+      userEvent.click(addButton);
       const saveButton = screen.getByText("Save changes");
       await waitFor(() => expect(saveButton).not.toBeDisabled());
       await waitFor(() => {
-        fireEvent.click(saveButton);
+        userEvent.click(saveButton);
         expect(updateUserPrivileges).toBeCalled();
       });
       expect(updateUserPrivileges).toBeCalledWith({
@@ -443,16 +444,16 @@ describe("ManageUsers", () => {
         email: "jane@smith.co",
       };
 
-      fireEvent.click(getByText("New User", { exact: false }));
+      userEvent.click(getByText("New User", { exact: false }));
       const [first, last, email] = await findAllByRole("textbox");
       fireEvent.change(first, inputValue(newUser.firstName));
       fireEvent.change(last, inputValue(newUser.lastName));
       fireEvent.change(email, inputValue(newUser.email));
-      fireEvent.click(screen.getByRole("checkbox"));
+      userEvent.click(screen.getByRole("checkbox"));
       const sendButton = getByText("Send invite");
       await waitFor(() => expect(sendButton).not.toBeDisabled());
       await waitFor(() => {
-        fireEvent.click(sendButton);
+        userEvent.click(sendButton);
         expect(addUserToOrg).toBeCalled();
       });
       expect(addUserToOrg).toBeCalledWith({
@@ -486,9 +487,9 @@ describe("ManageUsers", () => {
 
     it("reactivates a suspended user", async () => {
       const reactivateButton = await findByText("Reactivate", { exact: false });
-      fireEvent.click(reactivateButton);
+      userEvent.click(reactivateButton);
       const sureButton = await findByText("Yes", { exact: false });
-      fireEvent.click(sureButton);
+      userEvent.click(sureButton);
       await waitFor(() => expect(reactivateUser).toBeCalled());
       expect(reactivateUser).toBeCalledWith({
         variables: { id: suspendedUsers[0].id },
@@ -590,11 +591,11 @@ describe("ManageUsers", () => {
     )[0];
     const saveButton = await screen.findByText("Save changes");
     await waitFor(() => {
-      fireEvent.click(removeButton);
+      userEvent.click(removeButton);
       expect(saveButton).not.toBeDisabled();
     });
     await waitFor(() => {
-      fireEvent.click(saveButton);
+      userEvent.click(saveButton);
     });
     expect(updateUserPrivileges).toBeCalledWith({
       variables: {

--- a/frontend/src/app/accountCreation/MfaEmailVerify/MfaEmailVerify.test.tsx
+++ b/frontend/src/app/accountCreation/MfaEmailVerify/MfaEmailVerify.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Switch } from "react-router";
 
@@ -45,14 +46,12 @@ describe("Verify Email MFA", () => {
         { exact: false }
       )
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123456" },
-      }
+      "123456"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(
       screen.queryByText("Enter your security code")
@@ -71,14 +70,12 @@ describe("Verify Email MFA", () => {
         { exact: false }
       )
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "999999" },
-      }
+      "999999"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(screen.getByText("incorrect code")).toBeInTheDocument();
     expect(
@@ -89,7 +86,7 @@ describe("Verify Email MFA", () => {
   });
 
   it("requires a security code to be entered", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
     expect(
       screen.queryByText(

--- a/frontend/src/app/accountCreation/MfaGoogleAuthVerify/MfaGoogleAuthVerify.test.tsx
+++ b/frontend/src/app/accountCreation/MfaGoogleAuthVerify/MfaGoogleAuthVerify.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Switch } from "react-router";
 
@@ -52,14 +53,12 @@ describe("Verify Google Auth MFA", () => {
         exact: false,
       })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123456" },
-      }
+      "123456"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(
       screen.queryByText("Enter your security code")
@@ -77,14 +76,12 @@ describe("Verify Google Auth MFA", () => {
         exact: false,
       })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "999999" },
-      }
+      "999999"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(screen.getByText("incorrect code")).toBeInTheDocument();
     expect(
@@ -95,7 +92,7 @@ describe("Verify Google Auth MFA", () => {
   });
 
   it("requires a security code to be entered", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
     expect(
       screen.queryByText(

--- a/frontend/src/app/accountCreation/MfaOktaVerify/MfaOktaVerify.test.tsx
+++ b/frontend/src/app/accountCreation/MfaOktaVerify/MfaOktaVerify.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Switch } from "react-router";
 
@@ -49,14 +50,12 @@ describe("Verify Okta MFA", () => {
         exact: false,
       })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123456" },
-      }
+      "123456"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(
       screen.queryByText("Enter your security code")
@@ -74,14 +73,12 @@ describe("Verify Okta MFA", () => {
         exact: false,
       })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "999999" },
-      }
+      "999999"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(screen.getByText("incorrect code")).toBeInTheDocument();
     expect(
@@ -92,7 +89,7 @@ describe("Verify Okta MFA", () => {
   });
 
   it("requires a security code to be entered", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
     expect(
       screen.queryByText(

--- a/frontend/src/app/accountCreation/MfaPhone/MfaPhone.test.tsx
+++ b/frontend/src/app/accountCreation/MfaPhone/MfaPhone.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { MfaPhone } from "./MfaPhone";
 
@@ -9,13 +10,11 @@ describe("Phone call MFA", () => {
 
   it("can enter a valid phone number", async () => {
     await waitFor(() => {
-      fireEvent.change(
+      userEvent.type(
         screen.getByLabelText("Phone number", { exact: false }),
-        {
-          target: { value: "(910) 867-5309" },
-        }
+        "(910) 867-5309"
       );
-      fireEvent.click(screen.getByText("Send code"));
+      userEvent.click(screen.getByText("Send code"));
     });
 
     expect(
@@ -24,15 +23,16 @@ describe("Phone call MFA", () => {
   });
 
   it("requires a phone number", () => {
-    fireEvent.click(screen.getByText("Send code"));
+    userEvent.click(screen.getByText("Send code"));
     expect(screen.getByText("Enter your phone number")).toBeInTheDocument();
   });
 
   it("requires a valid phone number", () => {
-    fireEvent.change(screen.getByLabelText("Phone number", { exact: false }), {
-      target: { value: "(555) 555-5555" },
-    });
-    fireEvent.click(screen.getByText("Send code"));
+    userEvent.type(
+      screen.getByLabelText("Phone number", { exact: false }),
+      "(555) 555-5555"
+    );
+    userEvent.click(screen.getByText("Send code"));
     expect(screen.getByText("Enter a valid phone number")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/accountCreation/MfaPhoneVerify/MfaPhoneVerify.test.tsx
+++ b/frontend/src/app/accountCreation/MfaPhoneVerify/MfaPhoneVerify.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Switch } from "react-router";
 
@@ -48,14 +49,12 @@ describe("Verify Phone MFA", () => {
     expect(
       screen.getByText("530-867-5309", { exact: false })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123456" },
-      }
+      "123456"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(
       screen.queryByText("Enter your security code")
@@ -71,14 +70,12 @@ describe("Verify Phone MFA", () => {
     expect(
       screen.getByText("530-867-5309", { exact: false })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "999999" },
-      }
+      "999999"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(screen.getByText("incorrect code")).toBeInTheDocument();
     expect(
@@ -89,7 +86,7 @@ describe("Verify Phone MFA", () => {
   });
 
   it("requires a security code to be entered", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
     expect(
       screen.queryByText(

--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.test.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Switch } from "react-router";
 
 import { MfaEmailVerify } from "../MfaEmailVerify/MfaEmailVerify";
@@ -41,12 +42,12 @@ describe("MfaSelect", () => {
     const smsRadio = screen.getByLabelText("Text message (SMS)", {
       exact: false,
     });
-    fireEvent.click(smsRadio);
+    userEvent.click(smsRadio);
     expect(smsRadio).toBeChecked();
   });
 
   it("requires an mfa option", () => {
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(
       screen.getByText("Select an authentication option")
     ).toBeInTheDocument();
@@ -94,9 +95,9 @@ describe("MfaSelect routing", () => {
     const smsRadio = screen.getByLabelText("Text message (SMS)", {
       exact: false,
     });
-    fireEvent.click(smsRadio);
+    userEvent.click(smsRadio);
     expect(smsRadio).toBeChecked();
-    fireEvent.click(continueButton);
+    userEvent.click(continueButton);
     expect(
       screen.getByText("Get your security code via text message (SMS).")
     ).toBeInTheDocument();
@@ -106,9 +107,9 @@ describe("MfaSelect routing", () => {
     const googleRadio = screen.getByLabelText("Google Authenticator", {
       exact: false,
     });
-    fireEvent.click(googleRadio);
+    userEvent.click(googleRadio);
     expect(googleRadio).toBeChecked();
-    fireEvent.click(continueButton);
+    userEvent.click(continueButton);
     expect(
       await screen.findByText(
         "Get your security code via the Google Authenticator application."
@@ -120,9 +121,9 @@ describe("MfaSelect routing", () => {
     const oktaRadio = screen.getByLabelText("Okta Verify", {
       exact: false,
     });
-    fireEvent.click(oktaRadio);
+    userEvent.click(oktaRadio);
     expect(oktaRadio).toBeChecked();
-    fireEvent.click(continueButton);
+    userEvent.click(continueButton);
     expect(
       await screen.findByText(
         "Get your security code via the Okta Verify application."
@@ -139,9 +140,9 @@ describe("MfaSelect routing", () => {
     );
 
     await waitFor(() => {
-      fireEvent.click(securityKeyRadio);
+      userEvent.click(securityKeyRadio);
       expect(securityKeyRadio).toBeChecked();
-      fireEvent.click(continueButton);
+      userEvent.click(continueButton);
     });
 
     expect(
@@ -155,9 +156,9 @@ describe("MfaSelect routing", () => {
     const emailRadio = screen.getByLabelText("Email", {
       exact: false,
     });
-    fireEvent.click(emailRadio);
+    userEvent.click(emailRadio);
     expect(emailRadio).toBeChecked();
-    fireEvent.click(continueButton);
+    userEvent.click(continueButton);
     expect(
       screen.getByText(
         "We’ve sent you an email with a one-time security code.",
@@ -170,9 +171,9 @@ describe("MfaSelect routing", () => {
     const phoneRadio = screen.getByLabelText("Phone call", {
       exact: false,
     });
-    fireEvent.click(phoneRadio);
+    userEvent.click(phoneRadio);
     expect(phoneRadio).toBeChecked();
-    fireEvent.click(continueButton);
+    userEvent.click(continueButton);
     expect(
       screen.getByText("Get your security code via a phone call")
     ).toBeInTheDocument();

--- a/frontend/src/app/accountCreation/MfaSms/MfaSms.test.tsx
+++ b/frontend/src/app/accountCreation/MfaSms/MfaSms.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { MfaSms } from "./MfaSms";
 
@@ -9,13 +10,11 @@ describe("SMS MFA", () => {
 
   it("can enter a valid phone number", async () => {
     await waitFor(() => {
-      fireEvent.change(
+      userEvent.type(
         screen.getByLabelText("Phone number", { exact: false }),
-        {
-          target: { value: "(910) 867-5309" },
-        }
+        "(910) 867-5309"
       );
-      fireEvent.click(screen.getByText("Send code"));
+      userEvent.click(screen.getByText("Send code"));
     });
 
     expect(
@@ -24,15 +23,16 @@ describe("SMS MFA", () => {
   });
 
   it("requires a phone number", () => {
-    fireEvent.click(screen.getByText("Send code"));
+    userEvent.click(screen.getByText("Send code"));
     expect(screen.getByText("Enter your phone number")).toBeInTheDocument();
   });
 
   it("requires a valid phone number", () => {
-    fireEvent.change(screen.getByLabelText("Phone number", { exact: false }), {
-      target: { value: "(555) 555-5555" },
-    });
-    fireEvent.click(screen.getByText("Send code"));
+    userEvent.type(
+      screen.getByLabelText("Phone number", { exact: false }),
+      "(555) 555-5555"
+    );
+    userEvent.click(screen.getByText("Send code"));
     expect(screen.getByText("Enter a valid phone number")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/accountCreation/MfaSmsVerify/MfaSmsVerify.test.tsx
+++ b/frontend/src/app/accountCreation/MfaSmsVerify/MfaSmsVerify.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Switch } from "react-router";
 
@@ -48,14 +49,12 @@ describe("Verify SMS MFA", () => {
     expect(
       screen.getByText("530-867-5309", { exact: false })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123456" },
-      }
+      "123456"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(
       screen.queryByText("Enter your security code")
@@ -71,14 +70,12 @@ describe("Verify SMS MFA", () => {
     expect(
       screen.getByText("530-867-5309", { exact: false })
     ).toBeInTheDocument();
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "999999" },
-      }
+      "999999"
     );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Submit"));
+      await userEvent.click(screen.getByText("Submit"));
     });
     expect(screen.getByText("incorrect code")).toBeInTheDocument();
     expect(
@@ -89,7 +86,7 @@ describe("Verify SMS MFA", () => {
   });
 
   it("requires a security code to be entered", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
     expect(
       screen.queryByText(

--- a/frontend/src/app/accountCreation/PasswordCreate/PasswordCreate.test.tsx
+++ b/frontend/src/app/accountCreation/PasswordCreate/PasswordCreate.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router";
@@ -52,7 +53,7 @@ describe("PasswordCreate", () => {
   };
 
   it("requires a password", () => {
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(
       screen.getByText(
         "Your password must have at least 8 characters, a lowercase letter, an uppercase letter, and a number"
@@ -61,58 +62,42 @@ describe("PasswordCreate", () => {
   });
 
   it("thinks 'foo' is a weak password", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "foo" },
-    });
+    userEvent.type(screen.getByLabelText("Password"), "foo");
     expect(screen.getByText(strengthLabel("Weak"))).toBeInTheDocument();
   });
 
   it("thinks 'fooBAR' is a weak password", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "fooBAR" },
-    });
+    userEvent.type(screen.getByLabelText("Password"), "fooBAR");
     expect(screen.getByText(strengthLabel("Okay"))).toBeInTheDocument();
   });
 
   it("thinks 'fooB1' is an okay password", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "fooB1" },
-    });
+    userEvent.type(screen.getByLabelText("Password"), "fooB1");
     expect(screen.getByText(strengthLabel("Medium"))).toBeInTheDocument();
   });
 
   it("thinks 'fooBAR123!' is a good password", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "fooBAR123!" },
-    });
+    userEvent.type(screen.getByLabelText("Password"), "fooBAR123!");
     expect(screen.getByText(strengthLabel("Strong"))).toBeInTheDocument();
   });
 
   it("can type in the password confirmation", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "fooBAR123!" },
-    });
-    fireEvent.change(
+    userEvent.type(screen.getByLabelText("Password"), "fooBAR123!");
+    userEvent.type(
       screen.getByLabelText("Confirm password", { exact: false }),
-      {
-        target: { value: "fooBAR123!" },
-      }
+      "fooBAR123!"
     );
     expect(screen.getByText(strengthLabel("Strong"))).toBeInTheDocument();
   });
 
   it("requires password to be valid", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "foo" },
-    });
-    fireEvent.change(
+    userEvent.type(screen.getByLabelText("Password"), "foo");
+    userEvent.type(
       screen.getByLabelText("Confirm password", { exact: false }),
-      {
-        target: { value: "foo" },
-      }
+      "foo"
     );
     expect(screen.getByText(strengthLabel("Weak"))).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(
       screen.getByText(
         "Your password must have at least 8 characters, an uppercase letter, and a number"
@@ -121,49 +106,37 @@ describe("PasswordCreate", () => {
   });
 
   it("requires passwords to match", () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "fooBAR123!" },
-    });
-    fireEvent.change(
+    userEvent.type(screen.getByLabelText("Password"), "fooBAR123!");
+    userEvent.type(
       screen.getByLabelText("Confirm password", { exact: false }),
-      {
-        target: { value: "fooBAR123" },
-      }
+      "fooBAR123"
     );
     expect(screen.getByText(strengthLabel("Strong"))).toBeInTheDocument();
     expect(screen.getByText("Passwords must match")).toBeInTheDocument();
   });
 
   it("succeeds on submit with valid password", async () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "validPASS123!" },
-    });
-    fireEvent.change(
+    userEvent.type(screen.getByLabelText("Password"), "validPASS123!");
+    userEvent.type(
       screen.getByLabelText("Confirm password", { exact: false }),
-      {
-        target: { value: "validPASS123!" },
-      }
+      "validPASS123!"
     );
     expect(screen.getByText(strengthLabel("Strong"))).toBeInTheDocument();
     await act(async () => {
-      await fireEvent.click(screen.getByText("Continue"));
+      await userEvent.click(screen.getByText("Continue"));
     });
     expect(screen.getByText("Password set successfully.")).toBeInTheDocument();
   });
 
   it("fails on submit with invalid password", async () => {
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "INvalidPASS123!" },
-    });
-    fireEvent.change(
+    userEvent.type(screen.getByLabelText("Password"), "INvalidPASS123!");
+    userEvent.type(
       screen.getByLabelText("Confirm password", { exact: false }),
-      {
-        target: { value: "INvalidPASS123!" },
-      }
+      "INvalidPASS123!"
     );
     expect(screen.getByText(strengthLabel("Strong"))).toBeInTheDocument();
     await act(async () => {
-      await fireEvent.click(screen.getByText("Continue"));
+      await userEvent.click(screen.getByText("Continue"));
     });
     expect(screen.getByText("utter failure")).toBeInTheDocument();
   });

--- a/frontend/src/app/accountCreation/SecurityQuestion/SecurityQuestion.test.tsx
+++ b/frontend/src/app/accountCreation/SecurityQuestion/SecurityQuestion.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route } from "react-router";
@@ -38,19 +38,21 @@ describe("SecurityQuestion", () => {
       screen.getByLabelText("Security question", { exact: false }),
       ["In what city or town was your first job?"]
     );
-    fireEvent.change(screen.getByLabelText("Answer", { exact: false }), {
-      target: { value: "New York" },
-    });
+    userEvent.type(
+      screen.getByLabelText("Answer", { exact: false }),
+      "New York"
+    );
     expect(
       screen.getByText("In what city or town was your first job?")
     ).toBeInTheDocument();
   });
 
   it("requires a security question", () => {
-    fireEvent.change(screen.getByLabelText("Answer", { exact: false }), {
-      target: { value: "New York" },
-    });
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.type(
+      screen.getByLabelText("Answer", { exact: false }),
+      "New York"
+    );
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.getByText("Select a security question")).toBeInTheDocument();
   });
 
@@ -59,7 +61,7 @@ describe("SecurityQuestion", () => {
       screen.getByLabelText("Security question", { exact: false }),
       ["In what city or town was your first job?"]
     );
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(
       screen.getByText("Answer must be at least 4 characters")
     ).toBeInTheDocument();
@@ -70,11 +72,12 @@ describe("SecurityQuestion", () => {
       screen.getByLabelText("Security question", { exact: false }),
       ["In what city or town was your first job?"]
     );
-    fireEvent.change(screen.getByLabelText("Answer", { exact: false }), {
-      target: { value: "Valid answer" },
-    });
+    userEvent.type(
+      screen.getByLabelText("Answer", { exact: false }),
+      "Valid answer"
+    );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Continue"));
+      await userEvent.click(screen.getByText("Continue"));
     });
     expect(
       screen.getByText("Recovery question set successfully.")
@@ -86,11 +89,12 @@ describe("SecurityQuestion", () => {
       screen.getByLabelText("Security question", { exact: false }),
       ["In what city or town was your first job?"]
     );
-    fireEvent.change(screen.getByLabelText("Answer", { exact: false }), {
-      target: { value: "Invalid answer" },
-    });
+    userEvent.type(
+      screen.getByLabelText("Answer", { exact: false }),
+      "Invalid answer"
+    );
     await act(async () => {
-      await fireEvent.click(screen.getByText("Continue"));
+      await userEvent.click(screen.getByText("Continue"));
     });
     expect(screen.getByText("catastrophic failure")).toBeInTheDocument();
   });

--- a/frontend/src/app/admin/AddOrganizationAdmin/AddOrganizationAdminFormContainer.test.tsx
+++ b/frontend/src/app/admin/AddOrganizationAdmin/AddOrganizationAdminFormContainer.test.tsx
@@ -1,12 +1,7 @@
-import {
-  render,
-  screen,
-  waitFor,
-  fireEvent,
-  act,
-} from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router";
+import userEvent from "@testing-library/user-event";
 
 import {
   AddUserDocument,
@@ -97,9 +92,11 @@ describe("AddOrganizationAdminFormContainer", () => {
       describe("Blank value for first name", () => {
         beforeEach(async () => {
           await waitFor(async () => {
-            await fireEvent.blur(
-              screen.getByLabelText("First name", { exact: false })
-            );
+            const firstName = screen.getByLabelText("First name", {
+              exact: false,
+            });
+            userEvent.clear(firstName);
+            userEvent.tab();
           });
         });
         it("show an error", () => {
@@ -110,7 +107,7 @@ describe("AddOrganizationAdminFormContainer", () => {
         describe("Form submission", () => {
           beforeEach(async () => {
             await act(async () => {
-              await fireEvent.click(screen.getByText("Save Changes"));
+              await userEvent.click(screen.getByText("Save Changes"));
             });
           });
           it("shows the form title", () => {
@@ -123,31 +120,21 @@ describe("AddOrganizationAdminFormContainer", () => {
       describe("All required fields filled", () => {
         beforeEach(async () => {
           await waitFor(async () => {
-            await fireEvent.change(
+            await userEvent.selectOptions(
               screen.getByTestId("organization-dropdown"),
-              {
-                target: {
-                  value: "DC-Space-Camp-f34183c4-b4c5-449f-98b0-2e02abb7aae0",
-                },
-              }
+              "DC-Space-Camp-f34183c4-b4c5-449f-98b0-2e02abb7aae0"
             );
-            await fireEvent.change(
+            await userEvent.type(
               screen.getByLabelText("First name", { exact: false }),
-              {
-                target: { value: "Flora" },
-              }
+              "Flora"
             );
-            await fireEvent.change(
+            await userEvent.type(
               screen.getByLabelText("Last name", { exact: false }),
-              {
-                target: { value: "Murray" },
-              }
+              "Murray"
             );
-            await fireEvent.change(
+            await userEvent.type(
               screen.getByLabelText("Email", { exact: false }),
-              {
-                target: { value: "Flora.Murray@example.com" },
-              }
+              "Flora.Murray@example.com"
             );
           });
         });
@@ -160,7 +147,7 @@ describe("AddOrganizationAdminFormContainer", () => {
           let redirected: HTMLElement;
           beforeEach(async () => {
             await act(async () => {
-              await fireEvent.click(screen.getByText("Save Changes"));
+              await userEvent.click(screen.getByText("Save Changes"));
             });
             await waitFor(async () => {
               redirected = await screen.getByText("Redirected");

--- a/frontend/src/app/admin/DeviceType/DeviceTypeForm.test.tsx
+++ b/frontend/src/app/admin/DeviceType/DeviceTypeForm.test.tsx
@@ -1,11 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import DeviceTypeForm from "./DeviceTypeForm";
 
 const addValue = (name: string, value: string) => {
-  fireEvent.change(screen.getByLabelText(name, { exact: false }), {
-    target: { value },
-  });
+  userEvent.type(screen.getByLabelText(name, { exact: false }), value);
 };
 
 describe("DeviceTypeForm", () => {
@@ -35,7 +34,7 @@ describe("DeviceTypeForm", () => {
     describe("on form submission", () => {
       beforeEach(async () => {
         await waitFor(async () => {
-          fireEvent.click(screen.getByText("Save Changes"));
+          userEvent.click(screen.getByText("Save Changes"));
         });
       });
 

--- a/frontend/src/app/admin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
+++ b/frontend/src/app/admin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
@@ -1,10 +1,5 @@
-import {
-  waitFor,
-  render,
-  screen,
-  fireEvent,
-  act,
-} from "@testing-library/react";
+import { waitFor, render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 
 import {
@@ -107,7 +102,7 @@ describe("PendingOrganizationsContainer", () => {
     describe("marking an organization as verified", () => {
       beforeEach(async () => {
         await act(async () => {
-          await fireEvent.click(screen.getByText("Identity Verified"));
+          await userEvent.click(screen.getByText("Identity Verified"));
         });
       });
       it("enables submit", () => {
@@ -118,7 +113,7 @@ describe("PendingOrganizationsContainer", () => {
       describe("submitting the form", () => {
         beforeEach(async () => {
           await act(async () => {
-            await fireEvent.click(screen.getByText("Save Changes"));
+            await userEvent.click(screen.getByText("Save Changes"));
           });
           await waitFor(() =>
             expect(
@@ -135,7 +130,7 @@ describe("PendingOrganizationsContainer", () => {
       describe("then mark as unverified", () => {
         beforeEach(async () => {
           await act(async () => {
-            await fireEvent.click(screen.getByText("Identity Verified"));
+            await userEvent.click(screen.getByText("Identity Verified"));
           });
         });
         it("disables submit", () => {

--- a/frontend/src/app/admin/TenantDataAccess/TenantDataAccessForm.test.tsx
+++ b/frontend/src/app/admin/TenantDataAccess/TenantDataAccessForm.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 
 import { OrganizationOption } from "../Components/OrganizationDropDown";
@@ -28,23 +29,18 @@ describe("TenantDataAccessForm", () => {
         />
       </MemoryRouter>
     );
-    const organizationDropdown = screen.getByTestId("organization-dropdown");
-    fireEvent.change(organizationDropdown, {
-      target: { selectedValue: organizations[0].externalId },
-    });
-    fireEvent.change(organizationDropdown, {
-      target: { value: organizations[0].externalId },
-    });
-    await waitFor(async () => {
-      fireEvent.blur(organizationDropdown);
-    });
-    fireEvent.change(screen.getByLabelText("Justification", { exact: false }), {
-      target: { value: "sample justification text" },
-    });
+    userEvent.selectOptions(
+      screen.getByTestId("organization-dropdown"),
+      "Org 1 Name"
+    );
+    userEvent.type(
+      screen.getByLabelText("Justification", { exact: false }),
+      "sample justification text"
+    );
     const saveButton = await screen.getAllByText("Access data")[0];
     expect(saveButton).toBeEnabled();
     await waitFor(async () => {
-      fireEvent.click(saveButton);
+      userEvent.click(saveButton);
     });
     expect(saveTenantDataAccess).toBeCalledTimes(1);
   });
@@ -60,23 +56,18 @@ describe("TenantDataAccessForm", () => {
         />
       </MemoryRouter>
     );
-    const organizationDropdown = screen.getByTestId("organization-dropdown");
-    fireEvent.change(organizationDropdown, {
-      target: { selectedValue: organizations[0].externalId },
-    });
-    fireEvent.change(organizationDropdown, {
-      target: { value: organizations[0].externalId },
-    });
-    await waitFor(async () => {
-      fireEvent.blur(organizationDropdown);
-    });
-    fireEvent.change(screen.getByLabelText("Justification", { exact: false }), {
-      target: { value: "sample justification text" },
-    });
+    userEvent.selectOptions(
+      screen.getByTestId("organization-dropdown"),
+      "Org 1 Name"
+    );
+    userEvent.type(
+      screen.getByLabelText("Justification", { exact: false }),
+      "sample justification text"
+    );
     const cancelButton = await screen.getAllByText("Cancel access")[0];
     expect(cancelButton).toBeEnabled();
     await waitFor(async () => {
-      fireEvent.click(cancelButton);
+      userEvent.click(cancelButton);
     });
     expect(saveTenantDataAccess).toBeCalledTimes(1);
   });
@@ -95,7 +86,7 @@ describe("TenantDataAccessForm", () => {
     const cancelButton = await screen.getAllByText("Cancel access")[0];
     expect(cancelButton).toBeEnabled();
     await waitFor(async () => {
-      fireEvent.click(cancelButton);
+      userEvent.click(cancelButton);
     });
     expect(saveTenantDataAccess).toBeCalledTimes(1);
   });

--- a/frontend/src/app/admin/TenantDataAccess/TenantDataAccessFormContainer.test.tsx
+++ b/frontend/src/app/admin/TenantDataAccess/TenantDataAccessFormContainer.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { Provider } from "react-redux";
 import { MockedProvider } from "@apollo/client/testing";
@@ -136,7 +137,7 @@ describe("TenantDataAccessFormContainer", () => {
   it("Redirects on successful save", async () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
-      await fireEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(await screen.findByText("Redirected")).toBeDefined();
     });

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { Analytics } from "./Analytics";
 

--- a/frontend/src/app/commonComponents/ComboBox/ComboBox.test.tsx
+++ b/frontend/src/app/commonComponents/ComboBox/ComboBox.test.tsx
@@ -365,7 +365,7 @@ describe("ComboBox component", () => {
       // We are sure the first child exists
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const firstItem = getByTestId("combo-box-option-list").firstChild!;
-      fireEvent.click(firstItem);
+      userEvent.click(firstItem);
 
       expect(getByTestId("combo-box-clear-button")).toBeVisible();
     });
@@ -400,7 +400,7 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-clear-button"));
+      userEvent.click(getByTestId("combo-box-clear-button"));
 
       expect(onChange).toHaveBeenCalledWith(undefined);
     });
@@ -435,7 +435,7 @@ describe("ComboBox component", () => {
       );
       expect(getByTestId("combo-box-clear-button")).toBeVisible();
 
-      fireEvent.click(getByTestId("combo-box-clear-button"));
+      userEvent.click(getByTestId("combo-box-clear-button"));
 
       expect(getByTestId("combo-box-clear-button")).not.toBeVisible();
       expect(getByTestId("combo-box-input")).toHaveValue("");
@@ -726,7 +726,7 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-input"));
+      userEvent.click(getByTestId("combo-box-input"));
       userEvent.hover(getByTestId("combo-box-option-yuzu"));
       fireEvent.keyDown(getByTestId("combo-box-option-yuzu"), {
         key: "ArrowDown",
@@ -877,7 +877,7 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-input"));
+      userEvent.click(getByTestId("combo-box-input"));
 
       expect(getByTestId("combo-box-input")).toHaveAttribute(
         "aria-expanded",
@@ -918,7 +918,7 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-input"));
+      userEvent.click(getByTestId("combo-box-input"));
       fireEvent.blur(getByTestId("combo-box-input"));
 
       expect(getByTestId("combo-box-input")).toHaveAttribute(
@@ -938,7 +938,7 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-input"));
+      userEvent.click(getByTestId("combo-box-input"));
       userEvent.hover(getByTestId("combo-box-option-blackberry"));
 
       fireEvent.blur(getByTestId("combo-box-option-blackberry"));
@@ -960,7 +960,7 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-toggle"));
+      userEvent.click(getByTestId("combo-box-toggle"));
 
       expect(getByTestId("combo-box-input")).toHaveAttribute(
         "aria-expanded",
@@ -968,7 +968,7 @@ describe("ComboBox component", () => {
       );
       expect(getByTestId("combo-box-option-list")).toBeVisible();
 
-      fireEvent.click(getByTestId("combo-box-toggle"));
+      userEvent.click(getByTestId("combo-box-toggle"));
 
       expect(getByTestId("combo-box-input")).toHaveAttribute(
         "aria-expanded",
@@ -988,8 +988,8 @@ describe("ComboBox component", () => {
         />
       );
 
-      fireEvent.click(getByTestId("combo-box-toggle"));
-      fireEvent.click(getByTestId("combo-box-option-apple"));
+      userEvent.click(getByTestId("combo-box-toggle"));
+      userEvent.click(getByTestId("combo-box-option-apple"));
 
       expect(onChange).toHaveBeenLastCalledWith("apple");
       expect(getByTestId("combo-box-input")).toHaveValue("Apple");
@@ -1050,7 +1050,7 @@ describe("ComboBox component", () => {
 
       const input = getByTestId("combo-box-input");
       userEvent.type(input, "yu");
-      fireEvent.click(getByTestId("combo-box-option-yuzu"));
+      userEvent.click(getByTestId("combo-box-option-yuzu"));
 
       expect(input).toHaveValue("Yuzu");
       expect(onChange).toHaveBeenLastCalledWith("yuzu");
@@ -1115,7 +1115,7 @@ describe("ComboBox component", () => {
       const list = getByTestId("combo-box-option-list");
 
       // open options list
-      fireEvent.click(getByTestId("combo-box-input"));
+      userEvent.click(getByTestId("combo-box-input"));
 
       Object.values(list.children).forEach((node) => {
         if (node === getByTestId("combo-box-option-apricot")) {

--- a/frontend/src/app/commonComponents/RadioGroup.test.tsx
+++ b/frontend/src/app/commonComponents/RadioGroup.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import RadioGroup from "./RadioGroup";
 
@@ -15,9 +16,7 @@ describe("RadioGroup", () => {
   });
 
   it("selects the correct value from the props", () => {
-    fireEvent.click(screen.getByLabelText("Option 1"), {
-      target: { value: "second" },
-    });
+    userEvent.click(screen.getByLabelText("Option 1"));
     expect(onChange).toBeCalledWith("1");
   });
 

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import createMockStore from "redux-mock-store";
@@ -55,11 +56,11 @@ describe("Header.tsx", () => {
     process.env.REACT_APP_IS_TRAINING_SITE = "false";
     render(<WrappedHeader />);
     await waitFor(() => {
-      fireEvent.click(screen.getByTestId("user-button"));
+      userEvent.click(screen.getByTestId("user-button"));
     });
     expect(screen.getByTestId("support-link")).toBeVisible();
     await waitFor(() => {
-      fireEvent.click(screen.getByTestId("support-link"));
+      userEvent.click(screen.getByTestId("support-link"));
     });
     expect(useTrackEvent).toHaveBeenCalledWith(undefined, "Support", {});
   });
@@ -77,9 +78,7 @@ describe("Header.tsx", () => {
       );
       const dropdown = await screen.findAllByRole("option");
       await waitFor(() => {
-        fireEvent.change(dropdown[1].closest("select")!, {
-          target: { value: "2" },
-        });
+        userEvent.selectOptions(dropdown[1].closest("select")!, "2");
       });
       expect(
         await screen.findByText("Facility 2 is selected")

--- a/frontend/src/app/facilitySelect/WithFacility.test.tsx
+++ b/frontend/src/app/facilitySelect/WithFacility.test.tsx
@@ -1,13 +1,8 @@
 import { Provider } from "react-redux";
 import renderer from "react-test-renderer";
 import configureStore from "redux-mock-store";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter as Router } from "react-router";
 import { I18nextProvider } from "react-i18next";
@@ -138,7 +133,7 @@ describe("WithFacility", () => {
       beforeEach(async () => {
         const options = await screen.findAllByRole("button");
         await waitFor(() => {
-          fireEvent.click(options[0]);
+          userEvent.click(options[0]);
         });
       });
       it("should show the app", async () => {

--- a/frontend/src/app/login/LogIn/LogIn.test.tsx
+++ b/frontend/src/app/login/LogIn/LogIn.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { LogIn } from "./LogIn";
 
@@ -8,25 +9,27 @@ describe("MFA Email", () => {
   });
 
   it("can enter a valid email", () => {
-    fireEvent.change(screen.getByLabelText("Email address", { exact: false }), {
-      target: { value: "name@email.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Log in" }));
+    userEvent.type(
+      screen.getByLabelText("Email address", { exact: false }),
+      "name@email.com"
+    );
+    userEvent.click(screen.getByRole("button", { name: "Log in" }));
     expect(
       screen.queryByText("Enter a valid email address")
     ).not.toBeInTheDocument();
   });
 
   it("requires a email", () => {
-    fireEvent.click(screen.getByRole("button", { name: "Log in" }));
+    userEvent.click(screen.getByRole("button", { name: "Log in" }));
     expect(screen.getByText("Enter your email address")).toBeInTheDocument();
   });
 
   it("requires a valid email", () => {
-    fireEvent.change(screen.getByLabelText("Email address", { exact: false }), {
-      target: { value: "notanemail" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Log in" }));
+    userEvent.type(
+      screen.getByLabelText("Email address", { exact: false }),
+      "notanemail"
+    );
+    userEvent.click(screen.getByRole("button", { name: "Log in" }));
     expect(screen.getByText("Enter a valid email address")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/login/MfaAuthenticationApp/MfaAuthenticationApp.test.tsx
+++ b/frontend/src/app/login/MfaAuthenticationApp/MfaAuthenticationApp.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { MfaAuthenticationApp } from "./MfaAuthenticationApp";
 
@@ -8,18 +9,16 @@ describe("Submit Email MFA", () => {
   });
 
   it("can enter a security code", () => {
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123" },
-      }
+      "123"
     );
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("requires a security code", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     const error = screen.getByRole("alert");
     expect(error.textContent).toEqual("Error: Enter your security code");
   });

--- a/frontend/src/app/login/MfaPhone/MfaPhone.test.tsx
+++ b/frontend/src/app/login/MfaPhone/MfaPhone.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { MfaPhone } from "./MfaPhone";
 
@@ -8,18 +9,16 @@ describe("Submit Email MFA", () => {
   });
 
   it("can enter a security code", () => {
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123" },
-      }
+      "123"
     );
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("requires a security code", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     const error = screen.getByRole("alert");
     expect(error.textContent).toEqual("Error: Enter your security code");
   });

--- a/frontend/src/app/login/mfaSelect/MfaSelect.test.tsx
+++ b/frontend/src/app/login/mfaSelect/MfaSelect.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { MfaSelect } from "./MfaSelect";
 
@@ -11,12 +12,12 @@ describe("MfaSelect", () => {
     const smsRadio = screen.getByLabelText("Text message (SMS)", {
       exact: false,
     });
-    fireEvent.click(smsRadio);
+    userEvent.click(smsRadio);
     expect(smsRadio).toBeChecked();
   });
 
   it("requires an mfa option", () => {
-    fireEvent.click(screen.getByText("Sign in"));
+    userEvent.click(screen.getByText("Sign in"));
     expect(
       screen.getByText("Select an authentication option")
     ).toBeInTheDocument();

--- a/frontend/src/app/passwordReset/EmailConfirm/EmailConfirm.test.tsx
+++ b/frontend/src/app/passwordReset/EmailConfirm/EmailConfirm.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { EmailConfirm } from "./EmailConfirm";
 
@@ -8,25 +9,27 @@ describe("MFA Email", () => {
   });
 
   it("can enter a valid email", () => {
-    fireEvent.change(screen.getByLabelText("Email address", { exact: false }), {
-      target: { value: "name@email.com" },
-    });
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.type(
+      screen.getByLabelText("Email address", { exact: false }),
+      "name@email.com"
+    );
+    userEvent.click(screen.getByText("Continue"));
     expect(
       screen.queryByText("Enter a valid email address")
     ).not.toBeInTheDocument();
   });
 
   it("requires a email", () => {
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.getByText("Enter your email address")).toBeInTheDocument();
   });
 
   it("requires a valid email", () => {
-    fireEvent.change(screen.getByLabelText("Email address", { exact: false }), {
-      target: { value: "notanemail" },
-    });
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.type(
+      screen.getByLabelText("Email address", { exact: false }),
+      "notanemail"
+    );
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.getByText("Enter a valid email address")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/passwordReset/MfaSelect/MfaSelect.test.tsx
+++ b/frontend/src/app/passwordReset/MfaSelect/MfaSelect.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { MfaSelect } from "./MfaSelect";
 
@@ -8,25 +9,27 @@ describe("MFA Email", () => {
   });
 
   it("can enter a valid email", () => {
-    fireEvent.change(screen.getByLabelText("Email address", { exact: false }), {
-      target: { value: "name@email.com" },
-    });
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.type(
+      screen.getByLabelText("Email address", { exact: false }),
+      "name@email.com"
+    );
+    userEvent.click(screen.getByText("Continue"));
     expect(
       screen.queryByText("Enter a valid email address")
     ).not.toBeInTheDocument();
   });
 
   it("requires a email", () => {
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.getByText("Enter your email address")).toBeInTheDocument();
   });
 
   it("requires a valid email", () => {
-    fireEvent.change(screen.getByLabelText("Email address", { exact: false }), {
-      target: { value: "notanemail" },
-    });
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.type(
+      screen.getByLabelText("Email address", { exact: false }),
+      "notanemail"
+    );
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.getByText("Enter a valid email address")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/passwordReset/VerifyAuthenticationApp/VerifyAuthenticationApp.test.tsx
+++ b/frontend/src/app/passwordReset/VerifyAuthenticationApp/VerifyAuthenticationApp.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { VerifyAuthenticationApp } from "./VerifyAuthenticationApp";
 
@@ -8,20 +9,18 @@ describe("Verify Email MFA", () => {
   });
 
   it("can enter a security code", () => {
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123" },
-      }
+      "123"
     );
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(
       screen.queryByText("Enter your security code")
     ).not.toBeInTheDocument();
   });
 
   it("requires a security code", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/passwordReset/VerifyPhone/VerifyPhone.test.tsx
+++ b/frontend/src/app/passwordReset/VerifyPhone/VerifyPhone.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { VerifyPhone } from "./VerifyPhone";
 
@@ -8,20 +9,18 @@ describe("Verify Email MFA", () => {
   });
 
   it("can enter a security code", () => {
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123" },
-      }
+      "123"
     );
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(
       screen.queryByText("Enter your security code")
     ).not.toBeInTheDocument();
   });
 
   it("requires a security code", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/passwordReset/VerifySms/VerifySms.test.tsx
+++ b/frontend/src/app/passwordReset/VerifySms/VerifySms.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { VerifySms } from "./VerifySms";
 
@@ -8,20 +9,18 @@ describe("Verify Email MFA", () => {
   });
 
   it("can enter a security code", () => {
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("One-time security code", { exact: false }),
-      {
-        target: { value: "123" },
-      }
+      "123"
     );
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(
       screen.queryByText("Enter your security code")
     ).not.toBeInTheDocument();
   });
 
   it("requires a security code", () => {
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
     expect(screen.getByText("Enter your security code")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/passwordReset/securityQuestion/SecurityQuestion.test.tsx
+++ b/frontend/src/app/passwordReset/securityQuestion/SecurityQuestion.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { SecurityAnswer } from "./SecurityQuestion";
 import "../../../i18n";
@@ -9,20 +10,18 @@ describe("Verify Email MFA", () => {
   });
 
   it("can enter a security code", () => {
-    fireEvent.change(
+    userEvent.type(
       screen.getByLabelText("Where did you go for your favorite vacation?", {
         exact: false,
       }),
-      {
-        target: { value: "Hawaii" },
-      }
+      "Hawaii"
     );
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.queryByText("Enter your answer")).not.toBeInTheDocument();
   });
 
   it("requires a security code", () => {
-    fireEvent.click(screen.getByText("Continue"));
+    userEvent.click(screen.getByText("Continue"));
     expect(screen.getByText("Enter your answer")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.test.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.test.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import i18n from "../../../i18n";
 import { es } from "../../../lang/es";
@@ -36,14 +37,14 @@ describe("ManagePhoneNumbers", () => {
       exact: false,
     });
     // Enter bad info and blur
-    fireEvent.change(primary, { target: { value: "not a number" } });
-    fireEvent.blur(primary);
+    userEvent.type(primary, "not a number");
+    userEvent.tab();
     expect(
       await screen.findByText("Phone number is missing or invalid")
     ).toBeInTheDocument();
     // Enter good info and blur
-    fireEvent.change(primary, { target: { value: "202-867-5309" } });
-    fireEvent.blur(primary);
+    userEvent.type(primary, "202-867-5309");
+    userEvent.tab();
     await waitFor(() =>
       expect(
         screen.queryByText("Phone number is missing or invalid")
@@ -55,23 +56,23 @@ describe("ManagePhoneNumbers", () => {
       exact: false,
     });
     // Show two errors
-    fireEvent.change(primary, { target: { value: "" } });
-    fireEvent.blur(primary);
+    userEvent.clear(primary);
+    userEvent.tab();
     const addButton = screen.getByText("Add another number", { exact: false });
-    fireEvent.click(addButton);
+    userEvent.click(addButton);
     const second = await screen.findByLabelText("Additional phone", {
       exact: false,
     });
-    fireEvent.change(second, { target: { value: "" } });
-    fireEvent.blur(second);
+    userEvent.clear(second);
+    userEvent.tab();
     await waitFor(() => {
       expect(
         screen.getAllByText("Phone number is missing or invalid").length
       ).toBe(2);
     });
     // Fix one of the errors
-    fireEvent.change(primary, { target: { value: "3018675309" } });
-    fireEvent.blur(primary);
+    userEvent.type(primary, "3018675309");
+    userEvent.tab();
     await waitFor(() => {
       expect(
         screen.getAllByText("Phone number is missing or invalid").length
@@ -83,8 +84,9 @@ describe("ManagePhoneNumbers", () => {
       exact: false,
     });
     // Show two errors
-    fireEvent.change(primary, { target: { value: "" } });
-    fireEvent.blur(primary);
+    userEvent.clear(primary);
+    userEvent.tab();
+
     await waitFor(() => {
       i18n.changeLanguage("es");
     });
@@ -96,14 +98,14 @@ describe("ManagePhoneNumbers", () => {
     const primary = await screen.findByLabelText("Primary phone", {
       exact: false,
     });
-    fireEvent.change(primary, { target: { value: "202-867-5309" } });
+    userEvent.type(primary, "202-867-5309");
     const addButton = screen.getByText("Add another number", { exact: false });
-    fireEvent.click(addButton);
+    userEvent.click(addButton);
     const second = await screen.findByLabelText("Additional phone", {
       exact: false,
     });
-    fireEvent.change(second, { target: { value: "404-867-5309" } });
-    fireEvent.click(
+    userEvent.type(second, "404-867-5309");
+    userEvent.click(
       await screen.findByLabelText("Delete phone number 404-867-5309")
     );
     await waitFor(() => {

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -6,6 +6,7 @@ import {
   within,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -145,7 +146,7 @@ describe("EditPatient", () => {
 
     it("displays a validation failure alert if phone type not entered", async () => {
       await act(async () => {
-        fireEvent.click(
+        userEvent.click(
           screen.queryAllByText("Add another number", {
             exact: false,
           })[0]
@@ -162,7 +163,7 @@ describe("EditPatient", () => {
       });
 
       await waitFor(() => {
-        fireEvent.click(screen.getAllByText("Save changes")[0]);
+        userEvent.click(screen.getAllByText("Save changes")[0]);
       });
 
       expect(

--- a/frontend/src/app/patients/ManagePatients.test.tsx
+++ b/frontend/src/app/patients/ManagePatients.test.tsx
@@ -1,10 +1,10 @@
 import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
 import {
-  fireEvent,
   render,
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import createMockStore from "redux-mock-store";
@@ -53,9 +53,9 @@ describe("ManagePatients", () => {
     );
     expect(await screen.findByText(patients[0].lastName, { exact: false }));
     const btn = await screen.findByText("Filter", { exact: false });
-    fireEvent.click(btn);
+    userEvent.click(btn);
     const input = await screen.findByLabelText("Person");
-    fireEvent.change(input, { target: { value: "Al" } });
+    userEvent.type(input, "Al");
     await waitForElementToBeRemoved(() =>
       screen.queryByText("Abramcik", { exact: false })
     );

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import PersonalDetailsForm from "./PersonalDetailsForm";
 
@@ -32,7 +33,10 @@ describe("PersonalDetailsForm", () => {
 
   describe("Filling out the form", () => {
     beforeEach(() => {
-      fillInText("Email *", "bob@bob.bob");
+      userEvent.type(
+        screen.getByLabelText("Email *", { exact: false }),
+        "bob@bob.bob"
+      );
     });
 
     it("enables the submit button", () => {
@@ -58,8 +62,11 @@ describe("PersonalDetailsForm", () => {
     describe("On submitting with an invalid phone number", () => {
       beforeEach(async () => {
         await act(async () => {
-          fillInText("Phone number", "123");
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.type(
+            screen.getByLabelText("Phone number", { exact: false }),
+            "123"
+          );
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -71,10 +78,13 @@ describe("PersonalDetailsForm", () => {
     describe("On submitting an invalid street address 1", () => {
       beforeEach(async () => {
         await act(async () => {
-          fillInText("Street address 1", "111 greendale dr,");
+          userEvent.type(
+            screen.getByLabelText("Street address 1", { exact: false }),
+            "111 greendale dr,"
+          );
         });
         await act(async () => {
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -85,17 +95,17 @@ describe("PersonalDetailsForm", () => {
     });
     describe("On clicking an invalid date of birth and submitting", () => {
       beforeEach(async () => {
-        fireEvent.click(screen.getByTestId("date-picker-button"));
+        userEvent.click(screen.getByTestId("date-picker-button"));
         const nextMonthButton = screen.getByTestId("next-month");
         expect(nextMonthButton).toHaveClass(
           "usa-date-picker__calendar__next-month"
         );
-        fireEvent.click(nextMonthButton);
+        userEvent.click(nextMonthButton);
         const dateButton = screen.getByText("15");
         expect(dateButton).toHaveClass("usa-date-picker__calendar__date");
-        fireEvent.click(dateButton);
+        userEvent.click(dateButton);
         await act(async () => {
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -106,17 +116,17 @@ describe("PersonalDetailsForm", () => {
     });
     describe("On clicking a valid date of birth and submitting", () => {
       beforeEach(async () => {
-        fireEvent.click(screen.getByTestId("date-picker-button"));
+        userEvent.click(screen.getByTestId("date-picker-button"));
         const previousMonthButton = screen.getByTestId("previous-month");
         expect(previousMonthButton).toHaveClass(
           "usa-date-picker__calendar__previous-month"
         );
-        fireEvent.click(previousMonthButton);
+        userEvent.click(previousMonthButton);
         const dateButton = screen.getByText("15");
         expect(dateButton).toHaveClass("usa-date-picker__calendar__date");
-        fireEvent.click(dateButton);
+        userEvent.click(dateButton);
         await act(async () => {
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -128,10 +138,13 @@ describe("PersonalDetailsForm", () => {
     describe("On submitting an invalid street address 2", () => {
       beforeEach(async () => {
         await act(async () => {
-          fillInText("Street address 2", "111 greendale dr,");
+          userEvent.type(
+            screen.getByLabelText("Street address 2", { exact: false }),
+            "111 greendale dr,"
+          );
         });
         await act(async () => {
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -143,10 +156,13 @@ describe("PersonalDetailsForm", () => {
     describe("On submitting an invalid zip code", () => {
       beforeEach(async () => {
         await act(async () => {
-          fillInText("ZIP code", "1234");
+          userEvent.type(
+            screen.getByLabelText("ZIP code", { exact: false }),
+            "1234"
+          );
         });
         await act(async () => {
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -159,7 +175,7 @@ describe("PersonalDetailsForm", () => {
       beforeEach(async () => {
         await act(async () => {
           fillInText("Email", "bob@bob.bob");
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("shows an error", () => {
@@ -172,10 +188,10 @@ describe("PersonalDetailsForm", () => {
 
   describe("Completed form", () => {
     beforeEach(() => {
-      fireEvent.click(screen.getByTestId("date-picker-button"));
+      userEvent.click(screen.getByTestId("date-picker-button"));
       const dateButton = screen.getByText("15");
       expect(dateButton).toHaveClass("usa-date-picker__calendar__date");
-      fireEvent.click(dateButton);
+      userEvent.click(dateButton);
       fillInText("Email", "bob@bob.bob");
       fillInText("Phone number", "530-867-5309");
       fillInText("Street address 1", "123 Bob St");
@@ -187,7 +203,7 @@ describe("PersonalDetailsForm", () => {
     describe("On submit", () => {
       beforeEach(async () => {
         await act(async () => {
-          fireEvent.click(screen.getByText("Submit"));
+          userEvent.click(screen.getByText("Submit"));
         });
       });
       it("does not shows an error", () => {

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { exampleQuestionSet } from "./constants";
 import QuestionsForm from "./QuestionsForm";
@@ -29,9 +30,7 @@ describe("QuestionsForm", () => {
   });
   describe("One field entered", () => {
     beforeEach(() => {
-      fireEvent.click(screen.getByLabelText("2002", { exact: false }), {
-        target: { value: "1" },
-      });
+      userEvent.click(screen.getByLabelText("2002", { exact: false }));
     });
     it("enables the submit button", () => {
       expect(screen.getByText("Submit")).not.toHaveAttribute("disabled");
@@ -50,7 +49,7 @@ describe("QuestionsForm", () => {
     describe("On submit", () => {
       beforeEach(async () => {
         await act(async () => {
-          await fireEvent.click(
+          await userEvent.click(
             screen.queryAllByText("Submit", {
               exact: false,
             })[0]
@@ -67,36 +66,23 @@ describe("QuestionsForm", () => {
   });
   describe("Completed form", () => {
     beforeEach(() => {
-      fireEvent.click(screen.getByLabelText("2002", { exact: false }), {
-        target: { value: "1" },
-      });
-      fireEvent.click(
-        screen.getByLabelText("OPTICIAN / OPTOMETRIST", { exact: false }),
-        {
-          target: { value: "3" },
-        }
+      userEvent.click(screen.getByLabelText("2002", { exact: false }));
+      userEvent.click(
+        screen.getByLabelText("OPTICIAN / OPTOMETRIST", { exact: false })
       );
-      fireEvent.click(
-        screen.getByLabelText("MID AMERICA MORTGAGE", { exact: false }),
-        {
-          target: { value: "3" },
-        }
+      userEvent.click(
+        screen.getByLabelText("MID AMERICA MORTGAGE", { exact: false })
       );
-      fireEvent.click(screen.getByLabelText("TWO", { exact: false }), {
-        target: { value: "2" },
-      });
-      fireEvent.click(
-        screen.getByLabelText("AGUA DULCE HIGH SCHOOL", { exact: false }),
-        {
-          target: { value: "4" },
-        }
+      userEvent.click(screen.getByLabelText("TWO", { exact: false }));
+      userEvent.click(
+        screen.getByLabelText("AGUA DULCE HIGH SCHOOL", { exact: false })
       );
     });
 
     describe("On submit", () => {
       beforeEach(async () => {
         await act(async () => {
-          await fireEvent.click(
+          await userEvent.click(
             screen.queryAllByText("Submit", {
               exact: false,
             })[0]

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import OrganizationForm, {
@@ -18,10 +18,6 @@ const getLastNameInput = () => screen.getByLabelText("Last name *");
 const getEmailInput = () => screen.getByLabelText("Work email *");
 const getPhoneInput = () => screen.getByLabelText("Work phone number *");
 const getSubmitButton = () => screen.getByText("Submit");
-const fillIn = (input: any, text: string) =>
-  act(() => {
-    fireEvent.change(input, { target: { value: text } });
-  });
 
 const fillInDropDown = (input: any, text: string) =>
   act(() => {
@@ -105,14 +101,14 @@ describe("OrganizationForm", () => {
   });
 
   it("redirects to identity verification when submitting valid input", async () => {
-    fillIn(getOrgNameInput(), "Drake");
+    userEvent.type(getOrgNameInput(), "Drake");
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
-    fillIn(getFirstNameInput(), "Greatest");
-    fillIn(getMiddleNameInput(), "OG");
-    fillIn(getLastNameInput(), "Ever");
-    fillIn(getEmailInput(), "ever@greatest.com");
-    fillIn(getPhoneInput(), "8008675309");
+    userEvent.type(getFirstNameInput(), "Greatest");
+    userEvent.type(getMiddleNameInput(), "OG");
+    userEvent.type(getLastNameInput(), "Ever");
+    userEvent.type(getEmailInput(), "ever@greatest.com");
+    userEvent.type(getPhoneInput(), "8008675309");
     await act(async () => {
       await getSubmitButton().click();
     });
@@ -123,14 +119,14 @@ describe("OrganizationForm", () => {
   });
 
   it("displays a duplicate org error when submitting a duplicate org", async () => {
-    fillIn(getOrgNameInput(), "Duplicate");
+    userEvent.type(getOrgNameInput(), "Duplicate");
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
-    fillIn(getFirstNameInput(), "Greatest");
-    fillIn(getMiddleNameInput(), "OG");
-    fillIn(getLastNameInput(), "Ever");
-    fillIn(getEmailInput(), "ever@greatest.com");
-    fillIn(getPhoneInput(), "8008675309");
+    userEvent.type(getFirstNameInput(), "Greatest");
+    userEvent.type(getMiddleNameInput(), "OG");
+    userEvent.type(getLastNameInput(), "Ever");
+    userEvent.type(getEmailInput(), "ever@greatest.com");
+    userEvent.type(getPhoneInput(), "8008675309");
     await act(async () => {
       await getSubmitButton().click();
     });
@@ -144,14 +140,14 @@ describe("OrganizationForm", () => {
   });
 
   it("displays a duplicate email error when submitting a duplicate email", async () => {
-    fillIn(getOrgNameInput(), "Foo");
+    userEvent.type(getOrgNameInput(), "Foo");
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
-    fillIn(getFirstNameInput(), "Greatest");
-    fillIn(getMiddleNameInput(), "OG");
-    fillIn(getLastNameInput(), "Ever");
-    fillIn(getEmailInput(), "duplicate@test.com");
-    fillIn(getPhoneInput(), "8008675309");
+    userEvent.type(getFirstNameInput(), "Greatest");
+    userEvent.type(getMiddleNameInput(), "OG");
+    userEvent.type(getLastNameInput(), "Ever");
+    userEvent.type(getEmailInput(), "duplicate@test.com");
+    userEvent.type(getPhoneInput(), "8008675309");
     await act(async () => {
       await getSubmitButton().click();
     });
@@ -165,14 +161,14 @@ describe("OrganizationForm", () => {
   });
 
   it("displays a duplicate org error and id verification link for an admin re-signing up", async () => {
-    fillIn(getOrgNameInput(), "DuplicateAdmin");
+    userEvent.type(getOrgNameInput(), "DuplicateAdmin");
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
-    fillIn(getFirstNameInput(), "Greatest");
-    fillIn(getMiddleNameInput(), "OG");
-    fillIn(getLastNameInput(), "Ever");
-    fillIn(getEmailInput(), "admin@example.com");
-    fillIn(getPhoneInput(), "8008675309");
+    userEvent.type(getFirstNameInput(), "Greatest");
+    userEvent.type(getMiddleNameInput(), "OG");
+    userEvent.type(getLastNameInput(), "Ever");
+    userEvent.type(getEmailInput(), "admin@example.com");
+    userEvent.type(getPhoneInput(), "8008675309");
     await act(async () => {
       await getSubmitButton().click();
     });
@@ -186,14 +182,14 @@ describe("OrganizationForm", () => {
   });
 
   it("displays a duplicate org error and instructions for admin user who has finished id verification", async () => {
-    fillIn(getOrgNameInput(), "IdentityVerificationComplete");
+    userEvent.type(getOrgNameInput(), "IdentityVerificationComplete");
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
-    fillIn(getFirstNameInput(), "Greatest");
-    fillIn(getMiddleNameInput(), "OG");
-    fillIn(getLastNameInput(), "Ever");
-    fillIn(getEmailInput(), "admin@example.com");
-    fillIn(getPhoneInput(), "8008675309");
+    userEvent.type(getFirstNameInput(), "Greatest");
+    userEvent.type(getMiddleNameInput(), "OG");
+    userEvent.type(getLastNameInput(), "Ever");
+    userEvent.type(getEmailInput(), "admin@example.com");
+    userEvent.type(getPhoneInput(), "8008675309");
     await act(async () => {
       await getSubmitButton().click();
     });
@@ -207,14 +203,14 @@ describe("OrganizationForm", () => {
   });
 
   it("displays a generic error message for Okta internal errors", async () => {
-    fillIn(getOrgNameInput(), "InternalError");
+    userEvent.type(getOrgNameInput(), "InternalError");
     fillInDropDown(getOrgStateDropdown(), "TX");
     fillInDropDown(getOrgTypeDropdown(), "Employer");
-    fillIn(getFirstNameInput(), "Greatest");
-    fillIn(getMiddleNameInput(), "OG");
-    fillIn(getLastNameInput(), "Ever");
-    fillIn(getEmailInput(), "admin@example.com");
-    fillIn(getPhoneInput(), "8008675309");
+    userEvent.type(getFirstNameInput(), "Greatest");
+    userEvent.type(getMiddleNameInput(), "OG");
+    userEvent.type(getLastNameInput(), "Ever");
+    userEvent.type(getEmailInput(), "admin@example.com");
+    userEvent.type(getPhoneInput(), "8008675309");
     await act(async () => {
       await getSubmitButton().click();
     });

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -1,9 +1,9 @@
 import {
-  fireEvent,
   render,
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
 import { Provider } from "react-redux";
@@ -66,9 +66,9 @@ describe("TestQueue", () => {
     );
     expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
     const removeButton = (await screen.findAllByLabelText("Close"))[0];
-    fireEvent.click(removeButton);
+    userEvent.click(removeButton);
     const confirmButton = await screen.findByText("Yes", { exact: false });
-    fireEvent.click(confirmButton);
+    userEvent.click(confirmButton);
     await waitForElementToBeRemoved(() => screen.queryByText("Doe, John A"));
     expect(screen.queryByText("Doe, John A")).not.toBeInTheDocument();
   });

--- a/frontend/src/app/testQueue/TestTimer.test.tsx
+++ b/frontend/src/app/testQueue/TestTimer.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { getAppInsights } from "../TelemetryService";
 
@@ -95,7 +96,7 @@ describe("TestTimerWidget", () => {
       const startTimer = await screen.findByRole("button");
 
       act(() => {
-        fireEvent.click(startTimer);
+        userEvent.click(startTimer);
       });
       expect(trackEventMock).toHaveBeenCalled();
       expect(trackEventMock).toHaveBeenCalledTimes(1);
@@ -112,7 +113,7 @@ describe("TestTimerWidget", () => {
 
       // Start timer
       act(() => {
-        fireEvent.click(timerButton);
+        userEvent.click(timerButton);
       });
 
       // The timer does not enter the countdown state instantly, so clicking the
@@ -122,7 +123,7 @@ describe("TestTimerWidget", () => {
 
       // Reset timer
       act(() => {
-        fireEvent.click(timerButton);
+        userEvent.click(timerButton);
       });
 
       expect(trackEventMock).toHaveBeenCalledWith(
@@ -137,7 +138,7 @@ describe("TestTimerWidget", () => {
       const timerButton = await screen.findByRole("button");
 
       act(() => {
-        fireEvent.click(timerButton);
+        userEvent.click(timerButton);
       });
 
       // This is a 0-second timer, but it takes ~1 second to enter the

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
 
@@ -131,12 +132,10 @@ describe("AddToSearchQueue - add to queue", () => {
   });
 
   it("adds patient to queue from search form", async () => {
-    fireEvent.change(screen.getByRole("searchbox", { exact: false }), {
-      target: { value: "bar" },
-    });
+    userEvent.type(screen.getByRole("searchbox", { exact: false }), "bar");
 
     await waitFor(async () => {
-      fireEvent.click(screen.getAllByRole("button")[1]);
+      userEvent.click(screen.getAllByRole("button")[1]);
     });
 
     expect(queryPatientMockIsDone).toBe(true);

--- a/frontend/src/app/testResults/TestResultInput.test.tsx
+++ b/frontend/src/app/testResults/TestResultInput.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import TestResultInputForm from "./TestResultInputForm";
 
@@ -45,7 +46,7 @@ describe("TestResultInputForm", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText("Negative (-)"));
+    userEvent.click(screen.getByLabelText("Negative (-)"));
 
     expect(onChange).toBeCalledWith("NEGATIVE");
   });
@@ -61,7 +62,7 @@ describe("TestResultInputForm", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText("Positive (+)"));
+    userEvent.click(screen.getByLabelText("Positive (+)"));
 
     expect(onChange).toBeCalledWith(undefined);
   });
@@ -77,7 +78,7 @@ describe("TestResultInputForm", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
 
     expect(onSubmit).toHaveBeenCalledTimes(0);
   });
@@ -94,7 +95,7 @@ describe("TestResultInputForm", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
 
     expect(onSubmit).toHaveBeenCalledTimes(0);
   });
@@ -111,7 +112,7 @@ describe("TestResultInputForm", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
@@ -127,7 +128,7 @@ describe("TestResultInputForm", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByText("Submit"));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/app/testResults/TestResultPrintModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, RenderResult } from "@testing-library/react";
+import { act, render, RenderResult } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import MockDate from "mockdate";
 import ReactDOM from "react-dom";
 
@@ -70,7 +71,7 @@ describe("TestResultPrintModal", () => {
     expect(container).toMatchSnapshot();
 
     await act(async () => {
-      await fireEvent.click(component.getAllByRole("button")[2]);
+      await userEvent.click(component.getAllByRole("button")[2]);
     });
 
     expect(printSpy).toBeCalled();

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -1,7 +1,7 @@
 import qs from "querystring";
 
 import { MockedProvider } from "@apollo/client/testing";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
@@ -1086,9 +1086,9 @@ describe("TestResultsList", () => {
     const moreActions = within(screen.getByRole("table")).getAllByRole(
       "button"
     )[0];
-    fireEvent.click(moreActions);
+    userEvent.click(moreActions);
     const viewDetails = await screen.findByText("View details");
-    fireEvent.click(viewDetails);
+    userEvent.click(viewDetails);
     expect(screen.queryAllByText("Test details").length).toBe(2);
   });
 

--- a/frontend/src/patientApp/PatientHeader.test.tsx
+++ b/frontend/src/patientApp/PatientHeader.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
@@ -48,7 +49,7 @@ describe("PatientHeader", () => {
     expect(getByText("Español")).toBeInTheDocument();
 
     await act(async () => {
-      await fireEvent.click(getByRole("button"));
+      await userEvent.click(getByRole("button"));
     });
 
     expect(queryByText("Español")).not.toBeInTheDocument();

--- a/frontend/src/patientApp/timeOfTest/DOB.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.test.tsx
@@ -1,5 +1,6 @@
 import renderer from "react-test-renderer";
-import { render, fireEvent, RenderResult } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import "../../i18n";
@@ -32,31 +33,21 @@ describe("DOB", () => {
   });
 
   describe("behavior", () => {
-    let utils: RenderResult;
-
-    async function setup(utils: RenderResult) {
-      const input = await utils.findByLabelText("Date of birth");
-      const button = await utils.findByRole("button");
-      return { input, button };
-    }
-
     beforeEach(() => {
       const store = mockStore({
         plid: "foo",
       });
-      utils = render(mockContainer(store));
+      render(mockContainer(store));
     });
 
     it("validates birthdays", async () => {
-      // GIVEN
-      const { input, button } = await setup(utils);
+      userEvent.type(
+        await screen.findByLabelText("Date of birth"),
+        "99-99-9999"
+      );
+      userEvent.click(await screen.findByRole("button"));
+      const error = await screen.findByRole("alert");
 
-      // WHEN
-      fireEvent.change(input, { target: { value: "99-99-9999" } });
-      fireEvent.submit(button);
-      const error = await utils.findByRole("alert");
-
-      // THEN
       expect(error.textContent).toEqual("Error: Enter your date of birth");
     });
   });


### PR DESCRIPTION
## Related Issue or Background Info

- A bit of Friday yak shaving. It turns out the `userEvent` library better simulates browser interactions the `fireEvent`. For example `userEvent.type` issues `keyDown` `keyUp` and `keyPress`

## Changes Proposed

- convert as many `fireEvent` to `userEvent` as easily possible

## Additional Information
- this only changes test files
- There are still ~100 instances of `fireEvent`. I tried to get as many as I could but they take some time do to slight differences in behavior. For example `userEvent.type` will append the given string to the input so if the input has a value you first need to call `userEvent.clear` which is not the case for `fireEvent.change`

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
