### PR TITLE
P2: add specimen type to order test events app changes

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -35,6 +35,10 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   @JoinColumn(name = "device_type_id")
   private DeviceType deviceType;
 
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  @JoinColumn(name = "specimen_type_id")
+  private SpecimenType specimenType;
+
   @Column(nullable = true)
   @Type(type = "pg_enum")
   @Enumerated(EnumType.STRING)
@@ -66,6 +70,7 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     this.organization = facility.getOrganization();
     this.deviceSpecimen = deviceSpecimen;
     this.deviceType = deviceSpecimen.getDeviceType();
+    this.specimenType = deviceSpecimen.getSpecimenType();
     this.result = result;
     this.correctionStatus = TestCorrectionStatus.ORIGINAL;
   }
@@ -98,6 +103,10 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     return deviceType;
   }
 
+  public SpecimenType getSpecimenType() {
+    return specimenType;
+  }
+
   public DeviceSpecimenType getDeviceSpecimen() {
     return deviceSpecimen;
   }
@@ -125,6 +134,7 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   protected void setDeviceSpecimen(DeviceSpecimenType deviceSpecimen) {
     this.deviceSpecimen = deviceSpecimen;
     this.deviceType = deviceSpecimen.getDeviceType();
+    this.specimenType = deviceSpecimen.getSpecimenType();
   }
 
   public TestCorrectionStatus getCorrectionStatus() {

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3264,3 +3264,59 @@ databaseChangeLog:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
               UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+  - changeSet:
+      id: add-specimen_type-to-test_event
+      author: zedd@skylight.digital
+      comment: add specimen_type_id to test event
+      changes:
+        - tagDatabase:
+            tag: add-specimen_type-to-test_event
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: specimen_type_id
+                  afterColumn: device_type_id
+                  remarks: The specimen type for this test event.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__test_event__specimen_type
+                    references: specimen_type(internal_id)
+  - changeSet:
+      id: add-specimen_type-to-test_order
+      author: zedd@skylight.digital
+      comment: add specimen_type_id to test order
+      changes:
+        - tagDatabase:
+            tag: add-specimen_type-to-test_order
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: specimen_type_id
+                  afterColumn: device_type_id
+                  remarks: The specimen type for this test order.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__test_order__specimen_type
+                    references: specimen_type(internal_id)
+  - changeSet:
+      id: add-default_specimen_type_id-to-facility
+      author: zedd@skylight.digital
+      comment: add specimen_type_id to facility
+      changes:
+        - tagDatabase:
+            tag: add-default_specimen_type_id-to-facility
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_specimen_type_id
+                  remarks: The default specimen type (if any) for tests at this facility.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__facility__default_specimen_type
+                    references: specimen_type(internal_id)


### PR DESCRIPTION
## Related Issue or Background Info

- #3222
- #3228

this is addressing an issue where currently you can delete a `deviceSpecimenType`  through the
Manage Devices - support admin UI

Given that the `deviceSpecimenType` is used as a joinTable
https://github.com/CDCgov/prime-simplereport/blob/0e893a8fbab76d900dd79e4a31ada4565923bde4/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java#L34

This makes #3228 basically impossible since there is no support to filter on a joint table

So the fix is to make our App not use `deviceSpecimenType` as a dataType and treat is as a joint table


there are 3 used tables in the app that reference the `deviceSpecimenType`,

1. `TestEvent`
2. `TestOrder`
3. `Facility` defaultDeviceSpecimenType


## Changes Proposed

- given that  `TestEvent` and `TestOrder` already contain `device_type_id`
- add `specimen_type_id` to `TestEvent` and `TestOrder` and populate them with the values from `deviceSpecimenType` **[(P1)](https://github.com/CDCgov/prime-simplereport/pull/3244)**
- add `default_specimen_type_id` to Facility  **[(P1)](https://github.com/CDCgov/prime-simplereport/pull/3244)**

- change app code to start using the new columns **(THIS PR)**
- populate `Facility.default_specimen_type_id` and `TestEvent.specimen_type_id` and `TestOrder.specimen_type_id` **[(P3)](https://github.com/CDCgov/prime-simplereport/pull/3245)**

- Then delete deviceSpecimenType from  `TestEvent`, `TestOrder` And `Facility` **(FUTURE PR)**

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
