### PR TITLE
Address potential memory leak found by Fortify

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/RequestVariablesSerializer.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/RequestVariablesSerializer.java
@@ -20,14 +20,23 @@ public class RequestVariablesSerializer extends JsonSerializer<Map<String, Objec
   private Object parseValue(Object value) {
     if (value instanceof Part) {
       Part part = (Part) value;
+      BufferedReader br = null;
       try {
-        return new BufferedReader(
-                new InputStreamReader(part.getInputStream(), StandardCharset.UTF_8))
-            .lines()
-            .collect(Collectors.joining("\n"));
+        br =
+            new BufferedReader(new InputStreamReader(part.getInputStream(), StandardCharset.UTF_8));
+        return br.lines().collect(Collectors.joining("\n"));
       } catch (IOException e) {
         log.error("Unable to read uploaded file while writing audit log", e);
         throw new AuditLogFailureException();
+      } finally {
+        if (br != null) {
+          try {
+            br.close();
+          } catch (IOException e) {
+            log.error(
+                "Error attempting to close input stream after reading uploaded file while writing audit log");
+          }
+        }
       }
     }
     return value;


### PR DESCRIPTION
## Related Issue or Background Info
#2637 

Fixes a potential memory leak found by Fortify

## Changes Proposed

Fortify is mad that the implicit closing of `BufferedReader` at some point (presumably eventual garbage collection) could be exploited to cause resource depletion. The fix is to explicitly `close()` the input stream once finished.

## Additional Information

- The nested `try`/`catch` is a little messy but I don't know if we have this pattern elsewhere. If we do we could make the nested `close()` into a helper method.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
