### PR TITLE
Fix TZ offset problem that causes test to fail at certain times of day

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -122,7 +122,7 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
     // created_at to noon gmt the previous day, which will fall in the range of times the id
     // verification reminder email will be sent to.
     String query =
-        "UPDATE simple_report.organization SET created_at = (created_at - INTERVAL '1 DAY')::date + INTERVAL '12 hour' WHERE internal_id = ?";
+        "UPDATE simple_report.organization SET created_at = (NOW() + AGE(NOW() AT TIME ZONE 'America/New_York', NOW()) - INTERVAL '1 DAY')::date + INTERVAL '12 hour' WHERE internal_id = ?";
     Connection conn = _jdbc.getDataSource().getConnection();
     PreparedStatement statement = conn.prepareStatement(query);
     statement.setObject(1, org.getInternalId());


### PR DESCRIPTION
## Related Issue or Background Info

`sendAccountReminderEmails_sendEmails_success` fails at certain times of day because the test does an incorrect calculation to backdate a timestamp.  During the time between 00:00:00UTC and the number of hours offset to US eastern time, the test would fail because of test data being backdated to the wrong day

## Changes Proposed

- Fix backdate calculation in `ReminderServiceTest`

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
