### PR TITLE
[3033] Remove Prod DB Query Logging

### DIFF
--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -38,24 +38,3 @@ resource "azurerm_postgresql_database" "simple_report" {
   resource_group_name = var.rg_name
   server_name         = azurerm_postgresql_server.db.name
 }
-
-resource "azurerm_postgresql_configuration" "log_autovacuum_min_duration" {
-  name                = "log_autovacuum_min_duration"
-  resource_group_name = var.rg_name
-  server_name         = azurerm_postgresql_server.db.name
-  value               = 250
-}
-
-resource "azurerm_postgresql_configuration" "pg_qs_query_capture_mode" {
-  name                = "pg_qs.query_capture_mode"
-  resource_group_name = var.rg_name
-  server_name         = azurerm_postgresql_server.db.name
-  value               = "TOP"
-}
-
-resource "azurerm_postgresql_configuration" "pgms_wait_sampling_query_capture_mode" {
-  name                = "pgms_wait_sampling.query_capture_mode"
-  resource_group_name = var.rg_name
-  server_name         = azurerm_postgresql_server.db.name
-  value               = "ALL"
-}


### PR DESCRIPTION
## Related Issue or Background Info

DB Query Logging was enabled in this PR https://github.com/CDCgov/prime-simplereport/issues/2425 a discussion recently took place on slack https://skylight-hq.slack.com/archives/C01LTSNKEPP/p1637595424264600 to remove the query logging as it is too verbose and polluting the log stream.

The query logging helped discover the issue, but the issue has since been resolved and query logging is still enabled. https://github.com/CDCgov/prime-simplereport/issues/2425



## Changes Proposed

- Revert terraform changes related to query logging for the Prod DB

## Additional Information

```
Terraform will perform the following actions:

  # module.db.azurerm_postgresql_configuration.log_autovacuum_min_duration will be destroyed
  - resource "azurerm_postgresql_configuration" "log_autovacuum_min_duration" {
      - id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-prod/providers/Microsoft.DBforPostgreSQL/servers/simple-report-prod-db/configurations/log_autovacuum_min_duration" -> null
      - name                = "log_autovacuum_min_duration" -> null
      - resource_group_name = "prime-simple-report-prod" -> null
      - server_name         = "simple-report-prod-db" -> null
      - value               = "250" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Terraform will perform the following actions:

  # module.db.azurerm_postgresql_configuration.pg_qs_query_capture_mode will be destroyed
  - resource "azurerm_postgresql_configuration" "pg_qs_query_capture_mode" {
      - id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-prod/providers/Microsoft.DBforPostgreSQL/servers/simple-report-prod-db/configurations/pg_qs.query_capture_mode" -> null
      - name                = "pg_qs.query_capture_mode" -> null
      - resource_group_name = "prime-simple-report-prod" -> null
      - server_name         = "simple-report-prod-db" -> null
      - value               = "TOP" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

  # module.db.azurerm_postgresql_configuration.pgms_wait_sampling_query_capture_mode will be destroyed
  - resource "azurerm_postgresql_configuration" "pgms_wait_sampling_query_capture_mode" {
      - id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-prod/providers/Microsoft.DBforPostgreSQL/servers/simple-report-prod-db/configurations/pgms_wait_sampling.query_capture_mode" -> null
      - name                = "pgms_wait_sampling.query_capture_mode" -> null
      - resource_group_name = "prime-simple-report-prod" -> null
      - server_name         = "simple-report-prod-db" -> null
      - value               = "ALL" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

```






## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
