### PR TITLE
Revert "Rename references to wildcard cert to reflect new cert"

### DIFF
--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -25,9 +25,9 @@ data "azurerm_subnet" "app_gateways" {
   resource_group_name  = data.azurerm_resource_group.rg.name
 }
 
-data "azurerm_key_vault_certificate" "simplereport_gov" {
+data "azurerm_key_vault_certificate" "wildcard_simplereport_gov" {
   key_vault_id = data.azurerm_key_vault.global.id
-  name         = "simplereport-gov"
+  name         = "wildcard-simplereport-gov"
 }
 
 data "azurerm_key_vault_certificate" "simplereport_cdc_gov" {
@@ -152,12 +152,12 @@ resource "azurerm_application_gateway" "www_redirect" {
     frontend_ip_configuration_name = local.frontend_config
     frontend_port_name             = local.https_listener
     protocol                       = "Https"
-    ssl_certificate_name           = data.azurerm_key_vault_certificate.simplereport_gov.name
+    ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
   }
 
   ssl_certificate {
-    name                = data.azurerm_key_vault_certificate.simplereport_gov.name
-    key_vault_secret_id = data.azurerm_key_vault_certificate.simplereport_gov.secret_id
+    name                = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
+    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
   }
 
   ssl_policy {

--- a/ops/services/app_gateway/_data.tf
+++ b/ops/services/app_gateway/_data.tf
@@ -1,4 +1,4 @@
-data "azurerm_key_vault_certificate" "simplereport_gov" {
+data "azurerm_key_vault_certificate" "wildcard_simplereport_gov" {
   key_vault_id = var.key_vault_id
-  name         = "simplereport-gov"
+  name         = "wildcard-simplereport-gov"
 }

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -153,12 +153,12 @@ resource "azurerm_application_gateway" "load_balancer" {
     frontend_ip_configuration_name = local.frontend_config
     frontend_port_name             = local.https_listener
     protocol                       = "Https"
-    ssl_certificate_name           = data.azurerm_key_vault_certificate.simplereport_gov.name
+    ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
   }
 
   ssl_certificate {
-    name                = data.azurerm_key_vault_certificate.simplereport_gov.name
-    key_vault_secret_id = data.azurerm_key_vault_certificate.simplereport_gov.secret_id
+    name                = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
+    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
   }
 
   ssl_policy {


### PR DESCRIPTION
Reverts CDCgov/prime-simplereport#3071

* I forgot to add pentest to the SAN list so this should revert for now
* CDC has reversed and said actually we _can_ use a wildcard cert (in progress)