### PR TITLE
make app logs one line and json

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -120,5 +120,5 @@ twilio:
   from-number: "+12023014570"
 logging:
   pattern:
-    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
+    console: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": \"%replace(%m%wEx){'[\r\n]+', '\\n'}%nopex\"}%n"
 hibernate.query.interceptor.error-level: ERROR


### PR DESCRIPTION
## Related Issue or Background Info

- fixes #2630

## Changes Proposed

- change all logs to json single line

## Additional Information

this will apply to all env also local. let me know if thats an issue, if you want you local to not show json, add the old console patterns to your local profile yml
```yaml
logging:
    pattern:
      console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
```


## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [X] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes (including new error messages) have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Testing
- [X] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [X] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
