### PR TITLE
Drop max-lifetime of hikari connections to 15 minutes.

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,6 +8,7 @@ spring:
     password: api123
     url: jdbc:postgresql://localhost:${SR_DB_PORT:5432}/simple_report
     hikari:
+      maximum-pool-size: 20
       max-lifetime: 900000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   jpa:
     database: POSTGRESQL

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ spring:
     username: simple_report_app
     password: api123
     url: jdbc:postgresql://localhost:${SR_DB_PORT:5432}/simple_report
+    hikari:
+      max-lifetime: 900000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate


### PR DESCRIPTION
## Related Issue or Background Info

- We're seeing somewhat persistent DB connection issues, with three bursts of exceptions this week in regard to an inability to acquire JDBC connections. We'd like to experiment with dropping the `max-lifetime` value of closed connections from 30 minutes to 15 minutes.

## Changes Proposed

- Default `max-lifetime` to 15 minutes.
- Double available connections

## Additional Information

- This pulls in part of a previously-reverted PR (#3007 ), but leaves out the breaking change of dropping the connection pool size. It also performs a less-aggressive drop of the `max-lifetime` value.


## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
