### PR TITLE
disallow invalid zipcodes when doing a bulkupload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
@@ -47,9 +47,9 @@ public class UploadService {
   private static final int MAX_LINE_LENGTH = 1024 * 6;
   public static final String ZIP_CODE_REGEX = "^[0-9]{5}(?:-[0-9]{4})?$";
 
-  private final PersonService _ps;
-  private final AddressValidationService _avs;
-  private final OrganizationService _os;
+  private final PersonService personService;
+  private final AddressValidationService addressValidationService;
+  private final OrganizationService organizationService;
   private boolean hasHeaderRow = false;
 
   private MappingIterator<Map<String, String>> getIteratorForCsv(InputStream csvStream)
@@ -96,7 +96,7 @@ public class UploadService {
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public String processPersonCSV(InputStream csvStream) throws IllegalGraphqlArgumentException {
     final MappingIterator<Map<String, String>> valueIterator = getIteratorForCsv(csvStream);
-    final var org = _os.getCurrentOrganization();
+    final var org = organizationService.getCurrentOrganization();
 
     // Since the CSV parser won't fail when give a single string, we simple check to see if it has
     // any parsed values
@@ -115,7 +115,7 @@ public class UploadService {
       try {
         var facilityId = parseUUID(getRow(row, FACILITY_ID, false));
         Optional<Facility> facility =
-            Optional.ofNullable(facilityId).map(_os::getFacilityInCurrentOrg);
+            Optional.ofNullable(facilityId).map(organizationService::getFacilityInCurrentOrg);
 
         String zipCode = getRow(row, "ZipCode", true);
         if (!zipCode.matches(ZIP_CODE_REGEX)) {
@@ -123,7 +123,7 @@ public class UploadService {
         }
 
         StreetAddress address =
-            _avs.getValidatedAddress(
+            addressValidationService.getValidatedAddress(
                 getRow(row, "Street", true),
                 getRow(row, "Street2", false),
                 getRow(row, "City", false),
@@ -140,12 +140,12 @@ public class UploadService {
           country = "USA";
         }
 
-        if (_ps.isDuplicatePatient(
+        if (personService.isDuplicatePatient(
             firstName, lastName, dob, address.getPostalCode(), org, facility)) {
           continue;
         }
 
-        _ps.addPatient(
+        personService.addPatient(
             facilityId,
             null, // lookupID
             firstName,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -29,15 +29,15 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   public static final int PATIENT_PAGE_OFFSET = 0;
   public static final int PATIENT_PAGE_SIZE = 1000;
 
-  @Autowired private PersonService _ps;
-  @MockBean protected AddressValidationService _addressValidation;
+  @Autowired private PersonService personService;
+  @MockBean protected AddressValidationService addressValidationService;
   private StreetAddress address;
 
   @BeforeEach
   void setupData() {
     address = new StreetAddress("123 Main Street", null, "Washington", "DC", "20008", null);
     initSampleData();
-    when(_addressValidation.getValidatedAddress(any(), any(), any(), any(), any(), any()))
+    when(addressValidationService.getValidatedAddress(any(), any(), any(), any(), any(), any()))
         .thenReturn(address);
   }
 
@@ -161,7 +161,7 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   }
 
   @Test
-  void testNoHeader() {
+  void testNoHeader_success() {
     // GIVEN
     InputStream inputStream = loadCsv("test-upload-valid-no-header.csv");
 
@@ -177,6 +177,7 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   }
 
   private List<Person> getPatients() {
-    return this._ps.getPatients(null, PATIENT_PAGE_OFFSET, PATIENT_PAGE_SIZE, false, null);
+    return this.personService.getPatients(
+        null, PATIENT_PAGE_OFFSET, PATIENT_PAGE_SIZE, false, null);
   }
 }

--- a/backend/src/test/resources/test-upload-invalid-zipcode.csv
+++ b/backend/src/test/resources/test-upload-invalid-zipcode.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City ,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Lyndonville,,VT,5851,USA,5656667777,Yes,No,Staff,foo@example.com,


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #3111 

## Changes Proposed

- disallow invalid zipcodes during a bulkupload

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
