### PR TITLE
Fix field nullability & rename GetTopLevelDashboardMetrics operation

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -5,7 +5,7 @@ import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { GetTopLevelDashboardMetricsDocument } from "../generated/graphql";
+import { GetTopLevelDashboardMetricsNewDocument } from "../generated/graphql";
 
 import App, { WHOAMI_QUERY } from "./App";
 import { queueQuery } from "./testQueue/TestQueue";
@@ -167,7 +167,7 @@ const WhoAmIErrorQueryMock = {
 };
 const getAnalyticsQueryMock = () => ({
   request: {
-    query: GetTopLevelDashboardMetricsDocument,
+    query: GetTopLevelDashboardMetricsNewDocument,
     variables: {
       facilityId: "",
       startDate: getDateFromDaysAgo(7),

--- a/frontend/src/app/analytics/Analytics.stories.tsx
+++ b/frontend/src/app/analytics/Analytics.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: Analytics,
   argTypes: {},
   parameters: {
-    msw: getMocks("GetTopLevelDashboardMetrics"),
+    msw: getMocks("GetTopLevelDashboardMetricsNew"),
   },
   decorators: [
     (Story) => (

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -5,7 +5,7 @@ import { MockedProvider } from "@apollo/client/testing";
 import createMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 
-import { GetTopLevelDashboardMetricsDocument } from "../../generated/graphql";
+import { GetTopLevelDashboardMetricsNewDocument } from "../../generated/graphql";
 
 import {
   Analytics,
@@ -33,7 +33,7 @@ beforeAll(() => {
 const getMocks = () => [
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
         startDate: getDateFromDaysAgo(7),
@@ -51,7 +51,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
         startDate: getDateFromDaysAgo(1),
@@ -69,7 +69,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
         startDate: getDateFromDaysAgo(30),
@@ -87,7 +87,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "1",
         startDate: getDateFromDaysAgo(7),
@@ -105,7 +105,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "2",
         startDate: getDateFromDaysAgo(7),
@@ -123,7 +123,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
         startDate: getDateWithCurrentTimeFromString("07/01/2021"),
@@ -141,7 +141,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
         startDate: getDateWithCurrentTimeFromString("07/01/2021"),
@@ -159,7 +159,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "3",
         startDate: getDateFromDaysAgo(7),
@@ -177,7 +177,7 @@ const getMocks = () => [
   },
   {
     request: {
-      query: GetTopLevelDashboardMetricsDocument,
+      query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "3",
         startDate: getDateFromDaysAgo(30),

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 
 import { DatePicker } from "../commonComponents/DatePicker";
 import Dropdown from "../commonComponents/Dropdown";
-import { useGetTopLevelDashboardMetricsQuery } from "../../generated/graphql";
+import { useGetTopLevelDashboardMetricsNewQuery } from "../../generated/graphql";
 import { LoadingCard } from "../commonComponents/LoadingCard/LoadingCard";
 
 import "./Analytics.scss";
@@ -86,7 +86,7 @@ export const Analytics = () => {
     }
   };
 
-  const { data, loading, error } = useGetTopLevelDashboardMetricsQuery({
+  const { data, loading, error } = useGetTopLevelDashboardMetricsNewQuery({
     variables: {
       facilityId,
       startDate:

--- a/frontend/src/app/analytics/operations.graphql
+++ b/frontend/src/app/analytics/operations.graphql
@@ -1,7 +1,7 @@
 query GetTopLevelDashboardMetricsNew(
   $facilityId: ID
-  $startDate: DateTime!
-  $endDate: DateTime!
+  $startDate: DateTime
+  $endDate: DateTime
 ) {
   topLevelDashboardMetrics(
     facilityId: $facilityId

--- a/frontend/src/app/analytics/operations.graphql
+++ b/frontend/src/app/analytics/operations.graphql
@@ -1,4 +1,4 @@
-query GetTopLevelDashboardMetrics(
+query GetTopLevelDashboardMetricsNew(
   $facilityId: ID
   $startDate: DateTime!
   $endDate: DateTime!

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1230,8 +1230,8 @@ export type ResendActivationEmailMutation = {
 
 export type GetTopLevelDashboardMetricsNewQueryVariables = Exact<{
   facilityId?: Maybe<Scalars["ID"]>;
-  startDate: Scalars["DateTime"];
-  endDate: Scalars["DateTime"];
+  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: Maybe<Scalars["DateTime"]>;
 }>;
 
 export type GetTopLevelDashboardMetricsNewQuery = {
@@ -3110,8 +3110,8 @@ export type ResendActivationEmailMutationOptions = Apollo.BaseMutationOptions<
 export const GetTopLevelDashboardMetricsNewDocument = gql`
   query GetTopLevelDashboardMetricsNew(
     $facilityId: ID
-    $startDate: DateTime!
-    $endDate: DateTime!
+    $startDate: DateTime
+    $endDate: DateTime
   ) {
     topLevelDashboardMetrics(
       facilityId: $facilityId
@@ -3143,7 +3143,7 @@ export const GetTopLevelDashboardMetricsNewDocument = gql`
  * });
  */
 export function useGetTopLevelDashboardMetricsNewQuery(
-  baseOptions: Apollo.QueryHookOptions<
+  baseOptions?: Apollo.QueryHookOptions<
     GetTopLevelDashboardMetricsNewQuery,
     GetTopLevelDashboardMetricsNewQueryVariables
   >

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1228,13 +1228,13 @@ export type ResendActivationEmailMutation = {
   }>;
 };
 
-export type GetTopLevelDashboardMetricsQueryVariables = Exact<{
+export type GetTopLevelDashboardMetricsNewQueryVariables = Exact<{
   facilityId?: Maybe<Scalars["ID"]>;
   startDate: Scalars["DateTime"];
   endDate: Scalars["DateTime"];
 }>;
 
-export type GetTopLevelDashboardMetricsQuery = {
+export type GetTopLevelDashboardMetricsNewQuery = {
   __typename?: "Query";
   topLevelDashboardMetrics?: Maybe<{
     __typename?: "TopLevelDashboardMetrics";
@@ -3107,8 +3107,8 @@ export type ResendActivationEmailMutationOptions = Apollo.BaseMutationOptions<
   ResendActivationEmailMutation,
   ResendActivationEmailMutationVariables
 >;
-export const GetTopLevelDashboardMetricsDocument = gql`
-  query GetTopLevelDashboardMetrics(
+export const GetTopLevelDashboardMetricsNewDocument = gql`
+  query GetTopLevelDashboardMetricsNew(
     $facilityId: ID
     $startDate: DateTime!
     $endDate: DateTime!
@@ -3125,16 +3125,16 @@ export const GetTopLevelDashboardMetricsDocument = gql`
 `;
 
 /**
- * __useGetTopLevelDashboardMetricsQuery__
+ * __useGetTopLevelDashboardMetricsNewQuery__
  *
- * To run a query within a React component, call `useGetTopLevelDashboardMetricsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTopLevelDashboardMetricsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetTopLevelDashboardMetricsNewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTopLevelDashboardMetricsNewQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetTopLevelDashboardMetricsQuery({
+ * const { data, loading, error } = useGetTopLevelDashboardMetricsNewQuery({
  *   variables: {
  *      facilityId: // value for 'facilityId'
  *      startDate: // value for 'startDate'
@@ -3142,39 +3142,39 @@ export const GetTopLevelDashboardMetricsDocument = gql`
  *   },
  * });
  */
-export function useGetTopLevelDashboardMetricsQuery(
+export function useGetTopLevelDashboardMetricsNewQuery(
   baseOptions: Apollo.QueryHookOptions<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
+    GetTopLevelDashboardMetricsNewQuery,
+    GetTopLevelDashboardMetricsNewQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
-  >(GetTopLevelDashboardMetricsDocument, options);
+    GetTopLevelDashboardMetricsNewQuery,
+    GetTopLevelDashboardMetricsNewQueryVariables
+  >(GetTopLevelDashboardMetricsNewDocument, options);
 }
-export function useGetTopLevelDashboardMetricsLazyQuery(
+export function useGetTopLevelDashboardMetricsNewLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
+    GetTopLevelDashboardMetricsNewQuery,
+    GetTopLevelDashboardMetricsNewQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
-  >(GetTopLevelDashboardMetricsDocument, options);
+    GetTopLevelDashboardMetricsNewQuery,
+    GetTopLevelDashboardMetricsNewQueryVariables
+  >(GetTopLevelDashboardMetricsNewDocument, options);
 }
-export type GetTopLevelDashboardMetricsQueryHookResult = ReturnType<
-  typeof useGetTopLevelDashboardMetricsQuery
+export type GetTopLevelDashboardMetricsNewQueryHookResult = ReturnType<
+  typeof useGetTopLevelDashboardMetricsNewQuery
 >;
-export type GetTopLevelDashboardMetricsLazyQueryHookResult = ReturnType<
-  typeof useGetTopLevelDashboardMetricsLazyQuery
+export type GetTopLevelDashboardMetricsNewLazyQueryHookResult = ReturnType<
+  typeof useGetTopLevelDashboardMetricsNewLazyQuery
 >;
-export type GetTopLevelDashboardMetricsQueryResult = Apollo.QueryResult<
-  GetTopLevelDashboardMetricsQuery,
-  GetTopLevelDashboardMetricsQueryVariables
+export type GetTopLevelDashboardMetricsNewQueryResult = Apollo.QueryResult<
+  GetTopLevelDashboardMetricsNewQuery,
+  GetTopLevelDashboardMetricsNewQueryVariables
 >;
 export const PatientExistsDocument = gql`
   query PatientExists(

--- a/frontend/src/stories/storyMocks.tsx
+++ b/frontend/src/stories/storyMocks.tsx
@@ -66,8 +66,8 @@ const mocks = {
     "RemovePatientFromQueue",
     (req, res, ctx) => res(ctx.data({}))
   ),
-  GetTopLevelDashboardMetrics: graphql.query(
-    "GetTopLevelDashboardMetrics",
+  GetTopLevelDashboardMetricsNew: graphql.query(
+    "GetTopLevelDashboardMetricsNew",
     (req, res, ctx) =>
       res(
         ctx.data({


### PR DESCRIPTION
## Related Issue or Background Info

- This will hopefully remedy the 200/400 spikes from the dashboard analytics

## Changes Proposed

- Rename the operation, so we can be sure in app insights whether it's "stale clients" failing or not
- Update the query to make the endDate and startDate nullable on the client side. This is very likely the root cause of the issue in the first place

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
