### PR TITLE
Ignore changes in storage_mb Postgres DB values in TF

### DIFF
--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -26,7 +26,8 @@ resource "azurerm_postgresql_server" "db" {
 
   lifecycle {
     ignore_changes = [
-      identity
+      identity,
+      storage_mb
     ]
   }
 }


### PR DESCRIPTION
## Related Issue or Background Info

There appears to be a conflict between the `storage_mb` and `auto_grow_enabled` arguments in the `azurerm_postgresql_server` Terraform resource. Specifically, it seems that once auto-grow has taken place and the new storage capacity is larger than the `storage_mb` value, Terraform will read this as needing to reduce storage capacity to meet the `storage_mb` value, which is an unsupported operation.

https://github.com/hashicorp/terraform-provider-azurerm/issues/7475#issuecomment-648983700

## Changes Proposed

- Use `ignore_changes` to ignore the `storage_mb` value, making it effectively only an initial provisioning argument
