### PR TITLE
Add indexes for initial top-level metrics query

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2925,3 +2925,23 @@ databaseChangeLog:
                   remarks: patient_has_prior_tests will track whether a patient has prior test events
                   constraints:
                     nullable: true
+  - changeSet:
+      id: add-indexes-top_level_dashboard_metrics
+      author: brett.m.maden@omb.eop.gov
+      changes:
+        - createIndex:
+            tableName: test_event
+            indexName: ix__test_event__prior_corrected_test_event_id
+            columns:
+              - column:
+                  name: prior_corrected_test_event_id
+        - createIndex:
+            tableName: test_event
+            indexName: ix__test_event__fac_id-coal_test_date-test-corr_status
+            columns:
+              - column:
+                  name: facility_id
+              - column:
+                  name: COALESCE(date_tested_backdate, created_at)
+              - column:
+                  name: correction_status

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2929,6 +2929,8 @@ databaseChangeLog:
       id: add-indexes-top_level_dashboard_metrics
       author: brett.m.maden@omb.eop.gov
       changes:
+        - tagDatabase:
+            tag: add-indexes-top_level_dashboard_metrics
         - createIndex:
             tableName: test_event
             indexName: ix__test_event__prior_corrected_test_event_id
@@ -2945,3 +2947,8 @@ databaseChangeLog:
                   name: COALESCE(date_tested_backdate, created_at)
               - column:
                   name: correction_status
+      rollback:
+        - dropIndex:
+            indexName: ix__test_event__fac_id-coal_test_date-test-corr_status
+        - dropIndex:
+            indexName: ix__test_event__prior_corrected_test_event_id


### PR DESCRIPTION
## Related Issue or Background Info

We're going to roll out the initial version of the analytics dashboard using the initial query.  Performance was called out in review (https://github.com/CDCgov/prime-simplereport/pull/2579) and this PR adds indexes to address the concerns.

## Changes Proposed

- Add indexes to `test_event` to improve performance of the dashboard data query

## Additional Information

Query plan prior to adding these indexes:

```
GroupAggregate  (cost=17.98..18.01 rows=1 width=12) (actual time=0.018..0.019 rows=0 loops=1)
  Group Key: testevent0_.result
  ->  Sort  (cost=17.98..17.99 rows=1 width=20) (actual time=0.017..0.018 rows=0 loops=1)
        Sort Key: testevent0_.result
        Sort Method: quicksort  Memory: 25kB
        ->  Nested Loop Anti Join  (cost=0.14..17.97 rows=1 width=20) (actual time=0.009..0.010 rows=0 loops=1)
              Join Filter: (testevent1_.prior_corrected_test_event_id = testevent0_.internal_id)
              ->  Index Scan using ix__test_event__facility_id on test_event testevent0_  (cost=0.14..8.17 rows=1 width=20) (actual time=0.009..0.009 rows=0 loops=1)
                    Index Cond: (facility_id = '8c15e30b-88b3-4397-8316-3b6ffa378d38'::uuid)
                    Filter: ((COALESCE(date_tested_backdate, created_at) >= '2019-01-01 00:00:00'::timestamp without time zone) AND (COALESCE(date_tested_backdate, created_at) <= '2022-01-01 00:00:00'::timestamp without time zone) AND (correction_status = 'ORIGINAL'::simple_report.test_correction_status))
              ->  Seq Scan on test_event testevent1_  (cost=0.00..9.36 rows=36 width=16) (never executed)
Planning Time: 0.108 ms
Execution Time: 0.063 ms
```

and afterward:

```
GroupAggregate  (cost=16.34..16.36 rows=1 width=12) (actual time=0.020..0.020 rows=0 loops=1)
  Group Key: testevent0_.result
  ->  Sort  (cost=16.34..16.35 rows=1 width=20) (actual time=0.019..0.019 rows=0 loops=1)
        Sort Key: testevent0_.result
        Sort Method: quicksort  Memory: 25kB
        ->  Nested Loop Anti Join  (cost=0.28..16.33 rows=1 width=20) (actual time=0.011..0.011 rows=0 loops=1)
              ->  Index Scan using "ix__test_event__fac_id-coal_test_date-test-corr_status" on test_event testevent0_  (cost=0.14..8.17 rows=1 width=20) (actual time=0.010..0.010 rows=0 loops=1)
                    Index Cond: ((facility_id = '8c15e30b-88b3-4397-8316-3b6ffa378d38'::uuid) AND (COALESCE(date_tested_backdate, created_at) >= '2019-01-01 00:00:00'::timestamp without time zone) AND (COALESCE(date_tested_backdate, created_at) <= '2022-01-01 00:00:00'::timestamp without time zone) AND (correction_status = 'ORIGINAL'::simple_report.test_correction_status))"
              ->  Index Only Scan using ix__test_event__prior_corrected_test_event_id on test_event testevent1_  (cost=0.14..8.16 rows=1 width=16) (never executed)
                    Index Cond: (prior_corrected_test_event_id = testevent0_.internal_id)
                    Heap Fetches: 0
Planning Time: 0.385 ms
Execution Time: 0.059 ms
```


## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
