### PR TITLE
Add special CLIA rules for CA

### DIFF
--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -95,7 +95,7 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
       "facility-clia",
       ({ value }) => {
         if (
-          (value[2] === "Z" && value.length === 10) ||
+          (value.length === 10 && value[2] === "Z") ||
           /[a-zA-Z]/.test(value[0])
         ) {
           return "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -94,7 +94,7 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
     .test(
       "facility-clia",
       ({ value }) => {
-        if (value[2] === "Z" && value.length === 10) {
+        if ((value[2] === "Z" && value.length === 10) || (/[a-zA-Z]/).test(value[0])) {
           return "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";
         }
         return "CLIA number should be 10 characters (##D#######)";

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -94,7 +94,10 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
     .test(
       "facility-clia",
       ({ value }) => {
-        if ((value[2] === "Z" && value.length === 10) || (/[a-zA-Z]/).test(value[0])) {
+        if (
+          (value[2] === "Z" && value.length === 10) ||
+          /[a-zA-Z]/.test(value[0])
+        ) {
           return "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";
         }
         return "CLIA number should be 10 characters (##D#######)";

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -95,7 +95,7 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
       "facility-clia",
       ({ value }) => {
         if (value[2] === "Z" && value.length === 10) {
-          return "Special Z CLIAs are only valid in WA and WY";
+          return "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";
         }
         return "CLIA number should be 10 characters (##D#######)";
       },

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -363,7 +363,8 @@ describe("FacilityForm", () => {
         userEvent.type(cliaInput, "12Z3456789");
         userEvent.tab();
 
-        const expectedError = "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";
+        const expectedError =
+          "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";
 
         expect(
           await screen.findByText(expectedError, {

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -363,7 +363,7 @@ describe("FacilityForm", () => {
         userEvent.type(cliaInput, "12Z3456789");
         userEvent.tab();
 
-        const expectedError = "Special Z CLIAs are only valid in WA";
+        const expectedError = "Special temporary CLIAs are only valid in CA, IL, WA, and WY.";
 
         expect(
           await screen.findByText(expectedError, {

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -342,13 +342,14 @@ describe("FacilityForm", () => {
         await validateAddress(saveFacility);
         expect(saveFacility).toBeCalledTimes(1);
       });
+
       it("doesn't allow a Z-CLIA for a non-Washington state", async () => {
-        const californiaFacility: Facility = validFacility;
-        californiaFacility.state = "CA";
+        const marylandFacility: Facility = validFacility;
+        marylandFacility.state = "MD";
         render(
           <MemoryRouter>
             <FacilityForm
-              facility={californiaFacility}
+              facility={marylandFacility}
               deviceSpecimenTypeOptions={deviceSpecimenTypes}
               saveFacility={saveFacility}
             />
@@ -377,6 +378,34 @@ describe("FacilityForm", () => {
           userEvent.click(saveButton);
         });
         expect(saveFacility).toBeCalledTimes(0);
+      });
+
+      it("allows alphanumeric characters for California", async () => {
+        const californiaFacility: Facility = validFacility;
+        californiaFacility.state = "CA";
+
+        render(
+          <MemoryRouter>
+            <FacilityForm
+              facility={californiaFacility}
+              deviceSpecimenTypeOptions={deviceSpecimenTypes}
+              saveFacility={saveFacility}
+            />
+          </MemoryRouter>
+        );
+
+        const cliaInput = screen.getByLabelText("CLIA number", {
+          exact: false,
+        });
+
+        userEvent.clear(cliaInput);
+        userEvent.type(cliaInput, "CPDH000006");
+        userEvent.tab();
+
+        const saveButton = await screen.getAllByText("Save changes")[0];
+        userEvent.click(saveButton);
+        await validateAddress(saveFacility);
+        expect(saveFacility).toBeCalledTimes(1);
       });
     });
   });

--- a/frontend/src/app/utils/clia.ts
+++ b/frontend/src/app/utils/clia.ts
@@ -10,6 +10,8 @@ export function isValidCLIANumber(input: string, state: string): boolean {
   let cliaNumberValidator;
   if (state === "WA") {
     cliaNumberValidator = /^\d{2}[DZ]\d{7}$/;
+  } else if (state === "CA") {
+    cliaNumberValidator = /^\w{2}[D]\w{1}\d{6}$/;
   } else if (state === "IL" && input === "14DISBE123") {
     return true;
   } else if (state === "WY" && input === "12Z3456789") {


### PR DESCRIPTION
## Related Issue or Background Info

- https://skylight-hq.slack.com/archives/C019PRYMR0Q/p1633540100267700
- Fixes #2756 

## Changes Proposed

- Add new regex for California that allows alphanumeric chars at the front of the string, not just digits
- update error message based on Rebecca's suggestion
## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- n/a GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
