### PR TITLE
Remove duplicate Terraform Checks run on main.

### DIFF
--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches:
       - "**"
-  push:
-    branches:
-      - main
 
 defaults:
   run:


### PR DESCRIPTION
## Related Issue or Background Info

- The `Terraform Checks` workflow action runs when a PR is created, and again on a merge to `main`. We do not gate on this check, so it seems to be redundant.
- When a merge to `main` is completed, both `Deploy Prod` and `Terraform Checks` run at the same time. This has historically not created a problem, but our recent implementation of `terraform plan` as part of the `Terraform Checks` run locks the TF state file. This creates a conflict where `Deploy Prod` and `Terraform Checks` try to lock at the same time, and will result in a failure of one of the two steps.
- If `Terraform Checks` is able to lock before `Deploy Prod`, the deployment action will fail, and will require a manual intervention to re-trigger.

## Changes Proposed

- Remove the trigger for `Terraform Checks` to run as a result of a merge to `main`.

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
