### PR TITLE
Add swab type dropdown field to test card

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.model;
 
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
@@ -32,5 +33,9 @@ public class ApiTestOrder extends WrappedEntity<TestOrder> {
 
   public String getReasonForCorrection() {
     return wrapped.getReasonForCorrection();
+  }
+
+  public DeviceSpecimenType getDeviceSpecimenType() {
+    return wrapped.getDeviceSpecimen();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -34,13 +34,27 @@ public class QueueMutationResolver implements GraphQLMutationResolver {
   }
 
   public AddTestResultResponse addTestResultNew(
-      String deviceID, String result, UUID patientID, Date dateTested) throws NumberParseException {
-    return _tos.addTestResult(deviceID, TestResult.valueOf(result), patientID, dateTested);
+      String deviceID, UUID deviceSpecimenType, String result, UUID patientID, Date dateTested)
+      throws NumberParseException {
+    UUID deviceSpecimenTypeId =
+        deviceSpecimenType == null
+            ? _dts.getDefaultForDeviceId(UUID.fromString(deviceID)).getInternalId()
+            : deviceSpecimenType;
+
+    return _tos.addTestResult(
+        deviceSpecimenTypeId, TestResult.valueOf(result), patientID, dateTested);
   }
 
-  public ApiTestOrder addTestResult(String deviceID, String result, UUID patientID, Date dateTested)
+  public ApiTestOrder addTestResult(
+      String deviceID, UUID deviceSpecimenType, String result, UUID patientID, Date dateTested)
       throws NumberParseException {
-    return _tos.addTestResult(deviceID, TestResult.valueOf(result), patientID, dateTested)
+    UUID deviceSpecimenTypeId =
+        deviceSpecimenType == null
+            ? _dts.getDefaultForDeviceId(UUID.fromString(deviceID)).getInternalId()
+            : deviceSpecimenType;
+
+    return _tos.addTestResult(
+            deviceSpecimenTypeId, TestResult.valueOf(result), patientID, dateTested)
         .getTestResult();
   }
 
@@ -51,7 +65,6 @@ public class QueueMutationResolver implements GraphQLMutationResolver {
             ? _dts.getDefaultForDeviceId(UUID.fromString(deviceId)).getInternalId()
             : deviceSpecimenType;
 
-    // return new ApiTestOrder(_tos.editQueueItem(id, deviceId, result, dateTested));
     return new ApiTestOrder(_tos.editQueueItem(id, dst, result, dateTested));
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -8,6 +8,7 @@ import gov.cdc.usds.simplereport.api.model.ApiTestOrder;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
+import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -24,10 +25,12 @@ public class QueueMutationResolver implements GraphQLMutationResolver {
 
   private final TestOrderService _tos;
   private final PersonService _ps;
+  private final DeviceTypeService _dts;
 
-  public QueueMutationResolver(TestOrderService tos, PersonService ps) {
+  public QueueMutationResolver(TestOrderService tos, PersonService ps, DeviceTypeService dts) {
     _tos = tos;
     _ps = ps;
+    _dts = dts;
   }
 
   public AddTestResultResponse addTestResultNew(
@@ -41,8 +44,15 @@ public class QueueMutationResolver implements GraphQLMutationResolver {
         .getTestResult();
   }
 
-  public ApiTestOrder editQueueItem(UUID id, String deviceId, String result, Date dateTested) {
-    return new ApiTestOrder(_tos.editQueueItem(id, deviceId, result, dateTested));
+  public ApiTestOrder editQueueItem(
+      UUID id, String deviceId, UUID deviceSpecimenType, String result, Date dateTested) {
+    UUID dst =
+        deviceSpecimenType == null
+            ? _dts.getDefaultForDeviceId(UUID.fromString(deviceId)).getInternalId()
+            : deviceSpecimenType;
+
+    // return new ApiTestOrder(_tos.editQueueItem(id, deviceId, result, dateTested));
+    return new ApiTestOrder(_tos.editQueueItem(id, dst, result, dateTested));
   }
 
   public String addPatientToQueue(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -146,4 +146,8 @@ public class TestEvent extends BaseTestInfo {
   public UUID getPriorCorrectedTestEventId() {
     return priorCorrectedTestEventId;
   }
+
+  public DeviceSpecimenType getDeviceSpecimenType() {
+    return order.getDeviceSpecimen();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -71,6 +71,12 @@ public class DeviceTypeService {
     return _deviceSpecimenRepo.findAll();
   }
 
+  public DeviceSpecimenType getDeviceSpecimenType(UUID deviceSpecimenTypeId) {
+    return _deviceSpecimenRepo
+        .findById(deviceSpecimenTypeId)
+        .orElseThrow(() -> new IllegalGraphqlArgumentException("invalid device specimen type ID"));
+  }
+
   /**
    * Find the original device/specimen type combination created for this DeviceType, since that will
    * be the one that is assumed by callers who aren't aware that you can have multiple specimen

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -251,15 +251,14 @@ public class TestOrderService {
   @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
   @Transactional(noRollbackFor = {TwilioException.class, ApiException.class})
   public AddTestResultResponse addTestResult(
-      String deviceID, TestResult result, UUID patientId, Date dateTested) {
+      UUID deviceSpecimenTypeId, TestResult result, UUID patientId, Date dateTested) {
     Organization org = _os.getCurrentOrganization();
     Person person = _ps.getPatientNoPermissionsCheck(patientId, org);
     TestOrder order =
         _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
 
     UUID facilityId = order.getFacility().getInternalId();
-    DeviceSpecimenType deviceSpecimen =
-        _facilityDeviceTypeService.getDefaultForDeviceId(facilityId, UUID.fromString(deviceID));
+    DeviceSpecimenType deviceSpecimen = _dts.getDeviceSpecimenType(deviceSpecimenTypeId);
 
     lockOrder(order.getInternalId());
     try {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -220,13 +220,22 @@ public class TestOrderService {
   @AuthorizationConfiguration.RequirePermissionUpdateTestForTestOrder
   @Deprecated // switch to specifying device-specimen combo
   public TestOrder editQueueItem(
-      UUID testOrderId, String deviceId, String result, Date dateTested) {
+      UUID testOrderId, UUID deviceSpecimenTypeId, String result, Date dateTested) {
     lockOrder(testOrderId);
     try {
       TestOrder order = this.getTestOrder(testOrderId);
 
-      if (deviceId != null) {
-        order.setDeviceSpecimen(_dts.getDefaultForDeviceId(UUID.fromString(deviceId)));
+      if (deviceSpecimenTypeId != null) {
+        DeviceSpecimenType deviceSpecimenType = _dts.getDeviceSpecimenType(deviceSpecimenTypeId);
+
+        order.setDeviceSpecimen(deviceSpecimenType);
+
+        // Set the most-recently configured device specimen for a facility's
+        // test as facility default
+        if (!deviceSpecimenTypeId.equals(
+            order.getFacility().getDefaultDeviceSpecimen().getInternalId())) {
+          order.getFacility().addDefaultDeviceSpecimen(deviceSpecimenType);
+        }
       }
 
       order.setResult(result == null ? null : TestResult.valueOf(result));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -246,7 +246,6 @@ public class TestOrderService {
     TestOrder order =
         _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
 
-    UUID facilityId = order.getFacility().getInternalId();
     DeviceSpecimenType deviceSpecimen = _dts.getDeviceSpecimenType(deviceSpecimenTypeId);
 
     lockOrder(order.getInternalId());

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -532,6 +532,7 @@ type Mutation {
   editQueueItem(
     id: ID!
     deviceId: String
+    deviceSpecimenType: ID
     result: String
     dateTested: DateTime
   ): TestOrder @requiredPermissions(allOf: ["UPDATE_TEST"])

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -519,12 +519,14 @@ type Mutation {
     @requiredPermissions(allOf: ["ARCHIVE_PATIENT"])
   addTestResultNew(
     deviceId: String!
+    deviceSpecimenType: ID
     result: String!
     patientId: ID!
     dateTested: DateTime
   ): AddTestResultResponse @requiredPermissions(allOf: ["SUBMIT_TEST"])
   addTestResult(
     deviceId: String!
+    deviceSpecimenType: ID
     result: String!
     patientId: ID!
     dateTested: DateTime

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -215,6 +215,7 @@ type TestOrder {
   symptoms: String
   symptomOnset: LocalDate
   deviceType: DeviceType
+  deviceSpecimenType: DeviceSpecimenType
   result: String
   dateTested: DateTime
   correctionStatus: String
@@ -231,6 +232,7 @@ type TestResult {
   symptoms: String
   symptomOnset: LocalDate
   deviceType: DeviceType
+  deviceSpecimenType: DeviceSpecimenType
   result: String
   dateTested: DateTime
   testPerformed: TestDescription!

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -127,8 +127,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertEquals(1, queue.size());
 
     DeviceType devA = facility.getDefaultDeviceType();
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
@@ -170,7 +169,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     _service.addTestResult(
-        _dataFactory.getGenericDevice().getInternalId().toString(),
+        _dataFactory.getGenericDevice().getInternalId(),
         TestResult.POSITIVE,
         p.getInternalId(),
         null);
@@ -183,7 +182,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1866, 12, 25), false);
     _service.addTestResult(
-        _dataFactory.getGenericDevice().getInternalId().toString(),
+        _dataFactory.getGenericDevice().getInternalId(),
         TestResult.POSITIVE,
         p.getInternalId(),
         null);
@@ -326,8 +325,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     DeviceType devA = facility.getDefaultDeviceType();
 
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     verify(_smsService).sendToPatientLink(any(UUID.class), anyString());
 
@@ -366,8 +364,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     DeviceType devA = facility.getDefaultDeviceType();
 
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
@@ -452,7 +449,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         AccessDeniedException.class,
         () ->
             _service.addTestResult(
-                devA.getInternalId().toString(), TestResult.POSITIVE, p2.getInternalId(), null));
+                devA.getInternalId(), TestResult.POSITIVE, p2.getInternalId(), null));
 
     // caller has access to the patient (whose facility is null)
     // but cannot modify the test order which was created at a non-accessible facility
@@ -460,16 +457,14 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         AccessDeniedException.class,
         () ->
             _service.addTestResult(
-                devA.getInternalId().toString(), TestResult.POSITIVE, p1.getInternalId(), null));
+                devA.getInternalId(), TestResult.POSITIVE, p1.getInternalId(), null));
 
     TestUserIdentities.setFacilityAuthorities(facility1);
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p1.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p1.getInternalId(), null);
     List<TestOrder> queue = _service.getQueue(facility1.getInternalId());
     assertEquals(1, queue.size());
 
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.NEGATIVE, p2.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.NEGATIVE, p2.getInternalId(), null);
 
     queue = _service.getQueue(facility1.getInternalId());
     assertEquals(0, queue.size());
@@ -487,8 +482,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     DeviceType devA = facility.getDefaultDeviceType();
 
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     verify(_smsService).sendToPatientLink(any(UUID.class), anyString());
 
@@ -508,13 +502,12 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     DeviceType devA = facility.getDefaultDeviceType();
 
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
     assertThrows(
         NonexistentQueueItemException.class,
         () ->
             _service.addTestResult(
-                devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null));
+                devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null));
   }
 
   @Test
@@ -536,8 +529,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     doReturn(deliveryResults).when(_smsService).sendToPatientLink(any(), any());
 
     AddTestResultResponse res =
-        _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+        _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     assertEquals(false, res.getDeliverySuccess());
   }
@@ -568,7 +560,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // WHEN
     AddTestResultResponse res =
         _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
+            devA.getInternalId(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
     assertEquals(true, res.getDeliverySuccess());
@@ -604,7 +596,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // WHEN
     AddTestResultResponse res =
         _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
+            devA.getInternalId(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
     verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
@@ -637,7 +629,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // WHEN
     AddTestResultResponse res =
         _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
+            devA.getInternalId(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
     assertEquals(true, res.getDeliverySuccess());
@@ -670,7 +662,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // WHEN
     AddTestResultResponse res =
         _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
+            devA.getInternalId(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
     assertEquals(true, res.getDeliverySuccess());
@@ -717,7 +709,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertNotEquals(o.getDeviceType().getName(), devA.getName());
 
     _service.editQueueItem(
-        o.getInternalId(), devA.getInternalId().toString(), TestResult.POSITIVE.toString(), null);
+        o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null);
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
@@ -749,14 +741,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         AccessDeniedException.class,
         () ->
             _service.editQueueItem(
-                o.getInternalId(),
-                devA.getInternalId().toString(),
-                TestResult.POSITIVE.toString(),
-                null));
+                o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null));
 
     TestUserIdentities.setFacilityAuthorities(facility);
     _service.editQueueItem(
-        o.getInternalId(), devA.getInternalId().toString(), TestResult.POSITIVE.toString(), null);
+        o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null);
   }
 
   @Test
@@ -776,7 +765,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     DeviceType devA = facility.getDefaultDeviceType();
 
     _service.editQueueItem(
-        o.getInternalId(), devA.getInternalId().toString(), TestResult.POSITIVE.toString(), null);
+        o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null);
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
@@ -803,19 +792,15 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     DeviceType devA = facility.getDefaultDeviceType();
 
     _service.editQueueItem(
-        o.getInternalId(), devA.getInternalId().toString(), TestResult.NEGATIVE.toString(), null);
+        o.getInternalId(), devA.getInternalId(), TestResult.NEGATIVE.toString(), null);
 
-    _service.addTestResult(
-        devA.getInternalId().toString(), TestResult.POSITIVE, p.getInternalId(), null);
+    _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     assertThrows(
         NonexistentQueueItemException.class,
         () ->
             _service.editQueueItem(
-                o.getInternalId(),
-                devA.getInternalId().toString(),
-                TestResult.POSITIVE.toString(),
-                null));
+                o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -532,7 +532,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // WHEN
     AddTestResultResponse res =
         _service.addTestResult(
-            devA.getInternalId().toString(), TestResult.POSITIVE, patient.getInternalId(), null);
+            devA.getInternalId(), TestResult.POSITIVE, patient.getInternalId(), null);
 
     // THEN
     assertTrue(res.getDeliverySuccess());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -17,7 +17,7 @@ import gov.cdc.usds.simplereport.api.model.AddTestResultResponse;
 import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentQueueItemException;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
@@ -122,7 +122,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
 
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
     _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
     queue = _service.getQueue(facility.getInternalId());
@@ -165,7 +165,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     _service.addTestResult(
-        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericDeviceSpecimen().getInternalId(),
         TestResult.POSITIVE,
         p.getInternalId(),
         null);
@@ -178,7 +178,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1866, 12, 25), false);
     _service.addTestResult(
-        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericDeviceSpecimen().getInternalId(),
         TestResult.POSITIVE,
         p.getInternalId(),
         null);
@@ -319,7 +319,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
@@ -358,7 +358,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
@@ -440,7 +440,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     TestUserIdentities.setFacilityAuthorities();
 
-    DeviceType devA = _dataFactory.getGenericDevice();
+    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
     assertThrows(
         AccessDeniedException.class,
         () ->
@@ -476,7 +476,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
 
@@ -496,7 +496,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     _service.addTestResult(devA.getInternalId(), TestResult.POSITIVE, p.getInternalId(), null);
     assertThrows(
@@ -524,8 +524,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceType devA = facility.getDefaultDeviceType();
-
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
     when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
     when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
 
@@ -560,7 +559,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
     when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
@@ -593,7 +592,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
     when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
@@ -629,7 +628,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(false);
     when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(false);
@@ -662,8 +661,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceType devA = facility.getDefaultDeviceType();
-
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
     when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
     when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
 
@@ -696,7 +694,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     // WHEN
     AddTestResultResponse res =
@@ -743,8 +741,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             Collections.emptyMap(),
             LocalDate.of(1865, 12, 25),
             false);
-    DeviceType devA = _dataFactory.getGenericDevice();
-    assertNotEquals(o.getDeviceType().getName(), devA.getName());
+    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
+    assertNotEquals(o.getDeviceType().getName(), devA.getDeviceType().getName());
 
     _service.editQueueItem(
         o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null);
@@ -752,7 +750,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
     assertEquals(TestResult.POSITIVE, queue.get(0).getTestResult());
-    assertEquals(devA.getInternalId(), queue.get(0).getDeviceType().getInternalId());
+    assertEquals(
+        devA.getDeviceType().getInternalId(), queue.get(0).getDeviceType().getInternalId());
   }
 
   @Test
@@ -773,7 +772,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             false);
     TestUserIdentities.setFacilityAuthorities();
 
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     assertThrows(
         AccessDeniedException.class,
@@ -800,7 +799,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             Collections.emptyMap(),
             LocalDate.of(1865, 12, 25),
             false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     _service.editQueueItem(
         o.getInternalId(), devA.getInternalId(), TestResult.POSITIVE.toString(), null);
@@ -808,7 +807,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
     assertEquals(TestResult.POSITIVE, queue.get(0).getTestResult());
-    assertEquals(devA.getInternalId(), queue.get(0).getDeviceType().getInternalId());
+    assertEquals(
+        devA.getDeviceType().getInternalId(), queue.get(0).getDeviceType().getInternalId());
   }
 
   @Test
@@ -827,7 +827,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             Collections.emptyMap(),
             LocalDate.of(1865, 12, 25),
             false);
-    DeviceType devA = facility.getDefaultDeviceType();
+    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
 
     _service.editQueueItem(
         o.getInternalId(), devA.getInternalId(), TestResult.NEGATIVE.toString(), null);

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -73,6 +73,9 @@ const providerSchema: yup.SchemaOf<RequiredProviderFields> = yup.object({
 const deviceTypeSchema: yup.SchemaOf<DeviceType> = yup.object({
   internalId: yup.string().required(),
   name: yup.string().required(),
+  // TODO: This property does not represent user input, so it probably
+  // shouldn't be here -- for now, a shim to keep yup+TS compiler happy
+  testLength: yup.number().optional(),
 });
 
 const specimenTypeSchema: yup.SchemaOf<SpecimenType> = yup.object({

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -73,8 +73,6 @@ const providerSchema: yup.SchemaOf<RequiredProviderFields> = yup.object({
 const deviceTypeSchema: yup.SchemaOf<DeviceType> = yup.object({
   internalId: yup.string().required(),
   name: yup.string().required(),
-  // TODO: This property does not represent user input, so it probably
-  // shouldn't be here -- for now, a shim to keep yup+TS compiler happy
   testLength: yup.number().optional(),
 });
 

--- a/frontend/src/app/Settings/types.d.ts
+++ b/frontend/src/app/Settings/types.d.ts
@@ -5,7 +5,9 @@ type ISODate = `${number}${number}${number}${number}-${number}${number}-${number
 interface DeviceType {
   internalId: string;
   name: string;
+  testLength?: number | undefined;
 }
+
 interface DeviceTypes {
   deviceType: [DeviceType];
 }

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -57,6 +57,10 @@ describe("QueueItem", () => {
             askOnEntry={testProps.askOnEntry}
             selectedDeviceId={testProps.selectedDeviceId}
             selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+            selectedDeviceSpecimenTypeId={
+              testProps.selectedDeviceSpecimenTypeId
+            }
+            deviceSpecimenTypes={testProps.deviceSpecimenTypes}
             selectedTestResult={testProps.selectedTestResult}
             devices={testProps.devices}
             refetchQueue={testProps.refetchQueue}
@@ -82,6 +86,10 @@ describe("QueueItem", () => {
             askOnEntry={testProps.askOnEntry}
             selectedDeviceId={testProps.selectedDeviceId}
             selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+            selectedDeviceSpecimenTypeId={
+              testProps.selectedDeviceSpecimenTypeId
+            }
+            deviceSpecimenTypes={testProps.deviceSpecimenTypes}
             selectedTestResult={testProps.selectedTestResult}
             devices={testProps.devices}
             refetchQueue={testProps.refetchQueue}
@@ -127,6 +135,10 @@ describe("QueueItem", () => {
                 askOnEntry={testProps.askOnEntry}
                 selectedDeviceId={testProps.selectedDeviceId}
                 selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+                selectedDeviceSpecimenTypeId={
+                  testProps.selectedDeviceSpecimenTypeId
+                }
+                deviceSpecimenTypes={testProps.deviceSpecimenTypes}
                 selectedTestResult={testProps.selectedTestResult}
                 devices={testProps.devices}
                 refetchQueue={testProps.refetchQueue}
@@ -180,7 +192,7 @@ describe("QueueItem", () => {
         await screen.findByText(
           "Submitting test data for Potter, Harry James..."
         )
-      );
+      ).toBeInTheDocument();
 
       // Verify alert is displayed
       expect(
@@ -212,6 +224,10 @@ describe("QueueItem", () => {
             askOnEntry={testProps.askOnEntry}
             selectedDeviceId={testProps.selectedDeviceId}
             selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+            selectedDeviceSpecimenTypeId={
+              testProps.selectedDeviceSpecimenTypeId
+            }
+            deviceSpecimenTypes={testProps.deviceSpecimenTypes}
             selectedTestResult={testProps.selectedTestResult}
             devices={testProps.devices}
             refetchQueue={testProps.refetchQueue}
@@ -252,6 +268,10 @@ describe("QueueItem", () => {
             askOnEntry={testProps.askOnEntry}
             selectedDeviceId={testProps.selectedDeviceId}
             selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+            selectedDeviceSpecimenTypeId={
+              testProps.selectedDeviceSpecimenTypeId
+            }
+            deviceSpecimenTypes={testProps.deviceSpecimenTypes}
             selectedTestResult={testProps.selectedTestResult}
             devices={testProps.devices}
             refetchQueue={testProps.refetchQueue}
@@ -287,6 +307,10 @@ describe("QueueItem", () => {
               askOnEntry={testProps.askOnEntry}
               selectedDeviceId={testProps.selectedDeviceId}
               selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+              selectedDeviceSpecimenTypeId={
+                testProps.selectedDeviceSpecimenTypeId
+              }
+              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
               selectedTestResult={testProps.selectedTestResult}
               devices={testProps.devices}
               refetchQueue={testProps.refetchQueue}
@@ -351,6 +375,17 @@ describe("QueueItem", () => {
 });
 
 const internalId = "f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554";
+const deviceOne = {
+  name: "Access Bio CareStart",
+  internalId: internalId,
+  testLength: 10,
+};
+
+const deviceTwo = {
+  name: "LumiraDX",
+  internalId: "lumira",
+  testLength: 15,
+};
 
 const testProps = {
   internalId: internalId,
@@ -372,28 +407,36 @@ const testProps = {
       },
     ],
   },
-  devices: [
-    {
-      name: "Access Bio CareStart",
-      internalId: internalId,
-      testLength: 10,
-    },
-    {
-      name: "LumiraDX",
-      internalId: "lumira",
-      testLength: 15,
-    },
-  ],
+  devices: [deviceOne, deviceTwo],
   askOnEntry: {
     symptoms: "{}",
   },
   selectedDeviceId: internalId,
   selectedDeviceTestLength: 10,
+  selectedDeviceSpecimenTypeId: deviceOne.internalId,
   selectedTestResult: {},
   dateTestedProp: "",
   refetchQueue: {},
   facilityId: "Hogwarts",
   patientLinkId: "",
+  deviceSpecimenTypes: [
+    {
+      internalId: "device-specimen-1",
+      deviceType: deviceOne,
+      specimenType: {
+        internalId: "specimen-1",
+        name: "Specimen 1",
+      },
+    },
+    {
+      internalId: "device-specimen-2",
+      deviceType: deviceTwo,
+      specimenType: {
+        internalId: "specimen-2",
+        name: "Specimen 2",
+      },
+    },
+  ] as DeviceSpecimenType[],
 };
 
 const nowUTC = moment(new Date(fakeDate))
@@ -416,6 +459,7 @@ const mocks = [
       variables: {
         id: internalId,
         deviceId: "lumira",
+        deviceSpecimenType: "device-specimen-2",
         result: {},
       },
     },
@@ -424,9 +468,11 @@ const mocks = [
         editQueueItem: {
           result: {},
           dateTested: null,
-          deviceType: {
-            internalId: internalId,
-            testLength: 15,
+          deviceType: deviceTwo,
+          deviceSpecimenType: {
+            internalId: "device-specimen-2",
+            deviceType: deviceTwo,
+            specimenType: {},
           },
         },
       },
@@ -438,6 +484,7 @@ const mocks = [
       variables: {
         id: internalId,
         deviceId: internalId,
+        deviceSpecimenType: "device-specimen-1",
         dateTested: nowUTC,
         result: {},
       },
@@ -447,9 +494,11 @@ const mocks = [
         editQueueItem: {
           result: {},
           dateTested: null,
-          deviceType: {
-            internalId: internalId,
-            testLength: 15,
+          deviceType: deviceOne,
+          deviceSpecimenType: {
+            internalId: "device-specimen-1",
+            deviceType: deviceOne,
+            specimenType: {},
           },
         },
       },
@@ -461,6 +510,7 @@ const mocks = [
       variables: {
         id: internalId,
         deviceId: internalId,
+        deviceSpecimenType: "device-specimen-1",
         dateTested: updatedDateUTC,
         result: {},
       },
@@ -472,7 +522,12 @@ const mocks = [
           dateTested: null,
           deviceType: {
             internalId: internalId,
-            testLength: 15,
+            testLength: 10,
+          },
+          deviceSpecimenType: {
+            internalId: "device-specimen-1",
+            deviceType: deviceOne,
+            specimenType: {},
           },
         },
       },
@@ -484,6 +539,7 @@ const mocks = [
       variables: {
         id: internalId,
         deviceId: internalId,
+        deviceSpecimenType: "device-specimen-1",
         dateTested: updatedDateTimeUTC,
         result: {},
       },
@@ -495,7 +551,12 @@ const mocks = [
           dateTested: null,
           deviceType: {
             internalId: internalId,
-            testLength: 15,
+            testLength: 10,
+          },
+          deviceSpecimenType: {
+            internalId: "device-specimen-1",
+            deviceType: deviceOne,
+            specimenType: {},
           },
         },
       },
@@ -506,6 +567,7 @@ const mocks = [
       query: EDIT_QUEUE_ITEM,
       variables: {
         id: internalId,
+        deviceSpecimenType: "device-specimen-1",
         deviceId: internalId,
         result: "UNDETERMINED",
       },
@@ -517,7 +579,12 @@ const mocks = [
           dateTested: null,
           deviceType: {
             internalId: internalId,
-            testLength: 15,
+            testLength: 10,
+          },
+          deviceSpecimenType: {
+            internalId: "device-specimen-1",
+            deviceType: deviceOne,
+            specimenType: {},
           },
         },
       },
@@ -529,6 +596,7 @@ const mocks = [
       variables: {
         patientId: internalId,
         deviceId: internalId,
+        deviceSpecimenType: "device-specimen-1",
         dateTested: null,
         result: "UNDETERMINED",
       },

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -100,7 +100,6 @@ interface EditQueueItemResponse {
   };
 }
 
-// TODO: deviceId optional for now for BC reasons - needed?
 export const SUBMIT_TEST_RESULT = gql`
   mutation SubmitTestResult(
     $patientId: ID!
@@ -265,14 +264,14 @@ const QueueItem = ({
 
   const deviceTypes = deviceSpecimenTypes
     .map((d) => d.deviceType)
-    .reduce((devices, device: DeviceType) => {
+    .reduce((allDevices, device: DeviceType) => {
       const id = device.internalId;
 
-      if (!(id in devices)) {
-        devices[id] = device;
+      if (!(id in allDevices)) {
+        allDevices[id] = device;
       }
 
-      return devices;
+      return allDevices;
     }, {} as Record<string, DeviceType>);
 
   const [deviceTestLength, updateDeviceTestLength] = useState(
@@ -399,19 +398,14 @@ const QueueItem = ({
   };
 
   const updateQueueItem = useCallback(
-    ({
-      deviceId,
-      deviceSpecimenType,
-      result,
-      dateTested,
-    }: updateQueueItemProps) => {
+    (props: updateQueueItemProps) => {
       return editQueueItem({
         variables: {
           id: internalId,
-          deviceId,
-          result,
-          dateTested,
-          deviceSpecimenType,
+          deviceId: props.deviceId,
+          result: props.result,
+          dateTested: props.dateTested,
+          deviceSpecimenType: props.deviceSpecimenType,
         },
       })
         .then((response) => {

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -765,7 +765,7 @@ const QueueItem = ({
                       onChange={onDeviceChange}
                     />
                   </div>
-                  <div className="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1">
+                  <div className="prime-li flex-align-self-end tablet:grid-col-3 padding-left-1">
                     <Dropdown
                       options={(deviceLookup.get(
                         deviceTypes[deviceId]
@@ -782,7 +782,7 @@ const QueueItem = ({
                     />
                   </div>
                   {testDateFields}
-                  <div className="prime-li tablet:grid-col tablet:padding-left-1">
+                  <div className="prime-li tablet:grid-col tablet:padding-left-2">
                     <Checkboxes
                       boxes={[
                         {

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -53,6 +53,7 @@ describe("TestQueue", () => {
     expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
+
   it("should remove items queue using the transition group", async () => {
     jest.useFakeTimers();
     render(
@@ -115,12 +116,6 @@ const createPatient = ({
   symptoms,
   symptomOnset: null,
   noSymptoms: false,
-  deviceType: {
-    internalId,
-    testLength: 15,
-    name: "LumiraDX",
-    __typename: "DeviceType",
-  },
   patient: {
     internalId: "31d42f7a-0a14-46b7-bc8a-38b3b1e78659",
     telephone: "1234567890",
@@ -188,6 +183,50 @@ const result = {
       ],
       __typename: "Organization",
     },
+    deviceSpecimenTypes: [
+      {
+        internalId: "3d5c0c67-cddb-4344-8037-18008d6fe809",
+        deviceType: {
+          internalId: internalId,
+          name: "LumiraDx",
+          __typename: "DeviceType",
+        },
+        specimenType: {
+          internalId: "6aa957dc-add2-4938-8788-935aec3276d4",
+          name: "Swab of internal nose",
+          __typename: "SpecimenType",
+        },
+        __typename: "DeviceSpecimenType",
+      },
+      {
+        internalId: "0f3d7426-3476-4800-97e7-3de8a93b090c",
+        deviceType: {
+          internalId: "f8b9d9d6-c318-4c54-a516-76f0d9a25d32",
+          name: "Quidel Sofia 2",
+          __typename: "DeviceType",
+        },
+        specimenType: {
+          internalId: "6e4ccb35-d177-4ea0-9226-653358f1e081",
+          name: "Nasopharyngeal swab",
+          __typename: "SpecimenType",
+        },
+        __typename: "DeviceSpecimenType",
+      },
+      {
+        internalId: "c0c7b042-9a4f-47cd-b280-46c0daa51c86",
+        deviceType: {
+          internalId: "0f3d7426-3476-4800-97e7-3de8a93b090c",
+          name: "Quidel Sofia 2",
+          __typename: "DeviceType",
+        },
+        specimenType: {
+          internalId: "6aa957dc-add2-4938-8788-935aec3276d4",
+          name: "Swab of internal nose",
+          __typename: "SpecimenType",
+        },
+        __typename: "DeviceSpecimenType",
+      },
+    ],
   },
 };
 

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -166,7 +166,6 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     return <p>Facility not found</p>;
   }
 
-  // TODO: guessing this will go away - figure out what to do here
   if (facility.deviceTypes.length === 0) {
     showError(
       "This facility does not have any testing devices. Go into Settings -> Manage facilities and add a device."

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -53,6 +53,9 @@ export const queueQuery = gql`
         model
         testLength
       }
+      deviceSpecimenType {
+        internalId
+      }
       patient {
         internalId
         telephone
@@ -89,6 +92,17 @@ export const queueQuery = gql`
         }
       }
     }
+    deviceSpecimenTypes {
+      internalId
+      deviceType {
+        internalId
+        name
+      }
+      specimenType {
+        internalId
+        name
+      }
+    }
   }
 `;
 
@@ -103,6 +117,7 @@ interface QueueItemData extends AoEAnswers {
     internalId: string;
     testLength: number;
   };
+  deviceSpecimenType: DeviceSpecimenType;
   patient: TestQueuePerson;
   result: TestResult;
   dateTested: string;
@@ -150,11 +165,14 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   if (!facility) {
     return <p>Facility not found</p>;
   }
+
+  // TODO: guessing this will go away - figure out what to do here
   if (facility.deviceTypes.length === 0) {
     showError(
       "This facility does not have any testing devices. Go into Settings -> Manage facilities and add a device."
     );
   }
+
   let shouldRenderQueue =
     data.queue.length > 0 && facility.deviceTypes.length > 0;
 
@@ -165,6 +183,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
         ({
           internalId,
           deviceType,
+          deviceSpecimenType,
           patient,
           result,
           dateTested,
@@ -180,6 +199,10 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
                 internalId={internalId}
                 patient={patient}
                 askOnEntry={questions}
+                selectedDeviceSpecimenTypeId={
+                  deviceSpecimenType?.internalId ||
+                  facility.defaultDeviceType.internalId
+                }
                 selectedDeviceId={
                   deviceType?.internalId ||
                   facility.defaultDeviceType.internalId
@@ -190,6 +213,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
                 }
                 selectedTestResult={result}
                 devices={facility.deviceTypes}
+                deviceSpecimenTypes={data.deviceSpecimenTypes}
                 refetchQueue={refetch}
                 facilityName={selectedFacility?.name}
                 facilityId={activeFacilityId}

--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -181,6 +181,32 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                 </div>
               </div>
               <div
+                class="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1"
+              >
+                <div
+                  class="usa-form-group prime-dropdown "
+                >
+                  <label
+                    class="usa-label"
+                    for="2"
+                  >
+                    Swab type
+                  </label>
+                  <select
+                    aria-required="false"
+                    class="usa-select"
+                    id="2"
+                    name="swabType"
+                  >
+                    <option
+                      value="specimen-1"
+                    >
+                      Specimen 1
+                    </option>
+                  </select>
+                </div>
+              </div>
+              <div
                 class="prime-li tablet:grid-col tablet:padding-left-1"
               >
                 <div
@@ -203,14 +229,14 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                         <input
                           checked=""
                           class="usa-checkbox__input"
-                          id="2-val-0"
+                          id="3-val-0"
                           name="currentDateTime"
                           type="checkbox"
                           value="true"
                         />
                         <label
                           class="usa-checkbox__label"
-                          for="2-val-0"
+                          for="3-val-0"
                         >
                           Use current date
                         </label>
@@ -253,14 +279,14 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                     <input
                       class="usa-radio__input"
                       data-required="false"
-                      id="3-val-POSITIVE"
+                      id="4-val-POSITIVE"
                       name="covid-test-result-f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
                       type="radio"
                       value="POSITIVE"
                     />
                     <label
                       class="usa-radio__label"
-                      for="3-val-POSITIVE"
+                      for="4-val-POSITIVE"
                     >
                       Positive (+)
                     </label>
@@ -271,14 +297,14 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                     <input
                       class="usa-radio__input"
                       data-required="false"
-                      id="3-val-NEGATIVE"
+                      id="4-val-NEGATIVE"
                       name="covid-test-result-f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
                       type="radio"
                       value="NEGATIVE"
                     />
                     <label
                       class="usa-radio__label"
-                      for="3-val-NEGATIVE"
+                      for="4-val-NEGATIVE"
                     >
                       Negative (-)
                     </label>
@@ -289,14 +315,14 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                     <input
                       class="usa-radio__input"
                       data-required="false"
-                      id="3-val-UNDETERMINED"
+                      id="4-val-UNDETERMINED"
                       name="covid-test-result-f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
                       type="radio"
                       value="UNDETERMINED"
                     />
                     <label
                       class="usa-radio__label"
-                      for="3-val-UNDETERMINED"
+                      for="4-val-UNDETERMINED"
                     >
                       Inconclusive
                     </label>

--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                 </div>
               </div>
               <div
-                class="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1"
+                class="prime-li flex-align-self-end tablet:grid-col-3 padding-left-1"
               >
                 <div
                   class="usa-form-group prime-dropdown "
@@ -207,7 +207,7 @@ exports[`QueueItem correctly renders the test queue 1`] = `
                 </div>
               </div>
               <div
-                class="prime-li tablet:grid-col tablet:padding-left-1"
+                class="prime-li tablet:grid-col tablet:padding-left-2"
               >
                 <div
                   class="usa-form-group"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -218,12 +218,43 @@ exports[`TestQueue should render the test queue 1`] = `
                         <option
                           value="f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
                         >
-                          LumiraDX
+                          LumiraDx
+                        </option>
+                        <option
+                          value="f8b9d9d6-c318-4c54-a516-76f0d9a25d32"
+                        >
+                          Quidel Sofia 2
                         </option>
                         <option
                           value="0f3d7426-3476-4800-97e7-3de8a93b090c"
                         >
                           Quidel Sofia 2
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1"
+                  >
+                    <div
+                      class="usa-form-group prime-dropdown "
+                    >
+                      <label
+                        class="usa-label"
+                        for="2"
+                      >
+                        Swab type
+                      </label>
+                      <select
+                        aria-required="false"
+                        class="usa-select"
+                        id="2"
+                        name="swabType"
+                      >
+                        <option
+                          value="6aa957dc-add2-4938-8788-935aec3276d4"
+                        >
+                          Swab of internal nose
                         </option>
                       </select>
                     </div>
@@ -251,14 +282,14 @@ exports[`TestQueue should render the test queue 1`] = `
                             <input
                               checked=""
                               class="usa-checkbox__input"
-                              id="2-val-0"
+                              id="3-val-0"
                               name="currentDateTime"
                               type="checkbox"
                               value="true"
                             />
                             <label
                               class="usa-checkbox__label"
-                              for="2-val-0"
+                              for="3-val-0"
                             >
                               Use current date
                             </label>
@@ -301,14 +332,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="3-val-POSITIVE"
+                          id="4-val-POSITIVE"
                           name="covid-test-result-abc"
                           type="radio"
                           value="POSITIVE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="3-val-POSITIVE"
+                          for="4-val-POSITIVE"
                         >
                           Positive (+)
                         </label>
@@ -319,14 +350,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="3-val-NEGATIVE"
+                          id="4-val-NEGATIVE"
                           name="covid-test-result-abc"
                           type="radio"
                           value="NEGATIVE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="3-val-NEGATIVE"
+                          for="4-val-NEGATIVE"
                         >
                           Negative (-)
                         </label>
@@ -337,14 +368,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="3-val-UNDETERMINED"
+                          id="4-val-UNDETERMINED"
                           name="covid-test-result-abc"
                           type="radio"
                           value="UNDETERMINED"
                         />
                         <label
                           class="usa-radio__label"
-                          for="3-val-UNDETERMINED"
+                          for="4-val-UNDETERMINED"
                         >
                           Inconclusive
                         </label>
@@ -523,25 +554,56 @@ exports[`TestQueue should render the test queue 1`] = `
                     >
                       <label
                         class="usa-label"
-                        for="4"
+                        for="5"
                       >
                         Device
                       </label>
                       <select
                         aria-required="false"
                         class="usa-select"
-                        id="4"
+                        id="5"
                         name="testDevice"
                       >
                         <option
                           value="f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
                         >
-                          LumiraDX
+                          LumiraDx
+                        </option>
+                        <option
+                          value="f8b9d9d6-c318-4c54-a516-76f0d9a25d32"
+                        >
+                          Quidel Sofia 2
                         </option>
                         <option
                           value="0f3d7426-3476-4800-97e7-3de8a93b090c"
                         >
                           Quidel Sofia 2
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1"
+                  >
+                    <div
+                      class="usa-form-group prime-dropdown "
+                    >
+                      <label
+                        class="usa-label"
+                        for="6"
+                      >
+                        Swab type
+                      </label>
+                      <select
+                        aria-required="false"
+                        class="usa-select"
+                        id="6"
+                        name="swabType"
+                      >
+                        <option
+                          value="6aa957dc-add2-4938-8788-935aec3276d4"
+                        >
+                          Swab of internal nose
                         </option>
                       </select>
                     </div>
@@ -569,14 +631,14 @@ exports[`TestQueue should render the test queue 1`] = `
                             <input
                               checked=""
                               class="usa-checkbox__input"
-                              id="5-val-0"
+                              id="7-val-0"
                               name="currentDateTime"
                               type="checkbox"
                               value="true"
                             />
                             <label
                               class="usa-checkbox__label"
-                              for="5-val-0"
+                              for="7-val-0"
                             >
                               Use current date
                             </label>
@@ -619,14 +681,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="6-val-POSITIVE"
+                          id="8-val-POSITIVE"
                           name="covid-test-result-def"
                           type="radio"
                           value="POSITIVE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="6-val-POSITIVE"
+                          for="8-val-POSITIVE"
                         >
                           Positive (+)
                         </label>
@@ -637,14 +699,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="6-val-NEGATIVE"
+                          id="8-val-NEGATIVE"
                           name="covid-test-result-def"
                           type="radio"
                           value="NEGATIVE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="6-val-NEGATIVE"
+                          for="8-val-NEGATIVE"
                         >
                           Negative (-)
                         </label>
@@ -655,14 +717,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="6-val-UNDETERMINED"
+                          id="8-val-UNDETERMINED"
                           name="covid-test-result-def"
                           type="radio"
                           value="UNDETERMINED"
                         />
                         <label
                           class="usa-radio__label"
-                          for="6-val-UNDETERMINED"
+                          for="8-val-UNDETERMINED"
                         >
                           Inconclusive
                         </label>

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`TestQueue should render the test queue 1`] = `
                     </div>
                   </div>
                   <div
-                    class="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1"
+                    class="prime-li flex-align-self-end tablet:grid-col-3 padding-left-1"
                   >
                     <div
                       class="usa-form-group prime-dropdown "
@@ -260,7 +260,7 @@ exports[`TestQueue should render the test queue 1`] = `
                     </div>
                   </div>
                   <div
-                    class="prime-li tablet:grid-col tablet:padding-left-1"
+                    class="prime-li tablet:grid-col tablet:padding-left-2"
                   >
                     <div
                       class="usa-form-group"
@@ -583,7 +583,7 @@ exports[`TestQueue should render the test queue 1`] = `
                     </div>
                   </div>
                   <div
-                    class="prime-li flex-align-self-end tablet:grid-col-3 padding-right-1"
+                    class="prime-li flex-align-self-end tablet:grid-col-3 padding-left-1"
                   >
                     <div
                       class="usa-form-group prime-dropdown "
@@ -609,7 +609,7 @@ exports[`TestQueue should render the test queue 1`] = `
                     </div>
                   </div>
                   <div
-                    class="prime-li tablet:grid-col tablet:padding-left-1"
+                    class="prime-li tablet:grid-col tablet:padding-left-2"
                   >
                     <div
                       class="usa-form-group"

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -230,6 +230,7 @@ export type MutationAddPatientToQueueArgs = {
 export type MutationAddTestResultArgs = {
   dateTested?: Maybe<Scalars["DateTime"]>;
   deviceId: Scalars["String"];
+  deviceSpecimenType?: Maybe<Scalars["ID"]>;
   patientId: Scalars["ID"];
   result: Scalars["String"];
 };
@@ -237,6 +238,7 @@ export type MutationAddTestResultArgs = {
 export type MutationAddTestResultNewArgs = {
   dateTested?: Maybe<Scalars["DateTime"]>;
   deviceId: Scalars["String"];
+  deviceSpecimenType?: Maybe<Scalars["ID"]>;
   patientId: Scalars["ID"];
   result: Scalars["String"];
 };
@@ -336,6 +338,7 @@ export type MutationEditPendingOrganizationArgs = {
 export type MutationEditQueueItemArgs = {
   dateTested?: Maybe<Scalars["DateTime"]>;
   deviceId?: Maybe<Scalars["String"]>;
+  deviceSpecimenType?: Maybe<Scalars["ID"]>;
   id: Scalars["ID"];
   result?: Maybe<Scalars["String"]>;
 };
@@ -767,6 +770,7 @@ export type TestOrder = {
   correctionStatus?: Maybe<Scalars["String"]>;
   dateAdded?: Maybe<Scalars["String"]>;
   dateTested?: Maybe<Scalars["DateTime"]>;
+  deviceSpecimenType?: Maybe<DeviceSpecimenType>;
   deviceType?: Maybe<DeviceType>;
   id?: Maybe<Scalars["ID"]>;
   /** @deprecated alias for 'id' */
@@ -786,6 +790,7 @@ export type TestResult = {
   createdBy?: Maybe<ApiUser>;
   dateAdded?: Maybe<Scalars["String"]>;
   dateTested?: Maybe<Scalars["DateTime"]>;
+  deviceSpecimenType?: Maybe<DeviceSpecimenType>;
   deviceType?: Maybe<DeviceType>;
   facility?: Maybe<Facility>;
   internalId?: Maybe<Scalars["ID"]>;
@@ -1622,6 +1627,7 @@ export type RemovePatientFromQueueMutation = {
 export type EditQueueItemMutationVariables = Exact<{
   id: Scalars["ID"];
   deviceId?: Maybe<Scalars["String"]>;
+  deviceSpecimenType?: Maybe<Scalars["ID"]>;
   result?: Maybe<Scalars["String"]>;
   dateTested?: Maybe<Scalars["DateTime"]>;
 }>;
@@ -1637,12 +1643,17 @@ export type EditQueueItemMutation = {
       internalId: string;
       testLength?: Maybe<number>;
     }>;
+    deviceSpecimenType?: Maybe<{
+      __typename?: "DeviceSpecimenType";
+      internalId: string;
+    }>;
   }>;
 };
 
 export type SubmitTestResultMutationVariables = Exact<{
   patientId: Scalars["ID"];
   deviceId: Scalars["String"];
+  deviceSpecimenType?: Maybe<Scalars["ID"]>;
   result: Scalars["String"];
   dateTested?: Maybe<Scalars["DateTime"]>;
 }>;
@@ -1680,6 +1691,10 @@ export type GetFacilityQueueQuery = {
           name: string;
           model: string;
           testLength?: Maybe<number>;
+        }>;
+        deviceSpecimenType?: Maybe<{
+          __typename?: "DeviceSpecimenType";
+          internalId: string;
         }>;
         patient?: Maybe<{
           __typename?: "Patient";
@@ -1731,6 +1746,24 @@ export type GetFacilityQueueQuery = {
       }>;
     }>;
   }>;
+  deviceSpecimenTypes?: Maybe<
+    Array<
+      Maybe<{
+        __typename?: "DeviceSpecimenType";
+        internalId: string;
+        deviceType: {
+          __typename?: "DeviceType";
+          internalId: string;
+          name: string;
+        };
+        specimenType: {
+          __typename?: "SpecimenType";
+          internalId: string;
+          name: string;
+        };
+      }>
+    >
+  >;
 };
 
 export type GetPatientQueryVariables = Exact<{
@@ -4674,12 +4707,14 @@ export const EditQueueItemDocument = gql`
   mutation EditQueueItem(
     $id: ID!
     $deviceId: String
+    $deviceSpecimenType: ID
     $result: String
     $dateTested: DateTime
   ) {
     editQueueItem(
       id: $id
       deviceId: $deviceId
+      deviceSpecimenType: $deviceSpecimenType
       result: $result
       dateTested: $dateTested
     ) {
@@ -4688,6 +4723,9 @@ export const EditQueueItemDocument = gql`
       deviceType {
         internalId
         testLength
+      }
+      deviceSpecimenType {
+        internalId
       }
     }
   }
@@ -4712,6 +4750,7 @@ export type EditQueueItemMutationFn = Apollo.MutationFunction<
  *   variables: {
  *      id: // value for 'id'
  *      deviceId: // value for 'deviceId'
+ *      deviceSpecimenType: // value for 'deviceSpecimenType'
  *      result: // value for 'result'
  *      dateTested: // value for 'dateTested'
  *   },
@@ -4741,12 +4780,14 @@ export const SubmitTestResultDocument = gql`
   mutation SubmitTestResult(
     $patientId: ID!
     $deviceId: String!
+    $deviceSpecimenType: ID
     $result: String!
     $dateTested: DateTime
   ) {
     addTestResultNew(
       patientId: $patientId
       deviceId: $deviceId
+      deviceSpecimenType: $deviceSpecimenType
       result: $result
       dateTested: $dateTested
     ) {
@@ -4777,6 +4818,7 @@ export type SubmitTestResultMutationFn = Apollo.MutationFunction<
  *   variables: {
  *      patientId: // value for 'patientId'
  *      deviceId: // value for 'deviceId'
+ *      deviceSpecimenType: // value for 'deviceSpecimenType'
  *      result: // value for 'result'
  *      dateTested: // value for 'dateTested'
  *   },
@@ -4817,6 +4859,9 @@ export const GetFacilityQueueDocument = gql`
         model
         testLength
       }
+      deviceSpecimenType {
+        internalId
+      }
       patient {
         internalId
         telephone
@@ -4851,6 +4896,17 @@ export const GetFacilityQueueDocument = gql`
           model
           testLength
         }
+      }
+    }
+    deviceSpecimenTypes {
+      internalId
+      deviceType {
+        internalId
+        name
+      }
+      specimenType {
+        internalId
+        name
       }
     }
   }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1646,6 +1646,12 @@ export type EditQueueItemMutation = {
     deviceSpecimenType?: Maybe<{
       __typename?: "DeviceSpecimenType";
       internalId: string;
+      deviceType: {
+        __typename?: "DeviceType";
+        internalId: string;
+        testLength?: Maybe<number>;
+      };
+      specimenType: { __typename?: "SpecimenType"; internalId: string };
     }>;
   }>;
 };
@@ -4726,6 +4732,13 @@ export const EditQueueItemDocument = gql`
       }
       deviceSpecimenType {
         internalId
+        deviceType {
+          internalId
+          testLength
+        }
+        specimenType {
+          internalId
+        }
       }
     }
   }

--- a/frontend/src/stories/testQueue/QueueItem.stories.tsx
+++ b/frontend/src/stories/testQueue/QueueItem.stories.tsx
@@ -45,6 +45,12 @@ const Template: Story<QueueItemProps> = (args) => {
   );
 };
 
+const device = {
+  name: "TestPro 4000",
+  internalId: "tp4000",
+  testLength: 0.1,
+};
+
 const defaultProps: QueueItemProps = {
   internalId: "abc-123",
   patient: {
@@ -65,13 +71,18 @@ const defaultProps: QueueItemProps = {
     testResultDelivery: "SMS",
     gender: "male",
   },
-  devices: [
+  devices: [device],
+  deviceSpecimenTypes: [
     {
-      name: "TestPro 4000",
-      internalId: "tp4000",
-      testLength: 0.1,
+      internalId: "fake-dst-id",
+      deviceType: device,
+      specimenType: {
+        internalId: "fake-swab-id",
+        name: "Fake Swab Type",
+      },
     },
   ],
+  selectedDeviceSpecimenTypeId: "fake-dst-id",
   // askOnEntry prop is incorrectly typed as "string" in the component
   askOnEntry: {
     noSymptoms: undefined,


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #2949 

## Changes Proposed
- Add dropdown component for swab type on test cards
- The test queue management resolvers are backwards-compatible with older versions of the UI (i.e. those not sending `deviceSpecimenType` in the add/update test mutations

## Additional Information
- N/A

## Screenshots / Demos
- Swab type dropdown appears on test card:
<img width="795" alt="Screen Shot 2021-11-29 at 1 18 49 PM" src="https://user-images.githubusercontent.com/27730981/143921636-f39a26ed-ac26-4b9f-b98e-145c9b7d2286.png">

- Device specimen type changes made on test card are persisted as facility default
    - https://user-images.githubusercontent.com/27730981/143918791-f9670e63-8d81-40d5-8293-2beefda9ec3e.mov

- Selected device specimen type appears in `Results` view for submitted test
    - https://user-images.githubusercontent.com/27730981/143918753-711fab31-ee42-43fa-9104-6ba5feffd419.mov


## Checklist for Author and Reviewer
- [ ] How far do we want to go with unraveling the `facility_device_specimen_type` table in this PR? At this point I believe it could be removed in full and all code reading from and writing to that table is no longer necessary. This wasn't given as an AC, though, so maybe we will want to do this as a separate step.
    - [ ] Ditto goes for removing `deviceTypes` from the `Facility` type returned by GraphQL queries - there are a few points in code that touch on that property and yanking those might be a little messy
- [ ] I believe I have removed the newly-redundant data being returned in the test queue GraphQL queries - did I miss any?

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
