### PR TITLE
remove creating patient link when adding patient to queue

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -345,9 +345,7 @@ public class TestOrderService {
     PatientAnswers answers = new PatientAnswers(survey);
     _parepo.save(answers);
     newOrder.setAskOnEntrySurvey(answers);
-    TestOrder savedOrder = _repo.save(newOrder);
-    _pls.createPatientLink(savedOrder.getInternalId());
-    return savedOrder;
+    return _repo.save(newOrder);
   }
 
   @AuthorizationConfiguration.RequirePermissionUpdateTestForPatient


### PR DESCRIPTION
## Related Issue or Background Info

- addresses #3121 

## Changes Proposed

- only create patient link when submitting a test

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [x] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
