### PR TITLE
Remove unused DATA_HUB_API_KEY from lower envs

### DIFF
--- a/ops/demo/_data.tf
+++ b/ops/demo/_data.tf
@@ -51,12 +51,6 @@ data "azurerm_key_vault_secret" "sr_db_jdbc" {
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
-
-data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-dev"
-  key_vault_id = data.azurerm_key_vault.global.id
-}
-
 data "azurerm_key_vault_secret" "slack_notify_webhook_url" {
   name         = "slack-notify-webhook-url-dev"
   key_vault_id = data.azurerm_key_vault.global.id

--- a/ops/demo/api.tf
+++ b/ops/demo/api.tf
@@ -26,7 +26,6 @@ module "simple_report_api" {
     SPRING_PROFILES_ACTIVE                = "azure-demo"
     SPRING_DATASOURCE_URL                 = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_db_jdbc.id})"
     APPLICATIONINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.app_insights.connection_string
-    DATAHUB_API_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     SECRET_SLACK_NOTIFY_WEBHOOK_URL       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_notify_webhook_url.id})"
     TWILIO_ACCOUNT_SID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.twilio_account_sid.id})"
     TWILIO_AUTH_TOKEN                     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.twilio_auth_token.id})"

--- a/ops/pentest/_data.tf
+++ b/ops/pentest/_data.tf
@@ -52,11 +52,6 @@ data "azurerm_key_vault_secret" "sr_db_jdbc" {
 }
 
 
-data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-dev"
-  key_vault_id = data.azurerm_key_vault.global.id
-}
-
 data "azurerm_key_vault_secret" "slack_notify_webhook_url" {
   name         = "slack-notify-webhook-url-dev"
   key_vault_id = data.azurerm_key_vault.global.id

--- a/ops/pentest/api.tf
+++ b/ops/pentest/api.tf
@@ -29,7 +29,6 @@ module "simple_report_api" {
     SPRING_DATASOURCE_URL                 = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_db_jdbc.id})"
     OKTA_OAUTH2_CLIENT_SECRET             = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.okta_client_secret.id})"
     APPLICATIONINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.app_insights.connection_string
-    DATAHUB_API_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     SECRET_SLACK_NOTIFY_WEBHOOK_URL       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_notify_webhook_url.id})"
     OKTA_API_KEY                          = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.okta_api_key.id})"
     ORG_FACILITY_NAME                     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.org_facility_name.id})"

--- a/ops/stg/_data.tf
+++ b/ops/stg/_data.tf
@@ -52,11 +52,6 @@ data "azurerm_key_vault_secret" "sr_db_jdbc" {
 }
 
 
-data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-dev"
-  key_vault_id = data.azurerm_key_vault.global.id
-}
-
 data "azurerm_key_vault_secret" "slack_notify_webhook_url" {
   name         = "slack-notify-webhook-url-dev"
   key_vault_id = data.azurerm_key_vault.global.id

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -30,7 +30,6 @@ module "simple_report_api" {
     SPRING_DATASOURCE_URL                 = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_db_jdbc.id})"
     OKTA_OAUTH2_CLIENT_SECRET             = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.okta_client_secret.id})"
     APPLICATIONINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.app_insights.connection_string
-    DATAHUB_API_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     SECRET_SLACK_NOTIFY_WEBHOOK_URL       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_notify_webhook_url.id})"
     OKTA_API_KEY                          = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.okta_api_key.id})"
     ORG_FACILITY_NAME                     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.org_facility_name.id})"

--- a/ops/training/_data.tf
+++ b/ops/training/_data.tf
@@ -52,11 +52,6 @@ data "azurerm_key_vault_secret" "sr_db_jdbc" {
 }
 
 
-data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-dev"
-  key_vault_id = data.azurerm_key_vault.global.id
-}
-
 data "azurerm_key_vault_secret" "slack_notify_webhook_url" {
   name         = "slack-notify-webhook-url-dev"
   key_vault_id = data.azurerm_key_vault.global.id

--- a/ops/training/api.tf
+++ b/ops/training/api.tf
@@ -28,7 +28,6 @@ module "simple_report_api" {
     SPRING_PROFILES_ACTIVE                = "azure-training"
     SPRING_DATASOURCE_URL                 = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_db_jdbc.id})"
     APPLICATIONINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.app_insights.connection_string
-    DATAHUB_API_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     SECRET_SLACK_NOTIFY_WEBHOOK_URL       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_notify_webhook_url.id})"
     TWILIO_ACCOUNT_SID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.twilio_account_sid.id})"
     TWILIO_AUTH_TOKEN                     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.twilio_auth_token.id})"


### PR DESCRIPTION
## Related Issue or Background Info

- Stray, unused env vars are bad and we should feel bad for them

## Changes Proposed

- Remove them

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
