### PR TITLE
Move default country check to component initialization

### DIFF
--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -94,6 +94,10 @@ interface Props {
 const PersonForm = (props: Props) => {
   const [formChanged, setFormChanged] = useState(false);
   const [patient, setPatient] = useState(props.patient);
+  // Default country to USA if it's not set
+  if (patient.country === null) {
+    setPatient({ ...patient, country: "USA" });
+  }
   const [errors, setErrors] = useState<PersonErrors>({});
   const [addressModalOpen, setAddressModalOpen] = useState(false);
   const [addressSuggestion, setAddressSuggestion] = useState<
@@ -259,10 +263,6 @@ const PersonForm = (props: Props) => {
         showError(t("patient.form.errors.validationMsg"), error);
       });
       return;
-    }
-    // Default country to USA if it's not set
-    if (patient.country === null) {
-      setPatient({ ...patient, country: "USA" });
     }
     if (
       JSON.stringify(getAddress(patient)) ===


### PR DESCRIPTION
## Related Issue or Background Info

- Fix for #2880 bug which did yup validation before defaulting a null country to USA

## Changes Proposed

- Move default setting to component initialization

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
