### PR TITLE
Clear Okta token from LocalStorage on 401

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -34,6 +34,7 @@ import "./i18n";
 import getNodeEnv from "./app/utils/getNodeEnv";
 import PrimeErrorBoundary from "./app/PrimeErrorBoundary";
 import "./styles/App.css";
+import { getUrl } from "./app/utils/url";
 
 // Initialize telemetry early
 ai.initialize();
@@ -76,11 +77,13 @@ const apolloMiddleware = new ApolloLink((operation, forward) => {
 
 const logoutLink = onError(({ networkError, graphQLErrors }: ErrorResponse) => {
   if (networkError && process.env.REACT_APP_BASE_URL) {
+    // If unauthorized (expired or missing token), remove the access token and reload
     if ("statusCode" in networkError && networkError.statusCode === 401) {
       console.warn("[UNATHORIZED_ACCESS] !!");
-      console.warn("redirect-to:", process.env.REACT_APP_BASE_URL);
       localStorage.removeItem("access_token");
-      window.location.replace(process.env.REACT_APP_BASE_URL);
+      const appUrl = getUrl();
+      console.warn("redirect-to:", appUrl);
+      window.location.replace(appUrl);
     } else {
       const appInsights = getAppInsights();
       if (appInsights instanceof ApplicationInsights) {


### PR DESCRIPTION
## Related Issue or Background Info

- When https://github.com/CDCgov/prime-simplereport-site/pull/246 was merged, it seemed to break the login button - clicking it just reloaded the home page of the static site. This was because our `onError` handler in `index.tsx` was catching 401s for expired tokens and redirecting to `REACT_APP_BASE_URL`, ie `/`

## Changes Proposed

- This will remove the expired token from LocalStorage, and then redirect to `/app` instead of `/`, which will then trigger a redirect to Okta to login again

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
