### PR TITLE
Adjust production instance_count to reflect current manually-set value.

### DIFF
--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -3,7 +3,7 @@ module "simple_report_api" {
   name   = "${local.name}-api"
   env    = local.env
 
-  instance_count = 3
+  instance_count = 4
   instance_size  = "P2v2"
 
   resource_group_location = data.azurerm_resource_group.rg.location


### PR DESCRIPTION
## Related Issue or Background Info

We recently updated our number of production instances for autoscaling to be 4. Whenever we deploy, the discrepancy in values between TF and the autoscale will cause a momentary drop to 3 service instances. Overall time at reduced capacity is less than one second, but it does result in a blip that is measurable by our metrics.

## Changes Proposed

- Change TF to set `instance_count` to what is reflected by our manual scaling settings.
