### PR TITLE
make swab_type in device_type nullable

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3008,3 +3008,13 @@ databaseChangeLog:
             viewName: organization_queue_no_phi_view
         - dropTable:
             tableName: organization_queue
+  - changeSet:
+      id: drop-not-null-constraint-swab_type
+      author: zedd@skylight.digital
+      comment: Drop the not null constraint for swab_type in device_type
+      changes:
+        - tagDatabase:
+            tag: drop-not-null-constraint-swab_type
+        - dropNotNullConstraint:
+            columnName: swab_type
+            tableName: device_type


### PR DESCRIPTION
## Related Issue or Background Info

- part 1 for #2536

## Changes Proposed

- make swab_type in device_type nullable
- we will no longer populate swab_type fields since devices will map to many swab_types

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
