### PR TITLE
Add www subdomain to Okta redirects

### DIFF
--- a/ops/prod/persistent/okta.tf
+++ b/ops/prod/persistent/okta.tf
@@ -1,8 +1,8 @@
 module "okta" {
   source               = "../../services/okta-app"
   env                  = local.env
-  app_url              = "https://simplereport.gov/app"
-  logout_redirect_uris = ["https://simplereport.cdc.gov", "https://simplereport.gov"]
+  app_url              = "https://www.simplereport.gov/app"
+  logout_redirect_uris = ["https://simplereport.cdc.gov", "https://www.simplereport.gov"]
 }
 
 // Create the Okta secrets

--- a/ops/services/okta-app/_var.tf
+++ b/ops/services/okta-app/_var.tf
@@ -23,7 +23,8 @@ variable "redirect_urls" {
     "http://localhost:3000",
     "https://staging.simplereport.org/app",
     "https://simplereport.cdc.gov/app",
-    "https://simplereport.gov/app"
+    "https://simplereport.gov/app",
+    "https://www.simplereport.gov/app"
   ]
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

Okta needs to have the `www.` subdomain redirect URIs added to match the backend.

## Changes Proposed

- Add `www.simplereport.gov` to allowed login URIs and redirect URIs in production.
