### PR TITLE
Increase 4xx alert threshold

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -126,7 +126,7 @@ ${local.skip_on_weekends}
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
   name                = "${var.env}-api-4xx-errors"
-  description         = "${local.env_title} HTTP Server 4xx Errors (excluding 401s and 410s) >= 10"
+  description         = "${local.env_title} HTTP Server 4xx Errors (excluding 401s and 410s) >= 25"
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
@@ -144,7 +144,7 @@ ${local.skip_on_weekends}
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 9
+    threshold = 24
   }
 
   action {


### PR DESCRIPTION
Getting a lot of these alerts right now, and all of the matches are expected user errors like invalid activation / patient links, putting in the wrong MFA code, duplicate user emails, etc. Bumping the threshold up to 25 should reduce the frequency but still help us catch any outsize clusters