### PR TITLE
Force log4j to 2.16 to mitigate additional vulnerability disclosures.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // log4j vulnerability fixes (Dec 2021)
-    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
-    implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.16.0'
+    implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.16.0'
 
     // data layer dependencies
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -114,8 +114,8 @@ net.minidev:json-smart:2.3
 org.apache.commons:commons-lang3:3.11
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.14
-org.apache.logging.log4j:log4j-api:2.15.0
-org.apache.logging.log4j:log4j-to-slf4j:2.15.0
+org.apache.logging.log4j:log4j-api:2.16.0
+org.apache.logging.log4j:log4j-to-slf4j:2.16.0
 org.apache.tomcat.embed:tomcat-embed-core:9.0.41
 org.apache.tomcat.embed:tomcat-embed-websocket:9.0.41
 org.aspectj:aspectjweaver:1.9.6

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -128,8 +128,8 @@ org.apache.commons:commons-lang3:3.11
 org.apache.commons:commons-text:1.8
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.14
-org.apache.logging.log4j:log4j-api:2.15.0
-org.apache.logging.log4j:log4j-to-slf4j:2.15.0
+org.apache.logging.log4j:log4j-api:2.16.0
+org.apache.logging.log4j:log4j-to-slf4j:2.16.0
 org.apache.tomcat.embed:tomcat-embed-core:9.0.41
 org.apache.tomcat.embed:tomcat-embed-websocket:9.0.41
 org.aspectj:aspectjweaver:1.9.6


### PR DESCRIPTION
## Related Issue or Background Info

- An additional log4j vulnerability was disclosed this week. This PR bumps our version of the affected packages to the latest, which should mitigate any potential denial-of-service attack that can be exploited using version 2.15.0.
- CVE link: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046
- Additional context: https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046/

## Changes Proposed

- Force log4j version 2.16.0. Confirmed using following build scan: https://scans.gradle.com/s/45tu6pz6kyfpe/dependencies?dependencies=log4j&expandAll

