### PR TITLE
Add controls for Metabase connection pool sizing.

### DIFF
--- a/ops/services/app_service/metabase/main.tf
+++ b/ops/services/app_service/metabase/main.tf
@@ -1,9 +1,11 @@
 locals {
   app_setting_defaults = {
-    "MB_DB_CONNECTION_URI"           = var.postgres_url
-    "WEBSITE_VNET_ROUTE_ALL"         = 1
-    "WEBSITE_DNS_SERVER"             = "168.63.129.16"
-    "APPINSIGHTS_INSTRUMENTATIONKEY" = var.ai_instrumentation_key
+    "MB_DB_CONNECTION_URI"                            = var.postgres_url
+    "MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE"      = 4 # Controls internal Metabase connection pool sizing
+    "MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE" = 4 # Controls connection pool sizing to existing data sources (such as postgres)
+    "WEBSITE_VNET_ROUTE_ALL"                          = 1
+    "WEBSITE_DNS_SERVER"                              = "168.63.129.16"
+    "APPINSIGHTS_INSTRUMENTATIONKEY"                  = var.ai_instrumentation_key
   }
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

- As part of #2635, we intended to pare down the number of connections Metabase consumes. A PR that included these changes was approved and merged, but later had to be rolled back due to issues with unrelated code. This PR extracts the Metabase changes and resubmits them independently.

## Changes Proposed

- Reduce internal Metabase connection pool size to 4.
- Reduce number of postgresql connections that Metabase occupies to 4.
