### PR TITLE
Show new or updated facilities in the header dropdown and facilities

### DIFF
--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -386,7 +386,7 @@ type Mutation {
     deviceTypes: [String]!
     deviceSpecimenTypes: [ID]
     defaultDevice: String!
-  ): String @requiredPermissions(allOf: ["EDIT_FACILITY"])
+  ): Facility @requiredPermissions(allOf: ["EDIT_FACILITY"])
   addFacility(
     testingFacilityName: String!
     cliaNumber: String
@@ -415,7 +415,7 @@ type Mutation {
     deviceTypes: [String]!
     deviceSpecimenTypes: [ID]
     defaultDevice: String!
-  ): String @requiredPermissions(allOf: ["EDIT_FACILITY"])
+  ): Facility @requiredPermissions(allOf: ["EDIT_FACILITY"])
   addUserToCurrentOrg(
     name: NameInput
     firstName: String

--- a/backend/src/test/resources/queries/facility-create
+++ b/backend/src/test/resources/queries/facility-create
@@ -22,5 +22,7 @@ mutation addFac($deviceId: String!, $deviceSpecimenTypes: [ID]!) {
     deviceTypes: [$deviceId]
     deviceSpecimenTypes: $deviceSpecimenTypes
     defaultDevice: $deviceId
-  )
+  ) {
+    id
+  }
 }

--- a/backend/src/test/resources/queries/facility-update
+++ b/backend/src/test/resources/queries/facility-update
@@ -23,5 +23,7 @@ mutation updateFacility($facilityId: ID!, $deviceId: String!, $deviceSpecimenTyp
         deviceTypes: [$deviceId]
         deviceSpecimenTypes: $deviceSpecimenTypes
         defaultDevice: $deviceId
-    )
+    ) {
+        id
+    }
 }

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -235,10 +235,10 @@ const FacilityFormContainer: any = (props: Props) => {
       appInsights.trackEvent({ name: "Save Settings" });
     }
     const provider = facility.orderingProvider;
-    const saveFacility = props.facilityId
+    const saveFacilityMutation = props.facilityId
       ? updateFacilityMutation
       : addFacilityMutation;
-    const savedFacility = await saveFacility({
+    const savedFacility = await saveFacilityMutation({
       variables: {
         facilityId: props.facilityId,
         testingFacilityName: facility.name,
@@ -271,7 +271,7 @@ const FacilityFormContainer: any = (props: Props) => {
     setFacilityData(() => ({
       ...facility,
       id:
-        saveFacility === updateFacilityMutation
+        saveFacilityMutation === updateFacilityMutation
           ? savedFacility.data.updateFacility.id
           : savedFacility.data.addFacility.id,
     }));

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -3,7 +3,7 @@ import { gql, useQuery, useMutation } from "@apollo/client";
 import { Redirect } from "react-router-dom";
 import { useDispatch } from "react-redux";
 
-import { updateFacilities } from "../../store";
+import { updateFacility } from "../../store";
 import Alert from "../../commonComponents/Alert";
 import { showNotification } from "../../utils";
 import { getAppInsights } from "../../TelemetryService";
@@ -207,11 +207,11 @@ const FacilityFormContainer: any = (props: Props) => {
   );
 
   const appInsights = getAppInsights();
-  const [updateFacility] = useMutation(UPDATE_FACILITY_MUTATION);
-  const [addFacility] = useMutation(ADD_FACILITY_MUTATION);
+  const [updateFacilityMutation] = useMutation(UPDATE_FACILITY_MUTATION);
+  const [addFacilityMutation] = useMutation(ADD_FACILITY_MUTATION);
 
   const [saveSuccess, updateSaveSuccess] = useState(false);
-  const [updatedFacility, setUpdatedFacility] = useState<Facility | null>(null);
+  const [facilityData, setFacilityData] = useState<Facility | null>(null);
   const dispatch = useDispatch();
   if (loading) {
     return <p> Loading... </p>;
@@ -223,7 +223,7 @@ const FacilityFormContainer: any = (props: Props) => {
     return <p>Error: facility not found</p>;
   }
   if (saveSuccess) {
-    dispatch(updateFacilities(updatedFacility));
+    dispatch(updateFacility(facilityData));
     if (props.newOrg) {
       window.location.pathname = process.env.PUBLIC_URL || "";
     }
@@ -235,7 +235,9 @@ const FacilityFormContainer: any = (props: Props) => {
       appInsights.trackEvent({ name: "Save Settings" });
     }
     const provider = facility.orderingProvider;
-    const saveFacility = props.facilityId ? updateFacility : addFacility;
+    const saveFacility = props.facilityId
+      ? updateFacilityMutation
+      : addFacilityMutation;
     const savedFacility = await saveFacility({
       variables: {
         facilityId: props.facilityId,
@@ -266,10 +268,10 @@ const FacilityFormContainer: any = (props: Props) => {
         defaultDevice: facility.defaultDevice,
       },
     });
-    setUpdatedFacility(() => ({
+    setFacilityData(() => ({
       ...facility,
       id:
-        saveFacility === updateFacility
+        saveFacility === updateFacilityMutation
           ? savedFacility.data.updateFacility.id
           : savedFacility.data.addFacility.id,
     }));

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, act } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import configureStore from "redux-mock-store";
+
+import { GetManagedFacilitiesDocument } from "../../../generated/graphql";
+
+import ManageFacilitiesContainer from "./ManageFacilitiesContainer";
+
+const deviceSpecimenTypes: DeviceSpecimenType[] = [
+  {
+    internalId: "1",
+    deviceType: {
+      internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+      name: "Fake Device 1",
+    },
+    specimenType: {
+      internalId: "fake-specimen-id-1",
+      name: "Fake Specimen 1",
+    },
+  },
+  {
+    internalId: "2",
+    deviceType: {
+      internalId: "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
+      name: "Fake Device 2",
+    },
+    specimenType: {
+      internalId: "fake-specimen-id-1",
+      name: "Fake Specimen 1",
+    },
+  },
+];
+
+const mockFacility: Facility = {
+  id: "c0d32060-0580-4f8f-9e3d-2e16d65c1629",
+  cliaNumber: "99D1234567",
+  name: "Testing Site",
+  street: "1001 Rodeo Dr",
+  streetTwo: "qwqweqwe123123",
+  city: "Los Angeles",
+  state: "CA",
+  zipCode: "90000",
+  phone: "(516) 432-1390",
+  email: "testingsite@disorg.com",
+  defaultDevice: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+  deviceTypes: [
+    "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+    "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
+  ],
+  deviceSpecimenTypes: deviceSpecimenTypes,
+  orderingProvider: {
+    firstName: "Fred",
+    middleName: null,
+    lastName: "Flintstone",
+    suffix: null,
+    NPI: "PEBBLES",
+    street: "123 Main Street",
+    streetTwo: "",
+    city: "Oz",
+    state: "KS",
+    zipCode: "12345",
+    phone: "(202) 555-1212",
+  },
+};
+
+const store = configureStore([])({
+  organization: {
+    name: "Organization Name",
+  },
+  user: {
+    firstName: "Kim",
+    lastName: "Mendoza",
+  },
+  facilities: [{ id: mockFacility.id, name: mockFacility.name }],
+  facility: { id: mockFacility.id, name: mockFacility.name },
+});
+
+const mock = [
+  {
+    request: {
+      query: GetManagedFacilitiesDocument,
+    },
+    result: {
+      data: {
+        organization: {
+          internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
+          testingFacility: [
+            {
+              id: mockFacility.id,
+              cliaNumber: mockFacility.cliaNumber,
+              name: mockFacility.name,
+              street: mockFacility.street,
+              streetTwo: mockFacility.streetTwo,
+              city: mockFacility.city,
+              state: mockFacility.state,
+              zipCode: mockFacility.zipCode,
+              phone: mockFacility.phone,
+              email: mockFacility.email,
+              defaultDeviceType: {
+                internalId: deviceSpecimenTypes[0].internalId,
+              },
+              deviceTypes: [
+                {
+                  internalId: deviceSpecimenTypes[0].internalId,
+                },
+                {
+                  internalId: deviceSpecimenTypes[1].internalId,
+                },
+              ],
+              deviceSpecimenTypes,
+              orderingProvider: {
+                firstName: "Fred",
+                middleName: null,
+                lastName: "Flintstone",
+                suffix: null,
+                NPI: "PEBBLES",
+                street: "123 Main Street",
+                streetTwo: "",
+                city: "Oz",
+                state: "KS",
+                zipCode: "12345",
+                phone: "(202) 555-1212",
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+];
+
+describe("ManageFacilitiesContainer", () => {
+  beforeEach(() => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mock}>
+            <ManageFacilitiesContainer />
+          </MockedProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+  });
+
+  it("displays facilities", async () => {
+    await act(async () => {
+      expect(await screen.findByText(mockFacility.name)).toBeDefined();
+      expect(await screen.findByText(mockFacility.cliaNumber)).toBeDefined();
+      expect(await screen.findByText(mockFacility.name)).toContainHTML(
+        `<a href="/settings/facility/${mockFacility.id}">${mockFacility.name}</a>`
+      );
+    });
+  });
+});

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -146,8 +146,8 @@ describe("ManageFacilitiesContainer", () => {
 
   it("displays facilities", async () => {
     await act(async () => {
-      expect(await screen.findByText(mockFacility.name)).toBeDefined();
-      expect(await screen.findByText(mockFacility.cliaNumber)).toBeDefined();
+      expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
+      expect(await screen.findByText(mockFacility.cliaNumber)).toBeInTheDocument();
       expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
     });
   });

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -148,9 +148,7 @@ describe("ManageFacilitiesContainer", () => {
     await act(async () => {
       expect(await screen.findByText(mockFacility.name)).toBeDefined();
       expect(await screen.findByText(mockFacility.cliaNumber)).toBeDefined();
-      expect(await screen.findByText(mockFacility.name)).toContainHTML(
-        `<a href="/settings/facility/${mockFacility.id}">${mockFacility.name}</a>`
-      );
+      expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -147,7 +147,9 @@ describe("ManageFacilitiesContainer", () => {
   it("displays facilities", async () => {
     await act(async () => {
       expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
-      expect(await screen.findByText(mockFacility.cliaNumber)).toBeInTheDocument();
+      expect(
+        await screen.findByText(mockFacility.cliaNumber)
+      ).toBeInTheDocument();
       expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
     });
   });

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
@@ -1,56 +1,12 @@
-import React from "react";
-import { gql, useQuery } from "@apollo/client";
+import { useGetManagedFacilitiesQuery } from "../../../generated/graphql";
 
 import ManageFacilities from "./ManageFacilities";
 
-const GET_FACILITIES = gql`
-  query GetManagedFacilities {
-    organization {
-      testingFacility {
-        id
-        cliaNumber
-        name
-        street
-        streetTwo
-        city
-        state
-        zipCode
-        phone
-        email
-        defaultDeviceType {
-          internalId
-        }
-        deviceTypes {
-          internalId
-        }
-        deviceSpecimenTypes {
-          deviceType {
-            internalId
-          }
-          specimenType {
-            internalId
-          }
-        }
-        orderingProvider {
-          firstName
-          middleName
-          lastName
-          suffix
-          NPI
-          street
-          streetTwo
-          city
-          state
-          zipCode
-          phone
-        }
-      }
-    }
-  }
-`;
-
 const ManageFacilitiesContainer: any = () => {
-  const { data, loading, error } = useQuery<SettingsData, {}>(GET_FACILITIES);
+  const { data, loading, error } = useGetManagedFacilitiesQuery({
+    fetchPolicy: "no-cache",
+  });
+  const settingsData = data as SettingsData;
 
   if (loading) {
     return <p> Loading... </p>;
@@ -58,19 +14,21 @@ const ManageFacilitiesContainer: any = () => {
   if (error) {
     return error;
   }
-
-  if (data === undefined) {
+  if (!settingsData || !settingsData.organization) {
     return <p>Error: facilities not found</p>;
   }
 
-  const facilities: Facility[] = data.organization.testingFacility.map((f) => {
-    return {
-      ...f,
-      defaultDevice: f.defaultDeviceType ? f.defaultDeviceType.internalId : "",
-      deviceTypes: Object.values(f.deviceTypes).map((d) => d.internalId),
-    };
-  });
-
+  const facilities: Facility[] = settingsData.organization.testingFacility.map(
+    (f) => {
+      return {
+        ...f,
+        defaultDevice: f.defaultDeviceType
+          ? f.defaultDeviceType.internalId
+          : "",
+        deviceTypes: Object.values(f.deviceTypes).map((d) => d.internalId),
+      };
+    }
+  );
   return <ManageFacilities facilities={facilities} />;
 };
 

--- a/frontend/src/app/Settings/Facility/operations.graphql
+++ b/frontend/src/app/Settings/Facility/operations.graphql
@@ -1,0 +1,43 @@
+query GetManagedFacilities {
+  organization {
+    testingFacility {
+      id
+      cliaNumber
+      name
+      street
+      streetTwo
+      city
+      state
+      zipCode
+      phone
+      email
+      defaultDeviceType {
+        internalId
+      }
+      deviceTypes {
+        internalId
+      }
+      deviceSpecimenTypes {
+        deviceType {
+          internalId
+        }
+        specimenType {
+          internalId
+        }
+      }
+      orderingProvider {
+        firstName
+        middleName
+        lastName
+        suffix
+        NPI
+        street
+        streetTwo
+        city
+        state
+        zipCode
+        phone
+      }
+    }
+  }
+}

--- a/frontend/src/app/store.test.ts
+++ b/frontend/src/app/store.test.ts
@@ -1,0 +1,139 @@
+import reducers, {
+  initialState,
+  setInitialState,
+  SET_INITIAL_STATE,
+  updateOrganization,
+  UPDATE_ORGANIZATION,
+  updateFacility,
+  UPDATE_FACILITY,
+  setPatient,
+  SET_PATIENT,
+} from "./store";
+
+describe("store", () => {
+  let testState: any;
+  let setInitialStateState: any;
+  let updateOrganizationState: any;
+  let updateFacilityState: any;
+  let setPatientState: any;
+  const blankOrganization = {
+    name: "",
+  };
+  const blankPatient = {
+    birthDate: "",
+    firstName: "",
+    internalId: "",
+    isDeleted: false,
+    lastName: "",
+    lastTest: {
+      dateAdded: "",
+      dateTested: "",
+      deviceTypeModel: "",
+      result: "UNDETERMINED",
+    },
+    middleName: "",
+    role: "",
+  };
+  const blankUser = {
+    email: "",
+    firstName: "",
+    id: "",
+    isAdmin: false,
+    lastName: "",
+    middleName: "",
+    permissions: [],
+    roleDescription: "",
+    suffix: "",
+  };
+  const reduxState = {
+    dataLoaded: false,
+    facilities: [],
+    organization: blankOrganization,
+    patient: blankPatient,
+    user: blankUser,
+  };
+  setInitialStateState = {
+    type: SET_INITIAL_STATE,
+    payload: reduxState,
+  };
+  updateOrganizationState = {
+    type: UPDATE_ORGANIZATION,
+    payload: reduxState,
+  };
+  updateFacilityState = {
+    type: UPDATE_FACILITY,
+    payload: reduxState,
+  };
+  setPatientState = {
+    type: SET_PATIENT,
+    payload: reduxState,
+  };
+
+  beforeEach(() => {
+    testState = reduxState;
+    testState["organization"] = blankOrganization;
+    testState["patient"] = blankPatient;
+  });
+
+  it("should return initial state with type SET_INITIAL_STATE type and initialState payload", () => {
+    expect(setInitialState(initialState)).toEqual(setInitialStateState);
+  });
+  it("should return initial state with UPDATE_ORGANIZATION type and organization payload", () => {
+    expect(updateOrganization(initialState)).toEqual(updateOrganizationState);
+  });
+  it("should return initial state with UPDATE_FACILITY type and facility payload", () => {
+    expect(updateFacility(initialState)).toEqual(updateFacilityState);
+  });
+  it("should return initial state with SET_PATIENT type and patient payload", () => {
+    expect(setPatient(initialState)).toEqual(setPatientState);
+  });
+  it("should return initial state if type does not match", () => {
+    const brokenState = { brokenKey: "useless value" };
+    const action = { type: "A_TYPE_THAT_WE_DO_NOT_USE", payload: brokenState };
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should return the initial state", () => {
+    const action = { type: SET_INITIAL_STATE, payload: initialState };
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should update an organization", () => {
+    const organizationPayload = { name: "myNewName" };
+    const action = { type: UPDATE_ORGANIZATION, payload: organizationPayload };
+    testState["organization"] = organizationPayload;
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should add a facility", () => {
+    const facilityPayload = { id: "8675309", name: "myFacilityName" };
+    const payload = facilityPayload as Facility;
+    const action = { type: UPDATE_FACILITY, payload: payload };
+    testState["facilities"] = [payload];
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should update a facility", () => {
+    const facilityPayload = { id: "8675309", name: "myUpdatedFacilityName" };
+    const payload = facilityPayload as Facility;
+    const action = { type: UPDATE_FACILITY, payload: payload };
+    testState["facilities"] = [payload];
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should update a patient", () => {
+    const patientPayload = {
+      birthDate: "1999-01-01",
+      firstName: "Jill",
+      internalId: "42",
+      isDeleted: true,
+      lastName: "Mad Titan",
+      lastTest: {
+        dateAdded: "2001-01-01",
+        dateTested: "2002-01-01",
+        deviceTypeModel: "unknown",
+        result: "CONTAGIOUS",
+      },
+      middleName: "The",
+      role: "Star",
+    };
+    const action = { type: SET_PATIENT, payload: patientPayload };
+    testState["patient"] = patientPayload;
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+});

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -3,14 +3,14 @@ import { createStore } from "redux";
 import { COVID_RESULTS } from "../app/constants";
 import { UserPermission } from "../generated/graphql";
 
-const SET_INITIAL_STATE = "SET_INITIAL_STATE";
-const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
-const UPDATE_FACILITIES = "UPDATE_FACILITIES";
-const SET_PATIENT = "SET_PATIENT";
+export const SET_INITIAL_STATE = "SET_INITIAL_STATE";
+export const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
+export const UPDATE_FACILITY = "UPDATE_FACILITY";
+export const SET_PATIENT = "SET_PATIENT";
 
 // this should be the default value for a brand new org
 // TODO: get the fields from a schema or something; hard-coded fields are hard to maintain
-const initialState = {
+export const initialState = {
   dataLoaded: false,
   organization: {
     name: "",
@@ -59,7 +59,7 @@ const reducers = (state = initialState, action: any) => {
           ...action.payload,
         },
       };
-    case UPDATE_FACILITIES:
+    case UPDATE_FACILITY:
       const facilityIndex = state.facilities.findIndex(
         (f) => f.id === action.payload.id
       );
@@ -98,9 +98,9 @@ export const updateOrganization = (organization: any) => {
   };
 };
 
-export const updateFacilities = (facility: any) => {
+export const updateFacility = (facility: any) => {
   return {
-    type: UPDATE_FACILITIES,
+    type: UPDATE_FACILITY,
     payload: facility,
   };
 };
@@ -124,3 +124,5 @@ const configureStore = () => {
 export const store = configureStore();
 
 export type RootState = ReturnType<typeof store.getState>;
+
+export default reducers;

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -5,6 +5,7 @@ import { UserPermission } from "../generated/graphql";
 
 const SET_INITIAL_STATE = "SET_INITIAL_STATE";
 const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
+const UPDATE_FACILITIES = "UPDATE_FACILITIES";
 const SET_PATIENT = "SET_PATIENT";
 
 // this should be the default value for a brand new org
@@ -58,6 +59,19 @@ const reducers = (state = initialState, action: any) => {
           ...action.payload,
         },
       };
+    case UPDATE_FACILITIES:
+      const facilityIndex = state.facilities.findIndex(
+        (f) => f.id === action.payload.id
+      );
+      if (facilityIndex > -1) {
+        state.facilities[facilityIndex] = action.payload;
+      } else {
+        state.facilities.push(action.payload);
+      }
+      return {
+        ...state,
+        facilities: state.facilities,
+      };
     case SET_PATIENT:
       return {
         ...state,
@@ -81,6 +95,13 @@ export const updateOrganization = (organization: any) => {
   return {
     type: UPDATE_ORGANIZATION,
     payload: organization,
+  };
+};
+
+export const updateFacilities = (facility: any) => {
+  return {
+    type: UPDATE_FACILITIES,
+    payload: facility,
   };
 };
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
+
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
-
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -121,7 +121,7 @@ export type Facility = {
 
 export type Mutation = {
   __typename?: "Mutation";
-  addFacility?: Maybe<Scalars["String"]>;
+  addFacility?: Maybe<Facility>;
   addPatient?: Maybe<Patient>;
   addPatientToQueue?: Maybe<Scalars["String"]>;
   addTestResult?: Maybe<TestOrder>;
@@ -149,7 +149,7 @@ export type Mutation = {
   setRegistrationLinkIsDeleted?: Maybe<Scalars["String"]>;
   setUserIsDeleted?: Maybe<User>;
   updateDeviceType?: Maybe<DeviceType>;
-  updateFacility?: Maybe<Scalars["String"]>;
+  updateFacility?: Maybe<Facility>;
   updateOrganization?: Maybe<Scalars["String"]>;
   updatePatient?: Maybe<Patient>;
   updateRegistrationLink?: Maybe<Scalars["String"]>;
@@ -1003,7 +1003,7 @@ export type UpdateFacilityMutationVariables = Exact<{
 
 export type UpdateFacilityMutation = {
   __typename?: "Mutation";
-  updateFacility?: Maybe<string>;
+  updateFacility?: Maybe<{ __typename?: "Facility"; id: string }>;
 };
 
 export type AddFacilityMutationVariables = Exact<{
@@ -1034,7 +1034,7 @@ export type AddFacilityMutationVariables = Exact<{
 
 export type AddFacilityMutation = {
   __typename?: "Mutation";
-  addFacility?: Maybe<string>;
+  addFacility?: Maybe<{ __typename?: "Facility"; id: string }>;
 };
 
 export type GetManagedFacilitiesQueryVariables = Exact<{
@@ -2315,7 +2315,9 @@ export const UpdateFacilityDocument = gql`
       deviceTypes: $devices
       deviceSpecimenTypes: $deviceSpecimenTypes
       defaultDevice: $defaultDevice
-    )
+    ) {
+      id
+    }
   }
 `;
 export type UpdateFacilityMutationFn = Apollo.MutationFunction<
@@ -2433,7 +2435,9 @@ export const AddFacilityDocument = gql`
       deviceTypes: $devices
       deviceSpecimenTypes: $deviceSpecimenTypes
       defaultDevice: $defaultDevice
-    )
+    ) {
+      id
+    }
   }
 `;
 export type AddFacilityMutationFn = Apollo.MutationFunction<


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2828

## Changes Proposed

- Add or Update facilities in the store after saving.
- Do not cache Facilities on the manage facilities page

## Additional Information

- It may make sense to create a single unified way of supporting our access and utilization of facility data.
- Possibly extracting out queries to allow and encourage reuse.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
