### PR TITLE
[WIP][2775] Add ability to text patient covid results

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/SmsService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/SmsService.java
@@ -46,7 +46,6 @@ public class SmsService {
     log.debug("SmsService will send from {}", rawFromNumber);
   }
 
-  // @AuthorizationConfiguration.RequirePermissionStartTestWithPatientLink
   @Transactional(noRollbackFor = {TwilioException.class, ApiException.class})
   public List<SmsAPICallResult> sendToPatientLink(UUID patientLinkId, String text) {
     PatientLink pl = pls.getRefreshedPatientLink(patientLinkId);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/SmsService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/SmsService.java
@@ -46,7 +46,7 @@ public class SmsService {
     log.debug("SmsService will send from {}", rawFromNumber);
   }
 
-  @AuthorizationConfiguration.RequirePermissionStartTestWithPatientLink
+  // @AuthorizationConfiguration.RequirePermissionStartTestWithPatientLink
   @Transactional(noRollbackFor = {TwilioException.class, ApiException.class})
   public List<SmsAPICallResult> sendToPatientLink(UUID patientLinkId, String text) {
     PatientLink pl = pls.getRefreshedPatientLink(patientLinkId);

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -516,7 +516,7 @@ type Mutation {
     noSymptoms: Boolean
     testResultDelivery: TestResultDeliveryPreference
   ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
-  sendPatientLinkSms(internalId: String!): String
+  sendPatientLinkSms(internalId: ID!): String
     @requiredPermissions(allOf: ["UPDATE_TEST"])
   updateOrganization(type: String!): String
     @requiredPermissions(allOf: ["EDIT_ORGANIZATION"])

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -1,0 +1,265 @@
+import { gql } from "@apollo/client";
+import Modal from "react-modal";
+import moment from "moment";
+import classnames from "classnames";
+import iconClose from "uswds/dist/img/usa-icons/close.svg";
+
+import "./TestResultPrintModal.scss";
+import { QueryWrapper } from "../commonComponents/QueryWrapper";
+import { TestResult } from "../testQueue/QueueItem";
+import { formatFullName } from "../utils/user";
+import { symptomsStringToArray } from "../utils/symptoms";
+import {
+  PregnancyCode,
+  pregnancyMap,
+} from "../../patientApp/timeOfTest/constants";
+
+type Result = {
+  dateTested: string;
+  result: TestResult;
+  correctionStatus: TestCorrectionStatus;
+  noSymptoms: boolean;
+  symptoms: string;
+  symptomOnset: string;
+  pregnancy: PregnancyCode;
+  deviceType: {
+    name: string;
+  };
+  patient: {
+    firstName: string;
+    middleName: string;
+    lastName: string;
+    birthDate: string;
+  };
+  createdBy: {
+    name: {
+      firstName: string;
+      middleName: string;
+      lastName: string;
+    };
+  };
+};
+
+const formatDate = (date: string | undefined, withTime?: boolean) => {
+  const dateFormat = "MM/DD/yyyy";
+  const timeFormat = "h:mma";
+  const format = withTime ? `${dateFormat} ${timeFormat}` : dateFormat;
+  return moment(date)?.format(format);
+};
+
+export const testResultDetailsQuery = gql`
+  query getTestResultDetails($id: ID!) {
+    testResult(id: $id) {
+      dateTested
+      result
+      correctionStatus
+      symptoms
+      symptomOnset
+      pregnancy
+      deviceType {
+        name
+      }
+      patient {
+        firstName
+        middleName
+        lastName
+        birthDate
+      }
+      createdBy {
+        name {
+          firstName
+          middleName
+          lastName
+        }
+      }
+    }
+  }
+`;
+
+const labelClasses = "text-bold text-no-strike text-ink";
+const containerClasses =
+  "width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1";
+const strikeClasses = "text-base text-strike";
+
+interface Props {
+  data: { testResult: Nullable<Result> };
+  testResultId: string;
+  closeModal: () => void;
+}
+
+export const DetachedTestResultDetailsModal = ({ data, closeModal }: Props) => {
+  const {
+    dateTested,
+    result,
+    correctionStatus,
+    symptoms,
+    symptomOnset,
+    pregnancy,
+    deviceType,
+    patient,
+    createdBy,
+  } = { ...data?.testResult };
+
+  const removed = correctionStatus === "REMOVED";
+  const symptomList = symptoms ? symptomsStringToArray(symptoms) : [];
+
+  return (
+    <Modal
+      isOpen={true}
+      style={{
+        content: {
+          maxHeight: "90vh",
+          width: "50em",
+          position: "initial",
+        },
+      }}
+      overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
+      contentLabel="Unsaved changes to current user"
+      ariaHideApp={process.env.NODE_ENV !== "test"}
+    >
+      <div className="display-flex flex-justify">
+        <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
+          Text Results?
+        </h1>
+        <div className="sr-time-of-test-buttons">
+          <button
+            className="modal__close-button"
+            style={{ cursor: "pointer" }}
+            onClick={closeModal}
+          >
+            <img className="modal__close-img" src={iconClose} alt="Close" />
+          </button>
+        </div>
+      </div>
+      <div className="border-top border-base-lighter margin-x-neg-205 margin-top-1"></div>
+      <h2 className="font-sans-md margin-top-3">Patient</h2>
+      <div
+        className={classnames(containerClasses, "grid-row flex-row padding-0")}
+      >
+        <div className="grid-col padding-2 border-right-1px border-base-lighter">
+          <span
+            className={classnames(
+              labelClasses,
+              "display-block margin-bottom-1"
+            )}
+          >
+            Name
+          </span>
+          <span
+            className={classnames("font-sans-lg", removed && strikeClasses)}
+          >
+            {patient ? formatFullName(patient) : "--"}
+          </span>
+        </div>
+        <div className="grid-col padding-2">
+          <span
+            className={classnames(
+              labelClasses,
+              "display-block margin-bottom-1"
+            )}
+          >
+            Date of birth
+          </span>
+          <span
+            className={classnames("font-sans-lg", removed && strikeClasses)}
+          >
+            {patient?.birthDate ? formatDate(patient.birthDate) : "--"}
+          </span>
+        </div>
+      </div>
+      <h2 className="font-sans-md margin-top-3">Test details</h2>
+      <table className={containerClasses}>
+        <tbody>
+          <DetailsRow
+            label="SARS-CoV-2 result"
+            value={result}
+            removed={removed}
+          />
+          <DetailsRow
+            label="Test date"
+            value={dateTested && formatDate(dateTested, true)}
+            removed={removed}
+          />
+          <DetailsRow
+            label="Device"
+            value={deviceType && deviceType.name}
+            removed={removed}
+          />
+          <DetailsRow
+            label="Symptoms"
+            value={
+              symptomList.length > 0 ? symptomList.join(", ") : "No symptoms"
+            }
+            removed={removed}
+          />
+          <DetailsRow
+            label="Symptom onset"
+            value={symptomOnset && formatDate(symptomOnset)}
+            indent
+            removed={removed}
+          />
+          <DetailsRow
+            label="Pregnant?"
+            value={pregnancy && pregnancyMap[pregnancy]}
+            removed={removed}
+          />
+          <DetailsRow
+            label="Submitted by"
+            value={createdBy?.name && formatFullName(createdBy.name)}
+            removed={removed}
+            last
+          />
+        </tbody>
+      </table>
+    </Modal>
+  );
+};
+
+const TestResultDetailsModal = (props: Omit<Props, "data">) => (
+  <QueryWrapper<Props>
+    query={testResultDetailsQuery}
+    queryOptions={{ variables: { id: props.testResultId } }}
+    Component={DetachedTestResultDetailsModal}
+    componentProps={{ ...props }}
+    displayLoadingIndicator={false}
+  />
+);
+
+export default TestResultDetailsModal;
+
+type StringOrFalsey = string | null | undefined | false;
+
+const DetailsRow = ({
+  label,
+  value,
+  indent,
+  last,
+  removed,
+}: {
+  label: string;
+  value: StringOrFalsey;
+  indent?: boolean;
+  last?: boolean;
+  removed?: boolean;
+}) => {
+  const tdClasses = classnames(
+    "padding-y-3",
+    !last && "border-bottom-1px border-base-lighter"
+  );
+
+  const labelColumnClasses = classnames(
+    labelClasses,
+    tdClasses,
+    "width-card-lg text-left",
+    indent && "font-sans-sm padding-left-2"
+  );
+
+  return (
+    <tr>
+      <th className={labelColumnClasses}>{label}</th>
+      <td className={classnames(tdClasses, removed && strikeClasses)}>
+        {value || "--"}
+      </td>
+    </tr>
+  );
+};

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
 import moment from "moment";
@@ -13,7 +12,7 @@ import {
   QueryWrapper,
 } from "../commonComponents/QueryWrapper";
 import Alert from "../commonComponents/Alert";
-import { phoneNumberIsValid } from "../patients/personSchema";
+
 
 export const testQuery = gql`
   query getTestResultForText($id: ID!) {

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -4,6 +4,7 @@ import Modal from "react-modal";
 
 import Button from "../commonComponents/Button/Button";
 import { displayFullName, showNotification } from "../utils";
+import { formatFullName } from "../utils/user";
 import "./TestResultCorrectionModal.scss";
 import {
   InjectedQueryWrapperProps,
@@ -12,14 +13,9 @@ import {
 import Alert from "../commonComponents/Alert";
 
 export const testQuery = gql`
-  query getTestResultForCorrection($id: ID!) {
+  query getTestResultForText($id: ID!) {
     testResult(id: $id) {
       dateTested
-      result
-      correctionStatus
-      deviceType {
-        name
-      }
       patient {
         firstName
         middleName
@@ -77,22 +73,18 @@ export const DetachedTestResultCorrectionModal = ({
       overlayClassName="sr-test-correction-modal-overlay"
       contentLabel="Printable test result"
     >
-      <h3>Text Result?</h3>
+      <h3>Text Results?</h3>
       <p>
         {" "}
-        {displayFullName(
-          patient.firstName,
-          patient.middleName,
-          patient.lastName
+        {formatFullName(
+          patient
         )}{" "}
-        from July 21st will be sent to the following numbers:
+        test result from July 21st will be sent to the following numbers:
       </p>
-      as an error?
-      <p>If so, please enter a reason.</p>
       <div className="sr-test-correction-buttons">
         <Button variant="unstyled" label="Cancel" onClick={closeModal} />
         <Button
-          label="Send Result"
+          label="Send results"
           onClick={markAsError}
         />
       </div>

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -60,14 +60,15 @@ interface Props {
 }
 
 const mobilePhoneNumbers = (phoneArray: patientPhoneDetails[]) => {
-    let mobileNumbers: number[] = []
+    let mobileNumbers: any = []
     phoneArray.forEach(patientPhone => {
         if (patientPhone.type === "MOBILE") {
-            mobileNumbers.push(patientPhone.number)
+            mobileNumbers.push(<tr>{patientPhone.number}</tr>);
         }
     });
-    return mobileNumbers
+ return mobileNumbers;
 };
+
 
 
 export const DetachedTestResultCorrectionModal = ({
@@ -106,18 +107,13 @@ export const DetachedTestResultCorrectionModal = ({
       <h3>Text Results?</h3>
       <p>
         {" "}
-        {formatFullName(
-          patient
-        )}{" "}
-        testresults from {formatDate(dateTested)} will be sent to the following numbers:
-        {mobilePhoneNumbers(patient.phoneNumbers)}
+        {formatFullName(patient)} testresults from {formatDate(dateTested)} will
+        be sent to the following numbers:
+        <table>{mobilePhoneNumbers(patient.phoneNumbers)}</table>
       </p>
       <div className="sr-test-correction-buttons">
         <Button variant="unstyled" label="Cancel" onClick={closeModal} />
-        <Button
-          label="Send results"
-          onClick={markAsError}
-        />
+        <Button label="Send results" onClick={markAsError} />
       </div>
     </Modal>
   );
@@ -136,7 +132,4 @@ const TestResultCorrectionModal = (
 
 export default TestResultCorrectionModal;
 
-function patientPhone(patientPhone: patientPhoneDetails) {
-    throw new Error("Function not implemented.");
-}
 

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -13,6 +13,7 @@ import {
   QueryWrapper,
 } from "../commonComponents/QueryWrapper";
 import Alert from "../commonComponents/Alert";
+import { phoneNumberIsValid } from "../patients/personSchema";
 
 export const testQuery = gql`
   query getTestResultForText($id: ID!) {
@@ -23,16 +24,26 @@ export const testQuery = gql`
         middleName
         lastName
         birthDate
+        phoneNumbers {
+            type
+            number
+        }
       }
     }
   }
 `;
+interface patientPhoneDetails {
+    type: string
+    number: number
 
+}
 const formatDate = (date: string | undefined, withTime?: boolean) => {
   const dateFormat = "MMMM Do, YYYY";
   const format = withTime ? `${dateFormat}` : dateFormat;
   return moment(date)?.format(format);
 };
+
+
 
 const MARK_TEST_AS_ERROR = gql`
   mutation MarkTestAsError($id: ID!, $reason: String!) {
@@ -48,6 +59,17 @@ interface Props {
   closeModal: () => void;
 }
 
+const mobilePhoneNumbers = (phoneArray: patientPhoneDetails[]) => {
+    let mobileNumbers: number[] = []
+    phoneArray.forEach(patientPhone => {
+        if (patientPhone.type === "MOBILE") {
+            mobileNumbers.push(patientPhone.number)
+        }
+    });
+    return mobileNumbers
+};
+
+
 export const DetachedTestResultCorrectionModal = ({
   testResultId,
   data,
@@ -55,6 +77,7 @@ export const DetachedTestResultCorrectionModal = ({
 }: Props) => {
   const [markTestAsError] = useMutation(MARK_TEST_AS_ERROR);
   const { patient } = data.testResult;
+  console.log(patient,"HERE IT IS")
   const { dateTested } = data.testResult
   const markAsError = () => {
     markTestAsError({
@@ -86,12 +109,9 @@ export const DetachedTestResultCorrectionModal = ({
         {formatFullName(
           patient
         )}{" "}
-        test results from {formatDate(dateTested)} will be sent to the following numbers:
+        testresults from {formatDate(dateTested)} will be sent to the following numbers:
+        {mobilePhoneNumbers(patient.phoneNumbers)}
       </p>
-      <p>
-        
-      </p>
-
       <div className="sr-test-correction-buttons">
         <Button variant="unstyled" label="Cancel" onClick={closeModal} />
         <Button
@@ -115,3 +135,8 @@ const TestResultCorrectionModal = (
 );
 
 export default TestResultCorrectionModal;
+
+function patientPhone(patientPhone: patientPhoneDetails) {
+    throw new Error("Function not implemented.");
+}
+

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
+import moment from "moment";
+
 
 import Button from "../commonComponents/Button/Button";
-import { displayFullName, showNotification } from "../utils";
+import { showNotification } from "../utils";
 import { formatFullName } from "../utils/user";
 import "./TestResultCorrectionModal.scss";
 import {
@@ -26,6 +28,12 @@ export const testQuery = gql`
   }
 `;
 
+const formatDate = (date: string | undefined, withTime?: boolean) => {
+  const dateFormat = "MMMM Do, YYYY";
+  const format = withTime ? `${dateFormat}` : dateFormat;
+  return moment(date)?.format(format);
+};
+
 const MARK_TEST_AS_ERROR = gql`
   mutation MarkTestAsError($id: ID!, $reason: String!) {
     correctTestMarkAsError(id: $id, reason: $reason) {
@@ -47,12 +55,11 @@ export const DetachedTestResultCorrectionModal = ({
 }: Props) => {
   const [markTestAsError] = useMutation(MARK_TEST_AS_ERROR);
   const { patient } = data.testResult;
-  const [reason, setReason] = useState("");
+  const { dateTested } = data.testResult
   const markAsError = () => {
     markTestAsError({
       variables: {
         id: testResultId,
-        reason,
       },
     })
       .then(() => {
@@ -79,8 +86,12 @@ export const DetachedTestResultCorrectionModal = ({
         {formatFullName(
           patient
         )}{" "}
-        test result from July 21st will be sent to the following numbers:
+        test results from {formatDate(dateTested)} will be sent to the following numbers:
       </p>
+      <p>
+        
+      </p>
+
       <div className="sr-test-correction-buttons">
         <Button variant="unstyled" label="Cancel" onClick={closeModal} />
         <Button

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -1,8 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
 import moment from "moment";
-
-
 import Button from "../commonComponents/Button/Button";
 import { showNotification } from "../utils";
 import { formatFullName } from "../utils/user";
@@ -12,7 +10,6 @@ import {
   QueryWrapper,
 } from "../commonComponents/QueryWrapper";
 import Alert from "../commonComponents/Alert";
-
 
 export const testQuery = gql`
   query getTestResultForText($id: ID!) {
@@ -27,30 +24,26 @@ export const testQuery = gql`
         lastName
         birthDate
         phoneNumbers {
-            type
-            number
+          type
+          number
         }
       }
     }
   }
 `;
 interface patientPhoneDetails {
-    type: string
-    number: number
-
+  type: string;
+  number: number;
 }
 const formatDate = (date: string | undefined, withTime?: boolean) => {
   const dateFormat = "MMMM Do, YYYY";
   const format = withTime ? `${dateFormat}` : dateFormat;
-  
   return moment(date)?.format(format);
 };
 
-
-
 const SEND_SMS = gql`
   mutation sendSMS($id: ID!) {
-    sendPatientLinkSms(internalId: $id) 
+    sendPatientLinkSms(internalId: $id)
   }
 `;
 
@@ -61,16 +54,14 @@ interface Props {
 }
 
 const mobilePhoneNumbers = (phoneArray: patientPhoneDetails[]) => {
-    let mobileNumbers: any = []
-    phoneArray.forEach(patientPhone => {
-        if (patientPhone.type === "MOBILE") {
-            mobileNumbers.push(<tr>{patientPhone.number}</tr>);
-        }
-    });
- return mobileNumbers;
+  let mobileNumbers: any = [];
+  phoneArray.forEach((patientPhone) => {
+    if (patientPhone.type === "MOBILE") {
+      mobileNumbers.push(<tr>{patientPhone.number}</tr>);
+    }
+  });
+  return mobileNumbers;
 };
-
-
 
 export const DetachedTestResultCorrectionModal = ({
   data,
@@ -78,8 +69,8 @@ export const DetachedTestResultCorrectionModal = ({
 }: Props) => {
   const [sendSMS] = useMutation(SEND_SMS);
   const { patient } = data.testResult;
-  const  patientLink  = data.testResult.patientLink.internalId
-  const { dateTested } = data.testResult
+  const patientLink = data.testResult.patientLink.internalId;
+  const { dateTested } = data.testResult;
   const resendSMS = () => {
     sendSMS({
       variables: {
@@ -131,5 +122,3 @@ const TestResultCorrectionModal = (
 );
 
 export default TestResultCorrectionModal;
-
-

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -90,13 +90,12 @@ function testResultRows(
     const actionItems = [
       { name: "Print result", action: () => setPrintModalId(r.internalId) },
       { name: "Text result", action: () => setTextModalId(r.internalId) },
-      
+
       {
         name: "View details",
 
         action: () => setDetailsModalId(r.internalId),
       },
-      
     ];
     if (!removed) {
       actionItems.push({

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -43,6 +43,7 @@ import Select from "../commonComponents/Select";
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 import TestResultPrintModal from "./TestResultPrintModal";
+import TestResultTextModal from "./TestResultTextModal";
 import TestResultCorrectionModal from "./TestResultCorrectionModal";
 import TestResultDetailsModal from "./TestResultDetailsModal";
 
@@ -65,7 +66,8 @@ function testResultRows(
   testResults: any,
   setPrintModalId: SetStateAction<any>,
   setMarkErrorId: SetStateAction<any>,
-  setDetailsModalId: SetStateAction<any>
+  setDetailsModalId: SetStateAction<any>,
+  setTextModalId: SetStateAction<any>
 ) {
   const byDateTested = (a: any, b: any) => {
     // ISO string dates sort nicely
@@ -87,10 +89,14 @@ function testResultRows(
     const removed = r.correctionStatus === "REMOVED";
     const actionItems = [
       { name: "Print result", action: () => setPrintModalId(r.internalId) },
+      { name: "Text result", action: () => setTextModalId(r.internalId) },
+      
       {
         name: "View details",
+
         action: () => setDetailsModalId(r.internalId),
       },
+      
     ];
     if (!removed) {
       actionItems.push({
@@ -202,6 +208,7 @@ export const DetachedTestResultsList = ({
   const [printModalId, setPrintModalId] = useState(undefined);
   const [markErrorId, setMarkErrorId] = useState(undefined);
   const [detailsModalId, setDetailsModalId] = useState<string>();
+  const [textModalId, setTextModalId] = useState<string>();
   const [showSuggestion, setShowSuggestion] = useState(true);
   const [startDateError, setStartDateError] = useState<string | undefined>();
   const [endDateError, setEndDateError] = useState<string | undefined>();
@@ -279,6 +286,14 @@ export const DetachedTestResultsList = ({
       />
     );
   }
+  if (textModalId) {
+    return (
+      <TestResultTextModal
+        testResultId={textModalId}
+        closeModal={() => setTextModalId(undefined)}
+      />
+    );
+  }
   if (markErrorId) {
     return (
       <TestResultCorrectionModal
@@ -297,7 +312,8 @@ export const DetachedTestResultsList = ({
     testResults,
     setPrintModalId,
     setMarkErrorId,
-    setDetailsModalId
+    setDetailsModalId,
+    setTextModalId
   );
 
   const processStartDate = (value: string | undefined) => {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,15 +1,10 @@
-import { gql } from "@apollo/client";
-import * as Apollo from "@apollo/client";
-
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]: Maybe<T[SubKey]> };
-const defaultOptions = {};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+const defaultOptions =  {}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -23,587 +18,622 @@ export type Scalars = {
 };
 
 export type AddTestResultResponse = {
-  __typename?: "AddTestResultResponse";
-  deliverySuccess?: Maybe<Scalars["Boolean"]>;
+  __typename?: 'AddTestResultResponse';
+  deliverySuccess?: Maybe<Scalars['Boolean']>;
   testResult: TestOrder;
 };
 
 export type AddressInfo = {
-  __typename?: "AddressInfo";
-  city?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  postalCode?: Maybe<Scalars["String"]>;
-  state?: Maybe<Scalars["String"]>;
-  streetOne?: Maybe<Scalars["String"]>;
-  streetTwo?: Maybe<Scalars["String"]>;
+  __typename?: 'AddressInfo';
+  city?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  postalCode?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  streetOne?: Maybe<Scalars['String']>;
+  streetTwo?: Maybe<Scalars['String']>;
 };
 
 export type AggregateFacilityMetrics = {
-  __typename?: "AggregateFacilityMetrics";
-  facilityName?: Maybe<Scalars["String"]>;
-  negativeTestCount?: Maybe<Scalars["Int"]>;
-  positiveTestCount?: Maybe<Scalars["Int"]>;
-  totalTestCount?: Maybe<Scalars["Int"]>;
+  __typename?: 'AggregateFacilityMetrics';
+  facilityName?: Maybe<Scalars['String']>;
+  negativeTestCount?: Maybe<Scalars['Int']>;
+  positiveTestCount?: Maybe<Scalars['Int']>;
+  totalTestCount?: Maybe<Scalars['Int']>;
 };
 
 export type ApiUser = {
-  __typename?: "ApiUser";
-  email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["ID"]>;
-  lastName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
+  __typename?: 'ApiUser';
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
+  lastName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
   name: NameInfo;
   /** @deprecated needless connection of type to field name */
   nameInfo?: Maybe<NameInfo>;
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: Maybe<Scalars['String']>;
 };
 
 export type ApiUserWithStatus = {
-  __typename?: "ApiUserWithStatus";
-  email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
-  lastName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
+  __typename?: 'ApiUserWithStatus';
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  lastName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
   name: NameInfo;
-  status?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
+  status?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
 };
 
 export type DeviceSpecimenType = {
-  __typename?: "DeviceSpecimenType";
+  __typename?: 'DeviceSpecimenType';
   deviceType: DeviceType;
-  internalId: Scalars["ID"];
+  internalId: Scalars['ID'];
   specimenType: SpecimenType;
 };
 
 export type DeviceType = {
-  __typename?: "DeviceType";
-  internalId?: Maybe<Scalars["ID"]>;
-  loincCode?: Maybe<Scalars["String"]>;
-  manufacturer?: Maybe<Scalars["String"]>;
-  model?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
-  swabType?: Maybe<Scalars["String"]>;
-  swabTypes?: Maybe<Scalars["String"]>;
-  testLength?: Maybe<Scalars["Int"]>;
+  __typename?: 'DeviceType';
+  internalId?: Maybe<Scalars['ID']>;
+  loincCode?: Maybe<Scalars['String']>;
+  manufacturer?: Maybe<Scalars['String']>;
+  model?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  swabType?: Maybe<Scalars['String']>;
+  swabTypes?: Maybe<Scalars['String']>;
+  testLength?: Maybe<Scalars['Int']>;
 };
 
 export type Facility = {
-  __typename?: "Facility";
+  __typename?: 'Facility';
   address?: Maybe<AddressInfo>;
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
+  city?: Maybe<Scalars['String']>;
+  cliaNumber?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
   defaultDeviceType?: Maybe<DeviceType>;
   deviceSpecimenTypes?: Maybe<Array<Maybe<DeviceSpecimenType>>>;
   deviceTypes?: Maybe<Array<Maybe<DeviceType>>>;
-  email?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
-  name: Scalars["String"];
+  email?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  name: Scalars['String'];
   orderingProvider?: Maybe<Provider>;
-  patientSelfRegistrationLink?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
-  state?: Maybe<Scalars["String"]>;
-  street?: Maybe<Scalars["String"]>;
-  streetTwo?: Maybe<Scalars["String"]>;
-  zipCode?: Maybe<Scalars["String"]>;
+  patientSelfRegistrationLink?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  street?: Maybe<Scalars['String']>;
+  streetTwo?: Maybe<Scalars['String']>;
+  zipCode?: Maybe<Scalars['String']>;
 };
 
 export type Mutation = {
-  __typename?: "Mutation";
-  addFacility?: Maybe<Scalars["String"]>;
+  __typename?: 'Mutation';
+  addFacility?: Maybe<Scalars['String']>;
   addPatient?: Maybe<Patient>;
-  addPatientToQueue?: Maybe<Scalars["String"]>;
+  addPatientToQueue?: Maybe<Scalars['String']>;
   addTestResult?: Maybe<TestOrder>;
   addTestResultNew?: Maybe<AddTestResultResponse>;
   addUser?: Maybe<User>;
   addUserToCurrentOrg?: Maybe<User>;
-  adminUpdateOrganization?: Maybe<Scalars["String"]>;
+  adminUpdateOrganization?: Maybe<Scalars['String']>;
   correctTestMarkAsError?: Maybe<TestResult>;
   createDeviceType?: Maybe<DeviceType>;
   createDeviceTypeNew?: Maybe<DeviceType>;
-  createFacilityRegistrationLink?: Maybe<Scalars["String"]>;
+  createFacilityRegistrationLink?: Maybe<Scalars['String']>;
   createOrganization?: Maybe<Organization>;
-  createOrganizationRegistrationLink?: Maybe<Scalars["String"]>;
+  createOrganizationRegistrationLink?: Maybe<Scalars['String']>;
   editQueueItem?: Maybe<TestOrder>;
   reactivateUser?: Maybe<User>;
-  removePatientFromQueue?: Maybe<Scalars["String"]>;
+  removePatientFromQueue?: Maybe<Scalars['String']>;
   resendActivationEmail?: Maybe<User>;
-  resendToReportStream?: Maybe<Scalars["Boolean"]>;
+  resendToReportStream?: Maybe<Scalars['Boolean']>;
   resetUserPassword?: Maybe<User>;
-  sendPatientLinkSms?: Maybe<Scalars["String"]>;
+  sendPatientLinkSms?: Maybe<Scalars['String']>;
   setCurrentUserTenantDataAccess?: Maybe<User>;
-  setOrganizationIdentityVerified?: Maybe<Scalars["Boolean"]>;
+  setOrganizationIdentityVerified?: Maybe<Scalars['Boolean']>;
   setPatientIsDeleted?: Maybe<Patient>;
-  setRegistrationLinkIsDeleted?: Maybe<Scalars["String"]>;
+  setRegistrationLinkIsDeleted?: Maybe<Scalars['String']>;
   setUserIsDeleted?: Maybe<User>;
   updateDeviceType?: Maybe<DeviceType>;
-  updateFacility?: Maybe<Scalars["String"]>;
-  updateOrganization?: Maybe<Scalars["String"]>;
+  updateFacility?: Maybe<Scalars['String']>;
+  updateOrganization?: Maybe<Scalars['String']>;
   updatePatient?: Maybe<Patient>;
-  updateRegistrationLink?: Maybe<Scalars["String"]>;
-  updateTimeOfTestQuestions?: Maybe<Scalars["String"]>;
+  updateRegistrationLink?: Maybe<Scalars['String']>;
+  updateTimeOfTestQuestions?: Maybe<Scalars['String']>;
   updateUser?: Maybe<User>;
   updateUserPrivileges?: Maybe<User>;
-  uploadPatients?: Maybe<Scalars["String"]>;
+  uploadPatients?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationAddFacilityArgs = {
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  defaultDevice: Scalars["String"];
-  deviceSpecimenTypes?: Maybe<Array<Maybe<Scalars["ID"]>>>;
-  deviceTypes: Array<Maybe<Scalars["String"]>>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  testingFacilityName: Scalars["String"];
-  zipCode: Scalars["String"];
+  city?: Maybe<Scalars['String']>;
+  cliaNumber?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  defaultDevice: Scalars['String'];
+  deviceSpecimenTypes?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  deviceTypes: Array<Maybe<Scalars['String']>>;
+  email?: Maybe<Scalars['String']>;
+  orderingProviderCity?: Maybe<Scalars['String']>;
+  orderingProviderCounty?: Maybe<Scalars['String']>;
+  orderingProviderFirstName?: Maybe<Scalars['String']>;
+  orderingProviderLastName?: Maybe<Scalars['String']>;
+  orderingProviderMiddleName?: Maybe<Scalars['String']>;
+  orderingProviderNPI?: Maybe<Scalars['String']>;
+  orderingProviderPhone?: Maybe<Scalars['String']>;
+  orderingProviderState?: Maybe<Scalars['String']>;
+  orderingProviderStreet?: Maybe<Scalars['String']>;
+  orderingProviderStreetTwo?: Maybe<Scalars['String']>;
+  orderingProviderSuffix?: Maybe<Scalars['String']>;
+  orderingProviderZipCode?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  testingFacilityName: Scalars['String'];
+  zipCode: Scalars['String'];
 };
+
 
 export type MutationAddPatientArgs = {
-  birthDate: Scalars["LocalDate"];
-  city?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  firstName: Scalars["String"];
-  gender?: Maybe<Scalars["String"]>;
-  lastName: Scalars["String"];
-  lookupId?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  birthDate: Scalars['LocalDate'];
+  city?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  employedInHealthcare?: Maybe<Scalars['Boolean']>;
+  ethnicity?: Maybe<Scalars['String']>;
+  facilityId?: Maybe<Scalars['ID']>;
+  firstName: Scalars['String'];
+  gender?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  lookupId?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
   phoneNumbers?: Maybe<Array<PhoneNumberInput>>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  role?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  telephone?: Maybe<Scalars["String"]>;
+  preferredLanguage?: Maybe<Scalars['String']>;
+  race?: Maybe<Scalars['String']>;
+  residentCongregateSetting?: Maybe<Scalars['Boolean']>;
+  role?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
+  telephone?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
-  zipCode: Scalars["String"];
+  tribalAffiliation?: Maybe<Scalars['String']>;
+  zipCode: Scalars['String'];
 };
+
 
 export type MutationAddPatientToQueueArgs = {
-  facilityId: Scalars["ID"];
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
-  patientId: Scalars["ID"];
-  pregnancy?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  symptoms?: Maybe<Scalars["String"]>;
+  facilityId: Scalars['ID'];
+  noSymptoms?: Maybe<Scalars['Boolean']>;
+  patientId: Scalars['ID'];
+  pregnancy?: Maybe<Scalars['String']>;
+  symptomOnset?: Maybe<Scalars['LocalDate']>;
+  symptoms?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
 };
+
 
 export type MutationAddTestResultArgs = {
-  dateTested?: Maybe<Scalars["DateTime"]>;
-  deviceId: Scalars["String"];
-  patientId: Scalars["ID"];
-  result: Scalars["String"];
+  dateTested?: Maybe<Scalars['DateTime']>;
+  deviceId: Scalars['String'];
+  patientId: Scalars['ID'];
+  result: Scalars['String'];
 };
+
 
 export type MutationAddTestResultNewArgs = {
-  dateTested?: Maybe<Scalars["DateTime"]>;
-  deviceId: Scalars["String"];
-  patientId: Scalars["ID"];
-  result: Scalars["String"];
+  dateTested?: Maybe<Scalars['DateTime']>;
+  deviceId: Scalars['String'];
+  patientId: Scalars['ID'];
+  result: Scalars['String'];
 };
+
 
 export type MutationAddUserArgs = {
-  email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
   name?: Maybe<NameInput>;
-  organizationExternalId: Scalars["String"];
+  organizationExternalId: Scalars['String'];
   role: Role;
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationAddUserToCurrentOrgArgs = {
-  email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
   name?: Maybe<NameInput>;
   role: Role;
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationAdminUpdateOrganizationArgs = {
-  name: Scalars["String"];
-  type: Scalars["String"];
+  name: Scalars['String'];
+  type: Scalars['String'];
 };
+
 
 export type MutationCorrectTestMarkAsErrorArgs = {
-  id: Scalars["ID"];
-  reason?: Maybe<Scalars["String"]>;
+  id: Scalars['ID'];
+  reason?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationCreateDeviceTypeArgs = {
-  loincCode: Scalars["String"];
-  manufacturer: Scalars["String"];
-  model: Scalars["String"];
-  name: Scalars["String"];
-  swabType: Scalars["String"];
+  loincCode: Scalars['String'];
+  manufacturer: Scalars['String'];
+  model: Scalars['String'];
+  name: Scalars['String'];
+  swabType: Scalars['String'];
 };
+
 
 export type MutationCreateDeviceTypeNewArgs = {
-  loincCode: Scalars["String"];
-  manufacturer: Scalars["String"];
-  model: Scalars["String"];
-  name: Scalars["String"];
-  swabTypes: Array<Scalars["ID"]>;
+  loincCode: Scalars['String'];
+  manufacturer: Scalars['String'];
+  model: Scalars['String'];
+  name: Scalars['String'];
+  swabTypes: Array<Scalars['ID']>;
 };
+
 
 export type MutationCreateFacilityRegistrationLinkArgs = {
-  facilityId: Scalars["ID"];
-  link: Scalars["String"];
-  organizationExternalId: Scalars["String"];
+  facilityId: Scalars['ID'];
+  link: Scalars['String'];
+  organizationExternalId: Scalars['String'];
 };
+
 
 export type MutationCreateOrganizationArgs = {
-  adminEmail: Scalars["String"];
-  adminFirstName?: Maybe<Scalars["String"]>;
-  adminLastName?: Maybe<Scalars["String"]>;
-  adminMiddleName?: Maybe<Scalars["String"]>;
+  adminEmail: Scalars['String'];
+  adminFirstName?: Maybe<Scalars['String']>;
+  adminLastName?: Maybe<Scalars['String']>;
+  adminMiddleName?: Maybe<Scalars['String']>;
   adminName?: Maybe<NameInput>;
-  adminSuffix?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  defaultDevice: Scalars["String"];
-  deviceTypes: Array<Maybe<Scalars["String"]>>;
-  email?: Maybe<Scalars["String"]>;
-  externalId: Scalars["String"];
-  name: Scalars["String"];
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
+  adminSuffix?: Maybe<Scalars['String']>;
+  city?: Maybe<Scalars['String']>;
+  cliaNumber?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  defaultDevice: Scalars['String'];
+  deviceTypes: Array<Maybe<Scalars['String']>>;
+  email?: Maybe<Scalars['String']>;
+  externalId: Scalars['String'];
+  name: Scalars['String'];
+  orderingProviderCity?: Maybe<Scalars['String']>;
+  orderingProviderCounty?: Maybe<Scalars['String']>;
+  orderingProviderFirstName?: Maybe<Scalars['String']>;
+  orderingProviderLastName?: Maybe<Scalars['String']>;
+  orderingProviderMiddleName?: Maybe<Scalars['String']>;
+  orderingProviderNPI?: Maybe<Scalars['String']>;
   orderingProviderName?: Maybe<NameInput>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  testingFacilityName: Scalars["String"];
-  type: Scalars["String"];
-  zipCode: Scalars["String"];
+  orderingProviderPhone?: Maybe<Scalars['String']>;
+  orderingProviderState?: Maybe<Scalars['String']>;
+  orderingProviderStreet?: Maybe<Scalars['String']>;
+  orderingProviderStreetTwo?: Maybe<Scalars['String']>;
+  orderingProviderSuffix?: Maybe<Scalars['String']>;
+  orderingProviderZipCode?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  testingFacilityName: Scalars['String'];
+  type: Scalars['String'];
+  zipCode: Scalars['String'];
 };
+
 
 export type MutationCreateOrganizationRegistrationLinkArgs = {
-  link: Scalars["String"];
-  organizationExternalId: Scalars["String"];
+  link: Scalars['String'];
+  organizationExternalId: Scalars['String'];
 };
+
 
 export type MutationEditQueueItemArgs = {
-  dateTested?: Maybe<Scalars["DateTime"]>;
-  deviceId?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
-  result?: Maybe<Scalars["String"]>;
+  dateTested?: Maybe<Scalars['DateTime']>;
+  deviceId?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  result?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationReactivateUserArgs = {
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 };
+
 
 export type MutationRemovePatientFromQueueArgs = {
-  patientId: Scalars["ID"];
+  patientId: Scalars['ID'];
 };
+
 
 export type MutationResendActivationEmailArgs = {
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 };
+
 
 export type MutationResendToReportStreamArgs = {
-  testEventIds: Array<Scalars["ID"]>;
+  testEventIds: Array<Scalars['ID']>;
 };
+
 
 export type MutationResetUserPasswordArgs = {
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 };
+
 
 export type MutationSendPatientLinkSmsArgs = {
-  internalId: Scalars["String"];
+  internalId: Scalars['ID'];
 };
+
 
 export type MutationSetCurrentUserTenantDataAccessArgs = {
-  justification?: Maybe<Scalars["String"]>;
-  organizationExternalId?: Maybe<Scalars["String"]>;
+  justification?: Maybe<Scalars['String']>;
+  organizationExternalId?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationSetOrganizationIdentityVerifiedArgs = {
-  externalId: Scalars["String"];
-  verified: Scalars["Boolean"];
+  externalId: Scalars['String'];
+  verified: Scalars['Boolean'];
 };
+
 
 export type MutationSetPatientIsDeletedArgs = {
-  deleted: Scalars["Boolean"];
-  id: Scalars["ID"];
+  deleted: Scalars['Boolean'];
+  id: Scalars['ID'];
 };
+
 
 export type MutationSetRegistrationLinkIsDeletedArgs = {
-  deleted: Scalars["Boolean"];
-  link?: Maybe<Scalars["String"]>;
+  deleted: Scalars['Boolean'];
+  link?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationSetUserIsDeletedArgs = {
-  deleted: Scalars["Boolean"];
-  id: Scalars["ID"];
+  deleted: Scalars['Boolean'];
+  id: Scalars['ID'];
 };
+
 
 export type MutationUpdateDeviceTypeArgs = {
-  id: Scalars["String"];
-  loincCode?: Maybe<Scalars["String"]>;
-  manufacturer?: Maybe<Scalars["String"]>;
-  model?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
-  swabType?: Maybe<Scalars["String"]>;
+  id: Scalars['String'];
+  loincCode?: Maybe<Scalars['String']>;
+  manufacturer?: Maybe<Scalars['String']>;
+  model?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  swabType?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateFacilityArgs = {
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  defaultDevice: Scalars["String"];
-  deviceSpecimenTypes?: Maybe<Array<Maybe<Scalars["ID"]>>>;
-  deviceTypes: Array<Maybe<Scalars["String"]>>;
-  email?: Maybe<Scalars["String"]>;
-  facilityId: Scalars["ID"];
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  testingFacilityName: Scalars["String"];
-  zipCode: Scalars["String"];
+  city?: Maybe<Scalars['String']>;
+  cliaNumber?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  defaultDevice: Scalars['String'];
+  deviceSpecimenTypes?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  deviceTypes: Array<Maybe<Scalars['String']>>;
+  email?: Maybe<Scalars['String']>;
+  facilityId: Scalars['ID'];
+  orderingProviderCity?: Maybe<Scalars['String']>;
+  orderingProviderCounty?: Maybe<Scalars['String']>;
+  orderingProviderFirstName?: Maybe<Scalars['String']>;
+  orderingProviderLastName?: Maybe<Scalars['String']>;
+  orderingProviderMiddleName?: Maybe<Scalars['String']>;
+  orderingProviderNPI?: Maybe<Scalars['String']>;
+  orderingProviderPhone?: Maybe<Scalars['String']>;
+  orderingProviderState?: Maybe<Scalars['String']>;
+  orderingProviderStreet?: Maybe<Scalars['String']>;
+  orderingProviderStreetTwo?: Maybe<Scalars['String']>;
+  orderingProviderSuffix?: Maybe<Scalars['String']>;
+  orderingProviderZipCode?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  testingFacilityName: Scalars['String'];
+  zipCode: Scalars['String'];
 };
+
 
 export type MutationUpdateOrganizationArgs = {
-  type: Scalars["String"];
+  type: Scalars['String'];
 };
+
 
 export type MutationUpdatePatientArgs = {
-  birthDate: Scalars["LocalDate"];
-  city?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  firstName: Scalars["String"];
-  gender?: Maybe<Scalars["String"]>;
-  lastName: Scalars["String"];
-  lookupId?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  patientId: Scalars["ID"];
+  birthDate: Scalars['LocalDate'];
+  city?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  employedInHealthcare?: Maybe<Scalars['Boolean']>;
+  ethnicity?: Maybe<Scalars['String']>;
+  facilityId?: Maybe<Scalars['ID']>;
+  firstName: Scalars['String'];
+  gender?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  lookupId?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
+  patientId: Scalars['ID'];
   phoneNumbers?: Maybe<Array<PhoneNumberInput>>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  role?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  telephone?: Maybe<Scalars["String"]>;
+  preferredLanguage?: Maybe<Scalars['String']>;
+  race?: Maybe<Scalars['String']>;
+  residentCongregateSetting?: Maybe<Scalars['Boolean']>;
+  role?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
+  telephone?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
-  zipCode: Scalars["String"];
+  tribalAffiliation?: Maybe<Scalars['String']>;
+  zipCode: Scalars['String'];
 };
+
 
 export type MutationUpdateRegistrationLinkArgs = {
-  link: Scalars["String"];
-  newLink: Scalars["String"];
+  link: Scalars['String'];
+  newLink: Scalars['String'];
 };
 
+
 export type MutationUpdateTimeOfTestQuestionsArgs = {
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
-  patientId: Scalars["ID"];
-  pregnancy?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  symptoms?: Maybe<Scalars["String"]>;
+  noSymptoms?: Maybe<Scalars['Boolean']>;
+  patientId: Scalars['ID'];
+  pregnancy?: Maybe<Scalars['String']>;
+  symptomOnset?: Maybe<Scalars['LocalDate']>;
+  symptoms?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
 };
 
+
 export type MutationUpdateUserArgs = {
-  firstName?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  lastName?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
   name?: Maybe<NameInput>;
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: Maybe<Scalars['String']>;
 };
 
+
 export type MutationUpdateUserPrivilegesArgs = {
-  accessAllFacilities: Scalars["Boolean"];
-  facilities?: Maybe<Array<Scalars["ID"]>>;
-  id: Scalars["ID"];
+  accessAllFacilities: Scalars['Boolean'];
+  facilities?: Maybe<Array<Scalars['ID']>>;
+  id: Scalars['ID'];
   role: Role;
 };
 
+
 export type MutationUploadPatientsArgs = {
-  patientList: Scalars["Upload"];
+  patientList: Scalars['Upload'];
 };
 
 export type NameInfo = {
-  __typename?: "NameInfo";
-  firstName?: Maybe<Scalars["String"]>;
-  lastName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
+  __typename?: 'NameInfo';
+  firstName?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
 };
 
 export type NameInput = {
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
 };
 
 export type Organization = {
-  __typename?: "Organization";
-  externalId: Scalars["String"];
+  __typename?: 'Organization';
+  externalId: Scalars['String'];
   facilities: Array<Facility>;
-  id: Scalars["ID"];
-  identityVerified: Scalars["Boolean"];
+  id: Scalars['ID'];
+  identityVerified: Scalars['Boolean'];
   /** @deprecated alias for 'id' */
-  internalId: Scalars["ID"];
-  name: Scalars["String"];
-  patientSelfRegistrationLink?: Maybe<Scalars["String"]>;
+  internalId: Scalars['ID'];
+  name: Scalars['String'];
+  patientSelfRegistrationLink?: Maybe<Scalars['String']>;
   /** @deprecated Use the one that makes sense */
   testingFacility: Array<Facility>;
-  type: Scalars["String"];
+  type: Scalars['String'];
 };
 
 export type OrganizationLevelDashboardMetrics = {
-  __typename?: "OrganizationLevelDashboardMetrics";
+  __typename?: 'OrganizationLevelDashboardMetrics';
   facilityMetrics?: Maybe<Array<Maybe<AggregateFacilityMetrics>>>;
-  organizationNegativeTestCount?: Maybe<Scalars["Int"]>;
-  organizationPositiveTestCount?: Maybe<Scalars["Int"]>;
-  organizationTotalTestCount?: Maybe<Scalars["Int"]>;
+  organizationNegativeTestCount?: Maybe<Scalars['Int']>;
+  organizationPositiveTestCount?: Maybe<Scalars['Int']>;
+  organizationTotalTestCount?: Maybe<Scalars['Int']>;
 };
 
 export type Patient = {
-  __typename?: "Patient";
+  __typename?: 'Patient';
   address?: Maybe<AddressInfo>;
-  birthDate?: Maybe<Scalars["LocalDate"]>;
-  city?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
+  birthDate?: Maybe<Scalars['LocalDate']>;
+  city?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  employedInHealthcare?: Maybe<Scalars['Boolean']>;
+  ethnicity?: Maybe<Scalars['String']>;
   facility?: Maybe<Facility>;
-  firstName?: Maybe<Scalars["String"]>;
-  gender?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["ID"]>;
+  firstName?: Maybe<Scalars['String']>;
+  gender?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
   /** @deprecated alias for 'id' */
-  internalId?: Maybe<Scalars["ID"]>;
-  isDeleted?: Maybe<Scalars["Boolean"]>;
-  lastName?: Maybe<Scalars["String"]>;
+  internalId?: Maybe<Scalars['ID']>;
+  isDeleted?: Maybe<Scalars['Boolean']>;
+  lastName?: Maybe<Scalars['String']>;
   lastTest?: Maybe<TestResult>;
-  lookupId?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  lookupId?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
   name?: Maybe<NameInfo>;
   phoneNumbers?: Maybe<Array<Maybe<PhoneNumber>>>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  role?: Maybe<Scalars["String"]>;
-  state?: Maybe<Scalars["String"]>;
-  street?: Maybe<Scalars["String"]>;
-  streetTwo?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  telephone?: Maybe<Scalars["String"]>;
+  preferredLanguage?: Maybe<Scalars['String']>;
+  race?: Maybe<Scalars['String']>;
+  residentCongregateSetting?: Maybe<Scalars['Boolean']>;
+  role?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  street?: Maybe<Scalars['String']>;
+  streetTwo?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
+  telephone?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-  tribalAffiliation?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  zipCode?: Maybe<Scalars["String"]>;
+  tribalAffiliation?: Maybe<Array<Maybe<Scalars['String']>>>;
+  zipCode?: Maybe<Scalars['String']>;
 };
 
 export type PatientLink = {
-  __typename?: "PatientLink";
-  createdAt?: Maybe<Scalars["DateTime"]>;
-  expiresAt?: Maybe<Scalars["DateTime"]>;
-  internalId?: Maybe<Scalars["ID"]>;
+  __typename?: 'PatientLink';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  expiresAt?: Maybe<Scalars['DateTime']>;
+  internalId?: Maybe<Scalars['ID']>;
   testOrder?: Maybe<TestOrder>;
 };
 
 export type PhoneNumber = {
-  __typename?: "PhoneNumber";
-  number?: Maybe<Scalars["String"]>;
+  __typename?: 'PhoneNumber';
+  number?: Maybe<Scalars['String']>;
   type?: Maybe<PhoneType>;
 };
 
 export type PhoneNumberInput = {
-  number?: Maybe<Scalars["String"]>;
-  type?: Maybe<Scalars["String"]>;
+  number?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
 };
 
 export enum PhoneType {
-  Landline = "LANDLINE",
-  Mobile = "MOBILE",
+  Landline = 'LANDLINE',
+  Mobile = 'MOBILE'
 }
 
 export type Provider = {
-  __typename?: "Provider";
-  NPI?: Maybe<Scalars["String"]>;
+  __typename?: 'Provider';
+  NPI?: Maybe<Scalars['String']>;
   address?: Maybe<AddressInfo>;
-  city?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  city?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
   name?: Maybe<NameInfo>;
-  phone?: Maybe<Scalars["String"]>;
-  state?: Maybe<Scalars["String"]>;
-  street?: Maybe<Scalars["String"]>;
-  streetTwo?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  zipCode?: Maybe<Scalars["String"]>;
+  phone?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  street?: Maybe<Scalars['String']>;
+  streetTwo?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
+  zipCode?: Maybe<Scalars['String']>;
 };
 
 export type Query = {
-  __typename?: "Query";
+  __typename?: 'Query';
   deviceSpecimenTypes?: Maybe<Array<Maybe<DeviceSpecimenType>>>;
   /** @deprecated use the pluralized form to reduce confusion */
   deviceType?: Maybe<Array<Maybe<DeviceType>>>;
@@ -613,15 +643,15 @@ export type Query = {
   organizationLevelDashboardMetrics?: Maybe<OrganizationLevelDashboardMetrics>;
   organizations: Array<Organization>;
   patient?: Maybe<Patient>;
-  patientExists?: Maybe<Scalars["Boolean"]>;
+  patientExists?: Maybe<Scalars['Boolean']>;
   patients?: Maybe<Array<Maybe<Patient>>>;
-  patientsCount?: Maybe<Scalars["Int"]>;
+  patientsCount?: Maybe<Scalars['Int']>;
   queue?: Maybe<Array<Maybe<TestOrder>>>;
   specimenType?: Maybe<Array<Maybe<SpecimenType>>>;
   specimenTypes: Array<SpecimenType>;
   testResult?: Maybe<TestResult>;
   testResults?: Maybe<Array<Maybe<TestResult>>>;
-  testResultsCount?: Maybe<Scalars["Int"]>;
+  testResultsCount?: Maybe<Scalars['Int']>;
   topLevelDashboardMetrics?: Maybe<TopLevelDashboardMetrics>;
   user?: Maybe<User>;
   users?: Maybe<Array<Maybe<ApiUser>>>;
@@ -629,1328 +659,725 @@ export type Query = {
   whoami: User;
 };
 
+
 export type QueryOrganizationLevelDashboardMetricsArgs = {
-  endDate: Scalars["DateTime"];
-  startDate: Scalars["DateTime"];
+  endDate: Scalars['DateTime'];
+  startDate: Scalars['DateTime'];
 };
+
 
 export type QueryOrganizationsArgs = {
-  identityVerified?: Maybe<Scalars["Boolean"]>;
+  identityVerified?: Maybe<Scalars['Boolean']>;
 };
+
 
 export type QueryPatientArgs = {
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 };
+
 
 export type QueryPatientExistsArgs = {
-  birthDate: Scalars["LocalDate"];
-  facilityId?: Maybe<Scalars["ID"]>;
-  firstName: Scalars["String"];
-  lastName: Scalars["String"];
-  zipCode: Scalars["String"];
+  birthDate: Scalars['LocalDate'];
+  facilityId?: Maybe<Scalars['ID']>;
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  zipCode: Scalars['String'];
 };
+
 
 export type QueryPatientsArgs = {
-  facilityId?: Maybe<Scalars["ID"]>;
-  namePrefixMatch?: Maybe<Scalars["String"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
-  showDeleted?: Maybe<Scalars["Boolean"]>;
+  facilityId?: Maybe<Scalars['ID']>;
+  namePrefixMatch?: Maybe<Scalars['String']>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  showDeleted?: Maybe<Scalars['Boolean']>;
 };
+
 
 export type QueryPatientsCountArgs = {
-  facilityId?: Maybe<Scalars["ID"]>;
-  namePrefixMatch?: Maybe<Scalars["String"]>;
-  showDeleted?: Maybe<Scalars["Boolean"]>;
+  facilityId?: Maybe<Scalars['ID']>;
+  namePrefixMatch?: Maybe<Scalars['String']>;
+  showDeleted?: Maybe<Scalars['Boolean']>;
 };
+
 
 export type QueryQueueArgs = {
-  facilityId: Scalars["ID"];
+  facilityId: Scalars['ID'];
 };
+
 
 export type QueryTestResultArgs = {
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 };
+
 
 export type QueryTestResultsArgs = {
-  endDate?: Maybe<Scalars["DateTime"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: Maybe<Scalars['DateTime']>;
+  facilityId?: Maybe<Scalars['ID']>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  patientId?: Maybe<Scalars['ID']>;
+  result?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  startDate?: Maybe<Scalars['DateTime']>;
 };
+
 
 export type QueryTestResultsCountArgs = {
-  endDate?: Maybe<Scalars["DateTime"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: Maybe<Scalars['DateTime']>;
+  facilityId?: Maybe<Scalars['ID']>;
+  patientId?: Maybe<Scalars['ID']>;
+  result?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  startDate?: Maybe<Scalars['DateTime']>;
 };
+
 
 export type QueryTopLevelDashboardMetricsArgs = {
-  endDate?: Maybe<Scalars["DateTime"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: Maybe<Scalars['DateTime']>;
+  facilityId?: Maybe<Scalars['ID']>;
+  startDate?: Maybe<Scalars['DateTime']>;
 };
 
+
 export type QueryUserArgs = {
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 };
 
 export enum ResultValue {
-  Negative = "NEGATIVE",
-  Positive = "POSITIVE",
-  Undetermined = "UNDETERMINED",
+  Negative = 'NEGATIVE',
+  Positive = 'POSITIVE',
+  Undetermined = 'UNDETERMINED'
 }
 
 export enum Role {
-  Admin = "ADMIN",
-  EntryOnly = "ENTRY_ONLY",
-  User = "USER",
+  Admin = 'ADMIN',
+  EntryOnly = 'ENTRY_ONLY',
+  User = 'USER'
 }
 
 export type SpecimenType = {
-  __typename?: "SpecimenType";
-  collectionLocationCode?: Maybe<Scalars["String"]>;
-  collectionLocationName?: Maybe<Scalars["String"]>;
-  internalId: Scalars["ID"];
-  name: Scalars["String"];
-  typeCode: Scalars["String"];
+  __typename?: 'SpecimenType';
+  collectionLocationCode?: Maybe<Scalars['String']>;
+  collectionLocationName?: Maybe<Scalars['String']>;
+  internalId: Scalars['ID'];
+  name: Scalars['String'];
+  typeCode: Scalars['String'];
 };
 
 export enum TestCorrectionStatus {
-  Corrected = "CORRECTED",
-  Original = "ORIGINAL",
-  Removed = "REMOVED",
+  Corrected = 'CORRECTED',
+  Original = 'ORIGINAL',
+  Removed = 'REMOVED'
 }
 
 export type TestDescription = {
-  __typename?: "TestDescription";
-  loincCode: Scalars["String"];
-  name: Scalars["String"];
+  __typename?: 'TestDescription';
+  loincCode: Scalars['String'];
+  name: Scalars['String'];
 };
 
+
 export type TestDescriptionNameArgs = {
-  nameType?: Maybe<Scalars["String"]>;
+  nameType?: Maybe<Scalars['String']>;
 };
 
 export type TestOrder = {
-  __typename?: "TestOrder";
-  correctionStatus?: Maybe<Scalars["String"]>;
-  dateAdded?: Maybe<Scalars["String"]>;
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  __typename?: 'TestOrder';
+  correctionStatus?: Maybe<Scalars['String']>;
+  dateAdded?: Maybe<Scalars['String']>;
+  dateTested?: Maybe<Scalars['DateTime']>;
   deviceType?: Maybe<DeviceType>;
-  id?: Maybe<Scalars["ID"]>;
+  id?: Maybe<Scalars['ID']>;
   /** @deprecated alias for 'id' */
-  internalId?: Maybe<Scalars["ID"]>;
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
+  internalId?: Maybe<Scalars['ID']>;
+  noSymptoms?: Maybe<Scalars['Boolean']>;
   patient?: Maybe<Patient>;
-  pregnancy?: Maybe<Scalars["String"]>;
-  reasonForCorrection?: Maybe<Scalars["String"]>;
-  result?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  symptoms?: Maybe<Scalars["String"]>;
+  pregnancy?: Maybe<Scalars['String']>;
+  reasonForCorrection?: Maybe<Scalars['String']>;
+  result?: Maybe<Scalars['String']>;
+  symptomOnset?: Maybe<Scalars['LocalDate']>;
+  symptoms?: Maybe<Scalars['String']>;
 };
 
 export type TestResult = {
-  __typename?: "TestResult";
-  correctionStatus?: Maybe<Scalars["String"]>;
+  __typename?: 'TestResult';
+  correctionStatus?: Maybe<Scalars['String']>;
   createdBy?: Maybe<ApiUser>;
-  dateAdded?: Maybe<Scalars["String"]>;
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  dateAdded?: Maybe<Scalars['String']>;
+  dateTested?: Maybe<Scalars['DateTime']>;
   deviceType?: Maybe<DeviceType>;
   facility?: Maybe<Facility>;
-  internalId?: Maybe<Scalars["ID"]>;
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
+  internalId?: Maybe<Scalars['ID']>;
+  noSymptoms?: Maybe<Scalars['Boolean']>;
   patient?: Maybe<Patient>;
   patientLink?: Maybe<PatientLink>;
-  pregnancy?: Maybe<Scalars["String"]>;
-  reasonForCorrection?: Maybe<Scalars["String"]>;
-  result?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  symptoms?: Maybe<Scalars["String"]>;
+  pregnancy?: Maybe<Scalars['String']>;
+  reasonForCorrection?: Maybe<Scalars['String']>;
+  result?: Maybe<Scalars['String']>;
+  symptomOnset?: Maybe<Scalars['LocalDate']>;
+  symptoms?: Maybe<Scalars['String']>;
   testPerformed: TestDescription;
 };
 
 export enum TestResultDeliveryPreference {
-  None = "NONE",
-  Sms = "SMS",
+  None = 'NONE',
+  Sms = 'SMS'
 }
 
 export type TopLevelDashboardMetrics = {
-  __typename?: "TopLevelDashboardMetrics";
-  positiveTestCount?: Maybe<Scalars["Int"]>;
-  totalTestCount?: Maybe<Scalars["Int"]>;
+  __typename?: 'TopLevelDashboardMetrics';
+  positiveTestCount?: Maybe<Scalars['Int']>;
+  totalTestCount?: Maybe<Scalars['Int']>;
 };
 
 export type User = {
-  __typename?: "User";
-  email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
-  isAdmin?: Maybe<Scalars["Boolean"]>;
-  lastName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
+  __typename?: 'User';
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  isAdmin?: Maybe<Scalars['Boolean']>;
+  lastName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
   name: NameInfo;
   organization?: Maybe<Organization>;
   permissions: Array<UserPermission>;
   role?: Maybe<Role>;
-  roleDescription: Scalars["String"];
+  roleDescription: Scalars['String'];
   /** @deprecated Users have only one role now */
   roles: Array<Role>;
-  status?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
+  status?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
 };
 
 export enum UserPermission {
-  AccessAllFacilities = "ACCESS_ALL_FACILITIES",
-  ArchivePatient = "ARCHIVE_PATIENT",
-  EditFacility = "EDIT_FACILITY",
-  EditOrganization = "EDIT_ORGANIZATION",
-  EditPatient = "EDIT_PATIENT",
-  ManageUsers = "MANAGE_USERS",
-  ReadArchivedPatientList = "READ_ARCHIVED_PATIENT_LIST",
-  ReadPatientList = "READ_PATIENT_LIST",
-  ReadResultList = "READ_RESULT_LIST",
-  SearchPatients = "SEARCH_PATIENTS",
-  StartTest = "START_TEST",
-  SubmitTest = "SUBMIT_TEST",
-  UpdateTest = "UPDATE_TEST",
+  AccessAllFacilities = 'ACCESS_ALL_FACILITIES',
+  ArchivePatient = 'ARCHIVE_PATIENT',
+  EditFacility = 'EDIT_FACILITY',
+  EditOrganization = 'EDIT_ORGANIZATION',
+  EditPatient = 'EDIT_PATIENT',
+  ManageUsers = 'MANAGE_USERS',
+  ReadArchivedPatientList = 'READ_ARCHIVED_PATIENT_LIST',
+  ReadPatientList = 'READ_PATIENT_LIST',
+  ReadResultList = 'READ_RESULT_LIST',
+  SearchPatients = 'SEARCH_PATIENTS',
+  StartTest = 'START_TEST',
+  SubmitTest = 'SUBMIT_TEST',
+  UpdateTest = 'UPDATE_TEST'
 }
 
-export type WhoAmIQueryVariables = Exact<{ [key: string]: never }>;
+export type WhoAmIQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type WhoAmIQuery = {
-  __typename?: "Query";
-  whoami: {
-    __typename?: "User";
-    id: string;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName: string;
-    suffix?: Maybe<string>;
-    email: string;
-    isAdmin?: Maybe<boolean>;
-    permissions: Array<UserPermission>;
-    roleDescription: string;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      name: string;
-      testingFacility: Array<{
-        __typename?: "Facility";
-        id: string;
-        name: string;
-      }>;
-    }>;
-  };
-};
 
-export type GetFacilitiesQueryVariables = Exact<{ [key: string]: never }>;
+export type WhoAmIQuery = { __typename?: 'Query', whoami: { __typename?: 'User', id: string, firstName?: Maybe<string>, middleName?: Maybe<string>, lastName: string, suffix?: Maybe<string>, email: string, isAdmin?: Maybe<boolean>, permissions: Array<UserPermission>, roleDescription: string, organization?: Maybe<{ __typename?: 'Organization', name: string, testingFacility: Array<{ __typename?: 'Facility', id: string, name: string }> }> } };
 
-export type GetFacilitiesQuery = {
-  __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    internalId: string;
-    testingFacility: Array<{
-      __typename?: "Facility";
-      id: string;
-      cliaNumber?: Maybe<string>;
-      name: string;
-      street?: Maybe<string>;
-      streetTwo?: Maybe<string>;
-      city?: Maybe<string>;
-      state?: Maybe<string>;
-      zipCode?: Maybe<string>;
-      phone?: Maybe<string>;
-      email?: Maybe<string>;
-      defaultDeviceType?: Maybe<{
-        __typename?: "DeviceType";
-        internalId?: Maybe<string>;
-      }>;
-      deviceTypes?: Maybe<
-        Array<Maybe<{ __typename?: "DeviceType"; internalId?: Maybe<string> }>>
-      >;
-      deviceSpecimenTypes?: Maybe<
-        Array<
-          Maybe<{
-            __typename?: "DeviceSpecimenType";
-            internalId: string;
-            deviceType: {
-              __typename?: "DeviceType";
-              name?: Maybe<string>;
-              internalId?: Maybe<string>;
-            };
-            specimenType: {
-              __typename?: "SpecimenType";
-              internalId: string;
-              name: string;
-            };
-          }>
-        >
-      >;
-      orderingProvider?: Maybe<{
-        __typename?: "Provider";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        suffix?: Maybe<string>;
-        NPI?: Maybe<string>;
-        street?: Maybe<string>;
-        streetTwo?: Maybe<string>;
-        city?: Maybe<string>;
-        state?: Maybe<string>;
-        zipCode?: Maybe<string>;
-        phone?: Maybe<string>;
-      }>;
-    }>;
-  }>;
-  deviceType?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "DeviceType";
-        internalId?: Maybe<string>;
-        name?: Maybe<string>;
-      }>
-    >
-  >;
-  specimenType?: Maybe<
-    Array<
-      Maybe<{ __typename?: "SpecimenType"; internalId: string; name: string }>
-    >
-  >;
-  deviceSpecimenTypes?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "DeviceSpecimenType";
-        internalId: string;
-        deviceType: {
-          __typename?: "DeviceType";
-          internalId?: Maybe<string>;
-          name?: Maybe<string>;
-        };
-        specimenType: {
-          __typename?: "SpecimenType";
-          internalId: string;
-          name: string;
-        };
-      }>
-    >
-  >;
-};
+export type GetFacilitiesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetFacilitiesQuery = { __typename?: 'Query', organization?: Maybe<{ __typename?: 'Organization', internalId: string, testingFacility: Array<{ __typename?: 'Facility', id: string, cliaNumber?: Maybe<string>, name: string, street?: Maybe<string>, streetTwo?: Maybe<string>, city?: Maybe<string>, state?: Maybe<string>, zipCode?: Maybe<string>, phone?: Maybe<string>, email?: Maybe<string>, defaultDeviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string> }>, deviceTypes?: Maybe<Array<Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string> }>>>, deviceSpecimenTypes?: Maybe<Array<Maybe<{ __typename?: 'DeviceSpecimenType', internalId: string, deviceType: { __typename?: 'DeviceType', name?: Maybe<string>, internalId?: Maybe<string> }, specimenType: { __typename?: 'SpecimenType', internalId: string, name: string } }>>>, orderingProvider?: Maybe<{ __typename?: 'Provider', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, suffix?: Maybe<string>, NPI?: Maybe<string>, street?: Maybe<string>, streetTwo?: Maybe<string>, city?: Maybe<string>, state?: Maybe<string>, zipCode?: Maybe<string>, phone?: Maybe<string> }> }> }>, deviceType?: Maybe<Array<Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string>, name?: Maybe<string> }>>>, specimenType?: Maybe<Array<Maybe<{ __typename?: 'SpecimenType', internalId: string, name: string }>>>, deviceSpecimenTypes?: Maybe<Array<Maybe<{ __typename?: 'DeviceSpecimenType', internalId: string, deviceType: { __typename?: 'DeviceType', internalId?: Maybe<string>, name?: Maybe<string> }, specimenType: { __typename?: 'SpecimenType', internalId: string, name: string } }>>> };
 
 export type UpdateFacilityMutationVariables = Exact<{
-  facilityId: Scalars["ID"];
-  testingFacilityName: Scalars["String"];
-  cliaNumber?: Maybe<Scalars["String"]>;
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  zipCode: Scalars["String"];
-  phone?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  devices: Array<Maybe<Scalars["String"]>> | Maybe<Scalars["String"]>;
-  deviceSpecimenTypes: Array<Maybe<Scalars["ID"]>> | Maybe<Scalars["ID"]>;
-  defaultDevice: Scalars["String"];
+  facilityId: Scalars['ID'];
+  testingFacilityName: Scalars['String'];
+  cliaNumber?: Maybe<Scalars['String']>;
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  city?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  zipCode: Scalars['String'];
+  phone?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  orderingProviderFirstName?: Maybe<Scalars['String']>;
+  orderingProviderMiddleName?: Maybe<Scalars['String']>;
+  orderingProviderLastName?: Maybe<Scalars['String']>;
+  orderingProviderSuffix?: Maybe<Scalars['String']>;
+  orderingProviderNPI?: Maybe<Scalars['String']>;
+  orderingProviderStreet?: Maybe<Scalars['String']>;
+  orderingProviderStreetTwo?: Maybe<Scalars['String']>;
+  orderingProviderCity?: Maybe<Scalars['String']>;
+  orderingProviderState?: Maybe<Scalars['String']>;
+  orderingProviderZipCode?: Maybe<Scalars['String']>;
+  orderingProviderPhone?: Maybe<Scalars['String']>;
+  devices: Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>;
+  deviceSpecimenTypes: Array<Maybe<Scalars['ID']>> | Maybe<Scalars['ID']>;
+  defaultDevice: Scalars['String'];
 }>;
 
-export type UpdateFacilityMutation = {
-  __typename?: "Mutation";
-  updateFacility?: Maybe<string>;
-};
+
+export type UpdateFacilityMutation = { __typename?: 'Mutation', updateFacility?: Maybe<string> };
 
 export type AddFacilityMutationVariables = Exact<{
-  testingFacilityName: Scalars["String"];
-  cliaNumber?: Maybe<Scalars["String"]>;
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  zipCode: Scalars["String"];
-  phone?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  devices: Array<Maybe<Scalars["String"]>> | Maybe<Scalars["String"]>;
-  deviceSpecimenTypes: Array<Maybe<Scalars["ID"]>> | Maybe<Scalars["ID"]>;
-  defaultDevice: Scalars["String"];
+  testingFacilityName: Scalars['String'];
+  cliaNumber?: Maybe<Scalars['String']>;
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  city?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  zipCode: Scalars['String'];
+  phone?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  orderingProviderFirstName?: Maybe<Scalars['String']>;
+  orderingProviderMiddleName?: Maybe<Scalars['String']>;
+  orderingProviderLastName?: Maybe<Scalars['String']>;
+  orderingProviderSuffix?: Maybe<Scalars['String']>;
+  orderingProviderNPI?: Maybe<Scalars['String']>;
+  orderingProviderStreet?: Maybe<Scalars['String']>;
+  orderingProviderStreetTwo?: Maybe<Scalars['String']>;
+  orderingProviderCity?: Maybe<Scalars['String']>;
+  orderingProviderState?: Maybe<Scalars['String']>;
+  orderingProviderZipCode?: Maybe<Scalars['String']>;
+  orderingProviderPhone?: Maybe<Scalars['String']>;
+  devices: Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>;
+  deviceSpecimenTypes: Array<Maybe<Scalars['ID']>> | Maybe<Scalars['ID']>;
+  defaultDevice: Scalars['String'];
 }>;
 
-export type AddFacilityMutation = {
-  __typename?: "Mutation";
-  addFacility?: Maybe<string>;
-};
 
-export type GetManagedFacilitiesQueryVariables = Exact<{
-  [key: string]: never;
-}>;
+export type AddFacilityMutation = { __typename?: 'Mutation', addFacility?: Maybe<string> };
 
-export type GetManagedFacilitiesQuery = {
-  __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    testingFacility: Array<{
-      __typename?: "Facility";
-      id: string;
-      cliaNumber?: Maybe<string>;
-      name: string;
-      street?: Maybe<string>;
-      streetTwo?: Maybe<string>;
-      city?: Maybe<string>;
-      state?: Maybe<string>;
-      zipCode?: Maybe<string>;
-      phone?: Maybe<string>;
-      email?: Maybe<string>;
-      defaultDeviceType?: Maybe<{
-        __typename?: "DeviceType";
-        internalId?: Maybe<string>;
-      }>;
-      deviceTypes?: Maybe<
-        Array<Maybe<{ __typename?: "DeviceType"; internalId?: Maybe<string> }>>
-      >;
-      deviceSpecimenTypes?: Maybe<
-        Array<
-          Maybe<{
-            __typename?: "DeviceSpecimenType";
-            deviceType: {
-              __typename?: "DeviceType";
-              internalId?: Maybe<string>;
-            };
-            specimenType: { __typename?: "SpecimenType"; internalId: string };
-          }>
-        >
-      >;
-      orderingProvider?: Maybe<{
-        __typename?: "Provider";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        suffix?: Maybe<string>;
-        NPI?: Maybe<string>;
-        street?: Maybe<string>;
-        streetTwo?: Maybe<string>;
-        city?: Maybe<string>;
-        state?: Maybe<string>;
-        zipCode?: Maybe<string>;
-        phone?: Maybe<string>;
-      }>;
-    }>;
-  }>;
-};
+export type GetManagedFacilitiesQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type GetOrganizationQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetOrganizationQuery = {
-  __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    name: string;
-    type: string;
-  }>;
-};
+export type GetManagedFacilitiesQuery = { __typename?: 'Query', organization?: Maybe<{ __typename?: 'Organization', testingFacility: Array<{ __typename?: 'Facility', id: string, cliaNumber?: Maybe<string>, name: string, street?: Maybe<string>, streetTwo?: Maybe<string>, city?: Maybe<string>, state?: Maybe<string>, zipCode?: Maybe<string>, phone?: Maybe<string>, email?: Maybe<string>, defaultDeviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string> }>, deviceTypes?: Maybe<Array<Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string> }>>>, deviceSpecimenTypes?: Maybe<Array<Maybe<{ __typename?: 'DeviceSpecimenType', deviceType: { __typename?: 'DeviceType', internalId?: Maybe<string> }, specimenType: { __typename?: 'SpecimenType', internalId: string } }>>>, orderingProvider?: Maybe<{ __typename?: 'Provider', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, suffix?: Maybe<string>, NPI?: Maybe<string>, street?: Maybe<string>, streetTwo?: Maybe<string>, city?: Maybe<string>, state?: Maybe<string>, zipCode?: Maybe<string>, phone?: Maybe<string> }> }> }> };
+
+export type GetOrganizationQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetOrganizationQuery = { __typename?: 'Query', organization?: Maybe<{ __typename?: 'Organization', name: string, type: string }> };
 
 export type AdminSetOrganizationMutationVariables = Exact<{
-  name: Scalars["String"];
-  type: Scalars["String"];
+  name: Scalars['String'];
+  type: Scalars['String'];
 }>;
 
-export type AdminSetOrganizationMutation = {
-  __typename?: "Mutation";
-  adminUpdateOrganization?: Maybe<string>;
-};
+
+export type AdminSetOrganizationMutation = { __typename?: 'Mutation', adminUpdateOrganization?: Maybe<string> };
 
 export type SetOrganizationMutationVariables = Exact<{
-  type: Scalars["String"];
+  type: Scalars['String'];
 }>;
 
-export type SetOrganizationMutation = {
-  __typename?: "Mutation";
-  updateOrganization?: Maybe<string>;
-};
 
-export type AllSelfRegistrationLinksQueryVariables = Exact<{
-  [key: string]: never;
-}>;
+export type SetOrganizationMutation = { __typename?: 'Mutation', updateOrganization?: Maybe<string> };
 
-export type AllSelfRegistrationLinksQuery = {
-  __typename?: "Query";
-  whoami: {
-    __typename?: "User";
-    organization?: Maybe<{
-      __typename?: "Organization";
-      patientSelfRegistrationLink?: Maybe<string>;
-      facilities: Array<{
-        __typename?: "Facility";
-        name: string;
-        patientSelfRegistrationLink?: Maybe<string>;
-      }>;
-    }>;
-  };
-};
+export type AllSelfRegistrationLinksQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type AllSelfRegistrationLinksQuery = { __typename?: 'Query', whoami: { __typename?: 'User', organization?: Maybe<{ __typename?: 'Organization', patientSelfRegistrationLink?: Maybe<string>, facilities: Array<{ __typename?: 'Facility', name: string, patientSelfRegistrationLink?: Maybe<string> }> }> } };
 
 export type UpdateUserPrivilegesMutationVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
   role: Role;
-  accessAllFacilities: Scalars["Boolean"];
-  facilities: Array<Scalars["ID"]> | Scalars["ID"];
+  accessAllFacilities: Scalars['Boolean'];
+  facilities: Array<Scalars['ID']> | Scalars['ID'];
 }>;
 
-export type UpdateUserPrivilegesMutation = {
-  __typename?: "Mutation";
-  updateUserPrivileges?: Maybe<{ __typename?: "User"; id: string }>;
-};
+
+export type UpdateUserPrivilegesMutation = { __typename?: 'Mutation', updateUserPrivileges?: Maybe<{ __typename?: 'User', id: string }> };
 
 export type ResetUserPasswordMutationVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type ResetUserPasswordMutation = {
-  __typename?: "Mutation";
-  resetUserPassword?: Maybe<{ __typename?: "User"; id: string }>;
-};
+
+export type ResetUserPasswordMutation = { __typename?: 'Mutation', resetUserPassword?: Maybe<{ __typename?: 'User', id: string }> };
 
 export type SetUserIsDeletedMutationVariables = Exact<{
-  id: Scalars["ID"];
-  deleted: Scalars["Boolean"];
+  id: Scalars['ID'];
+  deleted: Scalars['Boolean'];
 }>;
 
-export type SetUserIsDeletedMutation = {
-  __typename?: "Mutation";
-  setUserIsDeleted?: Maybe<{ __typename?: "User"; id: string }>;
-};
+
+export type SetUserIsDeletedMutation = { __typename?: 'Mutation', setUserIsDeleted?: Maybe<{ __typename?: 'User', id: string }> };
 
 export type ReactivateUserMutationVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type ReactivateUserMutation = {
-  __typename?: "Mutation";
-  reactivateUser?: Maybe<{ __typename?: "User"; id: string }>;
-};
+
+export type ReactivateUserMutation = { __typename?: 'Mutation', reactivateUser?: Maybe<{ __typename?: 'User', id: string }> };
 
 export type AddUserToCurrentOrgMutationVariables = Exact<{
-  firstName?: Maybe<Scalars["String"]>;
-  lastName: Scalars["String"];
-  email: Scalars["String"];
+  firstName?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  email: Scalars['String'];
   role: Role;
 }>;
 
-export type AddUserToCurrentOrgMutation = {
-  __typename?: "Mutation";
-  addUserToCurrentOrg?: Maybe<{ __typename?: "User"; id: string }>;
-};
+
+export type AddUserToCurrentOrgMutation = { __typename?: 'Mutation', addUserToCurrentOrg?: Maybe<{ __typename?: 'User', id: string }> };
 
 export type GetUserQueryVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type GetUserQuery = {
-  __typename?: "Query";
-  user?: Maybe<{
-    __typename?: "User";
-    id: string;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName: string;
-    roleDescription: string;
-    role?: Maybe<Role>;
-    permissions: Array<UserPermission>;
-    email: string;
-    status?: Maybe<string>;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      testingFacility: Array<{
-        __typename?: "Facility";
-        id: string;
-        name: string;
-      }>;
-    }>;
-  }>;
-};
 
-export type GetUsersAndStatusQueryVariables = Exact<{ [key: string]: never }>;
+export type GetUserQuery = { __typename?: 'Query', user?: Maybe<{ __typename?: 'User', id: string, firstName?: Maybe<string>, middleName?: Maybe<string>, lastName: string, roleDescription: string, role?: Maybe<Role>, permissions: Array<UserPermission>, email: string, status?: Maybe<string>, organization?: Maybe<{ __typename?: 'Organization', testingFacility: Array<{ __typename?: 'Facility', id: string, name: string }> }> }> };
 
-export type GetUsersAndStatusQuery = {
-  __typename?: "Query";
-  usersWithStatus?: Maybe<
-    Array<{
-      __typename?: "ApiUserWithStatus";
-      id: string;
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName: string;
-      email: string;
-      status?: Maybe<string>;
-    }>
-  >;
-};
+export type GetUsersAndStatusQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetUsersAndStatusQuery = { __typename?: 'Query', usersWithStatus?: Maybe<Array<{ __typename?: 'ApiUserWithStatus', id: string, firstName?: Maybe<string>, middleName?: Maybe<string>, lastName: string, email: string, status?: Maybe<string> }>> };
 
 export type ResendActivationEmailMutationVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type ResendActivationEmailMutation = {
-  __typename?: "Mutation";
-  resendActivationEmail?: Maybe<{
-    __typename?: "User";
-    id: string;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName: string;
-    email: string;
-    status?: Maybe<string>;
-  }>;
-};
+
+export type ResendActivationEmailMutation = { __typename?: 'Mutation', resendActivationEmail?: Maybe<{ __typename?: 'User', id: string, firstName?: Maybe<string>, middleName?: Maybe<string>, lastName: string, email: string, status?: Maybe<string> }> };
 
 export type GetTopLevelDashboardMetricsQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  startDate: Scalars["DateTime"];
-  endDate: Scalars["DateTime"];
+  facilityId?: Maybe<Scalars['ID']>;
+  startDate: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
 }>;
 
-export type GetTopLevelDashboardMetricsQuery = {
-  __typename?: "Query";
-  topLevelDashboardMetrics?: Maybe<{
-    __typename?: "TopLevelDashboardMetrics";
-    positiveTestCount?: Maybe<number>;
-    totalTestCount?: Maybe<number>;
-  }>;
-};
+
+export type GetTopLevelDashboardMetricsQuery = { __typename?: 'Query', topLevelDashboardMetrics?: Maybe<{ __typename?: 'TopLevelDashboardMetrics', positiveTestCount?: Maybe<number>, totalTestCount?: Maybe<number> }> };
 
 export type PatientExistsQueryVariables = Exact<{
-  firstName: Scalars["String"];
-  lastName: Scalars["String"];
-  birthDate: Scalars["LocalDate"];
-  zipCode: Scalars["String"];
-  facilityId?: Maybe<Scalars["ID"]>;
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  birthDate: Scalars['LocalDate'];
+  zipCode: Scalars['String'];
+  facilityId?: Maybe<Scalars['ID']>;
 }>;
 
-export type PatientExistsQuery = {
-  __typename?: "Query";
-  patientExists?: Maybe<boolean>;
-};
+
+export type PatientExistsQuery = { __typename?: 'Query', patientExists?: Maybe<boolean> };
 
 export type AddPatientMutationVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  firstName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
-  lastName: Scalars["String"];
-  birthDate: Scalars["LocalDate"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  zipCode: Scalars["String"];
-  telephone?: Maybe<Scalars["String"]>;
+  facilityId?: Maybe<Scalars['ID']>;
+  firstName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  birthDate: Scalars['LocalDate'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  city?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  zipCode: Scalars['String'];
+  telephone?: Maybe<Scalars['String']>;
   phoneNumbers?: Maybe<Array<PhoneNumberInput> | PhoneNumberInput>;
-  role?: Maybe<Scalars["String"]>;
-  lookupId?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
-  gender?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
+  role?: Maybe<Scalars['String']>;
+  lookupId?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  race?: Maybe<Scalars['String']>;
+  ethnicity?: Maybe<Scalars['String']>;
+  tribalAffiliation?: Maybe<Scalars['String']>;
+  gender?: Maybe<Scalars['String']>;
+  residentCongregateSetting?: Maybe<Scalars['Boolean']>;
+  employedInHealthcare?: Maybe<Scalars['Boolean']>;
+  preferredLanguage?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
 }>;
 
-export type AddPatientMutation = {
-  __typename?: "Mutation";
-  addPatient?: Maybe<{
-    __typename?: "Patient";
-    internalId?: Maybe<string>;
-    facility?: Maybe<{ __typename?: "Facility"; id: string }>;
-  }>;
-};
+
+export type AddPatientMutation = { __typename?: 'Mutation', addPatient?: Maybe<{ __typename?: 'Patient', internalId?: Maybe<string>, facility?: Maybe<{ __typename?: 'Facility', id: string }> }> };
 
 export type ArchivePersonMutationVariables = Exact<{
-  id: Scalars["ID"];
-  deleted: Scalars["Boolean"];
+  id: Scalars['ID'];
+  deleted: Scalars['Boolean'];
 }>;
 
-export type ArchivePersonMutation = {
-  __typename?: "Mutation";
-  setPatientIsDeleted?: Maybe<{
-    __typename?: "Patient";
-    internalId?: Maybe<string>;
-  }>;
-};
+
+export type ArchivePersonMutation = { __typename?: 'Mutation', setPatientIsDeleted?: Maybe<{ __typename?: 'Patient', internalId?: Maybe<string> }> };
 
 export type GetPatientDetailsQueryVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type GetPatientDetailsQuery = {
-  __typename?: "Query";
-  patient?: Maybe<{
-    __typename?: "Patient";
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName?: Maybe<string>;
-    birthDate?: Maybe<any>;
-    street?: Maybe<string>;
-    streetTwo?: Maybe<string>;
-    city?: Maybe<string>;
-    state?: Maybe<string>;
-    zipCode?: Maybe<string>;
-    telephone?: Maybe<string>;
-    role?: Maybe<string>;
-    lookupId?: Maybe<string>;
-    email?: Maybe<string>;
-    county?: Maybe<string>;
-    race?: Maybe<string>;
-    ethnicity?: Maybe<string>;
-    tribalAffiliation?: Maybe<Array<Maybe<string>>>;
-    gender?: Maybe<string>;
-    residentCongregateSetting?: Maybe<boolean>;
-    employedInHealthcare?: Maybe<boolean>;
-    preferredLanguage?: Maybe<string>;
-    testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-    phoneNumbers?: Maybe<
-      Array<
-        Maybe<{
-          __typename?: "PhoneNumber";
-          type?: Maybe<PhoneType>;
-          number?: Maybe<string>;
-        }>
-      >
-    >;
-    facility?: Maybe<{ __typename?: "Facility"; id: string }>;
-  }>;
-};
+
+export type GetPatientDetailsQuery = { __typename?: 'Query', patient?: Maybe<{ __typename?: 'Patient', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, birthDate?: Maybe<any>, street?: Maybe<string>, streetTwo?: Maybe<string>, city?: Maybe<string>, state?: Maybe<string>, zipCode?: Maybe<string>, telephone?: Maybe<string>, role?: Maybe<string>, lookupId?: Maybe<string>, email?: Maybe<string>, county?: Maybe<string>, race?: Maybe<string>, ethnicity?: Maybe<string>, tribalAffiliation?: Maybe<Array<Maybe<string>>>, gender?: Maybe<string>, residentCongregateSetting?: Maybe<boolean>, employedInHealthcare?: Maybe<boolean>, preferredLanguage?: Maybe<string>, testResultDelivery?: Maybe<TestResultDeliveryPreference>, phoneNumbers?: Maybe<Array<Maybe<{ __typename?: 'PhoneNumber', type?: Maybe<PhoneType>, number?: Maybe<string> }>>>, facility?: Maybe<{ __typename?: 'Facility', id: string }> }> };
 
 export type UpdatePatientMutationVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId: Scalars["ID"];
-  firstName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
-  lastName: Scalars["String"];
-  birthDate: Scalars["LocalDate"];
-  street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
-  state: Scalars["String"];
-  zipCode: Scalars["String"];
-  telephone?: Maybe<Scalars["String"]>;
+  facilityId?: Maybe<Scalars['ID']>;
+  patientId: Scalars['ID'];
+  firstName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  birthDate: Scalars['LocalDate'];
+  street: Scalars['String'];
+  streetTwo?: Maybe<Scalars['String']>;
+  city?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  zipCode: Scalars['String'];
+  telephone?: Maybe<Scalars['String']>;
   phoneNumbers?: Maybe<Array<PhoneNumberInput> | PhoneNumberInput>;
-  role?: Maybe<Scalars["String"]>;
-  lookupId?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
-  gender?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
+  role?: Maybe<Scalars['String']>;
+  lookupId?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  county?: Maybe<Scalars['String']>;
+  race?: Maybe<Scalars['String']>;
+  ethnicity?: Maybe<Scalars['String']>;
+  tribalAffiliation?: Maybe<Scalars['String']>;
+  gender?: Maybe<Scalars['String']>;
+  residentCongregateSetting?: Maybe<Scalars['Boolean']>;
+  employedInHealthcare?: Maybe<Scalars['Boolean']>;
+  preferredLanguage?: Maybe<Scalars['String']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
 }>;
 
-export type UpdatePatientMutation = {
-  __typename?: "Mutation";
-  updatePatient?: Maybe<{ __typename?: "Patient"; internalId?: Maybe<string> }>;
-};
+
+export type UpdatePatientMutation = { __typename?: 'Mutation', updatePatient?: Maybe<{ __typename?: 'Patient', internalId?: Maybe<string> }> };
 
 export type GetPatientsCountByFacilityQueryVariables = Exact<{
-  facilityId: Scalars["ID"];
-  showDeleted: Scalars["Boolean"];
-  namePrefixMatch?: Maybe<Scalars["String"]>;
+  facilityId: Scalars['ID'];
+  showDeleted: Scalars['Boolean'];
+  namePrefixMatch?: Maybe<Scalars['String']>;
 }>;
 
-export type GetPatientsCountByFacilityQuery = {
-  __typename?: "Query";
-  patientsCount?: Maybe<number>;
-};
+
+export type GetPatientsCountByFacilityQuery = { __typename?: 'Query', patientsCount?: Maybe<number> };
 
 export type GetPatientsByFacilityQueryVariables = Exact<{
-  facilityId: Scalars["ID"];
-  pageNumber: Scalars["Int"];
-  pageSize: Scalars["Int"];
-  showDeleted?: Maybe<Scalars["Boolean"]>;
-  namePrefixMatch?: Maybe<Scalars["String"]>;
+  facilityId: Scalars['ID'];
+  pageNumber: Scalars['Int'];
+  pageSize: Scalars['Int'];
+  showDeleted?: Maybe<Scalars['Boolean']>;
+  namePrefixMatch?: Maybe<Scalars['String']>;
 }>;
 
-export type GetPatientsByFacilityQuery = {
-  __typename?: "Query";
-  patients?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "Patient";
-        internalId?: Maybe<string>;
-        firstName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        birthDate?: Maybe<any>;
-        isDeleted?: Maybe<boolean>;
-        role?: Maybe<string>;
-        lastTest?: Maybe<{
-          __typename?: "TestResult";
-          dateAdded?: Maybe<string>;
-        }>;
-      }>
-    >
-  >;
-};
+
+export type GetPatientsByFacilityQuery = { __typename?: 'Query', patients?: Maybe<Array<Maybe<{ __typename?: 'Patient', internalId?: Maybe<string>, firstName?: Maybe<string>, lastName?: Maybe<string>, middleName?: Maybe<string>, birthDate?: Maybe<any>, isDeleted?: Maybe<boolean>, role?: Maybe<string>, lastTest?: Maybe<{ __typename?: 'TestResult', dateAdded?: Maybe<string> }> }>>> };
 
 export type UploadPatientsMutationVariables = Exact<{
-  patientList: Scalars["Upload"];
+  patientList: Scalars['Upload'];
 }>;
 
-export type UploadPatientsMutation = {
-  __typename?: "Mutation";
-  uploadPatients?: Maybe<string>;
-};
+
+export type UploadPatientsMutation = { __typename?: 'Mutation', uploadPatients?: Maybe<string> };
 
 export type AddUserMutationVariables = Exact<{
-  firstName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  email: Scalars["String"];
-  organizationExternalId: Scalars["String"];
+  firstName?: Maybe<Scalars['String']>;
+  middleName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  suffix?: Maybe<Scalars['String']>;
+  email: Scalars['String'];
+  organizationExternalId: Scalars['String'];
   role: Role;
 }>;
 
-export type AddUserMutation = {
-  __typename?: "Mutation";
-  addUser?: Maybe<{ __typename?: "User"; id: string }>;
-};
+
+export type AddUserMutation = { __typename?: 'Mutation', addUser?: Maybe<{ __typename?: 'User', id: string }> };
 
 export type CreateDeviceTypeMutationVariables = Exact<{
-  name: Scalars["String"];
-  manufacturer: Scalars["String"];
-  model: Scalars["String"];
-  loincCode: Scalars["String"];
-  swabType: Scalars["String"];
+  name: Scalars['String'];
+  manufacturer: Scalars['String'];
+  model: Scalars['String'];
+  loincCode: Scalars['String'];
+  swabType: Scalars['String'];
 }>;
 
-export type CreateDeviceTypeMutation = {
-  __typename?: "Mutation";
-  createDeviceType?: Maybe<{
-    __typename?: "DeviceType";
-    internalId?: Maybe<string>;
-  }>;
-};
+
+export type CreateDeviceTypeMutation = { __typename?: 'Mutation', createDeviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string> }> };
 
 export type CreateDeviceTypeNewMutationVariables = Exact<{
-  name: Scalars["String"];
-  manufacturer: Scalars["String"];
-  model: Scalars["String"];
-  loincCode: Scalars["String"];
-  swabTypes: Array<Scalars["ID"]> | Scalars["ID"];
+  name: Scalars['String'];
+  manufacturer: Scalars['String'];
+  model: Scalars['String'];
+  loincCode: Scalars['String'];
+  swabTypes: Array<Scalars['ID']> | Scalars['ID'];
 }>;
 
-export type CreateDeviceTypeNewMutation = {
-  __typename?: "Mutation";
-  createDeviceTypeNew?: Maybe<{
-    __typename?: "DeviceType";
-    internalId?: Maybe<string>;
-  }>;
-};
 
-export type GetSpecimenTypesQueryVariables = Exact<{ [key: string]: never }>;
+export type CreateDeviceTypeNewMutation = { __typename?: 'Mutation', createDeviceTypeNew?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string> }> };
 
-export type GetSpecimenTypesQuery = {
-  __typename?: "Query";
-  specimenTypes: Array<{
-    __typename?: "SpecimenType";
-    internalId: string;
-    name: string;
-    typeCode: string;
-  }>;
-};
+export type GetSpecimenTypesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetSpecimenTypesQuery = { __typename?: 'Query', specimenTypes: Array<{ __typename?: 'SpecimenType', internalId: string, name: string, typeCode: string }> };
 
 export type SetOrgIdentityVerifiedMutationVariables = Exact<{
-  externalId: Scalars["String"];
-  verified: Scalars["Boolean"];
+  externalId: Scalars['String'];
+  verified: Scalars['Boolean'];
 }>;
 
-export type SetOrgIdentityVerifiedMutation = {
-  __typename?: "Mutation";
-  setOrganizationIdentityVerified?: Maybe<boolean>;
-};
+
+export type SetOrgIdentityVerifiedMutation = { __typename?: 'Mutation', setOrganizationIdentityVerified?: Maybe<boolean> };
 
 export type GetOrganizationsQueryVariables = Exact<{
-  identityVerified?: Maybe<Scalars["Boolean"]>;
+  identityVerified?: Maybe<Scalars['Boolean']>;
 }>;
 
-export type GetOrganizationsQuery = {
-  __typename?: "Query";
-  organizations: Array<{
-    __typename?: "Organization";
-    externalId: string;
-    name: string;
-  }>;
-};
+
+export type GetOrganizationsQuery = { __typename?: 'Query', organizations: Array<{ __typename?: 'Organization', externalId: string, name: string }> };
 
 export type SetCurrentUserTenantDataAccessOpMutationVariables = Exact<{
-  organizationExternalId?: Maybe<Scalars["String"]>;
-  justification?: Maybe<Scalars["String"]>;
+  organizationExternalId?: Maybe<Scalars['String']>;
+  justification?: Maybe<Scalars['String']>;
 }>;
 
-export type SetCurrentUserTenantDataAccessOpMutation = {
-  __typename?: "Mutation";
-  setCurrentUserTenantDataAccess?: Maybe<{
-    __typename?: "User";
-    id: string;
-    email: string;
-    permissions: Array<UserPermission>;
-    role?: Maybe<Role>;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      name: string;
-      externalId: string;
-    }>;
-  }>;
-};
+
+export type SetCurrentUserTenantDataAccessOpMutation = { __typename?: 'Mutation', setCurrentUserTenantDataAccess?: Maybe<{ __typename?: 'User', id: string, email: string, permissions: Array<UserPermission>, role?: Maybe<Role>, organization?: Maybe<{ __typename?: 'Organization', name: string, externalId: string }> }> };
 
 export type RemovePatientFromQueueMutationVariables = Exact<{
-  patientId: Scalars["ID"];
+  patientId: Scalars['ID'];
 }>;
 
-export type RemovePatientFromQueueMutation = {
-  __typename?: "Mutation";
-  removePatientFromQueue?: Maybe<string>;
-};
+
+export type RemovePatientFromQueueMutation = { __typename?: 'Mutation', removePatientFromQueue?: Maybe<string> };
 
 export type EditQueueItemMutationVariables = Exact<{
-  id: Scalars["ID"];
-  deviceId?: Maybe<Scalars["String"]>;
-  result?: Maybe<Scalars["String"]>;
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  id: Scalars['ID'];
+  deviceId?: Maybe<Scalars['String']>;
+  result?: Maybe<Scalars['String']>;
+  dateTested?: Maybe<Scalars['DateTime']>;
 }>;
 
-export type EditQueueItemMutation = {
-  __typename?: "Mutation";
-  editQueueItem?: Maybe<{
-    __typename?: "TestOrder";
-    result?: Maybe<string>;
-    dateTested?: Maybe<any>;
-    deviceType?: Maybe<{
-      __typename?: "DeviceType";
-      internalId?: Maybe<string>;
-      testLength?: Maybe<number>;
-    }>;
-  }>;
-};
+
+export type EditQueueItemMutation = { __typename?: 'Mutation', editQueueItem?: Maybe<{ __typename?: 'TestOrder', result?: Maybe<string>, dateTested?: Maybe<any>, deviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string>, testLength?: Maybe<number> }> }> };
 
 export type SubmitTestResultMutationVariables = Exact<{
-  patientId: Scalars["ID"];
-  deviceId: Scalars["String"];
-  result: Scalars["String"];
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  patientId: Scalars['ID'];
+  deviceId: Scalars['String'];
+  result: Scalars['String'];
+  dateTested?: Maybe<Scalars['DateTime']>;
 }>;
 
-export type SubmitTestResultMutation = {
-  __typename?: "Mutation";
-  addTestResultNew?: Maybe<{
-    __typename?: "AddTestResultResponse";
-    deliverySuccess?: Maybe<boolean>;
-    testResult: { __typename?: "TestOrder"; internalId?: Maybe<string> };
-  }>;
-};
+
+export type SubmitTestResultMutation = { __typename?: 'Mutation', addTestResultNew?: Maybe<{ __typename?: 'AddTestResultResponse', deliverySuccess?: Maybe<boolean>, testResult: { __typename?: 'TestOrder', internalId?: Maybe<string> } }> };
 
 export type GetFacilityQueueQueryVariables = Exact<{
-  facilityId: Scalars["ID"];
+  facilityId: Scalars['ID'];
 }>;
 
-export type GetFacilityQueueQuery = {
-  __typename?: "Query";
-  queue?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "TestOrder";
-        internalId?: Maybe<string>;
-        pregnancy?: Maybe<string>;
-        dateAdded?: Maybe<string>;
-        symptoms?: Maybe<string>;
-        symptomOnset?: Maybe<any>;
-        noSymptoms?: Maybe<boolean>;
-        result?: Maybe<string>;
-        dateTested?: Maybe<any>;
-        deviceType?: Maybe<{
-          __typename?: "DeviceType";
-          internalId?: Maybe<string>;
-          name?: Maybe<string>;
-          model?: Maybe<string>;
-          testLength?: Maybe<number>;
-        }>;
-        patient?: Maybe<{
-          __typename?: "Patient";
-          internalId?: Maybe<string>;
-          telephone?: Maybe<string>;
-          birthDate?: Maybe<any>;
-          firstName?: Maybe<string>;
-          middleName?: Maybe<string>;
-          lastName?: Maybe<string>;
-          gender?: Maybe<string>;
-          testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-          preferredLanguage?: Maybe<string>;
-          phoneNumbers?: Maybe<
-            Array<
-              Maybe<{
-                __typename?: "PhoneNumber";
-                type?: Maybe<PhoneType>;
-                number?: Maybe<string>;
-              }>
-            >
-          >;
-        }>;
-      }>
-    >
-  >;
-  organization?: Maybe<{
-    __typename?: "Organization";
-    testingFacility: Array<{
-      __typename?: "Facility";
-      id: string;
-      deviceTypes?: Maybe<
-        Array<
-          Maybe<{
-            __typename?: "DeviceType";
-            internalId?: Maybe<string>;
-            name?: Maybe<string>;
-            model?: Maybe<string>;
-            testLength?: Maybe<number>;
-          }>
-        >
-      >;
-      defaultDeviceType?: Maybe<{
-        __typename?: "DeviceType";
-        internalId?: Maybe<string>;
-        name?: Maybe<string>;
-        model?: Maybe<string>;
-        testLength?: Maybe<number>;
-      }>;
-    }>;
-  }>;
-};
+
+export type GetFacilityQueueQuery = { __typename?: 'Query', queue?: Maybe<Array<Maybe<{ __typename?: 'TestOrder', internalId?: Maybe<string>, pregnancy?: Maybe<string>, dateAdded?: Maybe<string>, symptoms?: Maybe<string>, symptomOnset?: Maybe<any>, noSymptoms?: Maybe<boolean>, result?: Maybe<string>, dateTested?: Maybe<any>, deviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string>, name?: Maybe<string>, model?: Maybe<string>, testLength?: Maybe<number> }>, patient?: Maybe<{ __typename?: 'Patient', internalId?: Maybe<string>, telephone?: Maybe<string>, birthDate?: Maybe<any>, firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, gender?: Maybe<string>, testResultDelivery?: Maybe<TestResultDeliveryPreference>, preferredLanguage?: Maybe<string>, phoneNumbers?: Maybe<Array<Maybe<{ __typename?: 'PhoneNumber', type?: Maybe<PhoneType>, number?: Maybe<string> }>>> }> }>>>, organization?: Maybe<{ __typename?: 'Organization', testingFacility: Array<{ __typename?: 'Facility', id: string, deviceTypes?: Maybe<Array<Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string>, name?: Maybe<string>, model?: Maybe<string>, testLength?: Maybe<number> }>>>, defaultDeviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string>, name?: Maybe<string>, model?: Maybe<string>, testLength?: Maybe<number> }> }> }> };
 
 export type GetPatientQueryVariables = Exact<{
-  internalId: Scalars["ID"];
+  internalId: Scalars['ID'];
 }>;
 
-export type GetPatientQuery = {
-  __typename?: "Query";
-  patient?: Maybe<{
-    __typename?: "Patient";
-    internalId?: Maybe<string>;
-    firstName?: Maybe<string>;
-    lastName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    birthDate?: Maybe<any>;
-    gender?: Maybe<string>;
-    telephone?: Maybe<string>;
-    testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-    phoneNumbers?: Maybe<
-      Array<
-        Maybe<{
-          __typename?: "PhoneNumber";
-          type?: Maybe<PhoneType>;
-          number?: Maybe<string>;
-        }>
-      >
-    >;
-  }>;
-};
+
+export type GetPatientQuery = { __typename?: 'Query', patient?: Maybe<{ __typename?: 'Patient', internalId?: Maybe<string>, firstName?: Maybe<string>, lastName?: Maybe<string>, middleName?: Maybe<string>, birthDate?: Maybe<any>, gender?: Maybe<string>, telephone?: Maybe<string>, testResultDelivery?: Maybe<TestResultDeliveryPreference>, phoneNumbers?: Maybe<Array<Maybe<{ __typename?: 'PhoneNumber', type?: Maybe<PhoneType>, number?: Maybe<string> }>>> }> };
 
 export type GetPatientsByFacilityForQueueQueryVariables = Exact<{
-  facilityId: Scalars["ID"];
-  namePrefixMatch?: Maybe<Scalars["String"]>;
+  facilityId: Scalars['ID'];
+  namePrefixMatch?: Maybe<Scalars['String']>;
 }>;
 
-export type GetPatientsByFacilityForQueueQuery = {
-  __typename?: "Query";
-  patients?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "Patient";
-        internalId?: Maybe<string>;
-        firstName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        birthDate?: Maybe<any>;
-        gender?: Maybe<string>;
-        telephone?: Maybe<string>;
-        testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-        phoneNumbers?: Maybe<
-          Array<
-            Maybe<{
-              __typename?: "PhoneNumber";
-              type?: Maybe<PhoneType>;
-              number?: Maybe<string>;
-            }>
-          >
-        >;
-      }>
-    >
-  >;
-};
+
+export type GetPatientsByFacilityForQueueQuery = { __typename?: 'Query', patients?: Maybe<Array<Maybe<{ __typename?: 'Patient', internalId?: Maybe<string>, firstName?: Maybe<string>, lastName?: Maybe<string>, middleName?: Maybe<string>, birthDate?: Maybe<any>, gender?: Maybe<string>, telephone?: Maybe<string>, testResultDelivery?: Maybe<TestResultDeliveryPreference>, phoneNumbers?: Maybe<Array<Maybe<{ __typename?: 'PhoneNumber', type?: Maybe<PhoneType>, number?: Maybe<string> }>>> }>>> };
 
 export type AddPatientToQueueMutationVariables = Exact<{
-  facilityId: Scalars["ID"];
-  patientId: Scalars["ID"];
-  symptoms?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  pregnancy?: Maybe<Scalars["String"]>;
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
+  facilityId: Scalars['ID'];
+  patientId: Scalars['ID'];
+  symptoms?: Maybe<Scalars['String']>;
+  symptomOnset?: Maybe<Scalars['LocalDate']>;
+  pregnancy?: Maybe<Scalars['String']>;
+  noSymptoms?: Maybe<Scalars['Boolean']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
 }>;
 
-export type AddPatientToQueueMutation = {
-  __typename?: "Mutation";
-  addPatientToQueue?: Maybe<string>;
-};
+
+export type AddPatientToQueueMutation = { __typename?: 'Mutation', addPatientToQueue?: Maybe<string> };
 
 export type UpdateAoeMutationVariables = Exact<{
-  patientId: Scalars["ID"];
-  symptoms?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  pregnancy?: Maybe<Scalars["String"]>;
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
+  patientId: Scalars['ID'];
+  symptoms?: Maybe<Scalars['String']>;
+  symptomOnset?: Maybe<Scalars['LocalDate']>;
+  pregnancy?: Maybe<Scalars['String']>;
+  noSymptoms?: Maybe<Scalars['Boolean']>;
   testResultDelivery?: Maybe<TestResultDeliveryPreference>;
 }>;
 
-export type UpdateAoeMutation = {
-  __typename?: "Mutation";
-  updateTimeOfTestQuestions?: Maybe<string>;
-};
+
+export type UpdateAoeMutation = { __typename?: 'Mutation', updateTimeOfTestQuestions?: Maybe<string> };
 
 export type GetTestResultForCorrectionQueryVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type GetTestResultForCorrectionQuery = {
-  __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    result?: Maybe<string>;
-    correctionStatus?: Maybe<string>;
-    deviceType?: Maybe<{ __typename?: "DeviceType"; name?: Maybe<string> }>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-    }>;
-  }>;
-};
+
+export type GetTestResultForCorrectionQuery = { __typename?: 'Query', testResult?: Maybe<{ __typename?: 'TestResult', dateTested?: Maybe<any>, result?: Maybe<string>, correctionStatus?: Maybe<string>, deviceType?: Maybe<{ __typename?: 'DeviceType', name?: Maybe<string> }>, patient?: Maybe<{ __typename?: 'Patient', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, birthDate?: Maybe<any> }> }> };
 
 export type MarkTestAsErrorMutationVariables = Exact<{
-  id: Scalars["ID"];
-  reason: Scalars["String"];
+  id: Scalars['ID'];
+  reason: Scalars['String'];
 }>;
 
-export type MarkTestAsErrorMutation = {
-  __typename?: "Mutation";
-  correctTestMarkAsError?: Maybe<{
-    __typename?: "TestResult";
-    internalId?: Maybe<string>;
-  }>;
-};
+
+export type MarkTestAsErrorMutation = { __typename?: 'Mutation', correctTestMarkAsError?: Maybe<{ __typename?: 'TestResult', internalId?: Maybe<string> }> };
 
 export type GetTestResultDetailsQueryVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type GetTestResultDetailsQuery = {
-  __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    result?: Maybe<string>;
-    correctionStatus?: Maybe<string>;
-    symptoms?: Maybe<string>;
-    symptomOnset?: Maybe<any>;
-    pregnancy?: Maybe<string>;
-    deviceType?: Maybe<{ __typename?: "DeviceType"; name?: Maybe<string> }>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-    }>;
-    createdBy?: Maybe<{
-      __typename?: "ApiUser";
-      name: {
-        __typename?: "NameInfo";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName: string;
-      };
-    }>;
-  }>;
-};
+
+export type GetTestResultDetailsQuery = { __typename?: 'Query', testResult?: Maybe<{ __typename?: 'TestResult', dateTested?: Maybe<any>, result?: Maybe<string>, correctionStatus?: Maybe<string>, symptoms?: Maybe<string>, symptomOnset?: Maybe<any>, pregnancy?: Maybe<string>, deviceType?: Maybe<{ __typename?: 'DeviceType', name?: Maybe<string> }>, patient?: Maybe<{ __typename?: 'Patient', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, birthDate?: Maybe<any> }>, createdBy?: Maybe<{ __typename?: 'ApiUser', name: { __typename?: 'NameInfo', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName: string } }> }> };
 
 export type GetTestResultForPrintQueryVariables = Exact<{
-  id: Scalars["ID"];
+  id: Scalars['ID'];
 }>;
 
-export type GetTestResultForPrintQuery = {
-  __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    result?: Maybe<string>;
-    correctionStatus?: Maybe<string>;
-    deviceType?: Maybe<{
-      __typename?: "DeviceType";
-      name?: Maybe<string>;
-      model?: Maybe<string>;
-    }>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-    }>;
-    facility?: Maybe<{
-      __typename?: "Facility";
-      name: string;
-      cliaNumber?: Maybe<string>;
-      phone?: Maybe<string>;
-      street?: Maybe<string>;
-      streetTwo?: Maybe<string>;
-      city?: Maybe<string>;
-      state?: Maybe<string>;
-      zipCode?: Maybe<string>;
-      orderingProvider?: Maybe<{
-        __typename?: "Provider";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        NPI?: Maybe<string>;
-      }>;
-    }>;
-  }>;
-};
+
+export type GetTestResultForPrintQuery = { __typename?: 'Query', testResult?: Maybe<{ __typename?: 'TestResult', dateTested?: Maybe<any>, result?: Maybe<string>, correctionStatus?: Maybe<string>, deviceType?: Maybe<{ __typename?: 'DeviceType', name?: Maybe<string>, model?: Maybe<string> }>, patient?: Maybe<{ __typename?: 'Patient', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, birthDate?: Maybe<any> }>, facility?: Maybe<{ __typename?: 'Facility', name: string, cliaNumber?: Maybe<string>, phone?: Maybe<string>, street?: Maybe<string>, streetTwo?: Maybe<string>, city?: Maybe<string>, state?: Maybe<string>, zipCode?: Maybe<string>, orderingProvider?: Maybe<{ __typename?: 'Provider', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, NPI?: Maybe<string> }> }> }> };
+
+export type GetTestResultForTextQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type GetTestResultForTextQuery = { __typename?: 'Query', testResult?: Maybe<{ __typename?: 'TestResult', dateTested?: Maybe<any>, patient?: Maybe<{ __typename?: 'Patient', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, birthDate?: Maybe<any>, phoneNumbers?: Maybe<Array<Maybe<{ __typename?: 'PhoneNumber', type?: Maybe<PhoneType>, number?: Maybe<string> }>>> }> }> };
+
+export type SendSmsMutationVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type SendSmsMutation = { __typename?: 'Mutation', sendPatientLinkSms?: Maybe<string> };
 
 export type GetResultsCountByFacilityQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
-  endDate?: Maybe<Scalars["DateTime"]>;
+  facilityId?: Maybe<Scalars['ID']>;
+  patientId?: Maybe<Scalars['ID']>;
+  result?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  startDate?: Maybe<Scalars['DateTime']>;
+  endDate?: Maybe<Scalars['DateTime']>;
 }>;
 
-export type GetResultsCountByFacilityQuery = {
-  __typename?: "Query";
-  testResultsCount?: Maybe<number>;
-};
+
+export type GetResultsCountByFacilityQuery = { __typename?: 'Query', testResultsCount?: Maybe<number> };
 
 export type GetFacilityResultsQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
-  endDate?: Maybe<Scalars["DateTime"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
+  facilityId?: Maybe<Scalars['ID']>;
+  patientId?: Maybe<Scalars['ID']>;
+  result?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  startDate?: Maybe<Scalars['DateTime']>;
+  endDate?: Maybe<Scalars['DateTime']>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 }>;
 
-export type GetFacilityResultsQuery = {
-  __typename?: "Query";
-  testResults?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "TestResult";
-        internalId?: Maybe<string>;
-        dateTested?: Maybe<any>;
-        result?: Maybe<string>;
-        correctionStatus?: Maybe<string>;
-        symptoms?: Maybe<string>;
-        noSymptoms?: Maybe<boolean>;
-        deviceType?: Maybe<{
-          __typename?: "DeviceType";
-          internalId?: Maybe<string>;
-          name?: Maybe<string>;
-        }>;
-        patient?: Maybe<{
-          __typename?: "Patient";
-          internalId?: Maybe<string>;
-          firstName?: Maybe<string>;
-          middleName?: Maybe<string>;
-          lastName?: Maybe<string>;
-          birthDate?: Maybe<any>;
-          gender?: Maybe<string>;
-          lookupId?: Maybe<string>;
-        }>;
-        createdBy?: Maybe<{
-          __typename?: "ApiUser";
-          nameInfo?: Maybe<{
-            __typename?: "NameInfo";
-            firstName?: Maybe<string>;
-            middleName?: Maybe<string>;
-            lastName: string;
-          }>;
-        }>;
-        patientLink?: Maybe<{
-          __typename?: "PatientLink";
-          internalId?: Maybe<string>;
-        }>;
-      }>
-    >
-  >;
-};
+
+export type GetFacilityResultsQuery = { __typename?: 'Query', testResults?: Maybe<Array<Maybe<{ __typename?: 'TestResult', internalId?: Maybe<string>, dateTested?: Maybe<any>, result?: Maybe<string>, correctionStatus?: Maybe<string>, symptoms?: Maybe<string>, noSymptoms?: Maybe<boolean>, deviceType?: Maybe<{ __typename?: 'DeviceType', internalId?: Maybe<string>, name?: Maybe<string> }>, patient?: Maybe<{ __typename?: 'Patient', internalId?: Maybe<string>, firstName?: Maybe<string>, middleName?: Maybe<string>, lastName?: Maybe<string>, birthDate?: Maybe<any>, gender?: Maybe<string>, lookupId?: Maybe<string> }>, createdBy?: Maybe<{ __typename?: 'ApiUser', nameInfo?: Maybe<{ __typename?: 'NameInfo', firstName?: Maybe<string>, middleName?: Maybe<string>, lastName: string }> }>, patientLink?: Maybe<{ __typename?: 'PatientLink', internalId?: Maybe<string> }> }>>> };
+
 
 export const WhoAmIDocument = gql`
-  query WhoAmI {
-    whoami {
-      id
-      firstName
-      middleName
-      lastName
-      suffix
-      email
-      isAdmin
-      permissions
-      roleDescription
-      organization {
+    query WhoAmI {
+  whoami {
+    id
+    firstName
+    middleName
+    lastName
+    suffix
+    email
+    isAdmin
+    permissions
+    roleDescription
+    organization {
+      name
+      testingFacility {
+        id
         name
-        testingFacility {
-          id
-          name
-        }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useWhoAmIQuery__
@@ -1967,77 +1394,74 @@ export const WhoAmIDocument = gql`
  *   },
  * });
  */
-export function useWhoAmIQuery(
-  baseOptions?: Apollo.QueryHookOptions<WhoAmIQuery, WhoAmIQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<WhoAmIQuery, WhoAmIQueryVariables>(
-    WhoAmIDocument,
-    options
-  );
-}
-export function useWhoAmILazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<WhoAmIQuery, WhoAmIQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<WhoAmIQuery, WhoAmIQueryVariables>(
-    WhoAmIDocument,
-    options
-  );
-}
+export function useWhoAmIQuery(baseOptions?: Apollo.QueryHookOptions<WhoAmIQuery, WhoAmIQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<WhoAmIQuery, WhoAmIQueryVariables>(WhoAmIDocument, options);
+      }
+export function useWhoAmILazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhoAmIQuery, WhoAmIQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<WhoAmIQuery, WhoAmIQueryVariables>(WhoAmIDocument, options);
+        }
 export type WhoAmIQueryHookResult = ReturnType<typeof useWhoAmIQuery>;
 export type WhoAmILazyQueryHookResult = ReturnType<typeof useWhoAmILazyQuery>;
-export type WhoAmIQueryResult = Apollo.QueryResult<
-  WhoAmIQuery,
-  WhoAmIQueryVariables
->;
+export type WhoAmIQueryResult = Apollo.QueryResult<WhoAmIQuery, WhoAmIQueryVariables>;
 export const GetFacilitiesDocument = gql`
-  query GetFacilities {
-    organization {
-      internalId
-      testingFacility {
-        id
-        cliaNumber
-        name
+    query GetFacilities {
+  organization {
+    internalId
+    testingFacility {
+      id
+      cliaNumber
+      name
+      street
+      streetTwo
+      city
+      state
+      zipCode
+      phone
+      email
+      defaultDeviceType {
+        internalId
+      }
+      deviceTypes {
+        internalId
+      }
+      deviceSpecimenTypes {
+        internalId
+        deviceType {
+          name
+          internalId
+        }
+        specimenType {
+          internalId
+          name
+        }
+      }
+      orderingProvider {
+        firstName
+        middleName
+        lastName
+        suffix
+        NPI
         street
         streetTwo
         city
         state
         zipCode
         phone
-        email
-        defaultDeviceType {
-          internalId
-        }
-        deviceTypes {
-          internalId
-        }
-        deviceSpecimenTypes {
-          internalId
-          deviceType {
-            name
-            internalId
-          }
-          specimenType {
-            internalId
-            name
-          }
-        }
-        orderingProvider {
-          firstName
-          middleName
-          lastName
-          suffix
-          NPI
-          street
-          streetTwo
-          city
-          state
-          zipCode
-          phone
-        }
       }
     }
+  }
+  deviceType {
+    internalId
+    name
+  }
+  specimenType {
+    internalId
+    name
+  }
+  deviceSpecimenTypes {
+    internalId
     deviceType {
       internalId
       name
@@ -2046,19 +1470,9 @@ export const GetFacilitiesDocument = gql`
       internalId
       name
     }
-    deviceSpecimenTypes {
-      internalId
-      deviceType {
-        internalId
-        name
-      }
-      specimenType {
-        internalId
-        name
-      }
-    }
   }
-`;
+}
+    `;
 
 /**
  * __useGetFacilitiesQuery__
@@ -2075,99 +1489,48 @@ export const GetFacilitiesDocument = gql`
  *   },
  * });
  */
-export function useGetFacilitiesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetFacilitiesQuery,
-    GetFacilitiesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetFacilitiesQuery, GetFacilitiesQueryVariables>(
-    GetFacilitiesDocument,
-    options
-  );
-}
-export function useGetFacilitiesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFacilitiesQuery,
-    GetFacilitiesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<GetFacilitiesQuery, GetFacilitiesQueryVariables>(
-    GetFacilitiesDocument,
-    options
-  );
-}
-export type GetFacilitiesQueryHookResult = ReturnType<
-  typeof useGetFacilitiesQuery
->;
-export type GetFacilitiesLazyQueryHookResult = ReturnType<
-  typeof useGetFacilitiesLazyQuery
->;
-export type GetFacilitiesQueryResult = Apollo.QueryResult<
-  GetFacilitiesQuery,
-  GetFacilitiesQueryVariables
->;
+export function useGetFacilitiesQuery(baseOptions?: Apollo.QueryHookOptions<GetFacilitiesQuery, GetFacilitiesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetFacilitiesQuery, GetFacilitiesQueryVariables>(GetFacilitiesDocument, options);
+      }
+export function useGetFacilitiesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetFacilitiesQuery, GetFacilitiesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetFacilitiesQuery, GetFacilitiesQueryVariables>(GetFacilitiesDocument, options);
+        }
+export type GetFacilitiesQueryHookResult = ReturnType<typeof useGetFacilitiesQuery>;
+export type GetFacilitiesLazyQueryHookResult = ReturnType<typeof useGetFacilitiesLazyQuery>;
+export type GetFacilitiesQueryResult = Apollo.QueryResult<GetFacilitiesQuery, GetFacilitiesQueryVariables>;
 export const UpdateFacilityDocument = gql`
-  mutation UpdateFacility(
-    $facilityId: ID!
-    $testingFacilityName: String!
-    $cliaNumber: String
-    $street: String!
-    $streetTwo: String
-    $city: String
-    $state: String!
-    $zipCode: String!
-    $phone: String
-    $email: String
-    $orderingProviderFirstName: String
-    $orderingProviderMiddleName: String
-    $orderingProviderLastName: String
-    $orderingProviderSuffix: String
-    $orderingProviderNPI: String
-    $orderingProviderStreet: String
-    $orderingProviderStreetTwo: String
-    $orderingProviderCity: String
-    $orderingProviderState: String
-    $orderingProviderZipCode: String
-    $orderingProviderPhone: String
-    $devices: [String]!
-    $deviceSpecimenTypes: [ID]!
-    $defaultDevice: String!
-  ) {
-    updateFacility(
-      facilityId: $facilityId
-      testingFacilityName: $testingFacilityName
-      cliaNumber: $cliaNumber
-      street: $street
-      streetTwo: $streetTwo
-      city: $city
-      state: $state
-      zipCode: $zipCode
-      phone: $phone
-      email: $email
-      orderingProviderFirstName: $orderingProviderFirstName
-      orderingProviderMiddleName: $orderingProviderMiddleName
-      orderingProviderLastName: $orderingProviderLastName
-      orderingProviderSuffix: $orderingProviderSuffix
-      orderingProviderNPI: $orderingProviderNPI
-      orderingProviderStreet: $orderingProviderStreet
-      orderingProviderStreetTwo: $orderingProviderStreetTwo
-      orderingProviderCity: $orderingProviderCity
-      orderingProviderState: $orderingProviderState
-      orderingProviderZipCode: $orderingProviderZipCode
-      orderingProviderPhone: $orderingProviderPhone
-      deviceTypes: $devices
-      deviceSpecimenTypes: $deviceSpecimenTypes
-      defaultDevice: $defaultDevice
-    )
-  }
-`;
-export type UpdateFacilityMutationFn = Apollo.MutationFunction<
-  UpdateFacilityMutation,
-  UpdateFacilityMutationVariables
->;
+    mutation UpdateFacility($facilityId: ID!, $testingFacilityName: String!, $cliaNumber: String, $street: String!, $streetTwo: String, $city: String, $state: String!, $zipCode: String!, $phone: String, $email: String, $orderingProviderFirstName: String, $orderingProviderMiddleName: String, $orderingProviderLastName: String, $orderingProviderSuffix: String, $orderingProviderNPI: String, $orderingProviderStreet: String, $orderingProviderStreetTwo: String, $orderingProviderCity: String, $orderingProviderState: String, $orderingProviderZipCode: String, $orderingProviderPhone: String, $devices: [String]!, $deviceSpecimenTypes: [ID]!, $defaultDevice: String!) {
+  updateFacility(
+    facilityId: $facilityId
+    testingFacilityName: $testingFacilityName
+    cliaNumber: $cliaNumber
+    street: $street
+    streetTwo: $streetTwo
+    city: $city
+    state: $state
+    zipCode: $zipCode
+    phone: $phone
+    email: $email
+    orderingProviderFirstName: $orderingProviderFirstName
+    orderingProviderMiddleName: $orderingProviderMiddleName
+    orderingProviderLastName: $orderingProviderLastName
+    orderingProviderSuffix: $orderingProviderSuffix
+    orderingProviderNPI: $orderingProviderNPI
+    orderingProviderStreet: $orderingProviderStreet
+    orderingProviderStreetTwo: $orderingProviderStreetTwo
+    orderingProviderCity: $orderingProviderCity
+    orderingProviderState: $orderingProviderState
+    orderingProviderZipCode: $orderingProviderZipCode
+    orderingProviderPhone: $orderingProviderPhone
+    deviceTypes: $devices
+    deviceSpecimenTypes: $deviceSpecimenTypes
+    defaultDevice: $defaultDevice
+  )
+}
+    `;
+export type UpdateFacilityMutationFn = Apollo.MutationFunction<UpdateFacilityMutation, UpdateFacilityMutationVariables>;
 
 /**
  * __useUpdateFacilityMutation__
@@ -2209,83 +1572,43 @@ export type UpdateFacilityMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateFacilityMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateFacilityMutation,
-    UpdateFacilityMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    UpdateFacilityMutation,
-    UpdateFacilityMutationVariables
-  >(UpdateFacilityDocument, options);
-}
-export type UpdateFacilityMutationHookResult = ReturnType<
-  typeof useUpdateFacilityMutation
->;
+export function useUpdateFacilityMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFacilityMutation, UpdateFacilityMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateFacilityMutation, UpdateFacilityMutationVariables>(UpdateFacilityDocument, options);
+      }
+export type UpdateFacilityMutationHookResult = ReturnType<typeof useUpdateFacilityMutation>;
 export type UpdateFacilityMutationResult = Apollo.MutationResult<UpdateFacilityMutation>;
-export type UpdateFacilityMutationOptions = Apollo.BaseMutationOptions<
-  UpdateFacilityMutation,
-  UpdateFacilityMutationVariables
->;
+export type UpdateFacilityMutationOptions = Apollo.BaseMutationOptions<UpdateFacilityMutation, UpdateFacilityMutationVariables>;
 export const AddFacilityDocument = gql`
-  mutation AddFacility(
-    $testingFacilityName: String!
-    $cliaNumber: String
-    $street: String!
-    $streetTwo: String
-    $city: String
-    $state: String!
-    $zipCode: String!
-    $phone: String
-    $email: String
-    $orderingProviderFirstName: String
-    $orderingProviderMiddleName: String
-    $orderingProviderLastName: String
-    $orderingProviderSuffix: String
-    $orderingProviderNPI: String
-    $orderingProviderStreet: String
-    $orderingProviderStreetTwo: String
-    $orderingProviderCity: String
-    $orderingProviderState: String
-    $orderingProviderZipCode: String
-    $orderingProviderPhone: String
-    $devices: [String]!
-    $deviceSpecimenTypes: [ID]!
-    $defaultDevice: String!
-  ) {
-    addFacility(
-      testingFacilityName: $testingFacilityName
-      cliaNumber: $cliaNumber
-      street: $street
-      streetTwo: $streetTwo
-      city: $city
-      state: $state
-      zipCode: $zipCode
-      phone: $phone
-      email: $email
-      orderingProviderFirstName: $orderingProviderFirstName
-      orderingProviderMiddleName: $orderingProviderMiddleName
-      orderingProviderLastName: $orderingProviderLastName
-      orderingProviderSuffix: $orderingProviderSuffix
-      orderingProviderNPI: $orderingProviderNPI
-      orderingProviderStreet: $orderingProviderStreet
-      orderingProviderStreetTwo: $orderingProviderStreetTwo
-      orderingProviderCity: $orderingProviderCity
-      orderingProviderState: $orderingProviderState
-      orderingProviderZipCode: $orderingProviderZipCode
-      orderingProviderPhone: $orderingProviderPhone
-      deviceTypes: $devices
-      deviceSpecimenTypes: $deviceSpecimenTypes
-      defaultDevice: $defaultDevice
-    )
-  }
-`;
-export type AddFacilityMutationFn = Apollo.MutationFunction<
-  AddFacilityMutation,
-  AddFacilityMutationVariables
->;
+    mutation AddFacility($testingFacilityName: String!, $cliaNumber: String, $street: String!, $streetTwo: String, $city: String, $state: String!, $zipCode: String!, $phone: String, $email: String, $orderingProviderFirstName: String, $orderingProviderMiddleName: String, $orderingProviderLastName: String, $orderingProviderSuffix: String, $orderingProviderNPI: String, $orderingProviderStreet: String, $orderingProviderStreetTwo: String, $orderingProviderCity: String, $orderingProviderState: String, $orderingProviderZipCode: String, $orderingProviderPhone: String, $devices: [String]!, $deviceSpecimenTypes: [ID]!, $defaultDevice: String!) {
+  addFacility(
+    testingFacilityName: $testingFacilityName
+    cliaNumber: $cliaNumber
+    street: $street
+    streetTwo: $streetTwo
+    city: $city
+    state: $state
+    zipCode: $zipCode
+    phone: $phone
+    email: $email
+    orderingProviderFirstName: $orderingProviderFirstName
+    orderingProviderMiddleName: $orderingProviderMiddleName
+    orderingProviderLastName: $orderingProviderLastName
+    orderingProviderSuffix: $orderingProviderSuffix
+    orderingProviderNPI: $orderingProviderNPI
+    orderingProviderStreet: $orderingProviderStreet
+    orderingProviderStreetTwo: $orderingProviderStreetTwo
+    orderingProviderCity: $orderingProviderCity
+    orderingProviderState: $orderingProviderState
+    orderingProviderZipCode: $orderingProviderZipCode
+    orderingProviderPhone: $orderingProviderPhone
+    deviceTypes: $devices
+    deviceSpecimenTypes: $deviceSpecimenTypes
+    defaultDevice: $defaultDevice
+  )
+}
+    `;
+export type AddFacilityMutationFn = Apollo.MutationFunction<AddFacilityMutation, AddFacilityMutationVariables>;
 
 /**
  * __useAddFacilityMutation__
@@ -2326,71 +1649,58 @@ export type AddFacilityMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddFacilityMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    AddFacilityMutation,
-    AddFacilityMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<AddFacilityMutation, AddFacilityMutationVariables>(
-    AddFacilityDocument,
-    options
-  );
-}
-export type AddFacilityMutationHookResult = ReturnType<
-  typeof useAddFacilityMutation
->;
+export function useAddFacilityMutation(baseOptions?: Apollo.MutationHookOptions<AddFacilityMutation, AddFacilityMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddFacilityMutation, AddFacilityMutationVariables>(AddFacilityDocument, options);
+      }
+export type AddFacilityMutationHookResult = ReturnType<typeof useAddFacilityMutation>;
 export type AddFacilityMutationResult = Apollo.MutationResult<AddFacilityMutation>;
-export type AddFacilityMutationOptions = Apollo.BaseMutationOptions<
-  AddFacilityMutation,
-  AddFacilityMutationVariables
->;
+export type AddFacilityMutationOptions = Apollo.BaseMutationOptions<AddFacilityMutation, AddFacilityMutationVariables>;
 export const GetManagedFacilitiesDocument = gql`
-  query GetManagedFacilities {
-    organization {
-      testingFacility {
-        id
-        cliaNumber
-        name
+    query GetManagedFacilities {
+  organization {
+    testingFacility {
+      id
+      cliaNumber
+      name
+      street
+      streetTwo
+      city
+      state
+      zipCode
+      phone
+      email
+      defaultDeviceType {
+        internalId
+      }
+      deviceTypes {
+        internalId
+      }
+      deviceSpecimenTypes {
+        deviceType {
+          internalId
+        }
+        specimenType {
+          internalId
+        }
+      }
+      orderingProvider {
+        firstName
+        middleName
+        lastName
+        suffix
+        NPI
         street
         streetTwo
         city
         state
         zipCode
         phone
-        email
-        defaultDeviceType {
-          internalId
-        }
-        deviceTypes {
-          internalId
-        }
-        deviceSpecimenTypes {
-          deviceType {
-            internalId
-          }
-          specimenType {
-            internalId
-          }
-        }
-        orderingProvider {
-          firstName
-          middleName
-          lastName
-          suffix
-          NPI
-          street
-          streetTwo
-          city
-          state
-          zipCode
-          phone
-        }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetManagedFacilitiesQuery__
@@ -2407,48 +1717,25 @@ export const GetManagedFacilitiesDocument = gql`
  *   },
  * });
  */
-export function useGetManagedFacilitiesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetManagedFacilitiesQuery,
-    GetManagedFacilitiesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetManagedFacilitiesQuery,
-    GetManagedFacilitiesQueryVariables
-  >(GetManagedFacilitiesDocument, options);
-}
-export function useGetManagedFacilitiesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetManagedFacilitiesQuery,
-    GetManagedFacilitiesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetManagedFacilitiesQuery,
-    GetManagedFacilitiesQueryVariables
-  >(GetManagedFacilitiesDocument, options);
-}
-export type GetManagedFacilitiesQueryHookResult = ReturnType<
-  typeof useGetManagedFacilitiesQuery
->;
-export type GetManagedFacilitiesLazyQueryHookResult = ReturnType<
-  typeof useGetManagedFacilitiesLazyQuery
->;
-export type GetManagedFacilitiesQueryResult = Apollo.QueryResult<
-  GetManagedFacilitiesQuery,
-  GetManagedFacilitiesQueryVariables
->;
+export function useGetManagedFacilitiesQuery(baseOptions?: Apollo.QueryHookOptions<GetManagedFacilitiesQuery, GetManagedFacilitiesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetManagedFacilitiesQuery, GetManagedFacilitiesQueryVariables>(GetManagedFacilitiesDocument, options);
+      }
+export function useGetManagedFacilitiesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetManagedFacilitiesQuery, GetManagedFacilitiesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetManagedFacilitiesQuery, GetManagedFacilitiesQueryVariables>(GetManagedFacilitiesDocument, options);
+        }
+export type GetManagedFacilitiesQueryHookResult = ReturnType<typeof useGetManagedFacilitiesQuery>;
+export type GetManagedFacilitiesLazyQueryHookResult = ReturnType<typeof useGetManagedFacilitiesLazyQuery>;
+export type GetManagedFacilitiesQueryResult = Apollo.QueryResult<GetManagedFacilitiesQuery, GetManagedFacilitiesQueryVariables>;
 export const GetOrganizationDocument = gql`
-  query GetOrganization {
-    organization {
-      name
-      type
-    }
+    query GetOrganization {
+  organization {
+    name
+    type
   }
-`;
+}
+    `;
 
 /**
  * __useGetOrganizationQuery__
@@ -2465,49 +1752,23 @@ export const GetOrganizationDocument = gql`
  *   },
  * });
  */
-export function useGetOrganizationQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetOrganizationQuery,
-    GetOrganizationQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetOrganizationQuery, GetOrganizationQueryVariables>(
-    GetOrganizationDocument,
-    options
-  );
-}
-export function useGetOrganizationLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetOrganizationQuery,
-    GetOrganizationQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetOrganizationQuery,
-    GetOrganizationQueryVariables
-  >(GetOrganizationDocument, options);
-}
-export type GetOrganizationQueryHookResult = ReturnType<
-  typeof useGetOrganizationQuery
->;
-export type GetOrganizationLazyQueryHookResult = ReturnType<
-  typeof useGetOrganizationLazyQuery
->;
-export type GetOrganizationQueryResult = Apollo.QueryResult<
-  GetOrganizationQuery,
-  GetOrganizationQueryVariables
->;
+export function useGetOrganizationQuery(baseOptions?: Apollo.QueryHookOptions<GetOrganizationQuery, GetOrganizationQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetOrganizationQuery, GetOrganizationQueryVariables>(GetOrganizationDocument, options);
+      }
+export function useGetOrganizationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetOrganizationQuery, GetOrganizationQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetOrganizationQuery, GetOrganizationQueryVariables>(GetOrganizationDocument, options);
+        }
+export type GetOrganizationQueryHookResult = ReturnType<typeof useGetOrganizationQuery>;
+export type GetOrganizationLazyQueryHookResult = ReturnType<typeof useGetOrganizationLazyQuery>;
+export type GetOrganizationQueryResult = Apollo.QueryResult<GetOrganizationQuery, GetOrganizationQueryVariables>;
 export const AdminSetOrganizationDocument = gql`
-  mutation AdminSetOrganization($name: String!, $type: String!) {
-    adminUpdateOrganization(name: $name, type: $type)
-  }
-`;
-export type AdminSetOrganizationMutationFn = Apollo.MutationFunction<
-  AdminSetOrganizationMutation,
-  AdminSetOrganizationMutationVariables
->;
+    mutation AdminSetOrganization($name: String!, $type: String!) {
+  adminUpdateOrganization(name: $name, type: $type)
+}
+    `;
+export type AdminSetOrganizationMutationFn = Apollo.MutationFunction<AdminSetOrganizationMutation, AdminSetOrganizationMutationVariables>;
 
 /**
  * __useAdminSetOrganizationMutation__
@@ -2527,35 +1788,19 @@ export type AdminSetOrganizationMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAdminSetOrganizationMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    AdminSetOrganizationMutation,
-    AdminSetOrganizationMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    AdminSetOrganizationMutation,
-    AdminSetOrganizationMutationVariables
-  >(AdminSetOrganizationDocument, options);
-}
-export type AdminSetOrganizationMutationHookResult = ReturnType<
-  typeof useAdminSetOrganizationMutation
->;
+export function useAdminSetOrganizationMutation(baseOptions?: Apollo.MutationHookOptions<AdminSetOrganizationMutation, AdminSetOrganizationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AdminSetOrganizationMutation, AdminSetOrganizationMutationVariables>(AdminSetOrganizationDocument, options);
+      }
+export type AdminSetOrganizationMutationHookResult = ReturnType<typeof useAdminSetOrganizationMutation>;
 export type AdminSetOrganizationMutationResult = Apollo.MutationResult<AdminSetOrganizationMutation>;
-export type AdminSetOrganizationMutationOptions = Apollo.BaseMutationOptions<
-  AdminSetOrganizationMutation,
-  AdminSetOrganizationMutationVariables
->;
+export type AdminSetOrganizationMutationOptions = Apollo.BaseMutationOptions<AdminSetOrganizationMutation, AdminSetOrganizationMutationVariables>;
 export const SetOrganizationDocument = gql`
-  mutation SetOrganization($type: String!) {
-    updateOrganization(type: $type)
-  }
-`;
-export type SetOrganizationMutationFn = Apollo.MutationFunction<
-  SetOrganizationMutation,
-  SetOrganizationMutationVariables
->;
+    mutation SetOrganization($type: String!) {
+  updateOrganization(type: $type)
+}
+    `;
+export type SetOrganizationMutationFn = Apollo.MutationFunction<SetOrganizationMutation, SetOrganizationMutationVariables>;
 
 /**
  * __useSetOrganizationMutation__
@@ -2574,39 +1819,26 @@ export type SetOrganizationMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSetOrganizationMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SetOrganizationMutation,
-    SetOrganizationMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    SetOrganizationMutation,
-    SetOrganizationMutationVariables
-  >(SetOrganizationDocument, options);
-}
-export type SetOrganizationMutationHookResult = ReturnType<
-  typeof useSetOrganizationMutation
->;
+export function useSetOrganizationMutation(baseOptions?: Apollo.MutationHookOptions<SetOrganizationMutation, SetOrganizationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetOrganizationMutation, SetOrganizationMutationVariables>(SetOrganizationDocument, options);
+      }
+export type SetOrganizationMutationHookResult = ReturnType<typeof useSetOrganizationMutation>;
 export type SetOrganizationMutationResult = Apollo.MutationResult<SetOrganizationMutation>;
-export type SetOrganizationMutationOptions = Apollo.BaseMutationOptions<
-  SetOrganizationMutation,
-  SetOrganizationMutationVariables
->;
+export type SetOrganizationMutationOptions = Apollo.BaseMutationOptions<SetOrganizationMutation, SetOrganizationMutationVariables>;
 export const AllSelfRegistrationLinksDocument = gql`
-  query AllSelfRegistrationLinks {
-    whoami {
-      organization {
+    query AllSelfRegistrationLinks {
+  whoami {
+    organization {
+      patientSelfRegistrationLink
+      facilities {
+        name
         patientSelfRegistrationLink
-        facilities {
-          name
-          patientSelfRegistrationLink
-        }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useAllSelfRegistrationLinksQuery__
@@ -2623,61 +1855,30 @@ export const AllSelfRegistrationLinksDocument = gql`
  *   },
  * });
  */
-export function useAllSelfRegistrationLinksQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    AllSelfRegistrationLinksQuery,
-    AllSelfRegistrationLinksQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    AllSelfRegistrationLinksQuery,
-    AllSelfRegistrationLinksQueryVariables
-  >(AllSelfRegistrationLinksDocument, options);
-}
-export function useAllSelfRegistrationLinksLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    AllSelfRegistrationLinksQuery,
-    AllSelfRegistrationLinksQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    AllSelfRegistrationLinksQuery,
-    AllSelfRegistrationLinksQueryVariables
-  >(AllSelfRegistrationLinksDocument, options);
-}
-export type AllSelfRegistrationLinksQueryHookResult = ReturnType<
-  typeof useAllSelfRegistrationLinksQuery
->;
-export type AllSelfRegistrationLinksLazyQueryHookResult = ReturnType<
-  typeof useAllSelfRegistrationLinksLazyQuery
->;
-export type AllSelfRegistrationLinksQueryResult = Apollo.QueryResult<
-  AllSelfRegistrationLinksQuery,
-  AllSelfRegistrationLinksQueryVariables
->;
+export function useAllSelfRegistrationLinksQuery(baseOptions?: Apollo.QueryHookOptions<AllSelfRegistrationLinksQuery, AllSelfRegistrationLinksQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AllSelfRegistrationLinksQuery, AllSelfRegistrationLinksQueryVariables>(AllSelfRegistrationLinksDocument, options);
+      }
+export function useAllSelfRegistrationLinksLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AllSelfRegistrationLinksQuery, AllSelfRegistrationLinksQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AllSelfRegistrationLinksQuery, AllSelfRegistrationLinksQueryVariables>(AllSelfRegistrationLinksDocument, options);
+        }
+export type AllSelfRegistrationLinksQueryHookResult = ReturnType<typeof useAllSelfRegistrationLinksQuery>;
+export type AllSelfRegistrationLinksLazyQueryHookResult = ReturnType<typeof useAllSelfRegistrationLinksLazyQuery>;
+export type AllSelfRegistrationLinksQueryResult = Apollo.QueryResult<AllSelfRegistrationLinksQuery, AllSelfRegistrationLinksQueryVariables>;
 export const UpdateUserPrivilegesDocument = gql`
-  mutation UpdateUserPrivileges(
-    $id: ID!
-    $role: Role!
-    $accessAllFacilities: Boolean!
-    $facilities: [ID!]!
+    mutation UpdateUserPrivileges($id: ID!, $role: Role!, $accessAllFacilities: Boolean!, $facilities: [ID!]!) {
+  updateUserPrivileges(
+    id: $id
+    role: $role
+    accessAllFacilities: $accessAllFacilities
+    facilities: $facilities
   ) {
-    updateUserPrivileges(
-      id: $id
-      role: $role
-      accessAllFacilities: $accessAllFacilities
-      facilities: $facilities
-    ) {
-      id
-    }
+    id
   }
-`;
-export type UpdateUserPrivilegesMutationFn = Apollo.MutationFunction<
-  UpdateUserPrivilegesMutation,
-  UpdateUserPrivilegesMutationVariables
->;
+}
+    `;
+export type UpdateUserPrivilegesMutationFn = Apollo.MutationFunction<UpdateUserPrivilegesMutation, UpdateUserPrivilegesMutationVariables>;
 
 /**
  * __useUpdateUserPrivilegesMutation__
@@ -2699,37 +1900,21 @@ export type UpdateUserPrivilegesMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateUserPrivilegesMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateUserPrivilegesMutation,
-    UpdateUserPrivilegesMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    UpdateUserPrivilegesMutation,
-    UpdateUserPrivilegesMutationVariables
-  >(UpdateUserPrivilegesDocument, options);
-}
-export type UpdateUserPrivilegesMutationHookResult = ReturnType<
-  typeof useUpdateUserPrivilegesMutation
->;
+export function useUpdateUserPrivilegesMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserPrivilegesMutation, UpdateUserPrivilegesMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateUserPrivilegesMutation, UpdateUserPrivilegesMutationVariables>(UpdateUserPrivilegesDocument, options);
+      }
+export type UpdateUserPrivilegesMutationHookResult = ReturnType<typeof useUpdateUserPrivilegesMutation>;
 export type UpdateUserPrivilegesMutationResult = Apollo.MutationResult<UpdateUserPrivilegesMutation>;
-export type UpdateUserPrivilegesMutationOptions = Apollo.BaseMutationOptions<
-  UpdateUserPrivilegesMutation,
-  UpdateUserPrivilegesMutationVariables
->;
+export type UpdateUserPrivilegesMutationOptions = Apollo.BaseMutationOptions<UpdateUserPrivilegesMutation, UpdateUserPrivilegesMutationVariables>;
 export const ResetUserPasswordDocument = gql`
-  mutation ResetUserPassword($id: ID!) {
-    resetUserPassword(id: $id) {
-      id
-    }
+    mutation ResetUserPassword($id: ID!) {
+  resetUserPassword(id: $id) {
+    id
   }
-`;
-export type ResetUserPasswordMutationFn = Apollo.MutationFunction<
-  ResetUserPasswordMutation,
-  ResetUserPasswordMutationVariables
->;
+}
+    `;
+export type ResetUserPasswordMutationFn = Apollo.MutationFunction<ResetUserPasswordMutation, ResetUserPasswordMutationVariables>;
 
 /**
  * __useResetUserPasswordMutation__
@@ -2748,37 +1933,21 @@ export type ResetUserPasswordMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useResetUserPasswordMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    ResetUserPasswordMutation,
-    ResetUserPasswordMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    ResetUserPasswordMutation,
-    ResetUserPasswordMutationVariables
-  >(ResetUserPasswordDocument, options);
-}
-export type ResetUserPasswordMutationHookResult = ReturnType<
-  typeof useResetUserPasswordMutation
->;
+export function useResetUserPasswordMutation(baseOptions?: Apollo.MutationHookOptions<ResetUserPasswordMutation, ResetUserPasswordMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ResetUserPasswordMutation, ResetUserPasswordMutationVariables>(ResetUserPasswordDocument, options);
+      }
+export type ResetUserPasswordMutationHookResult = ReturnType<typeof useResetUserPasswordMutation>;
 export type ResetUserPasswordMutationResult = Apollo.MutationResult<ResetUserPasswordMutation>;
-export type ResetUserPasswordMutationOptions = Apollo.BaseMutationOptions<
-  ResetUserPasswordMutation,
-  ResetUserPasswordMutationVariables
->;
+export type ResetUserPasswordMutationOptions = Apollo.BaseMutationOptions<ResetUserPasswordMutation, ResetUserPasswordMutationVariables>;
 export const SetUserIsDeletedDocument = gql`
-  mutation SetUserIsDeleted($id: ID!, $deleted: Boolean!) {
-    setUserIsDeleted(id: $id, deleted: $deleted) {
-      id
-    }
+    mutation SetUserIsDeleted($id: ID!, $deleted: Boolean!) {
+  setUserIsDeleted(id: $id, deleted: $deleted) {
+    id
   }
-`;
-export type SetUserIsDeletedMutationFn = Apollo.MutationFunction<
-  SetUserIsDeletedMutation,
-  SetUserIsDeletedMutationVariables
->;
+}
+    `;
+export type SetUserIsDeletedMutationFn = Apollo.MutationFunction<SetUserIsDeletedMutation, SetUserIsDeletedMutationVariables>;
 
 /**
  * __useSetUserIsDeletedMutation__
@@ -2798,37 +1967,21 @@ export type SetUserIsDeletedMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSetUserIsDeletedMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SetUserIsDeletedMutation,
-    SetUserIsDeletedMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    SetUserIsDeletedMutation,
-    SetUserIsDeletedMutationVariables
-  >(SetUserIsDeletedDocument, options);
-}
-export type SetUserIsDeletedMutationHookResult = ReturnType<
-  typeof useSetUserIsDeletedMutation
->;
+export function useSetUserIsDeletedMutation(baseOptions?: Apollo.MutationHookOptions<SetUserIsDeletedMutation, SetUserIsDeletedMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetUserIsDeletedMutation, SetUserIsDeletedMutationVariables>(SetUserIsDeletedDocument, options);
+      }
+export type SetUserIsDeletedMutationHookResult = ReturnType<typeof useSetUserIsDeletedMutation>;
 export type SetUserIsDeletedMutationResult = Apollo.MutationResult<SetUserIsDeletedMutation>;
-export type SetUserIsDeletedMutationOptions = Apollo.BaseMutationOptions<
-  SetUserIsDeletedMutation,
-  SetUserIsDeletedMutationVariables
->;
+export type SetUserIsDeletedMutationOptions = Apollo.BaseMutationOptions<SetUserIsDeletedMutation, SetUserIsDeletedMutationVariables>;
 export const ReactivateUserDocument = gql`
-  mutation ReactivateUser($id: ID!) {
-    reactivateUser(id: $id) {
-      id
-    }
+    mutation ReactivateUser($id: ID!) {
+  reactivateUser(id: $id) {
+    id
   }
-`;
-export type ReactivateUserMutationFn = Apollo.MutationFunction<
-  ReactivateUserMutation,
-  ReactivateUserMutationVariables
->;
+}
+    `;
+export type ReactivateUserMutationFn = Apollo.MutationFunction<ReactivateUserMutation, ReactivateUserMutationVariables>;
 
 /**
  * __useReactivateUserMutation__
@@ -2847,47 +2000,26 @@ export type ReactivateUserMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useReactivateUserMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    ReactivateUserMutation,
-    ReactivateUserMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    ReactivateUserMutation,
-    ReactivateUserMutationVariables
-  >(ReactivateUserDocument, options);
-}
-export type ReactivateUserMutationHookResult = ReturnType<
-  typeof useReactivateUserMutation
->;
+export function useReactivateUserMutation(baseOptions?: Apollo.MutationHookOptions<ReactivateUserMutation, ReactivateUserMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ReactivateUserMutation, ReactivateUserMutationVariables>(ReactivateUserDocument, options);
+      }
+export type ReactivateUserMutationHookResult = ReturnType<typeof useReactivateUserMutation>;
 export type ReactivateUserMutationResult = Apollo.MutationResult<ReactivateUserMutation>;
-export type ReactivateUserMutationOptions = Apollo.BaseMutationOptions<
-  ReactivateUserMutation,
-  ReactivateUserMutationVariables
->;
+export type ReactivateUserMutationOptions = Apollo.BaseMutationOptions<ReactivateUserMutation, ReactivateUserMutationVariables>;
 export const AddUserToCurrentOrgDocument = gql`
-  mutation AddUserToCurrentOrg(
-    $firstName: String
-    $lastName: String!
-    $email: String!
-    $role: Role!
+    mutation AddUserToCurrentOrg($firstName: String, $lastName: String!, $email: String!, $role: Role!) {
+  addUserToCurrentOrg(
+    firstName: $firstName
+    lastName: $lastName
+    email: $email
+    role: $role
   ) {
-    addUserToCurrentOrg(
-      firstName: $firstName
-      lastName: $lastName
-      email: $email
-      role: $role
-    ) {
-      id
-    }
+    id
   }
-`;
-export type AddUserToCurrentOrgMutationFn = Apollo.MutationFunction<
-  AddUserToCurrentOrgMutation,
-  AddUserToCurrentOrgMutationVariables
->;
+}
+    `;
+export type AddUserToCurrentOrgMutationFn = Apollo.MutationFunction<AddUserToCurrentOrgMutation, AddUserToCurrentOrgMutationVariables>;
 
 /**
  * __useAddUserToCurrentOrgMutation__
@@ -2909,47 +2041,34 @@ export type AddUserToCurrentOrgMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddUserToCurrentOrgMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    AddUserToCurrentOrgMutation,
-    AddUserToCurrentOrgMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    AddUserToCurrentOrgMutation,
-    AddUserToCurrentOrgMutationVariables
-  >(AddUserToCurrentOrgDocument, options);
-}
-export type AddUserToCurrentOrgMutationHookResult = ReturnType<
-  typeof useAddUserToCurrentOrgMutation
->;
+export function useAddUserToCurrentOrgMutation(baseOptions?: Apollo.MutationHookOptions<AddUserToCurrentOrgMutation, AddUserToCurrentOrgMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddUserToCurrentOrgMutation, AddUserToCurrentOrgMutationVariables>(AddUserToCurrentOrgDocument, options);
+      }
+export type AddUserToCurrentOrgMutationHookResult = ReturnType<typeof useAddUserToCurrentOrgMutation>;
 export type AddUserToCurrentOrgMutationResult = Apollo.MutationResult<AddUserToCurrentOrgMutation>;
-export type AddUserToCurrentOrgMutationOptions = Apollo.BaseMutationOptions<
-  AddUserToCurrentOrgMutation,
-  AddUserToCurrentOrgMutationVariables
->;
+export type AddUserToCurrentOrgMutationOptions = Apollo.BaseMutationOptions<AddUserToCurrentOrgMutation, AddUserToCurrentOrgMutationVariables>;
 export const GetUserDocument = gql`
-  query GetUser($id: ID!) {
-    user(id: $id) {
-      id
-      firstName
-      middleName
-      lastName
-      roleDescription
-      role
-      permissions
-      email
-      status
-      organization {
-        testingFacility {
-          id
-          name
-        }
+    query GetUser($id: ID!) {
+  user(id: $id) {
+    id
+    firstName
+    middleName
+    lastName
+    roleDescription
+    role
+    permissions
+    email
+    status
+    organization {
+      testingFacility {
+        id
+        name
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetUserQuery__
@@ -2967,42 +2086,29 @@ export const GetUserDocument = gql`
  *   },
  * });
  */
-export function useGetUserQuery(
-  baseOptions: Apollo.QueryHookOptions<GetUserQuery, GetUserQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetUserQuery, GetUserQueryVariables>(
-    GetUserDocument,
-    options
-  );
-}
-export function useGetUserLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<GetUserQuery, GetUserQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<GetUserQuery, GetUserQueryVariables>(
-    GetUserDocument,
-    options
-  );
-}
+export function useGetUserQuery(baseOptions: Apollo.QueryHookOptions<GetUserQuery, GetUserQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetUserQuery, GetUserQueryVariables>(GetUserDocument, options);
+      }
+export function useGetUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetUserQuery, GetUserQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetUserQuery, GetUserQueryVariables>(GetUserDocument, options);
+        }
 export type GetUserQueryHookResult = ReturnType<typeof useGetUserQuery>;
 export type GetUserLazyQueryHookResult = ReturnType<typeof useGetUserLazyQuery>;
-export type GetUserQueryResult = Apollo.QueryResult<
-  GetUserQuery,
-  GetUserQueryVariables
->;
+export type GetUserQueryResult = Apollo.QueryResult<GetUserQuery, GetUserQueryVariables>;
 export const GetUsersAndStatusDocument = gql`
-  query GetUsersAndStatus {
-    usersWithStatus {
-      id
-      firstName
-      middleName
-      lastName
-      email
-      status
-    }
+    query GetUsersAndStatus {
+  usersWithStatus {
+    id
+    firstName
+    middleName
+    lastName
+    email
+    status
   }
-`;
+}
+    `;
 
 /**
  * __useGetUsersAndStatusQuery__
@@ -3019,56 +2125,30 @@ export const GetUsersAndStatusDocument = gql`
  *   },
  * });
  */
-export function useGetUsersAndStatusQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >(GetUsersAndStatusDocument, options);
-}
-export function useGetUsersAndStatusLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetUsersAndStatusQuery,
-    GetUsersAndStatusQueryVariables
-  >(GetUsersAndStatusDocument, options);
-}
-export type GetUsersAndStatusQueryHookResult = ReturnType<
-  typeof useGetUsersAndStatusQuery
->;
-export type GetUsersAndStatusLazyQueryHookResult = ReturnType<
-  typeof useGetUsersAndStatusLazyQuery
->;
-export type GetUsersAndStatusQueryResult = Apollo.QueryResult<
-  GetUsersAndStatusQuery,
-  GetUsersAndStatusQueryVariables
->;
+export function useGetUsersAndStatusQuery(baseOptions?: Apollo.QueryHookOptions<GetUsersAndStatusQuery, GetUsersAndStatusQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetUsersAndStatusQuery, GetUsersAndStatusQueryVariables>(GetUsersAndStatusDocument, options);
+      }
+export function useGetUsersAndStatusLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetUsersAndStatusQuery, GetUsersAndStatusQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetUsersAndStatusQuery, GetUsersAndStatusQueryVariables>(GetUsersAndStatusDocument, options);
+        }
+export type GetUsersAndStatusQueryHookResult = ReturnType<typeof useGetUsersAndStatusQuery>;
+export type GetUsersAndStatusLazyQueryHookResult = ReturnType<typeof useGetUsersAndStatusLazyQuery>;
+export type GetUsersAndStatusQueryResult = Apollo.QueryResult<GetUsersAndStatusQuery, GetUsersAndStatusQueryVariables>;
 export const ResendActivationEmailDocument = gql`
-  mutation ResendActivationEmail($id: ID!) {
-    resendActivationEmail(id: $id) {
-      id
-      firstName
-      middleName
-      lastName
-      email
-      status
-    }
+    mutation ResendActivationEmail($id: ID!) {
+  resendActivationEmail(id: $id) {
+    id
+    firstName
+    middleName
+    lastName
+    email
+    status
   }
-`;
-export type ResendActivationEmailMutationFn = Apollo.MutationFunction<
-  ResendActivationEmailMutation,
-  ResendActivationEmailMutationVariables
->;
+}
+    `;
+export type ResendActivationEmailMutationFn = Apollo.MutationFunction<ResendActivationEmailMutation, ResendActivationEmailMutationVariables>;
 
 /**
  * __useResendActivationEmailMutation__
@@ -3087,42 +2167,25 @@ export type ResendActivationEmailMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useResendActivationEmailMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    ResendActivationEmailMutation,
-    ResendActivationEmailMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    ResendActivationEmailMutation,
-    ResendActivationEmailMutationVariables
-  >(ResendActivationEmailDocument, options);
-}
-export type ResendActivationEmailMutationHookResult = ReturnType<
-  typeof useResendActivationEmailMutation
->;
+export function useResendActivationEmailMutation(baseOptions?: Apollo.MutationHookOptions<ResendActivationEmailMutation, ResendActivationEmailMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ResendActivationEmailMutation, ResendActivationEmailMutationVariables>(ResendActivationEmailDocument, options);
+      }
+export type ResendActivationEmailMutationHookResult = ReturnType<typeof useResendActivationEmailMutation>;
 export type ResendActivationEmailMutationResult = Apollo.MutationResult<ResendActivationEmailMutation>;
-export type ResendActivationEmailMutationOptions = Apollo.BaseMutationOptions<
-  ResendActivationEmailMutation,
-  ResendActivationEmailMutationVariables
->;
+export type ResendActivationEmailMutationOptions = Apollo.BaseMutationOptions<ResendActivationEmailMutation, ResendActivationEmailMutationVariables>;
 export const GetTopLevelDashboardMetricsDocument = gql`
-  query GetTopLevelDashboardMetrics(
-    $facilityId: ID
-    $startDate: DateTime!
-    $endDate: DateTime!
+    query GetTopLevelDashboardMetrics($facilityId: ID, $startDate: DateTime!, $endDate: DateTime!) {
+  topLevelDashboardMetrics(
+    facilityId: $facilityId
+    startDate: $startDate
+    endDate: $endDate
   ) {
-    topLevelDashboardMetrics(
-      facilityId: $facilityId
-      startDate: $startDate
-      endDate: $endDate
-    ) {
-      positiveTestCount
-      totalTestCount
-    }
+    positiveTestCount
+    totalTestCount
   }
-`;
+}
+    `;
 
 /**
  * __useGetTopLevelDashboardMetricsQuery__
@@ -3142,57 +2205,28 @@ export const GetTopLevelDashboardMetricsDocument = gql`
  *   },
  * });
  */
-export function useGetTopLevelDashboardMetricsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
-  >(GetTopLevelDashboardMetricsDocument, options);
-}
-export function useGetTopLevelDashboardMetricsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetTopLevelDashboardMetricsQuery,
-    GetTopLevelDashboardMetricsQueryVariables
-  >(GetTopLevelDashboardMetricsDocument, options);
-}
-export type GetTopLevelDashboardMetricsQueryHookResult = ReturnType<
-  typeof useGetTopLevelDashboardMetricsQuery
->;
-export type GetTopLevelDashboardMetricsLazyQueryHookResult = ReturnType<
-  typeof useGetTopLevelDashboardMetricsLazyQuery
->;
-export type GetTopLevelDashboardMetricsQueryResult = Apollo.QueryResult<
-  GetTopLevelDashboardMetricsQuery,
-  GetTopLevelDashboardMetricsQueryVariables
->;
+export function useGetTopLevelDashboardMetricsQuery(baseOptions: Apollo.QueryHookOptions<GetTopLevelDashboardMetricsQuery, GetTopLevelDashboardMetricsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetTopLevelDashboardMetricsQuery, GetTopLevelDashboardMetricsQueryVariables>(GetTopLevelDashboardMetricsDocument, options);
+      }
+export function useGetTopLevelDashboardMetricsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTopLevelDashboardMetricsQuery, GetTopLevelDashboardMetricsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetTopLevelDashboardMetricsQuery, GetTopLevelDashboardMetricsQueryVariables>(GetTopLevelDashboardMetricsDocument, options);
+        }
+export type GetTopLevelDashboardMetricsQueryHookResult = ReturnType<typeof useGetTopLevelDashboardMetricsQuery>;
+export type GetTopLevelDashboardMetricsLazyQueryHookResult = ReturnType<typeof useGetTopLevelDashboardMetricsLazyQuery>;
+export type GetTopLevelDashboardMetricsQueryResult = Apollo.QueryResult<GetTopLevelDashboardMetricsQuery, GetTopLevelDashboardMetricsQueryVariables>;
 export const PatientExistsDocument = gql`
-  query PatientExists(
-    $firstName: String!
-    $lastName: String!
-    $birthDate: LocalDate!
-    $zipCode: String!
-    $facilityId: ID
-  ) {
-    patientExists(
-      firstName: $firstName
-      lastName: $lastName
-      birthDate: $birthDate
-      zipCode: $zipCode
-      facilityId: $facilityId
-    )
-  }
-`;
+    query PatientExists($firstName: String!, $lastName: String!, $birthDate: LocalDate!, $zipCode: String!, $facilityId: ID) {
+  patientExists(
+    firstName: $firstName
+    lastName: $lastName
+    birthDate: $birthDate
+    zipCode: $zipCode
+    facilityId: $facilityId
+  )
+}
+    `;
 
 /**
  * __usePatientExistsQuery__
@@ -3214,104 +2248,53 @@ export const PatientExistsDocument = gql`
  *   },
  * });
  */
-export function usePatientExistsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    PatientExistsQuery,
-    PatientExistsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<PatientExistsQuery, PatientExistsQueryVariables>(
-    PatientExistsDocument,
-    options
-  );
-}
-export function usePatientExistsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    PatientExistsQuery,
-    PatientExistsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<PatientExistsQuery, PatientExistsQueryVariables>(
-    PatientExistsDocument,
-    options
-  );
-}
-export type PatientExistsQueryHookResult = ReturnType<
-  typeof usePatientExistsQuery
->;
-export type PatientExistsLazyQueryHookResult = ReturnType<
-  typeof usePatientExistsLazyQuery
->;
-export type PatientExistsQueryResult = Apollo.QueryResult<
-  PatientExistsQuery,
-  PatientExistsQueryVariables
->;
-export const AddPatientDocument = gql`
-  mutation AddPatient(
-    $facilityId: ID
-    $firstName: String!
-    $middleName: String
-    $lastName: String!
-    $birthDate: LocalDate!
-    $street: String!
-    $streetTwo: String
-    $city: String
-    $state: String!
-    $zipCode: String!
-    $telephone: String
-    $phoneNumbers: [PhoneNumberInput!]
-    $role: String
-    $lookupId: String
-    $email: String
-    $county: String
-    $race: String
-    $ethnicity: String
-    $tribalAffiliation: String
-    $gender: String
-    $residentCongregateSetting: Boolean
-    $employedInHealthcare: Boolean
-    $preferredLanguage: String
-    $testResultDelivery: TestResultDeliveryPreference
-  ) {
-    addPatient(
-      facilityId: $facilityId
-      firstName: $firstName
-      middleName: $middleName
-      lastName: $lastName
-      birthDate: $birthDate
-      street: $street
-      streetTwo: $streetTwo
-      city: $city
-      state: $state
-      zipCode: $zipCode
-      telephone: $telephone
-      phoneNumbers: $phoneNumbers
-      role: $role
-      lookupId: $lookupId
-      email: $email
-      county: $county
-      race: $race
-      ethnicity: $ethnicity
-      tribalAffiliation: $tribalAffiliation
-      gender: $gender
-      residentCongregateSetting: $residentCongregateSetting
-      employedInHealthcare: $employedInHealthcare
-      preferredLanguage: $preferredLanguage
-      testResultDelivery: $testResultDelivery
-    ) {
-      internalId
-      facility {
-        id
+export function usePatientExistsQuery(baseOptions: Apollo.QueryHookOptions<PatientExistsQuery, PatientExistsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PatientExistsQuery, PatientExistsQueryVariables>(PatientExistsDocument, options);
       }
+export function usePatientExistsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PatientExistsQuery, PatientExistsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PatientExistsQuery, PatientExistsQueryVariables>(PatientExistsDocument, options);
+        }
+export type PatientExistsQueryHookResult = ReturnType<typeof usePatientExistsQuery>;
+export type PatientExistsLazyQueryHookResult = ReturnType<typeof usePatientExistsLazyQuery>;
+export type PatientExistsQueryResult = Apollo.QueryResult<PatientExistsQuery, PatientExistsQueryVariables>;
+export const AddPatientDocument = gql`
+    mutation AddPatient($facilityId: ID, $firstName: String!, $middleName: String, $lastName: String!, $birthDate: LocalDate!, $street: String!, $streetTwo: String, $city: String, $state: String!, $zipCode: String!, $telephone: String, $phoneNumbers: [PhoneNumberInput!], $role: String, $lookupId: String, $email: String, $county: String, $race: String, $ethnicity: String, $tribalAffiliation: String, $gender: String, $residentCongregateSetting: Boolean, $employedInHealthcare: Boolean, $preferredLanguage: String, $testResultDelivery: TestResultDeliveryPreference) {
+  addPatient(
+    facilityId: $facilityId
+    firstName: $firstName
+    middleName: $middleName
+    lastName: $lastName
+    birthDate: $birthDate
+    street: $street
+    streetTwo: $streetTwo
+    city: $city
+    state: $state
+    zipCode: $zipCode
+    telephone: $telephone
+    phoneNumbers: $phoneNumbers
+    role: $role
+    lookupId: $lookupId
+    email: $email
+    county: $county
+    race: $race
+    ethnicity: $ethnicity
+    tribalAffiliation: $tribalAffiliation
+    gender: $gender
+    residentCongregateSetting: $residentCongregateSetting
+    employedInHealthcare: $employedInHealthcare
+    preferredLanguage: $preferredLanguage
+    testResultDelivery: $testResultDelivery
+  ) {
+    internalId
+    facility {
+      id
     }
   }
-`;
-export type AddPatientMutationFn = Apollo.MutationFunction<
-  AddPatientMutation,
-  AddPatientMutationVariables
->;
+}
+    `;
+export type AddPatientMutationFn = Apollo.MutationFunction<AddPatientMutation, AddPatientMutationVariables>;
 
 /**
  * __useAddPatientMutation__
@@ -3353,37 +2336,21 @@ export type AddPatientMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddPatientMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    AddPatientMutation,
-    AddPatientMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<AddPatientMutation, AddPatientMutationVariables>(
-    AddPatientDocument,
-    options
-  );
-}
-export type AddPatientMutationHookResult = ReturnType<
-  typeof useAddPatientMutation
->;
+export function useAddPatientMutation(baseOptions?: Apollo.MutationHookOptions<AddPatientMutation, AddPatientMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddPatientMutation, AddPatientMutationVariables>(AddPatientDocument, options);
+      }
+export type AddPatientMutationHookResult = ReturnType<typeof useAddPatientMutation>;
 export type AddPatientMutationResult = Apollo.MutationResult<AddPatientMutation>;
-export type AddPatientMutationOptions = Apollo.BaseMutationOptions<
-  AddPatientMutation,
-  AddPatientMutationVariables
->;
+export type AddPatientMutationOptions = Apollo.BaseMutationOptions<AddPatientMutation, AddPatientMutationVariables>;
 export const ArchivePersonDocument = gql`
-  mutation ArchivePerson($id: ID!, $deleted: Boolean!) {
-    setPatientIsDeleted(id: $id, deleted: $deleted) {
-      internalId
-    }
+    mutation ArchivePerson($id: ID!, $deleted: Boolean!) {
+  setPatientIsDeleted(id: $id, deleted: $deleted) {
+    internalId
   }
-`;
-export type ArchivePersonMutationFn = Apollo.MutationFunction<
-  ArchivePersonMutation,
-  ArchivePersonMutationVariables
->;
+}
+    `;
+export type ArchivePersonMutationFn = Apollo.MutationFunction<ArchivePersonMutation, ArchivePersonMutationVariables>;
 
 /**
  * __useArchivePersonMutation__
@@ -3403,61 +2370,48 @@ export type ArchivePersonMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useArchivePersonMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    ArchivePersonMutation,
-    ArchivePersonMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    ArchivePersonMutation,
-    ArchivePersonMutationVariables
-  >(ArchivePersonDocument, options);
-}
-export type ArchivePersonMutationHookResult = ReturnType<
-  typeof useArchivePersonMutation
->;
+export function useArchivePersonMutation(baseOptions?: Apollo.MutationHookOptions<ArchivePersonMutation, ArchivePersonMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ArchivePersonMutation, ArchivePersonMutationVariables>(ArchivePersonDocument, options);
+      }
+export type ArchivePersonMutationHookResult = ReturnType<typeof useArchivePersonMutation>;
 export type ArchivePersonMutationResult = Apollo.MutationResult<ArchivePersonMutation>;
-export type ArchivePersonMutationOptions = Apollo.BaseMutationOptions<
-  ArchivePersonMutation,
-  ArchivePersonMutationVariables
->;
+export type ArchivePersonMutationOptions = Apollo.BaseMutationOptions<ArchivePersonMutation, ArchivePersonMutationVariables>;
 export const GetPatientDetailsDocument = gql`
-  query GetPatientDetails($id: ID!) {
-    patient(id: $id) {
-      firstName
-      middleName
-      lastName
-      birthDate
-      street
-      streetTwo
-      city
-      state
-      zipCode
-      telephone
-      phoneNumbers {
-        type
-        number
-      }
-      role
-      lookupId
-      email
-      county
-      race
-      ethnicity
-      tribalAffiliation
-      gender
-      residentCongregateSetting
-      employedInHealthcare
-      preferredLanguage
-      facility {
-        id
-      }
-      testResultDelivery
+    query GetPatientDetails($id: ID!) {
+  patient(id: $id) {
+    firstName
+    middleName
+    lastName
+    birthDate
+    street
+    streetTwo
+    city
+    state
+    zipCode
+    telephone
+    phoneNumbers {
+      type
+      number
     }
+    role
+    lookupId
+    email
+    county
+    race
+    ethnicity
+    tribalAffiliation
+    gender
+    residentCongregateSetting
+    employedInHealthcare
+    preferredLanguage
+    facility {
+      id
+    }
+    testResultDelivery
   }
-`;
+}
+    `;
 
 /**
  * __useGetPatientDetailsQuery__
@@ -3475,103 +2429,51 @@ export const GetPatientDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetPatientDetailsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetPatientDetailsQuery,
-    GetPatientDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetPatientDetailsQuery,
-    GetPatientDetailsQueryVariables
-  >(GetPatientDetailsDocument, options);
-}
-export function useGetPatientDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPatientDetailsQuery,
-    GetPatientDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetPatientDetailsQuery,
-    GetPatientDetailsQueryVariables
-  >(GetPatientDetailsDocument, options);
-}
-export type GetPatientDetailsQueryHookResult = ReturnType<
-  typeof useGetPatientDetailsQuery
->;
-export type GetPatientDetailsLazyQueryHookResult = ReturnType<
-  typeof useGetPatientDetailsLazyQuery
->;
-export type GetPatientDetailsQueryResult = Apollo.QueryResult<
-  GetPatientDetailsQuery,
-  GetPatientDetailsQueryVariables
->;
+export function useGetPatientDetailsQuery(baseOptions: Apollo.QueryHookOptions<GetPatientDetailsQuery, GetPatientDetailsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPatientDetailsQuery, GetPatientDetailsQueryVariables>(GetPatientDetailsDocument, options);
+      }
+export function useGetPatientDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPatientDetailsQuery, GetPatientDetailsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPatientDetailsQuery, GetPatientDetailsQueryVariables>(GetPatientDetailsDocument, options);
+        }
+export type GetPatientDetailsQueryHookResult = ReturnType<typeof useGetPatientDetailsQuery>;
+export type GetPatientDetailsLazyQueryHookResult = ReturnType<typeof useGetPatientDetailsLazyQuery>;
+export type GetPatientDetailsQueryResult = Apollo.QueryResult<GetPatientDetailsQuery, GetPatientDetailsQueryVariables>;
 export const UpdatePatientDocument = gql`
-  mutation UpdatePatient(
-    $facilityId: ID
-    $patientId: ID!
-    $firstName: String!
-    $middleName: String
-    $lastName: String!
-    $birthDate: LocalDate!
-    $street: String!
-    $streetTwo: String
-    $city: String
-    $state: String!
-    $zipCode: String!
-    $telephone: String
-    $phoneNumbers: [PhoneNumberInput!]
-    $role: String
-    $lookupId: String
-    $email: String
-    $county: String
-    $race: String
-    $ethnicity: String
-    $tribalAffiliation: String
-    $gender: String
-    $residentCongregateSetting: Boolean
-    $employedInHealthcare: Boolean
-    $preferredLanguage: String
-    $testResultDelivery: TestResultDeliveryPreference
+    mutation UpdatePatient($facilityId: ID, $patientId: ID!, $firstName: String!, $middleName: String, $lastName: String!, $birthDate: LocalDate!, $street: String!, $streetTwo: String, $city: String, $state: String!, $zipCode: String!, $telephone: String, $phoneNumbers: [PhoneNumberInput!], $role: String, $lookupId: String, $email: String, $county: String, $race: String, $ethnicity: String, $tribalAffiliation: String, $gender: String, $residentCongregateSetting: Boolean, $employedInHealthcare: Boolean, $preferredLanguage: String, $testResultDelivery: TestResultDeliveryPreference) {
+  updatePatient(
+    facilityId: $facilityId
+    patientId: $patientId
+    firstName: $firstName
+    middleName: $middleName
+    lastName: $lastName
+    birthDate: $birthDate
+    street: $street
+    streetTwo: $streetTwo
+    city: $city
+    state: $state
+    zipCode: $zipCode
+    telephone: $telephone
+    phoneNumbers: $phoneNumbers
+    role: $role
+    lookupId: $lookupId
+    email: $email
+    county: $county
+    race: $race
+    ethnicity: $ethnicity
+    tribalAffiliation: $tribalAffiliation
+    gender: $gender
+    residentCongregateSetting: $residentCongregateSetting
+    employedInHealthcare: $employedInHealthcare
+    preferredLanguage: $preferredLanguage
+    testResultDelivery: $testResultDelivery
   ) {
-    updatePatient(
-      facilityId: $facilityId
-      patientId: $patientId
-      firstName: $firstName
-      middleName: $middleName
-      lastName: $lastName
-      birthDate: $birthDate
-      street: $street
-      streetTwo: $streetTwo
-      city: $city
-      state: $state
-      zipCode: $zipCode
-      telephone: $telephone
-      phoneNumbers: $phoneNumbers
-      role: $role
-      lookupId: $lookupId
-      email: $email
-      county: $county
-      race: $race
-      ethnicity: $ethnicity
-      tribalAffiliation: $tribalAffiliation
-      gender: $gender
-      residentCongregateSetting: $residentCongregateSetting
-      employedInHealthcare: $employedInHealthcare
-      preferredLanguage: $preferredLanguage
-      testResultDelivery: $testResultDelivery
-    ) {
-      internalId
-    }
+    internalId
   }
-`;
-export type UpdatePatientMutationFn = Apollo.MutationFunction<
-  UpdatePatientMutation,
-  UpdatePatientMutationVariables
->;
+}
+    `;
+export type UpdatePatientMutationFn = Apollo.MutationFunction<UpdatePatientMutation, UpdatePatientMutationVariables>;
 
 /**
  * __useUpdatePatientMutation__
@@ -3614,39 +2516,22 @@ export type UpdatePatientMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdatePatientMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdatePatientMutation,
-    UpdatePatientMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    UpdatePatientMutation,
-    UpdatePatientMutationVariables
-  >(UpdatePatientDocument, options);
-}
-export type UpdatePatientMutationHookResult = ReturnType<
-  typeof useUpdatePatientMutation
->;
+export function useUpdatePatientMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePatientMutation, UpdatePatientMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdatePatientMutation, UpdatePatientMutationVariables>(UpdatePatientDocument, options);
+      }
+export type UpdatePatientMutationHookResult = ReturnType<typeof useUpdatePatientMutation>;
 export type UpdatePatientMutationResult = Apollo.MutationResult<UpdatePatientMutation>;
-export type UpdatePatientMutationOptions = Apollo.BaseMutationOptions<
-  UpdatePatientMutation,
-  UpdatePatientMutationVariables
->;
+export type UpdatePatientMutationOptions = Apollo.BaseMutationOptions<UpdatePatientMutation, UpdatePatientMutationVariables>;
 export const GetPatientsCountByFacilityDocument = gql`
-  query GetPatientsCountByFacility(
-    $facilityId: ID!
-    $showDeleted: Boolean!
-    $namePrefixMatch: String
-  ) {
-    patientsCount(
-      facilityId: $facilityId
-      showDeleted: $showDeleted
-      namePrefixMatch: $namePrefixMatch
-    )
-  }
-`;
+    query GetPatientsCountByFacility($facilityId: ID!, $showDeleted: Boolean!, $namePrefixMatch: String) {
+  patientsCount(
+    facilityId: $facilityId
+    showDeleted: $showDeleted
+    namePrefixMatch: $namePrefixMatch
+  )
+}
+    `;
 
 /**
  * __useGetPatientsCountByFacilityQuery__
@@ -3666,68 +2551,39 @@ export const GetPatientsCountByFacilityDocument = gql`
  *   },
  * });
  */
-export function useGetPatientsCountByFacilityQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetPatientsCountByFacilityQuery,
-    GetPatientsCountByFacilityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetPatientsCountByFacilityQuery,
-    GetPatientsCountByFacilityQueryVariables
-  >(GetPatientsCountByFacilityDocument, options);
-}
-export function useGetPatientsCountByFacilityLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPatientsCountByFacilityQuery,
-    GetPatientsCountByFacilityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetPatientsCountByFacilityQuery,
-    GetPatientsCountByFacilityQueryVariables
-  >(GetPatientsCountByFacilityDocument, options);
-}
-export type GetPatientsCountByFacilityQueryHookResult = ReturnType<
-  typeof useGetPatientsCountByFacilityQuery
->;
-export type GetPatientsCountByFacilityLazyQueryHookResult = ReturnType<
-  typeof useGetPatientsCountByFacilityLazyQuery
->;
-export type GetPatientsCountByFacilityQueryResult = Apollo.QueryResult<
-  GetPatientsCountByFacilityQuery,
-  GetPatientsCountByFacilityQueryVariables
->;
-export const GetPatientsByFacilityDocument = gql`
-  query GetPatientsByFacility(
-    $facilityId: ID!
-    $pageNumber: Int!
-    $pageSize: Int!
-    $showDeleted: Boolean
-    $namePrefixMatch: String
-  ) {
-    patients(
-      facilityId: $facilityId
-      pageNumber: $pageNumber
-      pageSize: $pageSize
-      showDeleted: $showDeleted
-      namePrefixMatch: $namePrefixMatch
-    ) {
-      internalId
-      firstName
-      lastName
-      middleName
-      birthDate
-      isDeleted
-      role
-      lastTest {
-        dateAdded
+export function useGetPatientsCountByFacilityQuery(baseOptions: Apollo.QueryHookOptions<GetPatientsCountByFacilityQuery, GetPatientsCountByFacilityQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPatientsCountByFacilityQuery, GetPatientsCountByFacilityQueryVariables>(GetPatientsCountByFacilityDocument, options);
       }
+export function useGetPatientsCountByFacilityLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPatientsCountByFacilityQuery, GetPatientsCountByFacilityQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPatientsCountByFacilityQuery, GetPatientsCountByFacilityQueryVariables>(GetPatientsCountByFacilityDocument, options);
+        }
+export type GetPatientsCountByFacilityQueryHookResult = ReturnType<typeof useGetPatientsCountByFacilityQuery>;
+export type GetPatientsCountByFacilityLazyQueryHookResult = ReturnType<typeof useGetPatientsCountByFacilityLazyQuery>;
+export type GetPatientsCountByFacilityQueryResult = Apollo.QueryResult<GetPatientsCountByFacilityQuery, GetPatientsCountByFacilityQueryVariables>;
+export const GetPatientsByFacilityDocument = gql`
+    query GetPatientsByFacility($facilityId: ID!, $pageNumber: Int!, $pageSize: Int!, $showDeleted: Boolean, $namePrefixMatch: String) {
+  patients(
+    facilityId: $facilityId
+    pageNumber: $pageNumber
+    pageSize: $pageSize
+    showDeleted: $showDeleted
+    namePrefixMatch: $namePrefixMatch
+  ) {
+    internalId
+    firstName
+    lastName
+    middleName
+    birthDate
+    isDeleted
+    role
+    lastTest {
+      dateAdded
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetPatientsByFacilityQuery__
@@ -3749,49 +2605,23 @@ export const GetPatientsByFacilityDocument = gql`
  *   },
  * });
  */
-export function useGetPatientsByFacilityQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetPatientsByFacilityQuery,
-    GetPatientsByFacilityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetPatientsByFacilityQuery,
-    GetPatientsByFacilityQueryVariables
-  >(GetPatientsByFacilityDocument, options);
-}
-export function useGetPatientsByFacilityLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPatientsByFacilityQuery,
-    GetPatientsByFacilityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetPatientsByFacilityQuery,
-    GetPatientsByFacilityQueryVariables
-  >(GetPatientsByFacilityDocument, options);
-}
-export type GetPatientsByFacilityQueryHookResult = ReturnType<
-  typeof useGetPatientsByFacilityQuery
->;
-export type GetPatientsByFacilityLazyQueryHookResult = ReturnType<
-  typeof useGetPatientsByFacilityLazyQuery
->;
-export type GetPatientsByFacilityQueryResult = Apollo.QueryResult<
-  GetPatientsByFacilityQuery,
-  GetPatientsByFacilityQueryVariables
->;
+export function useGetPatientsByFacilityQuery(baseOptions: Apollo.QueryHookOptions<GetPatientsByFacilityQuery, GetPatientsByFacilityQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPatientsByFacilityQuery, GetPatientsByFacilityQueryVariables>(GetPatientsByFacilityDocument, options);
+      }
+export function useGetPatientsByFacilityLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPatientsByFacilityQuery, GetPatientsByFacilityQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPatientsByFacilityQuery, GetPatientsByFacilityQueryVariables>(GetPatientsByFacilityDocument, options);
+        }
+export type GetPatientsByFacilityQueryHookResult = ReturnType<typeof useGetPatientsByFacilityQuery>;
+export type GetPatientsByFacilityLazyQueryHookResult = ReturnType<typeof useGetPatientsByFacilityLazyQuery>;
+export type GetPatientsByFacilityQueryResult = Apollo.QueryResult<GetPatientsByFacilityQuery, GetPatientsByFacilityQueryVariables>;
 export const UploadPatientsDocument = gql`
-  mutation UploadPatients($patientList: Upload!) {
-    uploadPatients(patientList: $patientList)
-  }
-`;
-export type UploadPatientsMutationFn = Apollo.MutationFunction<
-  UploadPatientsMutation,
-  UploadPatientsMutationVariables
->;
+    mutation UploadPatients($patientList: Upload!) {
+  uploadPatients(patientList: $patientList)
+}
+    `;
+export type UploadPatientsMutationFn = Apollo.MutationFunction<UploadPatientsMutation, UploadPatientsMutationVariables>;
 
 /**
  * __useUploadPatientsMutation__
@@ -3810,55 +2640,26 @@ export type UploadPatientsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUploadPatientsMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UploadPatientsMutation,
-    UploadPatientsMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    UploadPatientsMutation,
-    UploadPatientsMutationVariables
-  >(UploadPatientsDocument, options);
-}
-export type UploadPatientsMutationHookResult = ReturnType<
-  typeof useUploadPatientsMutation
->;
-export type UploadPatientsMutationResult = Apollo.MutationResult<UploadPatientsMutation>;
-export type UploadPatientsMutationOptions = Apollo.BaseMutationOptions<
-  UploadPatientsMutation,
-  UploadPatientsMutationVariables
->;
-export const AddUserDocument = gql`
-  mutation AddUser(
-    $firstName: String
-    $middleName: String
-    $lastName: String
-    $suffix: String
-    $email: String!
-    $organizationExternalId: String!
-    $role: Role!
-  ) {
-    addUser(
-      name: {
-        firstName: $firstName
-        middleName: $middleName
-        lastName: $lastName
-        suffix: $suffix
+export function useUploadPatientsMutation(baseOptions?: Apollo.MutationHookOptions<UploadPatientsMutation, UploadPatientsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UploadPatientsMutation, UploadPatientsMutationVariables>(UploadPatientsDocument, options);
       }
-      email: $email
-      organizationExternalId: $organizationExternalId
-      role: $role
-    ) {
-      id
-    }
+export type UploadPatientsMutationHookResult = ReturnType<typeof useUploadPatientsMutation>;
+export type UploadPatientsMutationResult = Apollo.MutationResult<UploadPatientsMutation>;
+export type UploadPatientsMutationOptions = Apollo.BaseMutationOptions<UploadPatientsMutation, UploadPatientsMutationVariables>;
+export const AddUserDocument = gql`
+    mutation AddUser($firstName: String, $middleName: String, $lastName: String, $suffix: String, $email: String!, $organizationExternalId: String!, $role: Role!) {
+  addUser(
+    name: {firstName: $firstName, middleName: $middleName, lastName: $lastName, suffix: $suffix}
+    email: $email
+    organizationExternalId: $organizationExternalId
+    role: $role
+  ) {
+    id
   }
-`;
-export type AddUserMutationFn = Apollo.MutationFunction<
-  AddUserMutation,
-  AddUserMutationVariables
->;
+}
+    `;
+export type AddUserMutationFn = Apollo.MutationFunction<AddUserMutation, AddUserMutationVariables>;
 
 /**
  * __useAddUserMutation__
@@ -3883,47 +2684,27 @@ export type AddUserMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddUserMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    AddUserMutation,
-    AddUserMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<AddUserMutation, AddUserMutationVariables>(
-    AddUserDocument,
-    options
-  );
-}
+export function useAddUserMutation(baseOptions?: Apollo.MutationHookOptions<AddUserMutation, AddUserMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddUserMutation, AddUserMutationVariables>(AddUserDocument, options);
+      }
 export type AddUserMutationHookResult = ReturnType<typeof useAddUserMutation>;
 export type AddUserMutationResult = Apollo.MutationResult<AddUserMutation>;
-export type AddUserMutationOptions = Apollo.BaseMutationOptions<
-  AddUserMutation,
-  AddUserMutationVariables
->;
+export type AddUserMutationOptions = Apollo.BaseMutationOptions<AddUserMutation, AddUserMutationVariables>;
 export const CreateDeviceTypeDocument = gql`
-  mutation createDeviceType(
-    $name: String!
-    $manufacturer: String!
-    $model: String!
-    $loincCode: String!
-    $swabType: String!
+    mutation createDeviceType($name: String!, $manufacturer: String!, $model: String!, $loincCode: String!, $swabType: String!) {
+  createDeviceType(
+    name: $name
+    manufacturer: $manufacturer
+    model: $model
+    loincCode: $loincCode
+    swabType: $swabType
   ) {
-    createDeviceType(
-      name: $name
-      manufacturer: $manufacturer
-      model: $model
-      loincCode: $loincCode
-      swabType: $swabType
-    ) {
-      internalId
-    }
+    internalId
   }
-`;
-export type CreateDeviceTypeMutationFn = Apollo.MutationFunction<
-  CreateDeviceTypeMutation,
-  CreateDeviceTypeMutationVariables
->;
+}
+    `;
+export type CreateDeviceTypeMutationFn = Apollo.MutationFunction<CreateDeviceTypeMutation, CreateDeviceTypeMutationVariables>;
 
 /**
  * __useCreateDeviceTypeMutation__
@@ -3946,49 +2727,27 @@ export type CreateDeviceTypeMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateDeviceTypeMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    CreateDeviceTypeMutation,
-    CreateDeviceTypeMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    CreateDeviceTypeMutation,
-    CreateDeviceTypeMutationVariables
-  >(CreateDeviceTypeDocument, options);
-}
-export type CreateDeviceTypeMutationHookResult = ReturnType<
-  typeof useCreateDeviceTypeMutation
->;
+export function useCreateDeviceTypeMutation(baseOptions?: Apollo.MutationHookOptions<CreateDeviceTypeMutation, CreateDeviceTypeMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateDeviceTypeMutation, CreateDeviceTypeMutationVariables>(CreateDeviceTypeDocument, options);
+      }
+export type CreateDeviceTypeMutationHookResult = ReturnType<typeof useCreateDeviceTypeMutation>;
 export type CreateDeviceTypeMutationResult = Apollo.MutationResult<CreateDeviceTypeMutation>;
-export type CreateDeviceTypeMutationOptions = Apollo.BaseMutationOptions<
-  CreateDeviceTypeMutation,
-  CreateDeviceTypeMutationVariables
->;
+export type CreateDeviceTypeMutationOptions = Apollo.BaseMutationOptions<CreateDeviceTypeMutation, CreateDeviceTypeMutationVariables>;
 export const CreateDeviceTypeNewDocument = gql`
-  mutation createDeviceTypeNew(
-    $name: String!
-    $manufacturer: String!
-    $model: String!
-    $loincCode: String!
-    $swabTypes: [ID!]!
+    mutation createDeviceTypeNew($name: String!, $manufacturer: String!, $model: String!, $loincCode: String!, $swabTypes: [ID!]!) {
+  createDeviceTypeNew(
+    name: $name
+    manufacturer: $manufacturer
+    model: $model
+    loincCode: $loincCode
+    swabTypes: $swabTypes
   ) {
-    createDeviceTypeNew(
-      name: $name
-      manufacturer: $manufacturer
-      model: $model
-      loincCode: $loincCode
-      swabTypes: $swabTypes
-    ) {
-      internalId
-    }
+    internalId
   }
-`;
-export type CreateDeviceTypeNewMutationFn = Apollo.MutationFunction<
-  CreateDeviceTypeNewMutation,
-  CreateDeviceTypeNewMutationVariables
->;
+}
+    `;
+export type CreateDeviceTypeNewMutationFn = Apollo.MutationFunction<CreateDeviceTypeNewMutation, CreateDeviceTypeNewMutationVariables>;
 
 /**
  * __useCreateDeviceTypeNewMutation__
@@ -4011,35 +2770,22 @@ export type CreateDeviceTypeNewMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateDeviceTypeNewMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    CreateDeviceTypeNewMutation,
-    CreateDeviceTypeNewMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    CreateDeviceTypeNewMutation,
-    CreateDeviceTypeNewMutationVariables
-  >(CreateDeviceTypeNewDocument, options);
-}
-export type CreateDeviceTypeNewMutationHookResult = ReturnType<
-  typeof useCreateDeviceTypeNewMutation
->;
+export function useCreateDeviceTypeNewMutation(baseOptions?: Apollo.MutationHookOptions<CreateDeviceTypeNewMutation, CreateDeviceTypeNewMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateDeviceTypeNewMutation, CreateDeviceTypeNewMutationVariables>(CreateDeviceTypeNewDocument, options);
+      }
+export type CreateDeviceTypeNewMutationHookResult = ReturnType<typeof useCreateDeviceTypeNewMutation>;
 export type CreateDeviceTypeNewMutationResult = Apollo.MutationResult<CreateDeviceTypeNewMutation>;
-export type CreateDeviceTypeNewMutationOptions = Apollo.BaseMutationOptions<
-  CreateDeviceTypeNewMutation,
-  CreateDeviceTypeNewMutationVariables
->;
+export type CreateDeviceTypeNewMutationOptions = Apollo.BaseMutationOptions<CreateDeviceTypeNewMutation, CreateDeviceTypeNewMutationVariables>;
 export const GetSpecimenTypesDocument = gql`
-  query getSpecimenTypes {
-    specimenTypes {
-      internalId
-      name
-      typeCode
-    }
+    query getSpecimenTypes {
+  specimenTypes {
+    internalId
+    name
+    typeCode
   }
-`;
+}
+    `;
 
 /**
  * __useGetSpecimenTypesQuery__
@@ -4056,52 +2802,23 @@ export const GetSpecimenTypesDocument = gql`
  *   },
  * });
  */
-export function useGetSpecimenTypesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetSpecimenTypesQuery,
-    GetSpecimenTypesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetSpecimenTypesQuery, GetSpecimenTypesQueryVariables>(
-    GetSpecimenTypesDocument,
-    options
-  );
-}
-export function useGetSpecimenTypesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetSpecimenTypesQuery,
-    GetSpecimenTypesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetSpecimenTypesQuery,
-    GetSpecimenTypesQueryVariables
-  >(GetSpecimenTypesDocument, options);
-}
-export type GetSpecimenTypesQueryHookResult = ReturnType<
-  typeof useGetSpecimenTypesQuery
->;
-export type GetSpecimenTypesLazyQueryHookResult = ReturnType<
-  typeof useGetSpecimenTypesLazyQuery
->;
-export type GetSpecimenTypesQueryResult = Apollo.QueryResult<
-  GetSpecimenTypesQuery,
-  GetSpecimenTypesQueryVariables
->;
+export function useGetSpecimenTypesQuery(baseOptions?: Apollo.QueryHookOptions<GetSpecimenTypesQuery, GetSpecimenTypesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSpecimenTypesQuery, GetSpecimenTypesQueryVariables>(GetSpecimenTypesDocument, options);
+      }
+export function useGetSpecimenTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSpecimenTypesQuery, GetSpecimenTypesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSpecimenTypesQuery, GetSpecimenTypesQueryVariables>(GetSpecimenTypesDocument, options);
+        }
+export type GetSpecimenTypesQueryHookResult = ReturnType<typeof useGetSpecimenTypesQuery>;
+export type GetSpecimenTypesLazyQueryHookResult = ReturnType<typeof useGetSpecimenTypesLazyQuery>;
+export type GetSpecimenTypesQueryResult = Apollo.QueryResult<GetSpecimenTypesQuery, GetSpecimenTypesQueryVariables>;
 export const SetOrgIdentityVerifiedDocument = gql`
-  mutation SetOrgIdentityVerified($externalId: String!, $verified: Boolean!) {
-    setOrganizationIdentityVerified(
-      externalId: $externalId
-      verified: $verified
-    )
-  }
-`;
-export type SetOrgIdentityVerifiedMutationFn = Apollo.MutationFunction<
-  SetOrgIdentityVerifiedMutation,
-  SetOrgIdentityVerifiedMutationVariables
->;
+    mutation SetOrgIdentityVerified($externalId: String!, $verified: Boolean!) {
+  setOrganizationIdentityVerified(externalId: $externalId, verified: $verified)
+}
+    `;
+export type SetOrgIdentityVerifiedMutationFn = Apollo.MutationFunction<SetOrgIdentityVerifiedMutation, SetOrgIdentityVerifiedMutationVariables>;
 
 /**
  * __useSetOrgIdentityVerifiedMutation__
@@ -4121,34 +2838,21 @@ export type SetOrgIdentityVerifiedMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSetOrgIdentityVerifiedMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SetOrgIdentityVerifiedMutation,
-    SetOrgIdentityVerifiedMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    SetOrgIdentityVerifiedMutation,
-    SetOrgIdentityVerifiedMutationVariables
-  >(SetOrgIdentityVerifiedDocument, options);
-}
-export type SetOrgIdentityVerifiedMutationHookResult = ReturnType<
-  typeof useSetOrgIdentityVerifiedMutation
->;
+export function useSetOrgIdentityVerifiedMutation(baseOptions?: Apollo.MutationHookOptions<SetOrgIdentityVerifiedMutation, SetOrgIdentityVerifiedMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetOrgIdentityVerifiedMutation, SetOrgIdentityVerifiedMutationVariables>(SetOrgIdentityVerifiedDocument, options);
+      }
+export type SetOrgIdentityVerifiedMutationHookResult = ReturnType<typeof useSetOrgIdentityVerifiedMutation>;
 export type SetOrgIdentityVerifiedMutationResult = Apollo.MutationResult<SetOrgIdentityVerifiedMutation>;
-export type SetOrgIdentityVerifiedMutationOptions = Apollo.BaseMutationOptions<
-  SetOrgIdentityVerifiedMutation,
-  SetOrgIdentityVerifiedMutationVariables
->;
+export type SetOrgIdentityVerifiedMutationOptions = Apollo.BaseMutationOptions<SetOrgIdentityVerifiedMutation, SetOrgIdentityVerifiedMutationVariables>;
 export const GetOrganizationsDocument = gql`
-  query GetOrganizations($identityVerified: Boolean) {
-    organizations(identityVerified: $identityVerified) {
-      externalId
-      name
-    }
+    query GetOrganizations($identityVerified: Boolean) {
+  organizations(identityVerified: $identityVerified) {
+    externalId
+    name
   }
-`;
+}
+    `;
 
 /**
  * __useGetOrganizationsQuery__
@@ -4166,64 +2870,35 @@ export const GetOrganizationsDocument = gql`
  *   },
  * });
  */
-export function useGetOrganizationsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetOrganizationsQuery,
-    GetOrganizationsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetOrganizationsQuery, GetOrganizationsQueryVariables>(
-    GetOrganizationsDocument,
-    options
-  );
-}
-export function useGetOrganizationsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetOrganizationsQuery,
-    GetOrganizationsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetOrganizationsQuery,
-    GetOrganizationsQueryVariables
-  >(GetOrganizationsDocument, options);
-}
-export type GetOrganizationsQueryHookResult = ReturnType<
-  typeof useGetOrganizationsQuery
->;
-export type GetOrganizationsLazyQueryHookResult = ReturnType<
-  typeof useGetOrganizationsLazyQuery
->;
-export type GetOrganizationsQueryResult = Apollo.QueryResult<
-  GetOrganizationsQuery,
-  GetOrganizationsQueryVariables
->;
-export const SetCurrentUserTenantDataAccessOpDocument = gql`
-  mutation SetCurrentUserTenantDataAccessOp(
-    $organizationExternalId: String
-    $justification: String
-  ) {
-    setCurrentUserTenantDataAccess(
-      organizationExternalId: $organizationExternalId
-      justification: $justification
-    ) {
-      id
-      email
-      permissions
-      role
-      organization {
-        name
-        externalId
+export function useGetOrganizationsQuery(baseOptions?: Apollo.QueryHookOptions<GetOrganizationsQuery, GetOrganizationsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetOrganizationsQuery, GetOrganizationsQueryVariables>(GetOrganizationsDocument, options);
       }
+export function useGetOrganizationsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetOrganizationsQuery, GetOrganizationsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetOrganizationsQuery, GetOrganizationsQueryVariables>(GetOrganizationsDocument, options);
+        }
+export type GetOrganizationsQueryHookResult = ReturnType<typeof useGetOrganizationsQuery>;
+export type GetOrganizationsLazyQueryHookResult = ReturnType<typeof useGetOrganizationsLazyQuery>;
+export type GetOrganizationsQueryResult = Apollo.QueryResult<GetOrganizationsQuery, GetOrganizationsQueryVariables>;
+export const SetCurrentUserTenantDataAccessOpDocument = gql`
+    mutation SetCurrentUserTenantDataAccessOp($organizationExternalId: String, $justification: String) {
+  setCurrentUserTenantDataAccess(
+    organizationExternalId: $organizationExternalId
+    justification: $justification
+  ) {
+    id
+    email
+    permissions
+    role
+    organization {
+      name
+      externalId
     }
   }
-`;
-export type SetCurrentUserTenantDataAccessOpMutationFn = Apollo.MutationFunction<
-  SetCurrentUserTenantDataAccessOpMutation,
-  SetCurrentUserTenantDataAccessOpMutationVariables
->;
+}
+    `;
+export type SetCurrentUserTenantDataAccessOpMutationFn = Apollo.MutationFunction<SetCurrentUserTenantDataAccessOpMutation, SetCurrentUserTenantDataAccessOpMutationVariables>;
 
 /**
  * __useSetCurrentUserTenantDataAccessOpMutation__
@@ -4243,35 +2918,19 @@ export type SetCurrentUserTenantDataAccessOpMutationFn = Apollo.MutationFunction
  *   },
  * });
  */
-export function useSetCurrentUserTenantDataAccessOpMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SetCurrentUserTenantDataAccessOpMutation,
-    SetCurrentUserTenantDataAccessOpMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    SetCurrentUserTenantDataAccessOpMutation,
-    SetCurrentUserTenantDataAccessOpMutationVariables
-  >(SetCurrentUserTenantDataAccessOpDocument, options);
-}
-export type SetCurrentUserTenantDataAccessOpMutationHookResult = ReturnType<
-  typeof useSetCurrentUserTenantDataAccessOpMutation
->;
+export function useSetCurrentUserTenantDataAccessOpMutation(baseOptions?: Apollo.MutationHookOptions<SetCurrentUserTenantDataAccessOpMutation, SetCurrentUserTenantDataAccessOpMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetCurrentUserTenantDataAccessOpMutation, SetCurrentUserTenantDataAccessOpMutationVariables>(SetCurrentUserTenantDataAccessOpDocument, options);
+      }
+export type SetCurrentUserTenantDataAccessOpMutationHookResult = ReturnType<typeof useSetCurrentUserTenantDataAccessOpMutation>;
 export type SetCurrentUserTenantDataAccessOpMutationResult = Apollo.MutationResult<SetCurrentUserTenantDataAccessOpMutation>;
-export type SetCurrentUserTenantDataAccessOpMutationOptions = Apollo.BaseMutationOptions<
-  SetCurrentUserTenantDataAccessOpMutation,
-  SetCurrentUserTenantDataAccessOpMutationVariables
->;
+export type SetCurrentUserTenantDataAccessOpMutationOptions = Apollo.BaseMutationOptions<SetCurrentUserTenantDataAccessOpMutation, SetCurrentUserTenantDataAccessOpMutationVariables>;
 export const RemovePatientFromQueueDocument = gql`
-  mutation RemovePatientFromQueue($patientId: ID!) {
-    removePatientFromQueue(patientId: $patientId)
-  }
-`;
-export type RemovePatientFromQueueMutationFn = Apollo.MutationFunction<
-  RemovePatientFromQueueMutation,
-  RemovePatientFromQueueMutationVariables
->;
+    mutation RemovePatientFromQueue($patientId: ID!) {
+  removePatientFromQueue(patientId: $patientId)
+}
+    `;
+export type RemovePatientFromQueueMutationFn = Apollo.MutationFunction<RemovePatientFromQueueMutation, RemovePatientFromQueueMutationVariables>;
 
 /**
  * __useRemovePatientFromQueueMutation__
@@ -4290,52 +2949,31 @@ export type RemovePatientFromQueueMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useRemovePatientFromQueueMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    RemovePatientFromQueueMutation,
-    RemovePatientFromQueueMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    RemovePatientFromQueueMutation,
-    RemovePatientFromQueueMutationVariables
-  >(RemovePatientFromQueueDocument, options);
-}
-export type RemovePatientFromQueueMutationHookResult = ReturnType<
-  typeof useRemovePatientFromQueueMutation
->;
-export type RemovePatientFromQueueMutationResult = Apollo.MutationResult<RemovePatientFromQueueMutation>;
-export type RemovePatientFromQueueMutationOptions = Apollo.BaseMutationOptions<
-  RemovePatientFromQueueMutation,
-  RemovePatientFromQueueMutationVariables
->;
-export const EditQueueItemDocument = gql`
-  mutation EditQueueItem(
-    $id: ID!
-    $deviceId: String
-    $result: String
-    $dateTested: DateTime
-  ) {
-    editQueueItem(
-      id: $id
-      deviceId: $deviceId
-      result: $result
-      dateTested: $dateTested
-    ) {
-      result
-      dateTested
-      deviceType {
-        internalId
-        testLength
+export function useRemovePatientFromQueueMutation(baseOptions?: Apollo.MutationHookOptions<RemovePatientFromQueueMutation, RemovePatientFromQueueMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RemovePatientFromQueueMutation, RemovePatientFromQueueMutationVariables>(RemovePatientFromQueueDocument, options);
       }
+export type RemovePatientFromQueueMutationHookResult = ReturnType<typeof useRemovePatientFromQueueMutation>;
+export type RemovePatientFromQueueMutationResult = Apollo.MutationResult<RemovePatientFromQueueMutation>;
+export type RemovePatientFromQueueMutationOptions = Apollo.BaseMutationOptions<RemovePatientFromQueueMutation, RemovePatientFromQueueMutationVariables>;
+export const EditQueueItemDocument = gql`
+    mutation EditQueueItem($id: ID!, $deviceId: String, $result: String, $dateTested: DateTime) {
+  editQueueItem(
+    id: $id
+    deviceId: $deviceId
+    result: $result
+    dateTested: $dateTested
+  ) {
+    result
+    dateTested
+    deviceType {
+      internalId
+      testLength
     }
   }
-`;
-export type EditQueueItemMutationFn = Apollo.MutationFunction<
-  EditQueueItemMutation,
-  EditQueueItemMutationVariables
->;
+}
+    `;
+export type EditQueueItemMutationFn = Apollo.MutationFunction<EditQueueItemMutation, EditQueueItemMutationVariables>;
 
 /**
  * __useEditQueueItemMutation__
@@ -4357,50 +2995,29 @@ export type EditQueueItemMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditQueueItemMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    EditQueueItemMutation,
-    EditQueueItemMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    EditQueueItemMutation,
-    EditQueueItemMutationVariables
-  >(EditQueueItemDocument, options);
-}
-export type EditQueueItemMutationHookResult = ReturnType<
-  typeof useEditQueueItemMutation
->;
-export type EditQueueItemMutationResult = Apollo.MutationResult<EditQueueItemMutation>;
-export type EditQueueItemMutationOptions = Apollo.BaseMutationOptions<
-  EditQueueItemMutation,
-  EditQueueItemMutationVariables
->;
-export const SubmitTestResultDocument = gql`
-  mutation SubmitTestResult(
-    $patientId: ID!
-    $deviceId: String!
-    $result: String!
-    $dateTested: DateTime
-  ) {
-    addTestResultNew(
-      patientId: $patientId
-      deviceId: $deviceId
-      result: $result
-      dateTested: $dateTested
-    ) {
-      testResult {
-        internalId
+export function useEditQueueItemMutation(baseOptions?: Apollo.MutationHookOptions<EditQueueItemMutation, EditQueueItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<EditQueueItemMutation, EditQueueItemMutationVariables>(EditQueueItemDocument, options);
       }
-      deliverySuccess
+export type EditQueueItemMutationHookResult = ReturnType<typeof useEditQueueItemMutation>;
+export type EditQueueItemMutationResult = Apollo.MutationResult<EditQueueItemMutation>;
+export type EditQueueItemMutationOptions = Apollo.BaseMutationOptions<EditQueueItemMutation, EditQueueItemMutationVariables>;
+export const SubmitTestResultDocument = gql`
+    mutation SubmitTestResult($patientId: ID!, $deviceId: String!, $result: String!, $dateTested: DateTime) {
+  addTestResultNew(
+    patientId: $patientId
+    deviceId: $deviceId
+    result: $result
+    dateTested: $dateTested
+  ) {
+    testResult {
+      internalId
     }
+    deliverySuccess
   }
-`;
-export type SubmitTestResultMutationFn = Apollo.MutationFunction<
-  SubmitTestResultMutation,
-  SubmitTestResultMutationVariables
->;
+}
+    `;
+export type SubmitTestResultMutationFn = Apollo.MutationFunction<SubmitTestResultMutation, SubmitTestResultMutationVariables>;
 
 /**
  * __useSubmitTestResultMutation__
@@ -4422,78 +3039,65 @@ export type SubmitTestResultMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSubmitTestResultMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SubmitTestResultMutation,
-    SubmitTestResultMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    SubmitTestResultMutation,
-    SubmitTestResultMutationVariables
-  >(SubmitTestResultDocument, options);
-}
-export type SubmitTestResultMutationHookResult = ReturnType<
-  typeof useSubmitTestResultMutation
->;
+export function useSubmitTestResultMutation(baseOptions?: Apollo.MutationHookOptions<SubmitTestResultMutation, SubmitTestResultMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SubmitTestResultMutation, SubmitTestResultMutationVariables>(SubmitTestResultDocument, options);
+      }
+export type SubmitTestResultMutationHookResult = ReturnType<typeof useSubmitTestResultMutation>;
 export type SubmitTestResultMutationResult = Apollo.MutationResult<SubmitTestResultMutation>;
-export type SubmitTestResultMutationOptions = Apollo.BaseMutationOptions<
-  SubmitTestResultMutation,
-  SubmitTestResultMutationVariables
->;
+export type SubmitTestResultMutationOptions = Apollo.BaseMutationOptions<SubmitTestResultMutation, SubmitTestResultMutationVariables>;
 export const GetFacilityQueueDocument = gql`
-  query GetFacilityQueue($facilityId: ID!) {
-    queue(facilityId: $facilityId) {
+    query GetFacilityQueue($facilityId: ID!) {
+  queue(facilityId: $facilityId) {
+    internalId
+    pregnancy
+    dateAdded
+    symptoms
+    symptomOnset
+    noSymptoms
+    deviceType {
       internalId
-      pregnancy
-      dateAdded
-      symptoms
-      symptomOnset
-      noSymptoms
-      deviceType {
+      name
+      model
+      testLength
+    }
+    patient {
+      internalId
+      telephone
+      birthDate
+      firstName
+      middleName
+      lastName
+      gender
+      testResultDelivery
+      preferredLanguage
+      phoneNumbers {
+        type
+        number
+      }
+    }
+    result
+    dateTested
+  }
+  organization {
+    testingFacility {
+      id
+      deviceTypes {
         internalId
         name
         model
         testLength
       }
-      patient {
+      defaultDeviceType {
         internalId
-        telephone
-        birthDate
-        firstName
-        middleName
-        lastName
-        gender
-        testResultDelivery
-        preferredLanguage
-        phoneNumbers {
-          type
-          number
-        }
-      }
-      result
-      dateTested
-    }
-    organization {
-      testingFacility {
-        id
-        deviceTypes {
-          internalId
-          name
-          model
-          testLength
-        }
-        defaultDeviceType {
-          internalId
-          name
-          model
-          testLength
-        }
+        name
+        model
+        testLength
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetFacilityQueueQuery__
@@ -4511,58 +3115,35 @@ export const GetFacilityQueueDocument = gql`
  *   },
  * });
  */
-export function useGetFacilityQueueQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFacilityQueueQuery,
-    GetFacilityQueueQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>(
-    GetFacilityQueueDocument,
-    options
-  );
-}
-export function useGetFacilityQueueLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFacilityQueueQuery,
-    GetFacilityQueueQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetFacilityQueueQuery,
-    GetFacilityQueueQueryVariables
-  >(GetFacilityQueueDocument, options);
-}
-export type GetFacilityQueueQueryHookResult = ReturnType<
-  typeof useGetFacilityQueueQuery
->;
-export type GetFacilityQueueLazyQueryHookResult = ReturnType<
-  typeof useGetFacilityQueueLazyQuery
->;
-export type GetFacilityQueueQueryResult = Apollo.QueryResult<
-  GetFacilityQueueQuery,
-  GetFacilityQueueQueryVariables
->;
-export const GetPatientDocument = gql`
-  query GetPatient($internalId: ID!) {
-    patient(id: $internalId) {
-      internalId
-      firstName
-      lastName
-      middleName
-      birthDate
-      gender
-      telephone
-      phoneNumbers {
-        type
-        number
+export function useGetFacilityQueueQuery(baseOptions: Apollo.QueryHookOptions<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>(GetFacilityQueueDocument, options);
       }
-      testResultDelivery
+export function useGetFacilityQueueLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>(GetFacilityQueueDocument, options);
+        }
+export type GetFacilityQueueQueryHookResult = ReturnType<typeof useGetFacilityQueueQuery>;
+export type GetFacilityQueueLazyQueryHookResult = ReturnType<typeof useGetFacilityQueueLazyQuery>;
+export type GetFacilityQueueQueryResult = Apollo.QueryResult<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>;
+export const GetPatientDocument = gql`
+    query GetPatient($internalId: ID!) {
+  patient(id: $internalId) {
+    internalId
+    firstName
+    lastName
+    middleName
+    birthDate
+    gender
+    telephone
+    phoneNumbers {
+      type
+      number
     }
+    testResultDelivery
   }
-`;
+}
+    `;
 
 /**
  * __useGetPatientQuery__
@@ -4580,65 +3161,41 @@ export const GetPatientDocument = gql`
  *   },
  * });
  */
-export function useGetPatientQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetPatientQuery,
-    GetPatientQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetPatientQuery, GetPatientQueryVariables>(
-    GetPatientDocument,
-    options
-  );
-}
-export function useGetPatientLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPatientQuery,
-    GetPatientQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<GetPatientQuery, GetPatientQueryVariables>(
-    GetPatientDocument,
-    options
-  );
-}
-export type GetPatientQueryHookResult = ReturnType<typeof useGetPatientQuery>;
-export type GetPatientLazyQueryHookResult = ReturnType<
-  typeof useGetPatientLazyQuery
->;
-export type GetPatientQueryResult = Apollo.QueryResult<
-  GetPatientQuery,
-  GetPatientQueryVariables
->;
-export const GetPatientsByFacilityForQueueDocument = gql`
-  query GetPatientsByFacilityForQueue(
-    $facilityId: ID!
-    $namePrefixMatch: String
-  ) {
-    patients(
-      facilityId: $facilityId
-      pageNumber: 0
-      pageSize: 100
-      showDeleted: false
-      namePrefixMatch: $namePrefixMatch
-    ) {
-      internalId
-      firstName
-      lastName
-      middleName
-      birthDate
-      gender
-      telephone
-      phoneNumbers {
-        type
-        number
+export function useGetPatientQuery(baseOptions: Apollo.QueryHookOptions<GetPatientQuery, GetPatientQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPatientQuery, GetPatientQueryVariables>(GetPatientDocument, options);
       }
-      testResultDelivery
+export function useGetPatientLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPatientQuery, GetPatientQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPatientQuery, GetPatientQueryVariables>(GetPatientDocument, options);
+        }
+export type GetPatientQueryHookResult = ReturnType<typeof useGetPatientQuery>;
+export type GetPatientLazyQueryHookResult = ReturnType<typeof useGetPatientLazyQuery>;
+export type GetPatientQueryResult = Apollo.QueryResult<GetPatientQuery, GetPatientQueryVariables>;
+export const GetPatientsByFacilityForQueueDocument = gql`
+    query GetPatientsByFacilityForQueue($facilityId: ID!, $namePrefixMatch: String) {
+  patients(
+    facilityId: $facilityId
+    pageNumber: 0
+    pageSize: 100
+    showDeleted: false
+    namePrefixMatch: $namePrefixMatch
+  ) {
+    internalId
+    firstName
+    lastName
+    middleName
+    birthDate
+    gender
+    telephone
+    phoneNumbers {
+      type
+      number
     }
+    testResultDelivery
   }
-`;
+}
+    `;
 
 /**
  * __useGetPatientsByFacilityForQueueQuery__
@@ -4657,65 +3214,31 @@ export const GetPatientsByFacilityForQueueDocument = gql`
  *   },
  * });
  */
-export function useGetPatientsByFacilityForQueueQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetPatientsByFacilityForQueueQuery,
-    GetPatientsByFacilityForQueueQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetPatientsByFacilityForQueueQuery,
-    GetPatientsByFacilityForQueueQueryVariables
-  >(GetPatientsByFacilityForQueueDocument, options);
-}
-export function useGetPatientsByFacilityForQueueLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPatientsByFacilityForQueueQuery,
-    GetPatientsByFacilityForQueueQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetPatientsByFacilityForQueueQuery,
-    GetPatientsByFacilityForQueueQueryVariables
-  >(GetPatientsByFacilityForQueueDocument, options);
-}
-export type GetPatientsByFacilityForQueueQueryHookResult = ReturnType<
-  typeof useGetPatientsByFacilityForQueueQuery
->;
-export type GetPatientsByFacilityForQueueLazyQueryHookResult = ReturnType<
-  typeof useGetPatientsByFacilityForQueueLazyQuery
->;
-export type GetPatientsByFacilityForQueueQueryResult = Apollo.QueryResult<
-  GetPatientsByFacilityForQueueQuery,
-  GetPatientsByFacilityForQueueQueryVariables
->;
+export function useGetPatientsByFacilityForQueueQuery(baseOptions: Apollo.QueryHookOptions<GetPatientsByFacilityForQueueQuery, GetPatientsByFacilityForQueueQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPatientsByFacilityForQueueQuery, GetPatientsByFacilityForQueueQueryVariables>(GetPatientsByFacilityForQueueDocument, options);
+      }
+export function useGetPatientsByFacilityForQueueLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPatientsByFacilityForQueueQuery, GetPatientsByFacilityForQueueQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPatientsByFacilityForQueueQuery, GetPatientsByFacilityForQueueQueryVariables>(GetPatientsByFacilityForQueueDocument, options);
+        }
+export type GetPatientsByFacilityForQueueQueryHookResult = ReturnType<typeof useGetPatientsByFacilityForQueueQuery>;
+export type GetPatientsByFacilityForQueueLazyQueryHookResult = ReturnType<typeof useGetPatientsByFacilityForQueueLazyQuery>;
+export type GetPatientsByFacilityForQueueQueryResult = Apollo.QueryResult<GetPatientsByFacilityForQueueQuery, GetPatientsByFacilityForQueueQueryVariables>;
 export const AddPatientToQueueDocument = gql`
-  mutation AddPatientToQueue(
-    $facilityId: ID!
-    $patientId: ID!
-    $symptoms: String
-    $symptomOnset: LocalDate
-    $pregnancy: String
-    $noSymptoms: Boolean
-    $testResultDelivery: TestResultDeliveryPreference
-  ) {
-    addPatientToQueue(
-      facilityId: $facilityId
-      patientId: $patientId
-      pregnancy: $pregnancy
-      noSymptoms: $noSymptoms
-      symptoms: $symptoms
-      symptomOnset: $symptomOnset
-      testResultDelivery: $testResultDelivery
-    )
-  }
-`;
-export type AddPatientToQueueMutationFn = Apollo.MutationFunction<
-  AddPatientToQueueMutation,
-  AddPatientToQueueMutationVariables
->;
+    mutation AddPatientToQueue($facilityId: ID!, $patientId: ID!, $symptoms: String, $symptomOnset: LocalDate, $pregnancy: String, $noSymptoms: Boolean, $testResultDelivery: TestResultDeliveryPreference) {
+  addPatientToQueue(
+    facilityId: $facilityId
+    patientId: $patientId
+    pregnancy: $pregnancy
+    noSymptoms: $noSymptoms
+    symptoms: $symptoms
+    symptomOnset: $symptomOnset
+    testResultDelivery: $testResultDelivery
+  )
+}
+    `;
+export type AddPatientToQueueMutationFn = Apollo.MutationFunction<AddPatientToQueueMutation, AddPatientToQueueMutationVariables>;
 
 /**
  * __useAddPatientToQueueMutation__
@@ -4740,49 +3263,26 @@ export type AddPatientToQueueMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddPatientToQueueMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    AddPatientToQueueMutation,
-    AddPatientToQueueMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    AddPatientToQueueMutation,
-    AddPatientToQueueMutationVariables
-  >(AddPatientToQueueDocument, options);
-}
-export type AddPatientToQueueMutationHookResult = ReturnType<
-  typeof useAddPatientToQueueMutation
->;
+export function useAddPatientToQueueMutation(baseOptions?: Apollo.MutationHookOptions<AddPatientToQueueMutation, AddPatientToQueueMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddPatientToQueueMutation, AddPatientToQueueMutationVariables>(AddPatientToQueueDocument, options);
+      }
+export type AddPatientToQueueMutationHookResult = ReturnType<typeof useAddPatientToQueueMutation>;
 export type AddPatientToQueueMutationResult = Apollo.MutationResult<AddPatientToQueueMutation>;
-export type AddPatientToQueueMutationOptions = Apollo.BaseMutationOptions<
-  AddPatientToQueueMutation,
-  AddPatientToQueueMutationVariables
->;
+export type AddPatientToQueueMutationOptions = Apollo.BaseMutationOptions<AddPatientToQueueMutation, AddPatientToQueueMutationVariables>;
 export const UpdateAoeDocument = gql`
-  mutation UpdateAOE(
-    $patientId: ID!
-    $symptoms: String
-    $symptomOnset: LocalDate
-    $pregnancy: String
-    $noSymptoms: Boolean
-    $testResultDelivery: TestResultDeliveryPreference
-  ) {
-    updateTimeOfTestQuestions(
-      patientId: $patientId
-      pregnancy: $pregnancy
-      symptoms: $symptoms
-      noSymptoms: $noSymptoms
-      symptomOnset: $symptomOnset
-      testResultDelivery: $testResultDelivery
-    )
-  }
-`;
-export type UpdateAoeMutationFn = Apollo.MutationFunction<
-  UpdateAoeMutation,
-  UpdateAoeMutationVariables
->;
+    mutation UpdateAOE($patientId: ID!, $symptoms: String, $symptomOnset: LocalDate, $pregnancy: String, $noSymptoms: Boolean, $testResultDelivery: TestResultDeliveryPreference) {
+  updateTimeOfTestQuestions(
+    patientId: $patientId
+    pregnancy: $pregnancy
+    symptoms: $symptoms
+    noSymptoms: $noSymptoms
+    symptomOnset: $symptomOnset
+    testResultDelivery: $testResultDelivery
+  )
+}
+    `;
+export type UpdateAoeMutationFn = Apollo.MutationFunction<UpdateAoeMutation, UpdateAoeMutationVariables>;
 
 /**
  * __useUpdateAoeMutation__
@@ -4806,44 +3306,31 @@ export type UpdateAoeMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateAoeMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateAoeMutation,
-    UpdateAoeMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<UpdateAoeMutation, UpdateAoeMutationVariables>(
-    UpdateAoeDocument,
-    options
-  );
-}
-export type UpdateAoeMutationHookResult = ReturnType<
-  typeof useUpdateAoeMutation
->;
+export function useUpdateAoeMutation(baseOptions?: Apollo.MutationHookOptions<UpdateAoeMutation, UpdateAoeMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateAoeMutation, UpdateAoeMutationVariables>(UpdateAoeDocument, options);
+      }
+export type UpdateAoeMutationHookResult = ReturnType<typeof useUpdateAoeMutation>;
 export type UpdateAoeMutationResult = Apollo.MutationResult<UpdateAoeMutation>;
-export type UpdateAoeMutationOptions = Apollo.BaseMutationOptions<
-  UpdateAoeMutation,
-  UpdateAoeMutationVariables
->;
+export type UpdateAoeMutationOptions = Apollo.BaseMutationOptions<UpdateAoeMutation, UpdateAoeMutationVariables>;
 export const GetTestResultForCorrectionDocument = gql`
-  query getTestResultForCorrection($id: ID!) {
-    testResult(id: $id) {
-      dateTested
-      result
-      correctionStatus
-      deviceType {
-        name
-      }
-      patient {
-        firstName
-        middleName
-        lastName
-        birthDate
-      }
+    query getTestResultForCorrection($id: ID!) {
+  testResult(id: $id) {
+    dateTested
+    result
+    correctionStatus
+    deviceType {
+      name
+    }
+    patient {
+      firstName
+      middleName
+      lastName
+      birthDate
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetTestResultForCorrectionQuery__
@@ -4861,51 +3348,25 @@ export const GetTestResultForCorrectionDocument = gql`
  *   },
  * });
  */
-export function useGetTestResultForCorrectionQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTestResultForCorrectionQuery,
-    GetTestResultForCorrectionQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetTestResultForCorrectionQuery,
-    GetTestResultForCorrectionQueryVariables
-  >(GetTestResultForCorrectionDocument, options);
-}
-export function useGetTestResultForCorrectionLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTestResultForCorrectionQuery,
-    GetTestResultForCorrectionQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetTestResultForCorrectionQuery,
-    GetTestResultForCorrectionQueryVariables
-  >(GetTestResultForCorrectionDocument, options);
-}
-export type GetTestResultForCorrectionQueryHookResult = ReturnType<
-  typeof useGetTestResultForCorrectionQuery
->;
-export type GetTestResultForCorrectionLazyQueryHookResult = ReturnType<
-  typeof useGetTestResultForCorrectionLazyQuery
->;
-export type GetTestResultForCorrectionQueryResult = Apollo.QueryResult<
-  GetTestResultForCorrectionQuery,
-  GetTestResultForCorrectionQueryVariables
->;
+export function useGetTestResultForCorrectionQuery(baseOptions: Apollo.QueryHookOptions<GetTestResultForCorrectionQuery, GetTestResultForCorrectionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetTestResultForCorrectionQuery, GetTestResultForCorrectionQueryVariables>(GetTestResultForCorrectionDocument, options);
+      }
+export function useGetTestResultForCorrectionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTestResultForCorrectionQuery, GetTestResultForCorrectionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetTestResultForCorrectionQuery, GetTestResultForCorrectionQueryVariables>(GetTestResultForCorrectionDocument, options);
+        }
+export type GetTestResultForCorrectionQueryHookResult = ReturnType<typeof useGetTestResultForCorrectionQuery>;
+export type GetTestResultForCorrectionLazyQueryHookResult = ReturnType<typeof useGetTestResultForCorrectionLazyQuery>;
+export type GetTestResultForCorrectionQueryResult = Apollo.QueryResult<GetTestResultForCorrectionQuery, GetTestResultForCorrectionQueryVariables>;
 export const MarkTestAsErrorDocument = gql`
-  mutation MarkTestAsError($id: ID!, $reason: String!) {
-    correctTestMarkAsError(id: $id, reason: $reason) {
-      internalId
-    }
+    mutation MarkTestAsError($id: ID!, $reason: String!) {
+  correctTestMarkAsError(id: $id, reason: $reason) {
+    internalId
   }
-`;
-export type MarkTestAsErrorMutationFn = Apollo.MutationFunction<
-  MarkTestAsErrorMutation,
-  MarkTestAsErrorMutationVariables
->;
+}
+    `;
+export type MarkTestAsErrorMutationFn = Apollo.MutationFunction<MarkTestAsErrorMutation, MarkTestAsErrorMutationVariables>;
 
 /**
  * __useMarkTestAsErrorMutation__
@@ -4925,54 +3386,41 @@ export type MarkTestAsErrorMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useMarkTestAsErrorMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    MarkTestAsErrorMutation,
-    MarkTestAsErrorMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    MarkTestAsErrorMutation,
-    MarkTestAsErrorMutationVariables
-  >(MarkTestAsErrorDocument, options);
-}
-export type MarkTestAsErrorMutationHookResult = ReturnType<
-  typeof useMarkTestAsErrorMutation
->;
-export type MarkTestAsErrorMutationResult = Apollo.MutationResult<MarkTestAsErrorMutation>;
-export type MarkTestAsErrorMutationOptions = Apollo.BaseMutationOptions<
-  MarkTestAsErrorMutation,
-  MarkTestAsErrorMutationVariables
->;
-export const GetTestResultDetailsDocument = gql`
-  query getTestResultDetails($id: ID!) {
-    testResult(id: $id) {
-      dateTested
-      result
-      correctionStatus
-      symptoms
-      symptomOnset
-      pregnancy
-      deviceType {
-        name
+export function useMarkTestAsErrorMutation(baseOptions?: Apollo.MutationHookOptions<MarkTestAsErrorMutation, MarkTestAsErrorMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MarkTestAsErrorMutation, MarkTestAsErrorMutationVariables>(MarkTestAsErrorDocument, options);
       }
-      patient {
+export type MarkTestAsErrorMutationHookResult = ReturnType<typeof useMarkTestAsErrorMutation>;
+export type MarkTestAsErrorMutationResult = Apollo.MutationResult<MarkTestAsErrorMutation>;
+export type MarkTestAsErrorMutationOptions = Apollo.BaseMutationOptions<MarkTestAsErrorMutation, MarkTestAsErrorMutationVariables>;
+export const GetTestResultDetailsDocument = gql`
+    query getTestResultDetails($id: ID!) {
+  testResult(id: $id) {
+    dateTested
+    result
+    correctionStatus
+    symptoms
+    symptomOnset
+    pregnancy
+    deviceType {
+      name
+    }
+    patient {
+      firstName
+      middleName
+      lastName
+      birthDate
+    }
+    createdBy {
+      name {
         firstName
         middleName
         lastName
-        birthDate
-      }
-      createdBy {
-        name {
-          firstName
-          middleName
-          lastName
-        }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetTestResultDetailsQuery__
@@ -4990,75 +3438,52 @@ export const GetTestResultDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetTestResultDetailsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >(GetTestResultDetailsDocument, options);
-}
-export function useGetTestResultDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >(GetTestResultDetailsDocument, options);
-}
-export type GetTestResultDetailsQueryHookResult = ReturnType<
-  typeof useGetTestResultDetailsQuery
->;
-export type GetTestResultDetailsLazyQueryHookResult = ReturnType<
-  typeof useGetTestResultDetailsLazyQuery
->;
-export type GetTestResultDetailsQueryResult = Apollo.QueryResult<
-  GetTestResultDetailsQuery,
-  GetTestResultDetailsQueryVariables
->;
-export const GetTestResultForPrintDocument = gql`
-  query getTestResultForPrint($id: ID!) {
-    testResult(id: $id) {
-      dateTested
-      result
-      correctionStatus
-      deviceType {
-        name
-        model
+export function useGetTestResultDetailsQuery(baseOptions: Apollo.QueryHookOptions<GetTestResultDetailsQuery, GetTestResultDetailsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetTestResultDetailsQuery, GetTestResultDetailsQueryVariables>(GetTestResultDetailsDocument, options);
       }
-      patient {
+export function useGetTestResultDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTestResultDetailsQuery, GetTestResultDetailsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetTestResultDetailsQuery, GetTestResultDetailsQueryVariables>(GetTestResultDetailsDocument, options);
+        }
+export type GetTestResultDetailsQueryHookResult = ReturnType<typeof useGetTestResultDetailsQuery>;
+export type GetTestResultDetailsLazyQueryHookResult = ReturnType<typeof useGetTestResultDetailsLazyQuery>;
+export type GetTestResultDetailsQueryResult = Apollo.QueryResult<GetTestResultDetailsQuery, GetTestResultDetailsQueryVariables>;
+export const GetTestResultForPrintDocument = gql`
+    query getTestResultForPrint($id: ID!) {
+  testResult(id: $id) {
+    dateTested
+    result
+    correctionStatus
+    deviceType {
+      name
+      model
+    }
+    patient {
+      firstName
+      middleName
+      lastName
+      birthDate
+    }
+    facility {
+      name
+      cliaNumber
+      phone
+      street
+      streetTwo
+      city
+      state
+      zipCode
+      orderingProvider {
         firstName
         middleName
         lastName
-        birthDate
-      }
-      facility {
-        name
-        cliaNumber
-        phone
-        street
-        streetTwo
-        city
-        state
-        zipCode
-        orderingProvider {
-          firstName
-          middleName
-          lastName
-          NPI
-        }
+        NPI
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetTestResultForPrintQuery__
@@ -5076,59 +3501,105 @@ export const GetTestResultForPrintDocument = gql`
  *   },
  * });
  */
-export function useGetTestResultForPrintQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >(GetTestResultForPrintDocument, options);
-}
-export function useGetTestResultForPrintLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >(GetTestResultForPrintDocument, options);
-}
-export type GetTestResultForPrintQueryHookResult = ReturnType<
-  typeof useGetTestResultForPrintQuery
->;
-export type GetTestResultForPrintLazyQueryHookResult = ReturnType<
-  typeof useGetTestResultForPrintLazyQuery
->;
-export type GetTestResultForPrintQueryResult = Apollo.QueryResult<
-  GetTestResultForPrintQuery,
-  GetTestResultForPrintQueryVariables
->;
-export const GetResultsCountByFacilityDocument = gql`
-  query GetResultsCountByFacility(
-    $facilityId: ID
-    $patientId: ID
-    $result: String
-    $role: String
-    $startDate: DateTime
-    $endDate: DateTime
-  ) {
-    testResultsCount(
-      facilityId: $facilityId
-      patientId: $patientId
-      result: $result
-      role: $role
-      startDate: $startDate
-      endDate: $endDate
-    )
+export function useGetTestResultForPrintQuery(baseOptions: Apollo.QueryHookOptions<GetTestResultForPrintQuery, GetTestResultForPrintQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetTestResultForPrintQuery, GetTestResultForPrintQueryVariables>(GetTestResultForPrintDocument, options);
+      }
+export function useGetTestResultForPrintLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTestResultForPrintQuery, GetTestResultForPrintQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetTestResultForPrintQuery, GetTestResultForPrintQueryVariables>(GetTestResultForPrintDocument, options);
+        }
+export type GetTestResultForPrintQueryHookResult = ReturnType<typeof useGetTestResultForPrintQuery>;
+export type GetTestResultForPrintLazyQueryHookResult = ReturnType<typeof useGetTestResultForPrintLazyQuery>;
+export type GetTestResultForPrintQueryResult = Apollo.QueryResult<GetTestResultForPrintQuery, GetTestResultForPrintQueryVariables>;
+export const GetTestResultForTextDocument = gql`
+    query getTestResultForText($id: ID!) {
+  testResult(id: $id) {
+    dateTested
+    patient {
+      firstName
+      middleName
+      lastName
+      birthDate
+      phoneNumbers {
+        type
+        number
+      }
+    }
   }
-`;
+}
+    `;
+
+/**
+ * __useGetTestResultForTextQuery__
+ *
+ * To run a query within a React component, call `useGetTestResultForTextQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTestResultForTextQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTestResultForTextQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetTestResultForTextQuery(baseOptions: Apollo.QueryHookOptions<GetTestResultForTextQuery, GetTestResultForTextQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetTestResultForTextQuery, GetTestResultForTextQueryVariables>(GetTestResultForTextDocument, options);
+      }
+export function useGetTestResultForTextLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTestResultForTextQuery, GetTestResultForTextQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetTestResultForTextQuery, GetTestResultForTextQueryVariables>(GetTestResultForTextDocument, options);
+        }
+export type GetTestResultForTextQueryHookResult = ReturnType<typeof useGetTestResultForTextQuery>;
+export type GetTestResultForTextLazyQueryHookResult = ReturnType<typeof useGetTestResultForTextLazyQuery>;
+export type GetTestResultForTextQueryResult = Apollo.QueryResult<GetTestResultForTextQuery, GetTestResultForTextQueryVariables>;
+export const SendSmsDocument = gql`
+    mutation sendSMS($id: ID!) {
+  sendPatientLinkSms(internalId: $id)
+}
+    `;
+export type SendSmsMutationFn = Apollo.MutationFunction<SendSmsMutation, SendSmsMutationVariables>;
+
+/**
+ * __useSendSmsMutation__
+ *
+ * To run a mutation, you first call `useSendSmsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSendSmsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [sendSmsMutation, { data, loading, error }] = useSendSmsMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useSendSmsMutation(baseOptions?: Apollo.MutationHookOptions<SendSmsMutation, SendSmsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SendSmsMutation, SendSmsMutationVariables>(SendSmsDocument, options);
+      }
+export type SendSmsMutationHookResult = ReturnType<typeof useSendSmsMutation>;
+export type SendSmsMutationResult = Apollo.MutationResult<SendSmsMutation>;
+export type SendSmsMutationOptions = Apollo.BaseMutationOptions<SendSmsMutation, SendSmsMutationVariables>;
+export const GetResultsCountByFacilityDocument = gql`
+    query GetResultsCountByFacility($facilityId: ID, $patientId: ID, $result: String, $role: String, $startDate: DateTime, $endDate: DateTime) {
+  testResultsCount(
+    facilityId: $facilityId
+    patientId: $patientId
+    result: $result
+    role: $role
+    startDate: $startDate
+    endDate: $endDate
+  )
+}
+    `;
 
 /**
  * __useGetResultsCountByFacilityQuery__
@@ -5151,93 +3622,61 @@ export const GetResultsCountByFacilityDocument = gql`
  *   },
  * });
  */
-export function useGetResultsCountByFacilityQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetResultsCountByFacilityQuery,
-    GetResultsCountByFacilityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetResultsCountByFacilityQuery,
-    GetResultsCountByFacilityQueryVariables
-  >(GetResultsCountByFacilityDocument, options);
-}
-export function useGetResultsCountByFacilityLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetResultsCountByFacilityQuery,
-    GetResultsCountByFacilityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetResultsCountByFacilityQuery,
-    GetResultsCountByFacilityQueryVariables
-  >(GetResultsCountByFacilityDocument, options);
-}
-export type GetResultsCountByFacilityQueryHookResult = ReturnType<
-  typeof useGetResultsCountByFacilityQuery
->;
-export type GetResultsCountByFacilityLazyQueryHookResult = ReturnType<
-  typeof useGetResultsCountByFacilityLazyQuery
->;
-export type GetResultsCountByFacilityQueryResult = Apollo.QueryResult<
-  GetResultsCountByFacilityQuery,
-  GetResultsCountByFacilityQueryVariables
->;
-export const GetFacilityResultsDocument = gql`
-  query GetFacilityResults(
-    $facilityId: ID
-    $patientId: ID
-    $result: String
-    $role: String
-    $startDate: DateTime
-    $endDate: DateTime
-    $pageNumber: Int
-    $pageSize: Int
-  ) {
-    testResults(
-      facilityId: $facilityId
-      patientId: $patientId
-      result: $result
-      role: $role
-      startDate: $startDate
-      endDate: $endDate
-      pageNumber: $pageNumber
-      pageSize: $pageSize
-    ) {
-      internalId
-      dateTested
-      result
-      correctionStatus
-      deviceType {
-        internalId
-        name
+export function useGetResultsCountByFacilityQuery(baseOptions?: Apollo.QueryHookOptions<GetResultsCountByFacilityQuery, GetResultsCountByFacilityQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetResultsCountByFacilityQuery, GetResultsCountByFacilityQueryVariables>(GetResultsCountByFacilityDocument, options);
       }
-      patient {
-        internalId
+export function useGetResultsCountByFacilityLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetResultsCountByFacilityQuery, GetResultsCountByFacilityQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetResultsCountByFacilityQuery, GetResultsCountByFacilityQueryVariables>(GetResultsCountByFacilityDocument, options);
+        }
+export type GetResultsCountByFacilityQueryHookResult = ReturnType<typeof useGetResultsCountByFacilityQuery>;
+export type GetResultsCountByFacilityLazyQueryHookResult = ReturnType<typeof useGetResultsCountByFacilityLazyQuery>;
+export type GetResultsCountByFacilityQueryResult = Apollo.QueryResult<GetResultsCountByFacilityQuery, GetResultsCountByFacilityQueryVariables>;
+export const GetFacilityResultsDocument = gql`
+    query GetFacilityResults($facilityId: ID, $patientId: ID, $result: String, $role: String, $startDate: DateTime, $endDate: DateTime, $pageNumber: Int, $pageSize: Int) {
+  testResults(
+    facilityId: $facilityId
+    patientId: $patientId
+    result: $result
+    role: $role
+    startDate: $startDate
+    endDate: $endDate
+    pageNumber: $pageNumber
+    pageSize: $pageSize
+  ) {
+    internalId
+    dateTested
+    result
+    correctionStatus
+    deviceType {
+      internalId
+      name
+    }
+    patient {
+      internalId
+      firstName
+      middleName
+      lastName
+      birthDate
+      gender
+      lookupId
+    }
+    createdBy {
+      nameInfo {
         firstName
         middleName
         lastName
-        birthDate
-        gender
-        lookupId
       }
-      createdBy {
-        nameInfo {
-          firstName
-          middleName
-          lastName
-        }
-      }
-      patientLink {
-        internalId
-      }
-      symptoms
-      noSymptoms
     }
+    patientLink {
+      internalId
+    }
+    symptoms
+    noSymptoms
   }
-`;
+}
+    `;
 
 /**
  * __useGetFacilityResultsQuery__
@@ -5262,37 +3701,14 @@ export const GetFacilityResultsDocument = gql`
  *   },
  * });
  */
-export function useGetFacilityResultsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetFacilityResultsQuery,
-    GetFacilityResultsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetFacilityResultsQuery,
-    GetFacilityResultsQueryVariables
-  >(GetFacilityResultsDocument, options);
-}
-export function useGetFacilityResultsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFacilityResultsQuery,
-    GetFacilityResultsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetFacilityResultsQuery,
-    GetFacilityResultsQueryVariables
-  >(GetFacilityResultsDocument, options);
-}
-export type GetFacilityResultsQueryHookResult = ReturnType<
-  typeof useGetFacilityResultsQuery
->;
-export type GetFacilityResultsLazyQueryHookResult = ReturnType<
-  typeof useGetFacilityResultsLazyQuery
->;
-export type GetFacilityResultsQueryResult = Apollo.QueryResult<
-  GetFacilityResultsQuery,
-  GetFacilityResultsQueryVariables
->;
+export function useGetFacilityResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetFacilityResultsQuery, GetFacilityResultsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetFacilityResultsQuery, GetFacilityResultsQueryVariables>(GetFacilityResultsDocument, options);
+      }
+export function useGetFacilityResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetFacilityResultsQuery, GetFacilityResultsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetFacilityResultsQuery, GetFacilityResultsQueryVariables>(GetFacilityResultsDocument, options);
+        }
+export type GetFacilityResultsQueryHookResult = ReturnType<typeof useGetFacilityResultsQuery>;
+export type GetFacilityResultsLazyQueryHookResult = ReturnType<typeof useGetFacilityResultsLazyQuery>;
+export type GetFacilityResultsQueryResult = Apollo.QueryResult<GetFacilityResultsQuery, GetFacilityResultsQueryVariables>;


### PR DESCRIPTION
## Related Issue or Background Info
[2775](https://app.zenhub.com/workspaces/simplereport-better-data-team-605b43d51ea9f700119a48ee/issues/cdcgov/prime-simplereport/2775)

There was a need to resend patient results via text message from the list of test results. This PR adds that functionality. 


## Changes Proposed

- Add Text Result to Drop Down
- Create text confirmation modal
- Integrate text with existing texting service

## Additional Information

## Screenshots / Demos
### Dropdown with text result
<img width="1089" alt="Screen Shot 2021-11-03 at 11 38 30 AM" src="https://user-images.githubusercontent.com/28940414/140172289-ad2fdeb7-8d63-47ed-a315-03d4f24a6b2a.png">
### Confirmation Modal
<img width="1109" alt="Screen Shot 2021-11-03 at 11 38 37 AM" src="https://user-images.githubusercontent.com/28940414/140172296-c063d7b5-1485-4738-ba2d-9f4f2f687299.png">
### Success Message
<img width="710" alt="Screen Shot 2021-11-03 at 11 38 41 AM" src="https://user-images.githubusercontent.com/28940414/140172302-281e6ccb-27d7-4ba5-99c8-7d818accb90e.png">


## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- To reproduce deploy this branch to a lower environment
- Create a test which goes to your phone number
- Select the hamburger menu to the right of the test
- Select text result
- ???
- Profit

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
