### PR TITLE
set docker posgres db version to match azure dbs and updated migration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       test-db:
-        image: postgres:12-alpine
+        image: postgres:11-alpine
         env:
           POSTGRES_PASSWORD: this_is_a_super_secure_admin_password
         # Set health checks to wait until postgres has started

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       test-db:
-        image: postgres:12-alpine
+        image: postgres:11-alpine
         env:
           POSTGRES_PASSWORD: this_is_a_super_secure_admin_password
         # Set health checks to wait until postgres has started

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   db:
-    image: postgres:12-alpine
+    image: postgres:11-alpine
     ports:
       - "${SR_DB_PORT:-5432}:${SR_DB_PORT:-5432}"
     environment:

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3186,6 +3186,7 @@ databaseChangeLog:
       id: add-email-all-to-test-result-delivery
       author: zedd@skylight.digital
       comment: Add EMAIL and ALL to test result delivery preferences
+      runInTransaction: false
       changes:
         - tagDatabase:
               tag: add-email-all-to-test-result-delivery


### PR DESCRIPTION
## Related Issue or Background Info

- addresses part 1 of #1950 failed migration in staging

## Changes Proposed

- set postgres local version to match azure
- change migration to run outside block since postgres version 11 doesnt support enum alteration inside transaction

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
