### PR TITLE
Initialize Application Insights instance before time of event tracking

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from "react";
 import { gql, useQuery, useMutation } from "@apollo/client";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
 import { Redirect } from "react-router-dom";
 
 import Alert from "../../commonComponents/Alert";
 import { showNotification } from "../../utils";
+import { getAppInsights } from "../../TelemetryService";
 
 import FacilityForm from "./FacilityForm";
 
@@ -172,10 +169,9 @@ const FacilityFormContainer: any = (props: Props) => {
       fetchPolicy: "no-cache",
     }
   );
-  const appInsights = useAppInsightsContext();
+  const appInsights = getAppInsights();
   const [updateFacility] = useMutation(UPDATE_FACILITY_MUTATION);
   const [addFacility] = useMutation(ADD_FACILITY_MUTATION);
-  const trackSaveSettings = useTrackEvent(appInsights, "Save Settings", null);
   const [saveSuccess, updateSaveSuccess] = useState(false);
 
   if (loading) {
@@ -197,7 +193,7 @@ const FacilityFormContainer: any = (props: Props) => {
 
   const saveFacility = async (facility: Facility) => {
     if (appInsights) {
-      trackSaveSettings(null);
+      appInsights.trackEvent({ name: "Save Settings" });
     }
     const provider = facility.orderingProvider;
     const saveFacility = props.facilityId ? updateFacility : addFacility;

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -1,12 +1,9 @@
 import React, { ComponentProps } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { gql, useQuery, useMutation } from "@apollo/client";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
 
 import Alert from "../commonComponents/Alert";
+import { getAppInsights } from "../TelemetryService";
 import { showNotification } from "../utils";
 import { RootState, updateOrganization } from "../store";
 
@@ -52,12 +49,7 @@ const ManageOrganizationContainer: any = () => {
   );
   const [adminSetOrganization] = useMutation(ADMIN_SET_ORGANIZATION);
   const [setOrganization] = useMutation(SET_ORGANIZATION);
-  const appInsights = useAppInsightsContext();
-  const trackSaveSettings = useTrackEvent(
-    appInsights,
-    "Save Organization",
-    null
-  );
+  const appInsights = getAppInsights();
 
   if (loading) {
     return <p> Loading... </p>;
@@ -72,7 +64,7 @@ const ManageOrganizationContainer: any = () => {
 
   const onSave = async ({ name, type }: EditableOrganization) => {
     if (appInsights) {
-      trackSaveSettings(null);
+      appInsights.trackEvent({ name: "Save Organization" });
     }
     const mutation = isSuperUser
       ? () => adminSetOrganization({ variables: { name, type } })

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -3,10 +3,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import { v4 as uuidv4 } from "uuid";
 import { useSelector, connect } from "react-redux";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
 
 import { PATIENT_TERM_PLURAL_CAP } from "../../config/constants";
 import { formatFullName, formatRole } from "../utils/user";
@@ -14,6 +10,7 @@ import siteLogo from "../../img/simplereport-logo-color.svg";
 import { hasPermission, appPermissions } from "../permissions";
 import { RootState } from "../store";
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
+import { getAppInsights } from "../TelemetryService";
 
 import Button from "./Button/Button";
 import Dropdown from "./Dropdown";
@@ -24,12 +21,13 @@ import ChangeUser from "./ChangeUser";
 import "./Header.scss";
 
 const Header: React.FC<{}> = () => {
-  const appInsights = useAppInsightsContext();
-  const trackSupport = useTrackEvent(appInsights, "Support", {});
+  const appInsights = getAppInsights();
 
   const handleSupportClick = (e: MouseEvent) => {
+    console.info("Preparing tracking...");
     if (appInsights) {
-      trackSupport(e);
+      console.info("Tracking...");
+      appInsights.trackEvent({ name: "Support" });
     }
   };
 

--- a/frontend/src/app/commonComponents/QueryWrapper.tsx
+++ b/frontend/src/app/commonComponents/QueryWrapper.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { gql, QueryHookOptions, useQuery } from "@apollo/client";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
+
+import { getAppInsights } from "../TelemetryService";
 
 export type InjectedQueryWrapperProps =
   | "data"
@@ -35,8 +33,8 @@ export function QueryWrapper<ComponentProps>({
   Component: React.ComponentType<ComponentProps>;
   componentProps: Omit<ComponentProps, InjectedQueryWrapperProps>;
 }): React.ReactElement {
-  const appInsights = useAppInsightsContext();
-  const trackAction = useTrackEvent(appInsights, "User Action", {});
+  const appInsights = getAppInsights();
+
   const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
     query,
     {
@@ -56,7 +54,7 @@ export function QueryWrapper<ComponentProps>({
   };
   const props = ({
     ...componentProps,
-    trackAction,
+    trackAction: appInsights?.trackEvent({ name: "User Action" }),
     data,
     loading,
     refetch: passOnRefetch,

--- a/frontend/src/app/commonComponents/__test__/Header.test.tsx
+++ b/frontend/src/app/commonComponents/__test__/Header.test.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import createMockStore from "redux-mock-store";
-import { useTrackEvent } from "@microsoft/applicationinsights-react-js";
 
 import Header from "../Header";
+import { getAppInsights } from "../../TelemetryService";
 import "../../../i18n";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
 
@@ -26,20 +26,23 @@ const store = mockStore({
   ],
 });
 
-jest.mock("@microsoft/applicationinsights-react-js", () => ({
-  useAppInsightsContext: () => {},
-  useTrackEvent: jest.fn(),
+jest.mock("../../TelemetryService", () => ({
+  getAppInsights: jest.fn(),
 }));
 
 describe("Header.tsx", () => {
   const OLD_ENV = process.env;
+  const trackEventMock = jest.fn();
 
   beforeEach(() => {
-    jest.resetModules();
+    (getAppInsights as jest.Mock).mockImplementation(() => ({
+      trackEvent: trackEventMock,
+    }));
     process.env = { ...OLD_ENV };
   });
 
   afterAll(() => {
+    (getAppInsights as jest.Mock).mockReset();
     process.env = OLD_ENV;
   });
 
@@ -62,7 +65,7 @@ describe("Header.tsx", () => {
     await waitFor(() => {
       userEvent.click(screen.getByTestId("support-link"));
     });
-    expect(useTrackEvent).toHaveBeenCalledWith(undefined, "Support", {});
+    expect(trackEventMock).toHaveBeenCalledWith({ name: "Support" });
   });
   it("it does not render login links", () => {
     expect(

--- a/frontend/src/app/supportAdmin/TenantDataAccess/TenantDataAccessFormContainer.tsx
+++ b/frontend/src/app/supportAdmin/TenantDataAccess/TenantDataAccessFormContainer.tsx
@@ -1,8 +1,4 @@
 import { useState } from "react";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
 import { Redirect } from "react-router-dom";
 
 import Alert from "../../commonComponents/Alert";
@@ -12,6 +8,7 @@ import {
   useGetOrganizationsQuery,
   useSetCurrentUserTenantDataAccessOpMutation,
 } from "../../../generated/graphql";
+import { getAppInsights } from "../../TelemetryService";
 
 import TenantDataAccessForm from "./TenantDataAccessForm";
 
@@ -21,9 +18,8 @@ const TenantDataAccessFormContainer = () => {
     fetchPolicy: "no-cache",
     variables: { identityVerified: true },
   });
-  const appInsights = useAppInsightsContext();
+  const appInsights = getAppInsights();
   const [setTenantDataAccess] = useSetCurrentUserTenantDataAccessOpMutation();
-  const trackSaveSettings = useTrackEvent(appInsights, "Save Settings", null);
 
   if (loading) {
     return <LoadingCard message={"Loading Organizations"} />;
@@ -41,7 +37,7 @@ const TenantDataAccessFormContainer = () => {
     justification?: string
   ) => {
     if (appInsights) {
-      trackSaveSettings(null);
+      appInsights.trackEvent({ name: "Save Settings " });
     }
     setTenantDataAccess({
       variables: {

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -2,10 +2,6 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
 import classnames from "classnames";
 import moment from "moment";
 import { DatePicker, Label } from "@trussworks/react-uswds";
@@ -34,6 +30,8 @@ import "./QueueItem.scss";
 import { AoEAnswers, TestQueuePerson } from "./AoEForm/AoEForm";
 import { QueueItemSubmitLoader } from "./QueueItemSubmitLoader";
 import { UPDATE_AOE } from "./addToQueue/AddToQueueSearch";
+
+import { getAppInsights } from "../TelemetryService";
 
 export type TestResult = "POSITIVE" | "NEGATIVE" | "UNDETERMINED" | "UNKNOWN";
 
@@ -185,22 +183,13 @@ const QueueItem = ({
   facilityId,
   dateTestedProp,
 }: QueueItemProps) => {
-  const appInsights = useAppInsightsContext();
-  const trackRemovePatientFromQueue = useTrackEvent(
-    appInsights,
-    "Remove Patient From Queue",
-    {}
-  );
-  const trackSubmitTestResult = useTrackEvent(
-    appInsights,
-    "Submit Test Result",
-    {}
-  );
-  const trackUpdateAoEResponse = useTrackEvent(
-    appInsights,
-    "Update AoE Response",
-    {}
-  );
+  const appInsights = getAppInsights();
+  const trackRemovePatientFromQueue = () =>
+    appInsights?.trackEvent({ name: "Remove Patient From Queue" });
+  const trackSubmitTestResult = () =>
+    appInsights?.trackEvent({ name: "Submit Test Result" });
+  const trackUpdateAoEResponse = () =>
+    appInsights?.trackEvent({ name: "Update AoE Response" });
 
   const [mutationError, updateMutationError] = useState(null);
   const [removePatientFromQueue] = useMutation(REMOVE_PATIENT_FROM_QUEUE);
@@ -305,7 +294,7 @@ const QueueItem = ({
 
     setSaveState("saving");
     if (appInsights) {
-      trackSubmitTestResult({});
+      trackSubmitTestResult();
     }
     setConfirmationType("none");
     try {
@@ -412,7 +401,7 @@ const QueueItem = ({
   const removeFromQueue = () => {
     setConfirmationType("none");
     if (appInsights) {
-      trackRemovePatientFromQueue({});
+      trackRemovePatientFromQueue();
     }
     removePatientFromQueue({
       variables: {
@@ -440,7 +429,7 @@ const QueueItem = ({
   const saveAoeCallback = (answers: AoEAnswers) => {
     setAoeAnswers(answers);
     if (appInsights) {
-      trackUpdateAoEResponse({});
+      trackUpdateAoEResponse();
     }
 
     const symptomOnset = answers.symptomOnset

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -6,10 +6,6 @@ import React, {
   useCallback,
 } from "react";
 import { gql, useMutation, useLazyQuery, useQuery } from "@apollo/client";
-import {
-  useAppInsightsContext,
-  useTrackEvent,
-} from "@microsoft/applicationinsights-react-js";
 import { useLocation } from "react-router";
 
 import Alert from "../../commonComponents/Alert";
@@ -23,6 +19,7 @@ import { showNotification } from "../../utils";
 import { useOutsideClick } from "../../utils/hooks";
 import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
+import { getAppInsights } from "../../TelemetryService";
 
 import SearchResults from "./SearchResults";
 import SearchInput from "./SearchInput";
@@ -137,12 +134,7 @@ const AddToQueueSearchBox = ({
   facilityId,
   patientsInQueue,
 }: Props) => {
-  const appInsights = useAppInsightsContext();
-  const trackAddPatientToQueue = useTrackEvent(
-    appInsights,
-    "Add Patient to Queue",
-    {}
-  );
+  const appInsights = getAppInsights();
 
   const [queryString, debounced, setDebounced] = useDebounce("", {
     debounceTime: SEARCH_DEBOUNCE_TIME,
@@ -222,7 +214,7 @@ const AddToQueueSearchBox = ({
     setDebounced("");
     setShowSuggestion(false);
     if (appInsights) {
-      trackAddPatientToQueue({});
+      appInsights.trackEvent({ name: "Add Patient To Queue" });
     }
     let callback;
     const variables: AoEAnswersForPatient = {


### PR DESCRIPTION
## Related Issue or Background Info
* Closes #2558 

## Changes Proposed
* Call `trackEvent` from configured Application Insights instance directly instead of relying on the hooks provided by the Application Insights React plugin

## Additional Information
- For background:
> [..]AppInsights isn’t defined at the exact moment during component initialization when the useEffect way down in Microsoft’s code is being executed – but it is defined by the time the event we want to track actually occurs

\- [05 May 2021 incident post-mortem](https://github.com/usds/prime-simplereport-docs/blob/main/incident_postmortem/05-26-2021-Application-Insights-Regression.md)

## Screenshots / Demos
<img width="422" alt="Screen Shot 2021-10-04 at 1 08 56 PM" src="https://user-images.githubusercontent.com/27730981/135894249-e57af2da-193b-4c77-9847-8a2c25a82e3e.png">

## Checklist for Author and Reviewer
- [ ] Did I miss any uses of the React plugin that will need to be replaced?
- [ ] Are there any custom properties we would like to track on these events?
    - This could make a good ticket if there's a lot we can think of
### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
