### PR TITLE
Pass App insights session ID to backend

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -38,12 +38,12 @@ runs:
       run: |
           echo "::group::Set build variables"
           az config set extension.use_dynamic_install=yes_without_prompt
-          INSIGHTS_KEY=$(
+          INSIGHTS_CONNECTION_STRING=$(
             az monitor app-insights component show \
               -g prime-simple-report-${{inputs.deploy-env}} \
               -a prime-simple-report-${{inputs.deploy-env}}-insights \
-            | jq -r '.instrumentationKey')
-          echo "REACT_APP_APPINSIGHTS_KEY=${INSIGHTS_KEY}" > .env.production.local
+            | jq -r '.connectionString')
+          echo "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING=${INSIGHTS_CONNECTION_STRING}" > .env.production.local
           if [[ -n "${{ inputs.base-domain-name }}" ]]
             then echo "REACT_APP_BASE_URL=https://${{inputs.base-domain-name}}" >> .env.production.local
           fi

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -6,7 +6,7 @@ COPY --chown=gradle:gradle backend/gradle ./gradle
 COPY --chown=gradle:gradle backend/*.gradle ./
 
 # Download the application insights JAR
-RUN wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.0.0/applicationinsights-agent-3.0.0.jar -O insights.jar
+RUN wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.2.2/applicationinsights-agent-3.2.2.jar -O insights.jar
 
 # nice optimization opportunity: get the dependencies cached in an intermediate
 # docker layer (have to tickle gradle, may not be worth it)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTelemetryConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTelemetryConfiguration.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.config;
 
 import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -12,6 +13,11 @@ public class AzureTelemetryConfiguration {
   @Bean
   @Scope("singleton")
   TelemetryClient getTelemetryClient() {
-    return new TelemetryClient();
+    TelemetryConfiguration config = TelemetryConfiguration.createDefault();
+    String connectionString = System.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING");
+    if (connectionString != null) {
+      config.setConnectionString(connectionString);
+    }
+    return new TelemetryClient(config);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -60,6 +60,9 @@ public class QueryLoggingInstrumentation extends SimpleInstrumentation {
     // Create a new Azure Telemetry Event
     final RequestTelemetry requestTelemetry = new RequestTelemetry();
     requestTelemetry.setId(executionId);
+    final String frontendAppInsightsSessionId =
+        context.getHttpServletRequest().getHeader("x-ms-session-id");
+    requestTelemetry.getContext().getSession().setId(frontendAppInsightsSessionId);
 
     // Try to get the operation name, if one exists
     final String name = parameters.getExecutionInput().getOperationName();

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,7 @@
             %REACT_APP_CONTENT_SECURITY_POLICY_SCRIPT_SRC%
             style-src 'self' 'unsafe-inline';
             img-src 'self' https://hhs-prime.okta.com data:;
-            connect-src 'self'  https://us-street.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track %REACT_APP_BACKEND_URL%/ ;
+            connect-src 'self'  https://us-street.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track https://*.applicationinsights.azure.com %REACT_APP_BACKEND_URL%/ ;
         ">
         <% } %>
     <meta charset="utf-8" />

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -10,11 +10,12 @@ let appInsights: ApplicationInsights | null = null;
 
 const createTelemetryService = () => {
   const initialize = (browserHistory?: ReturnType<typeof useHistory>) => {
-    const instrumentationKey = process.env.REACT_APP_APPINSIGHTS_KEY;
+    const connectionString =
+      process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING;
 
-    if (!instrumentationKey) {
+    if (!connectionString) {
       if (process.env.NODE_ENV !== "test") {
-        console.warn("Instrumentation key not provided");
+        console.warn("Connection string not provided");
       }
       return;
     }
@@ -23,7 +24,7 @@ const createTelemetryService = () => {
 
     appInsights = new ApplicationInsights({
       config: {
-        instrumentationKey,
+        connectionString,
         extensions: [reactPlugin],
         loggingLevelConsole: process.env.NODE_ENV === "development" ? 2 : 0,
         disableFetchTracking: false,
@@ -105,4 +106,16 @@ export function withInsights(console: Console) {
       });
     };
   });
+}
+
+export function getAppInsightsHeaders(): { [key: string]: string } {
+  // x-ms-session-id is passed explicitly to the backend so we can correlate
+  // backend operations with the frontend ones in App Insights
+  return {
+    "x-ms-session-id": getAppInsightsSessionId(),
+  };
+}
+
+function getAppInsightsSessionId(): string {
+  return appInsights?.context.sessionManager.automaticSession.id ?? "";
 }

--- a/frontend/src/app/accountCreation/AccountCreationApiService.test.ts
+++ b/frontend/src/app/accountCreation/AccountCreationApiService.test.ts
@@ -2,6 +2,10 @@ import { FetchMock } from "jest-fetch-mock/types";
 
 import { AccountCreationApi } from "./AccountCreationApiService";
 
+const appInsightsHeaders = {
+  "x-ms-session-id": "",
+};
+
 describe("AccountCreationApi", () => {
   beforeEach(() => {
     (fetch as FetchMock).resetMocks();
@@ -20,6 +24,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "GET",
         }
@@ -40,6 +45,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -60,6 +66,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -82,6 +89,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -101,6 +109,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -120,6 +129,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -138,6 +148,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -157,6 +168,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -175,6 +187,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -194,6 +207,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -213,6 +227,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -231,6 +246,7 @@ describe("AccountCreationApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }

--- a/frontend/src/app/signUp/SignUpApi.test.ts
+++ b/frontend/src/app/signUp/SignUpApi.test.ts
@@ -2,6 +2,10 @@ import { FetchMock } from "jest-fetch-mock/types";
 
 import { SignUpApi } from "./SignUpApi";
 
+const appInsightsHeaders = {
+  "x-ms-session-id": "",
+};
+
 describe("SignUpApi", () => {
   beforeEach(() => {
     (fetch as FetchMock).resetMocks();
@@ -32,6 +36,7 @@ describe("SignUpApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -56,6 +61,7 @@ describe("SignUpApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }
@@ -85,6 +91,7 @@ describe("SignUpApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
         }

--- a/frontend/src/app/telemetry.test.tsx
+++ b/frontend/src/app/telemetry.test.tsx
@@ -19,7 +19,7 @@ jest.mock("@microsoft/applicationinsights-web", () => {
   };
 });
 
-const oldEnv = process.env.REACT_APP_APPINSIGHTS_KEY;
+const oldEnv = process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING;
 
 describe("telemetry", () => {
   beforeEach(() => {
@@ -30,17 +30,19 @@ describe("telemetry", () => {
   });
   afterEach(() => {
     jest.resetAllMocks();
-    process.env.REACT_APP_APPINSIGHTS_KEY = oldEnv;
+    process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING = oldEnv;
   });
 
   it("initializes the appInsights service", () => {
-    process.env.REACT_APP_APPINSIGHTS_KEY = "fake-key";
+    process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+      "fake-connection-string";
     ai.initialize();
     expect(getAppInsights()).not.toBe(null);
   });
 
   it("calls app insights on console methods", () => {
-    process.env.REACT_APP_APPINSIGHTS_KEY = "fake-key";
+    process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+      "fake-connection-string";
     const appInsights = getAppInsights();
     withInsights(console);
     const message = "hello there";

--- a/frontend/src/app/utils/api.ts
+++ b/frontend/src/app/utils/api.ts
@@ -1,3 +1,5 @@
+import { getAppInsightsHeaders } from "../TelemetryService";
+
 interface JsonObject {
   [key: string]: any;
 }
@@ -6,10 +8,12 @@ type RequestMethod = "GET" | "POST";
 
 const JSON_CONTENT = "application/json";
 const TEXT_CONTENT = "text/plain";
-export const headers = {
+const baseHeaders = {
   "Content-Type": JSON_CONTENT,
   Accept: [JSON_CONTENT, TEXT_CONTENT].join(", "),
 };
+const instrumentationHeaders = getAppInsightsHeaders();
+export const headers = { ...baseHeaders, ...instrumentationHeaders };
 
 /**
  * Helper function to handle paths with or with out leading slash

--- a/frontend/src/patientApp/PxpApiService.test.ts
+++ b/frontend/src/patientApp/PxpApiService.test.ts
@@ -2,6 +2,10 @@ import { FetchMock } from "jest-fetch-mock/types";
 
 import { PxpApi, SelfRegistrationData } from "./PxpApiService";
 
+const appInsightsHeaders = {
+  "x-ms-session-id": "",
+};
+
 describe("PxpApi", () => {
   beforeEach(() => {
     (fetch as FetchMock).resetMocks();
@@ -24,6 +28,7 @@ describe("PxpApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
           mode: "cors",
@@ -50,6 +55,7 @@ describe("PxpApi", () => {
           headers: {
             Accept: "application/json, text/plain",
             "Content-Type": "application/json",
+            ...appInsightsHeaders,
           },
           method: "POST",
           mode: "cors",
@@ -74,6 +80,7 @@ describe("PxpApi", () => {
         headers: {
           Accept: "application/json, text/plain",
           "Content-Type": "application/json",
+          ...appInsightsHeaders,
         },
         method: "POST",
         mode: "cors",
@@ -108,6 +115,7 @@ describe("PxpApi", () => {
         headers: {
           Accept: "application/json, text/plain",
           "Content-Type": "application/json",
+          ...appInsightsHeaders,
         },
         method: "POST",
         mode: "cors",

--- a/ops/services/monitoring/main.tf
+++ b/ops/services/monitoring/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_application_insights" "app_insights" {
   location            = var.rg_location
   resource_group_name = var.rg_name
   name                = "prime-simple-report-${var.env}-insights"
+  disable_ip_masking  = true
 
   tags = var.tags
 }


### PR DESCRIPTION
## Related Issue or Background Info

#2786 

## Changes Proposed

* Update Java AI agent to 3.2.2 (fixes a bug where our old 3.0.0 agent ignored some 2.6.3 SDK settings, such as session ID)
* Frontend: Add new `x-ms-session-id header` to `api.ts` and Apollo client in `index.tsx`
* Backend: Use `x-ms-session-id` header from frontend requests to override `RequestTelemetry`'s
  session ID
* Both: pass full connection string to AI client to ensure default ingestion endpoint is overridden
* Azure: disable IP address masking

By passing the session ID as a header to the backend, the backend can extract the session ID from the request header, and override the session ID in the tracked request. This enables us to 1) better link frontend events to backend ones and 2) determine when a series of errors or requests is coming from the same session (which is a good non-PII proxy for same person).

## Additional Information

- This approach is extendable to additional headers (e.g., collecting IP addresses is approved).
- Custom dimensions now work correctly in the backend.

## Screenshots / Demos

## Checklist for Author and Reviewer

### Testing
- [ ] Deploy this branch to test and perform an action in `/admin` (such as editing a facility). Wait a few minutes and look for the corresponding `/graphql` request in App Insights logs. You should see a corresponding backend action (like `AdminSetOrganization`) that has a populated session ID field. That session ID should match the session ID sent by the browser (you can verify this in your browser's dev tools).
