### PR TITLE
Exclude particular exceptions from 4xx alerts

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -140,6 +140,13 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
 requests
 ${local.skip_on_weekends}
 | where toint(resultCode) >= 400 and toint(resultCode) < 500 and (set_has_element(dynamic([401, 410]), toint(resultCode)) == false) and timestamp >= ago(5m)
+| join kind= inner (
+    exceptions
+    | where timestamp >= ago(5m)
+    )
+    on operation_Id
+| where (type has_any (dynamic(["BadRequestException", "InvalidActivationLinkException"]))) == false
+| where (outerMessage has_any (dynamic(["Missing session attribute 'userId'"]))) == false
   QUERY
 
   trigger {


### PR DESCRIPTION
## Related Issue or Background Info

#2986

We're getting alerted on a lot of routine/expected exceptions, so let's exclude them from the alert.

## Changes Proposed

- Excluded `BadRequestException`, `InvalidActivationLinkException`, and session timeouts (`"Missing session attribute 'userId'"`) from `4xx` error alerts

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
