### PR TITLE
Add NPI Validation

### DIFF
--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -6,9 +6,6 @@ import {
   isValidCLIANumber,
   stateRequiresCLIANumberValidation,
 } from "../../utils/clia";
-// import {
-//   isValidNPI
-// } from "../../utils/npi";
 import { isEmptyString } from "../../utils";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
@@ -35,7 +32,6 @@ function isValidNpi(
   input = ""
 ): boolean {
   if (this?.options?.context?.orderingProviderIsRequired) {
-    // console.log("NPI is required so it better be good");
     let npiValidator = /^\d{1,10}$/;
     return npiValidator.test(input);
   }

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -6,6 +6,9 @@ import {
   isValidCLIANumber,
   stateRequiresCLIANumberValidation,
 } from "../../utils/clia";
+// import {
+//   isValidNPI
+// } from "../../utils/npi";
 import { isEmptyString } from "../../utils";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
@@ -23,6 +26,18 @@ function orderingProviderIsRequired(
 ): boolean {
   if (this?.options?.context?.orderingProviderIsRequired) {
     return !isEmptyString(input);
+  }
+  return true;
+}
+
+function isValidNpi(
+  this: yup.TestContext<Record<string, any>>,
+  input = ""
+): boolean {
+  if (this?.options?.context?.orderingProviderIsRequired) {
+    // console.log("NPI is required so it better be good");
+    let npiValidator = /^\d{1,10}$/;
+    return npiValidator.test(input);
   }
   return true;
 }
@@ -54,7 +69,7 @@ const providerSchema: yup.SchemaOf<RequiredProviderFields> = yup.object({
     .test(
       "ordering-provider-npi",
       orderingProviderFormatError("NPI"),
-      orderingProviderIsRequired
+      isValidNpi
     ),
   phone: yup
     .string()

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -40,7 +40,7 @@ const validFacility: Facility = {
   orderingProvider: {
     firstName: "Frank",
     lastName: "Grimes",
-    NPI: "npi",
+    NPI: "000",
     street: null,
     zipCode: null,
     state: null,
@@ -465,6 +465,40 @@ describe("FacilityForm", () => {
 
         const expectedError = "Ordering provider NPI is incorrectly formatted";
 
+        // The mock function was called at least once
+        expect(spy.mock.calls.length).toBeGreaterThan(0);
+        expect(
+          await screen.findByText(expectedError, {
+            exact: false,
+          })
+        ).toBeInTheDocument();
+
+        const saveButton = screen.getAllByText("Save changes")[0];
+        userEvent.click(saveButton);
+        await waitFor(async () => expect(saveButton).toBeEnabled());
+        expect(saveFacility).toBeCalledTimes(0);
+      });
+
+      it("requires a valid NPI (digits only)", async () => {
+        render(
+          <MemoryRouter>
+            <FacilityForm
+              facility={validFacility}
+              deviceSpecimenTypeOptions={deviceSpecimenTypes}
+              saveFacility={saveFacility}
+            />
+          </MemoryRouter>
+        );
+
+        const npiInput = screen.getByLabelText("NPI", {
+          exact: false,
+        });
+
+        userEvent.clear(npiInput);
+        userEvent.type(npiInput, "Facility name");
+        userEvent.tab();
+
+        const expectedError = "Ordering provider NPI is incorrectly formatted";
         // The mock function was called at least once
         expect(spy.mock.calls.length).toBeGreaterThan(0);
         expect(


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #3005 

## Changes Proposed

- Add NPI validation for states that require it
- The new rules allow only for digits, and strings must be between 1 and 10 chars in length
- This should allow us to keep using 000 as the default NPI, while not allowing for longer strings like facility name (which has been an issue in IL)

## Screenshots / Demos
000 still works:
![Screen Shot 2021-12-06 at 12 47 54 PM](https://user-images.githubusercontent.com/80282552/144920277-572621b2-2e67-499c-a517-c6698f446584.png)

alpha chars not allowed:
![Screen Shot 2021-12-06 at 12 48 01 PM](https://user-images.githubusercontent.com/80282552/144920308-b6053579-2f53-4102-a1b2-7fb0e15b9e5b.png)

long strings not allowed:
![Screen Shot 2021-12-06 at 12 48 21 PM](https://user-images.githubusercontent.com/80282552/144920391-d989d8a7-252c-45c1-8d45-5730945fa175.png)

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
