### PR TITLE
Revert App Insights agent to 3.0.3

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -6,7 +6,7 @@ COPY --chown=gradle:gradle backend/gradle ./gradle
 COPY --chown=gradle:gradle backend/*.gradle ./
 
 # Download the application insights JAR
-RUN wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.2.2/applicationinsights-agent-3.2.2.jar -O insights.jar
+RUN wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.0.3/applicationinsights-agent-3.0.3.jar -O insights.jar
 
 # nice optimization opportunity: get the dependencies cached in an intermediate
 # docker layer (have to tickle gradle, may not be worth it)


### PR DESCRIPTION
## Related Issue or Background Info

#2786 introduced some telemetry changes to better correlate events between frontend and backend. Unfortunately, version 3.2.2 of the App Insights agent also introduced an unexpected change (bug?) in auto-instrumentation and we're now missing a lot of end-to-end transaction data. This makes it difficult to investigate alerts and so let's revert while we investigate what exactly is happening.

## Changes Proposed

- Revert App Insights Java agent version in `Dockerfile.prod` from `3.2.2` to `3.0.3` (the latest version in the `3.0.x` tree, as anything `3.1.x` and up introduces the problem mentioned).