### PR TITLE
Allow special z-clia for WY

### DIFF
--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -79,7 +79,7 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
       "facility-clia",
       ({ value }) => {
         if (value[2] === "Z" && value.length === 10) {
-          return "Special Z CLIAs are only valid in WA";
+          return "Special Z CLIAs are only valid in WA and WY";
         }
         return "CLIA number should be 10 characters (##D#######)";
       },

--- a/frontend/src/app/utils/clia.ts
+++ b/frontend/src/app/utils/clia.ts
@@ -12,6 +12,8 @@ export function isValidCLIANumber(input: string, state: string): boolean {
     cliaNumberValidator = /^\d{2}[DZ]\d{7}$/;
   } else if (state === "IL" && input === "14DISBE123") {
     return true;
+  } else if (state === "WY" && input === "12Z3456789") {
+    return true;
   } else {
     cliaNumberValidator = /^\d{2}D\d{7}$/;
   }


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2735 

## Changes Proposed

- Allow WY to enter a special Z CLIA
- change error message to reflect that both WA and WY use a Z-CLIA

## Screenshots / Demos

![Screen Shot 2021-10-06 at 9 14 16 AM](https://user-images.githubusercontent.com/80282552/136243954-228804b4-8834-45bd-8ed5-f1397a028776.png)
![Screen Shot 2021-10-06 at 9 14 26 AM](https://user-images.githubusercontent.com/80282552/136243974-7f008835-e710-428a-95a8-d454b4307c05.png)

## Checklist for Author and Reviewer

### UI
- n/a Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
