### PR TITLE
Don't run app/e2e tests for /ops only changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore:
+      - 'ops/**'
 
 env:
   NODE_VERSION: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'ops/**'
 
 env:
   NODE_VERSION: 14


### PR DESCRIPTION
## Related Issue or Background Info

#2203 

Running app/e2e tests isn't necessary when changes are limited to the `/ops` directory (e.g. Terraform-only changes).

## Changes Proposed

- Add `paths-ignore: ops/**` to the `test.yml` and `e2e.yml` workflows
