### PR TITLE
Support multiple patient email addresses - DB [1/3]

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3230,3 +3230,26 @@ databaseChangeLog:
                   p.test_result_delivery_preference
                 FROM ${database.defaultSchemaName}.person p;
               GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
+  - changeSet:
+      id: add-emails-to-patient
+      author: nathan@skylight.digital
+      comment: add emails column to person table to allow multiple patient emails
+      changes:
+        - tagDatabase:
+            tag: add-emails-to-patient
+        - addColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: emails
+                  type: text[]
+                  afterColumn: email
+                  remarks: All patient email addresses
+        - sql:
+            remarks: Populate new `emails` column with value from patient `email`
+            sql: |
+              UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+      rollback:
+        - dropColumn:
+            tableName: person
+            columnName: emails


### PR DESCRIPTION
## Related Issue or Background Info
* Part 1 of 3 of #1951 

## Changes Proposed
* Adds an `emails` text array column to the `person` table and populates this column with the existing patient email address, if one exists.

## Additional Information
- @zdeveloper and I chatted on approach for a bit. While the very similar #1532 opted for a new join table to hold additional patient info, here we have selected a more simple on-table approach
    - Given that we don't expect to do much (if any) indexing, searching, or statistics on patient email addresses, this is likely to be simpler and more effective
- The existing `email` column will be used to hold the _default_ patient email - again, in parallel with the approach for multiple phone numbers

## Screenshots / Demos
* Before
<img width="463" alt="Screen Shot 2021-11-02 at 12 08 33 PM" src="https://user-images.githubusercontent.com/27730981/139906337-da4af323-69a2-4a4d-8cb0-2b8a428964ae.png">

* Migration ran successfully:
<img width="898" alt="Screen Shot 2021-11-02 at 12 09 17 PM" src="https://user-images.githubusercontent.com/27730981/139906341-b804504f-31d2-42b1-93fd-d3173af71452.png">

* New column appears as expected
<img width="400" alt="Screen Shot 2021-11-02 at 12 08 44 PM" src="https://user-images.githubusercontent.com/27730981/139906340-a4c66053-2523-4b5d-81e3-c6ed436293d6.png">

* Can roll back migration without issue
<img width="898" alt="Screen Shot 2021-11-02 at 12 08 01 PM" src="https://user-images.githubusercontent.com/27730981/139906329-0d0a0ac7-4c57-4fbd-99d8-840769aa0da0.png">


## Checklist for Author and Reviewer
- [ ] Speak now or forever hold your peace! If we would like to represent multiple emails in any other way in the data model, now's the time

### UI
- [x] ~Any changes to the UI/UX are approved by design~
- [x] ~Any new or updated content (e.g. error messages) are approved by design~

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] ~Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user~
  - [x] ~Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)~
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] ~GraphQL schema changes are backward compatible with older version of the front-end~

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
