### PR TITLE
Add support for sending multiple emails with dynamic template

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -273,6 +274,10 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
   }
 
   public List<String> getEmails() {
+    if (emails == null) {
+      return Collections.emptyList();
+    }
+
     return emails;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryService.java
@@ -6,6 +6,7 @@ import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -31,9 +32,9 @@ public class TestResultsDeliveryService {
   }
 
   public boolean emailTestResults(PatientLink patientLink) {
-    String recipientEmailAddresses = patientLink.getTestOrder().getPatient().getEmail();
+    List<String> recipientEmailAddresses = patientLink.getTestOrder().getPatient().getEmails();
 
-    if (recipientEmailAddresses == null) {
+    if (recipientEmailAddresses.isEmpty()) {
       log.error("Patient missing email address");
       return false;
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
@@ -135,7 +135,7 @@ public class EmailService {
       final EmailProviderTemplate providerTemplate,
       final Map<String, Object> templateVariables)
       throws IOException {
-    List<String> results = new ArrayList<String>();
+    List<String> results = new ArrayList<>();
 
     for (String toEmail : toEmails) {
       Mail mail = new Mail();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
@@ -120,11 +120,17 @@ public class EmailService {
 
   public String sendWithDynamicTemplate(
       final String toEmail, final EmailProviderTemplate providerTemplate) throws IOException {
-    return sendWithDynamicTemplate(toEmail, providerTemplate, null);
+    return sendWithDynamicTemplate(List.of(toEmail), providerTemplate, null);
   }
 
   public String sendWithDynamicTemplate(
-      final String toEmail,
+      final List<String> toEmails, final EmailProviderTemplate providerTemplate)
+      throws IOException {
+    return sendWithDynamicTemplate(toEmails, providerTemplate, null);
+  }
+
+  public String sendWithDynamicTemplate(
+      final List<String> toEmails,
       final EmailProviderTemplate providerTemplate,
       final Map<String, Object> templateVariables)
       throws IOException {
@@ -135,13 +141,13 @@ public class EmailService {
     mail.setTemplateId(sendGridProperties.getDynamicTemplateGuid(providerTemplate));
 
     Personalization personalization = new Personalization();
-    personalization.addTo(new Email(toEmail));
+    toEmails.stream().map(Email::new).forEach(personalization::addTo);
 
     if (templateVariables != null) {
       templateVariables.forEach(personalization::addDynamicTemplateData);
     }
-
     mail.addPersonalization(personalization);
+
     return emailProvider.send(mail);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
@@ -14,6 +14,7 @@ import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +55,7 @@ class TestResultsDeliveryServiceTest {
     assertThat(success).isTrue();
     verify(emailService)
         .sendWithDynamicTemplate(
-            "harry@hogwarts.edu",
+            List.of("harry@hogwarts.edu"),
             EmailProviderTemplate.SIMPLE_REPORT_TEST_RESULT,
             Map.of(
                 "facility_name", "House of Gryffindor",
@@ -78,7 +79,7 @@ class TestResultsDeliveryServiceTest {
     assertThat(success).isTrue();
     verify(emailService)
         .sendWithDynamicTemplate(
-            "harry@hogwarts.edu",
+            List.of("harry@hogwarts.edu"),
             EmailProviderTemplate.SIMPLE_REPORT_TEST_RESULT,
             Map.of(
                 "facility_name", "House of Gryffindor",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
@@ -14,6 +14,7 @@ import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -93,7 +94,7 @@ class TestResultsDeliveryServiceTest {
     // GIVEN
     UUID uuid = UUID.randomUUID();
     PatientLink patientLink = getMockedPatientLink(uuid);
-    when(patientLink.getTestOrder().getPatient().getEmail()).thenReturn(null);
+    when(patientLink.getTestOrder().getPatient().getEmails()).thenReturn(Collections.emptyList());
     when(patientLinkService.getRefreshedPatientLink(uuid)).thenReturn(patientLink);
 
     // WHEN
@@ -126,6 +127,7 @@ class TestResultsDeliveryServiceTest {
 
     Person person = mock(Person.class);
     when(person.getEmail()).thenReturn("harry@hogwarts.edu");
+    when(person.getEmails()).thenReturn(List.of("harry@hogwarts.edu"));
 
     TestOrder testOrder = mock(TestOrder.class);
     when(testOrder.getPatient()).thenReturn(person);


### PR DESCRIPTION
## Related Issue or Background Info

- Continues work on #1951 

## Changes Proposed
- I had hoped to include all necessary backend changes for this feature in #2897, but during the frontend development phase I discovered some minor changes that needed to be made
    - Namely, the email service now supports sending test results with the SendGrid dynamic template to multiple email addresses

## Additional Information
- N/A

## Screenshots / Demos
https://user-images.githubusercontent.com/27730981/141531595-863d14a8-1e77-44c2-ba4d-8a2c15ce6c1f.mov

## Checklist for Author and Reviewer
- [x] Question for @tim-skylight: when delivering test results to patients with multiple email addresses, should we send a single email with each address in to `To` field? Or a separate email to _each_ email address alone?
    - Resolution: we will send a separate email for each patient email address, per Slack convo 

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
