### PR TITLE
Add organization queue table and no PHI view

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2952,3 +2952,52 @@ databaseChangeLog:
             indexName: ix__test_event__fac_id-coal_test_date-test-corr_status
         - dropIndex:
             indexName: ix__test_event__prior_corrected_test_event_id
+  - changeSet:
+      id: add-organization-queue-table
+      author: brett.m.maden@omb.eop.gov
+      comment: Add table for newly requested, unverified organizations
+      changes:
+        - createTable:
+            tableName: organization_queue
+            remarks: Organizations that have requested to start using SimpleReport
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *soft_delete_column
+              - column:
+                  name: organization_name
+                  type: text
+                  remarks: Organization name (cleaned)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: organization_external_id
+                  type: text
+                  remarks: Organization external id (cleaned)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: request_data
+                  type: jsonb
+                  remarks: The original request data (including name, email, phone, etc)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: verified_organization_id
+                  type: uuid
+                  remarks: A foreign key to an organization created when this queue item was identity verified
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__internal_id__organization
+                    references: organization
+        - createView:
+            viewName: organization_queue_no_phi_view
+            remarks: A subset of the organization_queue table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, updated_at, organization_name, organization_external_id, verified_organization_id FROM ${database.defaultSchemaName}.organization_queue
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.organization_queue_no_phi_view TO ${noPhiUsername};

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2957,6 +2957,8 @@ databaseChangeLog:
       author: brett.m.maden@omb.eop.gov
       comment: Add table for newly requested, unverified organizations
       changes:
+        - tagDatabase:
+            tag: add-organization-queue-table
         - createTable:
             tableName: organization_queue
             remarks: Organizations that have requested to start using SimpleReport
@@ -3001,3 +3003,8 @@ databaseChangeLog:
             selectQuery: SELECT internal_id, created_at, updated_at, organization_name, organization_external_id, verified_organization_id FROM ${database.defaultSchemaName}.organization_queue
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.organization_queue_no_phi_view TO ${noPhiUsername};
+      rollback:
+        - dropView:
+            viewName: organization_queue_no_phi_view
+        - dropTable:
+            tableName: organization_queue


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/2565

## Changes Proposed

- Add table for organization queue (new orgs that have submitted a request before attempting identity verification)
- Add no phi view for use in metabase

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
