### PR TITLE
Use base64 encoding when adding to the RS exceptions queue

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -187,6 +187,8 @@ export async function reportExceptions(
       }))
     );
   return Promise.all(
-    payloads.map((p) => queueClient.sendMessage(JSON.stringify(p)))
+    payloads.map((p) =>
+      queueClient.sendMessage(Buffer.from(JSON.stringify(p)).toString("base64"))
+    )
   );
 }


### PR DESCRIPTION
## Related Issue or Background Info

- This should resolve the `ReportStreamExceptionHandler`'s failures to dequeue and process messages 

## Changes Proposed

- Encode messages in base64 on send 

## Additional Information

- The exception from Azure reads:
```
The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.
```

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
