### PR TITLE
Fix directory in reset training DB workflow

### DIFF
--- a/.github/workflows/resetTrainingDB.yml
+++ b/.github/workflows/resetTrainingDB.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./ops
+        working-directory: ./frontend
     steps:
       - uses: actions/checkout@v2
       - uses: azure/login@v1


### PR DESCRIPTION
## Related Issue or Background Info

#741, #2823 

## Changes Proposed

- Missed changing the directory in `resetTrainingDB.yml` - needs to be `frontend` instead of `ops`
