### PR TITLE
fix test result to fit in one page when printing

### DIFF
--- a/frontend/src/app/testResults/TestResultPrintModal.scss
+++ b/frontend/src/app/testResults/TestResultPrintModal.scss
@@ -123,6 +123,18 @@
   margin-left: 2%;
 }
 
+.sr-result-test-details {
+  .sr-details-list {
+    li {
+      b {
+        width: unset !important;
+        min-width: 8rem;
+        max-width: 12rem;
+      }
+    }
+  }
+}
+
 .sr-details-list {
   list-style-type: none;
   margin-left: 0.5rem;

--- a/frontend/src/app/testResults/TestResultPrintModal.scss
+++ b/frontend/src/app/testResults/TestResultPrintModal.scss
@@ -9,14 +9,14 @@
 
 @media print {
   body {
-    .sr-result-print-buttons {
-      display: none;
+    .dont-print {
+      display: none !important;
     }
 
     .sr-test-results-modal-content {
       transform: none;
       max-height: none;
-      padding: none;
+      padding: 0;
     }
   }
 }
@@ -62,6 +62,11 @@
       float: right;
       width: 200px;
     }
+
+    h1 {
+      padding: 0;
+      margin: 0;
+    }
   }
 
   main {
@@ -70,14 +75,16 @@
   }
 
   footer {
-    margin: 1rem 0;
+    p {
+      margin-bottom: 0;
+    }
   }
 }
 
 .sr-result-section {
   width: 100%;
   border: 1px solid #767676;
-  margin: 0.5rem 0;
+  margin: 0.25rem 0;
 
   h2 {
     font-size: 100%;

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -67,7 +67,7 @@ export const DetachedTestResultPrintModal = ({
   const { t } = useTranslation();
 
   const buttonGroup = (
-    <div className="sr-result-print-buttons">
+    <div className="sr-result-print-buttons dont-print">
       <Button
         variant="unstyled"
         label={t("testResult.close")}
@@ -85,7 +85,7 @@ export const DetachedTestResultPrintModal = ({
       overlayClassName="sr-test-results-modal-overlay"
       contentLabel="Printable test result"
     >
-      <div className="display-flex flex-align-center maxw-tablet grid-container patient-header padding-x-0">
+      <div className="display-flex flex-align-center maxw-tablet grid-container patient-header padding-x-0 dont-print">
         <LanguageToggler />
         {buttonGroup}
       </div>
@@ -95,9 +95,9 @@ export const DetachedTestResultPrintModal = ({
           correctionStatus === "REMOVED" && "sr-removed-result"
         )}
       >
-        <header>
-          <img alt="SimpleReport logo" src={logo} className="sr-print-logo" />
+        <header className="display-flex flex-align-end flex-justify margin-bottom-1">
           <h1>{t("testResult.result")}</h1>
+          <img alt="SimpleReport logo" src={logo} className="sr-print-logo" />
         </header>
         <main>
           <section className="sr-result-section sr-result-patient-details">

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -263,10 +263,9 @@ export const es: LanguageConfig = {
         name: "Nombre del centro",
         phone: "Teléfono del centro",
         address: "Dirección del centro",
-        clia:
-          "Número de Enmiendas para Mejoras de Laboratorios Clínicos (CLIA)",
+        clia: "Número de CLIA",
         orderingProvider: "Solicitado por",
-        npi: "Identificador de Proveedor Nacional (NPI)",
+        npi: "Número de NPI",
       },
       notes: {
         meaning:


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #3125
## Changes Proposed

- remove the word `Español/English` from the printed pdf
- slightly adjust the margins to make everything fit in one page for the positive test results

## Additional Information
- @Rebecca-LM  Spanish positive test case is still not showing right, I think its because the 
  - `CLIA number` Spanish translation is too long
  - `NPI` Spanish translation is too long

## Screenshots / Demos

##### Note that I am only showing positive cases in the screen shots because Negative and Inconclusive cases show less notes, so they all fit properly on one page.

### Before: positive case `English`:
![image](https://user-images.githubusercontent.com/4952042/147370778-364e6e96-a537-418b-8123-c61339a868c0.png)
### After: positive case `English`:
![image](https://user-images.githubusercontent.com/4952042/147370701-6534fbcd-dcfe-4056-a615-0adbcb15a4b5.png)

### Before: positive case `Spanish`:
![image](https://user-images.githubusercontent.com/4952042/147370792-20d0e63c-64dd-4dbe-84b8-f4e347624fd4.png)
### After: positive case `Spanish`:
![image](https://user-images.githubusercontent.com/4952042/147371031-56eef757-6cc0-4ed1-a2d3-8df41dc8d43b.png)


## Checklist for Author and Reviewer

### UI
- [x] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
