### PR TITLE
add indexes to organization_queue table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3065,3 +3065,29 @@ databaseChangeLog:
             columns:
               - column:
                   name: test_order_id
+  - changeSet:
+      id: add-indexes-organization-queue
+      author: brett.m.maden@omb.eop.gov
+      comment: Adds unique indexes on the organization_queue fields organization_external_id and verified_organization_id
+      changes:
+        - tagDatabase:
+            tag: add-indexes-organization-queue
+        - createIndex:
+            tableName: organization_queue
+            indexName: uk__organization_queue__organization_external_id
+            columns:
+              - column:
+                  name: organization_external_id
+            unique: true
+        - createIndex:
+            tableName: organization_queue
+            indexName: uk__organization_queue__verified_organization_id
+            columns:
+              - column:
+                  name: verified_organization_id
+            unique: true
+      rollback:
+        - dropIndex:
+            indexName: uk__organization_queue__organization_external_id
+        - dropIndex:
+            indexName: uk__organization_queue__verified_organization_id


### PR DESCRIPTION
## Related Issue or Background Info

Add unique indexes to the `organization_queue` table.

- Uniqueness of `organization_external_id` should be enforced.  This is also to support querying.
- Uniqueness of `verified_organization_id` should also be enforced.  One row on this table should ever reference a single created organization

## Changes Proposed

- add unique constraints on `organization_external_id` and `verified_organization_id`

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
