### PR TITLE
Fix reminder service test

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -24,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ReminderService {
 
+  private static final long LOCK_HOLD_MS = 1000L;
+
   private final OktaRepository _oktaRepo;
   private final OrganizationRepository _orgRepo;
   private final EmailService _emailService;
@@ -90,7 +92,7 @@ public class ReminderService {
 
     try {
       // hold the lock a little extra so other instances have a chance to fail to acquire it
-      Thread.sleep(1L);
+      Thread.sleep(LOCK_HOLD_MS);
     } catch (InterruptedException e) {
       log.debug("sendAccountReminderEmails: sleep interrupted");
       Thread.currentThread().interrupt();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -51,12 +51,7 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
     assertEquals(Set.of(email), remindedEmails);
   }
 
-  // This behavior has been verified to work on production, but this test fails fairly consistently
-  // when run with the github runners.  When run locally, the failure does not seem to be
-  // reproducible
-  // so more investigation is required.  For now, disabling this test for this reason.
   @Test
-  @org.junit.jupiter.api.Disabled("Test is unreliable, but behavior verified on prod")
   void sendAccountReminderEmails_concurrencyLock_success()
       throws InterruptedException, ExecutionException, SQLException {
     String email = "fake@example.org";


### PR DESCRIPTION
## Related Issue or Background Info

This test was not consistently passing with the github runner.  This aims to make it consistently pass.

## Changes Proposed

- Increase the extra amount of time the lock is held to give others who are started at about the time enough time to fail before the lock is released

## Additional Information

- The reminder service was erroneously sleeping for only 1ms instead of the intended 1s, which was likely the cause of this test failing.  In prod, where we are actually sending emails, this condition would probably only happen if no emails were being sent because of all the time we spend calling 3rd party services (get admin email addresses (okta) and send the emails (sendgrid)).

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
