### PR TITLE
Add -lock-timeout flag to terraform commands in makefile.

### DIFF
--- a/ops/Makefile
+++ b/ops/Makefile
@@ -43,16 +43,16 @@ api.tfvars: /dev/null
 	echo "deploy_actor=\"$(GITHUB_ACTOR)\"" >> $@;
 
 init-%: .valid-env-%
-	terraform -chdir=$*/persistent init
-	terraform -chdir=$* init
+	terraform -chdir=$*/persistent init -lock-timeout=15m
+	terraform -chdir=$* init -lock-timeout=15m
 
 plan-%: .valid-env-% api.tfvars
-	terraform -chdir=$*/persistent plan
-	terraform -chdir=$* plan -var-file=../api.tfvars
+	terraform -chdir=$*/persistent plan -lock-timeout=15m
+	terraform -chdir=$* plan -var-file=../api.tfvars -lock-timeout=15m
 
 deploy-%: .valid-env-% api.tfvars
-	terraform -chdir=$*/persistent apply -auto-approve
-	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars
+	terraform -chdir=$*/persistent apply -auto-approve -lock-timeout=15m
+	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=15m
 
 promote-%: .be-logged-in .valid-env-%
 	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)


### PR DESCRIPTION
## Related Issue or Background Info

- As our terraform actions become more robust, we have discovered the potential for multiple actions to contend with each other for state locking. As an example, the following scenario recently occurred:
  - A subordinate branch was undergoing a `terraform plan` check, and had locked state
  - A `Deploy Prod` action was triggered
  - `Deploy Prod` was unable to obtain a lock on the first attempt, and failed
  - A team member needed to wait for the subordinate `terraform plan` action to complete before manually re-triggering the `Deploy Prod` action.

## Changes Proposed

- Add `-lock-timeout=15m`, a 15-minute locking timeout, to all terraform actions.

## Additional Information

- During the timeout window, terraform will retry a state lock until it is successful, or until the timeout expires. This should allow for some greater autonomy, and queueing of lock actions.
- 15 minutes is a good starting point for a two-action-deep stack. If we find that we have greater contention, we may need to consider increasing the timeout window.
- Expect to see additional PRs forthcoming as the DevOps team works on improving our stability and reliability throughout the first quarter.

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**
