### PR TITLE
Include country in add patient mutation; add Canadian state/zip selection

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -281,13 +281,16 @@ public class Translators {
           "MS", "MT", "NC", "ND", "NE", "NH", "NJ", "NM", "NV", "NY", "OH", "OK", "OR", "PA", "PR",
           "PW", "RI", "SC", "SD", "TN", "TX", "UT", "VA", "VI", "VT", "WA", "WI", "WV", "WY", "NA");
 
+  private static final Set<String> CANADIAN_STATE_CODES =
+      Set.of("AB", "BC", "MB", "NB", "NL", "NT", "NS", "NU", "ON", "PE", "QC", "SK", "YT");
+
   public static String parseState(String s) {
     String state = parseString(s);
     if (state == null) {
       return null;
     }
     state = state.toUpperCase();
-    if (STATE_CODES.contains(state)) {
+    if (STATE_CODES.contains(state) || CANADIAN_STATE_CODES.contains(state)) {
       return state;
     }
     throw IllegalGraphqlArgumentException.invalidInput(s, "state");

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -221,10 +221,18 @@ describe("AddPatient", () => {
         expect(await screen.findByText("State")).toBeInTheDocument();
         expect(await screen.findByText("ZIP code")).toBeInTheDocument();
       });
-      it("should hide the state and zip code inputs for non-US countries", async () => {
+      it("should show the state and zip code inputs for Canada", async () => {
         userEvent.selectOptions(
           screen.getByLabelText("Country", { exact: false }),
           "CAN"
+        );
+        expect(await screen.findByText("State")).toBeInTheDocument();
+        expect(await screen.findByText("ZIP code")).toBeInTheDocument();
+      });
+      it("should hide the state and zip code inputs for non-US countries", async () => {
+        userEvent.selectOptions(
+          screen.getByLabelText("Country", { exact: false }),
+          "MEX"
         );
         expect(screen.queryByText("State")).not.toBeInTheDocument();
         expect(screen.queryByText("ZIP code")).not.toBeInTheDocument();

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -229,6 +229,20 @@ describe("AddPatient", () => {
         expect(await screen.findByText("State")).toBeInTheDocument();
         expect(await screen.findByText("ZIP code")).toBeInTheDocument();
       });
+      it("should show different states for Canada", async () => {
+        userEvent.selectOptions(
+          screen.getByLabelText("Country", { exact: false }),
+          "CAN"
+        );
+
+        let stateInput: HTMLSelectElement;
+        stateInput = screen.getByLabelText("State", {
+          exact: false,
+        }) as HTMLSelectElement;
+
+        userEvent.selectOptions(stateInput, "QC");
+        expect(stateInput.value).toBe("QC");
+      });
       it("should hide the state and zip code inputs for non-US countries", async () => {
         userEvent.selectOptions(
           screen.getByLabelText("Country", { exact: false }),

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -79,6 +79,7 @@ export const ADD_PATIENT = gql`
     $city: String
     $state: String!
     $zipCode: String!
+    $country: String!
     $telephone: String
     $phoneNumbers: [PhoneNumberInput!]
     $role: String
@@ -105,6 +106,7 @@ export const ADD_PATIENT = gql`
       city: $city
       state: $state
       zipCode: $zipCode
+      country: $country
       telephone: $telephone
       phoneNumbers: $phoneNumbers
       role: $role

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -4,7 +4,11 @@ import { SchemaOf } from "yup";
 import { useTranslation } from "react-i18next";
 import { ComboBox } from "@trussworks/react-uswds";
 
-import { countryOptions, stateCodes } from "../../../config/constants";
+import {
+  canadianProvinceCodes,
+  countryOptions,
+  stateCodes,
+} from "../../../config/constants";
 import getLanguages from "../../utils/languages";
 import i18n from "../../../i18n";
 import {
@@ -188,6 +192,7 @@ const PersonForm = (props: Props) => {
     // If a patient has an international address, use special values for state and zip code
     if (field === "country") {
       setFormChanged(true);
+
       if (value !== "USA") {
         setPatient({
           ...patient,
@@ -493,6 +498,39 @@ const PersonForm = (props: Props) => {
                   name="state"
                   value={patient.state || ""}
                   options={stateCodes.map((c) => ({ label: c, value: c }))}
+                  defaultOption={t("common.defaultDropdownOption")}
+                  defaultSelect
+                  onChange={onPersonChange("state")}
+                  onBlur={() => {
+                    onBlurField("state");
+                  }}
+                  validationStatus={validationStatus("state")}
+                  errorMessage={errors.state}
+                  required
+                />
+              </div>
+              <div className="mobile-lg:grid-col-6">
+                <Input
+                  {...commonInputProps}
+                  field="zipCode"
+                  label={t("patient.form.contact.zip")}
+                  required
+                />
+              </div>
+            </div>
+          ) : null}
+          {/*this is working on the frontend but it's not saving correctly - I assume there's some kind of auto-loader that checks the user's zip code and loads US based on that */}
+          {patient.country === "CAN" ? (
+            <div className="grid-row grid-gap">
+              <div className="mobile-lg:grid-col-6">
+                <Select
+                  label={t("patient.form.contact.state")}
+                  name="state"
+                  value={patient.state || ""}
+                  options={canadianProvinceCodes.map((c) => ({
+                    label: c,
+                    value: c,
+                  }))}
                   defaultOption={t("common.defaultDropdownOption")}
                   defaultSelect
                   onChange={onPersonChange("state")}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -519,7 +519,6 @@ const PersonForm = (props: Props) => {
               </div>
             </div>
           ) : null}
-          {/*this is working on the frontend but it's not saving correctly - I assume there's some kind of auto-loader that checks the user's zip code and loads US based on that */}
           {patient.country === "CAN" ? (
             <div className="grid-row grid-gap">
               <div className="mobile-lg:grid-col-6">

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -105,6 +105,24 @@ export const states = {
 
 export const stateCodes = Object.keys(states);
 
+export const canadianProvinces = {
+  AB: "Alberta",
+  BC: "British Columbia",
+  MB: "Manitoba",
+  NB: "New Brunswick",
+  NL: "Newfoundland and Labrador",
+  NT: "Northwest Territories",
+  NS: "Nova Scotia",
+  NU: "Nunavut",
+  ON: "Ontario",
+  PE: "Prince Edward Island",
+  QC: "Quebec",
+  SK: "Saskatchewan",
+  YT: "Yukon",
+};
+
+export const canadianProvinceCodes = Object.keys(canadianProvinces);
+
 export const countries = {
   AFG: "Afghanistan",
   ALB: "Albania",

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1331,6 +1331,7 @@ export type AddPatientMutationVariables = Exact<{
   city?: Maybe<Scalars["String"]>;
   state: Scalars["String"];
   zipCode: Scalars["String"];
+  country: Scalars["String"];
   telephone?: Maybe<Scalars["String"]>;
   phoneNumbers?: Maybe<Array<PhoneNumberInput> | PhoneNumberInput>;
   role?: Maybe<Scalars["String"]>;
@@ -3564,6 +3565,7 @@ export const AddPatientDocument = gql`
     $city: String
     $state: String!
     $zipCode: String!
+    $country: String!
     $telephone: String
     $phoneNumbers: [PhoneNumberInput!]
     $role: String
@@ -3590,6 +3592,7 @@ export const AddPatientDocument = gql`
       city: $city
       state: $state
       zipCode: $zipCode
+      country: $country
       telephone: $telephone
       phoneNumbers: $phoneNumbers
       role: $role
@@ -3640,6 +3643,7 @@ export type AddPatientMutationFn = Apollo.MutationFunction<
  *      city: // value for 'city'
  *      state: // value for 'state'
  *      zipCode: // value for 'zipCode'
+ *      country: // value for 'country'
  *      telephone: // value for 'telephone'
  *      phoneNumbers: // value for 'phoneNumbers'
  *      role: // value for 'role'


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #3201 

## Changes Proposed

- add a list of Canadian provinces as the dropdown when CAN is selected as the patient country
- fix add patient frontend to correctly store patient country

## Screenshots / Demos

![Screen Shot 2022-01-24 at 3 22 09 PM](https://user-images.githubusercontent.com/80282552/150881666-61c8fee5-37de-404e-a685-db5704be6e73.png)

![Screen Shot 2022-01-24 at 3 22 13 PM](https://user-images.githubusercontent.com/80282552/150881684-38a1a02d-c12a-4ade-acbf-75b722433a88.png)

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
