### PR TITLE
Add NAT gateways to each env + static IP

### DIFF
--- a/.github/workflows/checkGraphql.yml
+++ b/.github/workflows/checkGraphql.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - 'ops/**'
   push:
     branches:
       - main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
-      - 'ops/**'
 
 env:
   NODE_VERSION: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,9 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - 'ops/**'
   push:
     branches:
       - main
-    paths-ignore:
-      - 'ops/**'
 
 env:
   NODE_VERSION: 14

--- a/ops/demo/main.tf
+++ b/ops/demo/main.tf
@@ -99,3 +99,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_demo.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_demo.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_demo.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -56,3 +56,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_dev.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_dev.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_dev.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -45,3 +45,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_pentest.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_pentest.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_pentest.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -107,3 +107,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_prod.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_prod.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_prod.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}

--- a/ops/services/nat_gateway/_var.tf
+++ b/ops/services/nat_gateway/_var.tf
@@ -1,0 +1,8 @@
+variable "name" {}
+variable "env" {}
+variable "resource_group_name" {}
+variable "resource_group_location" {}
+variable "tags" {}
+variable "subnet_webapp_id" {}
+variable "subnet_lb_id" {}
+variable "subnet_vm_id" {}

--- a/ops/services/nat_gateway/main.tf
+++ b/ops/services/nat_gateway/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_nat_gateway_public_ip_association" "outbound" {
   public_ip_address_id = azurerm_public_ip.nat_outbound_static_ip.id
 }
 
-# TODO: uncomment everything below once Experian adjusts their IP allowlist as part of #2855
+# TODO:  uncomment everything below once Experian adjusts their IP allowlist as part of #2855
 
 # resource "azurerm_subnet_nat_gateway_association" "outbound_webapp" {
 #   subnet_id      = var.subnet_webapp_id

--- a/ops/services/nat_gateway/main.tf
+++ b/ops/services/nat_gateway/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_nat_gateway_public_ip_association" "outbound" {
   public_ip_address_id = azurerm_public_ip.nat_outbound_static_ip.id
 }
 
-# TODO:  uncomment everything below once Experian adjusts their IP allowlist as part of #2855
+# TODO: uncomment everything below once Experian adjusts their IP allowlist as part of #2855
 
 # resource "azurerm_subnet_nat_gateway_association" "outbound_webapp" {
 #   subnet_id      = var.subnet_webapp_id

--- a/ops/services/nat_gateway/main.tf
+++ b/ops/services/nat_gateway/main.tf
@@ -29,17 +29,20 @@ resource "azurerm_nat_gateway_public_ip_association" "outbound" {
   nat_gateway_id       = azurerm_nat_gateway.outbound.id
   public_ip_address_id = azurerm_public_ip.nat_outbound_static_ip.id
 }
-resource "azurerm_subnet_nat_gateway_association" "outbound_webapp" {
-  subnet_id      = var.subnet_webapp_id
-  nat_gateway_id = azurerm_nat_gateway.outbound.id
-}
 
-resource "azurerm_subnet_nat_gateway_association" "outbound_lb" {
-  subnet_id      = var.subnet_lb_id
-  nat_gateway_id = azurerm_nat_gateway.outbound.id
-}
+# TODO: uncomment everything below once Experian adjusts their IP allowlist as part of #2855
 
-resource "azurerm_subnet_nat_gateway_association" "outbound_vm" {
-  subnet_id      = var.subnet_vm_id
-  nat_gateway_id = azurerm_nat_gateway.outbound.id
-}
+# resource "azurerm_subnet_nat_gateway_association" "outbound_webapp" {
+#   subnet_id      = var.subnet_webapp_id
+#   nat_gateway_id = azurerm_nat_gateway.outbound.id
+# }
+
+# resource "azurerm_subnet_nat_gateway_association" "outbound_lb" {
+#   subnet_id      = var.subnet_lb_id
+#   nat_gateway_id = azurerm_nat_gateway.outbound.id
+# }
+
+# resource "azurerm_subnet_nat_gateway_association" "outbound_vm" {
+#   subnet_id      = var.subnet_vm_id
+#   nat_gateway_id = azurerm_nat_gateway.outbound.id
+# }

--- a/ops/services/nat_gateway/main.tf
+++ b/ops/services/nat_gateway/main.tf
@@ -1,0 +1,45 @@
+# Sets up a NAT gateway to be able to specifically route outbound traffic:
+# - Creates a static IP
+# - Create a NAT gateway
+# - Associate the static IP with the NAT gateway
+# - Associate the NAT gateway with the webapp and load balancer subnets
+#
+# The above will cause all outbound traffic from the associated subnets
+# to pass through the NAT gateway and originate from the static IP. The
+# static IP can then be used for allowlists.
+
+resource "azurerm_public_ip" "nat_outbound_static_ip" {
+  name                = "${var.name}-${var.env}-nat-outbound-static-ip"
+  location            = var.resource_group_location
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_nat_gateway" "outbound" {
+  name                = "${var.name}-${var.env}-outbound-nat-gateway"
+  location            = var.resource_group_location
+  resource_group_name = var.resource_group_name
+  sku_name            = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "outbound" {
+  nat_gateway_id       = azurerm_nat_gateway.outbound.id
+  public_ip_address_id = azurerm_public_ip.nat_outbound_static_ip.id
+}
+resource "azurerm_subnet_nat_gateway_association" "outbound_webapp" {
+  subnet_id      = var.subnet_webapp_id
+  nat_gateway_id = azurerm_nat_gateway.outbound.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "outbound_lb" {
+  subnet_id      = var.subnet_lb_id
+  nat_gateway_id = azurerm_nat_gateway.outbound.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "outbound_vm" {
+  subnet_id      = var.subnet_vm_id
+  nat_gateway_id = azurerm_nat_gateway.outbound.id
+}

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -98,3 +98,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_stg.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_stg.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_stg.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -56,3 +56,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_test.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_test.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_test.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}

--- a/ops/training/main.tf
+++ b/ops/training/main.tf
@@ -98,3 +98,15 @@ module "app_gateway" {
 
   tags = local.management_tags
 }
+
+module "nat_gateway" {
+  source                  = "../services/nat_gateway"
+  name                    = local.name
+  env                     = local.env
+  resource_group_location = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  subnet_webapp_id        = data.terraform_remote_state.persistent_training.outputs.subnet_webapp_id
+  subnet_lb_id            = data.terraform_remote_state.persistent_training.outputs.subnet_lbs_id
+  subnet_vm_id            = data.terraform_remote_state.persistent_training.outputs.subnet_vm_id
+  tags                    = local.management_tags
+}


### PR DESCRIPTION
## Related Issue or Background Info

#2855

We need control over the outbound IP addresses being used in order to pass a reasonable list of IPs to third parties to allowlist.

## Changes Proposed

- Create static IP
- Associate IP with NAT gateway
- Associate NAT gateway with VNet subnets for VMs, web apps, and load balancers
- Outbound traffic originating from within the VNet (e.g. the API making an external HTTP request) now originates from the static IP

## Additional Information

- This doesn't affect _all_ app traffic, just traffic that originates from within the VNet. Inbound traffic passing through the App Gateway will still return through the App Gateway, for instance.
- This is difficult to prove since we have to do so by originating outbound traffic from within the VNet - e.g. SSHing into an App Service container, which we can't do. One way you can see this by running a `curl` from within a VM.

## Checklist for Author and Reviewer

### Testing
- [ ] Create a VM in `test` with the following change: on the Networking tab, find the IP Address dropdown. Click "Create new" underneath and select Standard (Basic should be the initial value).
- [ ] Log into that VM and run `curl ipinfo.io`. The returned IP should match the IP assigned to the NAT gateway in `test`.
