### PR TITLE
logging audit log to console and changed all logs to json

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AuditingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AuditingConfig.java
@@ -34,7 +34,7 @@ public class AuditingConfig {
   }
 
   @Bean
-  public Logger auditLogger(@Value("${logging.pattern.json-log}") String jsonPattern) {
+  public Logger jsonLogger(@Value("${logging.pattern.json-log}") String jsonPattern) {
     LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
     PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AuditingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AuditingConfig.java
@@ -1,10 +1,18 @@
 package gov.cdc.usds.simplereport.config;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.service.ApiUserService;
+import gov.cdc.usds.simplereport.service.AuditService;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -23,5 +31,25 @@ public class AuditingConfig {
       Optional<ApiUser> user = Optional.of(_userService.getCurrentApiUserInContainedTransaction());
       return user;
     };
+  }
+
+  @Bean
+  public Logger auditLogger(@Value("${logging.pattern.json-log}") String jsonPattern) {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
+
+    patternLayoutEncoder.setPattern(jsonPattern);
+    patternLayoutEncoder.setContext(loggerContext);
+    patternLayoutEncoder.start();
+
+    ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
+    consoleAppender.setEncoder(patternLayoutEncoder);
+    consoleAppender.setContext(loggerContext);
+    consoleAppender.start();
+
+    Logger logger = (Logger) LoggerFactory.getLogger(AuditService.class);
+    logger.addAppender(consoleAppender);
+    logger.setAdditive(false);
+    return logger;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
@@ -17,6 +17,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Transient;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.Parameter;
@@ -106,6 +107,8 @@ public class ApiAuditEvent {
   @Column(nullable = true)
   @Type(type = "jsonb")
   private JsonNode session;
+
+  @Transient private final String type = "auditLog";
 
   protected ApiAuditEvent() {
     // hibernate
@@ -217,6 +220,6 @@ public class ApiAuditEvent {
   }
 
   public String getType() {
-    return "auditLog";
+    return type;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
@@ -108,7 +108,7 @@ public class ApiAuditEvent {
   @Type(type = "jsonb")
   private JsonNode session;
 
-  @Transient private final String type = "auditLog";
+  @Transient private static final String type = "auditLog";
 
   protected ApiAuditEvent() {
     // hibernate

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
@@ -215,4 +215,8 @@ public class ApiAuditEvent {
   public JsonNode getSession() {
     return session;
   }
+
+  public String getType() {
+    return "auditLog";
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiAuditEvent.java
@@ -108,7 +108,7 @@ public class ApiAuditEvent {
   @Type(type = "jsonb")
   private JsonNode session;
 
-  @Transient private static final String type = "auditLog";
+  @Transient private static final String TYPE = "auditLog";
 
   protected ApiAuditEvent() {
     // hibernate
@@ -220,6 +220,6 @@ public class ApiAuditEvent {
   }
 
   public String getType() {
-    return type;
+    return TYPE;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AuditService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AuditService.java
@@ -1,6 +1,9 @@
 package gov.cdc.usds.simplereport.service;
 
+import ch.qos.logback.classic.Logger;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import gov.cdc.usds.simplereport.config.authorization.UserPermission;
 import gov.cdc.usds.simplereport.db.model.ApiAuditEvent;
@@ -12,6 +15,7 @@ import gov.cdc.usds.simplereport.db.repository.ApiAuditEventRepository;
 import gov.cdc.usds.simplereport.logging.GraphqlQueryState;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.stereotype.Service;
@@ -23,17 +27,15 @@ import org.springframework.validation.annotation.Validated;
 @Transactional(readOnly = true)
 @Validated
 @Slf4j
+@RequiredArgsConstructor
 public class AuditService {
 
   public static final int MAX_EVENT_FETCH = 10;
 
+  private final Logger jsonLogger;
   private final ApiAuditEventRepository _repo;
   private final ApiUserService _userService;
-
-  public AuditService(ApiAuditEventRepository repo, ApiUserService userService) {
-    this._repo = repo;
-    this._userService = userService;
-  }
+  private final ObjectMapper objectMapper;
 
   public List<ApiAuditEvent> getLastEvents(@Range(min = 1, max = MAX_EVENT_FETCH) int count) {
     List<ApiAuditEvent> events = _repo.findFirst10ByOrderByEventTimestampDesc();
@@ -53,7 +55,7 @@ public class AuditService {
       boolean isAdmin,
       Organization organization) {
     log.trace("Saving audit event for {}", state.getRequestId());
-    _repo.save(
+    ApiAuditEvent apiAuditEvent =
         new ApiAuditEvent(
             state.getRequestId(),
             state.getHttpDetails(),
@@ -62,7 +64,9 @@ public class AuditService {
             user,
             permissions,
             isAdmin,
-            organization));
+            organization);
+    _repo.save(apiAuditEvent);
+    logEvent(apiAuditEvent);
   }
 
   @Transactional(readOnly = false)
@@ -75,7 +79,10 @@ public class AuditService {
     log.trace("Saving audit event for {}", requestId);
     HttpRequestDetails reqDetails = new HttpRequestDetails(request);
     ApiUser userInfo = _userService.getCurrentApiUserInContainedTransaction();
-    _repo.save(new ApiAuditEvent(requestId, reqDetails, responseCode, userInfo, org, patientLink));
+    ApiAuditEvent apiAuditEvent =
+        new ApiAuditEvent(requestId, reqDetails, responseCode, userInfo, org, patientLink);
+    _repo.save(apiAuditEvent);
+    logEvent(apiAuditEvent);
   }
 
   @Transactional(readOnly = false)
@@ -89,7 +96,10 @@ public class AuditService {
             ? null
             : JsonNodeFactory.instance.objectNode().put("userId", userIdObj.toString());
     ApiUser anonymousUser = _userService.getAnonymousApiUser();
-    _repo.save(new ApiAuditEvent(requestId, reqDetails, responseCode, userId, anonymousUser));
+    ApiAuditEvent apiAuditEvent =
+        new ApiAuditEvent(requestId, reqDetails, responseCode, userId, anonymousUser);
+    _repo.save(apiAuditEvent);
+    logEvent(apiAuditEvent);
   }
 
   @Transactional(readOnly = false)
@@ -102,6 +112,17 @@ public class AuditService {
             ? null
             : JsonNodeFactory.instance.objectNode().put("userId", userIdObj.toString());
     ApiUser webhookUser = _userService.getWebhookApiUser();
-    _repo.save(new ApiAuditEvent(requestId, reqDetails, responseCode, userId, webhookUser));
+    ApiAuditEvent apiAuditEvent =
+        new ApiAuditEvent(requestId, reqDetails, responseCode, userId, webhookUser);
+    _repo.save(apiAuditEvent);
+    logEvent(apiAuditEvent);
+  }
+
+  public void logEvent(ApiAuditEvent apiAuditEvent) {
+    try {
+      jsonLogger.info(objectMapper.writeValueAsString(apiAuditEvent));
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AuditService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AuditService.java
@@ -120,7 +120,8 @@ public class AuditService {
 
   public void logEvent(ApiAuditEvent apiAuditEvent) {
     try {
-      jsonLogger.info(objectMapper.writeValueAsString(apiAuditEvent));
+      String auditJson = objectMapper.writeValueAsString(apiAuditEvent);
+      jsonLogger.info(auditJson);
     } catch (JsonProcessingException e) {
       log.info("error transforming to json {}", e.toString());
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AuditService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AuditService.java
@@ -122,7 +122,7 @@ public class AuditService {
     try {
       jsonLogger.info(objectMapper.writeValueAsString(apiAuditEvent));
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
+      log.info("error transforming to json {}", e.toString());
     }
   }
 }

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -54,6 +54,11 @@
       "name": "simple-report.azure-reporting-queue",
       "type": "gov.cdc.usds.simplereport.properties.AzureStorageQueueReportingProperties",
       "description": "Properties for Azure Storage Queue for Test Event reporting to ReportStream."
+    },
+    {
+      "name": "logging.pattern.json-log",
+      "type": "java.lang.String",
+      "description": "the patterns used for json message"
     }
   ]
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -120,5 +120,7 @@ twilio:
   from-number: "+12023014570"
 logging:
   pattern:
-    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
+#    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
+    console: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": \"%replace(%m%wEx){'[\r\n]+', '\\n'}%nopex\"}%n"
+    json-log: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": %replace(%m%wEx){'[\r\n]+', '\\n'}%nopex}%n"
 hibernate.query.interceptor.error-level: ERROR

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -120,7 +120,6 @@ twilio:
   from-number: "+12023014570"
 logging:
   pattern:
-#    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
     console: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": \"%replace(%m%wEx){'[\r\n]+', '\\n'}%nopex\"}%n"
     json-log: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": %replace(%m%wEx){'[\r\n]+', '\\n'}%nopex}%n"
 hibernate.query.interceptor.error-level: ERROR


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #2630

## Changes Proposed

- change all logs to json single line
- log audit events
- future pr - stop writing audit log to the db

## Additional Information
To correctly format regular messages, I needed to add double quotes around every message, that didn't work for audit log json messages though, thus I created a new logger with a different pattern that doesn't include the double quotes around it

here is a reference for the logback pattern
https://logback.qos.ch/manual/layouts.html#ClassicPatternLayout

here is a reference how to configure logback with multiple loggers/appenders
https://howtodoinjava.com/spring-boot2/logging/multiple-log-files/

this will apply to all env also local. let me know if thats an issue, if you want you local to not show json, add the old console patterns to your local profile yml
```yaml
logging:
    pattern:
      console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
```


## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [X] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes (including new error messages) have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Testing
- [X] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [X] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
