### PR TITLE
extend the patient link life to 10 days and lockout attempts to 10

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLink.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLink.java
@@ -12,7 +12,7 @@ import javax.persistence.ManyToOne;
 
 @Entity
 public class PatientLink extends EternalAuditedEntity {
-  private static final int SHELF_LIFE = 5;
+  private static final int SHELF_LIFE = 10;
 
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "test_order_id", nullable = false)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLinkFailedAttempt.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientLinkFailedAttempt.java
@@ -10,7 +10,7 @@ import javax.persistence.OneToOne;
 
 @Entity
 public class PatientLinkFailedAttempt {
-  public static final byte LOCKOUT_THRESHOLD = 5;
+  public static final byte LOCKOUT_THRESHOLD = 10;
 
   @Id private UUID patientLinkInternalId;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
@@ -65,7 +65,7 @@ class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
 
   @Test
   void getPatientLinkSelfLife() {
-    assertEquals(5, _patientLink.getShelfLife());
+    assertEquals(10, _patientLink.getShelfLife());
   }
 
   @Test
@@ -133,6 +133,13 @@ class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
     assertFalse(failToVerify.getAsBoolean());
     assertFalse(failToVerify.getAsBoolean());
     assertFalse(failToVerify.getAsBoolean());
+
+    assertFalse(failToVerify.getAsBoolean());
+    assertFalse(failToVerify.getAsBoolean());
+    assertFalse(failToVerify.getAsBoolean());
+    assertFalse(failToVerify.getAsBoolean());
+    assertFalse(failToVerify.getAsBoolean());
+
     assertThrows(
         ExpiredPatientLinkException.class,
         () -> _service.verifyPatientLink(patientId, patientBirthDate));


### PR DESCRIPTION
## Related Issue or Background Info

- addresses #3247

## Changes Proposed

- extend the patient link life to 10 days 
- extend lockout attempts to 10

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
