### PR TITLE
Stop alerting on audit_log events for now

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -261,12 +261,12 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_t
   query = <<-QUERY
 dependencies
 ${local.skip_on_weekends}
-| where timestamp >= ago(5m) and name has "SQL:" and duration > 1250
+| where timestamp >= ago(5m) and name startswith "SQL:" and duration > 1250 and data !startswith "insert into public.api_audit_event"
   QUERY
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 10
+    threshold = 25
   }
 
   action {


### PR DESCRIPTION
## Related Issue or Background Info

Our audit log alerts are getting out of control and they're currently non-actionable.

## Changes Proposed

- Up the DB slow query alert threshold to 25 (we have a lot more traffic than before)
- Remove alerts pertaining to inserts into the audit log
