### PR TITLE
Clear default device when changed in frontend

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -38,6 +38,10 @@ const ManageDevices: React.FC<Props> = ({
     const newDeviceTypes = Array.from(deviceTypes);
     newDeviceTypes[newDeviceTypes.indexOf(oldDeviceId)] = newDeviceId;
     updateDeviceTypes(newDeviceTypes);
+    // If the changed device was previously the default device, unset default device
+    if (oldDeviceId === defaultDevice) {
+      updateDefaultDevice("");
+    }
   };
 
   const onDeviceRemove = (id: string) => {

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -521,6 +521,32 @@ describe("FacilityForm", () => {
       );
       expect(warning).toBeInTheDocument();
     });
+
+    it("properly unsets default device when the default device is changed", async () => {
+      const unusedDevice = { internalId: "device-3", name: "Device 3" };
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceOptions={devices.concat(unusedDevice)}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      // Change default device
+      const dropdown = await screen.getByDisplayValue(devices[0].name);
+      await waitFor(() => {
+        userEvent.selectOptions(dropdown, unusedDevice.name);
+      });
+      // Attempt save
+      const saveButtons = await screen.findAllByText("Save changes");
+      userEvent.click(saveButtons[0]);
+      const warning = await screen.findByText(
+        "A default device must be selected",
+        { exact: false }
+      );
+      expect(warning).toBeInTheDocument();
+    });
   });
 });
 


### PR DESCRIPTION
## Related Issue or Background Info

* Addresses #2512
* When editing a facility, changing the default device type did not properly reset the default device value.
* Adding a check to do so properly triggers the expected no default device error message when attempting to save.

## Changes Proposed

- Add a check to `onDeviceChange` to catch instances where the device being changed is the current default device, so we can `updateDefaultDevice("")`
- Add a test to capture issue/fix

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
