### PR TITLE
Use correct scope for Okta redirect

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -55,6 +55,13 @@ const App = () => {
   if (process.env.REACT_APP_OKTA_ENABLED === "true") {
     const accessToken = localStorage.getItem("access_token");
     if (!accessToken) {
+      // If Okta login has been attempted and returned to SR with an error, don't redirect back to Okta
+      const params = new URLSearchParams(window.location.hash.slice(1));
+      if (params.get("error")) {
+        throw new Error(
+          params.get("error_description") || "Unknown Okta error"
+        );
+      }
       throw new Error("Not authenticated, redirecting to Okta...");
     }
   }

--- a/frontend/src/app/PrimeErrorBoundary.tsx
+++ b/frontend/src/app/PrimeErrorBoundary.tsx
@@ -51,7 +51,9 @@ export default class PrimeErrorBoundary extends React.Component<
         process.env.REACT_APP_OKTA_URL
       }/oauth2/default/v1/authorize?client_id=${
         process.env.REACT_APP_OKTA_CLIENT_ID
-      }&redirect_uri=${getUrl()}&response_type=token id_token&scope=openid simple_report simple_report_test&nonce=thisisnotsafe&state=thisisbogus`;
+      }&redirect_uri=${getUrl()}&response_type=token id_token&scope=openid simple_report simple_report_${
+        process.env.DEPLOY_ENV
+      }&nonce=thisisnotsafe&state=thisisbogus`;
       return false;
     }
 


### PR DESCRIPTION
Tack on to #2774 - it turns out the redirect URL needs to include a scope that is specific to the environment. I discovered this after testing on `stg` and getting an infinite loop and cancelled the prod deploy. This will include the correct scope and prevent the issue. I also included a check to see if Okta returns an error message in the URL hash when it redirects back to SR, and prevent the app from infinitely redirecting back and forth.