### PR TITLE
Revert "Reduce aggregate size of DB connection pools"

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -7,9 +7,6 @@ spring:
     username: simple_report_app
     password: api123
     url: jdbc:postgresql://localhost:${SR_DB_PORT:5432}/simple_report
-    hikari:
-      maximum-pool-size: 5 # Maximum number of connections to which Hikari should be limited.
-      max-lifetime: 600000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -2,10 +2,7 @@ spring:
   profiles.include: no-security,no-okta-mgmt, no-okta-auth, no-experian
   datasource:
     url: jdbc:postgresql://localhost:${test-db-port:5444}/simple_report
-    hikari: # These values are specific to the testing flow. For runtime values, see 'application.yaml'.
-      minimum-idle: 2 # Minimum number of idle connections to maintain. Serves as a floor point for scaling. With the current liquibase settings, tests will fail if this value is removed.
-      maximum-pool-size: 5 # Maximum number of connections to which Hikari should be limited.
-      max-lifetime: 30000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
+    hikari.minimum-idle: 2 # when a context isn't being used, it should not leave lots of connections lying around
   liquibase:
     user: simple_report_migrations
     password: migrations456

--- a/ops/services/app_service/metabase/main.tf
+++ b/ops/services/app_service/metabase/main.tf
@@ -1,11 +1,9 @@
 locals {
   app_setting_defaults = {
-    "MB_DB_CONNECTION_URI"                            = var.postgres_url
-    "MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE"      = 4 # Controls internal Metabase connection pool sizing
-    "MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE" = 4 # Controls connection pool sizing to existing data sources (such as postgres)
-    "WEBSITE_VNET_ROUTE_ALL"                          = 1
-    "WEBSITE_DNS_SERVER"                              = "168.63.129.16"
-    "APPINSIGHTS_INSTRUMENTATIONKEY"                  = var.ai_instrumentation_key
+    "MB_DB_CONNECTION_URI"           = var.postgres_url
+    "WEBSITE_VNET_ROUTE_ALL"         = 1
+    "WEBSITE_DNS_SERVER"             = "168.63.129.16"
+    "APPINSIGHTS_INSTRUMENTATIONKEY" = var.ai_instrumentation_key
   }
 }
 


### PR DESCRIPTION
Reverts CDCgov/prime-simplereport#3007

After three hours in Production, we are starting to receive errors that state JDBC connections cannot be maintained. We should revert as a precaution.

Connection requests are timing out after 30 seconds.