### PR TITLE
Populate Patient Emails

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3253,3 +3253,14 @@ databaseChangeLog:
         - dropColumn:
             tableName: person
             columnName: emails
+  - changeSet:
+      id: populate-patient-emails
+      author: zedd@skylight.digital
+      comment: populate emails column from email
+      changes:
+        - tagDatabase:
+            tag: populate-patient-emails
+        - sql:
+            remarks: Populate new `emails` column with value from patient `email`
+            sql: |
+              UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;


### PR DESCRIPTION
For some reason, PROD DB didn't populate all emails with the value of email from the earlier migration.
we don't know exactly why, but we're trying to run this again, hopefully it works this time

## Related Issue or Background Info

- part of #1951 migration

## Changes Proposed

- Add another migration for populating emails because the first one didnt work for some reason

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [X] Any changes to the UI/UX are approved by design
- [X] Any new or updated content (e.g. error messages) are approved by design

### Testing
- [X] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [X] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
