### PR TITLE
(#2828) updateFacility and addFacility returns modified facility, upd…

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -156,6 +156,8 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
         deviceIds);
   }
 
+  /** updateFacility is the latest iteration */
+  /** remove updateFacilityNew at a later date */
   public ApiFacility updateFacility(
       UUID facilityId,
       String testingFacilityName,
@@ -221,6 +223,9 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
     return new ApiFacility(facility);
   }
 
+  /** updateFacilityNew is being kept along side updateFacility to ensure backwards compatibility */
+  /** updateFacilityNew calls updateFacility */
+  /** updateFacilityNew should be removed at a future date */
   public ApiFacility updateFacilityNew(
       UUID facilityId,
       String testingFacilityName,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -50,58 +50,6 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
       String street,
       String streetTwo,
       String city,
-      String county,
-      String state,
-      String zipCode,
-      String phone,
-      String email,
-      String orderingProviderFirstName,
-      String orderingProviderMiddleName,
-      String orderingProviderLastName,
-      String orderingProviderSuffix,
-      String orderingProviderNPI,
-      String orderingProviderStreet,
-      String orderingProviderStreetTwo,
-      String orderingProviderCity,
-      String orderingProviderCounty,
-      String orderingProviderState,
-      String orderingProviderZipCode,
-      String orderingProviderTelephone,
-      List<String> deviceIds,
-      List<UUID> deviceSpecimenTypes,
-      String defaultDeviceId) {
-
-    return addFacilityNew(
-        testingFacilityName,
-        cliaNumber,
-        street,
-        streetTwo,
-        city,
-        state,
-        zipCode,
-        phone,
-        email,
-        orderingProviderFirstName,
-        orderingProviderMiddleName,
-        orderingProviderLastName,
-        orderingProviderSuffix,
-        orderingProviderNPI,
-        orderingProviderStreet,
-        orderingProviderStreetTwo,
-        orderingProviderCity,
-        orderingProviderCounty,
-        orderingProviderState,
-        orderingProviderZipCode,
-        orderingProviderTelephone,
-        getDeviceIdsFromDeviceSpecimenTypes(deviceSpecimenTypes));
-  }
-
-  public ApiFacility addFacilityNew(
-      String testingFacilityName,
-      String cliaNumber,
-      String street,
-      String streetTwo,
-      String city,
       String state,
       String zipCode,
       String phone,
@@ -159,14 +107,12 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
     return new ApiFacility(created);
   }
 
-  public ApiFacility updateFacility(
-      UUID facilityId,
+  public ApiFacility addFacilityNew(
       String testingFacilityName,
       String cliaNumber,
       String street,
       String streetTwo,
       String city,
-      String county,
       String state,
       String zipCode,
       String phone,
@@ -183,12 +129,9 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
       String orderingProviderState,
       String orderingProviderZipCode,
       String orderingProviderTelephone,
-      List<String> deviceIds,
-      List<UUID> deviceSpecimenTypes,
-      String defaultDeviceId) {
+      List<UUID> deviceIds) {
 
-    return updateFacilityNew(
-        facilityId,
+    return addFacility(
         testingFacilityName,
         cliaNumber,
         street,
@@ -210,10 +153,10 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
         orderingProviderState,
         orderingProviderZipCode,
         orderingProviderTelephone,
-        getDeviceIdsFromDeviceSpecimenTypes(deviceSpecimenTypes));
+        deviceIds);
   }
 
-  public ApiFacility updateFacilityNew(
+  public ApiFacility updateFacility(
       UUID facilityId,
       String testingFacilityName,
       String cliaNumber,
@@ -276,6 +219,57 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
             parsePhoneNumber(orderingProviderTelephone),
             deviceIds);
     return new ApiFacility(facility);
+  }
+
+  public ApiFacility updateFacilityNew(
+      UUID facilityId,
+      String testingFacilityName,
+      String cliaNumber,
+      String street,
+      String streetTwo,
+      String city,
+      String state,
+      String zipCode,
+      String phone,
+      String email,
+      String orderingProviderFirstName,
+      String orderingProviderMiddleName,
+      String orderingProviderLastName,
+      String orderingProviderSuffix,
+      String orderingProviderNPI,
+      String orderingProviderStreet,
+      String orderingProviderStreetTwo,
+      String orderingProviderCity,
+      String orderingProviderCounty,
+      String orderingProviderState,
+      String orderingProviderZipCode,
+      String orderingProviderTelephone,
+      List<UUID> deviceIds) {
+
+    return updateFacility(
+        facilityId,
+        testingFacilityName,
+        cliaNumber,
+        street,
+        streetTwo,
+        city,
+        state,
+        zipCode,
+        phone,
+        email,
+        orderingProviderFirstName,
+        orderingProviderMiddleName,
+        orderingProviderLastName,
+        orderingProviderSuffix,
+        orderingProviderNPI,
+        orderingProviderStreet,
+        orderingProviderStreetTwo,
+        orderingProviderCity,
+        orderingProviderCounty,
+        orderingProviderState,
+        orderingProviderZipCode,
+        orderingProviderTelephone,
+        deviceIds);
   }
 
   @AuthorizationConfiguration.RequireGlobalAdminUser

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -39,6 +39,8 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
   private final AddressValidationService addressValidationService;
   private final ApiUserService apiUserService;
 
+  /** addFacility is the latest iteration */
+  /** remove addFacilityNew at a later date */
   public ApiFacility addFacility(
       String testingFacilityName,
       String cliaNumber,
@@ -102,6 +104,9 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
     return new ApiFacility(created);
   }
 
+  /** addFacilityNew is being kept along side addFacility to ensure backwards compatibility */
+  /** addFacilityNew calls addFacility */
+  /** addFacilityNew should be removed at a future date */
   public ApiFacility addFacilityNew(
       String testingFacilityName,
       String cliaNumber,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -17,7 +17,6 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.service.AddressValidationService;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.OrganizationQueueService;
@@ -39,7 +38,6 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
   private final OrganizationQueueService organizationQueueService;
   private final AddressValidationService addressValidationService;
   private final ApiUserService apiUserService;
-  private final DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
 
   public ApiFacility addFacility(
       String testingFacilityName,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -12,9 +12,7 @@ import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.api.model.ApiOrganization;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.Facility;
-import gov.cdc.usds.simplereport.db.model.IdentifiedEntity;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -26,7 +24,6 @@ import gov.cdc.usds.simplereport.service.OrganizationQueueService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -399,18 +396,5 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
   /** Support-only mutation to mark a facility as deleted. This is a soft deletion only. */
   public Facility markFacilityAsDeleted(UUID facilityId, boolean deleted) {
     return organizationService.markFacilityAsDeleted(facilityId, deleted);
-  }
-
-  private List<UUID> getDeviceIdsFromDeviceSpecimenTypes(List<UUID> deviceSpecimenTypes) {
-    return deviceSpecimenTypes.stream()
-        .map(
-            id ->
-                deviceSpecimenTypeRepository
-                    .findById(id)
-                    .map(DeviceSpecimenType::getDeviceType)
-                    .map(IdentifiedEntity::getInternalId)
-                    .orElse(null))
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
   }
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -373,8 +373,6 @@ type Mutation {
     street: String!
     streetTwo: String
     city: String
-    county: String
-      @deprecated(reason: "county is derived from smarty streets lookup")
     state: String!
     zipCode: String!
     phone: String
@@ -392,18 +390,14 @@ type Mutation {
     orderingProviderState: String
     orderingProviderZipCode: String
     orderingProviderPhone: String
-    deviceTypes: [String]!
-    deviceSpecimenTypes: [ID]
-    defaultDevice: String!
-  ): String @requiredPermissions(allOf: ["EDIT_FACILITY"])
+    deviceIds: [ID]!
+  ): Facility @requiredPermissions(allOf: ["EDIT_FACILITY"])
   addFacility(
     testingFacilityName: String!
     cliaNumber: String
     street: String!
     streetTwo: String
     city: String
-    county: String
-      @deprecated(reason: "county is derived from smarty streets lookup")
     state: String!
     zipCode: String!
     phone: String
@@ -421,10 +415,8 @@ type Mutation {
     orderingProviderState: String
     orderingProviderZipCode: String
     orderingProviderPhone: String
-    deviceTypes: [String]!
-    deviceSpecimenTypes: [ID]
-    defaultDevice: String!
-  ): String @requiredPermissions(allOf: ["EDIT_FACILITY"])
+    deviceIds: [ID]!
+  ): Facility @requiredPermissions(allOf: ["EDIT_FACILITY"])
   addFacilityNew(
     testingFacilityName: String!
     cliaNumber: String

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.api.organization;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -79,7 +78,7 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
         .thenReturn(address);
 
     // WHEN
-    organizationMutationResolver.addFacilityNew(
+    organizationMutationResolver.addFacility(
         facility.getFacilityName(),
         facility.getCliaNumber(),
         facility.getAddress().getStreetOne(),
@@ -122,7 +121,7 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
   }
 
   @Test
-  void addFacility_withDeviceSpecimenType_backwardCompatible_success() {
+  void addFacilityNew_backwardCompatible_success() {
     // GIVEN
     doNothing()
         .when(mockedOrganizationService)
@@ -139,13 +138,12 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
         .thenReturn(Optional.of(genericDeviceSpecimen));
 
     // WHEN
-    organizationMutationResolver.addFacility(
+    organizationMutationResolver.addFacilityNew(
         facility.getFacilityName(),
         facility.getCliaNumber(),
         facility.getAddress().getStreetOne(),
         facility.getAddress().getStreetTwo(),
         facility.getAddress().getCity(),
-        facility.getAddress().getCounty(),
         facility.getAddress().getState(),
         facility.getAddress().getPostalCode(),
         facility.getTelephone(),
@@ -162,9 +160,7 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
         facility.getOrderingProvider().getAddress().getState(),
         facility.getOrderingProvider().getAddress().getPostalCode(),
         facility.getOrderingProvider().getTelephone(),
-        List.of(deviceId.toString()),
-        List.of(genericDeviceSpecimen.getInternalId()),
-        deviceId.toString());
+        List.of(deviceId));
 
     // THEN
     verify(mockedOrganizationService)
@@ -195,9 +191,11 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
             address.getPostalCode(),
             "facility"))
         .thenReturn(address);
+    when(mockedDeviceSpecimenTypeRepository.findById(any()))
+        .thenReturn(Optional.of(genericDeviceSpecimen));
 
     // WHEN
-    organizationMutationResolver.updateFacilityNew(
+    organizationMutationResolver.updateFacility(
         facility.getInternalId(),
         facility.getFacilityName(),
         facility.getCliaNumber(),
@@ -242,7 +240,7 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
   }
 
   @Test
-  void updateFacility_backwardCompatible_success() {
+  void updateFacilityNew_backwardsCompatible_success() {
     // GIVEN
     when(mockedAddressValidationService.getValidatedAddress(
             address.getStreetOne(),
@@ -256,14 +254,13 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
         .thenReturn(Optional.of(genericDeviceSpecimen));
 
     // WHEN
-    organizationMutationResolver.updateFacility(
+    organizationMutationResolver.updateFacilityNew(
         facility.getInternalId(),
         facility.getFacilityName(),
         facility.getCliaNumber(),
         facility.getAddress().getStreetOne(),
         facility.getAddress().getStreetTwo(),
         facility.getAddress().getCity(),
-        facility.getAddress().getCounty(),
         facility.getAddress().getState(),
         facility.getAddress().getPostalCode(),
         facility.getTelephone(),
@@ -280,9 +277,7 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
         facility.getOrderingProvider().getAddress().getState(),
         facility.getOrderingProvider().getAddress().getPostalCode(),
         facility.getOrderingProvider().getTelephone(),
-        emptyList(),
-        List.of(genericDeviceSpecimen.getInternalId()),
-        null);
+        List.of(deviceId));
 
     // THEN
     verify(mockedOrganizationService)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
@@ -7,12 +7,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.service.AddressValidationService;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
@@ -22,7 +19,6 @@ import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,21 +40,16 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
   @Mock ApiUserService mockedApiUserService;
   @Mock OrganizationService mockedOrganizationService;
   @Mock OrganizationQueueService mockedOrganizationQueueService;
-  @Mock DeviceSpecimenTypeRepository mockedDeviceSpecimenTypeRepository;
   @InjectMocks OrganizationMutationResolver organizationMutationResolver;
 
   private Facility facility;
-  private DeviceSpecimenType genericDeviceSpecimen;
-  private UUID deviceId;
   private StreetAddress address;
+  private final UUID deviceId = UUID.randomUUID();
 
   @BeforeEach
   void setup() {
     Organization org = _dataFactory.createValidOrg();
     facility = _dataFactory.createValidFacility(org);
-    genericDeviceSpecimen = _dataFactory.getGenericDeviceSpecimen();
-    DeviceType genericDevice = genericDeviceSpecimen.getDeviceType();
-    deviceId = genericDevice.getInternalId();
     address = facility.getAddress();
   }
 
@@ -134,8 +125,6 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
             address.getPostalCode(),
             "facility"))
         .thenReturn(address);
-    when(mockedDeviceSpecimenTypeRepository.findById(any()))
-        .thenReturn(Optional.of(genericDeviceSpecimen));
 
     // WHEN
     organizationMutationResolver.addFacilityNew(
@@ -191,8 +180,6 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
             address.getPostalCode(),
             "facility"))
         .thenReturn(address);
-    when(mockedDeviceSpecimenTypeRepository.findById(any()))
-        .thenReturn(Optional.of(genericDeviceSpecimen));
 
     // WHEN
     organizationMutationResolver.updateFacility(
@@ -250,8 +237,6 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
             address.getPostalCode(),
             "facility"))
         .thenReturn(address);
-    when(mockedDeviceSpecimenTypeRepository.findById(any()))
-        .thenReturn(Optional.of(genericDeviceSpecimen));
 
     // WHEN
     organizationMutationResolver.updateFacilityNew(

--- a/backend/src/test/resources/queries/facility-create
+++ b/backend/src/test/resources/queries/facility-create
@@ -1,5 +1,5 @@
 mutation addFac($deviceId: ID!) {
-  addFacilityNew(
+  addFacility(
     testingFacilityName: "Nice Place"
     cliaNumber: "123457890987654321"
     street: "123 Main Street"
@@ -19,5 +19,7 @@ mutation addFac($deviceId: ID!) {
     orderingProviderZipCode: "11801"
     orderingProviderPhone: "(646) 5432123"
     deviceIds: [$deviceId]
-  )
+  ) {
+    id
+  }
 }

--- a/backend/src/test/resources/queries/facility-update
+++ b/backend/src/test/resources/queries/facility-update
@@ -1,5 +1,5 @@
 mutation updateFacility($facilityId: ID!, $deviceId: ID!) {
-    updateFacilityNew(
+    updateFacility(
         facilityId: $facilityId
         testingFacilityName: "Fake Facility"
         cliaNumber: "123457890987654321"
@@ -20,5 +20,7 @@ mutation updateFacility($facilityId: ID!, $deviceId: ID!) {
         orderingProviderZipCode: "11801"
         orderingProviderPhone: "(646) 5432123"
         deviceIds: [$deviceId]
-    )
+    ) {
+        id
+    }
 }

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
@@ -55,22 +55,75 @@ const mockFacility: Facility = {
   },
 };
 
-jest.mock("./FacilityForm", () => {
-  return (f: FacilityFormProps) => {
-    return (
-      <button type="submit" onClick={() => f.saveFacility(mockFacility)}>
-        I'm a magic fake button click me please
-      </button>
-    );
-  };
-});
-jest.mock("react-router-dom", () => ({
-  Redirect: () => <p>Redirected</p>,
-}));
+const getFacilityRequest: any = {
+  request: {
+    query: GET_FACILITY_QUERY,
+  },
+  result: {
+    data: {
+      organization: {
+        internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
+        testingFacility: [
+          {
+            id: mockFacility.id,
+            cliaNumber: "99D1234567",
+            name: "Testing Site",
+            street: "1001 Rodeo Dr",
+            streetTwo: "qwqweqwe123123",
+            city: "Los Angeles",
+            state: "CA",
+            zipCode: "90000",
+            phone: "(516) 432-1390",
+            email: "testingsite@disorg.com",
+            defaultDeviceSpecimen: {
+              internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+            },
+            deviceTypes,
+            orderingProvider: {
+              firstName: "Fred",
+              middleName: null,
+              lastName: "Flintstone",
+              suffix: null,
+              NPI: "PEBBLES",
+              street: "123 Main Street",
+              streetTwo: "",
+              city: "Oz",
+              state: "KS",
+              zipCode: "12345",
+              phone: "(202) 555-1212",
+            },
+          },
+        ],
+      },
+      deviceTypes,
+    },
+  },
+};
 
-jest.mock("../../TelemetryService", () => ({
-  getAppInsights: jest.fn(),
-}));
+const facilityVariables: any = {
+  facilityId: mockFacility.id,
+  testingFacilityName: mockFacility.name,
+  cliaNumber: mockFacility.cliaNumber,
+  street: mockFacility.street,
+  streetTwo: mockFacility.streetTwo,
+  city: mockFacility.city,
+  state: mockFacility.state,
+  zipCode: mockFacility.zipCode,
+  phone: mockFacility.phone,
+  email: mockFacility.email,
+  orderingProviderFirstName: mockFacility.orderingProvider.firstName,
+  orderingProviderMiddleName: mockFacility.orderingProvider.middleName,
+  orderingProviderLastName: mockFacility.orderingProvider.lastName,
+  orderingProviderSuffix: mockFacility.orderingProvider.suffix,
+  orderingProviderNPI: mockFacility.orderingProvider.NPI,
+  orderingProviderStreet: mockFacility.orderingProvider.street,
+  orderingProviderStreetTwo: mockFacility.orderingProvider.streetTwo,
+  orderingProviderCity: mockFacility.orderingProvider.city,
+  orderingProviderState: mockFacility.orderingProvider.state,
+  orderingProviderZipCode: mockFacility.orderingProvider.zipCode,
+  orderingProviderPhone: mockFacility.orderingProvider.phone || null,
+  devices: mockFacility.deviceTypes.map((d) => d.internalId),
+};
 
 const store = configureStore([])({
   organization: {
@@ -88,86 +141,38 @@ const store = configureStore([])({
 });
 
 const mocks = [
-  {
-    request: {
-      query: GET_FACILITY_QUERY,
-    },
-    result: {
-      data: {
-        organization: {
-          internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
-          testingFacility: [
-            {
-              id: mockFacility.id,
-              cliaNumber: "99D1234567",
-              name: "Testing Site",
-              street: "1001 Rodeo Dr",
-              streetTwo: "qwqweqwe123123",
-              city: "Los Angeles",
-              state: "CA",
-              zipCode: "90000",
-              phone: "(516) 432-1390",
-              email: "testingsite@disorg.com",
-              defaultDeviceSpecimen: {
-                internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
-              },
-              deviceTypes,
-              orderingProvider: {
-                firstName: "Fred",
-                middleName: null,
-                lastName: "Flintstone",
-                suffix: null,
-                NPI: "PEBBLES",
-                street: "123 Main Street",
-                streetTwo: "",
-                city: "Oz",
-                state: "KS",
-                zipCode: "12345",
-                phone: "(202) 555-1212",
-              },
-            },
-          ],
-        },
-        deviceTypes,
-      },
-    },
-  },
+  getFacilityRequest,
   {
     request: {
       query: UPDATE_FACILITY_MUTATION,
-      variables: {
-        facilityId: mockFacility.id,
-        testingFacilityName: mockFacility.name,
-        cliaNumber: mockFacility.cliaNumber,
-        street: mockFacility.street,
-        streetTwo: mockFacility.streetTwo,
-        city: mockFacility.city,
-        state: mockFacility.state,
-        zipCode: mockFacility.zipCode,
-        phone: mockFacility.phone,
-        email: mockFacility.email,
-        orderingProviderFirstName: mockFacility.orderingProvider.firstName,
-        orderingProviderMiddleName: mockFacility.orderingProvider.middleName,
-        orderingProviderLastName: mockFacility.orderingProvider.lastName,
-        orderingProviderSuffix: mockFacility.orderingProvider.suffix,
-        orderingProviderNPI: mockFacility.orderingProvider.NPI,
-        orderingProviderStreet: mockFacility.orderingProvider.street,
-        orderingProviderStreetTwo: mockFacility.orderingProvider.streetTwo,
-        orderingProviderCity: mockFacility.orderingProvider.city,
-        orderingProviderState: mockFacility.orderingProvider.state,
-        orderingProviderZipCode: mockFacility.orderingProvider.zipCode,
-        orderingProviderPhone: mockFacility.orderingProvider.phone || null,
-        devices: mockFacility.deviceTypes.map((d) => d.internalId),
-      },
+      variables: facilityVariables,
     },
     result: {
       data: {
-        updateFacilityNew:
-          "this doesn't get serialized, it's an object pointer, whoops",
+        updateFacility: {
+          id: mockFacility.id,
+        },
       },
     },
   },
 ];
+
+jest.mock("./FacilityForm", () => {
+  return (f: FacilityFormProps) => {
+    return (
+      <button type="submit" onClick={() => f.saveFacility(mockFacility)}>
+        I'm a magic fake button click me please
+      </button>
+    );
+  };
+});
+jest.mock("react-router-dom", () => ({
+  Redirect: () => <p>Redirected</p>,
+}));
+
+jest.mock("../../TelemetryService", () => ({
+  getAppInsights: jest.fn(),
+}));
 
 describe("FacilityFormContainer", () => {
   const trackEventMock = jest.fn();
@@ -176,7 +181,6 @@ describe("FacilityFormContainer", () => {
     (getAppInsights as jest.Mock).mockImplementation(() => ({
       trackEvent: trackEventMock,
     }));
-
     render(
       <MemoryRouter>
         <Provider store={store}>
@@ -192,13 +196,13 @@ describe("FacilityFormContainer", () => {
     (getAppInsights as jest.Mock).mockReset();
   });
 
-  it("redirects on successful save", async () => {
+  it("redirects on successful facilty update", async () => {
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     userEvent.click(screen.getByRole("button"));
     expect(await screen.findByText("Redirected")).toBeInTheDocument();
   });
 
-  it("tracks custom telemetry event on successful save", async () => {
+  it("tracks custom telemetry event on successful facility update", async () => {
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     userEvent.click(screen.getByRole("button"));
     expect(trackEventMock).toBeCalledWith({ name: "Save Settings" });

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, act } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import configureStore from "redux-mock-store";
+
+import { GetManagedFacilitiesDocument } from "../../../generated/graphql";
+
+import ManageFacilitiesContainer from "./ManageFacilitiesContainer";
+
+const deviceSpecimenTypes: DeviceSpecimenType[] = [
+  {
+    internalId: "1",
+    deviceType: {
+      internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+      name: "Fake Device 1",
+    },
+    specimenType: {
+      internalId: "fake-specimen-id-1",
+      name: "Fake Specimen 1",
+    },
+  },
+  {
+    internalId: "2",
+    deviceType: {
+      internalId: "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
+      name: "Fake Device 2",
+    },
+    specimenType: {
+      internalId: "fake-specimen-id-1",
+      name: "Fake Specimen 1",
+    },
+  },
+];
+
+const mockFacility: Facility = {
+  id: "c0d32060-0580-4f8f-9e3d-2e16d65c1629",
+  cliaNumber: "99D1234567",
+  name: "Testing Site",
+  street: "1001 Rodeo Dr",
+  streetTwo: "qwqweqwe123123",
+  city: "Los Angeles",
+  state: "CA",
+  zipCode: "90000",
+  phone: "(516) 432-1390",
+  email: "testingsite@disorg.com",
+  defaultDevice: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+  deviceTypes: [
+    "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
+    "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
+  ],
+  deviceSpecimenTypes: deviceSpecimenTypes,
+  orderingProvider: {
+    firstName: "Fred",
+    middleName: null,
+    lastName: "Flintstone",
+    suffix: null,
+    NPI: "PEBBLES",
+    street: "123 Main Street",
+    streetTwo: "",
+    city: "Oz",
+    state: "KS",
+    zipCode: "12345",
+    phone: "(202) 555-1212",
+  },
+};
+
+const store = configureStore([])({
+  organization: {
+    name: "Organization Name",
+  },
+  user: {
+    firstName: "Kim",
+    lastName: "Mendoza",
+  },
+  facilities: [{ id: mockFacility.id, name: mockFacility.name }],
+  facility: { id: mockFacility.id, name: mockFacility.name },
+});
+
+const mock = [
+  {
+    request: {
+      query: GetManagedFacilitiesDocument,
+    },
+    result: {
+      data: {
+        organization: {
+          internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
+          testingFacility: [
+            {
+              id: mockFacility.id,
+              cliaNumber: mockFacility.cliaNumber,
+              name: mockFacility.name,
+              street: mockFacility.street,
+              streetTwo: mockFacility.streetTwo,
+              city: mockFacility.city,
+              state: mockFacility.state,
+              zipCode: mockFacility.zipCode,
+              phone: mockFacility.phone,
+              email: mockFacility.email,
+              defaultDeviceType: {
+                internalId: deviceSpecimenTypes[0].internalId,
+              },
+              deviceTypes: [
+                {
+                  internalId: deviceSpecimenTypes[0].internalId,
+                },
+                {
+                  internalId: deviceSpecimenTypes[1].internalId,
+                },
+              ],
+              deviceSpecimenTypes,
+              orderingProvider: {
+                firstName: "Fred",
+                middleName: null,
+                lastName: "Flintstone",
+                suffix: null,
+                NPI: "PEBBLES",
+                street: "123 Main Street",
+                streetTwo: "",
+                city: "Oz",
+                state: "KS",
+                zipCode: "12345",
+                phone: "(202) 555-1212",
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+];
+
+describe("ManageFacilitiesContainer", () => {
+  beforeEach(() => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mock}>
+            <ManageFacilitiesContainer />
+          </MockedProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+  });
+
+  it("displays facilities", async () => {
+    await act(async () => {
+      expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
+      expect(
+        await screen.findByText(mockFacility.cliaNumber)
+      ).toBeInTheDocument();
+      expect(await screen.findByText(mockFacility.name)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -86,7 +86,7 @@ const mock = [
       data: {
         organization: {
           internalId: "30b1d934-a877-4b1d-9565-575afd4d797e",
-          testingFacility: [
+          facilities: [
             {
               id: mockFacility.id,
               cliaNumber: mockFacility.cliaNumber,

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
@@ -1,24 +1,21 @@
 import React from "react";
-import { gql, useQuery } from "@apollo/client";
+
+import { useGetManagedFacilitiesQuery } from "../../../generated/graphql";
 
 import ManageFacilities from "./ManageFacilities";
 
-const GET_FACILITIES = gql`
-  query GetManagedFacilities {
-    organization {
-      testingFacility {
-        id
-        cliaNumber
-        name
-      }
-    }
-  }
-`;
-
 const ManageFacilitiesContainer: any = () => {
-  const { data, loading, error } = useQuery<SettingsData, {}>(GET_FACILITIES, {
+  const { data, loading, error } = useGetManagedFacilitiesQuery({
     fetchPolicy: "no-cache",
   });
+
+  type SettingsData = {
+    organization: {
+      facilities: Facility[];
+    };
+  };
+
+  const settingsData = data as SettingsData;
 
   if (loading) {
     return <p> Loading... </p>;
@@ -26,12 +23,11 @@ const ManageFacilitiesContainer: any = () => {
   if (error) {
     return error;
   }
-
-  if (data === undefined) {
+  if (!settingsData || !settingsData.organization) {
     return <p>Error: facilities not found</p>;
   }
 
-  return <ManageFacilities facilities={data.organization.testingFacility} />;
+  return <ManageFacilities facilities={settingsData.organization.facilities} />;
 };
 
 export default ManageFacilitiesContainer;

--- a/frontend/src/app/Settings/Facility/operations.graphql
+++ b/frontend/src/app/Settings/Facility/operations.graphql
@@ -1,0 +1,9 @@
+query GetManagedFacilities {
+  organization {
+    facilities {
+      id
+      cliaNumber
+      name
+    }
+  }
+}

--- a/frontend/src/app/Settings/types.d.ts
+++ b/frontend/src/app/Settings/types.d.ts
@@ -98,55 +98,6 @@ interface PhoneNumber {
   number: string;
 }
 
-interface SettingsData {
-  organization: {
-    internalId: string;
-    name: string;
-    testingFacility: [
-      {
-        id: string;
-        cliaNumber: string;
-        name: string;
-        street: string;
-        streetTwo: string;
-        city: string;
-        county: string;
-        state: string;
-        zipCode: string;
-        phone: string;
-        email: string;
-        defaultDeviceSpecimen: string;
-        deviceTypes: [
-          {
-            name: string;
-            internalId: string;
-          }
-        ];
-        orderingProvider: {
-          firstName: string;
-          middleName: string;
-          lastName: string;
-          suffix: string;
-          NPI: string;
-          street: string;
-          streetTwo: string;
-          city: string;
-          county: string;
-          state: string;
-          zipCode: string;
-          phone: string;
-        };
-      }
-    ];
-  };
-  deviceTypes: [
-    {
-      internalId: string;
-      name: string;
-    }
-  ];
-}
-
 interface FacilityData {
   organization: {
     internalId: string;

--- a/frontend/src/app/store.test.ts
+++ b/frontend/src/app/store.test.ts
@@ -1,0 +1,140 @@
+import reducers, {
+  initialState,
+  setInitialState,
+  SET_INITIAL_STATE,
+  updateOrganization,
+  UPDATE_ORGANIZATION,
+  updateFacility,
+  UPDATE_FACILITY,
+  setPatient,
+  SET_PATIENT,
+} from "./store";
+
+describe("store", () => {
+  let testState: any;
+  let setInitialStateState: any;
+  let updateOrganizationState: any;
+  let updateFacilityState: any;
+  let setPatientState: any;
+  const blankOrganization = {
+    name: "",
+  };
+  const blankPatient = {
+    birthDate: "",
+    firstName: "",
+    internalId: "",
+    isDeleted: false,
+    lastName: "",
+    lastTest: {
+      dateAdded: "",
+      dateTested: "",
+      deviceTypeModel: "",
+      deviceTypeName: "",
+      result: "UNDETERMINED",
+    },
+    middleName: "",
+    role: "",
+  };
+  const blankUser = {
+    email: "",
+    firstName: "",
+    id: "",
+    isAdmin: false,
+    lastName: "",
+    middleName: "",
+    permissions: [],
+    roleDescription: "",
+    suffix: "",
+  };
+  const reduxState = {
+    dataLoaded: false,
+    facilities: [],
+    organization: blankOrganization,
+    patient: blankPatient,
+    user: blankUser,
+  };
+  setInitialStateState = {
+    type: SET_INITIAL_STATE,
+    payload: reduxState,
+  };
+  updateOrganizationState = {
+    type: UPDATE_ORGANIZATION,
+    payload: reduxState,
+  };
+  updateFacilityState = {
+    type: UPDATE_FACILITY,
+    payload: reduxState,
+  };
+  setPatientState = {
+    type: SET_PATIENT,
+    payload: reduxState,
+  };
+
+  beforeEach(() => {
+    testState = reduxState;
+    testState["organization"] = blankOrganization;
+    testState["patient"] = blankPatient;
+  });
+
+  it("should return initial state with type SET_INITIAL_STATE type and initialState payload", () => {
+    expect(setInitialState(initialState)).toEqual(setInitialStateState);
+  });
+  it("should return initial state with UPDATE_ORGANIZATION type and organization payload", () => {
+    expect(updateOrganization(initialState)).toEqual(updateOrganizationState);
+  });
+  it("should return initial state with UPDATE_FACILITY type and facility payload", () => {
+    expect(updateFacility(initialState)).toEqual(updateFacilityState);
+  });
+  it("should return initial state with SET_PATIENT type and patient payload", () => {
+    expect(setPatient(initialState)).toEqual(setPatientState);
+  });
+  it("should return initial state if type does not match", () => {
+    const brokenState = { brokenKey: "useless value" };
+    const action = { type: "A_TYPE_THAT_WE_DO_NOT_USE", payload: brokenState };
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should return the initial state", () => {
+    const action = { type: SET_INITIAL_STATE, payload: initialState };
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should update an organization", () => {
+    const organizationPayload = { name: "myNewName" };
+    const action = { type: UPDATE_ORGANIZATION, payload: organizationPayload };
+    testState["organization"] = organizationPayload;
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should add a facility", () => {
+    const facilityPayload = { id: "8675309", name: "myFacilityName" };
+    const payload = facilityPayload as Facility;
+    const action = { type: UPDATE_FACILITY, payload: payload };
+    testState["facilities"] = [payload];
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should update a facility", () => {
+    const facilityPayload = { id: "8675309", name: "myUpdatedFacilityName" };
+    const payload = facilityPayload as Facility;
+    const action = { type: UPDATE_FACILITY, payload: payload };
+    testState["facilities"] = [payload];
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+  it("should update a patient", () => {
+    const patientPayload = {
+      birthDate: "1999-01-01",
+      firstName: "Jill",
+      internalId: "42",
+      isDeleted: true,
+      lastName: "Mad Titan",
+      lastTest: {
+        dateAdded: "2001-01-01",
+        dateTested: "2002-01-01",
+        deviceTypeModel: "unknown",
+        result: "CONTAGIOUS",
+      },
+      middleName: "The",
+      role: "Star",
+    };
+    const action = { type: SET_PATIENT, payload: patientPayload };
+    testState["patient"] = patientPayload;
+    expect(reducers(undefined, action)).toEqual(testState);
+  });
+});

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -3,13 +3,14 @@ import { createStore } from "redux";
 import { COVID_RESULTS } from "../app/constants";
 import { UserPermission } from "../generated/graphql";
 
-const SET_INITIAL_STATE = "SET_INITIAL_STATE";
-const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
-const SET_PATIENT = "SET_PATIENT";
+export const SET_INITIAL_STATE = "SET_INITIAL_STATE";
+export const UPDATE_ORGANIZATION = "UPDATE_ORGANIZATION";
+export const UPDATE_FACILITY = "UPDATE_FACILITY";
+export const SET_PATIENT = "SET_PATIENT";
 
 // this should be the default value for a brand new org
 // TODO: get the fields from a schema or something; hard-coded fields are hard to maintain
-const initialState = {
+export const initialState = {
   dataLoaded: false,
   organization: {
     name: "",
@@ -59,6 +60,19 @@ const reducers = (state = initialState, action: any) => {
           ...action.payload,
         },
       };
+    case UPDATE_FACILITY:
+      const facilityIndex = state.facilities.findIndex(
+        (f) => f.id === action.payload.id
+      );
+      if (facilityIndex > -1) {
+        state.facilities[facilityIndex] = action.payload;
+      } else {
+        state.facilities.push(action.payload);
+      }
+      return {
+        ...state,
+        facilities: state.facilities,
+      };
     case SET_PATIENT:
       return {
         ...state,
@@ -85,6 +99,13 @@ export const updateOrganization = (organization: any) => {
   };
 };
 
+export const updateFacility = (facility: any) => {
+  return {
+    type: UPDATE_FACILITY,
+    payload: facility,
+  };
+};
+
 export const setPatient = (patient: any) => {
   return {
     type: SET_PATIENT,
@@ -104,3 +125,5 @@ const configureStore = () => {
 export const store = configureStore();
 
 export type RootState = ReturnType<typeof store.getState>;
+
+export default reducers;

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -124,7 +124,7 @@ export type Facility = {
 
 export type Mutation = {
   __typename?: "Mutation";
-  addFacility?: Maybe<Scalars["String"]>;
+  addFacility?: Maybe<Facility>;
   addFacilityNew?: Maybe<Scalars["String"]>;
   addPatient?: Maybe<Patient>;
   addPatientToQueue?: Maybe<Scalars["String"]>;
@@ -157,7 +157,7 @@ export type Mutation = {
   setRegistrationLinkIsDeleted?: Maybe<Scalars["String"]>;
   setUserIsDeleted?: Maybe<User>;
   updateDeviceType?: Maybe<DeviceType>;
-  updateFacility?: Maybe<Scalars["String"]>;
+  updateFacility?: Maybe<Facility>;
   updateFacilityNew?: Maybe<Scalars["String"]>;
   updateOrganization?: Maybe<Scalars["String"]>;
   updatePatient?: Maybe<Patient>;
@@ -172,10 +172,7 @@ export type Mutation = {
 export type MutationAddFacilityArgs = {
   city?: Maybe<Scalars["String"]>;
   cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  defaultDevice: Scalars["String"];
-  deviceSpecimenTypes?: Maybe<Array<Maybe<Scalars["ID"]>>>;
-  deviceTypes: Array<Maybe<Scalars["String"]>>;
+  deviceIds: Array<Maybe<Scalars["ID"]>>;
   email?: Maybe<Scalars["String"]>;
   orderingProviderCity?: Maybe<Scalars["String"]>;
   orderingProviderCounty?: Maybe<Scalars["String"]>;
@@ -455,10 +452,7 @@ export type MutationUpdateDeviceTypeArgs = {
 export type MutationUpdateFacilityArgs = {
   city?: Maybe<Scalars["String"]>;
   cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  defaultDevice: Scalars["String"];
-  deviceSpecimenTypes?: Maybe<Array<Maybe<Scalars["ID"]>>>;
-  deviceTypes: Array<Maybe<Scalars["String"]>>;
+  deviceIds: Array<Maybe<Scalars["ID"]>>;
   email?: Maybe<Scalars["String"]>;
   facilityId: Scalars["ID"];
   orderingProviderCity?: Maybe<Scalars["String"]>;
@@ -1054,7 +1048,7 @@ export type UpdateFacilityMutationVariables = Exact<{
 
 export type UpdateFacilityMutation = {
   __typename?: "Mutation";
-  updateFacilityNew?: Maybe<string>;
+  updateFacility?: Maybe<{ __typename?: "Facility"; id: string }>;
 };
 
 export type AddFacilityMutationVariables = Exact<{
@@ -1083,7 +1077,7 @@ export type AddFacilityMutationVariables = Exact<{
 
 export type AddFacilityMutation = {
   __typename?: "Mutation";
-  addFacilityNew?: Maybe<string>;
+  addFacility?: Maybe<{ __typename?: "Facility"; id: string }>;
 };
 
 export type GetManagedFacilitiesQueryVariables = Exact<{
@@ -1094,7 +1088,7 @@ export type GetManagedFacilitiesQuery = {
   __typename?: "Query";
   organization?: Maybe<{
     __typename?: "Organization";
-    testingFacility: Array<{
+    facilities: Array<{
       __typename?: "Facility";
       id: string;
       cliaNumber?: Maybe<string>;
@@ -2324,7 +2318,7 @@ export const UpdateFacilityDocument = gql`
     $orderingProviderPhone: String
     $devices: [ID]!
   ) {
-    updateFacilityNew(
+    updateFacility(
       facilityId: $facilityId
       testingFacilityName: $testingFacilityName
       cliaNumber: $cliaNumber
@@ -2347,7 +2341,9 @@ export const UpdateFacilityDocument = gql`
       orderingProviderZipCode: $orderingProviderZipCode
       orderingProviderPhone: $orderingProviderPhone
       deviceIds: $devices
-    )
+    ) {
+      id
+    }
   }
 `;
 export type UpdateFacilityMutationFn = Apollo.MutationFunction<
@@ -2437,7 +2433,7 @@ export const AddFacilityDocument = gql`
     $orderingProviderPhone: String
     $devices: [ID]!
   ) {
-    addFacilityNew(
+    addFacility(
       testingFacilityName: $testingFacilityName
       cliaNumber: $cliaNumber
       street: $street
@@ -2459,7 +2455,9 @@ export const AddFacilityDocument = gql`
       orderingProviderZipCode: $orderingProviderZipCode
       orderingProviderPhone: $orderingProviderPhone
       deviceIds: $devices
-    )
+    ) {
+      id
+    }
   }
 `;
 export type AddFacilityMutationFn = Apollo.MutationFunction<
@@ -2527,7 +2525,7 @@ export type AddFacilityMutationOptions = Apollo.BaseMutationOptions<
 export const GetManagedFacilitiesDocument = gql`
   query GetManagedFacilities {
     organization {
-      testingFacility {
+      facilities {
         id
         cliaNumber
         name


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2828

## Changes Proposed

- Add or Update facilities in the store after saving.
- Do not cache Facilities on the manage facilities page
- Backwards compatible

## Screenshots / Demos

## Checklist for Author and Reviewer

### UI
- [ ] Any changes to the UI/UX are approved by design 
- [ ] Any new or updated content (e.g. error messages) are approved by design 

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
