### PR TITLE
Patient date of birth validation error renders correctly

### DIFF
--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -285,10 +285,10 @@ const translatePersonSchema: TranslatedSchema<RequiredPersonFields> = (t) =>
       .string()
       .test(
         "birth-date",
-        t("patient.form.errors.birthDate"),
+        t("patient.form.errors.birthDate.base"),
         isValidBirthdate18n(t)
       )
-      .required(t("patient.form.errors.birthDate")),
+      .required(t("patient.form.errors.birthDate.base")),
     facilityId: yup
       .string()
       .nullable()
@@ -319,7 +319,7 @@ const translateSelfRegistrationSchema: TranslatedSchema<SelfRegistationFields> =
         t("patient.form.errors.birthDate.base"),
         isValidBirthdate18n(t)
       )
-      .required(t("patient.form.errors.birthDate")),
+      .required(t("patient.form.errors.birthDate.base")),
     ...updateFieldSchemata(t),
   });
 


### PR DESCRIPTION
## Related Issue or Background Info

* Closes #2843 

## Changes Proposed
- This change was introduced when the shape of the `patient.form.errors.birthDate` entry in the translation configuration file was changed and the person schema validators did not read from the update path

## Additional Information
- I was afraid there was some gross `yup` problem at the root of this but it turns out we just needed a tiny change! 🎉 

## Screenshots / Demos
<img width="362" alt="Screen Shot 2021-11-12 at 2 03 47 PM" src="https://user-images.githubusercontent.com/27730981/141522036-a068368e-66ad-4b64-9d7b-011b7269b9e0.png">

<img width="378" alt="Screen Shot 2021-11-12 at 2 03 55 PM" src="https://user-images.githubusercontent.com/27730981/141522038-4994e050-ca0c-42f3-9bb1-a42a72c6cdcb.png">

<img width="375" alt="Screen Shot 2021-11-12 at 2 04 02 PM" src="https://user-images.githubusercontent.com/27730981/141522041-4fcd0377-39e1-4244-81dd-04580cc308ad.png">

<img width="392" alt="Screen Shot 2021-11-12 at 2 07 21 PM" src="https://user-images.githubusercontent.com/27730981/141522044-16cd2d15-1a49-43ae-b9b9-3c8968318fd7.png">

## Checklist for Author and Reviewer
- [ ] Did I miss anything?

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
