### PR TITLE
Add availability tests for prod URL redirects

### DIFF
--- a/ops/prod/alerts.tf
+++ b/ops/prod/alerts.tf
@@ -8,6 +8,14 @@ module "metric_alerts" {
   rg_name             = data.azurerm_resource_group.rg.name
   tags                = local.management_tags
 
+  // Add additional tests for the following special case redirects:
+  // simplereport.gov     -> www.simplereport.gov
+  // simplereport.cdc.gov -> www.simplereport.gov
+  additional_uptime_test_urls = {
+    "${local.env}-simplereport-gov-www-redirect" = "https://simplereport.gov/",
+    "${local.env}-simplereport-gov-cdc-redirect" = "https://simplereport.cdc.gov/",
+  }
+
   mem_threshold = 80
 
   action_group_ids = [

--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -1,8 +1,7 @@
-# Production has three special App Gateways that perform global redirects instead of routing
-# to apps: simplereport-gateway and simplereport-internal-gw
+# Production has two special App Gateways that perform global redirects instead of routing
+# to apps: simplereport-gateway and simple-report-www-redirect
 #
 # simplereport-gateway:       redirects simplereport.cdc.gov -> www.simplereport.gov (TODO)
-# simplereport-internal-gw:   redirects simplereport.org     -> www.simplereport.gov (TODO)
 # simple-report-www-redirect: redirects simplereport.gov     -> www.simplereport.gov
 #
 # TODO = extant but not yet managed by Terraform

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -73,3 +73,10 @@ variable "failed_http_2xx_threshold" {
 variable "skip_on_weekends" {
   default = false
 }
+
+// Additional URLs to monitor via App Insights availability tests
+// Format: map of { test name = URL } pairs
+variable "additional_uptime_test_urls" {
+  type    = map(string)
+  default = {}
+}

--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -9,11 +9,14 @@ locals {
 
   url_prefix = var.env == "prod" ? "www" : var.env
 
-  url_map = {
-    "${var.env}-simplereport-gov"     = "https://${local.url_prefix}.simplereport.gov/",
-    "${var.env}-simplereport-gov-api" = "https://${local.url_prefix}.simplereport.gov/api/actuator/health",
-    "${var.env}-simplereport-gov-app" = "https://${local.url_prefix}.simplereport.gov/app/health/ping"
-  }
+  url_map = merge(
+    {
+      "${var.env}-simplereport-gov"     = "https://${local.url_prefix}.simplereport.gov/",
+      "${var.env}-simplereport-gov-api" = "https://${local.url_prefix}.simplereport.gov/api/actuator/health",
+      "${var.env}-simplereport-gov-app" = "https://${local.url_prefix}.simplereport.gov/app/health/ping"
+    },
+    var.additional_uptime_test_urls
+  )
 }
 
 resource "azurerm_application_insights_web_test" "uptime" {


### PR DESCRIPTION
## Related Issue or Background Info

#2806

Postportem issue. We need an alert on our special prod redirects: simplereport.gov, simplereport.cdc.gov -> www.simplereport.gov

## Changes Proposed

- Extend TF code for App Insights availability tests to support custom additional test URLs
- Using the new code, add tests and alerts for simplereport.gov and simplereport.cdc.gov
- Remove TF references to simplereport.org

### Testing
- [ ] `terraform plan` in `ops/prod` should show 4 resources to be created - two tests and two alerts.
