### PR TITLE
Increase Hikari connection pool size to 50. Cut max-lifetime value to…

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,8 +8,8 @@ spring:
     password: api123
     url: jdbc:postgresql://localhost:${SR_DB_PORT:5432}/simple_report
     hikari:
-      maximum-pool-size: 20
-      max-lifetime: 900000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
+      maximum-pool-size: 50 # Maximum size that the pool is allowed to reach, including both idle and active connections. Effectively reflects number of concurrent database request threads. (Ex: A size of 50 represents a maximum capacity of 50 concurrent DB requests.)
+      max-lifetime: 600000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -10,7 +10,8 @@ spring:
     hikari:
       maximum-pool-size: 50 # Maximum size that the pool is allowed to reach, including both idle and active connections. Effectively reflects number of concurrent database request threads. (Ex: A size of 50 represents a maximum capacity of 50 concurrent DB requests.)
       max-lifetime: 600000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
-      minimum-idle: 30 # When a connection has been idle for 10 minutes (unless idleTimeout is overridden), it will be purged from the pool. This will allow for any un-closed, inactive transactions to be cleaned up more readily.
+      minimum-idle: 30 # Minimum number of idle connections to be retained in the pool. When a connection has been idle for the length of time specified in `idle-timeout`, it will be purged from the pool. This will allow for any un-closed, inactive transactions to be cleaned up more readily.
+      # idle-timeout: 600000 # Maximum lifetime for idle connections before they are purged from the pool. Only active if `minimum-idle` is set to less than `maximum-pool-size`. Defaults to 10 minutes.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
     hikari:
       maximum-pool-size: 50 # Maximum size that the pool is allowed to reach, including both idle and active connections. Effectively reflects number of concurrent database request threads. (Ex: A size of 50 represents a maximum capacity of 50 concurrent DB requests.)
       max-lifetime: 600000 # Maximum lifetime for a connection to be retained in the pool, in milliseconds, once it is closed.
+      minimum-idle: 30 # When a connection has been idle for 10 minutes (unless idleTimeout is overridden), it will be purged from the pool. This will allow for any un-closed, inactive transactions to be cleaned up more readily.
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate


### PR DESCRIPTION
… 10 minutes, down from 15. Add minimum-Idle Hikari connection property.

## Related Issue or Background Info

- On Dec 17, we saw two additional occurrences where SimpleReport was unable to acquire additional JDBC connections. As we experience spikes in demand, our database connection pool just hasn't been able to keep up.
- `spring.datasource.hikari.maximumPoolSize` effectively represents the number of concurrent database request threads that can be active at one time. Once these connections are occupied, additional users have to wait for connections to finish before they can take one. Any connection that runs for longer than a second or two increases the potential that more of the pool will be needed.
- From a code perspective, any connection that is not properly committed and closed will keep the connection allocated indefinitely. By setting a `minimum-idle` value, and letting Hikari use its default `idleTimeout` value of 10 minutes, we may be able to more proactively clean up stale connections before they become a problem visible to an end user. This may buy us more time to optimize things within our transactional code.

## Changes Proposed

- Increase `maximumPoolSize` to 50 connections.
- Decrease `maxLifetime` to 10 minutes, to keep stale connections from lingering too long.
- Implement a `minimumIdle` setting, to coax Hikari into purging idle connections that could be taking up valuable resources.
- Create issue #3129 for additional code-level optimizations.

