### PR TITLE
Extend CURL_TIMEOUT from 2 seconds to 20 seconds.

### DIFF
--- a/ops/Makefile
+++ b/ops/Makefile
@@ -7,7 +7,7 @@ SOURCE_SLOT?=staging
 TARGET_SLOT?=production
 DEPLOYED_COMMIT?=$(shell git show --abbrev=7 -s --pretty=%h)
 RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
-CURL_TIMEOUT?=2
+CURL_TIMEOUT?=20
 
 # Internal DRYing (also overrideable if you are sufficiently desperate)
 API_NAME=simple-report-api-$*


### PR DESCRIPTION
## Related Issue or Background Info

- Related issue: #3207 
- A short `curl` time can cause deployments to fail outright, particularly if frontend changes that require additional loading time arise, or if there is any delay with and part of the infrastructure.

## Changes Proposed

- Increase `CURL_TIMEOUT` from 2 seconds to 20 seconds.
- This change allows for more resiliency before a deployment failure, while retaining the capability of quick failure if something is irrecoverably wrong with the deployment itself.

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**
