### PR TITLE
Don't associate the VMs subnet with the NAT gateway

### DIFF
--- a/ops/services/nat_gateway/main.tf
+++ b/ops/services/nat_gateway/main.tf
@@ -39,8 +39,3 @@ resource "azurerm_subnet_nat_gateway_association" "outbound_lb" {
   subnet_id      = var.subnet_lb_id
   nat_gateway_id = azurerm_nat_gateway.outbound.id
 }
-
-resource "azurerm_subnet_nat_gateway_association" "outbound_vm" {
-  subnet_id      = var.subnet_vm_id
-  nat_gateway_id = azurerm_nat_gateway.outbound.id
-}


### PR DESCRIPTION
## Related Issue or Background Info

When we enabled static outbound IPs in #2882, we associated all of our existing VNet subnets with that gateway. This turned out not to work for VMs, because it forced them to use a static IP, which didn't play well with IP auto-creation during the VM creation process.

## Changes Proposed

- Don't associate the VMs subnet with the NAT gateway. Our outbound traffic to Experian doesn't originate from this subnet so it's okay not to have a fixed outbound IP address here.