### PR TITLE
Use www.simplereport.gov from the Function App

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/main.tf
@@ -1,5 +1,5 @@
 locals {
-  simple_report_callback_url = "https://${var.environment == "prod" ? "" : "${var.environment}."}simplereport.gov/api/reportstream/callback"
+  simple_report_callback_url = "https://${var.environment == "prod" ? "www" : var.environment}.simplereport.gov/api/reportstream/callback"
   resource_group_name        = "${var.resource_group_name_prefix}${var.environment}"
   report_stream_url          = "https://${var.environment == "prod" ? "" : "staging."}prime.cdc.gov/api/reports?option=SkipInvalidItems&verbose=true"
   management_tags = {


### PR DESCRIPTION
## Related Issue or Background Info

- Fix the 401s happening to the ReportStreamExceptionHandler due to a lack of `www.`
