### PR TITLE
Rin/maintenance banner fix

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
         run: |
           export MAINTENANCE_BOOLEAN=$( if [ "${{ github.event.inputs.active }}" = "true" ]; then echo true; else echo false; fi )
-          export MAINTENANCE_MESSAGE=${{ github.event.inputs.message }}
+          export MAINTENANCE_MESSAGE="${{ github.event.inputs.message }}"
           export MAINTENANCE_ENV=${{ github.event.inputs.env }}
           echo "{\"active\": $MAINTENANCE_BOOLEAN, \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
           yarn run maintenance:deploy

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -10,7 +10,7 @@ on:
       message:
         description: "Message to display"
         required: true
-        default: "We're working on getting this fixed as soon as possible."
+        default: "We are working on getting this fixed as soon as possible."
 
 jobs:
   pushMaintenanceBlob:
@@ -18,10 +18,6 @@ jobs:
     defaults:
       run:
         working-directory: ./frontend
-    strategy:
-      matrix:
-        deploy-env:
-          ["demo", "dev", "pentest", "prod", "stg", "test", "training"]
     steps:
       - uses: actions/checkout@v2
       - uses: azure/login@v1
@@ -32,6 +28,6 @@ jobs:
         run: |
           export MAINTENANCE_BOOLEAN=$( if [ "${{ github.event.inputs.active }}" = "true" ]; then echo true; else echo false; fi )
           export MAINTENANCE_MESSAGE=${{ github.event.inputs.message }}
-          export MAINTENANCE_ENV=${{ matrix.deploy-env }}
+          export MAINTENANCE_ENV=${{ github.event.inputs.env }}
           echo "{\"active\": $MAINTENANCE_BOOLEAN, \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
           yarn run maintenance:deploy

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -37,4 +37,4 @@ jobs:
           export MAINTENANCE_MESSAGE="${{ github.event.inputs.message }}"
           export MAINTENANCE_ENV=${{ github.event.inputs.env }}
           echo "{\"active\": $MAINTENANCE_BOOLEAN, \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
-          yarn run maintenance:deploy --ignore-engines
+          yarn run maintenance:deploy

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -14,7 +14,7 @@ on:
       env:
         description: "Environment target"
         required: true
-        default: "dev"  
+        default: "prod"  
 
 jobs:
   pushMaintenanceBlob:
@@ -34,4 +34,4 @@ jobs:
           export MAINTENANCE_MESSAGE="${{ github.event.inputs.message }}"
           export MAINTENANCE_ENV=${{ github.event.inputs.env }}
           echo "{\"active\": $MAINTENANCE_BOOLEAN, \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
-          yarn run maintenance:deploy
+          yarn run maintenance:deploy --ignore-engines

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -24,6 +24,9 @@ jobs:
         working-directory: ./frontend
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.0"
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -11,6 +11,10 @@ on:
         description: "Message to display"
         required: true
         default: "We are working on getting this fixed as soon as possible."
+      env:
+        description: "Environment target"
+        required: true
+        default: "dev"  
 
 jobs:
   pushMaintenanceBlob:

--- a/.github/workflows/resetTrainingDB.yml
+++ b/.github/workflows/resetTrainingDB.yml
@@ -20,6 +20,9 @@ jobs:
         working-directory: ./frontend
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.0"
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
## Related Issue or Background Info

- Recent production incidents have revealed that our Maintenance Mode action is malfunctioning. #3046 was created to address the problem.

## Changes Proposed

- Fix message formatting issues
- Add configurable environment value
- Apply `node-setup` action to work around recent Github runner updates
- Apply `node-setup` action to other jobs affected by Github runner updates

## Additional Information

- It appears that, 14 hours ago, Github updated its action runners to use a default Node version of 16. Any actions we use that don't execute `node-setup` will fail if they touch our frontend, as we manually set our node version in the `engines` directive of `package.json`. As a note: we will need to update these jobs if/when we elect to update Node on the frontend.
- The flow has been fully-tested on the `dev` environment, and shows proper activation and deactivation of the maintenance banner.

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
