### PR TITLE
Add metamodels to Gradle sources

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -182,6 +182,7 @@ spotless {
         importOrder()
         removeUnusedImports()
         googleJavaFormat()
+        targetExclude("build/generated/sources/**/*.java")
     }
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -122,20 +122,6 @@ springBoot {
     buildInfo()
 }
 
-test {
-    // people sometimes export this to run local dev more easily: don't let it break the tests
-    environment "SPRING_PROFILES_ACTIVE", ""
-    // For some reason, setting this in application-default doesn't work, but it's needed
-    // to prevent the Okta client from throwing an exception when we point it at WireMock,
-    // which doesn't use HTTPS
-    environment "OKTA_TESTING_DISABLEHTTPSCHECK", "true"
-    useJUnitPlatform()
-    // uncomment this to log to stdout when each test starts, so you can tell what's going on
-    // testLogging {
-    //   events "started", "failed"
-    // }
-}
-
 configurations {
     liquibaseRuntime.extendsFrom runtimeClasspath // inefficient but extremely effective
     compileClasspath {
@@ -214,9 +200,26 @@ task testDbReset(type: Exec) {
 }
 
 test {
+    // people sometimes export this to run local dev more easily: don't let it break the tests
+    environment "SPRING_PROFILES_ACTIVE", ""
+    // For some reason, setting this in application-default doesn't work, but it's needed
+    // to prevent the Okta client from throwing an exception when we point it at WireMock,
+    // which doesn't use HTTPS
+    environment "OKTA_TESTING_DISABLEHTTPSCHECK", "true"
+    useJUnitPlatform()
+    // uncomment this to log to stdout when each test starts, so you can tell what's going on
+    // testLogging {
+    //   events "started", "failed"
+    // }
     systemProperty "test-db-port", testDbPort
     if (System.getenv("CI") == null) {
         dependsOn testDbStart
         finalizedBy testDbStop
     }
+}
+
+sourceSets {
+  main {
+    java.srcDirs += "build/generated/sources/annotationProcessor/java/main"
+  }
 }

--- a/backend/config/checkstyle/suppressions.xml
+++ b/backend/config/checkstyle/suppressions.xml
@@ -38,5 +38,37 @@
 	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java" />
 	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java" />
 	<suppress checks="FileTabCharacter" files="src/main/java/gov/cdc/usds/simplereport/service/UploadService.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/ApiAuditEvent_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/ApiUser_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/AuditedEntity_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/BaseTestInfo_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/DataHubUpload_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/DeviceSpecimenType_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/DeviceType_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/EternalAuditedEntity_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/EternalSystemManagedEntity_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/FacilityDeviceSpecimenType_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/Facility_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/OrganizationQueueItem_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/OrganizationScopedEternalEntity_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/Organization_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/PatientAnswers_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/PatientLinkFailedAttempt_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/PatientLink_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/PatientSelfRegistrationLink_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/Person_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/PhoneNumber_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/Provider_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/SpecimenType_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/SystemManagedEntity_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/TenantDataAccess_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/TestEvent_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/TestOrder_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/TextMessageSent_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/TextMessageStatus_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/TimeOfConsent_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/auxiliary/PersonName_.java" />
+	<suppress checks="FileTabCharacter" files="build/generated/sources/annotationProcessor/java/main/gov/cdc/usds/simplereport/db/model/auxiliary/StreetAddress_.java" />
+	
 	<!-- IF AND WHEN THIS COMMENT LINE MEETS THE COMMENTS AT THE TOP, PLEASE DELETE THIS FILE -->
 </suppressions>


### PR DESCRIPTION
## Related Issue or Background Info

- VS Code currently throws a bunch of errors like this for metamodel imports used in our JPA Specifications:
![image](https://user-images.githubusercontent.com/9121162/135883870-3d414d54-677c-4ded-bf82-f3153f8c8b8d.png)

## Changes Proposed

- Add `build/generated/sources/annotationProcessor/java/main` to our `sourceSets` in `build.gradle`. This gets rid of the errors
- Also combined the split `test` sections in `build.gradle` to get rid of a warning about them being split

## Additional Information

- See this [StackOverflow post](https://stackoverflow.com/questions/28345705/how-can-i-add-a-generated-source-folder-to-my-source-path-in-gradle)

## Screenshots / Demos
![image](https://user-images.githubusercontent.com/9121162/135884179-e0b1280a-5a9a-4046-9dd6-a3de16fb8a98.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
