### PR TITLE
Bump theshold for AccountRequestFailureException

### DIFF
--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -136,7 +136,7 @@ ${local.skip_on_weekends}
   time_window = 5
   trigger {
     operator  = "GreaterThan"
-    threshold = 0
+    threshold = 4
   }
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

This alert change was agreed to during the 11-10 engineering sync.

## Changes Proposed

- bump `AccountRequestFailureException` alert threshold from >= 0 to >= 5