### PR TITLE
Revert "start using organization queue (#2859)"

### DIFF
--- a/frontend/src/app/signUp/SignUpApi.test.ts
+++ b/frontend/src/app/signUp/SignUpApi.test.ts
@@ -78,7 +78,7 @@ describe("SignUpApi", () => {
     });
     it("calls fetch with the correct data", () => {
       expect(fetch).toHaveBeenCalledWith(
-        "http://localhost:8080/account-request/organization-add-to-queue",
+        "http://localhost:8080/account-request/organization-create-without-facility",
         {
           body:
             '{"firstName":"Laslo","lastName":"Dickens","email":"laslo@shadow.corp","name":"Shadow","type":"treatment_center","state":"NY","workPhoneNumber":"665-452-5484"}',

--- a/frontend/src/app/signUp/SignUpApi.ts
+++ b/frontend/src/app/signUp/SignUpApi.ts
@@ -22,6 +22,9 @@ export class SignUpApi {
   static createOrganization(
     request: OrganizationCreateRequest
   ): Promise<OrganizationCreateResponse> {
-    return api.request("/account-request/organization-add-to-queue", request);
+    return api.request(
+      "/account-request/organization-create-without-facility",
+      request
+    );
   }
 }


### PR DESCRIPTION
This reverts commit 4571f3fec5bdb0ca4414b18c4eb6c42677b7fb2a.

## Related Issue or Background Info

- get-questions is not looking for orgs in the queue table, which causes all id verifications to fail due to not finding the organization that is working on id verification.

## Changes Proposed

- swap back to old organization creation endpoint

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
