### PR TITLE
Remove @EnableAsync from app

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -22,7 +22,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.info.GitProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Slf4j
@@ -39,7 +38,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
   CorsProperties.class,
   AzureStorageQueueReportingProperties.class
 })
-@EnableAsync
 @EnableScheduling
 public class SimpleReportApplication {
   public static void main(String[] args) {


### PR DESCRIPTION
## Related Issue or Background Info

`@EnableAsync` was added to the app with the Dynamics integration.  Dynamics has since been removed, but this unused relic remains.

## Changes Proposed

- Remove top-level `@EnableAsync` annotation

## Additional Information

- There aren't any uses of `@Async` remaining, so this is unnecessary

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
