### PR TITLE
always create patient link

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientLinkService.java
@@ -38,7 +38,6 @@ public class PatientLinkService {
 
   public PatientLink getRefreshedPatientLink(UUID internalId) {
     PatientLink pl = plrepo.findById(internalId).orElseThrow(InvalidPatientLinkException::new);
-
     PatientLinkFailedAttempt patientLinkFailedAttempt =
         plfarepo.findById(pl.getInternalId()).orElse(new PatientLinkFailedAttempt(pl));
     patientLinkFailedAttempt.resetFailedAttempts();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientLinkService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientLinkService.java
@@ -38,6 +38,7 @@ public class PatientLinkService {
 
   public PatientLink getRefreshedPatientLink(UUID internalId) {
     PatientLink pl = plrepo.findById(internalId).orElseThrow(InvalidPatientLinkException::new);
+
     PatientLinkFailedAttempt patientLinkFailedAttempt =
         plfarepo.findById(pl.getInternalId()).orElse(new PatientLinkFailedAttempt(pl));
     patientLinkFailedAttempt.resetFailedAttempts();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -263,8 +263,8 @@ public class TestOrderService {
       _testEventReportingService.report(testEvent);
       ArrayList<Boolean> deliveryStatuses = new ArrayList<>();
 
+      PatientLink patientLink = _pls.createPatientLink(savedOrder.getInternalId());
       if (patientHasDeliveryPreference(savedOrder)) {
-        PatientLink patientLink = _pls.createPatientLink(savedOrder.getInternalId());
 
         if (smsDeliveryPreference(savedOrder) || smsAndEmailDeliveryPreference(savedOrder)) {
           boolean smsDeliveryStatus = testResultsDeliveryService.smsTestResults(patientLink);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.TestPropertySource;
 
@@ -65,7 +66,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @Autowired private PersonService _personService;
   @Autowired private TestEventRepository _testEventRepository;
   @Autowired private TestDataFactory _dataFactory;
-  @Autowired private PatientLinkService patientLinkService;
+  @SpyBean private PatientLinkService patientLinkService;
   @MockBean private TestResultsDeliveryService testResultsDeliveryService;
 
   private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -65,6 +65,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @Autowired private PersonService _personService;
   @Autowired private TestEventRepository _testEventRepository;
   @Autowired private TestDataFactory _dataFactory;
+  @Autowired private PatientLinkService patientLinkService;
   @MockBean private TestResultsDeliveryService testResultsDeliveryService;
 
   private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
@@ -132,6 +133,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
     assertThat(testEvents).hasSize(1);
     assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+    verify(patientLinkService).createPatientLink(any());
   }
 
   @Test


### PR DESCRIPTION
## Related Issue or Background Info

- we need to always create a patient link regardless of preference

## Changes Proposed

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
