### PR TITLE
Add report_stream_response table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3027,6 +3027,7 @@ databaseChangeLog:
             tableName: report_stream_response
             remarks: A non-audited table to track exceptional publish responses from ReportStream
             columns:
+              - column: *pk_column
               - column:
                   name: test_event_internal_id
                   type: uuid

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3044,6 +3044,10 @@ databaseChangeLog:
                   name: is_error
                   type: boolean
                   remarks: Is this exception an error? If not, it's a warning
+              - column:
+                  name: resolution_note
+                  type: text
+                  remarks: When this warning or error has been manually resolved, leave a note
               - column: *created_at_column
         - sql: |
             GRANT SELECT ON TABLE ${database.defaultSchemaName}.report_stream_response TO ${noPhiUsername};

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3018,3 +3018,32 @@ databaseChangeLog:
         - dropNotNullConstraint:
             columnName: swab_type
             tableName: device_type
+  - changeSet:
+      id: add-reportstream-response-table
+      author: adam@skylight.digital
+      comment: Adds a non-audited table to track publish responses (warnings & errors) from ReportStream
+      changes:
+        - createTable:
+            tableName: report_stream_response
+            remarks: A non-audited table to track exceptional publish responses from ReportStream
+            columns:
+              - column:
+                  name: test_event_internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity, and a foreign key to test_event
+                  constraints:
+                    primaryKey: false
+                    nullable: false
+                    foreignKeyName: fk__report_stream_response__test_event
+                    references: test_event
+              - column:
+                  name: details
+                  type: text
+                  remarks: Explanatory details about the failure
+              - column:
+                  name: is_error
+                  type: boolean
+                  remarks: Is this exception an error? If not, it's a warning
+              - column: *created_at_column
+        - sql: |
+            GRANT SELECT ON TABLE ${database.defaultSchemaName}.report_stream_response TO ${noPhiUsername};


### PR DESCRIPTION
## Related Issue or Background Info

- #2698 

## Changes Proposed

- Add `report_stream_response` table to track errors and warnings from queue-based publish to ReportStream
- Grant metabase access to this table 

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
