### PR TITLE
Configure automatic retries for all end-to-end tests

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -2,5 +2,9 @@
   "baseUrl": "http://localhost.simplereport.gov",
   "viewportWidth": 1200,
   "viewportHeight": 800,
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "retries": {
+    "runMode": 2,
+    "openMode": 1
+  }
 }

--- a/frontend/cypress/integration/07-account_creation_spec.js
+++ b/frontend/cypress/integration/07-account_creation_spec.js
@@ -56,163 +56,154 @@ Cypress.Commands.add("verifySecurityCode", (code) => {
   cy.get(submitButton).first().click();
 });
 
-describe(
-  "Okta account creation",
-  {
-    retries: {
-      runMode: 2,
-      openMode: 1,
-    },
-  },
-  () => {
-    // Since these tests interact with Okta, we need to use
-    // Wiremock to stub out the Okta API calls.
+describe("Okta account creation", () => {
+  // Since these tests interact with Okta, we need to use
+  // Wiremock to stub out the Okta API calls.
+  before(() => {
+    cy.clearCookies();
+    cy.task("downloadWiremock");
+    cy.restartWiremock("accountCreation");
+  });
+  beforeEach(() => {
+    // Cypress clears cookies by default, but for these tests
+    // we want to preserve the Spring session cookie
+    Cypress.Cookies.preserveOnce("SESSION");
+  });
+  after(() => {
+    cy.clearCookies();
+    cy.task("stopWiremock");
+  });
+  describe("Account creation w/ SMS MFA", () => {
+    it("navigates to the activation link", () => {
+      cy.visit("/uac/?activationToken=h971awbXda7y7jGaxN8f");
+      cy.contains("Create your password");
+    });
+    it("sets a password", () => {
+      cy.setPassword();
+    });
+    it("sets a security question", () => {
+      cy.setSecurityQuestion();
+    });
+    it("selects SMS MFA", () => {
+      cy.mfaSelect("sms");
+    });
+    it("enters a phone number", () => {
+      cy.enterPhoneNumber();
+    });
+    it("enters a verification code", () => {
+      cy.verifySecurityCode("033457");
+    });
+    it("displays a success message", () => {
+      cy.contains("Account set up complete");
+    });
+  });
+
+  describe("Account creation w/ Okta Verify MFA", () => {
     before(() => {
-      cy.clearCookies();
-      cy.task("downloadWiremock");
       cy.restartWiremock("accountCreation");
     });
-    beforeEach(() => {
-      // Cypress clears cookies by default, but for these tests
-      // we want to preserve the Spring session cookie
-      Cypress.Cookies.preserveOnce("SESSION");
+    it("navigates to the activation link", () => {
+      cy.visit("/uac/?activationToken=NOr20VqF5M6m8AnwcSUJ");
+      cy.contains("Create your password");
     });
-    after(() => {
-      cy.clearCookies();
-      cy.task("stopWiremock");
+    it("sets a password", () => {
+      cy.setPassword();
     });
-    describe("Account creation w/ SMS MFA", () => {
-      it("navigates to the activation link", () => {
-        cy.visit("/uac/?activationToken=h971awbXda7y7jGaxN8f");
-        cy.contains("Create your password");
-      });
-      it("sets a password", () => {
-        cy.setPassword();
-      });
-      it("sets a security question", () => {
-        cy.setSecurityQuestion();
-      });
-      it("selects SMS MFA", () => {
-        cy.mfaSelect("sms");
-      });
-      it("enters a phone number", () => {
-        cy.enterPhoneNumber();
-      });
-      it("enters a verification code", () => {
-        cy.verifySecurityCode("033457");
-      });
-      it("displays a success message", () => {
-        cy.contains("Account set up complete");
-      });
+    it("sets a security question", () => {
+      cy.setSecurityQuestion();
     });
+    it("selects Okta Verify MFA", () => {
+      cy.mfaSelect("okta");
+    });
+    it("'scans' a QR code", () => {
+      cy.scanQrCode();
+    });
+    it("enters a verification code", () => {
+      cy.verifySecurityCode("543663");
+    });
+    it("displays a success message", () => {
+      cy.contains("Account set up complete");
+    });
+  });
 
-    describe("Account creation w/ Okta Verify MFA", () => {
-      before(() => {
-        cy.restartWiremock("accountCreation");
-      });
-      it("navigates to the activation link", () => {
-        cy.visit("/uac/?activationToken=NOr20VqF5M6m8AnwcSUJ");
-        cy.contains("Create your password");
-      });
-      it("sets a password", () => {
-        cy.setPassword();
-      });
-      it("sets a security question", () => {
-        cy.setSecurityQuestion();
-      });
-      it("selects Okta Verify MFA", () => {
-        cy.mfaSelect("okta");
-      });
-      it("'scans' a QR code", () => {
-        cy.scanQrCode();
-      });
-      it("enters a verification code", () => {
-        cy.verifySecurityCode("543663");
-      });
-      it("displays a success message", () => {
-        cy.contains("Account set up complete");
-      });
+  describe("Account creation w/ Google Authenticator MFA", () => {
+    before(() => {
+      cy.restartWiremock("accountCreation");
     });
+    it("navigates to the activation link", () => {
+      cy.visit("/uac/?activationToken=gqYPzH1FlPzVr0U3tQ7H");
+      cy.contains("Create your password");
+    });
+    it("sets a password", () => {
+      cy.setPassword();
+    });
+    it("sets a security question", () => {
+      cy.setSecurityQuestion();
+    });
+    it("selects Google Authenticator MFA", () => {
+      cy.mfaSelect("google");
+    });
+    it("'scans' a QR code", () => {
+      cy.scanQrCode();
+    });
+    it("enters a verification code", () => {
+      cy.verifySecurityCode("985721");
+    });
+    it("displays a success message", () => {
+      cy.contains("Account set up complete");
+    });
+  });
 
-    describe("Account creation w/ Google Authenticator MFA", () => {
-      before(() => {
-        cy.restartWiremock("accountCreation");
-      });
-      it("navigates to the activation link", () => {
-        cy.visit("/uac/?activationToken=gqYPzH1FlPzVr0U3tQ7H");
-        cy.contains("Create your password");
-      });
-      it("sets a password", () => {
-        cy.setPassword();
-      });
-      it("sets a security question", () => {
-        cy.setSecurityQuestion();
-      });
-      it("selects Google Authenticator MFA", () => {
-        cy.mfaSelect("google");
-      });
-      it("'scans' a QR code", () => {
-        cy.scanQrCode();
-      });
-      it("enters a verification code", () => {
-        cy.verifySecurityCode("985721");
-      });
-      it("displays a success message", () => {
-        cy.contains("Account set up complete");
-      });
+  describe("Account creation w/ Voice Call MFA", () => {
+    before(() => {
+      cy.restartWiremock("accountCreation");
     });
+    it("navigates to the activation link", () => {
+      cy.visit("/uac/?activationToken=wN5mR-8SXao1TP2PLaFe");
+      cy.contains("Create your password");
+    });
+    it("sets a password", () => {
+      cy.setPassword();
+    });
+    it("sets a security question", () => {
+      cy.setSecurityQuestion();
+    });
+    it("selects voice call MFA", () => {
+      cy.mfaSelect("voice");
+    });
+    it("enters a phone number", () => {
+      cy.enterPhoneNumber();
+    });
+    it("enters a verification code", () => {
+      cy.verifySecurityCode("30835");
+    });
+    it("displays a success message", () => {
+      cy.contains("Account set up complete");
+    });
+  });
 
-    describe("Account creation w/ Voice Call MFA", () => {
-      before(() => {
-        cy.restartWiremock("accountCreation");
-      });
-      it("navigates to the activation link", () => {
-        cy.visit("/uac/?activationToken=wN5mR-8SXao1TP2PLaFe");
-        cy.contains("Create your password");
-      });
-      it("sets a password", () => {
-        cy.setPassword();
-      });
-      it("sets a security question", () => {
-        cy.setSecurityQuestion();
-      });
-      it("selects voice call MFA", () => {
-        cy.mfaSelect("voice");
-      });
-      it("enters a phone number", () => {
-        cy.enterPhoneNumber();
-      });
-      it("enters a verification code", () => {
-        cy.verifySecurityCode("30835");
-      });
-      it("displays a success message", () => {
-        cy.contains("Account set up complete");
-      });
+  describe("Account creation w/ Email MFA", () => {
+    before(() => {
+      cy.restartWiremock("accountCreation");
     });
-
-    describe("Account creation w/ Email MFA", () => {
-      before(() => {
-        cy.restartWiremock("accountCreation");
-      });
-      it("navigates to the activation link", () => {
-        cy.visit("/uac/?activationToken=4OVwdVhc6M1I-UwvLrNX");
-        cy.contains("Create your password");
-      });
-      it("sets a password", () => {
-        cy.setPassword();
-      });
-      it("sets a security question", () => {
-        cy.setSecurityQuestion();
-      });
-      it("selects email MFA", () => {
-        cy.mfaSelect("email");
-      });
-      it("enters a verification code", () => {
-        cy.verifySecurityCode("007781");
-      });
-      it("displays a success message", () => {
-        cy.contains("Account set up complete");
-      });
+    it("navigates to the activation link", () => {
+      cy.visit("/uac/?activationToken=4OVwdVhc6M1I-UwvLrNX");
+      cy.contains("Create your password");
     });
-  }
-);
+    it("sets a password", () => {
+      cy.setPassword();
+    });
+    it("sets a security question", () => {
+      cy.setSecurityQuestion();
+    });
+    it("selects email MFA", () => {
+      cy.mfaSelect("email");
+    });
+    it("enters a verification code", () => {
+      cy.verifySecurityCode("007781");
+    });
+    it("displays a success message", () => {
+      cy.contains("Account set up complete");
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #3154

## Changes Proposed

- Configure automatic retries for all end-to-end tests
- The changes to the account creation spec are just indentation changes. [Diff without whitespace changes](https://github.com/CDCgov/prime-simplereport/pull/3171/files?diff=split&w=1)
