### PR TITLE
Fix the RS queue publisher

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -7,6 +7,7 @@ import {
 } from "@azure/storage-queue";
 import * as csvStringify from "csv-stringify/lib/sync";
 import { ENV, uploaderVersion } from "./config";
+import fetch, { Headers } from "node-fetch";
 
 const {
   REPORT_STREAM_BATCH_MINIMUM,

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/tsconfig.json
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/tsconfig.json
@@ -7,5 +7,6 @@
     "rootDir": ".",
     "sourceMap": true,
     "strict": false
-  }
+  },
+  "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Related Issue or Background Info

- Lost an import when refactoring for testability
- Function failed to execute with this exception:

```
ailure Exception: ReferenceError: Headers is not defined Stack: ReferenceError: Headers is not defined at uploadResult (/home/site/wwwroot/dist/QueueBatchedReportStreamUploader/lib.js:78:21) at Object.QueueBatchedTestEventPublisher [as default] (/home/site/wwwroot/dist/QueueBatchedReportStreamUploader/index.js:34:53) at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

## Changes Proposed

- Add the missing import 

## Additional Information

- ReportStream publishes will not occur until this is merged and deployed!

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
