### PR TITLE
Add design/content language to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,10 @@
 ### Content
 - [ ] Any content changes (including new error messages) have been approved by content team
 
+### Support
+- [ ] Any changes that might generate new support requests have been flagged to the support team
+- [ ] Any changes to support infrastructure have been demo'd to support team
+
 ### Testing
 - [ ] Includes a summary of what a code reviewer should verify
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,7 @@
 ## Checklist for Author and Reviewer
 
 ### Design
-- [ ] Any changes to the UI/UX are approved by design 
-- [ ] Any new or updated content (e.g. error messages) are approved by design 
+- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
 - [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams
 
 ### Content

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,13 @@
 
 ## Checklist for Author and Reviewer
 
-### UI
+### Design
 - [ ] Any changes to the UI/UX are approved by design 
 - [ ] Any new or updated content (e.g. error messages) are approved by design 
+- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams
+
+### Content
+- [ ] Any content changes (including new error messages) have been approved by content team
 
 ### Testing
 - [ ] Includes a summary of what a code reviewer should verify


### PR DESCRIPTION
Following the action items from 12/14 P-D sync, updating the PR checklist to include reviews from design/content.