### PR TITLE
Fix join type on 4xx alert to properly exclude frontend exceptions

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -139,14 +139,17 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
   query = <<-QUERY
 requests
 ${local.skip_on_weekends}
-| where toint(resultCode) >= 400 and toint(resultCode) < 500 and (set_has_element(dynamic([401, 410]), toint(resultCode)) == false) and timestamp >= ago(5m)
-| join kind= inner (
+| where toint(resultCode) >= 400
+    and toint(resultCode) < 500
+    and (set_has_element(dynamic([401, 410]), toint(resultCode)) == false)
+    and timestamp >= ago(5m)
+| join kind= leftsemi (
     exceptions
     | where timestamp >= ago(5m)
+        and (type has_any (dynamic(["BadRequestException", "InvalidActivationLinkException"]))) == false
+        and (outerMessage has_any (dynamic(["Missing session attribute 'userId'"]))) == false
     )
     on operation_Id
-| where (type has_any (dynamic(["BadRequestException", "InvalidActivationLinkException"]))) == false
-| where (outerMessage has_any (dynamic(["Missing session attribute 'userId'"]))) == false
   QUERY
 
   trigger {


### PR DESCRIPTION
## Related Issue or Background Info

Fixes query issue in #3003 where the wrong join was used.

## Changes Proposed

- Change join type from `inner` to `leftsemi`. `inner` was causing all of the related frontend exceptions in the `exceptions` table to be joined to the results as well, returning more results than we were expecting. `leftsemi` now correctly only returns the results from `requests` that satisfy the condition.
