### PR TITLE
Alert on Experian auth failures

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/errors/ExperianAuthException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/errors/ExperianAuthException.java
@@ -1,0 +1,18 @@
+package gov.cdc.usds.simplereport.service.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class ExperianAuthException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public ExperianAuthException(String description) {
+    super(description);
+  }
+
+  public ExperianAuthException(String description, Exception exception) {
+    super(description, exception);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
@@ -13,6 +13,7 @@ import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationAn
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationQuestionsRequest;
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationQuestionsResponse;
 import gov.cdc.usds.simplereport.properties.ExperianProperties;
+import gov.cdc.usds.simplereport.service.errors.ExperianAuthException;
 import gov.cdc.usds.simplereport.service.errors.ExperianGetQuestionsException;
 import gov.cdc.usds.simplereport.service.errors.ExperianKbaResultException;
 import gov.cdc.usds.simplereport.service.errors.ExperianNullNodeException;
@@ -95,11 +96,11 @@ public class LiveExperianService
           _restTemplate.postForObject(
               _experianProperties.getTokenEndpoint(), entity, ObjectNode.class);
       if (responseBody == null) {
-        throw new RestClientException("The Experian token request returned a null response.");
+        throw new ExperianAuthException("The Experian token request returned a null response.");
       }
       return responseBody.path("access_token").asText();
     } catch (RestClientException e) {
-      throw new IllegalArgumentException("The activation token could not be retrieved: ", e);
+      throw new ExperianAuthException("The activation token could not be retrieved.", e);
     }
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianServiceTest.java
@@ -194,6 +194,24 @@ class LiveExperianServiceTest {
   }
 
   @Test
+  void getQuestions_nullAuthResponse_failure() {
+    // somehow failed to get an access token from experian
+    when(_mockRestTemplate.postForObject(
+            eq(FAKE_PROPERTIES.getTokenEndpoint()), any(), eq(ObjectNode.class)))
+        .thenReturn(null);
+
+    IdentityVerificationQuestionsRequest request = createValidQuestionsRequest();
+
+    ExperianAuthException e =
+        assertThrows(
+            ExperianAuthException.class,
+            () -> {
+              _service.getQuestions(request);
+            });
+    assertEquals("The Experian token request returned a null response.", e.getMessage());
+  }
+
+  @Test
   void submitAnswers_correctResponsesAcceptResponse_success() throws JsonProcessingException {
     setExperianMockResponse(EXPERIAN_ANSWERS_SAMPLE_RESPONSE_ACCEPT);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianServiceTest.java
@@ -18,6 +18,7 @@ import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationAn
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationQuestionsRequest;
 import gov.cdc.usds.simplereport.api.model.accountrequest.IdentityVerificationQuestionsResponse;
 import gov.cdc.usds.simplereport.properties.ExperianProperties;
+import gov.cdc.usds.simplereport.service.errors.ExperianAuthException;
 import gov.cdc.usds.simplereport.service.errors.ExperianGetQuestionsException;
 import gov.cdc.usds.simplereport.service.errors.ExperianKbaResultException;
 import gov.cdc.usds.simplereport.service.errors.ExperianNullNodeException;
@@ -172,6 +173,24 @@ class LiveExperianServiceTest {
               _service.getQuestions(request);
             });
     assertEquals(KBA_CODE_DESCRIPTION_DECEASED, e.getMessage());
+  }
+
+  @Test
+  void getQuestions_authFailure_failure() {
+    // somehow failed to get an access token from experian
+    when(_mockRestTemplate.postForObject(
+            eq(FAKE_PROPERTIES.getTokenEndpoint()), any(), eq(ObjectNode.class)))
+        .thenThrow(RestClientException.class);
+
+    IdentityVerificationQuestionsRequest request = createValidQuestionsRequest();
+
+    ExperianAuthException e =
+        assertThrows(
+            ExperianAuthException.class,
+            () -> {
+              _service.getQuestions(request);
+            });
+    assertEquals("The activation token could not be retrieved.", e.getMessage());
   }
 
   @Test

--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -16,6 +16,7 @@ module "metric_alerts" {
     "http_5xx_errors",
     "first_error_in_a_week",
     "account_request_failures",
+    "experian_auth_failures",
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -26,6 +26,7 @@ variable "disabled_alerts" {
       "http_5xx_errors",
       "first_error_in_a_week",
       "account_request_failures",
+      "experian_auth_failures",
       "frontend_error_boundary",
       "db_query_duration",
       "db_query_duration_over_time_window",

--- a/ops/stg/alerts.tf
+++ b/ops/stg/alerts.tf
@@ -13,6 +13,7 @@ module "metric_alerts" {
     "http_5xx_errors",
     "first_error_in_a_week",
     "account_request_failures",
+    "experian_auth_failures",
     "frontend_error_boundary",
   ]
 

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -16,6 +16,7 @@ module "metric_alerts" {
     "http_5xx_errors",
     "first_error_in_a_week",
     "account_request_failures",
+    "experian_auth_failures",
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",


### PR DESCRIPTION
## Related Issue or Background Info

On 10/27/2021 and 10/28/2021 we experienced auth failures to Experian and although we did notice it, we were not alerted of it explicitly.  This adds a new exception when Experian CrossCore auth fails and an alert when the exception is seen.

## Changes Proposed

- New exception type on unsuccessful CrossCore auth
- New alert when this exception is seen

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
