### PR TITLE
Add Application Insights quotas to Terraform

### DIFF
--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -24,6 +24,8 @@ module "monitoring" {
 
   app_url = "${local.env}.simplereport.gov"
 
+  daily_data_cap_in_gb = 200
+
   tags = local.management_tags
 }
 

--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -24,7 +24,7 @@ module "monitoring" {
 
   app_url = "${local.env}.simplereport.gov"
 
-  daily_data_cap_in_gb = 200
+  ai_ingest_cap_gb = 200
 
   tags = local.management_tags
 }

--- a/ops/services/monitoring/_var.tf
+++ b/ops/services/monitoring/_var.tf
@@ -30,7 +30,7 @@ variable "app_url" {
 
 variable "ai_ingest_cap_gb" {
   description = "Cap for data ingested into Application Insights, per day."
-  default     = 100
+  default     = 50
 }
 
 variable "ai_retention_days" {

--- a/ops/services/monitoring/_var.tf
+++ b/ops/services/monitoring/_var.tf
@@ -27,3 +27,13 @@ variable "app_url" {
   description = "test that the app_url is running."
   default     = "simplereport.cdc.gov"
 }
+
+variable "ai_ingest_cap_gb" {
+  description = "Cap for data ingested into Application Insights, per day."
+  default     = 100
+}
+
+variable "ai_retention_days" {
+  description = "Number of days to retain Application Insights data."
+  default     = 90
+}

--- a/ops/services/monitoring/main.tf
+++ b/ops/services/monitoring/main.tf
@@ -1,7 +1,5 @@
 locals {
   is_prod = var.env == "prod"
-  // This is commented out until we actually have production deployments. Right now, it's just set to test that simplereport.cdc.gov is running.
-  //  app_url = local.is_prod ? "simplereport.cdc.gov" : "${var.env}.simplereport.cdc.gov"
 }
 
 data "azurerm_log_analytics_workspace" "law" {

--- a/ops/services/monitoring/main.tf
+++ b/ops/services/monitoring/main.tf
@@ -17,5 +17,8 @@ resource "azurerm_application_insights" "app_insights" {
   name                = "prime-simple-report-${var.env}-insights"
   disable_ip_masking  = true
 
+  daily_data_cap_in_gb = var.ai_ingest_cap_gb
+  retention_in_days    = var.ai_retention_days
+
   tags = var.tags
 }


### PR DESCRIPTION
## Related Issue or Background Info

- Addresses part of the acceptance criteria for #3195.

## Changes Proposed

- Encapsulate daily ingest quota and retention values, with desired defaults.
- Override production default to reflect its current setting of 200 GB/day.

## Additional Information

- Full argument reference: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
