### PR TITLE
Don't allow making dashboard request with null dates; show 0% positivity rate

### DIFF
--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -175,6 +175,24 @@ const getMocks = () => [
       },
     },
   },
+  {
+    request: {
+      query: GetTopLevelDashboardMetricsDocument,
+      variables: {
+        facilityId: "3",
+        startDate: getDateFromDaysAgo(30),
+        endDate: new Date(),
+      },
+    },
+    result: {
+      data: {
+        topLevelDashboardMetrics: {
+          totalTestCount: 5,
+          positiveTestCount: 0,
+        },
+      },
+    },
+  },
 ];
 
 describe("Analytics", () => {
@@ -299,5 +317,18 @@ describe("Analytics", () => {
       ]);
     });
     expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+  it("shows 0% for positivity rate at Empty School over last month", async () => {
+    await act(async () => {
+      await screen.findByText("COVID-19 testing data");
+      userEvent.selectOptions(screen.getByLabelText("Testing facility"), [
+        "Empty School",
+      ]);
+      await screen.findByText("COVID-19 testing data");
+      userEvent.selectOptions(screen.getByLabelText("Date range"), [
+        "Last month (30 days)",
+      ]);
+    });
+    expect(await screen.findByText("0.0%")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -89,8 +89,9 @@ export const Analytics = () => {
   const { data, loading, error } = useGetTopLevelDashboardMetricsQuery({
     variables: {
       facilityId,
-      startDate: getDateWithCurrentTimeFromString(startDate),
-      endDate: getDateWithCurrentTimeFromString(endDate),
+      startDate:
+        getDateWithCurrentTimeFromString(startDate) || getDateFromDaysAgo(7),
+      endDate: getDateWithCurrentTimeFromString(endDate) || new Date(),
     },
     fetchPolicy: "no-cache",
   });
@@ -230,7 +231,9 @@ export const Analytics = () => {
                   <div className="card display-flex flex-column flex-align-center">
                     <h2>Positivity rate</h2>
                     <h1>
-                      {positivityRate ? positivityRate.toFixed(1) + "%" : "N/A"}
+                      {positivityRate !== null
+                        ? positivityRate.toFixed(1) + "%"
+                        : "N/A"}
                     </h1>
                     <p className="font-ui-2xs">
                       Positives <span>÷</span> total tests


### PR DESCRIPTION
This prevents the `Analytics` component from ever making the `TopLevelDashboardMetrics` graphql query with a null date - it will default to using the last week if either the start date or end date is null.

This also fixes the positivity rate conditional so that it shows 0.0% if there only negative tests