### PR TITLE
fix content for re-texting test results

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientLinkMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientLinkMutationResolver.java
@@ -1,10 +1,7 @@
 package gov.cdc.usds.simplereport.api.pxp;
 
 import gov.cdc.usds.simplereport.service.TestResultsDeliveryService;
-import gov.cdc.usds.simplereport.service.model.SmsAPICallResult;
-import gov.cdc.usds.simplereport.service.sms.SmsService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,20 +10,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 public class PatientLinkMutationResolver implements GraphQLMutationResolver {
-
-  private final SmsService smsService;
   private final TestResultsDeliveryService testResultsDeliveryService;
 
   @Value("${simple-report.patient-link-url:https://simplereport.gov/pxp?plid=}")
   private String patientLinkUrl;
 
-  public List<SmsAPICallResult> sendPatientLinkSms(UUID internalId) {
-    return smsService.sendToPatientLink(
-        internalId,
-        "Please fill out your Covid-19 pre-test questionnaire: " + patientLinkUrl + internalId);
+  public boolean sendPatientLinkSms(UUID patientLinkId) {
+    return testResultsDeliveryService.smsTestResults(patientLinkId);
   }
 
-  public boolean sendPatientLinkEmail(UUID internalId) {
-    return testResultsDeliveryService.emailTestResults(internalId);
+  public boolean sendPatientLinkEmail(UUID patientLinkId) {
+    return testResultsDeliveryService.emailTestResults(patientLinkId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/SmsAPICallResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/SmsAPICallResult.java
@@ -1,26 +1,14 @@
 package gov.cdc.usds.simplereport.service.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
 public class SmsAPICallResult {
   private String telephone;
   private String messageId;
-  private boolean deliverySuccess;
-
-  public SmsAPICallResult(String telephone, String messageId, boolean deliverySuccess) {
-    super();
-    this.telephone = telephone;
-    this.messageId = messageId;
-    this.deliverySuccess = deliverySuccess;
-  }
-
-  public String getTelephone() {
-    return telephone;
-  }
-
-  public String getMessageId() {
-    return messageId;
-  }
-
-  public boolean getDeliverySuccess() {
-    return deliverySuccess;
-  }
+  private boolean successful;
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -554,7 +554,7 @@ type Mutation {
     noSymptoms: Boolean
     testResultDelivery: TestResultDeliveryPreference
   ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
-  sendPatientLinkSms(internalId: ID!): String
+  sendPatientLinkSms(internalId: ID!): Boolean
     @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkEmail(internalId: ID!): Boolean
   updateOrganization(type: String!): String

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2,13 +2,13 @@ package gov.cdc.usds.simplereport.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -31,8 +31,6 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
-import gov.cdc.usds.simplereport.service.model.SmsAPICallResult;
-import gov.cdc.usds.simplereport.service.sms.SmsService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyAllFacilitiesUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
@@ -43,7 +41,6 @@ import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -69,7 +66,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @Autowired private TestEventRepository _testEventRepository;
   @Autowired private TestDataFactory _dataFactory;
   @MockBean private TestResultsDeliveryService testResultsDeliveryService;
-  @MockBean private SmsService _smsService;
 
   private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
   private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
@@ -329,7 +325,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addTestResult(
         devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
 
-    verify(_smsService).sendToPatientLink(any(UUID.class), anyString());
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
@@ -490,7 +486,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addTestResult(
         devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
 
-    verify(_smsService).sendToPatientLink(any(UUID.class), anyString());
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
@@ -519,27 +515,71 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
   @Test
   @WithSimpleReportOrgAdminUser
-  void addTestResult_smsDelivery_invalidPhoneNumber() {
+  void addTestResult_smsDelivery() {
+    // GIVEN
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p = _dataFactory.createFullPerson(org);
+    Person patient = _dataFactory.createFullPerson(org);
 
     _personService.updateTestResultDeliveryPreference(
-        p.getInternalId(), TestResultDeliveryPreference.SMS);
+        patient.getInternalId(), TestResultDeliveryPreference.SMS);
+
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        patient,
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
     DeviceType devA = facility.getDefaultDeviceType();
 
-    List<SmsAPICallResult> deliveryResults = new ArrayList<SmsAPICallResult>();
-    deliveryResults.add(new SmsAPICallResult("message-id", "id", false));
+    when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
+    when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
 
-    doReturn(deliveryResults).when(_smsService).sendToPatientLink(any(), any());
-
+    // WHEN
     AddTestResultResponse res =
         _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
 
-    assertEquals(false, res.getDeliverySuccess());
+    // THEN
+    assertTrue(res.getDeliverySuccess());
+    ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
+    verify(testResultsDeliveryService).smsTestResults(patientLinkCaptor.capture());
+    assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
+        .isEqualTo(patient.getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_smsDelivery_failure() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
+
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.SMS);
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType devA = facility.getDefaultDeviceType();
+
+    when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
+    when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
+
+    // WHEN
+    AddTestResultResponse res =
+        _service.addTestResult(
+            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
+
+    // THEN
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+    assertFalse(res.getDeliverySuccess());
   }
 
   @Test
@@ -571,7 +611,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
-    assertEquals(true, res.getDeliverySuccess());
+    assertTrue(res.getDeliverySuccess());
     ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
     verify(testResultsDeliveryService).emailTestResults(patientLinkCaptor.capture());
     assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
@@ -608,7 +648,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // THEN
     verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
-    assertEquals(false, res.getDeliverySuccess());
+    assertFalse(res.getDeliverySuccess());
   }
 
   @Test
@@ -640,11 +680,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
-    assertEquals(true, res.getDeliverySuccess());
-
     verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
-    verify(_smsService).sendToPatientLink(any(UUID.class), anyString());
-    assertEquals(true, res.getDeliverySuccess());
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+    assertTrue(res.getDeliverySuccess());
   }
 
   @Test
@@ -673,9 +711,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
-    assertEquals(true, res.getDeliverySuccess());
+    assertTrue(res.getDeliverySuccess());
     verifyNoInteractions(testResultsDeliveryService);
-    verifyNoInteractions(_smsService);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/SmsServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/SmsServiceTest.java
@@ -149,7 +149,7 @@ class SmsServiceTest extends BaseServiceTest<SmsService> {
             .collect(Collectors.toList());
 
     assertEquals(1, failedDelivery.size());
-    assertEquals(false, failedDelivery.get(0).getDeliverySuccess());
+    assertEquals(false, failedDelivery.get(0).isSuccessful());
   }
 
   @Test
@@ -189,7 +189,7 @@ class SmsServiceTest extends BaseServiceTest<SmsService> {
     var result = sut.get(0);
     assertEquals(_person.getPrimaryPhone().getNumber(), result.getTelephone());
     assertEquals("some-twilio-id-10", result.getMessageId());
-    assertEquals(true, result.getDeliverySuccess());
+    assertEquals(true, result.isSuccessful());
   }
 
   @Test

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -142,7 +142,7 @@ export type Mutation = {
   resendToReportStream?: Maybe<Scalars["Boolean"]>;
   resetUserPassword?: Maybe<User>;
   sendPatientLinkEmail?: Maybe<Scalars["Boolean"]>;
-  sendPatientLinkSms?: Maybe<Scalars["String"]>;
+  sendPatientLinkSms?: Maybe<Scalars["Boolean"]>;
   setCurrentUserTenantDataAccess?: Maybe<User>;
   setOrganizationIdentityVerified?: Maybe<Scalars["Boolean"]>;
   setPatientIsDeleted?: Maybe<Patient>;
@@ -1976,7 +1976,7 @@ export type SendSmsMutationVariables = Exact<{
 
 export type SendSmsMutation = {
   __typename?: "Mutation";
-  sendPatientLinkSms?: Maybe<string>;
+  sendPatientLinkSms?: Maybe<boolean>;
 };
 
 export type GetResultsCountByFacilityQueryVariables = Exact<{


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #3025

## Changes Proposed

- fix content for resending results via sms
- change Covid-19 to COVID-19
- expiration period is generated from patientLink, no longer hardcoded to 5 days for sms

## Screenshots / Demos
First message on test submit, second message is on re-text
![image](https://user-images.githubusercontent.com/4952042/142929491-306780db-b0dd-4e73-abe3-d24714072d88.png)

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
