### PR TITLE
Use start/end of day for analytics dashboard queries

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -11,7 +11,7 @@ import App, { WHOAMI_QUERY } from "./App";
 import { queueQuery } from "./testQueue/TestQueue";
 import PrimeErrorBoundary from "./PrimeErrorBoundary";
 import { TRAINING_PURPOSES_ONLY } from "./commonComponents/TrainingNotification";
-import { getDateFromDaysAgo } from "./analytics/Analytics";
+import { getStartDateFromDaysAgo, getEndDateFromDaysAgo } from "./analytics/Analytics";
 
 jest.mock("uuid");
 jest.mock("./VersionService", () => ({
@@ -170,8 +170,8 @@ const getAnalyticsQueryMock = () => ({
     query: GetTopLevelDashboardMetricsNewDocument,
     variables: {
       facilityId: "",
-      startDate: getDateFromDaysAgo(7),
-      endDate: new Date(),
+      startDate: getStartDateFromDaysAgo(7),
+      endDate: getEndDateFromDaysAgo(0),
     },
   },
   result: {

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -11,7 +11,10 @@ import App, { WHOAMI_QUERY } from "./App";
 import { queueQuery } from "./testQueue/TestQueue";
 import PrimeErrorBoundary from "./PrimeErrorBoundary";
 import { TRAINING_PURPOSES_ONLY } from "./commonComponents/TrainingNotification";
-import { getStartDateFromDaysAgo, getEndDateFromDaysAgo } from "./analytics/Analytics";
+import {
+  getStartDateFromDaysAgo,
+  getEndDateFromDaysAgo,
+} from "./analytics/Analytics";
 
 jest.mock("uuid");
 jest.mock("./VersionService", () => ({

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -9,8 +9,10 @@ import { GetTopLevelDashboardMetricsNewDocument } from "../../generated/graphql"
 
 import {
   Analytics,
-  getDateFromDaysAgo,
-  getDateWithCurrentTimeFromString,
+  getStartDateFromDaysAgo,
+  getEndDateFromDaysAgo,
+  setStartTimeForDateRange,
+  setEndTimeForDateRange,
 } from "./Analytics";
 
 const mockStore = createMockStore([]);
@@ -36,8 +38,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
-        startDate: getDateFromDaysAgo(7),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(7),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -54,8 +56,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
-        startDate: getDateFromDaysAgo(1),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(1),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -72,8 +74,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
-        startDate: getDateFromDaysAgo(30),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(30),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -90,8 +92,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "1",
-        startDate: getDateFromDaysAgo(7),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(7),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -108,8 +110,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "2",
-        startDate: getDateFromDaysAgo(7),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(7),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -126,8 +128,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
-        startDate: getDateWithCurrentTimeFromString("07/01/2021"),
-        endDate: getDateWithCurrentTimeFromString("07/31/2021"),
+        startDate: setStartTimeForDateRange(new Date("07/01/2021")),
+        endDate: setEndTimeForDateRange(new Date("07/31/2021")),
       },
     },
     result: {
@@ -144,8 +146,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "",
-        startDate: getDateWithCurrentTimeFromString("07/01/2021"),
-        endDate: new Date(),
+        startDate: setStartTimeForDateRange(new Date("07/01/2021")),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -162,8 +164,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "3",
-        startDate: getDateFromDaysAgo(7),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(7),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {
@@ -180,8 +182,8 @@ const getMocks = () => [
       query: GetTopLevelDashboardMetricsNewDocument,
       variables: {
         facilityId: "3",
-        startDate: getDateFromDaysAgo(30),
-        endDate: new Date(),
+        startDate: getStartDateFromDaysAgo(30),
+        endDate: getEndDateFromDaysAgo(0),
       },
     },
     result: {

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -8,23 +8,44 @@ import { LoadingCard } from "../commonComponents/LoadingCard/LoadingCard";
 
 import "./Analytics.scss";
 
-export const getDateFromDaysAgo = (daysAgo: number): Date => {
+const getDateFromDaysAgo = (daysAgo: number): Date => {
   const date = new Date();
   date.setDate(date.getDate() - daysAgo);
   return date;
 };
 
-export const getDateStringFromDaysAgo = (daysAgo: number): string => {
-  return getDateFromDaysAgo(daysAgo).toLocaleDateString();
+export const setStartTimeForDateRange = (date: Date): Date => {
+  date.setHours(0);
+  date.setMinutes(0);
+  date.setSeconds(0);
+  return date;
 };
 
-export const getDateWithCurrentTimeFromString = (date: string): Date => {
-  const now = new Date();
-  const newDate = new Date(date);
-  newDate.setHours(now.getHours());
-  newDate.setMinutes(now.getMinutes());
-  newDate.setSeconds(now.getSeconds());
-  return newDate;
+export const setEndTimeForDateRange = (date: Date): Date => {
+  date.setHours(23);
+  date.setMinutes(59);
+  date.setSeconds(59);
+  return date;
+};
+
+export const getStartDateFromDaysAgo = (daysAgo: number): Date => {
+  const newDate = getDateFromDaysAgo(daysAgo);
+  return setStartTimeForDateRange(newDate);
+};
+
+export const getStartDateStringFromDaysAgo = (daysAgo: number): string => {
+  const newDate = getStartDateFromDaysAgo(daysAgo);
+  return newDate.toLocaleDateString();
+};
+
+export const getEndDateFromDaysAgo = (daysAgo: number): Date => {
+  const newDate = getDateFromDaysAgo(daysAgo);
+  return setEndTimeForDateRange(newDate);
+};
+
+export const getEndDateStringFromDaysAgo = (daysAgo: number): string => {
+  const newDate = getEndDateFromDaysAgo(daysAgo);
+  return newDate.toLocaleDateString();
 };
 
 interface Props {
@@ -43,10 +64,10 @@ export const Analytics = (props: Props) => {
   const [facilityName, setFacilityName] = useState<string>(organization.name);
   const [dateRange, setDateRange] = useState<string>("week");
   const [startDate, setStartDate] = useState<string>(
-    props.startDate || getDateStringFromDaysAgo(7)
+    props.startDate || getStartDateStringFromDaysAgo(7)
   );
   const [endDate, setEndDate] = useState<string>(
-    props.endDate || new Date().toLocaleDateString()
+    props.endDate || getEndDateStringFromDaysAgo(0)
   );
 
   useEffect(() => {
@@ -75,16 +96,16 @@ export const Analytics = (props: Props) => {
     setDateRange(value);
     switch (value) {
       case "day":
-        setStartDate(getDateStringFromDaysAgo(1));
-        setEndDate(new Date().toLocaleDateString());
+        setStartDate(getStartDateStringFromDaysAgo(1));
+        setEndDate(getEndDateStringFromDaysAgo(0));
         break;
       case "week":
-        setStartDate(getDateStringFromDaysAgo(7));
-        setEndDate(new Date().toLocaleDateString());
+        setStartDate(getStartDateStringFromDaysAgo(7));
+        setEndDate(getEndDateStringFromDaysAgo(0));
         break;
       case "month":
-        setStartDate(getDateStringFromDaysAgo(30));
-        setEndDate(new Date().toLocaleDateString());
+        setStartDate(getStartDateStringFromDaysAgo(30));
+        setEndDate(getEndDateStringFromDaysAgo(0));
         break;
       default:
         break;
@@ -95,8 +116,10 @@ export const Analytics = (props: Props) => {
     variables: {
       facilityId,
       startDate:
-        getDateWithCurrentTimeFromString(startDate) || getDateFromDaysAgo(7),
-      endDate: getDateWithCurrentTimeFromString(endDate) || new Date(),
+        setStartTimeForDateRange(new Date(startDate)) ||
+        getStartDateFromDaysAgo(7),
+      endDate:
+        setEndTimeForDateRange(new Date(endDate)) || getEndDateFromDaysAgo(0),
     },
     fetchPolicy: "no-cache",
   });
@@ -182,7 +205,11 @@ export const Analytics = (props: Props) => {
                       onChange={(date?: string) => {
                         if (date && date.length === 10) {
                           const newDate = new Date(date);
-                          setStartDate(newDate.toLocaleDateString());
+                          setStartDate(
+                            setStartTimeForDateRange(
+                              newDate
+                            ).toLocaleDateString()
+                          );
                         }
                       }}
                       noHint
@@ -195,7 +222,9 @@ export const Analytics = (props: Props) => {
                       onChange={(date?: string) => {
                         if (date && date.length === 10) {
                           const newDate = new Date(date);
-                          setEndDate(newDate.toLocaleDateString());
+                          setEndDate(
+                            setEndTimeForDateRange(newDate).toLocaleDateString()
+                          );
                         }
                       }}
                       noHint

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
+
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
-
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];


### PR DESCRIPTION
## Related Issue or Background Info

#2918 (inconsistent number of test results for a given time period between the Results section and the analytics dashboard)

It turns out that the analytics dashboard is using the user's current time during date range searches, rather than midnight of the start day / 11:59:59 of the end day. This means that if you search late enough in the day, you could be excluding almost an entire day of results from the first day in the range.

This issue can be reproduced locally as well by creating a few early morning test results on the first day of the date range.

## Changes Proposed

- Refactor `Analytics.tsx` slightly to force dates to use start of day / end of day instead of local time

## Screenshots / Demos

Before:

![image](https://user-images.githubusercontent.com/883108/142489802-a104d90f-7c19-48ef-bccc-405ba20b958f.png)

After:

![image](https://user-images.githubusercontent.com/883108/142489679-8885f95a-ac5e-49ff-ac55-25ac52f8c785.png)
