### PR TITLE
Add aria-describedby to Begin test button

### DIFF
--- a/frontend/src/app/commonComponents/Button/Button.tsx
+++ b/frontend/src/app/commonComponents/Button/Button.tsx
@@ -7,6 +7,7 @@ interface Props {
   type?: "button" | "submit";
   icon?: any;
   label?: string;
+  ariaDescribedBy?: string;
   children?: React.ReactNode;
   disabled?: boolean;
   variant?:
@@ -28,6 +29,7 @@ const Button = ({
   icon,
   disabled,
   label,
+  ariaDescribedBy,
   children,
   variant,
   className,
@@ -45,6 +47,7 @@ const Button = ({
     )}
     id={id}
     onClick={onClick}
+    aria-describedby={ariaDescribedBy || undefined}
   >
     {icon && <FontAwesomeIcon icon={icon} className="margin-right-1" />}
     {label || children}

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -59,7 +59,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
     return <Redirect to={redirect} />;
   }
 
-  const actionByPage = (patient: Patient) => {
+  const actionByPage = (patient: Patient, idx: Number) => {
     if (props.page === "queue") {
       const canAddToTestQueue =
         props.patientsInQueue.indexOf(patient.internalId) === -1;
@@ -67,6 +67,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
         <Button
           variant="unstyled"
           label="Begin test"
+          ariaDescribedBy={`name${idx} birthdate${idx}`}
           onClick={() => {
             setDialogPatient(patient);
             setCanAddToQueue(canAddToTestQueue);
@@ -123,11 +124,15 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
           </tr>
         </thead>
         <tbody>
-          {patients.map((p) => (
+          {patients.map((p, idx) => (
             <tr key={p.internalId}>
-              <td>{displayFullName(p.firstName, p.middleName, p.lastName)}</td>
-              <td>{moment(p.birthDate).format("MM/DD/YYYY")}</td>
-              <td>{actionByPage(p)}</td>
+              <td id={`name${idx}`}>
+                {displayFullName(p.firstName, p.middleName, p.lastName)}
+              </td>
+              <td id={`birthdate${idx}`}>
+                {moment(p.birthDate).format("MM/DD/YYYY")}
+              </td>
+              <td>{actionByPage(p, idx)}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/app/testQueue/addToQueue/__snapshots__/SearchResults.test.tsx.snap
+++ b/frontend/src/app/testQueue/addToQueue/__snapshots__/SearchResults.test.tsx.snap
@@ -61,14 +61,19 @@ exports[`SearchResults should show matching results 1`] = `
       </thead>
       <tbody>
         <tr>
-          <td>
+          <td
+            id="name0"
+          >
             Washington, George
           </td>
-          <td>
+          <td
+            id="birthdate0"
+          >
             01/01/1950
           </td>
           <td>
             <button
+              aria-describedby="name0 birthdate0"
               className="usa-button usa-button--unstyled"
               onClick={[Function]}
               type="button"
@@ -78,14 +83,19 @@ exports[`SearchResults should show matching results 1`] = `
           </td>
         </tr>
         <tr>
-          <td>
+          <td
+            id="name1"
+          >
             King, Martin Luther
           </td>
-          <td>
+          <td
+            id="birthdate1"
+          >
             01/01/1950
           </td>
           <td>
             <button
+              aria-describedby="name1 birthdate1"
               className="usa-button usa-button--unstyled"
               onClick={[Function]}
               type="button"
@@ -95,14 +105,19 @@ exports[`SearchResults should show matching results 1`] = `
           </td>
         </tr>
         <tr>
-          <td>
+          <td
+            id="name2"
+          >
             Obama, Barack Hussein
           </td>
-          <td>
+          <td
+            id="birthdate2"
+          >
             01/01/1950
           </td>
           <td>
             <button
+              aria-describedby="name2 birthdate2"
               className="usa-button usa-button--unstyled"
               onClick={[Function]}
               type="button"


### PR DESCRIPTION
## Related Issue or Background Info

#2268

The "Begin test" button isn't labeled with an aria and as such isn't very accessible for screen readers.

## Changes Proposed

- Add dynamic `id`s to the `Full name` and `Date of birth` elements associated with the `Begin test` button
- Add an `aria-describedby` to the button using those `id`s

## Additional Information

- Is there a more idiomatic way to do this? It feels like this could be DRYer.

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/883108/142038907-86ffe923-8c66-4f44-877e-a1bcddd70df0.png)

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
