### PR TITLE
Minor copy updates for duplicate patient modal

### DIFF
--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -579,7 +579,7 @@ describe("AddPatient", () => {
       fireEvent.blur(zip);
 
       expect(
-        await screen.findByText("You already have a profile at", {
+        await screen.findByText("This person is already registered", {
           exact: false,
         })
       ).toBeInTheDocument();

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -579,7 +579,7 @@ describe("AddPatient", () => {
       fireEvent.blur(zip);
 
       expect(
-        await screen.findByText("This person is already registered", {
+        await screen.findByText("This patient is already registered", {
           exact: false,
         })
       ).toBeInTheDocument();

--- a/frontend/src/app/patients/Components/DuplicatePatientModal.tsx
+++ b/frontend/src/app/patients/Components/DuplicatePatientModal.tsx
@@ -44,7 +44,7 @@ export const DuplicatePatientModal: React.FC<DuplicateModalProps> = ({
     >
       <Modal.Header>
         {onClose
-          ? `This person is already registered at ${entityName}`
+          ? `This patient is already registered at ${entityName}`
           : `${t("selfRegistration.duplicate.heading")} ${entityName}`}
       </Modal.Header>
       <p>

--- a/frontend/src/app/patients/Components/DuplicatePatientModal.tsx
+++ b/frontend/src/app/patients/Components/DuplicatePatientModal.tsx
@@ -37,15 +37,21 @@ export const DuplicatePatientModal: React.FC<DuplicateModalProps> = ({
 
   return (
     <Modal
-      onClose={typeof onClose === "function" ? onClose : noop}
+      onClose={onClose || noop}
       showModal={showModal}
       showClose={false}
       variant="warning"
     >
       <Modal.Header>
-        {`${t("selfRegistration.duplicate.heading")} ${entityName}`}
+        {onClose
+          ? `This person is already registered at ${entityName}`
+          : `${t("selfRegistration.duplicate.heading")} ${entityName}`}
       </Modal.Header>
-      <p>{t("selfRegistration.duplicate.message")}</p>
+      <p>
+        {onClose
+          ? "Our records show someone has registered with the same name, date of birth, and ZIP code. You don't need to register this patient again."
+          : t("selfRegistration.duplicate.message")}
+      </p>
       <Modal.Footer>
         <Button onClick={onDuplicate}>
           {t("selfRegistration.duplicate.exit")}

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -210,10 +210,10 @@ export const en = {
           "When you arrive for your test, check in by giving your first and last name.",
       },
       duplicate: {
-        heading: "You already have a profile at",
+        heading: "You're already registered at",
         message:
           "Our records show someone has registered with the same name, date of birth, and ZIP code. Please check in with " +
-          "your testing site staff. You do not need to register again.",
+          "your testing facility staff. You don't need to register again.",
         exit: "Exit sign up",
       },
     },

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
@@ -127,7 +127,7 @@ describe("SelfRegistration", () => {
     });
     fireEvent.blur(firstNameInput);
     // Duplicate modal shows
-    await screen.findByText("You already have a profile", { exact: false });
+    await screen.findByText("You're already registered at", { exact: false });
     const exitButton = await screen.findByText("Exit sign up");
     fireEvent.click(exitButton);
     expect(


### PR DESCRIPTION
## Related Issue or Background Info

* Closes #2644 

## Changes Proposed
- Duplicate patient modal does not use pronoun "you" to indicate the duplicate user outside of self-registration workflow

## Additional Information
- N/A

## Screenshots / Demos
### Admin Patient Registration
* <img width="753" alt="Screen Shot 2021-10-05 at 12 36 18 PM" src="https://user-images.githubusercontent.com/27730981/136065303-a1f91384-1281-4c87-99dc-6a0641867b63.png">
    * @Rebecca-LM what do you think of this language - follow-up to https://app.zenhub.com/workspaces/simplereport-better-data-team-605b43d51ea9f700119a48ee/issues/cdcgov/prime-simplereport/2644#issuecomment-934561239

### Self-Registration
* <img width="735" alt="Screen Shot 2021-10-05 at 12 46 21 PM" src="https://user-images.githubusercontent.com/27730981/136066795-cb7e027b-dd02-4485-98c1-3bdd0a358116.png">

## Checklist for Author and Reviewer
- [x] @Rebecca-LM do we need to update any translations for the changes made to the self-registration version of the modal?

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
