### PR TITLE
Use www

### DIFF
--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
           smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
-          base-domain-name: simplereport.gov
+          base-domain-name: www.simplereport.gov
           client-tarball: ./client.tgz
           okta-enabled: true
           okta-url: https://hhs-prime.okta.com

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -4,8 +4,8 @@ simple-report:
   azure-reporting-queue:
     enabled: true
     exception-webhook-enabled: true
-  patient-link-url: https://simplereport.gov/app/pxp?plid=
-  twilio-callback-url: https://simplereport.gov/api/pxp/callback
+  patient-link-url: https://www.simplereport.gov/app/pxp?plid=
+  twilio-callback-url: https://www.simplereport.gov/api/pxp/callback
   id-verification-reminders:
     enabled: true
   sendgrid:

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -236,7 +236,7 @@ const Header: React.FC<{}> = () => {
             <div>
               <div className="navlink__support">
                 <a
-                  href="https://simplereport.gov/support"
+                  href="https://www.simplereport.gov/support"
                   target="none"
                   onClick={() => handleSupportClick()}
                 >
@@ -381,7 +381,7 @@ const Header: React.FC<{}> = () => {
                   <li className="usa-sidenav__item">{facility.name}</li>
                   <li className="usa-sidenav__item navlink__support">
                     <a
-                      href="https://simplereport.gov/support"
+                      href="https://www.simplereport.gov/support"
                       target="none"
                       onClick={() => handleSupportClick()}
                       data-testid="support-link"


### PR DESCRIPTION
## Related Issue or Background Info

- Due to a typo in a DNS cutover, `simplereport.gov` is down but `www.simplereport.gov` is working just fine. This update serves to mitigate the outage while DNS propagates. 

## Changes Proposed

- Use `www.` 
