### PR TITLE
create a missing patient link when sending email/sms test results

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientLinkMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientLinkMutationResolver.java
@@ -22,4 +22,12 @@ public class PatientLinkMutationResolver implements GraphQLMutationResolver {
   public boolean sendPatientLinkEmail(UUID patientLinkId) {
     return testResultsDeliveryService.emailTestResults(patientLinkId);
   }
+
+  public boolean sendPatientLinkSmsByTestEventId(UUID testEventId) {
+    return testResultsDeliveryService.smsTestResultsForTestEvent(testEventId);
+  }
+
+  public boolean sendPatientLinkEmailByTestEventId(UUID testEventId) {
+    return testResultsDeliveryService.emailTestResultsForTestEvent(testEventId);
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
@@ -1,9 +1,13 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.db.model.PatientLink;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface PatientLinkRepository extends EternalAuditedEntityRepository<PatientLink> {
   List<PatientLink> findAllByTestOrderInternalIdIn(List<UUID> testOrderIds);
+
+  Optional<PatientLink> findFirstByTestOrder(TestOrder testOrder);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryService.java
@@ -83,4 +83,14 @@ public class TestResultsDeliveryService {
     List<SmsAPICallResult> smsSendResults = smsService.sendToPatientLink(patientLink, message);
     return smsSendResults.stream().allMatch(SmsAPICallResult::isSuccessful);
   }
+
+  public boolean smsTestResultsForTestEvent(UUID testEventId) {
+    PatientLink patientLink = patientLinkService.getPatientLinkForTestEvent(testEventId);
+    return this.smsTestResults(patientLink.getInternalId());
+  }
+
+  public boolean emailTestResultsForTestEvent(UUID testEventId) {
+    PatientLink patientLink = patientLinkService.getPatientLinkForTestEvent(testEventId);
+    return this.emailTestResults(patientLink.getInternalId());
+  }
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -621,7 +621,10 @@ type Mutation {
   ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkSms(internalId: ID!): Boolean
     @requiredPermissions(allOf: ["UPDATE_TEST"])
+  sendPatientLinkSmsByTestEventId(testEventId: ID!): Boolean
+  @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkEmail(internalId: ID!): Boolean
+  sendPatientLinkEmailByTestEventId(testEventId: ID!): Boolean
   updateOrganization(type: String!): String
     @requiredPermissions(allOf: ["EDIT_ORGANIZATION"])
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
@@ -1,9 +1,11 @@
 package gov.cdc.usds.simplereport.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import gov.cdc.usds.simplereport.api.model.errors.ExpiredPatientLinkException;
 import gov.cdc.usds.simplereport.api.model.errors.InvalidPatientLinkException;
@@ -12,7 +14,9 @@ import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.repository.PatientLinkRepository;
 import gov.cdc.usds.simplereport.service.dataloader.PatientLinkDataLoader;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.time.LocalDate;
@@ -30,38 +34,33 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 @SuppressWarnings("checkstyle:MagicNumber")
 class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
+  @Autowired private PatientLinkRepository patientLinkRepository;
   @Autowired private OrganizationService _organizationService;
   @Autowired private TestDataFactory _dataFactory;
   @MockBean private CurrentPatientContextHolder _contextHolder;
 
-  private Organization _organization;
-  private Facility _facility;
   private Person _person;
   private TestOrder _testOrder;
+  private TestEvent _testEvent;
   private PatientLink _patientLink;
 
   @BeforeEach
   void setupData() {
     initSampleData();
-    _organization = _organizationService.getCurrentOrganization();
-    _facility = _dataFactory.createValidFacility(_organization);
+    Organization _organization = _organizationService.getCurrentOrganization();
+    Facility _facility = _dataFactory.createValidFacility(_organization);
     _person = _dataFactory.createFullPerson(_organization);
-    _testOrder = _dataFactory.createTestOrder(_person, _facility);
+    _testEvent = _dataFactory.createTestEvent(_person, _facility);
+    _testOrder = _testEvent.getTestOrder();
     _patientLink = _dataFactory.createPatientLink(_testOrder);
   }
 
   @Test
-  void getPatientLink() throws Exception {
+  void getPatientLink() {
     PatientLink result = _service.getPatientLink(_patientLink.getInternalId());
     assertEquals(result.getInternalId(), _patientLink.getInternalId());
     assertThrows(
         InvalidPatientLinkException.class, () -> _service.getPatientLink(UUID.randomUUID()));
-  }
-
-  @Test
-  void getPatientFromLink() throws Exception {
-    Person result = _service.getPatientFromLink(_patientLink.getInternalId());
-    assertEquals(result.getInternalId(), _person.getInternalId());
   }
 
   @Test
@@ -70,14 +69,52 @@ class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
   }
 
   @Test
-  void getRefreshedPatientLink() throws Exception {
+  void getRefreshedPatientLink() {
     Date previousExpiry = _patientLink.getExpiresAt();
     PatientLink result = _service.getRefreshedPatientLink(_patientLink.getInternalId());
     assertTrue(result.getExpiresAt().after(previousExpiry));
   }
 
   @Test
-  void verifyPatientLink() throws Exception {
+  void getPatientLinkForTestEvent_patientLinkIsCreated() {
+    // GIVEN
+    patientLinkRepository.deleteAll();
+    PatientLink expectedPatientLink = _dataFactory.createPatientLink(_testEvent.getTestOrder());
+    patientLinkRepository.save(expectedPatientLink);
+
+    // WHEN
+    PatientLink patientLink = _service.getPatientLinkForTestEvent(_testEvent.getInternalId());
+
+    // THEN
+    assertThat(patientLink).isNotNull();
+    assertThat(patientLink.getInternalId()).isEqualTo(expectedPatientLink.getInternalId());
+  }
+
+  @Test
+  void getPatientLinkForTestEvent_createsPatientLinkWhenMissing() {
+    // GIVEN
+    patientLinkRepository.deleteAll();
+    assertThat(patientLinkRepository.findFirstByTestOrder(_testEvent.getTestOrder())).isEmpty();
+
+    // WHEN
+    PatientLink patientLink = _service.getPatientLinkForTestEvent(_testEvent.getInternalId());
+
+    // THEN
+    assertThat(patientLink).isNotNull();
+    assertThat(patientLinkRepository.findFirstByTestOrder(_testEvent.getTestOrder())).isPresent();
+  }
+
+  @Test
+  void getPatientLinkForTestEvent_null() {
+    // WHEN
+    PatientLink patientLink = _service.getPatientLinkForTestEvent(mock(UUID.class));
+
+    // THEN
+    assertThat(patientLink).isNull();
+  }
+
+  @Test
+  void verifyPatientLink() {
     assertTrue(_service.verifyPatientLink(_patientLink.getInternalId(), _person.getBirthDate()));
     assertFalse(
         _service.verifyPatientLink(
@@ -85,7 +122,7 @@ class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
   }
 
   @Test
-  void patientLinkLockout() throws Exception {
+  void patientLinkLockout() {
     UUID patientId = _patientLink.getInternalId();
     LocalDate patientBirthDate = _person.getBirthDate();
     BooleanSupplier failToVerify =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
@@ -69,6 +69,32 @@ class TestResultsDeliveryServiceTest {
   }
 
   @Test
+  void emailTestResultTests_forTestEventId() throws IOException {
+
+    // GIVEN
+    UUID patientLinkId = UUID.randomUUID();
+    UUID testEventId = UUID.randomUUID();
+    PatientLink patientLink = getMockedPatientLink(patientLinkId);
+
+    when(patientLinkService.getPatientLinkForTestEvent(testEventId)).thenReturn(patientLink);
+    when(patientLinkService.getRefreshedPatientLink(patientLinkId)).thenReturn(patientLink);
+
+    // WHEN
+    boolean success = testResultsDeliveryService.emailTestResultsForTestEvent(testEventId);
+
+    // THEN
+    assertThat(success).isTrue();
+    verify(emailService)
+        .sendWithDynamicTemplate(
+            List.of("harry@hogwarts.edu"),
+            EmailProviderTemplate.SIMPLE_REPORT_TEST_RESULT,
+            Map.of(
+                "facility_name", "House of Gryffindor",
+                "expiration_duration", "2 days",
+                "test_result_url", "https://simplereport.gov/pxp?plid=" + patientLinkId));
+  }
+
+  @Test
   void emailTestResultTests_singleDayDuration() throws IOException {
 
     // GIVEN
@@ -123,6 +149,29 @@ class TestResultsDeliveryServiceTest {
 
     // THEN
     assertThat(success).isFalse();
+  }
+
+  @Test
+  void smsTextTestResultTest_forTestEventId() {
+    // GIVEN
+    UUID patientLinkId = UUID.randomUUID();
+    UUID testEventId = UUID.randomUUID();
+    PatientLink patientLink = getMockedPatientLink(patientLinkId);
+
+    when(patientLinkService.getPatientLinkForTestEvent(testEventId)).thenReturn(patientLink);
+    when(patientLinkService.getRefreshedPatientLink(patientLinkId)).thenReturn(patientLink);
+    when(smsService.sendToPatientLink(any(PatientLink.class), anyString()))
+        .thenReturn(List.of(SmsAPICallResult.builder().successful(true).build()));
+
+    // WHEN
+    boolean success = testResultsDeliveryService.smsTestResultsForTestEvent(testEventId);
+
+    // THEN
+    assertThat(success).isTrue();
+    String message =
+        "Your COVID-19 test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
+            + patientLinkId;
+    verify(smsService).sendToPatientLink(patientLink, message);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -54,6 +54,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Component
 public class TestDataFactory {
 
@@ -324,6 +325,7 @@ public class TestDataFactory {
   public TestEvent createTestEvent(Person p, Facility f, TestResult r, Boolean hasPriorTests) {
     TestOrder o = createTestOrder(p, f);
     o.setResult(r);
+    o = _testOrderRepo.save(o);
 
     TestEvent e = _testEventRepo.save(new TestEvent(o, hasPriorTests));
     o.setTestEventRef(e);

--- a/frontend/src/app/testResults/EmailTestResultModal.test.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.test.tsx
@@ -20,7 +20,7 @@ jest.mock("../../generated/graphql", () => ({
     (options: any) => {
       mockResendTestResultsEmail(options);
       return Promise.resolve({
-        data: { sendPatientLinkEmail: mockResendSuccessValue },
+        data: { sendPatientLinkEmailByTestEventId: mockResendSuccessValue },
       });
     },
   ],
@@ -36,10 +36,6 @@ jest.mock("../../generated/graphql", () => ({
             email: "gesezyx@mailinator.com",
             emails: ["gesezyx@mailinator.com"],
             __typename: "Patient",
-          },
-          patientLink: {
-            internalId: "e4c1c27f-768e-44d2-b9d5-e047454c1d24",
-            __typename: "PatientLink",
           },
           __typename: "TestResult",
         },
@@ -88,7 +84,7 @@ describe("EmailTestResultModal", () => {
       userEvent.click(screen.getByText("Send result"));
 
       expect(mockResendTestResultsEmail).toHaveBeenCalledWith({
-        variables: { patientLinkId: "e4c1c27f-768e-44d2-b9d5-e047454c1d24" },
+        variables: { testEventId: "super-fancy-id" },
       });
 
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -108,7 +104,7 @@ describe("EmailTestResultModal", () => {
       userEvent.click(screen.getByText("Send result"));
 
       expect(mockResendTestResultsEmail).toHaveBeenCalledWith({
-        variables: { patientLinkId: "e4c1c27f-768e-44d2-b9d5-e047454c1d24" },
+        variables: { testEventId: "super-fancy-id" },
       });
 
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/frontend/src/app/testResults/EmailTestResultModal.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.tsx
@@ -30,7 +30,6 @@ export const EmailTestResultModal = ({ closeModal, testResultId }: Props) => {
 
   const patient = data?.testResult?.patient as Person;
   const dateTested = data?.testResult?.dateTested;
-  const patientLinkId = data?.testResult?.patientLink?.internalId || "";
 
   return (
     <Modal
@@ -59,9 +58,10 @@ export const EmailTestResultModal = ({ closeModal, testResultId }: Props) => {
               label="Send result"
               onClick={() => {
                 emailTestResult({
-                  variables: { patientLinkId },
+                  variables: { testEventId: testResultId },
                 }).then((response) => {
-                  const success = response.data?.sendPatientLinkEmail;
+                  const success =
+                    response.data?.sendPatientLinkEmailByTestEventId;
                   showAlertNotification(
                     success ? "success" : "error",
                     success

--- a/frontend/src/app/testResults/TestResultTextModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.test.tsx
@@ -56,10 +56,6 @@ describe("TestResultTextModal", () => {
                   },
                 ],
               },
-              patientLink: {
-                internalId: "e4c1c27f-768e-44d2-b9d5-e047454c1d24",
-                __typename: "PatientLink",
-              },
               __typename: "TestResult",
             },
           }}
@@ -108,10 +104,6 @@ describe("TestResultTextModal", () => {
                   },
                 ],
               },
-              patientLink: {
-                internalId: "e4c1c27f-768e-44d2-b9d5-e047454c1d24",
-                __typename: "PatientLink",
-              },
               __typename: "TestResult",
             },
           },
@@ -121,7 +113,7 @@ describe("TestResultTextModal", () => {
         request: {
           query: SEND_SMS,
           variables: {
-            id: "e4c1c27f-768e-44d2-b9d5-e047454c1d24",
+            id: "super-fancy-id",
           },
         },
         result: () => {
@@ -129,7 +121,7 @@ describe("TestResultTextModal", () => {
 
           return {
             data: {
-              sendPatientLinkSms: true,
+              sendPatientLinkSmsByTestEventId: true,
             },
           };
         },

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -14,9 +14,6 @@ import {
 export const testQuery = gql`
   query getTestResultForText($id: ID!) {
     testResult(id: $id) {
-      patientLink {
-        internalId
-      }
       dateTested
       patient {
         firstName
@@ -40,7 +37,7 @@ const formatDate = (date: string | undefined, withTime?: boolean) => {
 
 export const SEND_SMS = gql`
   mutation sendSMS($id: ID!) {
-    sendPatientLinkSms(internalId: $id)
+    sendPatientLinkSmsByTestEventId(testEventId: $id)
   }
 `;
 
@@ -64,19 +61,22 @@ const mobilePhoneNumbers = (phoneArray: PhoneNumber[]) => {
   return mobileNumbers;
 };
 
-export const DetachedTestResultTextModal = ({ data, closeModal }: Props) => {
+export const DetachedTestResultTextModal = ({
+  data,
+  closeModal,
+  testResultId,
+}: Props) => {
   const [sendSMS] = useMutation(SEND_SMS);
   const { patient } = data.testResult;
-  const patientLink = data.testResult.patientLink.internalId;
   const { dateTested } = data.testResult;
   const resendSMS = () => {
     sendSMS({
       variables: {
-        id: patientLink,
+        id: testResultId,
       },
     })
       .then((response) => {
-        const success = response.data?.sendPatientLinkSms;
+        const success = response.data?.sendPatientLinkSmsByTestEventId;
         showAlertNotification(
           success ? "success" : "error",
           success ? "Texted test results." : "Failed to text test results."

--- a/frontend/src/app/testResults/operations.graphql
+++ b/frontend/src/app/testResults/operations.graphql
@@ -8,12 +8,9 @@ query getTestResultForResendingEmails($id: ID!) {
       email
       emails
     }
-    patientLink {
-      internalId
-    }
   }
 }
 
-mutation resendTestResultsEmail($patientLinkId: ID!) {
-  sendPatientLinkEmail(internalId: $patientLinkId)
+mutation resendTestResultsEmail($testEventId: ID!) {
+  sendPatientLinkEmailByTestEventId(testEventId: $testEventId)
 }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -148,7 +148,9 @@ export type Mutation = {
   resetUserMfa?: Maybe<User>;
   resetUserPassword?: Maybe<User>;
   sendPatientLinkEmail?: Maybe<Scalars["Boolean"]>;
+  sendPatientLinkEmailByTestEventId?: Maybe<Scalars["Boolean"]>;
   sendPatientLinkSms?: Maybe<Scalars["Boolean"]>;
+  sendPatientLinkSmsByTestEventId?: Maybe<Scalars["Boolean"]>;
   setCurrentUserTenantDataAccess?: Maybe<User>;
   setOrganizationIdentityVerified?: Maybe<Scalars["Boolean"]>;
   setPatientIsDeleted?: Maybe<Patient>;
@@ -409,8 +411,16 @@ export type MutationSendPatientLinkEmailArgs = {
   internalId: Scalars["ID"];
 };
 
+export type MutationSendPatientLinkEmailByTestEventIdArgs = {
+  testEventId: Scalars["ID"];
+};
+
 export type MutationSendPatientLinkSmsArgs = {
   internalId: Scalars["ID"];
+};
+
+export type MutationSendPatientLinkSmsByTestEventIdArgs = {
+  testEventId: Scalars["ID"];
 };
 
 export type MutationSetCurrentUserTenantDataAccessArgs = {
@@ -2009,10 +2019,6 @@ export type GetTestResultForTextQuery = {
   testResult?: Maybe<{
     __typename?: "TestResult";
     dateTested?: Maybe<any>;
-    patientLink?: Maybe<{
-      __typename?: "PatientLink";
-      internalId?: Maybe<string>;
-    }>;
     patient?: Maybe<{
       __typename?: "Patient";
       firstName?: Maybe<string>;
@@ -2038,7 +2044,7 @@ export type SendSmsMutationVariables = Exact<{
 
 export type SendSmsMutation = {
   __typename?: "Mutation";
-  sendPatientLinkSms?: Maybe<boolean>;
+  sendPatientLinkSmsByTestEventId?: Maybe<boolean>;
 };
 
 export type GetResultsCountByFacilityQueryVariables = Exact<{
@@ -2129,20 +2135,16 @@ export type GetTestResultForResendingEmailsQuery = {
       email?: Maybe<string>;
       emails?: Maybe<Array<Maybe<string>>>;
     }>;
-    patientLink?: Maybe<{
-      __typename?: "PatientLink";
-      internalId?: Maybe<string>;
-    }>;
   }>;
 };
 
 export type ResendTestResultsEmailMutationVariables = Exact<{
-  patientLinkId: Scalars["ID"];
+  testEventId: Scalars["ID"];
 }>;
 
 export type ResendTestResultsEmailMutation = {
   __typename?: "Mutation";
-  sendPatientLinkEmail?: Maybe<boolean>;
+  sendPatientLinkEmailByTestEventId?: Maybe<boolean>;
 };
 
 export const WhoAmIDocument = gql`
@@ -5652,9 +5654,6 @@ export type GetTestResultForPrintQueryResult = Apollo.QueryResult<
 export const GetTestResultForTextDocument = gql`
   query getTestResultForText($id: ID!) {
     testResult(id: $id) {
-      patientLink {
-        internalId
-      }
       dateTested
       patient {
         firstName
@@ -5722,7 +5721,7 @@ export type GetTestResultForTextQueryResult = Apollo.QueryResult<
 >;
 export const SendSmsDocument = gql`
   mutation sendSMS($id: ID!) {
-    sendPatientLinkSms(internalId: $id)
+    sendPatientLinkSmsByTestEventId(testEventId: $id)
   }
 `;
 export type SendSmsMutationFn = Apollo.MutationFunction<
@@ -5963,9 +5962,6 @@ export const GetTestResultForResendingEmailsDocument = gql`
         email
         emails
       }
-      patientLink {
-        internalId
-      }
     }
   }
 `;
@@ -6021,8 +6017,8 @@ export type GetTestResultForResendingEmailsQueryResult = Apollo.QueryResult<
   GetTestResultForResendingEmailsQueryVariables
 >;
 export const ResendTestResultsEmailDocument = gql`
-  mutation resendTestResultsEmail($patientLinkId: ID!) {
-    sendPatientLinkEmail(internalId: $patientLinkId)
+  mutation resendTestResultsEmail($testEventId: ID!) {
+    sendPatientLinkEmailByTestEventId(testEventId: $testEventId)
   }
 `;
 export type ResendTestResultsEmailMutationFn = Apollo.MutationFunction<
@@ -6043,7 +6039,7 @@ export type ResendTestResultsEmailMutationFn = Apollo.MutationFunction<
  * @example
  * const [resendTestResultsEmailMutation, { data, loading, error }] = useResendTestResultsEmailMutation({
  *   variables: {
- *      patientLinkId: // value for 'patientLinkId'
+ *      testEventId: // value for 'testEventId'
  *   },
  * });
  */


### PR DESCRIPTION
## Related Issue or Background Info

previously we were only creating a patientLink when the patient had selected text or email delivery when they submit their test, however, we still allowed the users to resend the test results via text/mail, so if you resend a test result that didn't have a patientLink, the app would crash, this pr will create a patient link and resend the results

## Changes Proposed

- create a patientLink when missing
- use `testEventId` to trigger a resend instead of a `patientLinkId` since it can be missing

## Additional Information

there will be a follow up pr to remove the following qraphql queries
  - `sendPatientLinkSms(internalId: ID!): Boolean`
  - `sendPatientLinkEmail(internalId: ID!): Boolean`
 
they have been replaced with:
 -  ` sendPatientLinkSmsByTestEventId(testEventId: ID!): Boolean`
 -   `sendPatientLinkEmailByTestEventId(testEventId: ID!): Boolean`

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [X] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes (including new error messages) have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Testing
- [X] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [X] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
