### PR TITLE
Remove old org signup

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -5,10 +5,8 @@ import static gov.cdc.usds.simplereport.config.WebConfiguration.ACCOUNT_REQUEST;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.okta.sdk.resource.ResourceException;
 import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.accountrequest.errors.AccountRequestFailureException;
-import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.accountrequest.AccountResponse;
 import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
 import gov.cdc.usds.simplereport.api.model.accountrequest.WaitlistRequest;
@@ -16,7 +14,6 @@ import gov.cdc.usds.simplereport.api.model.errors.BadRequestException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
-import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
 import gov.cdc.usds.simplereport.service.ApiUserService;
@@ -35,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -79,45 +75,6 @@ public class AccountRequestController {
     _es.send(sendGridProperties.getWaitlistRecipient(), subject, request);
   }
 
-  /** Organization Account request without facility for experian id verification workflow. */
-  @SuppressWarnings("checkstyle:illegalcatch")
-  @PostMapping("/organization-create-without-facility")
-  @Transactional(readOnly = false)
-  public AccountResponse submitOrganizationAccountRequest(
-      @Valid @RequestBody OrganizationAccountRequest request) throws IOException {
-    try {
-      logOrganizationAccountRequest(request);
-      Organization org = checkAccountRequestAndCreateOrg(request);
-      createAdminUser(
-          request.getFirstName(), request.getLastName(), request.getEmail(), org.getExternalId());
-      return new AccountResponse(org.getExternalId());
-    } catch (ResourceException e) {
-      // The `ResourceException` is mostly thrown when a user requests an account with an email
-      // address that's already in Okta, but can be thrown for other Okta internal errors as well.
-      // We rethrow it as a BadRequestException so that users get a toast informing them of the
-      // error.
-      if (e.getMessage().contains("An object with this field already exists")) {
-        throw new BadRequestException(
-            "This email address is already associated with a SimpleReport user.");
-      } else {
-        throw new BadRequestException(
-            "An unknown error occurred when creating this organization in Okta.");
-      }
-    } catch (BadRequestException e) {
-      // Need to catch and re-throw these BadRequestExceptions or they get rethrown as
-      // AccountRequestFailureExceptions
-      throw e;
-    } catch (UnexpectedRollbackException e) {
-      // This `UnexpectedRollbackException` is thrown if a duplicate org somehow slips past our
-      // checks and is attempted to be committed to the database.
-      // We rethrow it as a BadRequestException so that users get a toast informing them of the
-      // error.
-      throw new BadRequestException("This organization has already registered with SimpleReport.");
-    } catch (IOException | RuntimeException e) {
-      throw new AccountRequestFailureException(e);
-    }
-  }
-
   @SuppressWarnings("checkstyle:illegalcatch")
   @PostMapping("/organization-add-to-queue")
   @Transactional(readOnly = false)
@@ -150,15 +107,6 @@ public class AccountRequestController {
     } catch (IOException | RuntimeException e) {
       throw new AccountRequestFailureException(e);
     }
-  }
-
-  private Organization checkAccountRequestAndCreateOrg(OrganizationAccountRequest request) {
-    String parsedStateCode = Translators.parseState(request.getState());
-    String organizationName =
-        checkForDuplicateOrg(request.getName(), parsedStateCode, request.getEmail());
-    String orgExternalId = createOrgExternalId(organizationName, parsedStateCode);
-    String organizationType = Translators.parseOrganizationType(request.getType());
-    return _os.createOrganization(organizationName, organizationType, orgExternalId);
   }
 
   private String checkForDuplicateOrg(String organizationName, String state, String email) {
@@ -214,12 +162,6 @@ public class AccountRequestController {
       throw new BadRequestException("The organization name is invalid.");
     }
     return String.format("%s-%s-%s", state, organizationName, UUID.randomUUID());
-  }
-
-  private void createAdminUser(String firstName, String lastName, String email, String externalId) {
-    PersonName adminName =
-        Translators.consolidateNameArguments(null, firstName, null, lastName, null);
-    _aus.createUser(email, adminName, externalId, Role.ADMIN);
   }
 
   private void logOrganizationAccountRequest(@RequestBody @Valid OrganizationAccountRequest request)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
@@ -89,9 +89,9 @@ class IdentityVerificationControllerTest {
   private static final String VALID_SESSION_STRING = "099244e0-bebc-4f59-83fd-453dc7f0b858";
   private static final UUID VALID_SESSION_UUID = UUID.fromString(VALID_SESSION_STRING);
 
-  protected static final String GET_QUESTIONS_REQUEST_TEMPLATE =
+  private static final String GET_QUESTIONS_REQUEST_TEMPLATE =
       "{\"orgExternalId\": \"%s\", \"firstName\":\"Jane\", \"lastName\":\"Doe\", \"dateOfBirth\":\"1980-08-12\", \"email\":\"%s\", \"phoneNumber\":\"410-867-5309\", \"streetAddress1\":\"1600 Pennsylvania Ave\", \"city\":\"Washington\", \"state\":\"DC\", \"zip\":\"20500\"}";
-  protected static final String SUBMIT_ANSWERS_REQUEST_TEMPLATE =
+  private static final String SUBMIT_ANSWERS_REQUEST_TEMPLATE =
       "{\"orgExternalId\": \"%s\", \"sessionId\": \"%s\", \"answers\": [%s]}";
 
   @BeforeEach

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/IdentityVerificationControllerTest.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.api;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -21,25 +20,20 @@ import gov.cdc.usds.simplereport.api.accountrequest.IdentityVerificationControll
 import gov.cdc.usds.simplereport.api.accountrequest.errors.AccountRequestFailureException;
 import gov.cdc.usds.simplereport.api.model.accountrequest.AccountRequestOrganizationCreateTemplate;
 import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
-import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.TemplateConfiguration;
 import gov.cdc.usds.simplereport.config.WebConfiguration;
 import gov.cdc.usds.simplereport.config.authorization.DemoAuthenticationConfiguration;
-import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
-import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
 import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.OrganizationQueueService;
-import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.service.idverification.DemoExperianService;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +51,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @Import({
   DemoAuthenticationConfiguration.class,
   DemoExperianService.class,
+  DemoOktaRepository.class,
 })
 @WebMvcTest(
     controllers = IdentityVerificationController.class,
@@ -73,10 +68,7 @@ class IdentityVerificationControllerTest {
   @Autowired private MockMvc _mockMvc;
 
   @Autowired private DemoExperianService _experianService;
-  @MockBean private OktaRepository _oktaRepo;
   @MockBean private EmailService _emailService;
-  @MockBean private OrganizationService _orgService;
-
   @MockBean private OrganizationQueueService _orgQueueService;
 
   // Dependencies of TenantDataAccessFilter
@@ -97,9 +89,9 @@ class IdentityVerificationControllerTest {
   private static final String VALID_SESSION_STRING = "099244e0-bebc-4f59-83fd-453dc7f0b858";
   private static final UUID VALID_SESSION_UUID = UUID.fromString(VALID_SESSION_STRING);
 
-  private static final String GET_QUESTIONS_REQUEST_TEMPLATE =
+  protected static final String GET_QUESTIONS_REQUEST_TEMPLATE =
       "{\"orgExternalId\": \"%s\", \"firstName\":\"Jane\", \"lastName\":\"Doe\", \"dateOfBirth\":\"1980-08-12\", \"email\":\"%s\", \"phoneNumber\":\"410-867-5309\", \"streetAddress1\":\"1600 Pennsylvania Ave\", \"city\":\"Washington\", \"state\":\"DC\", \"zip\":\"20500\"}";
-  private static final String SUBMIT_ANSWERS_REQUEST_TEMPLATE =
+  protected static final String SUBMIT_ANSWERS_REQUEST_TEMPLATE =
       "{\"orgExternalId\": \"%s\", \"sessionId\": \"%s\", \"answers\": [%s]}";
 
   @BeforeEach
@@ -108,18 +100,14 @@ class IdentityVerificationControllerTest {
 
     _experianService.addSessionId(VALID_SESSION_UUID);
 
-    Organization org = mock(Organization.class);
-    when(_orgService.getOrganization(FAKE_ORG_EXTERNAL_ID)).thenReturn(org);
-    when(_orgService.getOrganization(not(eq(FAKE_ORG_EXTERNAL_ID))))
-        .thenThrow(IllegalGraphqlArgumentException.class);
-    when(org.getExternalId()).thenReturn(FAKE_ORG_EXTERNAL_ID);
-    Set<String> orgEmails =
-        new HashSet<>() {
-          {
-            add(FAKE_ORG_ADMIN_EMAIL);
-          }
-        };
-    when(_oktaRepo.getAllUsersForOrganization(org)).thenReturn(orgEmails);
+    OrganizationAccountRequest accountRequest = mock(OrganizationAccountRequest.class);
+    when(accountRequest.getEmail()).thenReturn(FAKE_ORG_ADMIN_EMAIL);
+
+    OrganizationQueueItem orgQueueItem = mock(OrganizationQueueItem.class);
+    when(_orgQueueService.getUnverifiedQueuedOrganizationByExternalId(FAKE_ORG_EXTERNAL_ID))
+        .thenReturn(Optional.of(orgQueueItem));
+    when(orgQueueItem.getRequestData()).thenReturn(accountRequest);
+    when(orgQueueItem.getExternalId()).thenReturn(FAKE_ORG_EXTERNAL_ID);
   }
 
   @Test
@@ -225,31 +213,6 @@ class IdentityVerificationControllerTest {
   }
 
   @Test
-  void getQuestions_badOrg_failure() throws Exception {
-    // org should not be verified and only have 1 member
-    Set<String> orgEmailSet =
-        new HashSet<>() {
-          {
-            add("user1@example.org");
-            add("user2@example.org");
-          }
-        };
-    when(_oktaRepo.getAllUsersForOrganization(any())).thenReturn(orgEmailSet);
-
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.ID_VERIFICATION_GET_QUESTIONS)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(getQuestionsRequestBody(FAKE_ORG_EXTERNAL_ID, FAKE_ORG_ADMIN_EMAIL));
-
-    this._mockMvc.perform(builder).andExpect(status().isBadRequest());
-
-    // not a new org, no emails sent
-    verifyEmailsNotSent();
-  }
-
-  @Test
   void getQuestions_restClientException_failure() throws Exception {
     MockHttpServletRequestBuilder builder =
         post(ResourceLinks.ID_VERIFICATION_GET_QUESTIONS)
@@ -266,7 +229,8 @@ class IdentityVerificationControllerTest {
 
   @Test
   void submitAnswers_correctAnswer_success() throws Exception {
-    when(_orgService.verifyOrganizationNoPermissions(any())).thenReturn(FAKE_ACTIVATION_TOKEN);
+    when(_orgQueueService.createAndActivateQueuedOrganization(any()))
+        .thenReturn(FAKE_ACTIVATION_TOKEN);
 
     MockHttpServletRequestBuilder builder =
         post(ResourceLinks.ID_VERIFICATION_SUBMIT_ANSWERS)
@@ -396,31 +360,6 @@ class IdentityVerificationControllerTest {
   }
 
   @Test
-  void submitAnswers_badOrg_failure() throws Exception {
-    // org should not be verified and only have 1 member
-    Set<String> orgEmailSet =
-        new HashSet<>() {
-          {
-            add("user1@example.org");
-            add("user2@example.org");
-          }
-        };
-    when(_oktaRepo.getAllUsersForOrganization(any())).thenReturn(orgEmailSet);
-
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.ID_VERIFICATION_SUBMIT_ANSWERS)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(submitAnswersRequestBody(FAKE_ORG_EXTERNAL_ID, VALID_SESSION_STRING, true));
-
-    this._mockMvc.perform(builder).andExpect(status().isBadRequest());
-
-    // too many users in org, no emails sent
-    verifyEmailsNotSent();
-  }
-
-  @Test
   void submitAnswers_restClientException_failure() throws Exception {
     MockHttpServletRequestBuilder builder =
         post(ResourceLinks.ID_VERIFICATION_SUBMIT_ANSWERS)
@@ -435,6 +374,32 @@ class IdentityVerificationControllerTest {
 
     // general request failure to experian, send emails
     verifyEmailsSent();
+  }
+
+  @Test
+  void submitAnswers_queuedOrgNotFound_failure() throws Exception {
+    final String nonExistentOrgExtId = "THIS_ORG_DOES_NOT_EXIST";
+
+    // given
+    when(_orgQueueService.getUnverifiedQueuedOrganizationByExternalId(nonExistentOrgExtId))
+        .thenReturn(Optional.empty());
+
+    // when
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.ID_VERIFICATION_SUBMIT_ANSWERS)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(submitAnswersRequestBody(nonExistentOrgExtId, VALID_SESSION_STRING, true));
+    MvcResult result =
+        this._mockMvc.perform(builder).andExpect(status().isBadRequest()).andReturn();
+
+    // then
+    assertEquals(
+        String.format("An organization with external_id=%s does not exist", nonExistentOrgExtId),
+        result.getResponse().getContentAsString());
+
+    verifyEmailsNotSent();
   }
 
   private String getQuestionsRequestBody(String orgExternalId, String email) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -10,11 +10,8 @@ public final class ResourceLinks {
   public static final String ENTITY_NAME = "/pxp/register/entity-name";
 
   public static final String WAITLIST_REQUEST = "/account-request/waitlist";
-  public static final String ACCOUNT_REQUEST_ORGANIZATION_CREATE =
-      "/account-request/organization-create-without-facility";
   public static final String ACCOUNT_REQUEST_ORGANIZATION_ADD_TO_QUEUE =
       "/account-request/organization-add-to-queue";
-  public static final String USER_ACCOUNT_REQUEST = "/user-account";
   public static final String USER_GET_STATUS = "/user-account/user-status";
   public static final String USER_ACTIVATE_ACCOUNT_REQUEST = "/user-account/initialize";
   public static final String USER_SET_PASSWORD = "/user-account/set-password";


### PR DESCRIPTION
## Related Issue or Background Info

Removes old org creation and code to support transition to new process.

## Changes Proposed

- Remove old org creation endpoint
- Update tests

## Additional Information

A couple of tickets have been added to help round out transition to the org queue:

* https://github.com/CDCgov/prime-simplereport/issues/2863
* https://github.com/CDCgov/prime-simplereport/issues/2927

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
