### PR TITLE
P3: populate `specimen_type` for `test_order`, `test_event` and `facility` from `device_specimen_type`

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3320,3 +3320,40 @@ databaseChangeLog:
                     nullable: true
                     foreignKeyName: fk__facility__default_specimen_type
                     references: specimen_type(internal_id)
+  - changeSet:
+      id: populate-test_event-specimen_type_id
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: populate-test_event-specimen_type_id
+        - sql:
+            remarks: Populate test_event.specimen_type_id from test_event.device_specimen_type
+            sql: |
+              update ${database.defaultSchemaName}.test_event
+              set specimen_type_id=(select specimen_type_id from ${database.defaultSchemaName}.device_specimen_type dst where dst.internal_id = device_specimen_type_id)
+              where test_event.device_specimen_type_id is not null and specimen_type_id is null
+  - changeSet:
+      id: populate-test_order-specimen_type_id
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: populate-test_event-specimen_type_id
+        - sql:
+            remarks: Populate test_order.specimen_type_id from test_order.device_specimen_type
+            sql: |
+              update ${database.defaultSchemaName}.test_order
+              set specimen_type_id=(select specimen_type_id from ${database.defaultSchemaName}.device_specimen_type dst where dst.internal_id = device_specimen_type_id)
+              where test_order.device_specimen_type_id is not null and specimen_type_id is null
+  - changeSet:
+      id: populate-facility-default_specimen_type_id
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: populate-test_event-specimen_type_id
+        - sql:
+            remarks: Populate test_order.specimen_type_id from test_order.device_specimen_type
+            sql: |
+              update ${database.defaultSchemaName}.facility
+              set default_specimen_type_id=(select specimen_type_id from ${database.defaultSchemaName}.device_specimen_type dst where dst.internal_id = default_device_specimen_type_id),
+                  default_device_type_id=(select device_type_id from ${database.defaultSchemaName}.device_specimen_type dst where dst.internal_id = default_device_specimen_type_id)
+              where facility.default_device_specimen_type_id is not null

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3337,7 +3337,7 @@ databaseChangeLog:
       author: zedd@skylight.digital
       changes:
         - tagDatabase:
-            tag: populate-test_event-specimen_type_id
+            tag: populate-test_order-specimen_type_id
         - sql:
             remarks: Populate test_order.specimen_type_id from test_order.device_specimen_type
             sql: |
@@ -3349,7 +3349,7 @@ databaseChangeLog:
       author: zedd@skylight.digital
       changes:
         - tagDatabase:
-            tag: populate-test_event-specimen_type_id
+            tag: populate-facility-default_specimen_type_id
         - sql:
             remarks: Populate test_order.specimen_type_id from test_order.device_specimen_type
             sql: |


### PR DESCRIPTION
## Related Issue or Background Info

- #3222
- #3228

this is addressing an issue where currently you can delete a `deviceSpecimenType`  through the
Manage Devices - support admin UI

Given that the `deviceSpecimenType` is used as a joinTable
https://github.com/CDCgov/prime-simplereport/blob/0e893a8fbab76d900dd79e4a31ada4565923bde4/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java#L34

This makes #3228 basically impossible since there is no support to filter on a joint table

So the fix is to make our App not use `deviceSpecimenType` as a dataType and treat it as a joint table


there are 3 used tables in the app that reference the `deviceSpecimenType`,

1. `TestEvent`
2. `TestOrder`
3. `Facility` defaultDeviceSpecimenType


## Changes Proposed

- given that  `TestEvent` and `TestOrder` already contain `device_type_id`
- add `specimen_type_id` to `TestEvent` and `TestOrder` and populate them with the values from `deviceSpecimenType` **([PR1](https://github.com/CDCgov/prime-simplereport/pull/3244))**
- add `default_specimen_type_id` to Facility  **([PR1](https://github.com/CDCgov/prime-simplereport/pull/3244))**

- change app code to start using the new columns **(FUTURE PR)**
- populate `Facility.default_specimen_type_id` and `TestEvent.specimen_type_id` and `TestOrder.specimen_type_id` **(THIS PR)**

- Then delete deviceSpecimenType from  `TestEvent`, `TestOrder` And `Facility` **(FUTURE PR)**

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
