### PR TITLE
Add yarn tasks to start/end maintenance mode

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -6,7 +6,7 @@ on:
       active:
         description: "Active outage? (true/false)"
         required: true
-        default: "true"
+        default: true
       message:
         description: "Message to display"
         required: true
@@ -15,17 +15,23 @@ on:
 jobs:
   pushMaintenanceBlob:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
     strategy:
       matrix:
         deploy-env:
           ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
     steps:
+      - uses: actions/checkout@v2
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Push maintenance.json
         shell: bash
         run: |
-          echo '{"active": ${{ inputs.active }}, "message": "${{ inputs.message }}"}' > maintenance.json
-          az storage blob upload -f maintenance.json -n maintenance.json -c '$web' \
-            --account-name simplereport${{ matrix.deploy-env }}app
+          export MAINTENANCE_BOOLEAN=$( if [ "${{ github.event.inputs.active }}" = "true" ]; then echo true; else echo false; fi )
+          export MAINTENANCE_MESSAGE=${{ github.event.inputs.message }}
+          export MAINTENANCE_ENV=${{ matrix.deploy-env }}
+          echo "{\"active\": $MAINTENANCE_BOOLEAN, \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
+          yarn run maintenance:deploy

--- a/.github/workflows/resetTrainingDB.yml
+++ b/.github/workflows/resetTrainingDB.yml
@@ -23,6 +23,12 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Enter maintenance mode
+        shell: bash
+        run: |
+          export MAINTENANCE_ENV=training
+          echo '{"active": true, "message": "SimpleReport is undergoing routine maintenance and will be available shortly."}' > maintenance.json
+          yarn run maintenance:deploy
       - name: Reset Azure training DB
         run: |
           export RUNNER_PUBLIC_IP=$(curl -s ipinfo.io/ip)
@@ -46,6 +52,12 @@ jobs:
           # Close the firewall
           az postgres server firewall-rule delete --name runner-ip --server-name $SERVER_NAME --resource-group $RG_NAME --yes
           az postgres server update --public disabled --name $SERVER_NAME --resource-group $RG_NAME
+      - name: Exit maintenance mode
+        shell: bash
+        run: |
+          export MAINTENANCE_ENV=training
+          echo '{"active": false, "message": ""}' > maintenance.json
+          yarn run maintenance:deploy
       - name: Restart Training App Service
         run: |
           az webapp restart --resource-group prime-simple-report-${{ env.DEPLOY_ENV }} --name simple-report-api-${{ env.DEPLOY_ENV }}

--- a/README.md
+++ b/README.md
@@ -382,3 +382,13 @@ Navigate to the [Github Actions Tab](https://github.com/CDCgov/prime-simplerepor
 4. Click the green "Run workflow" button.
 5. After the workflow is completed you can verify the changes are live by Checking the deployed commit hash. This is done my going to `/app/static/commit.txt` and `/api/actuator/info`
 
+## Deployment Issues
+### Maintenance Mode
+
+Users can be notified of deployment issues by placing SimpleReport in maintenance mode. When maintenance mode is enabled, a banner will appear at the top of each page stating that SimpleReport is currently experiencing an outage, along with a configurable supplemental message (e.g. a reason why).
+
+To do so manually:
+1. Create a `MAINTENANCE MESSAGE` in JSON format with an `active` and a `message` key. Example: `{"active": true, "message": "SimpleReport is currently undergoing maintenance"}`. Note that the `active` value must be a _boolean_, not a string.
+2. `cd frontend && MAINTENANCE_MESSAGE=(JSON message here) MAINTENANCE_ENV=(desired env) yarn run maintenance:start`
+
+An easier way is to run the `Maintenance Mode` Action, which will automatically enable/disable maintenance mode for all environments with your desired message.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,5 +12,6 @@ tests_output/
 storybook-static
 build-storybook.log
 /storybook_public
+maintenance.json
 
 wiremock-jre8-standalone-2.29.1.jar

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,7 +88,9 @@
     "watch-css": "yarn compile-scss && sass --load-path=./node_modules/uswds/dist/scss --style=compressed --no-source-map -w src/scss/App.scss:src/styles/App.css",
     "create-storybook-public": "rm -rf ./storybook_public && cp -R ./public ./storybook_public && cp mockServiceWorker.js ./storybook_public",
     "storybook": "yarn create-storybook-public && yarn watch-css & start-storybook -p 6006 -s storybook_public",
-    "build-storybook": "yarn create-storybook-public && yarn compile-scss && REACT_APP_BACKEND_URL=http://localhost:8080 build-storybook -s storybook_public"
+    "build-storybook": "yarn create-storybook-public && yarn compile-scss && REACT_APP_BACKEND_URL=http://localhost:8080 build-storybook -s storybook_public",
+    "maintenance:start": "[ -z \"$MAINTENANCE_MESSAGE\" ] && echo \"MAINTENANCE_MESSAGE must be set!\" || (echo $MAINTENANCE_MESSAGE > maintenance.json && yarn maintenance:deploy && rm maintenance.json)",
+    "maintenance:deploy": "[ -z \"$MAINTENANCE_ENV\" ] && echo \"MAINTENANCE_ENV must be set!\" || az storage blob upload -f maintenance.json -n maintenance.json -c '$web' --account-name simplereport${MAINTENANCE_ENV}app"
   },
   "prettier": {
     "singleQuote": false


### PR DESCRIPTION
## Related Issue or Background Info

#741

## Changes Proposed

- Add yarn tasks to start/end maintenance mode
- Use these yarn tasks to put training in maintenance mode while
  performing the daily DB reset

## Additional Information

- Left current maintenance mode Action alone. Right now it's an all/nothing toggle for all environments, but it would be nice to have this configurable. GH Actions don't currently support checkboxes or anything that convenient, but we could probably come up with a solution.
- If we absolutely need to put only one environment into maintenance mode, the yarn tasks in this PR will work.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
