### PR TITLE
Skip duplicate patients in CSV Upload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
@@ -30,6 +30,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 /** Created by nickrobison on 11/21/20 */
 @Service
 @Transactional
+@RequiredArgsConstructor
 @Slf4j
 public class UploadService {
   private static final String FACILITY_ID = "facilityId";
@@ -44,12 +47,8 @@ public class UploadService {
 
   private final PersonService _ps;
   private final AddressValidationService _avs;
+  private final OrganizationService _os;
   private boolean hasHeaderRow = false;
-
-  public UploadService(PersonService ps, AddressValidationService avs) {
-    this._ps = ps;
-    this._avs = avs;
-  }
 
   private MappingIterator<Map<String, String>> getIteratorForCsv(InputStream csvStream)
       throws IllegalGraphqlArgumentException {
@@ -95,6 +94,7 @@ public class UploadService {
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public String processPersonCSV(InputStream csvStream) throws IllegalGraphqlArgumentException {
     final MappingIterator<Map<String, String>> valueIterator = getIteratorForCsv(csvStream);
+    final var org = _os.getCurrentOrganization();
 
     // Since the CSV parser won't fail when give a single string, we simple check to see if it has
     // any parsed values
@@ -111,6 +111,9 @@ public class UploadService {
       final Map<String, String> row = getNextRow(valueIterator);
       rowNumber++;
       try {
+        var facilityId = parseUUID(getRow(row, FACILITY_ID, false));
+        var facility = _os.getFacilityInCurrentOrg(facilityId);
+
         StreetAddress address =
             _avs.getValidatedAddress(
                 getRow(row, "Street", true),
@@ -119,14 +122,24 @@ public class UploadService {
                 getRow(row, "State", true),
                 getRow(row, "ZipCode", true),
                 null);
+
+        var firstName = parseString(getRow(row, "FirstName", true));
+        var lastName = parseString(getRow(row, "LastName", true));
+        var dob = parseUserShortDate(getRow(row, "DOB", true));
+
+        if (_ps.isDuplicatePatient(
+            firstName, lastName, dob, address.getPostalCode(), org, Optional.of(facility))) {
+          continue;
+        }
+
         _ps.addPatient(
-            parseUUID(getRow(row, FACILITY_ID, false)),
+            facilityId,
             null, // lookupID
-            parseString(getRow(row, "FirstName", true)),
+            firstName,
+            lastName,
             parseString(getRow(row, "MiddleName", false)),
-            parseString(getRow(row, "LastName", true)),
             parseString(getRow(row, "Suffix", false)),
-            parseUserShortDate(getRow(row, "DOB", true)),
+            dob,
             address,
             parsePhoneNumbers(
                 List.of(


### PR DESCRIPTION
## Related Issue or Background Info

- Bulk upload of patients via CSV creates a lot of duplicates. This will prevent that, though it will substantially decrease performance 

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
