### PR TITLE
Forcibly upgrade log4j-related packages to version 2.15.0.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     // core infrastructure
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // log4j vulnerability fixes (Dec 2021)
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.15.0'
+
     // data layer dependencies
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -114,8 +114,8 @@ net.minidev:json-smart:2.3
 org.apache.commons:commons-lang3:3.11
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.14
-org.apache.logging.log4j:log4j-api:2.13.3
-org.apache.logging.log4j:log4j-to-slf4j:2.13.3
+org.apache.logging.log4j:log4j-api:2.15.0
+org.apache.logging.log4j:log4j-to-slf4j:2.15.0
 org.apache.tomcat.embed:tomcat-embed-core:9.0.41
 org.apache.tomcat.embed:tomcat-embed-websocket:9.0.41
 org.aspectj:aspectjweaver:1.9.6

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -128,8 +128,8 @@ org.apache.commons:commons-lang3:3.11
 org.apache.commons:commons-text:1.8
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.14
-org.apache.logging.log4j:log4j-api:2.13.3
-org.apache.logging.log4j:log4j-to-slf4j:2.13.3
+org.apache.logging.log4j:log4j-api:2.15.0
+org.apache.logging.log4j:log4j-to-slf4j:2.15.0
 org.apache.tomcat.embed:tomcat-embed-core:9.0.41
 org.apache.tomcat.embed:tomcat-embed-websocket:9.0.41
 org.aspectj:aspectjweaver:1.9.6


### PR DESCRIPTION
## Related Issue or Background Info

- A zero-day vulnerability for log4j was discovered today, 10 December: https://www.lunasec.io/docs/blog/log4j-zero-day/
- Investigation has found that we currently leverage version 2.13.3 of the log4j package. That is considered a vulnerable version.
Looking at our specific dockerfiles... PROD is using 11.0.11+9, which should render PROD invulnerable to the LDAP vector. Our standard dockerfile leverages 11.0.9.1+1, which should render other environment levels invulnerable to the LDAP vector. Unfortunately, it looks like we would be vulnerable to other vectors.

## Changes Proposed

- Forcibly upgrade log4j-adjacent backend packages to 2.15.0.

