### PR TITLE
Add resend invitation button to users pending account setup

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -91,6 +91,11 @@ public class UserMutationResolver implements GraphQLMutationResolver {
     return new User(user);
   }
 
+  public User resendActivationEmail(UUID id) {
+    UserInfo user = _us.resendActivationEmail(id);
+    return new User(user);
+  }
+
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public User setCurrentUserTenantDataAccess(String organizationExternalID, String justification) {
     UserInfo user =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -179,6 +179,13 @@ public class DemoOktaRepository implements OktaRepository {
     }
   }
 
+  public void resendActivationEmail(String username) {
+    if (!usernameOrgRolesMap.containsKey(username)) {
+      throw new IllegalGraphqlArgumentException(
+          "Cannot reset password for Okta user with unrecognized username");
+    }
+  }
+
   public Set<String> getAllUsersForOrganization(Organization org) {
     if (!orgUsernamesMap.containsKey(org.getExternalId())) {
       throw new IllegalGraphqlArgumentException(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -405,6 +405,23 @@ public class LiveOktaRepository implements OktaRepository {
     user.unsuspend();
   }
 
+  public void resendActivationEmail(String username) {
+    UserList users = _client.listUsers(username, null, null, null, null);
+    if (users.stream().count() == 0) {
+      throw new IllegalGraphqlArgumentException(
+          "Cannot reactivate Okta user with unrecognized username");
+    }
+    User user = users.single();
+    if (user.getStatus() == UserStatus.PROVISIONED) {
+      user.reactivate(true);
+    } else if (user.getStatus() == UserStatus.STAGED) {
+      user.activate(true);
+    } else {
+      throw new IllegalGraphqlArgumentException(
+          "Cannot reactivate user with status: " + user.getStatus());
+    }
+  }
+
   /**
    * Iterates over all OrganizationRole's, creating new corresponding Okta groups for this
    * organization where they do not already exist. For those OrganizationRole's that are in

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -38,6 +38,8 @@ public interface OktaRepository {
 
   void reactivateUser(String username);
 
+  void resendActivationEmail(String username);
+
   UserStatus getUserStatus(String username);
 
   Set<String> getAllUsersForOrganization(Organization org);

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -379,6 +379,7 @@ type Mutation {
   setUserIsDeleted(id: ID!, deleted: Boolean!): User
     @requiredPermissions(allOf: ["MANAGE_USERS"])
   reactivateUser(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
+  resendActivationEmail(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   setCurrentUserTenantDataAccess(
     organizationExternalId: String
     justification: String

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -551,6 +551,43 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   }
 
   @Test
+  void resendActivationEmail_orgUser_success() {
+    useSuperUser();
+
+    ObjectNode addUser = runBoilerplateAddUser(Role.ADMIN);
+    String id = addUser.get("id").asText();
+
+    useOrgAdmin();
+
+    ObjectNode resendActivationEmailVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    ObjectNode resp =
+        runQuery(
+            "resend-activation-email",
+            "resendActivationEmail",
+            resendActivationEmailVariables,
+            null);
+    ObjectNode resendActivationEmailResponse = (ObjectNode) resp.get("resendActivationEmail");
+    assertEquals(USERNAMES.get(0), resendActivationEmailResponse.get("email").asText());
+  }
+
+  @Test
+  void resendActivationEmail_orgUser_failure() {
+    useSuperUser();
+
+    ObjectNode addUser = runBoilerplateAddUser(Role.ADMIN);
+    String id = addUser.get("id").asText();
+
+    useOrgUser();
+
+    ObjectNode resendActivationEmailVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    runQuery(
+        "resend-activation-email",
+        "resendActivationEmail",
+        resendActivationEmailVariables,
+        "Current user does not have permission to request [/resendActivationEmail]");
+  }
+
+  @Test
   void updateUserPrivileges_orgAdmin_success() {
     useOrgAdmin();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -225,6 +225,19 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
   }
 
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void resendActivationEmail_orgAdmin_success() {
+    initSampleData();
+
+    final String email = "allfacilities@example.com";
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+
+    UserInfo userInfo = _service.resendActivationEmail(apiUser.getInternalId());
+
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+  }
+
   private void roleCheck(final UserInfo userInfo, final Set<OrganizationRole> expected) {
     EnumSet<OrganizationRole> actual = EnumSet.copyOf(userInfo.getRoles());
     assertEquals(expected, actual);

--- a/backend/src/test/resources/queries/resend-activation-email
+++ b/backend/src/test/resources/queries/resend-activation-email
@@ -1,0 +1,17 @@
+mutation resendActivationEmail (
+    $id: ID!
+    ){
+  resendActivationEmail(
+    id: $id
+  ) {
+      id
+      firstName,
+      lastName,
+      email,
+      organization {
+        name
+        externalId
+      }
+    }
+}
+

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -324,7 +324,6 @@ const ManageUsers: React.FC<Props> = ({
         userWithPermissions?.lastName
       );
       updateShowResendUserActivationEmailModal(false);
-      reload();
       showNotification(
         <Alert
           type="success"

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -30,6 +30,7 @@ interface Props {
   resetUserPassword: (variables: any) => Promise<any>;
   deleteUser: (variables: any) => Promise<any>;
   reactivateUser: (variables: any) => Promise<any>;
+  resendUserActivationEmail: (variables: any) => Promise<any>;
   getUsers: () => Promise<ApolloQueryResult<GetUsersAndStatusQuery>>;
 }
 
@@ -78,6 +79,7 @@ const ManageUsers: React.FC<Props> = ({
   resetUserPassword,
   deleteUser,
   reactivateUser,
+  resendUserActivationEmail,
   getUsers,
 }) => {
   const [activeUser, updateActiveUser] = useState<LimitedUser>();
@@ -102,6 +104,10 @@ const ManageUsers: React.FC<Props> = ({
   const [showReactivateUserModal, updateShowReactivateUserModal] = useState(
     false
   );
+  const [
+    showResendUserActivationEmailModal,
+    updateShowResendUserActivationEmailModal,
+  ] = useState(false);
   const [isUserEdited, updateIsUserEdited] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState<Error>();
@@ -305,6 +311,31 @@ const ManageUsers: React.FC<Props> = ({
     }
   };
 
+  const handleResendUserActivationEmail = async (userId: string) => {
+    try {
+      await resendUserActivationEmail({
+        variables: {
+          id: userId,
+        },
+      });
+      const fullName = displayFullName(
+        userWithPermissions?.firstName,
+        userWithPermissions?.middleName,
+        userWithPermissions?.lastName
+      );
+      updateShowResendUserActivationEmailModal(false);
+      reload();
+      showNotification(
+        <Alert
+          type="success"
+          title={`${fullName} has been sent a new invitation.`}
+        />
+      );
+    } catch (e) {
+      setError(e);
+    }
+  };
+
   // Default to first user
   useEffect(() => {
     if (!activeUser && sortedUsers.length) {
@@ -389,6 +420,12 @@ const ManageUsers: React.FC<Props> = ({
               updateUser={updateUser}
               showReactivateUserModal={showReactivateUserModal}
               updateShowReactivateUserModal={updateShowReactivateUserModal}
+              showResendUserActivationEmailModal={
+                showResendUserActivationEmailModal
+              }
+              updateShowResendUserActivationEmailModal={
+                updateShowResendUserActivationEmailModal
+              }
               showResetUserPasswordModal={showResetPasswordModal}
               updateShowResetPasswordModal={updateShowResetPasswordModal}
               showDeleteUserModal={showDeleteUserModal}
@@ -399,6 +436,7 @@ const ManageUsers: React.FC<Props> = ({
               onContinueChangeActiveUser={onContinueChangeActiveUser}
               handleReactivateUser={handleReactivateUser}
               handleResetUserPassword={handleResetUserPassword}
+              handleResendUserActivationEmail={handleResendUserActivationEmail}
             />
           </div>
         </div>

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -83,6 +83,14 @@ const REACTIVATE_USER = gql`
   }
 `;
 
+const RESEND_ACTIVATION_EMAIL = gql`
+  mutation ResendActivationEmail($id: ID!) {
+    resendActivationEmail(id: $id) {
+      id
+    }
+  }
+`;
+
 const ADD_USER_TO_ORG = gql`
   mutation AddUserToCurrentOrg(
     $firstName: String
@@ -116,6 +124,7 @@ const ManageUsersContainer = () => {
   const [reactivateUser] = useMutation(REACTIVATE_USER);
   const [addUserToOrg] = useMutation(ADD_USER_TO_ORG);
   const [resetPassword] = useMutation(RESET_USER_PASSWORD);
+  const [resendUserActivationEmail] = useMutation(RESEND_ACTIVATION_EMAIL);
 
   const {
     data,
@@ -146,6 +155,7 @@ const ManageUsersContainer = () => {
       resetUserPassword={resetPassword}
       deleteUser={deleteUser}
       reactivateUser={reactivateUser}
+      resendUserActivationEmail={resendUserActivationEmail}
       getUsers={getUsers}
     />
   );

--- a/frontend/src/app/Settings/Users/ResendActivationEmailModal.tsx
+++ b/frontend/src/app/Settings/Users/ResendActivationEmailModal.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import Modal from "react-modal";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import Button from "../../commonComponents/Button/Button";
+import { displayFullName } from "../../utils";
+
+import { SettingsUser } from "./ManageUsersContainer";
+import "./ManageUsers.scss";
+
+interface Props {
+  onClose: () => void;
+  onResendActivationEmail: (userId: string) => void;
+  user: SettingsUser;
+}
+
+const ResendActivationEmailModal: React.FC<Props> = ({
+  onClose,
+  onResendActivationEmail,
+  user,
+}) => {
+  return (
+    <Modal
+      isOpen={true}
+      style={{
+        content: {
+          maxHeight: "90vh",
+          width: "40em",
+          position: "initial",
+        },
+      }}
+      overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
+      contentLabel="Unsaved changes to current user"
+      ariaHideApp={process.env.NODE_ENV !== "test"}
+    >
+      <div className="border-0 card-container">
+        <div className="display-flex flex-justify">
+          <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
+            Resend account set up email
+          </h1>
+          <button onClick={onClose} className="close-button" aria-label="Close">
+            <span className="fa-layers">
+              <FontAwesomeIcon icon={"circle"} size="2x" inverse />
+              <FontAwesomeIcon icon={"times-circle"} size="2x" />
+            </span>
+          </button>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
+        <div className="grid-row grid-gap">
+          <p>
+            Do you want to resend an account set up email to{" "}
+            <strong>
+              {displayFullName(user.firstName, user.middleName, user.lastName)}
+            </strong>
+            ?
+          </p>
+          <p>
+            Doing so will email this person a new link to set up their account.
+          </p>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
+          <div className="display-flex flex-justify-end">
+            <Button
+              className="margin-right-2"
+              onClick={onClose}
+              variant="unstyled"
+              label="No, go back"
+            />
+            <Button
+              className="margin-right-205"
+              onClick={() => onResendActivationEmail(user.id)}
+              label="Yes, I'm sure"
+            />
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ResendActivationEmailModal;

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -98,7 +98,7 @@ const UserDetail: React.FC<Props> = ({
             disabled={isUpdating}
           />
         ) : null}
-        {user.status === "ACTIVE" ? (
+        {user.status === "PROVISIONED" ? (
           <Button
             variant="outline"
             className="margin-left-auto margin-bottom-1"

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -15,6 +15,7 @@ import UserRoleSettingsForm from "./UserRoleSettingsForm";
 import ReactivateUserModal from "./ReactivateUserModal";
 import ResetUserPasswordModal from "./ResetUserPasswordModal";
 import "./ManageUsers.scss";
+import ResendActivationEmailModal from "./ResendActivationEmailModal";
 
 interface Props {
   user: SettingsUser;
@@ -26,6 +27,10 @@ interface Props {
   updateUser: UpdateUser;
   showReactivateUserModal: boolean;
   updateShowReactivateUserModal: (showReactivateUserModal: boolean) => void;
+  showResendUserActivationEmailModal: boolean;
+  updateShowResendUserActivationEmailModal: (
+    showResendUserActivationEmail: boolean
+  ) => void;
   showResetUserPasswordModal: boolean;
   updateShowResetPasswordModal: (showResetPasswordModal: boolean) => void;
   showDeleteUserModal: boolean;
@@ -36,6 +41,7 @@ interface Props {
   onContinueChangeActiveUser: () => void;
   handleReactivateUser: (userId: string) => void;
   handleResetUserPassword: (userId: string) => void;
+  handleResendUserActivationEmail: (userId: string) => void;
 }
 const roles: Role[] = ["ADMIN", "ENTRY_ONLY", "USER"];
 
@@ -49,6 +55,8 @@ const UserDetail: React.FC<Props> = ({
   handleDeleteUser,
   showReactivateUserModal,
   updateShowReactivateUserModal,
+  showResendUserActivationEmailModal,
+  updateShowResendUserActivationEmailModal,
   showResetUserPasswordModal,
   updateShowResetPasswordModal,
   showDeleteUserModal,
@@ -59,6 +67,7 @@ const UserDetail: React.FC<Props> = ({
   onContinueChangeActiveUser,
   handleReactivateUser,
   handleResetUserPassword,
+  handleResendUserActivationEmail,
 }) => {
   return (
     <div className="tablet:grid-col padding-left-2">
@@ -89,7 +98,18 @@ const UserDetail: React.FC<Props> = ({
             disabled={isUpdating}
           />
         ) : null}
-        {user.status !== "SUSPENDED" && user?.id !== loggedInUser.id ? (
+        {user.status === "PROVISIONED" ? (
+          <Button
+            variant="outline"
+            className="margin-left-auto margin-bottom-1"
+            onClick={() => updateShowResendUserActivationEmailModal(true)}
+            label="Resend account set up email"
+            disabled={isUpdating}
+          />
+        ) : null}
+        {user.status !== "SUSPENDED" &&
+        user.status !== "PROVISIONED" &&
+        user?.id !== loggedInUser.id ? (
           <Button
             variant="outline"
             className="margin-left-auto margin-bottom-1"
@@ -169,6 +189,13 @@ const UserDetail: React.FC<Props> = ({
           user={user}
           onClose={() => updateShowReactivateUserModal(false)}
           onReactivateUser={handleReactivateUser}
+        />
+      ) : null}
+      {showResendUserActivationEmailModal ? (
+        <ResendActivationEmailModal
+          user={user}
+          onClose={() => updateShowReactivateUserModal(false)}
+          onResendActivationEmail={handleResendUserActivationEmail}
         />
       ) : null}
       {showResetUserPasswordModal ? (

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -98,7 +98,7 @@ const UserDetail: React.FC<Props> = ({
             disabled={isUpdating}
           />
         ) : null}
-        {user.status === "PROVISIONED" ? (
+        {user.status === "ACTIVE" ? (
           <Button
             variant="outline"
             className="margin-left-auto margin-bottom-1"
@@ -194,7 +194,7 @@ const UserDetail: React.FC<Props> = ({
       {showResendUserActivationEmailModal ? (
         <ResendActivationEmailModal
           user={user}
-          onClose={() => updateShowReactivateUserModal(false)}
+          onClose={() => updateShowResendUserActivationEmailModal(false)}
           onResendActivationEmail={handleResendUserActivationEmail}
         />
       ) : null}

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -62,7 +62,7 @@ const UsersSideNav: React.FC<Props> = ({
                       {" "}
                       <FontAwesomeIcon
                         icon={faCircle}
-                        className={"prime-orange-icon suspended-icon"}
+                        className={"prime-blue-icon suspended-icon"}
                       />
                     </span>
                   )}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -114,6 +114,7 @@ export type Mutation = {
   editQueueItem?: Maybe<TestOrder>;
   reactivateUser?: Maybe<User>;
   removePatientFromQueue?: Maybe<Scalars["String"]>;
+  resendActivationEmail?: Maybe<User>;
   resendToReportStream?: Maybe<Scalars["Boolean"]>;
   resetUserPassword?: Maybe<User>;
   sendPatientLinkSms?: Maybe<Scalars["String"]>;
@@ -320,6 +321,10 @@ export type MutationReactivateUserArgs = {
 
 export type MutationRemovePatientFromQueueArgs = {
   patientId: Scalars["ID"];
+};
+
+export type MutationResendActivationEmailArgs = {
+  id: Scalars["ID"];
 };
 
 export type MutationResendToReportStreamArgs = {

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -334,7 +334,7 @@
 }
 
 .prime-blue-icon {
-  color: color($theme-color-primary-darker);
+  color: color($theme-color-primary);
 }
 
 // General group of related items on a form

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -333,6 +333,10 @@
   color: orange;
 }
 
+.prime-blue-icon {
+  color: color($theme-color-primary-darker);
+}
+
 // General group of related items on a form
 .sr-section {
   border: 1px solid #ccc;


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2477 

## Changes Proposed

- adds a new capability to the Manage Users page, to resend an activation email to users pending account setup
- changes the icon color for pending users to blue (was previously orange)

## Additional Information

- the button only shows for pending users (users who have completed account setup get a password reset button)
- this should help reduce the volume of support requests we get around resending this email

## Screenshots / Demos
![Screen Shot 2021-10-05 at 4 00 41 PM](https://user-images.githubusercontent.com/80282552/136114929-9e4aa908-111b-4286-8255-ad8f8d2a7612.png)
![Screen Shot 2021-10-05 at 3 27 14 PM](https://user-images.githubusercontent.com/80282552/136114976-3eeb2e86-e866-415a-88f7-70a638890622.png)
![Screen Shot 2021-10-05 at 3 26 38 PM](https://user-images.githubusercontent.com/80282552/136114993-abfc2a78-6979-47c4-82ff-07a48b6eeceb.png)


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
