### PR TITLE
Reminder service emails from organization queue

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationQueueRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationQueueRepository.java
@@ -7,7 +7,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 
 public interface OrganizationQueueRepository
-    extends EternalAuditedEntityRepository<OrganizationQueueItem> {
+    extends EternalAuditedEntityRepository<OrganizationQueueItem>, AdvisoryLockManager {
+
+  int ORG_QUEUE_REMINDER_LOCK = 66543221; // arbitrary 32-bit integer for our lock
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.verifiedOrganization IS NULL")
   List<OrganizationQueueItem> findAllNotIdentityVerified();
@@ -22,4 +24,14 @@ public interface OrganizationQueueRepository
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.verifiedOrganization IS NULL and e.externalId = :orgExternalId")
   Optional<OrganizationQueueItem> findUnverifiedByExternalId(String orgExternalId);
+
+  /**
+   * Try to obtain the lock for the unverified organization reminders task. (It will be released
+   * automatically when the current transaction closes.)
+   *
+   * @return true if the lock was obtained, false otherwise.
+   */
+  default boolean tryOrgReminderLock() {
+    return tryTransactionLock(CORE_API_LOCK_SCOPE, ORG_QUEUE_REMINDER_LOCK);
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationQueueRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationQueueRepository.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +11,12 @@ public interface OrganizationQueueRepository
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.verifiedOrganization IS NULL")
   List<OrganizationQueueItem> findAllNotIdentityVerified();
+
+  @Query(
+      EternalAuditedEntityRepository.BASE_QUERY
+          + " and e.verifiedOrganization IS NULL and e.createdAt > :rangeStartDate and e.createdAt <= :rangeStopDate")
+  List<OrganizationQueueItem> findAllNotIdentityVerifiedByCreatedAtRange(
+      Date rangeStartDate, Date rangeStopDate);
 
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -2,16 +2,12 @@ package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 
 /** Interface specification for fetching and manipulating {@link Organization} entities */
-public interface OrganizationRepository
-    extends EternalAuditedEntityRepository<Organization>, AdvisoryLockManager {
-
-  int ORG_REMINDER_LOCK = 66543221; // arbitrary 32-bit integer for our lock
+public interface OrganizationRepository extends EternalAuditedEntityRepository<Organization> {
 
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.externalId = :externalId")
   Optional<Organization> findByExternalId(String externalId);
@@ -23,22 +19,6 @@ public interface OrganizationRepository
   List<Organization> findAllByIdentityVerified(boolean identityVerified);
 
   @Query(
-      EternalAuditedEntityRepository.BASE_QUERY
-          + " and e.identityVerified = :identityVerified and e.createdAt > :rangeStartDate and e.createdAt <= :rangeStopDate")
-  List<Organization> findAllByIdentityVerifiedAndCreatedAtRange(
-      boolean identityVerified, Date rangeStartDate, Date rangeStopDate);
-
-  @Query(
       EternalAuditedEntityRepository.BASE_QUERY + " and UPPER(e.organizationName) = UPPER(:name)")
   List<Organization> findAllByName(String name);
-
-  /**
-   * Try to obtain the lock for the unverified organization reminders task. (It will be released
-   * automatically when the current transaction closes.)
-   *
-   * @return true if the lock was obtained, false otherwise.
-   */
-  default boolean tryOrgReminderLock() {
-    return tryTransactionLock(CORE_API_LOCK_SCOPE, ORG_REMINDER_LOCK);
-  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -1,8 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
-import gov.cdc.usds.simplereport.db.model.Organization;
-import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
-import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
+import gov.cdc.usds.simplereport.db.repository.OrganizationQueueRepository;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import java.io.IOException;
@@ -13,7 +12,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,14 +24,11 @@ public class ReminderService {
 
   private static final long LOCK_HOLD_MS = 1000L;
 
-  private final OktaRepository _oktaRepo;
-  private final OrganizationRepository _orgRepo;
+  private final OrganizationQueueRepository _orgQueueRepo;
   private final EmailService _emailService;
 
-  public ReminderService(
-      OktaRepository oktaRepo, OrganizationRepository orgRepo, EmailService emailService) {
-    _oktaRepo = oktaRepo;
-    _orgRepo = orgRepo;
+  public ReminderService(OrganizationQueueRepository orgQueueRepo, EmailService emailService) {
+    _orgQueueRepo = orgQueueRepo;
     _emailService = emailService;
   }
 
@@ -41,9 +36,9 @@ public class ReminderService {
    * Send reminder emails to complete identity verification to members of organizations that
    * were created and did not complete id verification
    */
-  public Map<Organization, Set<String>> sendAccountReminderEmails() {
+  public Map<String, OrganizationQueueItem> sendAccountReminderEmails() {
     // take the advisory lock for this process. auto released after transaction
-    if (_orgRepo.tryOrgReminderLock()) {
+    if (_orgQueueRepo.tryOrgReminderLock()) {
       log.info("Reminder lock obtained: commencing email sending");
     } else {
       log.info("Reminders locked out by mutex: aborting");
@@ -59,35 +54,29 @@ public class ReminderService {
 
     log.info("CRON -- account reminder emails for {} - {}", rangeStartDate, rangeStopDate);
 
-    List<Organization> organizations =
-        _orgRepo.findAllByIdentityVerifiedAndCreatedAtRange(false, rangeStartDate, rangeStopDate);
+    List<OrganizationQueueItem> queueItems =
+        _orgQueueRepo.findAllNotIdentityVerifiedByCreatedAtRange(rangeStartDate, rangeStopDate);
 
-    Map<Organization, Set<String>> orgReminderMap = new HashMap<>();
+    Map<String, OrganizationQueueItem> orgReminderMap = new HashMap<>();
 
-    for (Organization org : organizations) {
-      log.info("sending reminders for org: {}", org.getExternalId());
+    for (OrganizationQueueItem queueItem : queueItems) {
+      log.info("sending reminders for queued org: {}", queueItem.getExternalId());
+      String orgAdminEmail = queueItem.getRequestData().getEmail();
 
-      // This could be problematic depending on the number of unverified organizations created
-      // on the previous day.  It will make 2 requests to okta per organization.
-      Set<String> emailsInOrg = _oktaRepo.getAllUsersForOrganization(org);
-
-      if (emailsInOrg.isEmpty()) {
-        log.info(
-            "no emails sent: organization \"{}\" has no members in default group",
-            org.getExternalId());
+      if (orgReminderMap.containsKey(orgAdminEmail)) {
+        // in the queue, there can be repeated email addresses
+        log.warn("Already sent id verification reminder email to: {}", orgAdminEmail);
+        continue;
       }
 
-      for (String email : emailsInOrg) {
-        // unverified organizations will only have 1 associated email at this time
-        try {
-          _emailService.sendWithDynamicTemplate(
-              email, EmailProviderTemplate.ORGANIZATION_ID_VERIFICATION_REMINDER);
-        } catch (IOException e) {
-          log.warn("Failed to send id verification reminder email to: {}", email);
-        }
+      try {
+        _emailService.sendWithDynamicTemplate(
+            orgAdminEmail, EmailProviderTemplate.ORGANIZATION_ID_VERIFICATION_REMINDER);
+      } catch (IOException e) {
+        log.warn("Failed to send id verification reminder email to: {}", orgAdminEmail);
       }
 
-      orgReminderMap.put(org, emailsInOrg);
+      orgReminderMap.put(orgAdminEmail, queueItem);
     }
 
     try {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -3,10 +3,7 @@ package gov.cdc.usds.simplereport.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
-import gov.cdc.usds.simplereport.db.model.Organization;
-import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
-import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
+import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -26,46 +23,51 @@ import org.springframework.transaction.annotation.Transactional;
 
 class ReminderServiceTest extends BaseServiceTest<ReminderService> {
 
-  @Autowired private DemoOktaRepository _demoOktaRepo;
   @Autowired private JdbcTemplate _jdbc;
 
   @Test
   void sendAccountReminderEmails_noEmails_success() {
-    Map<Organization, Set<String>> orgEmailsSent = _service.sendAccountReminderEmails();
+    Map<String, OrganizationQueueItem> orgEmailsSent = _service.sendAccountReminderEmails();
     assertEquals(Set.of(), orgEmailsSent.keySet());
   }
 
   @Test
   void sendAccountReminderEmails_sendEmails_success() throws SQLException {
     String email = "fake@example.org";
-    Organization unverifiedOrg = _dataFactory.createUnverifiedOrg();
-    initAndBackdateUnverifiedOrg(unverifiedOrg, email);
+    OrganizationQueueItem unverifiedQueuedOrg =
+        _dataFactory.createOrganizationQueueItem("New Org Name", "NEW_ORG_NAME", email);
+    initAndBackdateUnverifiedQueuedOrg(unverifiedQueuedOrg);
 
-    Map<Organization, Set<String>> orgEmailsSentMap = _service.sendAccountReminderEmails();
+    // person submitted a second time (still only 1 email sent)
+    OrganizationQueueItem unverifiedQueuedOrg2 =
+        _dataFactory.createOrganizationQueueItem("New Org Name", "NEW_ORG_NAME_AGAIN", email);
+    backdateQueuedOrgCreatedAt(unverifiedQueuedOrg2);
+
+    Map<String, OrganizationQueueItem> orgEmailsSentMap = _service.sendAccountReminderEmails();
     assertEquals(1, orgEmailsSentMap.keySet().size());
 
-    Organization remindedOrg = orgEmailsSentMap.keySet().iterator().next();
-    assertEquals(unverifiedOrg.getExternalId(), remindedOrg.getExternalId());
+    String remindedEmail = orgEmailsSentMap.keySet().iterator().next();
+    assertEquals(email, remindedEmail);
 
-    Set<String> remindedEmails = orgEmailsSentMap.get(remindedOrg);
-    assertEquals(Set.of(email), remindedEmails);
+    OrganizationQueueItem remindedOrg = orgEmailsSentMap.get(remindedEmail);
+    assertEquals(unverifiedQueuedOrg.getExternalId(), remindedOrg.getExternalId());
   }
 
   @Test
   void sendAccountReminderEmails_concurrencyLock_success()
       throws InterruptedException, ExecutionException, SQLException {
     String email = "fake@example.org";
-    Organization unverifiedOrg = _dataFactory.createUnverifiedOrg();
-    initAndBackdateUnverifiedOrg(unverifiedOrg, email);
+    OrganizationQueueItem unverifiedQueuedOrg = _dataFactory.createOrganizationQueueItem();
+    initAndBackdateUnverifiedQueuedOrg(unverifiedQueuedOrg);
 
     int n = 3;
-    List<Future<Map<Organization, Set<String>>>> futures = new ArrayList<>();
+    List<Future<Map<String, OrganizationQueueItem>>> futures = new ArrayList<>();
 
     ThreadPoolExecutor executor =
         new ThreadPoolExecutor(n, n, 1, TimeUnit.MINUTES, new ArrayBlockingQueue<>(n));
 
     for (int i = 0; i < n; i++) {
-      Future<Map<Organization, Set<String>>> future =
+      Future<Map<String, OrganizationQueueItem>> future =
           executor.submit(() -> _service.sendAccountReminderEmails());
       futures.add(future);
     }
@@ -75,11 +77,11 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
 
     assertEquals(n, futures.size());
 
-    Map<Organization, Set<String>> successResult = null;
+    Map<String, OrganizationQueueItem> successResult = null;
     int emptyResultCount = 0;
 
-    for (Future<Map<Organization, Set<String>>> resultFuture : futures) {
-      Map<Organization, Set<String>> result = resultFuture.get();
+    for (Future<Map<String, OrganizationQueueItem>> resultFuture : futures) {
+      Map<String, OrganizationQueueItem> result = resultFuture.get();
       if (result.keySet().size() > 0) {
         successResult = result;
       } else {
@@ -95,32 +97,28 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
     assertEquals(n - 1, emptyResultCount);
   }
 
-  void initAndBackdateUnverifiedOrg(Organization unverifiedOrg, String email) throws SQLException {
-    backdateOrgCreatedAt(unverifiedOrg);
+  void initAndBackdateUnverifiedQueuedOrg(OrganizationQueueItem unverifiedQueuedOrg)
+      throws SQLException {
+    backdateQueuedOrgCreatedAt(unverifiedQueuedOrg);
 
     // another unverified org, too new to be reminded
-    _dataFactory.createValidOrg("Second Org Name", "k12", "SECOND_ORG_NAME", false);
+    _dataFactory.createOrganizationQueueItem(
+        "Second Org Name", "SECOND_ORG_NAME", "second.org.email@example.com");
     // verified org should not be reminded
-    _dataFactory.createValidOrg();
-
-    _demoOktaRepo.createUser(
-        new IdentityAttributes(email, "First", "Middle", "Last", ""),
-        unverifiedOrg,
-        Set.of(),
-        Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ADMIN),
-        true);
+    _dataFactory.createVerifiedOrganizationQueueItem(
+        "Verified Org", "A_VERIFIED_ORG", "verifiedorgemail@example.com");
   }
 
   @Transactional
-  void backdateOrgCreatedAt(Organization org) throws SQLException {
+  void backdateQueuedOrgCreatedAt(OrganizationQueueItem queuedOrg) throws SQLException {
     // Ugly, but avoids exposing createdAt to modification.  This backdates an organization's
     // created_at to noon gmt the previous day, which will fall in the range of times the id
     // verification reminder email will be sent to.
     String query =
-        "UPDATE simple_report.organization SET created_at = (NOW() + AGE(NOW() AT TIME ZONE 'America/New_York', NOW()) - INTERVAL '1 DAY')::date + INTERVAL '12 hour' WHERE internal_id = ?";
+        "UPDATE simple_report.organization_queue SET created_at = (NOW() + AGE(NOW() AT TIME ZONE 'America/New_York', NOW()) - INTERVAL '1 DAY')::date + INTERVAL '12 hour' WHERE internal_id = ?";
     Connection conn = _jdbc.getDataSource().getConnection();
     PreparedStatement statement = conn.prepareStatement(query);
-    statement.setObject(1, org.getInternalId());
+    statement.setObject(1, queuedOrg.getInternalId());
     statement.execute();
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -112,6 +112,19 @@ public class TestDataFactory {
         "New Org Queue Name", "CA-New-Org-Queue-Name-12345", "org.queue.admin@example.com");
   }
 
+  public OrganizationQueueItem createVerifiedOrganizationQueueItem(
+      String orgName, String orgExternalId, String adminEmail) {
+    Organization org = createValidOrg(orgName, "k12", orgExternalId, true);
+    OrganizationQueueItem queueItem =
+        new OrganizationQueueItem(
+            orgName,
+            orgExternalId,
+            new OrganizationAccountRequest(
+                "First", "Last", adminEmail, "800-555-1212", "CA", null, null));
+    queueItem.setVerifiedOrganization(org);
+    return _orgQueueRepo.save(queueItem);
+  }
+
   public Facility createValidFacility(Organization org) {
     return createValidFacility(org, "Imaginary Site");
   }


### PR DESCRIPTION
## Related Issue or Background Info

Fixes https://github.com/CDCgov/prime-simplereport/issues/2795

## Changes Proposed

- Send reminders to unverified orgs from `organization_queue` instead of the actual `organization` table

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
