### PR TITLE
Reduce aggregate size of DB connection pools

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -7,6 +7,9 @@ spring:
     username: simple_report_app
     password: api123
     url: jdbc:postgresql://localhost:${SR_DB_PORT:5432}/simple_report
+    hikari:
+      maximum-pool-size: 5 # Maximum number of connections to which Hikari should be limited.
+      max-lifetime: 60000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
     url: jdbc:postgresql://localhost:${SR_DB_PORT:5432}/simple_report
     hikari:
       maximum-pool-size: 5 # Maximum number of connections to which Hikari should be limited.
-      max-lifetime: 60000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
+      max-lifetime: 600000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -2,7 +2,10 @@ spring:
   profiles.include: no-security,no-okta-mgmt, no-okta-auth, no-experian
   datasource:
     url: jdbc:postgresql://localhost:${test-db-port:5444}/simple_report
-    hikari.minimum-idle: 2 # when a context isn't being used, it should not leave lots of connections lying around
+    hikari: # These values are specific to the testing flow. For runtime values, see 'application.yaml'.
+      minimum-idle: 2 # Minimum number of idle connections to maintain. Serves as a floor point for scaling. With the current liquibase settings, tests will fail if this value is removed.
+      maximum-pool-size: 5 # Maximum number of connections to which Hikari should be limited.
+      max-lifetime: 30000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   liquibase:
     user: simple_report_migrations
     password: migrations456

--- a/ops/services/app_service/metabase/main.tf
+++ b/ops/services/app_service/metabase/main.tf
@@ -1,9 +1,11 @@
 locals {
   app_setting_defaults = {
-    "MB_DB_CONNECTION_URI"           = var.postgres_url
-    "WEBSITE_VNET_ROUTE_ALL"         = 1
-    "WEBSITE_DNS_SERVER"             = "168.63.129.16"
-    "APPINSIGHTS_INSTRUMENTATIONKEY" = var.ai_instrumentation_key
+    "MB_DB_CONNECTION_URI"                            = var.postgres_url
+    "MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE"      = 4 # Controls internal Metabase connection pool sizing
+    "MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE" = 4 # Controls connection pool sizing to existing data sources (such as postgres)
+    "WEBSITE_VNET_ROUTE_ALL"                          = 1
+    "WEBSITE_DNS_SERVER"                              = "168.63.129.16"
+    "APPINSIGHTS_INSTRUMENTATIONKEY"                  = var.ai_instrumentation_key
   }
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

Originally sourced from #2181. In short, we are seeing potentially inflated application latency and resource consumption due to a large amount of unrelinquished connections within our postgres and Metabase pools. We'd like to better manage those numbers, if possible.

## Changes Proposed

- Update default Spring Profile to limit the maximum pool size for Hikari to 5, and the maximum lifetime for connection retention to 60 seconds.
- Update testing Spring Profile to limit the maximum pool size for Hikari to 5, and the maximum lifetime for connection retention to 60 seconds.
- Add variable for MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE to limit Metabase connections to 4.
- Add variable for MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE to limit Metabase JDBC connections to 4.

## Additional Information

- Load testing via unit test runs (100 workflows per minute, approximately) shows that 5 connections seems to be the sweet spot for sustainability. The application starts to choke at 3. We're running a total of 10 connections right now.
- We don't currently set a maximum lifetime value for idle connections. Azure Postgres has this set to an infinite value, and Hikari defaults to 30 minutes. We will want to monitor after these changes go in, just to ensure we are not prematurely closing a connection.

## Testing Methodology

- Hikari changes were instrumented and tested by using repeated local load test runs on isolated hardware with dedicated memory and CPU reservations. Timings were checked for consistency, and the absence of errors was verified at the currently set levels.
- Metabase changes were verified through the use of a local Docker container and manual log inspection.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
