### PR TITLE
Allow null dates on TopLevelDashboardMetrics request

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -464,6 +464,11 @@ public class TestOrderService {
       UUID facilityId, Date startDate, Date endDate) {
     Set<UUID> facilityIds;
 
+    if (startDate == null || endDate == null) {
+      // if null dates somehow get through, just return zeroes
+      return new TopLevelDashboardMetrics(0L, 0L);
+    }
+
     if (facilityId != null) {
       Facility fac = _os.getFacilityInCurrentOrg(facilityId);
       facilityIds = Set.of(fac.getInternalId());

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -276,7 +276,7 @@ type Query {
   ): Int @requiredPermissions(allOf: ["READ_RESULT_LIST"])
   testResult(id: ID!): TestResult
     @requiredPermissions(allOf: ["READ_RESULT_LIST"])
-  topLevelDashboardMetrics(facilityId: ID, startDate: DateTime!, endDate: DateTime!): TopLevelDashboardMetrics
+  topLevelDashboardMetrics(facilityId: ID, startDate: DateTime, endDate: DateTime): TopLevelDashboardMetrics
     @requiredPermissions(allOf: ["EDIT_ORGANIZATION"])
   users: [ApiUser] @requiredPermissions(allOf: ["MANAGE_USERS"])
   usersWithStatus: [ApiUserWithStatus!] @requiredPermissions(allOf: ["MANAGE_USERS"])

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -643,9 +643,9 @@ export type QueryTestResultsCountArgs = {
 };
 
 export type QueryTopLevelDashboardMetricsArgs = {
-  endDate: Scalars["DateTime"];
+  endDate?: Maybe<Scalars["DateTime"]>;
   facilityId?: Maybe<Scalars["ID"]>;
-  startDate: Scalars["DateTime"];
+  startDate?: Maybe<Scalars["DateTime"]>;
 };
 
 export type QueryUserArgs = {


### PR DESCRIPTION
This should prevent the recurring `graphql.execution.NonNullableValueCoercedAsNullException: Field 'startDate' of variable 'startDate' has coerced Null value for NonNull type 'DateTime!'` errors.