### PR TITLE
Dynamically size Postgres database based on environment

### DIFF
--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_postgresql_server" "db" {
   name                          = "simple-report-${var.env}-db"
   location                      = var.rg_location
   resource_group_name           = var.rg_name
-  sku_name                      = "GP_Gen5_4"
+  sku_name                      = var.env == "prod" ? "GP_Gen5_8" : "GP_Gen5_4"
   version                       = "11"
   ssl_enforcement_enabled       = var.tls_enabled
   public_network_access_enabled = false


### PR DESCRIPTION
## Related Issue or Background Info

- We discovered that all of our environments currently leverage the same SKU within TF for their databases. This has been fine up until now, but PROD has grown. When the TF was changed to match, **ALL** databases in lower environments were scaled up to match. We need to prevent this from happening as we move forward.

## Changes Proposed

- Modify the postgres TF to change sku based on detected environment.

