### PR TITLE
Don't hide az config output, it fails sometimes

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -28,7 +28,7 @@ runs:
       working-directory: ./frontend
       run: |
           echo "::group::Set build variables"
-          az config set extension.use_dynamic_install=yes_without_prompt > /dev/null 2>&1
+          az config set extension.use_dynamic_install=yes_without_prompt
           INSIGHTS_KEY=$(
             az monitor app-insights component show \
               -g prime-simple-report-${{inputs.deploy-env}} \


### PR DESCRIPTION
## Related Issue or Background Info

Sometimes `az config` fails, but we hide its output and continue anyway.  The problem surfaces later, but it is less clear what was actually wrong.  This will show the output, so it should be easier to tell what actually failed.

## Changes Proposed

- don't swallow the output of `az config`

## Additional Information

An example of the downstream failure:

https://github.com/CDCgov/prime-simplereport/runs/3792948296?check_suite_focus=true

This PR will cause the output below at the "Set build variables" step on the frontend build.  Hiding this output may have been the reason the output was hidden before, but since this command seems to fail sometimes, it should be better to leave it so we can see the output when there is an error.

```
  WARNING: Command group 'config' is experimental and under development. Reference and support levels: https://aka.ms/CLI_refstatus
  WARNING: The command requires the extension application-insights. It will be installed first.
  WARNING: The installed extension 'application-insights' is in preview.
```

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
