### PR TITLE
Make race a required field on the person form

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
@@ -160,7 +160,7 @@ public class UploadService {
                         null, parsePhoneNumber((getRow(row, "PhoneNumber", true)))))),
             parsePersonRole(getRow(row, "Role", false), false),
             parseEmails(List.of(getRow(row, "Email", false))),
-            parseRaceDisplayValue(getRow(row, "Race", false)),
+            parseRaceDisplayValue(getRow(row, "Race", true)),
             parseEthnicity(getRow(row, "Ethnicity", false)),
             null,
             parseGender(getRow(row, "biologicalSex", true)),

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
@@ -161,7 +161,7 @@ public class UploadService {
             parsePersonRole(getRow(row, "Role", false), false),
             parseEmails(List.of(getRow(row, "Email", false))),
             parseRaceDisplayValue(getRow(row, "Race", true)),
-            parseEthnicity(getRow(row, "Ethnicity", false)),
+            parseEthnicity(getRow(row, "Ethnicity", true)),
             null,
             parseGender(getRow(row, "biologicalSex", true)),
             parseYesNo(getRow(row, "residentCongregateSetting", true)),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -146,7 +146,37 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   }
 
   @Test
-  void testInvalidRace() {
+  void testNoEthnicity() {
+    // GIVEN
+    InputStream inputStream = loadCsv("test-upload-no-ethnicity.csv");
+
+    // WHEN
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
+
+    // THEN
+    assertThat(error.getMessage()).isEqualTo("Error on row 1; Ethnicity is required.");
+  }
+
+  @Test
+  void testInvalidEthnicity() {
+    // GIVEN
+    InputStream inputStream = loadCsv("test-upload-invalid-ethnicity.csv");
+
+    // WHEN
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
+
+    // THEN
+    assertThat(error.getMessage())
+        .isEqualTo(
+            "Error on row 1; \"InvalidEthnicity\" must be one of [refused, hispanic, not_hispanic]");
+  }
+
+  @Test
+  void testNoRace() {
     // GIVEN
     InputStream inputStream = loadCsv("test-upload-no-race.csv");
 
@@ -157,6 +187,22 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
 
     // THEN
     assertThat(error.getMessage()).isEqualTo("Error on row 1; Race is required.");
+  }
+
+  @Test
+  void testInvalidRace() {
+    // GIVEN
+    InputStream inputStream = loadCsv("test-upload-invalid-race.csv");
+
+    // WHEN
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
+
+    // THEN
+    assertThat(error.getMessage())
+        .isEqualTo(
+            "Error on row 1; \"InvalidRace\" must be one of [unknown, white, black or african american, prefer not to answer, asian, other, american indian or alaskan native, native hawaiian or other pacific islander]");
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -146,6 +146,20 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   }
 
   @Test
+  void testInvalidRace() {
+    // GIVEN
+    InputStream inputStream = loadCsv("test-upload-no-race.csv");
+
+    // WHEN
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
+
+    // THEN
+    assertThat(error.getMessage()).isEqualTo("Error on row 1; Race is required.");
+  }
+
+  @Test
   void testInvalidPhoneNumber() {
     // GIVEN
     InputStream inputStream = loadCsv("test-upload-invalid-phone.csv");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -170,8 +170,7 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
             IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
 
     // THEN
-    assertThat("Error on row 1; \"InvalidEthnicity\" must be one of")
-        .isSubstringOf(error.getMessage());
+    assertThat(error.getMessage()).contains("Error on row 1; \"InvalidEthnicity\" must be one of");
   }
 
   @Test
@@ -199,7 +198,7 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
             IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
 
     // THEN
-    assertThat("Error on row 1; \"InvalidRace\" must be one of").isSubstringOf(error.getMessage());
+    assertThat(error.getMessage()).contains("Error on row 1; \"InvalidRace\" must be one of");
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -170,9 +170,8 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
             IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
 
     // THEN
-    assertThat(error.getMessage())
-        .isEqualTo(
-            "Error on row 1; \"InvalidEthnicity\" must be one of [refused, hispanic, not_hispanic]");
+    assertThat("Error on row 1; \"InvalidEthnicity\" must be one of")
+        .isSubstringOf(error.getMessage());
   }
 
   @Test
@@ -200,9 +199,7 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
             IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
 
     // THEN
-    assertThat(error.getMessage())
-        .isEqualTo(
-            "Error on row 1; \"InvalidRace\" must be one of [unknown, white, black or african american, prefer not to answer, asian, other, american indian or alaskan native, native hawaiian or other pacific islander]");
+    assertThat("Error on row 1; \"InvalidRace\" must be one of").isSubstringOf(error.getMessage());
   }
 
   @Test

--- a/backend/src/test/resources/test-upload-invalid-ethnicity.csv
+++ b/backend/src/test/resources/test-upload-invalid-ethnicity.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,InvalidEthnicity,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-invalid-race.csv
+++ b/backend/src/test/resources/test-upload-invalid-race.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,InvalidRace,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-no-ethnicity.csv
+++ b/backend/src/test/resources/test-upload-no-ethnicity.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-no-race.csv
+++ b/backend/src/test/resources/test-upload-no-race.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,

--- a/frontend/cypress/integration/02-add_patient_spec.js
+++ b/frontend/cypress/integration/02-add_patient_spec.js
@@ -29,6 +29,7 @@ describe("Adding a patient", () => {
     cy.get(".prime-edit-patient").contains("Student ID");
     cy.get('input[name="lookupId"]').type(patient.studentId);
     cy.get('input[name="race"][value="other"]+label').click();
+    cy.get('input[name="ethnicity"][value="refused"]+label').click();
     cy.get('input[name="residentCongregateSetting"][value="NO"]+label').click();
     cy.get('input[name="employedInHealthcare"][value="NO"]+label').click();
   });

--- a/frontend/cypress/integration/02-add_patient_spec.js
+++ b/frontend/cypress/integration/02-add_patient_spec.js
@@ -28,6 +28,7 @@ describe("Adding a patient", () => {
     cy.get('select[name="role"]').select("STUDENT");
     cy.get(".prime-edit-patient").contains("Student ID");
     cy.get('input[name="lookupId"]').type(patient.studentId);
+    cy.get('input[name="race"][value="other"]+label').click();
     cy.get('input[name="residentCongregateSetting"][value="NO"]+label').click();
     cy.get('input[name="employedInHealthcare"][value="NO"]+label').click();
   });

--- a/frontend/cypress/integration/05-self_registration_spec.js
+++ b/frontend/cypress/integration/05-self_registration_spec.js
@@ -29,6 +29,7 @@ describe("Patient self registration", () => {
     cy.get('select[name="role"]').select("Student");
     cy.get(".prime-formgroup").contains("Student ID");
     cy.get('input[name="lookupId"]').type(patient.studentId);
+    cy.get('input[name="race"][value="other"]+label').click();
     cy.get('input[name="residentCongregateSetting"][value="NO"]+label').click();
     cy.get('input[name="employedInHealthcare"][value="NO"]+label').click();
   });

--- a/frontend/cypress/integration/05-self_registration_spec.js
+++ b/frontend/cypress/integration/05-self_registration_spec.js
@@ -30,6 +30,7 @@ describe("Patient self registration", () => {
     cy.get(".prime-formgroup").contains("Student ID");
     cy.get('input[name="lookupId"]').type(patient.studentId);
     cy.get('input[name="race"][value="other"]+label').click();
+    cy.get('input[name="ethnicity"][value="refused"]+label').click();
     cy.get('input[name="residentCongregateSetting"][value="NO"]+label').click();
     cy.get('input[name="employedInHealthcare"][value="NO"]+label').click();
   });

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -130,7 +130,7 @@ describe("AddPatient", () => {
               emails: ["foo@bar.org"],
               county: "",
               race: "other",
-              ethnicity: null,
+              ethnicity: "refused",
               gender: "female",
               facilityId: mockFacilityID,
               preferredLanguage: null,
@@ -174,7 +174,7 @@ describe("AddPatient", () => {
               emails: [],
               county: "",
               race: "other",
-              ethnicity: null,
+              ethnicity: "refused",
               gender: "female",
               facilityId: mockFacilityID,
               preferredLanguage: null,
@@ -270,6 +270,11 @@ describe("AddPatient", () => {
             Race: {
               label: "Other",
               value: "other",
+              exact: true,
+            },
+            "Are you Hispanic or Latino?": {
+              label: "Prefer not to answer",
+              value: "refused",
               exact: true,
             },
             "Sex assigned at birth": {
@@ -407,6 +412,11 @@ describe("AddPatient", () => {
             Race: {
               label: "Other",
               value: "other",
+              exact: true,
+            },
+            "Are you Hispanic or Latino?": {
+              label: "Prefer not to answer",
+              value: "refused",
               exact: true,
             },
             "Sex assigned at birth": {

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -32,7 +32,7 @@ jest.mock("../utils/smartyStreets", () => ({
   suggestionIsCloseEnough: () => false,
 }));
 
-export const fillOutForm = (
+const fillOutForm = (
   inputs: { [label: string]: string },
   dropdowns: { [label: string]: string },
   inputGroups: {

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -548,6 +548,7 @@ const PersonForm = (props: Props) => {
           buttons={ETHNICITY_VALUES}
           selectedRadio={patient.ethnicity}
           onChange={onPersonChange("ethnicity")}
+          required={true}
         />
         <RadioGroup
           legend={t("patient.form.demographics.gender")}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -527,6 +527,7 @@ const PersonForm = (props: Props) => {
           selectedRadio={patient.race}
           onChange={onPersonChange("race")}
           required={true}
+          validationStatus={validationStatus("race")}
         />
         <div className="usa-form-group">
           <label className="usa-legend" htmlFor="tribal-affiliation">
@@ -549,6 +550,7 @@ const PersonForm = (props: Props) => {
           selectedRadio={patient.ethnicity}
           onChange={onPersonChange("ethnicity")}
           required={true}
+          validationStatus={validationStatus("ethnicity")}
         />
         <RadioGroup
           legend={t("patient.form.demographics.gender")}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -526,6 +526,7 @@ const PersonForm = (props: Props) => {
           buttons={RACE_VALUES}
           selectedRadio={patient.race}
           onChange={onPersonChange("race")}
+          required={true}
         />
         <div className="usa-form-group">
           <label className="usa-legend" htmlFor="tribal-affiliation">

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -358,6 +358,7 @@ describe("EditPatient", () => {
       });
     });
   });
+
   describe("form validations", () => {
     beforeEach(async () => {
       render(

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -2229,6 +2229,13 @@ Object {
                         class="usa-legend"
                       >
                         Are you Hispanic or Latino?
+                        <abbr
+                          class="usa-hint usa-hint--required"
+                          title="required"
+                        >
+                           
+                          *
+                        </abbr>
                       </legend>
                       <div
                         class=""
@@ -2238,7 +2245,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="87-val-hispanic"
                             name="ethnicity"
                             type="radio"
@@ -2256,7 +2263,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="87-val-not_hispanic"
                             name="ethnicity"
                             type="radio"
@@ -2274,7 +2281,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="87-val-refused"
                             name="ethnicity"
                             type="radio"
@@ -4801,6 +4808,13 @@ Object {
                       class="usa-legend"
                     >
                       Are you Hispanic or Latino?
+                      <abbr
+                        class="usa-hint usa-hint--required"
+                        title="required"
+                      >
+                         
+                        *
+                      </abbr>
                     </legend>
                     <div
                       class=""
@@ -4810,7 +4824,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="87-val-hispanic"
                           name="ethnicity"
                           type="radio"
@@ -4828,7 +4842,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="87-val-not_hispanic"
                           name="ethnicity"
                           type="radio"
@@ -4846,7 +4860,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="87-val-refused"
                           name="ethnicity"
                           type="radio"

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -2069,6 +2069,13 @@ Object {
                         class="usa-legend"
                       >
                         Race
+                        <abbr
+                          class="usa-hint usa-hint--required"
+                          title="required"
+                        >
+                           
+                          *
+                        </abbr>
                       </legend>
                       <div
                         class=""
@@ -2078,7 +2085,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-native"
                             name="race"
                             type="radio"
@@ -2096,7 +2103,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-asian"
                             name="race"
                             type="radio"
@@ -2114,7 +2121,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-black"
                             name="race"
                             type="radio"
@@ -2132,7 +2139,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-pacific"
                             name="race"
                             type="radio"
@@ -2150,7 +2157,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-white"
                             name="race"
                             type="radio"
@@ -2168,7 +2175,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-other"
                             name="race"
                             type="radio"
@@ -2186,7 +2193,7 @@ Object {
                         >
                           <input
                             class="usa-radio__input"
-                            data-required="false"
+                            data-required="true"
                             id="86-val-refused"
                             name="race"
                             type="radio"
@@ -4634,6 +4641,13 @@ Object {
                       class="usa-legend"
                     >
                       Race
+                      <abbr
+                        class="usa-hint usa-hint--required"
+                        title="required"
+                      >
+                         
+                        *
+                      </abbr>
                     </legend>
                     <div
                       class=""
@@ -4643,7 +4657,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-native"
                           name="race"
                           type="radio"
@@ -4661,7 +4675,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-asian"
                           name="race"
                           type="radio"
@@ -4679,7 +4693,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-black"
                           name="race"
                           type="radio"
@@ -4697,7 +4711,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-pacific"
                           name="race"
                           type="radio"
@@ -4715,7 +4729,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-white"
                           name="race"
                           type="radio"
@@ -4733,7 +4747,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-other"
                           name="race"
                           type="radio"
@@ -4751,7 +4765,7 @@ Object {
                       >
                         <input
                           class="usa-radio__input"
-                          data-required="false"
+                          data-required="true"
                           id="86-val-refused"
                           name="race"
                           type="radio"

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -246,10 +246,7 @@ const updateFieldSchemata: (
   country: yup.string().required(t("patient.form.errors.country")),
   race: yup
     .mixed()
-    .oneOf(
-      [...getValues(RACE_VALUES), "", null],
-      t("patient.form.errors.race")
-    ),
+    .oneOf(getValues(RACE_VALUES), t("patient.form.errors.race")),
   ethnicity: yup
     .mixed()
     .oneOf(

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -249,10 +249,7 @@ const updateFieldSchemata: (
     .oneOf(getValues(RACE_VALUES), t("patient.form.errors.race")),
   ethnicity: yup
     .mixed()
-    .oneOf(
-      [...getValues(ETHNICITY_VALUES), "", null],
-      t("patient.form.errors.ethnicity")
-    ),
+    .oneOf(getValues(ETHNICITY_VALUES), t("patient.form.errors.ethnicity")),
   gender: yup
     .mixed()
     .oneOf(getValues(GENDER_VALUES))

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -188,7 +188,7 @@ export const en = {
           city: "City is incorrectly formatted",
           county: "County is incorrectly formatted",
           country: "Country is incorrectly formatted",
-          race: "Race is incorrectly formatted",
+          race: "Race is required",
           tribalAffiliation: "Tribal affiliation is incorrectly formatted",
           ethnicity: "Ethnicity is incorrectly formatted",
           gender: "Sex assigned at birth is incorrectly formatted",

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -190,7 +190,7 @@ export const en = {
           country: "Country is incorrectly formatted",
           race: "Race is required",
           tribalAffiliation: "Tribal affiliation is incorrectly formatted",
-          ethnicity: "Ethnicity is incorrectly formatted",
+          ethnicity: "Ethnicity is required",
           gender: "Sex assigned at birth is incorrectly formatted",
           residentCongregateSetting:
             "Are you a resident in a congregate living setting? is required",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -199,6 +199,7 @@ export const es: LanguageConfig = {
           city: "La ciudad tiene un formato incorrecto",
           county: "El formato del condado es incorrecto",
           country: "El formato del país es incorrecto",
+          // TODO: update translation - "incorrect" -> "required"
           race: "La raza tiene un formato incorrecto",
           tribalAffiliation: "La afiliación tribal tiene un formato incorrecto",
           ethnicity: "La etnia tiene un formato incorrecto",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -201,7 +201,7 @@ export const es: LanguageConfig = {
           country: "El formato del país es incorrecto",
           race: "La raza es obligatoria",
           tribalAffiliation: "La afiliación tribal tiene un formato incorrecto",
-          ethnicity: "La etnia tiene un formato incorrecto",
+          ethnicity: "La etnia es obligatoria",
           gender: "El sexo asignado al nacer tiene un formato incorrecto",
           residentCongregateSetting:
             "¿Reside usted en un entorno compartido por muchas personas?  Se requiere una respuesta",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -199,8 +199,7 @@ export const es: LanguageConfig = {
           city: "La ciudad tiene un formato incorrecto",
           county: "El formato del condado es incorrecto",
           country: "El formato del país es incorrecto",
-          // TODO: update translation - "incorrect" -> "required"
-          race: "La raza tiene un formato incorrecto",
+          race: "La raza es obligatoria",
           tribalAffiliation: "La afiliación tribal tiene un formato incorrecto",
           ethnicity: "La etnia tiene un formato incorrecto",
           gender: "El sexo asignado al nacer tiene un formato incorrecto",

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.test.tsx
@@ -93,6 +93,7 @@ describe("SelfRegistration", () => {
     screen.getAllByLabelText("No").forEach(fireEvent.click);
     fireEvent.click(screen.getByLabelText("Mobile"));
     fireEvent.click(screen.getByLabelText("Female"));
+    fireEvent.click(screen.getByText("Native Hawaiian/other Pacific Islander"));
     fireEvent.click(screen.getByText("Submit"));
     await screen.findByText("Address validation");
     fireEvent.click(screen.getByLabelText("Use address", { exact: false }));


### PR DESCRIPTION
## Related Issue or Background Info
* Closes #3123

## Changes Proposed
- Make `Race` and `Ethnicity` required for bulk uploads
- Make `Race` and `Ethnicity` a required field on the person form UI

## Additional Information
- ~We will also want to update the bulk upload guide PDF, but I don't know how that's done~
    - ~@nickclyde I feel like you have done this before?~
    - https://github.com/CDCgov/prime-simplereport-site/pull/264

## Screenshots / Demos
https://user-images.githubusercontent.com/27730981/151242414-ac287844-ad45-41c6-b0e6-fd339b69bb3c.mov

## Checklist for Author and Reviewer
- [ ] We will still have many, many patients without a value for `race` in the database. Let's make super-sure that ReportStream will be OK with null `race`s for the foreseeable future
- [x] @Rebecca-LM some small copy/translation things here to check out; I'll call them out in comments

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
