### PR TITLE
Show patient result errors again

### DIFF
--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -72,11 +72,12 @@ const DOB = () => {
       );
       dispatch(setPatient(response));
     } catch (error: any) {
+      console.log(error);
       if (error?.status === 410) {
         setLinkExpiredError(true);
       } else if (error?.status === 404) {
         setLinkNotFoundError(true);
-      } else if (error?.status === 403) {
+      } else if (error?.status === 403 || error?.status === 401) {
         setBirthDateError(t("testResult.dob.error"));
       }
     } finally {

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -77,7 +77,12 @@ const DOB = () => {
         setLinkExpiredError(true);
       } else if (error?.status === 404 || strError.includes("404")) {
         setLinkNotFoundError(true);
-      } else if (error?.status === 403 || error?.status === 401 || strError.includes("403") || strError.includes("401")) {
+      } else if (
+        error?.status === 403 ||
+        error?.status === 401 ||
+        strError.includes("403") ||
+        strError.includes("401")
+      ) {
         setBirthDateError(t("testResult.dob.error"));
       }
     } finally {

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -72,12 +72,12 @@ const DOB = () => {
       );
       dispatch(setPatient(response));
     } catch (error: any) {
-      console.log(error);
-      if (error?.status === 410) {
+      let strError = String(error);
+      if (error?.status === 410 || strError.includes("410")) {
         setLinkExpiredError(true);
-      } else if (error?.status === 404) {
+      } else if (error?.status === 404 || strError.includes("404")) {
         setLinkNotFoundError(true);
-      } else if (error?.status === 403 || error?.status === 401) {
+      } else if (error?.status === 403 || error?.status === 401 || strError.includes("403") || strError.includes("401")) {
         setBirthDateError(t("testResult.dob.error"));
       }
     } finally {


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #2922 
- Currently we are not showing ANY errors for patient results (expired/invalid link or incorrect DOB)

## Changes Proposed

- updates error handling to include string responses, not just status code

## Additional Information

- deeper investigation into root cause is pending (why did error type change?), but this is a safe temporary fix

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
