### PR TITLE
Return `testLength` subfield of DeviceType in `GetFacilityQueue` query

### DIFF
--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -93,6 +93,7 @@ export const queueQuery = gql`
       deviceType {
         internalId
         name
+        testLength
       }
       specimenType {
         internalId


### PR DESCRIPTION
## Related Issue or Background Info

- Follow-up to #3177 
    - A bug in that patch prevented the test timer from behaving correctly. This fixes the issue.

## Changes Proposed
- Return `testLength` subfield of DeviceType in `GetFacilityQueue` query
    - I thought we were safe here but `DeviceType`s are being pulled in in a couple of places in that query and `testLength` was only present on one - sorry!

## Additional Information
- N/A

## Screenshots / Demos

## Checklist for Author and Reviewer
**BEFORE**
<img width="793" alt="Screen Shot 2022-01-25 at 12 52 14 PM" src="https://user-images.githubusercontent.com/27730981/151032442-ea56e98d-b625-4cfe-ac3d-7be871b37872.png">


**AFTER**
<img width="796" alt="Screen Shot 2022-01-25 at 12 52 37 PM" src="https://user-images.githubusercontent.com/27730981/151032457-816c8bd5-3de3-4104-be22-7ff3232b61b0.png">

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
