### PR TITLE
Edit queue items backend mutation

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -352,5 +353,13 @@ public class Translators {
       return type;
     }
     throw IllegalGraphqlArgumentException.invalidInput(t, "organization type");
+  }
+
+  public static Optional<String> toOptional(String str) {
+    if (str == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(str);
+    }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/OrganizationAccountRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/OrganizationAccountRequest.java
@@ -8,10 +8,12 @@ import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 public class OrganizationAccountRequest implements TemplateVariablesProvider {
 
   private static final String TEMPLATE_NAME = "organization-account-request";

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -1,12 +1,12 @@
 package gov.cdc.usds.simplereport.api.organization;
 
-import static gov.cdc.usds.simplereport.api.Translators.toOptional;
-import static gov.cdc.usds.simplereport.api.Translators.parseString;
-import static gov.cdc.usds.simplereport.api.Translators.parseState;
-import static gov.cdc.usds.simplereport.api.Translators.parsePhoneNumber;
-import static gov.cdc.usds.simplereport.api.Translators.parseEmail;
 import static gov.cdc.usds.simplereport.api.Translators.consolidateNameArguments;
+import static gov.cdc.usds.simplereport.api.Translators.parseEmail;
 import static gov.cdc.usds.simplereport.api.Translators.parseOrganizationType;
+import static gov.cdc.usds.simplereport.api.Translators.parsePhoneNumber;
+import static gov.cdc.usds.simplereport.api.Translators.parseState;
+import static gov.cdc.usds.simplereport.api.Translators.parseString;
+import static gov.cdc.usds.simplereport.api.Translators.toOptional;
 
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.api.model.ApiOrganization;
@@ -304,13 +304,14 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
       String adminLastName,
       String adminEmail,
       String adminPhone) {
-    OrganizationQueueItem editedItem =_oqs.editQueueItem(
-        orgExternalId,
-        toOptional(name),
-        toOptional(adminFirstName),
-        toOptional(adminLastName),
-        toOptional(adminEmail),
-        toOptional(adminPhone));
+    OrganizationQueueItem editedItem =
+        _oqs.editQueueItem(
+            orgExternalId,
+            toOptional(name),
+            toOptional(adminFirstName),
+            toOptional(adminLastName),
+            toOptional(adminEmail),
+            toOptional(adminPhone));
     return editedItem.getExternalId();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -297,19 +297,20 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
     return _os.setIdentityVerified(externalId, verified);
   }
 
-  public void editPendingOrganization(
+  public String editPendingOrganization(
       String orgExternalId,
       String name,
       String adminFirstName,
       String adminLastName,
       String adminEmail,
       String adminPhone) {
-    _oqs.editQueueItem(
+    OrganizationQueueItem editedItem =_oqs.editQueueItem(
         orgExternalId,
         toOptional(name),
         toOptional(adminFirstName),
         toOptional(adminLastName),
         toOptional(adminEmail),
         toOptional(adminPhone));
+    return editedItem.getExternalId();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -1,6 +1,13 @@
 package gov.cdc.usds.simplereport.api.organization;
 
-import gov.cdc.usds.simplereport.api.Translators;
+import static gov.cdc.usds.simplereport.api.Translators.toOptional;
+import static gov.cdc.usds.simplereport.api.Translators.parseString;
+import static gov.cdc.usds.simplereport.api.Translators.parseState;
+import static gov.cdc.usds.simplereport.api.Translators.parsePhoneNumber;
+import static gov.cdc.usds.simplereport.api.Translators.parseEmail;
+import static gov.cdc.usds.simplereport.api.Translators.consolidateNameArguments;
+import static gov.cdc.usds.simplereport.api.Translators.parseOrganizationType;
+
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.api.model.ApiOrganization;
 import gov.cdc.usds.simplereport.api.model.Role;
@@ -91,12 +98,12 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             street, streetTwo, city, state, zipCode, _avs.FACILITY_DISPLAY_NAME);
     StreetAddress providerAddress =
         new StreetAddress(
-            Translators.parseString(orderingProviderStreet),
-            Translators.parseString(orderingProviderStreetTwo),
-            Translators.parseString(orderingProviderCity),
-            Translators.parseState(orderingProviderState),
-            Translators.parseString(orderingProviderZipCode),
-            Translators.parseString(orderingProviderCounty));
+            parseString(orderingProviderStreet),
+            parseString(orderingProviderStreetTwo),
+            parseString(orderingProviderCity),
+            parseState(orderingProviderState),
+            parseString(orderingProviderZipCode),
+            parseString(orderingProviderCounty));
     PersonName providerName =
         new PersonName(
             orderingProviderFirstName,
@@ -108,8 +115,8 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             testingFacilityName,
             cliaNumber,
             facilityAddress,
-            Translators.parsePhoneNumber(phone),
-            Translators.parseEmail(email),
+            parsePhoneNumber(phone),
+            parseEmail(email),
             dstHolder,
             providerName,
             providerAddress,
@@ -164,27 +171,27 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
 
     StreetAddress providerAddress =
         new StreetAddress(
-            Translators.parseString(orderingProviderStreet),
-            Translators.parseString(orderingProviderStreetTwo),
-            Translators.parseString(orderingProviderCity),
-            Translators.parseState(orderingProviderState),
-            Translators.parseString(orderingProviderZipCode),
-            Translators.parseString(orderingProviderCounty));
+            parseString(orderingProviderStreet),
+            parseString(orderingProviderStreetTwo),
+            parseString(orderingProviderCity),
+            parseState(orderingProviderState),
+            parseString(orderingProviderZipCode),
+            parseString(orderingProviderCounty));
     Facility facility =
         _os.updateFacility(
             facilityId,
             testingFacilityName,
             cliaNumber,
             facilityAddress,
-            Translators.parsePhoneNumber(phone),
-            Translators.parseEmail(email),
+            parsePhoneNumber(phone),
+            parseEmail(email),
             orderingProviderFirstName,
             orderingProviderMiddleName,
             orderingProviderLastName,
             orderingProviderSuffix,
             orderingProviderNPI,
             providerAddress,
-            Translators.parsePhoneNumber(orderingProviderTelephone),
+            parsePhoneNumber(orderingProviderTelephone),
             dstHolder);
     return new ApiFacility(facility);
   }
@@ -234,14 +241,14 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             street, streetTwo, city, state, zipCode, _avs.FACILITY_DISPLAY_NAME);
     StreetAddress providerAddress =
         new StreetAddress(
-            Translators.parseString(orderingProviderStreet),
-            Translators.parseString(orderingProviderStreetTwo),
-            Translators.parseString(orderingProviderCity),
-            Translators.parseState(orderingProviderState),
-            Translators.parseString(orderingProviderZipCode),
-            Translators.parseString(orderingProviderCounty));
+            parseString(orderingProviderStreet),
+            parseString(orderingProviderStreetTwo),
+            parseString(orderingProviderCity),
+            parseState(orderingProviderState),
+            parseString(orderingProviderZipCode),
+            parseString(orderingProviderCounty));
     providerName = // SPECIAL CASE: MAY BE ALL NULLS/BLANKS
-        Translators.consolidateNameArguments(
+        consolidateNameArguments(
             providerName,
             orderingProviderFirstName,
             orderingProviderMiddleName,
@@ -249,22 +256,22 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             orderingProviderSuffix,
             true);
     adminName =
-        Translators.consolidateNameArguments(
+        consolidateNameArguments(
             adminName, adminFirstName, adminMiddleName, adminLastName, adminSuffix);
     Organization org =
         _os.createOrganizationAndFacility(
             name,
-            Translators.parseOrganizationType(type),
+            parseOrganizationType(type),
             externalId,
             testingFacilityName,
             cliaNumber,
             facilityAddress,
-            Translators.parsePhoneNumber(phone),
-            Translators.parseEmail(email),
+            parsePhoneNumber(phone),
+            parseEmail(email),
             deviceSpecimenTypes,
             providerName,
             providerAddress,
-            Translators.parsePhoneNumber(orderingProviderTelephone),
+            parsePhoneNumber(orderingProviderTelephone),
             orderingProviderNPI);
     _aus.createUser(adminEmail, adminName, externalId, Role.ADMIN);
     List<Facility> facilities = _os.getFacilities(org);
@@ -272,12 +279,12 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
   }
 
   public void adminUpdateOrganization(String name, String type) {
-    String parsedType = Translators.parseOrganizationType(type);
+    String parsedType = parseOrganizationType(type);
     _os.updateOrganization(name, parsedType);
   }
 
   public void updateOrganization(String type) {
-    String parsedType = Translators.parseOrganizationType(type);
+    String parsedType = parseOrganizationType(type);
     _os.updateOrganization(parsedType);
   }
 
@@ -288,5 +295,21 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
       _oqs.createAndActivateQueuedOrganization(orgQueueItem.get());
     }
     return _os.setIdentityVerified(externalId, verified);
+  }
+
+  public void editPendingOrganization(
+      String orgExternalId,
+      String name,
+      String adminFirstName,
+      String adminLastName,
+      String adminEmail,
+      String adminPhone) {
+    _oqs.editQueueItem(
+        orgExternalId,
+        toOptional(name),
+        toOptional(adminFirstName),
+        toOptional(adminLastName),
+        toOptional(adminEmail),
+        toOptional(adminPhone));
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationQueueItem.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationQueueItem.java
@@ -41,6 +41,14 @@ public class OrganizationQueueItem extends EternalAuditedEntity {
     this.requestData = requestData;
   }
 
+  public OrganizationQueueItem editOrganizationQueueItem(
+      String orgName, String externalId, OrganizationAccountRequest requestData) {
+    this.organizationName = orgName;
+    this.externalId = externalId;
+    this.requestData = requestData;
+    return this;
+  }
+
   public void setVerifiedOrganization(Organization org) {
     verifiedOrganization = org;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/OrganizationUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/OrganizationUtils.java
@@ -1,0 +1,28 @@
+package gov.cdc.usds.simplereport.utils;
+
+import gov.cdc.usds.simplereport.api.model.errors.BadRequestException;
+import java.util.UUID;
+
+public class OrganizationUtils {
+
+  private OrganizationUtils() {
+    throw new IllegalStateException("OrganizationUtils is a utility class");
+  }
+
+  public static String generateOrgExternalId(String organizationName, String state) {
+    organizationName =
+        organizationName
+            // remove all non-alpha-numeric
+            .replaceAll("[^-A-Za-z0-9 ]", "")
+            // spaces to hyphens
+            .replace(' ', '-')
+            // reduce repeated hyphens to one
+            .replaceAll("-+", "-")
+            // remove leading hyphens
+            .replaceAll("^-+", "");
+    if (organizationName.length() == 0) {
+      throw new BadRequestException("The organization name is invalid.");
+    }
+    return String.format("%s-%s-%s", state, organizationName, UUID.randomUUID());
+  }
+}

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -66,6 +66,14 @@ extend type Mutation {
     externalId: String!
     verified: Boolean!
   ): Boolean
+  editPendingOrganization(
+    orgExternalId: String!
+    name: String
+    adminFirstName: String
+    adminLastName: String
+    adminEmail: String
+    adminPhone: String
+  ) : String
   createOrganizationRegistrationLink(
     organizationExternalId: String!
     link: String!

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
@@ -1,6 +1,8 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
@@ -53,6 +55,83 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
     assertTrue(optFetchedQueueItem.isPresent());
     OrganizationQueueItem fetchedQueueItem = optFetchedQueueItem.get();
     assertEquals(createdQueueItem.getOrganizationName(), fetchedQueueItem.getOrganizationName());
+  }
+
+  @Test
+  void editQueueItem_newOrgName_success() {
+    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+
+    OrganizationQueueItem editedItem =
+        _service.editQueueItem(
+            createdQueueItem.getExternalId(),
+            Optional.of("Edited Org Queue Name"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    // external id changed because name changed
+    assertFalse(editedItem.getExternalId().equals(createdQueueItem.getExternalId()));
+
+    Optional<OrganizationQueueItem> optFetchedQueueItem =
+        _service.getUnverifiedQueuedOrganizationByExternalId(editedItem.getExternalId());
+    assertEquals(optFetchedQueueItem.get().getOrganizationName(), "Edited Org Queue Name");
+  }
+
+  @Test
+  void editQueueItem_newAdminName_success() {
+    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+
+    _service.editQueueItem(
+        createdQueueItem.getExternalId(),
+        Optional.empty(),
+        Optional.of("Sarah"),
+        Optional.of("Samuels"),
+        Optional.empty(),
+        Optional.empty());
+
+    // re-fetch queue item and see changes reflected
+    Optional<OrganizationQueueItem> optFetchedQueueItem =
+        _service.getUnverifiedQueuedOrganizationByExternalId(createdQueueItem.getExternalId());
+    assertEquals(optFetchedQueueItem.get().getRequestData().getFirstName(), "Sarah");
+    assertEquals(optFetchedQueueItem.get().getRequestData().getLastName(), "Samuels");
+  }
+
+  @Test
+  void editQueueItem_newContactInfo_success() {
+    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+
+    _service.editQueueItem(
+        createdQueueItem.getExternalId(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of("foo@bar.com"),
+        Optional.of("123-456-7890"));
+
+    // re-fetch queue item and see changes reflected
+    Optional<OrganizationQueueItem> optFetchedQueueItem =
+        _service.getUnverifiedQueuedOrganizationByExternalId(createdQueueItem.getExternalId());
+    assertEquals(optFetchedQueueItem.get().getRequestData().getEmail(), "foo@bar.com");
+    assertEquals(optFetchedQueueItem.get().getRequestData().getWorkPhoneNumber(), "123-456-7890");
+  }
+
+  @Test
+  void editQueueItem_failsToFindValidOrg() {
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              _service.editQueueItem(
+                  "nonsense id",
+                  Optional.empty(),
+                  Optional.empty(),
+                  Optional.empty(),
+                  Optional.of("foo@bar.com"),
+                  Optional.of("123-456-7890"));
+            });
+    assertEquals(
+        exception.getMessage(), "Requesting edits on an organization that does not exist.");
   }
 
   @Test

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
+
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
-
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
@@ -134,6 +133,7 @@ export type Mutation = {
   createFacilityRegistrationLink?: Maybe<Scalars["String"]>;
   createOrganization?: Maybe<Organization>;
   createOrganizationRegistrationLink?: Maybe<Scalars["String"]>;
+  editPendingOrganization?: Maybe<Scalars["String"]>;
   editQueueItem?: Maybe<TestOrder>;
   reactivateUser?: Maybe<User>;
   removePatientFromQueue?: Maybe<Scalars["String"]>;
@@ -318,6 +318,15 @@ export type MutationCreateOrganizationArgs = {
 export type MutationCreateOrganizationRegistrationLinkArgs = {
   link: Scalars["String"];
   organizationExternalId: Scalars["String"];
+};
+
+export type MutationEditPendingOrganizationArgs = {
+  adminEmail?: Maybe<Scalars["String"]>;
+  adminFirstName?: Maybe<Scalars["String"]>;
+  adminLastName?: Maybe<Scalars["String"]>;
+  adminPhone?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
+  orgExternalId: Scalars["String"];
 };
 
 export type MutationEditQueueItemArgs = {


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #2800 

## Changes Proposed

- Adds a new mutation to edit queue items

## Additional Information

- Pulled out some utility methods to common files (org external id creation and a null-or-optional method)
- Most of the changes in the OrganizationMutationResolver are import changes; the only real change is adding the `editPendingOrganization` method

## Checklist for Author and Reviewer

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- n/a Database changes are submitted as a separate PR
  - n/a Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - n/a Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - n/a Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - n/a Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- n/a Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- n/a Any dependencies introduced have been vetted and discussed

## Cloud
- n/a DevOps team has been notified if PR requires ops support
- n/a If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
