### PR TITLE
add specimen_type_id on test_event and test_order DB

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3264,3 +3264,43 @@ databaseChangeLog:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
               UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+  - changeSet:
+      id: add-specimen_type-to-test_event
+      author: zedd@skylight.digital
+      comment: add specimen_type_id to test event
+      changes:
+        - tagDatabase:
+            tag: add-specimen_type-to-test_event
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: specimen_type_id
+                  afterColumn: device_type_id
+                  valueComputed: (select specimen_type_id from ${database.defaultSchemaName}.device_specimen_type dst where dst.internal_id = device_specimen_type_id)
+                  remarks: The specimen type for this test event.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__test_event__specimen_type
+                    references: specimen_type(internal_id)
+  - changeSet:
+      id: add-specimen_type-to-test_order
+      author: zedd@skylight.digital
+      comment: add specimen_type_id to test order
+      changes:
+        - tagDatabase:
+            tag: add-specimen_type-to-test_order
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: specimen_type_id
+                  afterColumn: device_type_id
+                  valueComputed: (select specimen_type_id from ${database.defaultSchemaName}.device_specimen_type dst where dst.internal_id = device_specimen_type_id)
+                  remarks: The specimen type for this test order.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__test_order__specimen_type
+                    references: specimen_type(internal_id)

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3304,3 +3304,21 @@ databaseChangeLog:
                     nullable: true
                     foreignKeyName: fk__test_order__specimen_type
                     references: specimen_type(internal_id)
+  - changeSet:
+      id: add-default_specimen_type_id-to-facility
+      author: zedd@skylight.digital
+      comment: add specimen_type_id to facility
+      changes:
+        - tagDatabase:
+            tag: add-default_specimen_type_id-to-facility
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_specimen_type_id
+                  remarks: The default specimen type (if any) for tests at this facility.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__facility__default_specimen_type
+                    references: specimen_type(internal_id)


### PR DESCRIPTION
## Related Issue or Background Info

- #3222
- #3228

this is addressing an issue where currently you can delete a `deviceSpecimenType`  through the 
Manage Devices - support admin UI

Given that the `deviceSpecimenType` is used as a joinTable 
https://github.com/CDCgov/prime-simplereport/blob/0e893a8fbab76d900dd79e4a31ada4565923bde4/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java#L34 

This makes #3228 basically impossible since there is no support to filter on a joint table

So the fix is to make our App not use `deviceSpecimenType` as a dataType and treat is as a joint table


there are 3 used tables in the app that reference the `deviceSpecimenType`, 

1. `TestEvent`
2. `TestOrder`
3. `Facility` defaultDeviceSpecimenType


## Changes Proposed

- given that  `TestEvent` and `TestOrder` already contain `device_type_id`
- add `specimen_type_id` to `TestEvent` and `TestOrder` and populate them with the values from `deviceSpecimenType` **(THIS PR)**
- add `default_specimen_type_id` to Facility  **(THIS PR)**
- Then delete deviceSpecimenType from  `TestEvent`, `TestOrder` And `Facility` **(FUTURE PR)**

## Additional Information

- This PR splits the DB migration and code changes
  - we push the db migration that creates and populates specimen_type_id
  - Any new entries to `TestEvent` and `TestOrder` will not have  `specimen_type_id` populated then

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
