### PR TITLE
Validate ZIP code for facility state

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,7 @@
             %REACT_APP_CONTENT_SECURITY_POLICY_SCRIPT_SRC%
             style-src 'self' 'unsafe-inline';
             img-src 'self' https://hhs-prime.okta.com data:;
-            connect-src 'self'  https://us-street.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track https://*.applicationinsights.azure.com %REACT_APP_BACKEND_URL%/ ;
+            connect-src 'self'  https://us-street.api.smartystreets.com https://us-zipcode.api.smartystreets.com www.google-analytics.com https://dc.services.visualstudio.com/v2/track https://*.applicationinsights.azure.com %REACT_APP_BACKEND_URL%/ ;
         ">
         <% } %>
     <meta charset="utf-8" />

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -205,9 +205,11 @@ const FacilityForm: React.FC<Props> = (props) => {
   };
 
   const validateFacilityAddresses = async () => {
+    const originalFacilityAddress = getFacilityAddress(facility);
+
     const isValidZipForState = await isValidZipCodeForState(
-      facility.state,
-      facility.zipCode
+      originalFacilityAddress.state,
+      originalFacilityAddress.zipCode
     );
 
     if (!isValidZipForState) {
@@ -224,7 +226,6 @@ const FacilityForm: React.FC<Props> = (props) => {
       return;
     }
 
-    const originalFacilityAddress = getFacilityAddress(facility);
     const suggestedFacilityAddress = await getBestSuggestion(
       originalFacilityAddress
     );

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -13,6 +13,7 @@ import {
   getBestSuggestion,
   suggestionIsCloseEnough,
   isValidZipCodeForState,
+  getZipCodeData,
 } from "../../utils/smartyStreets";
 import {
   AddressConfirmationModal,
@@ -207,9 +208,10 @@ const FacilityForm: React.FC<Props> = (props) => {
   const validateFacilityAddresses = async () => {
     const originalFacilityAddress = getFacilityAddress(facility);
 
-    const isValidZipForState = await isValidZipCodeForState(
+    const zipCodeData = await getZipCodeData(originalFacilityAddress.zipCode);
+    const isValidZipForState = isValidZipCodeForState(
       originalFacilityAddress.state,
-      originalFacilityAddress.zipCode
+      zipCodeData
     );
 
     if (!isValidZipForState) {

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -12,6 +12,7 @@ import { getStateNameFromCode, requiresOrderProvider } from "../../utils/state";
 import {
   getBestSuggestion,
   suggestionIsCloseEnough,
+  isValidZipCodeForState,
 } from "../../utils/smartyStreets";
 import {
   AddressConfirmationModal,
@@ -204,6 +205,25 @@ const FacilityForm: React.FC<Props> = (props) => {
   };
 
   const validateFacilityAddresses = async () => {
+    const isValidZipForState = await isValidZipCodeForState(
+      facility.state,
+      facility.zipCode
+    );
+
+    if (!isValidZipForState) {
+      const alert = (
+        <Alert
+          type="error"
+          title="Form Errors"
+          body="Invalid ZIP code for the selected state"
+        />
+      );
+
+      showNotification(alert);
+
+      return;
+    }
+
     const originalFacilityAddress = getFacilityAddress(facility);
     const suggestedFacilityAddress = await getBestSuggestion(
       originalFacilityAddress

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -94,7 +94,7 @@ describe("FacilityForm", () => {
     saveFacility = jest.fn();
     getIsValidZipForStateSpy = jest
       .spyOn(smartyStreets, "isValidZipCodeForState")
-      .mockReturnValue(Promise.resolve(true));
+      .mockReturnValue(true);
     getBestSuggestionSpy = jest
       .spyOn(smartyStreets, "getBestSuggestion")
       .mockImplementation(
@@ -611,7 +611,7 @@ describe("FacilityForm", () => {
       getIsValidZipForStateSpy.mockRestore();
       getIsValidZipForStateSpy = jest
         .spyOn(smartyStreets, "isValidZipCodeForState")
-        .mockReturnValue(Promise.resolve(false));
+        .mockReturnValue(false);
 
       const facility = validFacility;
 

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -1,11 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
+import { ToastContainer } from "react-toastify";
 
 import * as clia from "../utils/clia";
 import * as state from "../utils/state";
+import * as smartyStreets from "../utils/smartyStreets";
 
 import FacilityForm from "./Facility/FacilityForm";
+
 import "../../i18n";
 
 let saveFacility: jest.Mock;
@@ -82,128 +85,152 @@ const addresses = [
   },
 ];
 
-jest.mock("../utils/smartyStreets", () => ({
-  getBestSuggestion: (
-    address: Address
-  ): Promise<AddressWithMetaData | undefined> => {
-    const lookup = addresses.find(({ bad }) => bad.street === address.street);
-    return Promise.resolve(lookup ? lookup.good : undefined);
-  },
-  suggestionIsCloseEnough: () => false,
-}));
-
 describe("FacilityForm", () => {
+  let getIsValidZipForStateSpy: jest.SpyInstance;
+  let getBestSuggestionSpy: jest.SpyInstance;
+  let suggestionIsCloseEnoughSpy: jest.SpyInstance;
+
   beforeEach(() => {
     saveFacility = jest.fn();
+    getIsValidZipForStateSpy = jest
+      .spyOn(smartyStreets, "isValidZipCodeForState")
+      .mockReturnValue(Promise.resolve(true));
+    getBestSuggestionSpy = jest
+      .spyOn(smartyStreets, "getBestSuggestion")
+      .mockImplementation(
+        (address: Address): Promise<AddressWithMetaData | undefined> => {
+          const lookup = addresses.find(
+            ({ bad }) => bad.street === address.street
+          );
+          return Promise.resolve(lookup ? lookup.good : undefined);
+        }
+      );
+    suggestionIsCloseEnoughSpy = jest
+      .spyOn(smartyStreets, "suggestionIsCloseEnough")
+      .mockReturnValue(false);
   });
 
-  it("submits a valid form", async () => {
-    render(
-      <MemoryRouter>
-        <FacilityForm
-          facility={validFacility}
-          deviceTypes={devices}
-          saveFacility={saveFacility}
-        />
-      </MemoryRouter>
-    );
-    const saveButton = await screen.getAllByText("Save changes")[0];
-    userEvent.type(
-      screen.getByLabelText("Testing facility name", { exact: false }),
-      "Bar Facility"
-    );
-    userEvent.click(saveButton);
-    await validateAddress(saveFacility);
+  afterEach(() => {
+    getIsValidZipForStateSpy.mockRestore();
+    getBestSuggestionSpy.mockRestore();
+    suggestionIsCloseEnoughSpy.mockRestore();
   });
-  it("provides validation feedback during form completion", async () => {
-    render(
-      <MemoryRouter>
-        <FacilityForm
-          facility={validFacility}
-          deviceTypes={devices}
-          saveFacility={saveFacility}
-        />
-      </MemoryRouter>
-    );
-    const facilityNameInput = screen.getByLabelText("Testing facility name", {
-      exact: false,
-    });
-    userEvent.clear(facilityNameInput);
-    userEvent.tab();
-    const warning = await screen.findByText("Facility name is missing");
-    expect(warning).toBeInTheDocument();
-  });
-  it("prevents submit for invalid form", async () => {
-    render(
-      <MemoryRouter>
-        <FacilityForm
-          facility={validFacility}
-          deviceTypes={devices}
-          saveFacility={saveFacility}
-        />
-      </MemoryRouter>
-    );
-    const saveButton = await screen.getAllByText("Save changes")[0];
-    const facilityNameInput = screen.getByLabelText("Testing facility name", {
-      exact: false,
-    });
-    userEvent.clear(facilityNameInput);
-    userEvent.click(saveButton);
-    await waitFor(async () => expect(saveButton).toBeEnabled());
-    expect(saveFacility).toBeCalledTimes(0);
-  });
-  it("validates optional email field", async () => {
-    render(
-      <MemoryRouter>
-        <FacilityForm
-          facility={validFacility}
-          deviceTypes={devices}
-          saveFacility={saveFacility}
-        />
-      </MemoryRouter>
-    );
-    const saveButton = (await screen.findAllByText("Save changes"))[0];
-    const emailInput = screen.getByLabelText("Email", {
-      exact: false,
-    });
-    userEvent.type(emailInput, "123-456-7890");
-    userEvent.tab();
 
-    expect(
-      await screen.findByText("Email is incorrectly formatted", {
+  describe("form submission", () => {
+    it("submits a valid form", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      const saveButton = await screen.getAllByText("Save changes")[0];
+      userEvent.type(
+        screen.getByLabelText("Testing facility name", { exact: false }),
+        "Bar Facility"
+      );
+      userEvent.click(saveButton);
+      await validateAddress(saveFacility);
+    });
+
+    it("provides validation feedback during form completion", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      const facilityNameInput = screen.getByLabelText("Testing facility name", {
         exact: false,
-      })
-    ).toBeInTheDocument();
+      });
+      userEvent.clear(facilityNameInput);
+      userEvent.tab();
+      const warning = await screen.findByText("Facility name is missing");
+      expect(warning).toBeInTheDocument();
+    });
 
-    userEvent.click(saveButton);
-    expect(saveFacility).toBeCalledTimes(0);
+    it("prevents submit for invalid form", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      const saveButton = await screen.getAllByText("Save changes")[0];
+      const facilityNameInput = screen.getByLabelText("Testing facility name", {
+        exact: false,
+      });
+      userEvent.clear(facilityNameInput);
+      userEvent.click(saveButton);
+      await waitFor(async () => expect(saveButton).toBeEnabled());
+      expect(saveFacility).toBeCalledTimes(0);
+    });
 
-    userEvent.type(emailInput, "foofacility@example.com");
-    userEvent.click(saveButton);
-    await waitFor(async () => expect(saveButton).toBeEnabled());
-    await validateAddress(saveFacility);
-  });
-  it("only accepts live jurisdictions", async () => {
-    render(
-      <MemoryRouter>
-        <FacilityForm
-          facility={validFacility}
-          deviceTypes={devices}
-          saveFacility={saveFacility}
-        />
-      </MemoryRouter>
-    );
-    const stateDropdownElement = screen.getByTestId("facility-state-dropdown");
-    userEvent.selectOptions(stateDropdownElement, "PW");
-    userEvent.tab();
-    // There's a line break between these two statements, so they have to be separated
-    const warning = await screen.findByText(
-      "SimpleReport isn’t currently supported in",
-      { exact: false }
-    );
-    expect(warning).toBeInTheDocument();
-    const state = await screen.findByText("Palau", { exact: false });
-    expect(state).toBeInTheDocument();
+    it("validates optional email field", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      const saveButton = (await screen.findAllByText("Save changes"))[0];
+      const emailInput = screen.getByLabelText("Email", {
+        exact: false,
+      });
+      userEvent.type(emailInput, "123-456-7890");
+      userEvent.tab();
+
+      expect(
+        await screen.findByText("Email is incorrectly formatted", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+
+      userEvent.click(saveButton);
+      expect(saveFacility).toBeCalledTimes(0);
+
+      userEvent.type(emailInput, "foofacility@example.com");
+      userEvent.click(saveButton);
+      await waitFor(async () => expect(saveButton).toBeEnabled());
+      await validateAddress(saveFacility);
+    });
+
+    it("only accepts live jurisdictions", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      const stateDropdownElement = screen.getByTestId(
+        "facility-state-dropdown"
+      );
+      userEvent.selectOptions(stateDropdownElement, "PW");
+      userEvent.tab();
+      // There's a line break between these two statements, so they have to be separated
+      const warning = await screen.findByText(
+        "SimpleReport isn’t currently supported in",
+        { exact: false }
+      );
+      expect(warning).toBeInTheDocument();
+      const state = await screen.findByText("Palau", { exact: false });
+      expect(state).toBeInTheDocument();
+    });
   });
 
   describe("CLIA number validation", () => {
@@ -424,8 +451,7 @@ describe("FacilityForm", () => {
       let spy: jest.SpyInstance;
 
       beforeEach(() => {
-        spy = jest.spyOn(state, "requiresOrderProvider");
-        spy.mockReturnValue(true);
+        spy = jest.spyOn(state, "requiresOrderProvider").mockReturnValue(true);
       });
 
       afterEach(() => {
@@ -568,6 +594,7 @@ describe("FacilityForm", () => {
       userEvent.type(facilityName, "La Croix Facility");
       userEvent.click(saveButton);
       await validateAddress(saveFacility, "suggested address");
+      expect(getIsValidZipForStateSpy).toBeCalledTimes(1);
       expect(saveFacility).toBeCalledWith({
         ...validFacility,
         name: "La Croix Facility",
@@ -577,6 +604,63 @@ describe("FacilityForm", () => {
           ...addresses[1].good,
         },
       });
+    });
+
+    it("blocks submission of facility on invalid ZIP code for state", async () => {
+      // GIVEN
+      getIsValidZipForStateSpy.mockRestore();
+      getIsValidZipForStateSpy = jest
+        .spyOn(smartyStreets, "isValidZipCodeForState")
+        .mockReturnValue(Promise.resolve(false));
+
+      const facility: Facility = {
+        ...validFacility,
+        ...addresses[0].bad,
+      };
+
+      // WHEN
+      render(
+        <>
+          <MemoryRouter>
+            <FacilityForm
+              facility={facility}
+              deviceTypes={devices}
+              saveFacility={saveFacility}
+            />
+          </MemoryRouter>
+          <ToastContainer
+            autoClose={5000}
+            closeButton={false}
+            limit={2}
+            position="bottom-center"
+            hideProgressBar={true}
+          />
+        </>
+      );
+
+      const facilityName = await screen.findByLabelText(
+        "Testing facility name",
+        {
+          exact: false,
+        }
+      );
+      userEvent.clear(facilityName);
+      userEvent.type(facilityName, "La Croix Facility");
+      const saveButton = (await screen.findAllByText("Save changes"))[0];
+      userEvent.click(saveButton);
+
+      // THEN
+      // Toast alert appears
+      expect(
+        await screen.findByText("Invalid ZIP code for the selected state", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+
+      expect(getIsValidZipForStateSpy).toBeCalledTimes(1);
+
+      // Does not perform further address validation on invalid ZIP code for state
+      expect(getBestSuggestionSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/app/Settings/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/FacilityForm.test.tsx
@@ -613,10 +613,7 @@ describe("FacilityForm", () => {
         .spyOn(smartyStreets, "isValidZipCodeForState")
         .mockReturnValue(Promise.resolve(false));
 
-      const facility: Facility = {
-        ...validFacility,
-        ...addresses[0].bad,
-      };
+      const facility = validFacility;
 
       // WHEN
       render(

--- a/frontend/src/app/Settings/types.d.ts
+++ b/frontend/src/app/Settings/types.d.ts
@@ -2,6 +2,12 @@ type Nullable<T> = { [P in keyof T]: T[P] | null };
 
 type ISODate = `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
 
+type RequiredExceptFor<T, TOptional extends keyof T> = Pick<
+  T,
+  Exclude<keyof T, TOptional>
+> &
+  Partial<T>;
+
 interface DeviceType {
   internalId: string;
   name: string;

--- a/frontend/src/app/utils/smartyStreets.test.ts
+++ b/frontend/src/app/utils/smartyStreets.test.ts
@@ -1,72 +1,171 @@
-import { suggestionIsCloseEnough } from "./smartyStreets";
+import {
+  suggestionIsCloseEnough,
+  isValidZipCodeForState,
+  ZipCodeResult,
+} from "./smartyStreets";
 
-describe("smartyStreets.suggestionIsCloseEnough", () => {
-  it("should not match substantial differences", () => {
-    const original: Address = {
-      street: "123 Wherever St",
-      streetTwo: null,
-      city: "Long Beach",
-      state: "NY",
-      zipCode: "11561",
-    };
-    const suggested: Address = {
-      street: "456 Nowhere Pl",
-      streetTwo: null,
-      city: "Long Beach",
-      state: "NY",
-      zipCode: "11561",
-    };
-    expect(suggestionIsCloseEnough(original, suggested)).toBeFalsy();
+describe("smartStreets", () => {
+  describe("smartyStreets.suggestionIsCloseEnough", () => {
+    it("should not match substantial differences", () => {
+      const original: Address = {
+        street: "123 Wherever St",
+        streetTwo: null,
+        city: "Long Beach",
+        state: "NY",
+        zipCode: "11561",
+      };
+      const suggested: Address = {
+        street: "456 Nowhere Pl",
+        streetTwo: null,
+        city: "Long Beach",
+        state: "NY",
+        zipCode: "11561",
+      };
+      expect(suggestionIsCloseEnough(original, suggested)).toBeFalsy();
+    });
+
+    it("should match zip codes with different last-fours", () => {
+      const original: Address = {
+        street: "123 Wherever St",
+        streetTwo: null,
+        city: "Long Beach",
+        state: "NY",
+        zipCode: "11561",
+      };
+      const suggested: Address = {
+        ...original,
+        zipCode: "11561-1234",
+      };
+      expect(suggestionIsCloseEnough(original, suggested)).toBeTruthy();
+    });
+
+    it("should match semantically same values with different capitalization", () => {
+      const original: Address = {
+        street: "123 WhErEvEr St",
+        streetTwo: null,
+        city: "LoNg BeAcH",
+        state: "ny",
+        zipCode: "11561",
+      };
+      const suggested: Address = {
+        street: "123 Wherever St",
+        streetTwo: null,
+        city: "Long Beach",
+        state: "NY",
+        zipCode: "11561",
+      };
+      expect(suggestionIsCloseEnough(original, suggested)).toBeTruthy();
+    });
+
+    it("doesn't care about whitespace", () => {
+      const original: Address = {
+        street: "123WhereverSt",
+        streetTwo: null,
+        city: "LongBeach",
+        state: "NY",
+        zipCode: "11561",
+      };
+      const suggested: Address = {
+        street: "123 Wherever St",
+        streetTwo: null,
+        city: "Long Beach",
+        state: "NY",
+        zipCode: "11561",
+      };
+      expect(suggestionIsCloseEnough(original, suggested)).toBeTruthy();
+    });
   });
 
-  it("should match zip codes with different last-fours", () => {
-    const original: Address = {
-      street: "123 Wherever St",
-      streetTwo: null,
-      city: "Long Beach",
-      state: "NY",
-      zipCode: "11561",
-    };
-    const suggested: Address = {
-      ...original,
-      zipCode: "11561-1234",
-    };
-    expect(suggestionIsCloseEnough(original, suggested)).toBeTruthy();
-  });
+  describe("isValidZipCodeForState", () => {
+    it("returns `true` on falsy input", () => {
+      const result = undefined;
 
-  it("should match semantically same values with different capitalization", () => {
-    const original: Address = {
-      street: "123 WhErEvEr St",
-      streetTwo: null,
-      city: "LoNg BeAcH",
-      state: "ny",
-      zipCode: "11561",
-    };
-    const suggested: Address = {
-      street: "123 Wherever St",
-      streetTwo: null,
-      city: "Long Beach",
-      state: "NY",
-      zipCode: "11561",
-    };
-    expect(suggestionIsCloseEnough(original, suggested)).toBeTruthy();
-  });
+      const sut = isValidZipCodeForState("CA", result);
 
-  it("doesn't care about whitespace", () => {
-    const original: Address = {
-      street: "123WhereverSt",
-      streetTwo: null,
-      city: "LongBeach",
-      state: "NY",
-      zipCode: "11561",
-    };
-    const suggested: Address = {
-      street: "123 Wherever St",
-      streetTwo: null,
-      city: "Long Beach",
-      state: "NY",
-      zipCode: "11561",
-    };
-    expect(suggestionIsCloseEnough(original, suggested)).toBeTruthy();
+      expect(sut).toBe(true);
+    });
+
+    it("returns `false` if ZIP code is invalid", () => {
+      const result: ZipCodeResult = {
+        inputIndex: "0",
+        valid: false,
+        status: "invalid_zipcode",
+        reason: "Invalid ZIP Code.",
+        cities: [],
+        zipcodes: [],
+      };
+
+      const sut = isValidZipCodeForState("CA", result);
+
+      expect(sut).toBe(false);
+    });
+
+    it("returns `false` if ZIP code is not valid for state", () => {
+      const result: ZipCodeResult = {
+        inputIndex: "0",
+        valid: true,
+        cities: [
+          {
+            city: "Schenectady",
+            stateAbbreviation: "NY",
+            state: "New York",
+            mailableCity: "true",
+          },
+        ],
+        zipcodes: [
+          {
+            zipcode: "12345",
+            zipcodeType: "U",
+            defaultCity: "Schenectady",
+            countyFips: "36093",
+            countyName: "Schenectady",
+            latitude: 42.82509,
+            longitude: -73.87898,
+            precision: "Zip5",
+            stateAbbreviation: "NY",
+            state: "New York",
+            alternateCounties: [],
+          },
+        ],
+      };
+
+      const sut = isValidZipCodeForState("CA", result);
+
+      expect(sut).toBe(false);
+    });
+
+    it("returns `true` if ZIP code is valid for state", () => {
+      const result: ZipCodeResult = {
+        inputIndex: "0",
+        valid: true,
+        cities: [
+          {
+            city: "Schenectady",
+            stateAbbreviation: "NY",
+            state: "New York",
+            mailableCity: "true",
+          },
+        ],
+        zipcodes: [
+          {
+            zipcode: "12345",
+            zipcodeType: "U",
+            defaultCity: "Schenectady",
+            countyFips: "36093",
+            countyName: "Schenectady",
+            latitude: 42.82509,
+            longitude: -73.87898,
+            precision: "Zip5",
+            stateAbbreviation: "NY",
+            state: "New York",
+            alternateCounties: [],
+          },
+        ],
+      };
+
+      const sut = isValidZipCodeForState("NY", result);
+
+      expect(sut).toBe(true);
+    });
   });
 });

--- a/frontend/src/app/utils/smartyStreets.test.ts
+++ b/frontend/src/app/utils/smartyStreets.test.ts
@@ -1,11 +1,30 @@
 import {
-  suggestionIsCloseEnough,
+  buildClient,
   isValidZipCodeForState,
+  SmartyStreetsError,
+  suggestionIsCloseEnough,
   ZipCodeResult,
 } from "./smartyStreets";
 
 describe("smartStreets", () => {
-  describe("smartyStreets.suggestionIsCloseEnough", () => {
+  describe("buildClient", () => {
+    it("throws an error if SmartyStreets API key is not in environment", () => {
+      const smartyStreetsAPIKey = process.env.REACT_APP_SMARTY_STREETS_KEY;
+      delete process.env.REACT_APP_SMARTY_STREETS_KEY;
+
+      try {
+        buildClient(() => {});
+
+        fail();
+      } catch (error) {
+        expect(error).toBeInstanceOf(SmartyStreetsError);
+      }
+
+      process.env.REACT_APP_SMARTY_STREETS_KEY = smartyStreetsAPIKey;
+    });
+  });
+
+  describe("suggestionIsCloseEnough", () => {
     it("should not match substantial differences", () => {
       const original: Address = {
         street: "123 Wherever St",

--- a/frontend/src/app/utils/smartyStreets.ts
+++ b/frontend/src/app/utils/smartyStreets.ts
@@ -1,5 +1,6 @@
-import { core, usStreet, usZipcode } from "smartystreets-javascript-sdk";
+import { usStreet, usZipcode } from "smartystreets-javascript-sdk";
 
+import { getZipCodeClient, getClient } from "./smartyStreetsClients";
 import { toLowerStripWhitespace } from "./text";
 
 // cf. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/11436c5a19fc6aabfd6b8d93b37dac38b4ab9bc2/types/smartystreets-javascript-sdk/index.d.ts#L625
@@ -7,13 +8,6 @@ export type ZipCodeResult = RequiredExceptFor<
   usZipcode.Result,
   "status" | "reason"
 >;
-
-export class SmartyStreetsError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SmartyStreetsError";
-  }
-}
 
 const getLookup = (address: Address) => {
   const lookup = new usStreet.Lookup();
@@ -110,24 +104,4 @@ export function isValidZipCodeForState(
   }
 
   return result.zipcodes[0].stateAbbreviation === state;
-}
-
-export function buildClient(builder: Function) {
-  if (process.env.REACT_APP_SMARTY_STREETS_KEY === undefined) {
-    throw new SmartyStreetsError("Missing REACT_APP_SMARTY_STREETS_KEY");
-  }
-
-  const credentials = new core.SharedCredentials(
-    process.env.REACT_APP_SMARTY_STREETS_KEY
-  );
-
-  return builder(credentials);
-}
-
-export function getClient() {
-  return buildClient(core.buildClient.usStreet);
-}
-
-export function getZipCodeClient() {
-  return buildClient(core.buildClient.usZipcode);
 }

--- a/frontend/src/app/utils/smartyStreets.ts
+++ b/frontend/src/app/utils/smartyStreets.ts
@@ -8,7 +8,7 @@ export type ZipCodeResult = RequiredExceptFor<
   "status" | "reason"
 >;
 
-class SmartyStreetsError extends Error {
+export class SmartyStreetsError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "SmartyStreetsError";
@@ -25,11 +25,7 @@ const getLookup = (address: Address) => {
   return lookup;
 };
 
-const getAddress = (result: usStreet.Candidate) => {
-  if (!result) {
-    return;
-  }
-
+export const getAddress = (result: usStreet.Candidate) => {
   const zipCode = result.components.plus4Code
     ? `${result.components.zipCode}-${result.components.plus4Code}`
     : result.components.zipCode;

--- a/frontend/src/app/utils/smartyStreetsClients.ts
+++ b/frontend/src/app/utils/smartyStreetsClients.ts
@@ -1,0 +1,28 @@
+import { core } from "smartystreets-javascript-sdk";
+
+export class SmartyStreetsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SmartyStreetsError";
+  }
+}
+
+export function buildClient(builder: Function) {
+  if (process.env.REACT_APP_SMARTY_STREETS_KEY === undefined) {
+    throw new SmartyStreetsError("Missing REACT_APP_SMARTY_STREETS_KEY");
+  }
+
+  const credentials = new core.SharedCredentials(
+    process.env.REACT_APP_SMARTY_STREETS_KEY
+  );
+
+  return builder(credentials);
+}
+
+export function getClient() {
+  return buildClient(core.buildClient.usStreet);
+}
+
+export function getZipCodeClient() {
+  return buildClient(core.buildClient.usZipcode);
+}


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #3044

## Changes Proposed
- Prevent address validation if the provided ZIP code is not in the selected state
    - For facilities _only_ at this time
    - Not worrying about patient/provider address validation for now

## Additional Information
- The structure of the existing `FacilityForm.test.tsx` was not friendly to the mocking I wanted to do here
    - Broke up the module-level mocking of `smartyStreets` API
    - Added more `describe` blocks for clarity and better control of state

## Screenshots / Demos
https://user-images.githubusercontent.com/27730981/147703062-a12a4394-13c9-4753-b95b-d7bfc83ec431.mov
* **Note**: in the above clip, `90000` is a completely invalid ZIP code (i.e. it does not exist anywhere in the US) and `12345` is invalid _for the selected state_

## Checklist for Author and Reviewer
- [ ] @Rebecca-LM if there's an error message you like better than `Invalid ZIP code for the selected state` drop me a comment here and I'll update it 👍 

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
