### PR TITLE
Increase threshold for 2xx and 4xx to 25.

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -68,7 +68,7 @@ variable "http_response_time_aggregation" {
 
 variable "failed_http_2xx_threshold" {
   // The resource that uses this value doesn't have a >= check, so we need n - 1 here
-  default = 9
+  default = 24
 }
 
 variable "skip_on_weekends" {

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -98,7 +98,7 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_2xx_failed_requests" {
   name                = "${var.env}-api-2xx-failed-requests"
-  description         = "${local.env_title} HTTP Server 2xx Errors (where successful request == false) >= 10"
+  description         = "${local.env_title} HTTP Server 2xx Errors (where successful request == false) >= 25"
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
@@ -126,7 +126,7 @@ ${local.skip_on_weekends}
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
   name                = "${var.env}-api-4xx-errors"
-  description         = "${local.env_title} HTTP Server 4xx Errors (excluding 401s and 410s) >= 10"
+  description         = "${local.env_title} HTTP Server 4xx Errors (excluding 401s and 410s) >= 25"
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
@@ -154,7 +154,7 @@ ${local.skip_on_weekends}
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 9
+    threshold = 24
   }
 
   action {

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -9,7 +9,6 @@ module "metric_alerts" {
   mem_threshold                  = 85
   cpu_window_size                = "PT1H"
   http_response_time_aggregation = "Minimum"
-  failed_http_2xx_threshold      = 14
   skip_on_weekends               = true
   disabled_alerts = [
     "frontend_error_boundary",


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #3274 .

## Changes Proposed

- Increase threshold for 2xx alerts to 25 per 5 minutes.
- Increase threshold for 4xx alerts to 25 per 5 minutes.
- Remove custom threshold for `training` environment, as it no longer appears to be needed.

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**
