### PR TITLE
Fix resendToReportStream migration

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.api.testresult;
 
-import gov.cdc.usds.simplereport.service.DataHubUploaderService;
+import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
+import gov.cdc.usds.simplereport.service.TestEventReportingService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import java.util.List;
 import java.util.UUID;
@@ -10,13 +11,13 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class TestResultMutationResolver implements GraphQLMutationResolver {
-  private final DataHubUploaderService _dataHubUploaderService;
+  private final TestEventRepository testEventRepository;
+  private final TestEventReportingService testEventReportingService;
 
   public boolean resendToReportStream(List<UUID> testEventIds) {
-    /*
-     * NOTE: This when the DataHubUploaderService is decommissioned, this will need to be replaced with some logic like:
-     * TestEventRepository.findAllByInternalIdIn(testEventIds).forEach(testEvent -> TestEventReportingService.report(testEvent))
-     */
-    return _dataHubUploaderService.dataHubUploaderTask(testEventIds);
+    testEventRepository
+        .findAllByInternalIdIn(testEventIds)
+        .forEach(testEventReportingService::report);
+    return true;
   }
 }


### PR DESCRIPTION
## Related Issue or Background Info

- Per the comment removed in this PR: moving to the queued uploader breaks the resend logic. This is the fix.

## Changes Proposed

- Drive TestEvents to the queue on request instead of uploading directly to ReportStream

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
