### PR TITLE
Bugfix: can delete one or more device-specimen types used by a facility

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/FacilityDeviceSpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/FacilityDeviceSpecimenType.java
@@ -6,18 +6,16 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
 
 @Entity
 public class FacilityDeviceSpecimenType {
-  @Id private UUID deviceSpecimenTypeId;
+  @Id private UUID internalId;
 
   public DeviceSpecimenType getDeviceSpecimenType() {
     return deviceSpecimenType;
   }
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @MapsId
   @JoinColumn(name = "device_specimen_type_id")
   private DeviceSpecimenType deviceSpecimenType;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityDeviceSpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityDeviceSpecimenTypeRepository.java
@@ -14,4 +14,6 @@ public interface FacilityDeviceSpecimenTypeRepository
 
   Optional<List<FacilityDeviceSpecimenType>>
       findByFacilityInternalIdOrderByDeviceSpecimenTypeCreatedAt(UUID facilityId);
+
+  void deleteByDeviceSpecimenTypeInternalIdIn(List<UUID> deviceSpecimenTypeIds);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface FacilityRepository extends EternalAuditedEntityRepository<Facility> {
 
@@ -32,4 +34,12 @@ public interface FacilityRepository extends EternalAuditedEntityRepository<Facil
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.organization = :org order by e.facilityName")
   List<Facility> findByOrganizationOrderByFacilityName(Organization org);
+
+  @Modifying
+  @Transactional
+  @Query(
+      value =
+          "UPDATE {h-schema}#{#entityName} SET default_device_specimen_type_id = null WHERE is_deleted = false AND default_device_specimen_type_id in :deviceSpecimenTypeIds",
+      nativeQuery = true)
+  void unsetDefaultDeviceSpecimenTypeIdsIn(List<UUID> deviceSpecimenTypeIds);
 }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3264,3 +3264,25 @@ databaseChangeLog:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
               UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+  - changeSet:
+      id: add-internal-id-to-facility-device-specimen-type
+      author: nathan@skylight.digital
+      comment: Add primary key to facility_device_specimen_type
+      changes:
+        - addColumn:
+            tableName: facility_device_specimen_type
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  defaultValue: gen_random_uuid()
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: facility
+            baseColumnNames: default_device_specimen_type_id
+            constraintName: fk__facility__default_device_specimen_type
+            referencedColumnNames: internal_id
+            referencedTableName: device_specimen_type


### PR DESCRIPTION
## Related Issue or Background Info
- Closes #2848 
- There were two issues preventing a user from deleting device-specimen types in use by a facility:
    - The `device_specimen_type` would still be referenced from `facility_device_specimen_type.device_specimen_type_id`
    - The `device_specimen_type` would still be referenced from `facility.default_device_specimen_type_id`
* **NOTE**: this pull request includes a migration - please review here for convenience, and I will submit it as a separate PR

## Changes Proposed
- In `DeviceTypeService::updateDeviceType`:
    - Before deleting old devices:
        - Un-set any facility defaults that refer to the old device
        - Remove old device-swab types from facility device configuration

## Additional Information
- As nice as it would be to have Hibernate and Postgres take care of this for us, this was not ideal for performance and data safety reasons:
    - [Why you should avoid CascadeType.REMOVE for to-many associations and what to do instead](https://thorben-janssen.com/avoid-cascadetype-delete-many-assocations/)
    - [Have JPA/Hibernate to replicate the "ON DELETE SET NULL" functionality](https://stackoverflow.com/questions/9944137/have-jpa-hibernate-to-replicate-the-on-delete-set-null-functionality)
- Why do we need a primary key `internal_id` on the `facility_device_specimen_type` table?
    - The `@MapsId` annotation on the `deviceSpecimenType` property (`FacilityDeviceSpecimenType.java`) made it so that the identifier for the device specimen type was being treated as the primary key for the table
    - This isn't a problem if a device is only configured to one facility - a single result is expected and a single was returned, so the operation completes successfully
    - If the device is configured with _multiple_ facilities, it's a different story - Hibernate thinks it's deleting a row by a primary key, so when two results for that key are returned the operation fails
    - So, here we give `facility_device_specimen_type` its own identifier
    - If I am missing a better way of doing this please do not hesitate to tell me!
 - I added a foreign key constraint on the `facility.default_device_specimen_type_id` column. I think it was supposed to exist already, but the Liquibase syntax wasn't quite right:
    - https://github.com/CDCgov/prime-simplereport/blob/main/backend/src/main/resources/db/changelog/db.changelog-master.yaml#L1456-L1464
    - `referencedTableName` is for altering existing columns, not adding new ones
    - I don't know that this is necessary; I can revert it if anyone likes

## Screenshots / Demos
### Setup
- Establish multiple facilities configured with the device+specimen type that you intend to delete
    - Have at least one of the facilities select the device as the default
<img width="808" alt="Screen Shot 2021-11-18 at 12 45 42 PM" src="https://user-images.githubusercontent.com/27730981/142495812-7904a131-a174-4d5a-9c5e-96136638e6d4.png">
<img width="765" alt="Screen Shot 2021-11-18 at 12 45 52 PM" src="https://user-images.githubusercontent.com/27730981/142495813-7d9039b2-505d-4e68-900e-2417ffa27f24.png">

* Delete the device+specimen type selected earlier

https://user-images.githubusercontent.com/27730981/142495811-7fdf5ee4-958a-4e10-9749-aebad34aca2e.mov

* Confirm that the device+specimen type is no longer configured with the 
<img width="781" alt="Screen Shot 2021-11-18 at 12 47 21 PM" src="https://user-images.githubusercontent.com/27730981/142495814-4d929cd0-6b21-486a-bdb0-9750dbbebdec.png">
<img width="772" alt="Screen Shot 2021-11-18 at 12 47 30 PM" src="https://user-images.githubusercontent.com/27730981/142495815-cd486383-84a1-4500-b0c8-3a49dcb72d81.png">

## Checklist for Author and Reviewer
- [ ] Is there anything that would be better done outside of code?
- [ ] Can a given device-specimen type be removed _and_ added at the same time?
- [ ] If a device is removed that a facility had specified as its default, should it fall back to another default? Or just leave the facility without a default (which is typically not allowed)?

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
