### PR TITLE
Upgrade apollo and related packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "npm": "6.13.4"
   },
   "dependencies": {
-    "@apollo/client": "3.4.1",
+    "@apollo/client": "3.5.8",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.16",
@@ -23,7 +23,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-transition-group": "^4.4.4",
     "@types/testing-library__jest-dom": "^5.14.2",
-    "apollo-upload-client": "^14.1.3",
+    "apollo-upload-client": "^17.0.0",
     "classnames": "^2.2.6",
     "google-libphonenumber": "^3.2.26",
     "graphql": "^15.4.0",
@@ -181,10 +181,10 @@
     ]
   },
   "devDependencies": {
-    "@graphql-codegen/cli": "2.2.0",
-    "@graphql-codegen/typescript": "2.2.2",
-    "@graphql-codegen/typescript-operations": "2.1.4",
-    "@graphql-codegen/typescript-react-apollo": "3.1.4",
+    "@graphql-codegen/cli": "2.4.0",
+    "@graphql-codegen/typescript": "2.4.2",
+    "@graphql-codegen/typescript-operations": "2.2.2",
+    "@graphql-codegen/typescript-react-apollo": "3.2.4",
     "@storybook/addon-a11y": "^6.4.12",
     "@storybook/addon-actions": "^6.4.12",
     "@storybook/addon-essentials": "^6.4.12",
@@ -194,7 +194,7 @@
     "@storybook/node-logger": "^6.4.12",
     "@storybook/preset-create-react-app": "^4.0.0",
     "@storybook/react": "^6.4.12",
-    "@types/apollo-upload-client": "^14.1.0",
+    "@types/apollo-upload-client": "^17.0.0",
     "@types/classnames": "^2.2.11",
     "@types/faker": "^5.5.9",
     "@types/jest": "^27.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "apollo-upload-client": "^17.0.0",
     "classnames": "^2.2.6",
     "google-libphonenumber": "^3.2.26",
-    "graphql": "^15.4.0",
+    "graphql": "^16.3.0",
     "i18next": "^20.3.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "npm": "6.13.4"
   },
   "dependencies": {
-    "@apollo/client": "3.5.8",
+    "@apollo/client": "3.4.17",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.16",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
 import { useDispatch, connect } from "react-redux";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
 
 export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
@@ -9,7 +10,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
   { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
   { [SubKey in K]: Maybe<T[SubKey]> };
-const defaultOptions = {};
+const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -171,130 +172,130 @@ export type Mutation = {
 };
 
 export type MutationAddFacilityArgs = {
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  deviceIds: Array<Maybe<Scalars["ID"]>>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
+  deviceIds: Array<InputMaybe<Scalars["ID"]>>;
+  email?: InputMaybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderCounty?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  phone?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
   testingFacilityName: Scalars["String"];
   zipCode: Scalars["String"];
 };
 
 export type MutationAddFacilityNewArgs = {
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  deviceIds: Array<Maybe<Scalars["ID"]>>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
+  deviceIds: Array<InputMaybe<Scalars["ID"]>>;
+  email?: InputMaybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderCounty?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  phone?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
   testingFacilityName: Scalars["String"];
   zipCode: Scalars["String"];
 };
 
 export type MutationAddPatientArgs = {
   birthDate: Scalars["LocalDate"];
-  city?: Maybe<Scalars["String"]>;
-  country?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  emails?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  country?: InputMaybe<Scalars["String"]>;
+  county?: InputMaybe<Scalars["String"]>;
+  email?: InputMaybe<Scalars["String"]>;
+  emails?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  employedInHealthcare?: InputMaybe<Scalars["Boolean"]>;
+  ethnicity?: InputMaybe<Scalars["String"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
   firstName: Scalars["String"];
-  gender?: Maybe<Scalars["String"]>;
+  gender?: InputMaybe<Scalars["String"]>;
   lastName: Scalars["String"];
-  lookupId?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  phoneNumbers?: Maybe<Array<PhoneNumberInput>>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  role?: Maybe<Scalars["String"]>;
+  lookupId?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  phoneNumbers?: InputMaybe<Array<PhoneNumberInput>>;
+  preferredLanguage?: InputMaybe<Scalars["String"]>;
+  race?: InputMaybe<Scalars["String"]>;
+  residentCongregateSetting?: InputMaybe<Scalars["Boolean"]>;
+  role?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  telephone?: Maybe<Scalars["String"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
+  telephone?: InputMaybe<Scalars["String"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
+  tribalAffiliation?: InputMaybe<Scalars["String"]>;
   zipCode: Scalars["String"];
 };
 
 export type MutationAddPatientToQueueArgs = {
   facilityId: Scalars["ID"];
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
+  noSymptoms?: InputMaybe<Scalars["Boolean"]>;
   patientId: Scalars["ID"];
-  pregnancy?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  symptoms?: Maybe<Scalars["String"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
+  pregnancy?: InputMaybe<Scalars["String"]>;
+  symptomOnset?: InputMaybe<Scalars["LocalDate"]>;
+  symptoms?: InputMaybe<Scalars["String"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 };
 
 export type MutationAddTestResultArgs = {
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
   deviceId: Scalars["String"];
-  deviceSpecimenType?: Maybe<Scalars["ID"]>;
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
   patientId: Scalars["ID"];
   result: Scalars["String"];
 };
 
 export type MutationAddTestResultNewArgs = {
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
   deviceId: Scalars["String"];
-  deviceSpecimenType?: Maybe<Scalars["ID"]>;
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
   patientId: Scalars["ID"];
   result: Scalars["String"];
 };
 
 export type MutationAddUserArgs = {
   email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  name?: Maybe<NameInput>;
+  firstName?: InputMaybe<Scalars["String"]>;
+  lastName?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<NameInput>;
   organizationExternalId: Scalars["String"];
   role: Role;
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationAddUserToCurrentOrgArgs = {
   email: Scalars["String"];
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  name?: Maybe<NameInput>;
+  firstName?: InputMaybe<Scalars["String"]>;
+  lastName?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<NameInput>;
   role: Role;
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationAdminUpdateOrganizationArgs = {
@@ -304,7 +305,7 @@ export type MutationAdminUpdateOrganizationArgs = {
 
 export type MutationCorrectTestMarkAsErrorArgs = {
   id: Scalars["ID"];
-  reason?: Maybe<Scalars["String"]>;
+  reason?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationCreateDeviceTypeArgs = {
@@ -319,36 +320,36 @@ export type MutationCreateFacilityRegistrationLinkArgs = {
 
 export type MutationCreateOrganizationArgs = {
   adminEmail: Scalars["String"];
-  adminFirstName?: Maybe<Scalars["String"]>;
-  adminLastName?: Maybe<Scalars["String"]>;
-  adminMiddleName?: Maybe<Scalars["String"]>;
-  adminName?: Maybe<NameInput>;
-  adminSuffix?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
+  adminFirstName?: InputMaybe<Scalars["String"]>;
+  adminLastName?: InputMaybe<Scalars["String"]>;
+  adminMiddleName?: InputMaybe<Scalars["String"]>;
+  adminName?: InputMaybe<NameInput>;
+  adminSuffix?: InputMaybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
+  county?: InputMaybe<Scalars["String"]>;
   defaultDevice: Scalars["String"];
-  deviceTypes: Array<Maybe<Scalars["String"]>>;
-  email?: Maybe<Scalars["String"]>;
+  deviceTypes: Array<InputMaybe<Scalars["String"]>>;
+  email?: InputMaybe<Scalars["String"]>;
   externalId: Scalars["String"];
   name: Scalars["String"];
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderName?: Maybe<NameInput>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderCounty?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderName?: InputMaybe<NameInput>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  phone?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
   testingFacilityName: Scalars["String"];
   type: Scalars["String"];
   zipCode: Scalars["String"];
@@ -360,20 +361,20 @@ export type MutationCreateOrganizationRegistrationLinkArgs = {
 };
 
 export type MutationEditPendingOrganizationArgs = {
-  adminEmail?: Maybe<Scalars["String"]>;
-  adminFirstName?: Maybe<Scalars["String"]>;
-  adminLastName?: Maybe<Scalars["String"]>;
-  adminPhone?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  adminEmail?: InputMaybe<Scalars["String"]>;
+  adminFirstName?: InputMaybe<Scalars["String"]>;
+  adminLastName?: InputMaybe<Scalars["String"]>;
+  adminPhone?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
   orgExternalId: Scalars["String"];
 };
 
 export type MutationEditQueueItemArgs = {
-  dateTested?: Maybe<Scalars["DateTime"]>;
-  deviceId?: Maybe<Scalars["String"]>;
-  deviceSpecimenType?: Maybe<Scalars["ID"]>;
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
+  deviceId?: InputMaybe<Scalars["String"]>;
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
   id: Scalars["ID"];
-  result?: Maybe<Scalars["String"]>;
+  result?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationMarkFacilityAsDeletedArgs = {
@@ -427,8 +428,8 @@ export type MutationSendPatientLinkSmsByTestEventIdArgs = {
 };
 
 export type MutationSetCurrentUserTenantDataAccessArgs = {
-  justification?: Maybe<Scalars["String"]>;
-  organizationExternalId?: Maybe<Scalars["String"]>;
+  justification?: InputMaybe<Scalars["String"]>;
+  organizationExternalId?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationSetOrganizationIdentityVerifiedArgs = {
@@ -443,7 +444,7 @@ export type MutationSetPatientIsDeletedArgs = {
 
 export type MutationSetRegistrationLinkIsDeletedArgs = {
   deleted: Scalars["Boolean"];
-  link?: Maybe<Scalars["String"]>;
+  link?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationSetUserIsDeletedArgs = {
@@ -456,53 +457,53 @@ export type MutationUpdateDeviceTypeArgs = {
 };
 
 export type MutationUpdateFacilityArgs = {
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  deviceIds: Array<Maybe<Scalars["ID"]>>;
-  email?: Maybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
+  deviceIds: Array<InputMaybe<Scalars["ID"]>>;
+  email?: InputMaybe<Scalars["String"]>;
   facilityId: Scalars["ID"];
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderCounty?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  phone?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
   testingFacilityName: Scalars["String"];
   zipCode: Scalars["String"];
 };
 
 export type MutationUpdateFacilityNewArgs = {
-  city?: Maybe<Scalars["String"]>;
-  cliaNumber?: Maybe<Scalars["String"]>;
-  deviceIds: Array<Maybe<Scalars["ID"]>>;
-  email?: Maybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
+  deviceIds: Array<InputMaybe<Scalars["ID"]>>;
+  email?: InputMaybe<Scalars["String"]>;
   facilityId: Scalars["ID"];
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderCounty?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  phone?: Maybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderCounty?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  phone?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
   testingFacilityName: Scalars["String"];
   zipCode: Scalars["String"];
 };
@@ -513,32 +514,32 @@ export type MutationUpdateOrganizationArgs = {
 
 export type MutationUpdatePatientArgs = {
   birthDate: Scalars["LocalDate"];
-  city?: Maybe<Scalars["String"]>;
-  country?: Maybe<Scalars["String"]>;
-  county?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  emails?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
+  city?: InputMaybe<Scalars["String"]>;
+  country?: InputMaybe<Scalars["String"]>;
+  county?: InputMaybe<Scalars["String"]>;
+  email?: InputMaybe<Scalars["String"]>;
+  emails?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  employedInHealthcare?: InputMaybe<Scalars["Boolean"]>;
+  ethnicity?: InputMaybe<Scalars["String"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
   firstName: Scalars["String"];
-  gender?: Maybe<Scalars["String"]>;
+  gender?: InputMaybe<Scalars["String"]>;
   lastName: Scalars["String"];
-  lookupId?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
+  lookupId?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
   patientId: Scalars["ID"];
-  phoneNumbers?: Maybe<Array<PhoneNumberInput>>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  role?: Maybe<Scalars["String"]>;
+  phoneNumbers?: InputMaybe<Array<PhoneNumberInput>>;
+  preferredLanguage?: InputMaybe<Scalars["String"]>;
+  race?: InputMaybe<Scalars["String"]>;
+  residentCongregateSetting?: InputMaybe<Scalars["Boolean"]>;
+  role?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
-  telephone?: Maybe<Scalars["String"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
+  telephone?: InputMaybe<Scalars["String"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
+  tribalAffiliation?: InputMaybe<Scalars["String"]>;
   zipCode: Scalars["String"];
 };
 
@@ -548,31 +549,31 @@ export type MutationUpdateRegistrationLinkArgs = {
 };
 
 export type MutationUpdateTimeOfTestQuestionsArgs = {
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
+  noSymptoms?: InputMaybe<Scalars["Boolean"]>;
   patientId: Scalars["ID"];
-  pregnancy?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  symptoms?: Maybe<Scalars["String"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
+  pregnancy?: InputMaybe<Scalars["String"]>;
+  symptomOnset?: InputMaybe<Scalars["LocalDate"]>;
+  symptoms?: InputMaybe<Scalars["String"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 };
 
 export type MutationUpdateUserArgs = {
-  firstName?: Maybe<Scalars["String"]>;
+  firstName?: InputMaybe<Scalars["String"]>;
   id: Scalars["ID"];
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  name?: Maybe<NameInput>;
-  suffix?: Maybe<Scalars["String"]>;
+  lastName?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<NameInput>;
+  suffix?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationUpdateUserEmailArgs = {
-  email?: Maybe<Scalars["String"]>;
+  email?: InputMaybe<Scalars["String"]>;
   id: Scalars["ID"];
 };
 
 export type MutationUpdateUserPrivilegesArgs = {
   accessAllFacilities: Scalars["Boolean"];
-  facilities?: Maybe<Array<Scalars["ID"]>>;
+  facilities?: InputMaybe<Array<Scalars["ID"]>>;
   id: Scalars["ID"];
   role: Role;
 };
@@ -590,10 +591,10 @@ export type NameInfo = {
 };
 
 export type NameInput = {
-  firstName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
+  firstName?: InputMaybe<Scalars["String"]>;
+  lastName?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
 };
 
 export type Organization = {
@@ -683,8 +684,8 @@ export type PhoneNumber = {
 };
 
 export type PhoneNumberInput = {
-  number?: Maybe<Scalars["String"]>;
-  type?: Maybe<Scalars["String"]>;
+  number?: InputMaybe<Scalars["String"]>;
+  type?: InputMaybe<Scalars["String"]>;
 };
 
 export enum PhoneType {
@@ -745,7 +746,7 @@ export type QueryOrganizationLevelDashboardMetricsArgs = {
 };
 
 export type QueryOrganizationsArgs = {
-  identityVerified?: Maybe<Scalars["Boolean"]>;
+  identityVerified?: InputMaybe<Scalars["Boolean"]>;
 };
 
 export type QueryPatientArgs = {
@@ -754,7 +755,7 @@ export type QueryPatientArgs = {
 
 export type QueryPatientExistsArgs = {
   birthDate: Scalars["LocalDate"];
-  facilityId?: Maybe<Scalars["ID"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
   firstName: Scalars["String"];
   lastName: Scalars["String"];
   zipCode: Scalars["String"];
@@ -762,23 +763,23 @@ export type QueryPatientExistsArgs = {
 
 export type QueryPatientExistsWithoutZipArgs = {
   birthDate: Scalars["LocalDate"];
-  facilityId?: Maybe<Scalars["ID"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
   firstName: Scalars["String"];
   lastName: Scalars["String"];
 };
 
 export type QueryPatientsArgs = {
-  facilityId?: Maybe<Scalars["ID"]>;
-  namePrefixMatch?: Maybe<Scalars["String"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
-  showDeleted?: Maybe<Scalars["Boolean"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  namePrefixMatch?: InputMaybe<Scalars["String"]>;
+  pageNumber?: InputMaybe<Scalars["Int"]>;
+  pageSize?: InputMaybe<Scalars["Int"]>;
+  showDeleted?: InputMaybe<Scalars["Boolean"]>;
 };
 
 export type QueryPatientsCountArgs = {
-  facilityId?: Maybe<Scalars["ID"]>;
-  namePrefixMatch?: Maybe<Scalars["String"]>;
-  showDeleted?: Maybe<Scalars["Boolean"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  namePrefixMatch?: InputMaybe<Scalars["String"]>;
+  showDeleted?: InputMaybe<Scalars["Boolean"]>;
 };
 
 export type QueryQueueArgs = {
@@ -790,29 +791,29 @@ export type QueryTestResultArgs = {
 };
 
 export type QueryTestResultsArgs = {
-  endDate?: Maybe<Scalars["DateTime"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  pageNumber?: InputMaybe<Scalars["Int"]>;
+  pageSize?: InputMaybe<Scalars["Int"]>;
+  patientId?: InputMaybe<Scalars["ID"]>;
+  result?: InputMaybe<Scalars["String"]>;
+  role?: InputMaybe<Scalars["String"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
 };
 
 export type QueryTestResultsCountArgs = {
-  endDate?: Maybe<Scalars["DateTime"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  patientId?: InputMaybe<Scalars["ID"]>;
+  result?: InputMaybe<Scalars["String"]>;
+  role?: InputMaybe<Scalars["String"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
 };
 
 export type QueryTopLevelDashboardMetricsArgs = {
-  endDate?: Maybe<Scalars["DateTime"]>;
-  facilityId?: Maybe<Scalars["ID"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
 };
 
 export type QueryUserArgs = {
@@ -853,7 +854,7 @@ export type TestDescription = {
 };
 
 export type TestDescriptionNameArgs = {
-  nameType?: Maybe<Scalars["String"]>;
+  nameType?: InputMaybe<Scalars["String"]>;
 };
 
 export type TestOrder = {
@@ -960,23 +961,26 @@ export type WhoAmIQuery = {
   whoami: {
     __typename?: "User";
     id: string;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
+    firstName?: string | null | undefined;
+    middleName?: string | null | undefined;
     lastName: string;
-    suffix?: Maybe<string>;
+    suffix?: string | null | undefined;
     email: string;
-    isAdmin?: Maybe<boolean>;
+    isAdmin?: boolean | null | undefined;
     permissions: Array<UserPermission>;
     roleDescription: string;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      name: string;
-      testingFacility: Array<{
-        __typename?: "Facility";
-        id: string;
-        name: string;
-      }>;
-    }>;
+    organization?:
+      | {
+          __typename?: "Organization";
+          name: string;
+          testingFacility: Array<{
+            __typename?: "Facility";
+            id: string;
+            name: string;
+          }>;
+        }
+      | null
+      | undefined;
   };
 };
 
@@ -984,42 +988,55 @@ export type GetFacilitiesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetFacilitiesQuery = {
   __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    internalId: string;
-    testingFacility: Array<{
-      __typename?: "Facility";
-      id: string;
-      cliaNumber?: Maybe<string>;
-      name: string;
-      street?: Maybe<string>;
-      streetTwo?: Maybe<string>;
-      city?: Maybe<string>;
-      state?: Maybe<string>;
-      zipCode?: Maybe<string>;
-      phone?: Maybe<string>;
-      email?: Maybe<string>;
-      deviceTypes?: Maybe<
-        Array<
-          Maybe<{ __typename?: "DeviceType"; name: string; internalId: string }>
-        >
-      >;
-      orderingProvider?: Maybe<{
-        __typename?: "Provider";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        suffix?: Maybe<string>;
-        NPI?: Maybe<string>;
-        street?: Maybe<string>;
-        streetTwo?: Maybe<string>;
-        city?: Maybe<string>;
-        state?: Maybe<string>;
-        zipCode?: Maybe<string>;
-        phone?: Maybe<string>;
-      }>;
-    }>;
-  }>;
+  organization?:
+    | {
+        __typename?: "Organization";
+        internalId: string;
+        testingFacility: Array<{
+          __typename?: "Facility";
+          id: string;
+          cliaNumber?: string | null | undefined;
+          name: string;
+          street?: string | null | undefined;
+          streetTwo?: string | null | undefined;
+          city?: string | null | undefined;
+          state?: string | null | undefined;
+          zipCode?: string | null | undefined;
+          phone?: string | null | undefined;
+          email?: string | null | undefined;
+          deviceTypes?:
+            | Array<
+                | {
+                    __typename?: "DeviceType";
+                    name: string;
+                    internalId: string;
+                  }
+                | null
+                | undefined
+              >
+            | null
+            | undefined;
+          orderingProvider?:
+            | {
+                __typename?: "Provider";
+                firstName?: string | null | undefined;
+                middleName?: string | null | undefined;
+                lastName?: string | null | undefined;
+                suffix?: string | null | undefined;
+                NPI?: string | null | undefined;
+                street?: string | null | undefined;
+                streetTwo?: string | null | undefined;
+                city?: string | null | undefined;
+                state?: string | null | undefined;
+                zipCode?: string | null | undefined;
+                phone?: string | null | undefined;
+              }
+            | null
+            | undefined;
+        }>;
+      }
+    | null
+    | undefined;
   deviceTypes: Array<{
     __typename?: "DeviceType";
     internalId: string;
@@ -1030,60 +1047,60 @@ export type GetFacilitiesQuery = {
 export type UpdateFacilityMutationVariables = Exact<{
   facilityId: Scalars["ID"];
   testingFacilityName: Scalars["String"];
-  cliaNumber?: Maybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   zipCode: Scalars["String"];
-  phone?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  devices: Array<Maybe<Scalars["ID"]>> | Maybe<Scalars["ID"]>;
+  phone?: InputMaybe<Scalars["String"]>;
+  email?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  devices: Array<InputMaybe<Scalars["ID"]>> | InputMaybe<Scalars["ID"]>;
 }>;
 
 export type UpdateFacilityMutation = {
   __typename?: "Mutation";
-  updateFacility?: Maybe<{ __typename?: "Facility"; id: string }>;
+  updateFacility?: { __typename?: "Facility"; id: string } | null | undefined;
 };
 
 export type AddFacilityMutationVariables = Exact<{
   testingFacilityName: Scalars["String"];
-  cliaNumber?: Maybe<Scalars["String"]>;
+  cliaNumber?: InputMaybe<Scalars["String"]>;
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   zipCode: Scalars["String"];
-  phone?: Maybe<Scalars["String"]>;
-  email?: Maybe<Scalars["String"]>;
-  orderingProviderFirstName?: Maybe<Scalars["String"]>;
-  orderingProviderMiddleName?: Maybe<Scalars["String"]>;
-  orderingProviderLastName?: Maybe<Scalars["String"]>;
-  orderingProviderSuffix?: Maybe<Scalars["String"]>;
-  orderingProviderNPI?: Maybe<Scalars["String"]>;
-  orderingProviderStreet?: Maybe<Scalars["String"]>;
-  orderingProviderStreetTwo?: Maybe<Scalars["String"]>;
-  orderingProviderCity?: Maybe<Scalars["String"]>;
-  orderingProviderState?: Maybe<Scalars["String"]>;
-  orderingProviderZipCode?: Maybe<Scalars["String"]>;
-  orderingProviderPhone?: Maybe<Scalars["String"]>;
-  devices: Array<Maybe<Scalars["ID"]>> | Maybe<Scalars["ID"]>;
+  phone?: InputMaybe<Scalars["String"]>;
+  email?: InputMaybe<Scalars["String"]>;
+  orderingProviderFirstName?: InputMaybe<Scalars["String"]>;
+  orderingProviderMiddleName?: InputMaybe<Scalars["String"]>;
+  orderingProviderLastName?: InputMaybe<Scalars["String"]>;
+  orderingProviderSuffix?: InputMaybe<Scalars["String"]>;
+  orderingProviderNPI?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreet?: InputMaybe<Scalars["String"]>;
+  orderingProviderStreetTwo?: InputMaybe<Scalars["String"]>;
+  orderingProviderCity?: InputMaybe<Scalars["String"]>;
+  orderingProviderState?: InputMaybe<Scalars["String"]>;
+  orderingProviderZipCode?: InputMaybe<Scalars["String"]>;
+  orderingProviderPhone?: InputMaybe<Scalars["String"]>;
+  devices: Array<InputMaybe<Scalars["ID"]>> | InputMaybe<Scalars["ID"]>;
 }>;
 
 export type AddFacilityMutation = {
   __typename?: "Mutation";
-  addFacility?: Maybe<{ __typename?: "Facility"; id: string }>;
+  addFacility?: { __typename?: "Facility"; id: string } | null | undefined;
 };
 
 export type GetManagedFacilitiesQueryVariables = Exact<{
@@ -1092,26 +1109,28 @@ export type GetManagedFacilitiesQueryVariables = Exact<{
 
 export type GetManagedFacilitiesQuery = {
   __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    facilities: Array<{
-      __typename?: "Facility";
-      id: string;
-      cliaNumber?: Maybe<string>;
-      name: string;
-    }>;
-  }>;
+  organization?:
+    | {
+        __typename?: "Organization";
+        facilities: Array<{
+          __typename?: "Facility";
+          id: string;
+          cliaNumber?: string | null | undefined;
+          name: string;
+        }>;
+      }
+    | null
+    | undefined;
 };
 
 export type GetOrganizationQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetOrganizationQuery = {
   __typename?: "Query";
-  organization?: Maybe<{
-    __typename?: "Organization";
-    name: string;
-    type: string;
-  }>;
+  organization?:
+    | { __typename?: "Organization"; name: string; type: string }
+    | null
+    | undefined;
 };
 
 export type AdminSetOrganizationMutationVariables = Exact<{
@@ -1121,7 +1140,7 @@ export type AdminSetOrganizationMutationVariables = Exact<{
 
 export type AdminSetOrganizationMutation = {
   __typename?: "Mutation";
-  adminUpdateOrganization?: Maybe<string>;
+  adminUpdateOrganization?: string | null | undefined;
 };
 
 export type SetOrganizationMutationVariables = Exact<{
@@ -1130,7 +1149,7 @@ export type SetOrganizationMutationVariables = Exact<{
 
 export type SetOrganizationMutation = {
   __typename?: "Mutation";
-  updateOrganization?: Maybe<string>;
+  updateOrganization?: string | null | undefined;
 };
 
 export type AllSelfRegistrationLinksQueryVariables = Exact<{
@@ -1141,15 +1160,18 @@ export type AllSelfRegistrationLinksQuery = {
   __typename?: "Query";
   whoami: {
     __typename?: "User";
-    organization?: Maybe<{
-      __typename?: "Organization";
-      patientSelfRegistrationLink?: Maybe<string>;
-      facilities: Array<{
-        __typename?: "Facility";
-        name: string;
-        patientSelfRegistrationLink?: Maybe<string>;
-      }>;
-    }>;
+    organization?:
+      | {
+          __typename?: "Organization";
+          patientSelfRegistrationLink?: string | null | undefined;
+          facilities: Array<{
+            __typename?: "Facility";
+            name: string;
+            patientSelfRegistrationLink?: string | null | undefined;
+          }>;
+        }
+      | null
+      | undefined;
   };
 };
 
@@ -1162,7 +1184,7 @@ export type UpdateUserPrivilegesMutationVariables = Exact<{
 
 export type UpdateUserPrivilegesMutation = {
   __typename?: "Mutation";
-  updateUserPrivileges?: Maybe<{ __typename?: "User"; id: string }>;
+  updateUserPrivileges?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type ResetUserPasswordMutationVariables = Exact<{
@@ -1171,7 +1193,7 @@ export type ResetUserPasswordMutationVariables = Exact<{
 
 export type ResetUserPasswordMutation = {
   __typename?: "Mutation";
-  resetUserPassword?: Maybe<{ __typename?: "User"; id: string }>;
+  resetUserPassword?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type SetUserIsDeletedMutationVariables = Exact<{
@@ -1181,7 +1203,7 @@ export type SetUserIsDeletedMutationVariables = Exact<{
 
 export type SetUserIsDeletedMutation = {
   __typename?: "Mutation";
-  setUserIsDeleted?: Maybe<{ __typename?: "User"; id: string }>;
+  setUserIsDeleted?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type ReactivateUserMutationVariables = Exact<{
@@ -1190,11 +1212,11 @@ export type ReactivateUserMutationVariables = Exact<{
 
 export type ReactivateUserMutation = {
   __typename?: "Mutation";
-  reactivateUser?: Maybe<{ __typename?: "User"; id: string }>;
+  reactivateUser?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type AddUserToCurrentOrgMutationVariables = Exact<{
-  firstName?: Maybe<Scalars["String"]>;
+  firstName?: InputMaybe<Scalars["String"]>;
   lastName: Scalars["String"];
   email: Scalars["String"];
   role: Role;
@@ -1202,7 +1224,7 @@ export type AddUserToCurrentOrgMutationVariables = Exact<{
 
 export type AddUserToCurrentOrgMutation = {
   __typename?: "Mutation";
-  addUserToCurrentOrg?: Maybe<{ __typename?: "User"; id: string }>;
+  addUserToCurrentOrg?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type GetUserQueryVariables = Exact<{
@@ -1211,43 +1233,50 @@ export type GetUserQueryVariables = Exact<{
 
 export type GetUserQuery = {
   __typename?: "Query";
-  user?: Maybe<{
-    __typename?: "User";
-    id: string;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName: string;
-    roleDescription: string;
-    role?: Maybe<Role>;
-    permissions: Array<UserPermission>;
-    email: string;
-    status?: Maybe<string>;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      testingFacility: Array<{
-        __typename?: "Facility";
+  user?:
+    | {
+        __typename?: "User";
         id: string;
-        name: string;
-      }>;
-    }>;
-  }>;
+        firstName?: string | null | undefined;
+        middleName?: string | null | undefined;
+        lastName: string;
+        roleDescription: string;
+        role?: Role | null | undefined;
+        permissions: Array<UserPermission>;
+        email: string;
+        status?: string | null | undefined;
+        organization?:
+          | {
+              __typename?: "Organization";
+              testingFacility: Array<{
+                __typename?: "Facility";
+                id: string;
+                name: string;
+              }>;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type GetUsersAndStatusQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetUsersAndStatusQuery = {
   __typename?: "Query";
-  usersWithStatus?: Maybe<
-    Array<{
-      __typename?: "ApiUserWithStatus";
-      id: string;
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName: string;
-      email: string;
-      status?: Maybe<string>;
-    }>
-  >;
+  usersWithStatus?:
+    | Array<{
+        __typename?: "ApiUserWithStatus";
+        id: string;
+        firstName?: string | null | undefined;
+        middleName?: string | null | undefined;
+        lastName: string;
+        email: string;
+        status?: string | null | undefined;
+      }>
+    | null
+    | undefined;
 };
 
 export type ResendActivationEmailMutationVariables = Exact<{
@@ -1256,38 +1285,44 @@ export type ResendActivationEmailMutationVariables = Exact<{
 
 export type ResendActivationEmailMutation = {
   __typename?: "Mutation";
-  resendActivationEmail?: Maybe<{
-    __typename?: "User";
-    id: string;
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName: string;
-    email: string;
-    status?: Maybe<string>;
-  }>;
+  resendActivationEmail?:
+    | {
+        __typename?: "User";
+        id: string;
+        firstName?: string | null | undefined;
+        middleName?: string | null | undefined;
+        lastName: string;
+        email: string;
+        status?: string | null | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type UpdateUserNameMutationVariables = Exact<{
   id: Scalars["ID"];
   firstName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
   lastName: Scalars["String"];
-  suffix?: Maybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type UpdateUserNameMutation = {
   __typename?: "Mutation";
-  updateUser?: Maybe<{ __typename?: "User"; id: string }>;
+  updateUser?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type EditUserEmailMutationVariables = Exact<{
   id: Scalars["ID"];
-  email?: Maybe<Scalars["String"]>;
+  email?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type EditUserEmailMutation = {
   __typename?: "Mutation";
-  updateUserEmail?: Maybe<{ __typename?: "User"; id: string; email: string }>;
+  updateUserEmail?:
+    | { __typename?: "User"; id: string; email: string }
+    | null
+    | undefined;
 };
 
 export type ResetUserMfaMutationVariables = Exact<{
@@ -1296,71 +1331,79 @@ export type ResetUserMfaMutationVariables = Exact<{
 
 export type ResetUserMfaMutation = {
   __typename?: "Mutation";
-  resetUserMfa?: Maybe<{ __typename?: "User"; id: string }>;
+  resetUserMfa?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type GetTopLevelDashboardMetricsNewQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
-  endDate?: Maybe<Scalars["DateTime"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
 export type GetTopLevelDashboardMetricsNewQuery = {
   __typename?: "Query";
-  topLevelDashboardMetrics?: Maybe<{
-    __typename?: "TopLevelDashboardMetrics";
-    positiveTestCount?: Maybe<number>;
-    totalTestCount?: Maybe<number>;
-  }>;
+  topLevelDashboardMetrics?:
+    | {
+        __typename?: "TopLevelDashboardMetrics";
+        positiveTestCount?: number | null | undefined;
+        totalTestCount?: number | null | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type PatientExistsQueryVariables = Exact<{
   firstName: Scalars["String"];
   lastName: Scalars["String"];
   birthDate: Scalars["LocalDate"];
-  facilityId?: Maybe<Scalars["ID"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
 }>;
 
 export type PatientExistsQuery = {
   __typename?: "Query";
-  patientExistsWithoutZip?: Maybe<boolean>;
+  patientExistsWithoutZip?: boolean | null | undefined;
 };
 
 export type AddPatientMutationVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
   firstName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
   lastName: Scalars["String"];
   birthDate: Scalars["LocalDate"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   zipCode: Scalars["String"];
   country: Scalars["String"];
-  telephone?: Maybe<Scalars["String"]>;
-  phoneNumbers?: Maybe<Array<PhoneNumberInput> | PhoneNumberInput>;
-  role?: Maybe<Scalars["String"]>;
-  lookupId?: Maybe<Scalars["String"]>;
-  emails?: Maybe<Array<Maybe<Scalars["String"]>> | Maybe<Scalars["String"]>>;
-  county?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
-  gender?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
+  telephone?: InputMaybe<Scalars["String"]>;
+  phoneNumbers?: InputMaybe<Array<PhoneNumberInput> | PhoneNumberInput>;
+  role?: InputMaybe<Scalars["String"]>;
+  lookupId?: InputMaybe<Scalars["String"]>;
+  emails?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>> | InputMaybe<Scalars["String"]>
+  >;
+  county?: InputMaybe<Scalars["String"]>;
+  race?: InputMaybe<Scalars["String"]>;
+  ethnicity?: InputMaybe<Scalars["String"]>;
+  tribalAffiliation?: InputMaybe<Scalars["String"]>;
+  gender?: InputMaybe<Scalars["String"]>;
+  residentCongregateSetting?: InputMaybe<Scalars["Boolean"]>;
+  employedInHealthcare?: InputMaybe<Scalars["Boolean"]>;
+  preferredLanguage?: InputMaybe<Scalars["String"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 }>;
 
 export type AddPatientMutation = {
   __typename?: "Mutation";
-  addPatient?: Maybe<{
-    __typename?: "Patient";
-    internalId?: Maybe<string>;
-    facility?: Maybe<{ __typename?: "Facility"; id: string }>;
-  }>;
+  addPatient?:
+    | {
+        __typename?: "Patient";
+        internalId?: string | null | undefined;
+        facility?: { __typename?: "Facility"; id: string } | null | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type ArchivePersonMutationVariables = Exact<{
@@ -1370,10 +1413,10 @@ export type ArchivePersonMutationVariables = Exact<{
 
 export type ArchivePersonMutation = {
   __typename?: "Mutation";
-  setPatientIsDeleted?: Maybe<{
-    __typename?: "Patient";
-    internalId?: Maybe<string>;
-  }>;
+  setPatientIsDeleted?:
+    | { __typename?: "Patient"; internalId?: string | null | undefined }
+    | null
+    | undefined;
 };
 
 export type GetPatientDetailsQueryVariables = Exact<{
@@ -1382,118 +1425,135 @@ export type GetPatientDetailsQueryVariables = Exact<{
 
 export type GetPatientDetailsQuery = {
   __typename?: "Query";
-  patient?: Maybe<{
-    __typename?: "Patient";
-    firstName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    lastName?: Maybe<string>;
-    birthDate?: Maybe<any>;
-    street?: Maybe<string>;
-    streetTwo?: Maybe<string>;
-    city?: Maybe<string>;
-    state?: Maybe<string>;
-    zipCode?: Maybe<string>;
-    telephone?: Maybe<string>;
-    role?: Maybe<string>;
-    lookupId?: Maybe<string>;
-    email?: Maybe<string>;
-    emails?: Maybe<Array<Maybe<string>>>;
-    county?: Maybe<string>;
-    country?: Maybe<string>;
-    race?: Maybe<string>;
-    ethnicity?: Maybe<string>;
-    tribalAffiliation?: Maybe<Array<Maybe<string>>>;
-    gender?: Maybe<string>;
-    residentCongregateSetting?: Maybe<boolean>;
-    employedInHealthcare?: Maybe<boolean>;
-    preferredLanguage?: Maybe<string>;
-    testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-    phoneNumbers?: Maybe<
-      Array<
-        Maybe<{
-          __typename?: "PhoneNumber";
-          type?: Maybe<PhoneType>;
-          number?: Maybe<string>;
-        }>
-      >
-    >;
-    facility?: Maybe<{ __typename?: "Facility"; id: string }>;
-  }>;
+  patient?:
+    | {
+        __typename?: "Patient";
+        firstName?: string | null | undefined;
+        middleName?: string | null | undefined;
+        lastName?: string | null | undefined;
+        birthDate?: any | null | undefined;
+        street?: string | null | undefined;
+        streetTwo?: string | null | undefined;
+        city?: string | null | undefined;
+        state?: string | null | undefined;
+        zipCode?: string | null | undefined;
+        telephone?: string | null | undefined;
+        role?: string | null | undefined;
+        lookupId?: string | null | undefined;
+        email?: string | null | undefined;
+        emails?: Array<string | null | undefined> | null | undefined;
+        county?: string | null | undefined;
+        country?: string | null | undefined;
+        race?: string | null | undefined;
+        ethnicity?: string | null | undefined;
+        tribalAffiliation?: Array<string | null | undefined> | null | undefined;
+        gender?: string | null | undefined;
+        residentCongregateSetting?: boolean | null | undefined;
+        employedInHealthcare?: boolean | null | undefined;
+        preferredLanguage?: string | null | undefined;
+        testResultDelivery?: TestResultDeliveryPreference | null | undefined;
+        phoneNumbers?:
+          | Array<
+              | {
+                  __typename?: "PhoneNumber";
+                  type?: PhoneType | null | undefined;
+                  number?: string | null | undefined;
+                }
+              | null
+              | undefined
+            >
+          | null
+          | undefined;
+        facility?: { __typename?: "Facility"; id: string } | null | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type UpdatePatientMutationVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
   patientId: Scalars["ID"];
   firstName: Scalars["String"];
-  middleName?: Maybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
   lastName: Scalars["String"];
   birthDate: Scalars["LocalDate"];
   street: Scalars["String"];
-  streetTwo?: Maybe<Scalars["String"]>;
-  city?: Maybe<Scalars["String"]>;
+  streetTwo?: InputMaybe<Scalars["String"]>;
+  city?: InputMaybe<Scalars["String"]>;
   state: Scalars["String"];
   zipCode: Scalars["String"];
-  telephone?: Maybe<Scalars["String"]>;
-  phoneNumbers?: Maybe<Array<PhoneNumberInput> | PhoneNumberInput>;
-  role?: Maybe<Scalars["String"]>;
-  lookupId?: Maybe<Scalars["String"]>;
-  emails?: Maybe<Array<Maybe<Scalars["String"]>> | Maybe<Scalars["String"]>>;
-  county?: Maybe<Scalars["String"]>;
-  country?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  ethnicity?: Maybe<Scalars["String"]>;
-  tribalAffiliation?: Maybe<Scalars["String"]>;
-  gender?: Maybe<Scalars["String"]>;
-  residentCongregateSetting?: Maybe<Scalars["Boolean"]>;
-  employedInHealthcare?: Maybe<Scalars["Boolean"]>;
-  preferredLanguage?: Maybe<Scalars["String"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
+  telephone?: InputMaybe<Scalars["String"]>;
+  phoneNumbers?: InputMaybe<Array<PhoneNumberInput> | PhoneNumberInput>;
+  role?: InputMaybe<Scalars["String"]>;
+  lookupId?: InputMaybe<Scalars["String"]>;
+  emails?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>> | InputMaybe<Scalars["String"]>
+  >;
+  county?: InputMaybe<Scalars["String"]>;
+  country?: InputMaybe<Scalars["String"]>;
+  race?: InputMaybe<Scalars["String"]>;
+  ethnicity?: InputMaybe<Scalars["String"]>;
+  tribalAffiliation?: InputMaybe<Scalars["String"]>;
+  gender?: InputMaybe<Scalars["String"]>;
+  residentCongregateSetting?: InputMaybe<Scalars["Boolean"]>;
+  employedInHealthcare?: InputMaybe<Scalars["Boolean"]>;
+  preferredLanguage?: InputMaybe<Scalars["String"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 }>;
 
 export type UpdatePatientMutation = {
   __typename?: "Mutation";
-  updatePatient?: Maybe<{ __typename?: "Patient"; internalId?: Maybe<string> }>;
+  updatePatient?:
+    | { __typename?: "Patient"; internalId?: string | null | undefined }
+    | null
+    | undefined;
 };
 
 export type GetPatientsCountByFacilityQueryVariables = Exact<{
   facilityId: Scalars["ID"];
   showDeleted: Scalars["Boolean"];
-  namePrefixMatch?: Maybe<Scalars["String"]>;
+  namePrefixMatch?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type GetPatientsCountByFacilityQuery = {
   __typename?: "Query";
-  patientsCount?: Maybe<number>;
+  patientsCount?: number | null | undefined;
 };
 
 export type GetPatientsByFacilityQueryVariables = Exact<{
   facilityId: Scalars["ID"];
   pageNumber: Scalars["Int"];
   pageSize: Scalars["Int"];
-  showDeleted?: Maybe<Scalars["Boolean"]>;
-  namePrefixMatch?: Maybe<Scalars["String"]>;
+  showDeleted?: InputMaybe<Scalars["Boolean"]>;
+  namePrefixMatch?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type GetPatientsByFacilityQuery = {
   __typename?: "Query";
-  patients?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "Patient";
-        internalId?: Maybe<string>;
-        firstName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        birthDate?: Maybe<any>;
-        isDeleted?: Maybe<boolean>;
-        role?: Maybe<string>;
-        lastTest?: Maybe<{
-          __typename?: "TestResult";
-          dateAdded?: Maybe<string>;
-        }>;
-      }>
-    >
-  >;
+  patients?:
+    | Array<
+        | {
+            __typename?: "Patient";
+            internalId?: string | null | undefined;
+            firstName?: string | null | undefined;
+            lastName?: string | null | undefined;
+            middleName?: string | null | undefined;
+            birthDate?: any | null | undefined;
+            isDeleted?: boolean | null | undefined;
+            role?: string | null | undefined;
+            lastTest?:
+              | {
+                  __typename?: "TestResult";
+                  dateAdded?: string | null | undefined;
+                }
+              | null
+              | undefined;
+          }
+        | null
+        | undefined
+      >
+    | null
+    | undefined;
 };
 
 export type UploadPatientsMutationVariables = Exact<{
@@ -1502,14 +1562,14 @@ export type UploadPatientsMutationVariables = Exact<{
 
 export type UploadPatientsMutation = {
   __typename?: "Mutation";
-  uploadPatients?: Maybe<string>;
+  uploadPatients?: string | null | undefined;
 };
 
 export type AddUserMutationVariables = Exact<{
-  firstName?: Maybe<Scalars["String"]>;
-  middleName?: Maybe<Scalars["String"]>;
-  lastName?: Maybe<Scalars["String"]>;
-  suffix?: Maybe<Scalars["String"]>;
+  firstName?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  lastName?: InputMaybe<Scalars["String"]>;
+  suffix?: InputMaybe<Scalars["String"]>;
   email: Scalars["String"];
   organizationExternalId: Scalars["String"];
   role: Role;
@@ -1517,7 +1577,7 @@ export type AddUserMutationVariables = Exact<{
 
 export type AddUserMutation = {
   __typename?: "Mutation";
-  addUser?: Maybe<{ __typename?: "User"; id: string }>;
+  addUser?: { __typename?: "User"; id: string } | null | undefined;
 };
 
 export type CreateDeviceTypeMutationVariables = Exact<{
@@ -1530,7 +1590,10 @@ export type CreateDeviceTypeMutationVariables = Exact<{
 
 export type CreateDeviceTypeMutation = {
   __typename?: "Mutation";
-  createDeviceType?: Maybe<{ __typename?: "DeviceType"; internalId: string }>;
+  createDeviceType?:
+    | { __typename?: "DeviceType"; internalId: string }
+    | null
+    | undefined;
 };
 
 export type UpdateDeviceTypeMutationVariables = Exact<{
@@ -1544,7 +1607,10 @@ export type UpdateDeviceTypeMutationVariables = Exact<{
 
 export type UpdateDeviceTypeMutation = {
   __typename?: "Mutation";
-  updateDeviceType?: Maybe<{ __typename?: "DeviceType"; internalId: string }>;
+  updateDeviceType?:
+    | { __typename?: "DeviceType"; internalId: string }
+    | null
+    | undefined;
 };
 
 export type GetSpecimenTypesQueryVariables = Exact<{ [key: string]: never }>;
@@ -1588,10 +1654,10 @@ export type GetPendingOrganizationsQuery = {
     __typename?: "PendingOrganization";
     externalId: string;
     name: string;
-    adminFirstName?: Maybe<string>;
-    adminLastName?: Maybe<string>;
-    adminEmail?: Maybe<string>;
-    adminPhone?: Maybe<string>;
+    adminFirstName?: string | null | undefined;
+    adminLastName?: string | null | undefined;
+    adminEmail?: string | null | undefined;
+    adminPhone?: string | null | undefined;
     createdAt: any;
   }>;
 };
@@ -1603,7 +1669,7 @@ export type SetOrgIdentityVerifiedMutationVariables = Exact<{
 
 export type SetOrgIdentityVerifiedMutation = {
   __typename?: "Mutation";
-  setOrganizationIdentityVerified?: Maybe<boolean>;
+  setOrganizationIdentityVerified?: boolean | null | undefined;
 };
 
 export type MarkPendingOrganizationAsDeletedMutationVariables = Exact<{
@@ -1613,25 +1679,25 @@ export type MarkPendingOrganizationAsDeletedMutationVariables = Exact<{
 
 export type MarkPendingOrganizationAsDeletedMutation = {
   __typename?: "Mutation";
-  markPendingOrganizationAsDeleted?: Maybe<string>;
+  markPendingOrganizationAsDeleted?: string | null | undefined;
 };
 
 export type EditPendingOrganizationMutationVariables = Exact<{
   externalId: Scalars["String"];
-  name?: Maybe<Scalars["String"]>;
-  adminFirstName?: Maybe<Scalars["String"]>;
-  adminLastName?: Maybe<Scalars["String"]>;
-  adminEmail?: Maybe<Scalars["String"]>;
-  adminPhone?: Maybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
+  adminFirstName?: InputMaybe<Scalars["String"]>;
+  adminLastName?: InputMaybe<Scalars["String"]>;
+  adminEmail?: InputMaybe<Scalars["String"]>;
+  adminPhone?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type EditPendingOrganizationMutation = {
   __typename?: "Mutation";
-  editPendingOrganization?: Maybe<string>;
+  editPendingOrganization?: string | null | undefined;
 };
 
 export type GetOrganizationsQueryVariables = Exact<{
-  identityVerified?: Maybe<Scalars["Boolean"]>;
+  identityVerified?: InputMaybe<Scalars["Boolean"]>;
 }>;
 
 export type GetOrganizationsQuery = {
@@ -1644,24 +1710,26 @@ export type GetOrganizationsQuery = {
 };
 
 export type SetCurrentUserTenantDataAccessOpMutationVariables = Exact<{
-  organizationExternalId?: Maybe<Scalars["String"]>;
-  justification?: Maybe<Scalars["String"]>;
+  organizationExternalId?: InputMaybe<Scalars["String"]>;
+  justification?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type SetCurrentUserTenantDataAccessOpMutation = {
   __typename?: "Mutation";
-  setCurrentUserTenantDataAccess?: Maybe<{
-    __typename?: "User";
-    id: string;
-    email: string;
-    permissions: Array<UserPermission>;
-    role?: Maybe<Role>;
-    organization?: Maybe<{
-      __typename?: "Organization";
-      name: string;
-      externalId: string;
-    }>;
-  }>;
+  setCurrentUserTenantDataAccess?:
+    | {
+        __typename?: "User";
+        id: string;
+        email: string;
+        permissions: Array<UserPermission>;
+        role?: Role | null | undefined;
+        organization?:
+          | { __typename?: "Organization"; name: string; externalId: string }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type RemovePatientFromQueueMutationVariables = Exact<{
@@ -1670,56 +1738,71 @@ export type RemovePatientFromQueueMutationVariables = Exact<{
 
 export type RemovePatientFromQueueMutation = {
   __typename?: "Mutation";
-  removePatientFromQueue?: Maybe<string>;
+  removePatientFromQueue?: string | null | undefined;
 };
 
 export type EditQueueItemMutationVariables = Exact<{
   id: Scalars["ID"];
-  deviceId?: Maybe<Scalars["String"]>;
-  deviceSpecimenType?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  deviceId?: InputMaybe<Scalars["String"]>;
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
+  result?: InputMaybe<Scalars["String"]>;
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
 export type EditQueueItemMutation = {
   __typename?: "Mutation";
-  editQueueItem?: Maybe<{
-    __typename?: "TestOrder";
-    result?: Maybe<string>;
-    dateTested?: Maybe<any>;
-    deviceType?: Maybe<{
-      __typename?: "DeviceType";
-      internalId: string;
-      testLength?: Maybe<number>;
-    }>;
-    deviceSpecimenType?: Maybe<{
-      __typename?: "DeviceSpecimenType";
-      internalId: string;
-      deviceType: {
-        __typename?: "DeviceType";
-        internalId: string;
-        testLength?: Maybe<number>;
-      };
-      specimenType: { __typename?: "SpecimenType"; internalId: string };
-    }>;
-  }>;
+  editQueueItem?:
+    | {
+        __typename?: "TestOrder";
+        result?: string | null | undefined;
+        dateTested?: any | null | undefined;
+        deviceType?:
+          | {
+              __typename?: "DeviceType";
+              internalId: string;
+              testLength?: number | null | undefined;
+            }
+          | null
+          | undefined;
+        deviceSpecimenType?:
+          | {
+              __typename?: "DeviceSpecimenType";
+              internalId: string;
+              deviceType: {
+                __typename?: "DeviceType";
+                internalId: string;
+                testLength?: number | null | undefined;
+              };
+              specimenType: { __typename?: "SpecimenType"; internalId: string };
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type SubmitTestResultMutationVariables = Exact<{
   patientId: Scalars["ID"];
   deviceId: Scalars["String"];
-  deviceSpecimenType?: Maybe<Scalars["ID"]>;
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
   result: Scalars["String"];
-  dateTested?: Maybe<Scalars["DateTime"]>;
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
 export type SubmitTestResultMutation = {
   __typename?: "Mutation";
-  addTestResultNew?: Maybe<{
-    __typename?: "AddTestResultResponse";
-    deliverySuccess?: Maybe<boolean>;
-    testResult: { __typename?: "TestOrder"; internalId?: Maybe<string> };
-  }>;
+  addTestResultNew?:
+    | {
+        __typename?: "AddTestResultResponse";
+        deliverySuccess?: boolean | null | undefined;
+        testResult: {
+          __typename?: "TestOrder";
+          internalId?: string | null | undefined;
+        };
+      }
+    | null
+    | undefined;
 };
 
 export type GetFacilityQueueQueryVariables = Exact<{
@@ -1728,93 +1811,117 @@ export type GetFacilityQueueQueryVariables = Exact<{
 
 export type GetFacilityQueueQuery = {
   __typename?: "Query";
-  queue?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "TestOrder";
-        internalId?: Maybe<string>;
-        pregnancy?: Maybe<string>;
-        dateAdded?: Maybe<string>;
-        symptoms?: Maybe<string>;
-        symptomOnset?: Maybe<any>;
-        noSymptoms?: Maybe<boolean>;
-        result?: Maybe<string>;
-        dateTested?: Maybe<any>;
-        deviceType?: Maybe<{
-          __typename?: "DeviceType";
-          internalId: string;
-          name: string;
-          model: string;
-          testLength?: Maybe<number>;
+  queue?:
+    | Array<
+        | {
+            __typename?: "TestOrder";
+            internalId?: string | null | undefined;
+            pregnancy?: string | null | undefined;
+            dateAdded?: string | null | undefined;
+            symptoms?: string | null | undefined;
+            symptomOnset?: any | null | undefined;
+            noSymptoms?: boolean | null | undefined;
+            result?: string | null | undefined;
+            dateTested?: any | null | undefined;
+            deviceType?:
+              | {
+                  __typename?: "DeviceType";
+                  internalId: string;
+                  name: string;
+                  model: string;
+                  testLength?: number | null | undefined;
+                }
+              | null
+              | undefined;
+            deviceSpecimenType?:
+              | { __typename?: "DeviceSpecimenType"; internalId: string }
+              | null
+              | undefined;
+            patient?:
+              | {
+                  __typename?: "Patient";
+                  internalId?: string | null | undefined;
+                  telephone?: string | null | undefined;
+                  birthDate?: any | null | undefined;
+                  firstName?: string | null | undefined;
+                  middleName?: string | null | undefined;
+                  lastName?: string | null | undefined;
+                  gender?: string | null | undefined;
+                  testResultDelivery?:
+                    | TestResultDeliveryPreference
+                    | null
+                    | undefined;
+                  preferredLanguage?: string | null | undefined;
+                  email?: string | null | undefined;
+                  emails?: Array<string | null | undefined> | null | undefined;
+                  phoneNumbers?:
+                    | Array<
+                        | {
+                            __typename?: "PhoneNumber";
+                            type?: PhoneType | null | undefined;
+                            number?: string | null | undefined;
+                          }
+                        | null
+                        | undefined
+                      >
+                    | null
+                    | undefined;
+                }
+              | null
+              | undefined;
+          }
+        | null
+        | undefined
+      >
+    | null
+    | undefined;
+  organization?:
+    | {
+        __typename?: "Organization";
+        testingFacility: Array<{
+          __typename?: "Facility";
+          id: string;
+          defaultDeviceSpecimen?: string | null | undefined;
+          deviceTypes?:
+            | Array<
+                | {
+                    __typename?: "DeviceType";
+                    internalId: string;
+                    name: string;
+                    model: string;
+                    testLength?: number | null | undefined;
+                  }
+                | null
+                | undefined
+              >
+            | null
+            | undefined;
         }>;
-        deviceSpecimenType?: Maybe<{
-          __typename?: "DeviceSpecimenType";
-          internalId: string;
-        }>;
-        patient?: Maybe<{
-          __typename?: "Patient";
-          internalId?: Maybe<string>;
-          telephone?: Maybe<string>;
-          birthDate?: Maybe<any>;
-          firstName?: Maybe<string>;
-          middleName?: Maybe<string>;
-          lastName?: Maybe<string>;
-          gender?: Maybe<string>;
-          testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-          preferredLanguage?: Maybe<string>;
-          email?: Maybe<string>;
-          emails?: Maybe<Array<Maybe<string>>>;
-          phoneNumbers?: Maybe<
-            Array<
-              Maybe<{
-                __typename?: "PhoneNumber";
-                type?: Maybe<PhoneType>;
-                number?: Maybe<string>;
-              }>
-            >
-          >;
-        }>;
-      }>
-    >
-  >;
-  organization?: Maybe<{
-    __typename?: "Organization";
-    testingFacility: Array<{
-      __typename?: "Facility";
-      id: string;
-      defaultDeviceSpecimen?: Maybe<string>;
-      deviceTypes?: Maybe<
-        Array<
-          Maybe<{
-            __typename?: "DeviceType";
+      }
+    | null
+    | undefined;
+  deviceSpecimenTypes?:
+    | Array<
+        | {
+            __typename?: "DeviceSpecimenType";
             internalId: string;
-            name: string;
-            model: string;
-            testLength?: Maybe<number>;
-          }>
-        >
-      >;
-    }>;
-  }>;
-  deviceSpecimenTypes?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "DeviceSpecimenType";
-        internalId: string;
-        deviceType: {
-          __typename?: "DeviceType";
-          internalId: string;
-          name: string;
-          testLength?: Maybe<number>;
-        };
-        specimenType: {
-          __typename?: "SpecimenType";
-          internalId: string;
-          name: string;
-        };
-      }>
-    >
-  >;
+            deviceType: {
+              __typename?: "DeviceType";
+              internalId: string;
+              name: string;
+              testLength?: number | null | undefined;
+            };
+            specimenType: {
+              __typename?: "SpecimenType";
+              internalId: string;
+              name: string;
+            };
+          }
+        | null
+        | undefined
+      >
+    | null
+    | undefined;
 };
 
 export type GetPatientQueryVariables = Exact<{
@@ -1823,90 +1930,105 @@ export type GetPatientQueryVariables = Exact<{
 
 export type GetPatientQuery = {
   __typename?: "Query";
-  patient?: Maybe<{
-    __typename?: "Patient";
-    internalId?: Maybe<string>;
-    firstName?: Maybe<string>;
-    lastName?: Maybe<string>;
-    middleName?: Maybe<string>;
-    birthDate?: Maybe<any>;
-    gender?: Maybe<string>;
-    telephone?: Maybe<string>;
-    testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-    phoneNumbers?: Maybe<
-      Array<
-        Maybe<{
-          __typename?: "PhoneNumber";
-          type?: Maybe<PhoneType>;
-          number?: Maybe<string>;
-        }>
-      >
-    >;
-  }>;
+  patient?:
+    | {
+        __typename?: "Patient";
+        internalId?: string | null | undefined;
+        firstName?: string | null | undefined;
+        lastName?: string | null | undefined;
+        middleName?: string | null | undefined;
+        birthDate?: any | null | undefined;
+        gender?: string | null | undefined;
+        telephone?: string | null | undefined;
+        testResultDelivery?: TestResultDeliveryPreference | null | undefined;
+        phoneNumbers?:
+          | Array<
+              | {
+                  __typename?: "PhoneNumber";
+                  type?: PhoneType | null | undefined;
+                  number?: string | null | undefined;
+                }
+              | null
+              | undefined
+            >
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type GetPatientsByFacilityForQueueQueryVariables = Exact<{
   facilityId: Scalars["ID"];
-  namePrefixMatch?: Maybe<Scalars["String"]>;
+  namePrefixMatch?: InputMaybe<Scalars["String"]>;
 }>;
 
 export type GetPatientsByFacilityForQueueQuery = {
   __typename?: "Query";
-  patients?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "Patient";
-        internalId?: Maybe<string>;
-        firstName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        birthDate?: Maybe<any>;
-        gender?: Maybe<string>;
-        telephone?: Maybe<string>;
-        email?: Maybe<string>;
-        emails?: Maybe<Array<Maybe<string>>>;
-        testResultDelivery?: Maybe<TestResultDeliveryPreference>;
-        phoneNumbers?: Maybe<
-          Array<
-            Maybe<{
-              __typename?: "PhoneNumber";
-              type?: Maybe<PhoneType>;
-              number?: Maybe<string>;
-            }>
-          >
-        >;
-      }>
-    >
-  >;
+  patients?:
+    | Array<
+        | {
+            __typename?: "Patient";
+            internalId?: string | null | undefined;
+            firstName?: string | null | undefined;
+            lastName?: string | null | undefined;
+            middleName?: string | null | undefined;
+            birthDate?: any | null | undefined;
+            gender?: string | null | undefined;
+            telephone?: string | null | undefined;
+            email?: string | null | undefined;
+            emails?: Array<string | null | undefined> | null | undefined;
+            testResultDelivery?:
+              | TestResultDeliveryPreference
+              | null
+              | undefined;
+            phoneNumbers?:
+              | Array<
+                  | {
+                      __typename?: "PhoneNumber";
+                      type?: PhoneType | null | undefined;
+                      number?: string | null | undefined;
+                    }
+                  | null
+                  | undefined
+                >
+              | null
+              | undefined;
+          }
+        | null
+        | undefined
+      >
+    | null
+    | undefined;
 };
 
 export type AddPatientToQueueMutationVariables = Exact<{
   facilityId: Scalars["ID"];
   patientId: Scalars["ID"];
-  symptoms?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  pregnancy?: Maybe<Scalars["String"]>;
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
+  symptoms?: InputMaybe<Scalars["String"]>;
+  symptomOnset?: InputMaybe<Scalars["LocalDate"]>;
+  pregnancy?: InputMaybe<Scalars["String"]>;
+  noSymptoms?: InputMaybe<Scalars["Boolean"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 }>;
 
 export type AddPatientToQueueMutation = {
   __typename?: "Mutation";
-  addPatientToQueue?: Maybe<string>;
+  addPatientToQueue?: string | null | undefined;
 };
 
 export type UpdateAoeMutationVariables = Exact<{
   patientId: Scalars["ID"];
-  symptoms?: Maybe<Scalars["String"]>;
-  symptomOnset?: Maybe<Scalars["LocalDate"]>;
-  pregnancy?: Maybe<Scalars["String"]>;
-  noSymptoms?: Maybe<Scalars["Boolean"]>;
-  testResultDelivery?: Maybe<TestResultDeliveryPreference>;
+  symptoms?: InputMaybe<Scalars["String"]>;
+  symptomOnset?: InputMaybe<Scalars["LocalDate"]>;
+  pregnancy?: InputMaybe<Scalars["String"]>;
+  noSymptoms?: InputMaybe<Scalars["Boolean"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 }>;
 
 export type UpdateAoeMutation = {
   __typename?: "Mutation";
-  updateTimeOfTestQuestions?: Maybe<string>;
+  updateTimeOfTestQuestions?: string | null | undefined;
 };
 
 export type GetTestResultForCorrectionQueryVariables = Exact<{
@@ -1915,20 +2037,29 @@ export type GetTestResultForCorrectionQueryVariables = Exact<{
 
 export type GetTestResultForCorrectionQuery = {
   __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    result?: Maybe<string>;
-    correctionStatus?: Maybe<string>;
-    deviceType?: Maybe<{ __typename?: "DeviceType"; name: string }>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-    }>;
-  }>;
+  testResult?:
+    | {
+        __typename?: "TestResult";
+        dateTested?: any | null | undefined;
+        result?: string | null | undefined;
+        correctionStatus?: string | null | undefined;
+        deviceType?:
+          | { __typename?: "DeviceType"; name: string }
+          | null
+          | undefined;
+        patient?:
+          | {
+              __typename?: "Patient";
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              birthDate?: any | null | undefined;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type MarkTestAsErrorMutationVariables = Exact<{
@@ -1938,10 +2069,10 @@ export type MarkTestAsErrorMutationVariables = Exact<{
 
 export type MarkTestAsErrorMutation = {
   __typename?: "Mutation";
-  correctTestMarkAsError?: Maybe<{
-    __typename?: "TestResult";
-    internalId?: Maybe<string>;
-  }>;
+  correctTestMarkAsError?:
+    | { __typename?: "TestResult"; internalId?: string | null | undefined }
+    | null
+    | undefined;
 };
 
 export type GetTestResultDetailsQueryVariables = Exact<{
@@ -1950,32 +2081,44 @@ export type GetTestResultDetailsQueryVariables = Exact<{
 
 export type GetTestResultDetailsQuery = {
   __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    result?: Maybe<string>;
-    correctionStatus?: Maybe<string>;
-    symptoms?: Maybe<string>;
-    symptomOnset?: Maybe<any>;
-    pregnancy?: Maybe<string>;
-    deviceType?: Maybe<{ __typename?: "DeviceType"; name: string }>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-    }>;
-    createdBy?: Maybe<{
-      __typename?: "ApiUser";
-      name: {
-        __typename?: "NameInfo";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName: string;
-      };
-    }>;
-  }>;
+  testResult?:
+    | {
+        __typename?: "TestResult";
+        dateTested?: any | null | undefined;
+        result?: string | null | undefined;
+        correctionStatus?: string | null | undefined;
+        symptoms?: string | null | undefined;
+        symptomOnset?: any | null | undefined;
+        pregnancy?: string | null | undefined;
+        deviceType?:
+          | { __typename?: "DeviceType"; name: string }
+          | null
+          | undefined;
+        patient?:
+          | {
+              __typename?: "Patient";
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              birthDate?: any | null | undefined;
+            }
+          | null
+          | undefined;
+        createdBy?:
+          | {
+              __typename?: "ApiUser";
+              name: {
+                __typename?: "NameInfo";
+                firstName?: string | null | undefined;
+                middleName?: string | null | undefined;
+                lastName: string;
+              };
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type GetTestResultForPrintQueryVariables = Exact<{
@@ -1984,42 +2127,53 @@ export type GetTestResultForPrintQueryVariables = Exact<{
 
 export type GetTestResultForPrintQuery = {
   __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    result?: Maybe<string>;
-    correctionStatus?: Maybe<string>;
-    deviceType?: Maybe<{
-      __typename?: "DeviceType";
-      name: string;
-      model: string;
-    }>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-    }>;
-    facility?: Maybe<{
-      __typename?: "Facility";
-      name: string;
-      cliaNumber?: Maybe<string>;
-      phone?: Maybe<string>;
-      street?: Maybe<string>;
-      streetTwo?: Maybe<string>;
-      city?: Maybe<string>;
-      state?: Maybe<string>;
-      zipCode?: Maybe<string>;
-      orderingProvider?: Maybe<{
-        __typename?: "Provider";
-        firstName?: Maybe<string>;
-        middleName?: Maybe<string>;
-        lastName?: Maybe<string>;
-        NPI?: Maybe<string>;
-      }>;
-    }>;
-  }>;
+  testResult?:
+    | {
+        __typename?: "TestResult";
+        dateTested?: any | null | undefined;
+        result?: string | null | undefined;
+        correctionStatus?: string | null | undefined;
+        deviceType?:
+          | { __typename?: "DeviceType"; name: string; model: string }
+          | null
+          | undefined;
+        patient?:
+          | {
+              __typename?: "Patient";
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              birthDate?: any | null | undefined;
+            }
+          | null
+          | undefined;
+        facility?:
+          | {
+              __typename?: "Facility";
+              name: string;
+              cliaNumber?: string | null | undefined;
+              phone?: string | null | undefined;
+              street?: string | null | undefined;
+              streetTwo?: string | null | undefined;
+              city?: string | null | undefined;
+              state?: string | null | undefined;
+              zipCode?: string | null | undefined;
+              orderingProvider?:
+                | {
+                    __typename?: "Provider";
+                    firstName?: string | null | undefined;
+                    middleName?: string | null | undefined;
+                    lastName?: string | null | undefined;
+                    NPI?: string | null | undefined;
+                  }
+                | null
+                | undefined;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type GetTestResultForTextQueryVariables = Exact<{
@@ -2028,26 +2182,35 @@ export type GetTestResultForTextQueryVariables = Exact<{
 
 export type GetTestResultForTextQuery = {
   __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      birthDate?: Maybe<any>;
-      phoneNumbers?: Maybe<
-        Array<
-          Maybe<{
-            __typename?: "PhoneNumber";
-            type?: Maybe<PhoneType>;
-            number?: Maybe<string>;
-          }>
-        >
-      >;
-    }>;
-  }>;
+  testResult?:
+    | {
+        __typename?: "TestResult";
+        dateTested?: any | null | undefined;
+        patient?:
+          | {
+              __typename?: "Patient";
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              birthDate?: any | null | undefined;
+              phoneNumbers?:
+                | Array<
+                    | {
+                        __typename?: "PhoneNumber";
+                        type?: PhoneType | null | undefined;
+                        number?: string | null | undefined;
+                      }
+                    | null
+                    | undefined
+                  >
+                | null
+                | undefined;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type SendSmsMutationVariables = Exact<{
@@ -2056,78 +2219,92 @@ export type SendSmsMutationVariables = Exact<{
 
 export type SendSmsMutation = {
   __typename?: "Mutation";
-  sendPatientLinkSmsByTestEventId?: Maybe<boolean>;
+  sendPatientLinkSmsByTestEventId?: boolean | null | undefined;
 };
 
 export type GetResultsCountByFacilityQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
-  endDate?: Maybe<Scalars["DateTime"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  patientId?: InputMaybe<Scalars["ID"]>;
+  result?: InputMaybe<Scalars["String"]>;
+  role?: InputMaybe<Scalars["String"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
 export type GetResultsCountByFacilityQuery = {
   __typename?: "Query";
-  testResultsCount?: Maybe<number>;
+  testResultsCount?: number | null | undefined;
 };
 
 export type GetFacilityResultsQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
-  endDate?: Maybe<Scalars["DateTime"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  patientId?: InputMaybe<Scalars["ID"]>;
+  result?: InputMaybe<Scalars["String"]>;
+  role?: InputMaybe<Scalars["String"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
+  pageNumber?: InputMaybe<Scalars["Int"]>;
+  pageSize?: InputMaybe<Scalars["Int"]>;
 }>;
 
 export type GetFacilityResultsQuery = {
   __typename?: "Query";
-  testResults?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "TestResult";
-        internalId?: Maybe<string>;
-        dateTested?: Maybe<any>;
-        result?: Maybe<string>;
-        correctionStatus?: Maybe<string>;
-        symptoms?: Maybe<string>;
-        noSymptoms?: Maybe<boolean>;
-        deviceType?: Maybe<{
-          __typename?: "DeviceType";
-          internalId: string;
-          name: string;
-        }>;
-        patient?: Maybe<{
-          __typename?: "Patient";
-          internalId?: Maybe<string>;
-          firstName?: Maybe<string>;
-          middleName?: Maybe<string>;
-          lastName?: Maybe<string>;
-          birthDate?: Maybe<any>;
-          gender?: Maybe<string>;
-          lookupId?: Maybe<string>;
-          email?: Maybe<string>;
-        }>;
-        createdBy?: Maybe<{
-          __typename?: "ApiUser";
-          nameInfo?: Maybe<{
-            __typename?: "NameInfo";
-            firstName?: Maybe<string>;
-            middleName?: Maybe<string>;
-            lastName: string;
-          }>;
-        }>;
-        patientLink?: Maybe<{
-          __typename?: "PatientLink";
-          internalId?: Maybe<string>;
-        }>;
-      }>
-    >
-  >;
+  testResults?:
+    | Array<
+        | {
+            __typename?: "TestResult";
+            internalId?: string | null | undefined;
+            dateTested?: any | null | undefined;
+            result?: string | null | undefined;
+            correctionStatus?: string | null | undefined;
+            symptoms?: string | null | undefined;
+            noSymptoms?: boolean | null | undefined;
+            deviceType?:
+              | { __typename?: "DeviceType"; internalId: string; name: string }
+              | null
+              | undefined;
+            patient?:
+              | {
+                  __typename?: "Patient";
+                  internalId?: string | null | undefined;
+                  firstName?: string | null | undefined;
+                  middleName?: string | null | undefined;
+                  lastName?: string | null | undefined;
+                  birthDate?: any | null | undefined;
+                  gender?: string | null | undefined;
+                  lookupId?: string | null | undefined;
+                  email?: string | null | undefined;
+                }
+              | null
+              | undefined;
+            createdBy?:
+              | {
+                  __typename?: "ApiUser";
+                  nameInfo?:
+                    | {
+                        __typename?: "NameInfo";
+                        firstName?: string | null | undefined;
+                        middleName?: string | null | undefined;
+                        lastName: string;
+                      }
+                    | null
+                    | undefined;
+                }
+              | null
+              | undefined;
+            patientLink?:
+              | {
+                  __typename?: "PatientLink";
+                  internalId?: string | null | undefined;
+                }
+              | null
+              | undefined;
+          }
+        | null
+        | undefined
+      >
+    | null
+    | undefined;
 };
 
 export type GetTestResultForResendingEmailsQueryVariables = Exact<{
@@ -2136,18 +2313,24 @@ export type GetTestResultForResendingEmailsQueryVariables = Exact<{
 
 export type GetTestResultForResendingEmailsQuery = {
   __typename?: "Query";
-  testResult?: Maybe<{
-    __typename?: "TestResult";
-    dateTested?: Maybe<any>;
-    patient?: Maybe<{
-      __typename?: "Patient";
-      firstName?: Maybe<string>;
-      middleName?: Maybe<string>;
-      lastName?: Maybe<string>;
-      email?: Maybe<string>;
-      emails?: Maybe<Array<Maybe<string>>>;
-    }>;
-  }>;
+  testResult?:
+    | {
+        __typename?: "TestResult";
+        dateTested?: any | null | undefined;
+        patient?:
+          | {
+              __typename?: "Patient";
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              email?: string | null | undefined;
+              emails?: Array<string | null | undefined> | null | undefined;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type ResendTestResultsEmailMutationVariables = Exact<{
@@ -2156,78 +2339,99 @@ export type ResendTestResultsEmailMutationVariables = Exact<{
 
 export type ResendTestResultsEmailMutation = {
   __typename?: "Mutation";
-  sendPatientLinkEmailByTestEventId?: Maybe<boolean>;
+  sendPatientLinkEmailByTestEventId?: boolean | null | undefined;
 };
 
 export type GetFacilityResultsForCsvQueryVariables = Exact<{
-  facilityId?: Maybe<Scalars["ID"]>;
-  patientId?: Maybe<Scalars["ID"]>;
-  result?: Maybe<Scalars["String"]>;
-  role?: Maybe<Scalars["String"]>;
-  startDate?: Maybe<Scalars["DateTime"]>;
-  endDate?: Maybe<Scalars["DateTime"]>;
-  pageNumber?: Maybe<Scalars["Int"]>;
-  pageSize?: Maybe<Scalars["Int"]>;
+  facilityId?: InputMaybe<Scalars["ID"]>;
+  patientId?: InputMaybe<Scalars["ID"]>;
+  result?: InputMaybe<Scalars["String"]>;
+  role?: InputMaybe<Scalars["String"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
+  endDate?: InputMaybe<Scalars["DateTime"]>;
+  pageNumber?: InputMaybe<Scalars["Int"]>;
+  pageSize?: InputMaybe<Scalars["Int"]>;
 }>;
 
 export type GetFacilityResultsForCsvQuery = {
   __typename?: "Query";
-  testResults?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: "TestResult";
-        dateTested?: Maybe<any>;
-        result?: Maybe<string>;
-        correctionStatus?: Maybe<string>;
-        reasonForCorrection?: Maybe<string>;
-        symptoms?: Maybe<string>;
-        noSymptoms?: Maybe<boolean>;
-        symptomOnset?: Maybe<any>;
-        facility?: Maybe<{ __typename?: "Facility"; name: string }>;
-        deviceType?: Maybe<{
-          __typename?: "DeviceType";
-          name: string;
-          manufacturer: string;
-          model: string;
-          swabType?: Maybe<string>;
-        }>;
-        patient?: Maybe<{
-          __typename?: "Patient";
-          firstName?: Maybe<string>;
-          middleName?: Maybe<string>;
-          lastName?: Maybe<string>;
-          birthDate?: Maybe<any>;
-          gender?: Maybe<string>;
-          race?: Maybe<string>;
-          ethnicity?: Maybe<string>;
-          tribalAffiliation?: Maybe<Array<Maybe<string>>>;
-          lookupId?: Maybe<string>;
-          telephone?: Maybe<string>;
-          email?: Maybe<string>;
-          street?: Maybe<string>;
-          streetTwo?: Maybe<string>;
-          city?: Maybe<string>;
-          county?: Maybe<string>;
-          state?: Maybe<string>;
-          zipCode?: Maybe<string>;
-          country?: Maybe<string>;
-          role?: Maybe<string>;
-          residentCongregateSetting?: Maybe<boolean>;
-          employedInHealthcare?: Maybe<boolean>;
-          preferredLanguage?: Maybe<string>;
-        }>;
-        createdBy?: Maybe<{
-          __typename?: "ApiUser";
-          nameInfo?: Maybe<{
-            __typename?: "NameInfo";
-            firstName?: Maybe<string>;
-            middleName?: Maybe<string>;
-            lastName: string;
-          }>;
-        }>;
-      }>
-    >
-  >;
+  testResults?:
+    | Array<
+        | {
+            __typename?: "TestResult";
+            dateTested?: any | null | undefined;
+            result?: string | null | undefined;
+            correctionStatus?: string | null | undefined;
+            reasonForCorrection?: string | null | undefined;
+            symptoms?: string | null | undefined;
+            noSymptoms?: boolean | null | undefined;
+            symptomOnset?: any | null | undefined;
+            facility?:
+              | { __typename?: "Facility"; name: string }
+              | null
+              | undefined;
+            deviceType?:
+              | {
+                  __typename?: "DeviceType";
+                  name: string;
+                  manufacturer: string;
+                  model: string;
+                  swabType?: string | null | undefined;
+                }
+              | null
+              | undefined;
+            patient?:
+              | {
+                  __typename?: "Patient";
+                  firstName?: string | null | undefined;
+                  middleName?: string | null | undefined;
+                  lastName?: string | null | undefined;
+                  birthDate?: any | null | undefined;
+                  gender?: string | null | undefined;
+                  race?: string | null | undefined;
+                  ethnicity?: string | null | undefined;
+                  tribalAffiliation?:
+                    | Array<string | null | undefined>
+                    | null
+                    | undefined;
+                  lookupId?: string | null | undefined;
+                  telephone?: string | null | undefined;
+                  email?: string | null | undefined;
+                  street?: string | null | undefined;
+                  streetTwo?: string | null | undefined;
+                  city?: string | null | undefined;
+                  county?: string | null | undefined;
+                  state?: string | null | undefined;
+                  zipCode?: string | null | undefined;
+                  country?: string | null | undefined;
+                  role?: string | null | undefined;
+                  residentCongregateSetting?: boolean | null | undefined;
+                  employedInHealthcare?: boolean | null | undefined;
+                  preferredLanguage?: string | null | undefined;
+                }
+              | null
+              | undefined;
+            createdBy?:
+              | {
+                  __typename?: "ApiUser";
+                  nameInfo?:
+                    | {
+                        __typename?: "NameInfo";
+                        firstName?: string | null | undefined;
+                        middleName?: string | null | undefined;
+                        lastName: string;
+                      }
+                    | null
+                    | undefined;
+                }
+              | null
+              | undefined;
+          }
+        | null
+        | undefined
+      >
+    | null
+    | undefined;
 };
 
 export const WhoAmIDocument = gql`

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12543,15 +12543,10 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.0.tgz#79f10248d23d104369eaef93acb9f887276a2c42"
   integrity sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==
 
-"graphql@14 - 16":
+"graphql@14 - 16", graphql@^16.3.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
   integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
-
-graphql@^15.4.0:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.3.tgz#c72349017d5c9f5446a897fe6908b3186db1da00"
-  integrity sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==
 
 graphql@^15.5.1:
   version "15.8.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11,10 +11,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apollo/client@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.1.tgz#e55cf8fd64eeff38860f55bee40c4cc626bb31dc"
-  integrity sha512-CT7ZBSHQD4UG1PDvMS9qOz5ACRIR0b4mBkqjCXEVjteOxA4wpFqUX3dg2bNl+Ok3LwPxFT4b3FwC3+LVcWFa6w==
+"@apollo/client@3.5.8", "@apollo/client@^3.0.0":
+  version "3.5.8"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.8.tgz#7215b974c5988b6157530eb69369209210349fe0"
+  integrity sha512-MAm05+I1ullr64VLpZwon/ISnkMuNLf6vDqgo9wiMhHYBGT4yOAbAIseRdjCHZwfSx/7AUuBgaTNOssZPIr6FQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"
@@ -25,28 +25,9 @@
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.9.0"
+    ts-invariant "^0.9.4"
     tslib "^2.3.0"
-    zen-observable-ts "^1.1.0"
-
-"@apollo/client@^3.1.3", "@apollo/client@^3.2.5":
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.7.tgz#f15bf961dc0c2bee37a47bf86b8881fdc6183810"
-  integrity sha512-Cb0OqqvlehlRHtHIXRIS/Pe5WYU4hHl1FznXTRSxBAN42WmBUM3zy/Unvw183RdWMyV6Kc2pFKOEuaG1K7JTAQ==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
-    "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.3.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.11.0"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.14.0"
-    prop-types "^15.7.2"
-    symbol-observable "^2.0.0"
-    ts-invariant "^0.6.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
+    zen-observable-ts "^1.2.0"
 
 "@ardatan/aggregate-error@0.0.6":
   version "0.0.6"
@@ -3479,13 +3460,13 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@graphql-codegen/cli@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.2.0.tgz#84a909cb46f009cafc59aa719b816494b0ca222b"
-  integrity sha512-f4EsScASza57aPM1z6eKAaYmwz83B/LsmiyBb8phy1NfbWea2IBUCfEgtvOHN85xbiMpdQfNtckE2mC84yH80w==
+"@graphql-codegen/cli@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.4.0.tgz#7df3ee2bdd5b88a5904ee6f52eafeb370ef70e51"
+  integrity sha512-4iiHH2AxBE17lX5cFdFg6+kh7I6uKQLYG0IZRalRbW/grKL7kuVp/RDUjmVB2GNJTJEhjxYLMJFJZocUmAUBlw==
   dependencies:
-    "@graphql-codegen/core" "2.1.0"
-    "@graphql-codegen/plugin-helpers" "^2.1.0"
+    "@graphql-codegen/core" "2.4.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
     "@graphql-tools/apollo-engine-loader" "^7.0.5"
     "@graphql-tools/code-file-loader" "^7.0.6"
     "@graphql-tools/git-loader" "^7.0.5"
@@ -3507,8 +3488,8 @@
     detect-indent "^6.0.0"
     glob "^7.1.6"
     globby "^11.0.4"
-    graphql-config "^4.0.1"
-    inquirer "^7.3.3"
+    graphql-config "^4.1.0"
+    inquirer "^8.0.0"
     is-glob "^4.0.1"
     json-to-pretty-yaml "^1.2.2"
     latest-version "5.1.0"
@@ -3525,69 +3506,79 @@
     yaml "^1.10.0"
     yargs "^17.0.0"
 
-"@graphql-codegen/core@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-2.1.0.tgz#c0b2d63ad3e77b794b6a84485c4a8ac72c291c6b"
-  integrity sha512-pNzpBZWP+B7doPtANN61CMoBq382KMuGierbZXyilrO6RAqgN/DgU4UEIaQFat1BfiVA5GFDAQryysOv4glU8g==
+"@graphql-codegen/core@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-2.4.0.tgz#d94dcc088b5e117c847ce5b10c4fe1eb7325e180"
+  integrity sha512-5RiYE1+07jayp/3w/bkyaCXtfKNeKmRabpPP4aRi369WeH2cH37l2K8NbhkIU+zhpnhoqMID61TO56x2fKldZQ==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.1.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
     "@graphql-tools/schema" "^8.1.2"
     "@graphql-tools/utils" "^8.1.1"
     tslib "~2.3.0"
 
-"@graphql-codegen/plugin-helpers@^2.1.0", "@graphql-codegen/plugin-helpers@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.1.1.tgz#fc13e735763574ef308045bbb95c3e7201ec0027"
-  integrity sha512-7jjN9fekMQkpd7cRTbaBxgqt/hkR3CXeOUSsEyHFDDHKtvCrnev3iyc75IeWXpO9tOwDE8mVPTzEZnu4QukrNA==
+"@graphql-codegen/plugin-helpers@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.3.2.tgz#3f9ba625791901d19be733db1dfc9a3dbd0dac44"
+  integrity sha512-19qFA5XMAWaAY64sBljjDPYfHjE+QMk/+oalCyY13WjSlcLDvYPfmFlCNgFSsydArDELlHR8T1GMbA7C42M8TA==
   dependencies:
-    "@graphql-tools/utils" "^8.1.1"
+    "@graphql-tools/utils" "^8.5.2"
     change-case-all "1.0.14"
-    common-tags "1.8.0"
+    common-tags "1.8.2"
     import-from "4.0.0"
     lodash "~4.17.0"
     tslib "~2.3.0"
 
-"@graphql-codegen/typescript-operations@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.1.4.tgz#4cc093188abd4da573ee882b6a1c300523b69e97"
-  integrity sha512-IftToh41G1haeRZ4dJw0zG0MTkAS1JvdTrn3ZwVbzpXks98utC4X93qJnbd1h7rTAtZa0Kk6YS2F5OP/64ZWpg==
+"@graphql-codegen/schema-ast@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.4.1.tgz#ad742b53e32f7a2fbff8ea8a91ba7e617e6ef236"
+  integrity sha512-bIWlKk/ShoVJfghA4Rt1OWnd34/dQmZM/vAe6fu6QKyOh44aAdqPtYQ2dbTyFXoknmu504etKJGEDllYNUJRfg==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.1.1"
-    "@graphql-codegen/typescript" "^2.2.2"
-    "@graphql-codegen/visitor-plugin-common" "2.2.1"
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
+    "@graphql-tools/utils" "^8.1.1"
+    tslib "~2.3.0"
+
+"@graphql-codegen/typescript-operations@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.2.2.tgz#028f2850ae85021d8932b5670e5feca7b0d5c767"
+  integrity sha512-J50AuTA37RYv67hP2oHbfr3iGxexTCoadQsbr5pEUGucrIupCA0hLEJH2W+9/h6YNh0UlZT3kRTJp81ARoAjOA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
+    "@graphql-codegen/typescript" "^2.4.2"
+    "@graphql-codegen/visitor-plugin-common" "2.5.2"
     auto-bind "~4.0.0"
     tslib "~2.3.0"
 
-"@graphql-codegen/typescript-react-apollo@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-3.1.4.tgz#be198c36ef3caa8f30d5e2a609ccb8950fcec946"
-  integrity sha512-XuQ5owAyqaewUU0Je2ye8NWWCcKEo/C/ruEqYHQaFyswCE4KGNbCcfxrl0+dW788qk/NI5dVrConwbH2ze5YnQ==
+"@graphql-codegen/typescript-react-apollo@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-3.2.4.tgz#3dd419cccdb016b2a8171b5e9d89ee411d17a5df"
+  integrity sha512-IcbvGYHZy2hX9aGvxm3t9EBQ1lBgAod3jY/is53QEstdUWHNB+cEVtePgtUJGMm637KYcw4tvygaqrSeoWq8Sw==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.1.1"
-    "@graphql-codegen/visitor-plugin-common" "2.2.1"
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
+    "@graphql-codegen/visitor-plugin-common" "2.5.2"
     auto-bind "~4.0.0"
     change-case-all "1.0.14"
     tslib "~2.3.0"
 
-"@graphql-codegen/typescript@2.2.2", "@graphql-codegen/typescript@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.2.2.tgz#8ea14c0a7853f6b73cca0ed10ff43b6dbd3731c6"
-  integrity sha512-prcB4nNi2iQzZRLla6N6kEPmnE2WU1zz5+sEBcZcqphjWERqQ3zwdSKsuLorE/XxMp500p6BQ96cVo+bFkmVtA==
+"@graphql-codegen/typescript@2.4.2", "@graphql-codegen/typescript@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.4.2.tgz#a239d5fd8f11140d5d4c81cfae7ff02054b724dc"
+  integrity sha512-8ajWidiFqF1KNAywtb/692SjwTyjzrDHo1sf2Q7Z+rh9qDEIrh83VHB8naT/1CefOvxj3MS6GbcsvJMizaE/AQ==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.1.1"
-    "@graphql-codegen/visitor-plugin-common" "2.2.1"
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
+    "@graphql-codegen/schema-ast" "^2.4.1"
+    "@graphql-codegen/visitor-plugin-common" "2.5.2"
     auto-bind "~4.0.0"
     tslib "~2.3.0"
 
-"@graphql-codegen/visitor-plugin-common@2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.2.1.tgz#721b646d3d19ec0fcf9509f516e788b7151be003"
-  integrity sha512-RbTCaayVCAEMp2jRUAwAp6Y49gq7K+SV/rwzdkoMUJUOUu4PxM4bCbWdnnXr0CIpbwjYIOnoqx729q6riT5+hg==
+"@graphql-codegen/visitor-plugin-common@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.5.2.tgz#90aa4add41e17bca83f1c7c8ad674f2a06065efd"
+  integrity sha512-qDMraPmumG+vEGAz42/asRkdgIRmQWH5HTc320UX+I6CY6eE/Ey85cgzoqeQGLV8gu4sj3UkNx/3/r79eX4u+Q==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.1.1"
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
     "@graphql-tools/optimize" "^1.0.1"
     "@graphql-tools/relay-operation-optimizer" "^6.3.7"
-    "@graphql-tools/utils" "8.2.2"
+    "@graphql-tools/utils" "^8.3.0"
     auto-bind "~4.0.0"
     change-case-all "1.0.14"
     dependency-graph "^0.11.0"
@@ -3625,6 +3616,16 @@
     tslib "~2.3.0"
     value-or-promise "1.0.10"
 
+"@graphql-tools/batch-execute@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz#0b74c54db5ac1c5b9a273baefc034c2343ebbb74"
+  integrity sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==
+  dependencies:
+    "@graphql-tools/utils" "^8.5.1"
+    dataloader "2.0.0"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
+
 "@graphql-tools/code-file-loader@^7.0.6":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.1.0.tgz#3fd040ce92510a12c361bac85d0d954951e231f5"
@@ -3661,6 +3662,18 @@
     tslib "~2.3.0"
     value-or-promise "1.0.10"
 
+"@graphql-tools/delegate@^8.4.1", "@graphql-tools/delegate@^8.4.2":
+  version "8.4.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-8.4.3.tgz#ad73ed7cc3b4cad9242c6d4835a5ae0b640f7164"
+  integrity sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==
+  dependencies:
+    "@graphql-tools/batch-execute" "^8.3.1"
+    "@graphql-tools/schema" "^8.3.1"
+    "@graphql-tools/utils" "^8.5.4"
+    dataloader "2.0.0"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
+
 "@graphql-tools/git-loader@^7.0.5":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-7.1.0.tgz#6d4978752e058b69047bccca1d11c50b1e29b401"
@@ -3692,13 +3705,24 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/graphql-file-loader@^7.0.1", "@graphql-tools/graphql-file-loader@^7.0.5":
+"@graphql-tools/graphql-file-loader@^7.0.5":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.1.0.tgz#6249074a7d268a30c81e923ee2bb991ec9a4c7b7"
   integrity sha512-VWGetkBuyWrUxSpMnbpzZs2yHWBFeo9nTYjc8+o+xyJKpG/CRfvQrhBRNRFfV/5C0j5/Z1FMfUgsroEAG5H3HQ==
   dependencies:
     "@graphql-tools/import" "^6.4.0"
     "@graphql-tools/utils" "^8.2.0"
+    globby "^11.0.3"
+    tslib "~2.3.0"
+    unixify "^1.0.0"
+
+"@graphql-tools/graphql-file-loader@^7.3.2":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.3.tgz#7cee2f84f08dc13fa756820b510248b857583d36"
+  integrity sha512-6kUJZiNpYKVhum9E5wfl5PyLLupEDYdH7c8l6oMrk6c7EPEVs6iSUyB7yQoWrtJccJLULBW2CRQ5IHp5JYK0mA==
+  dependencies:
+    "@graphql-tools/import" "^6.5.7"
+    "@graphql-tools/utils" "^8.5.1"
     globby "^11.0.3"
     tslib "~2.3.0"
     unixify "^1.0.0"
@@ -3730,6 +3754,15 @@
     resolve-from "5.0.0"
     tslib "~2.3.0"
 
+"@graphql-tools/import@^6.5.7":
+  version "6.6.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.6.5.tgz#e1ec593960288ceda7d5c56c0073c702b1bdcfa0"
+  integrity sha512-w0/cYuhrr2apn+iGoTToCqt65x2NN2iHQyqRNk/Zw1NJ+e8/C3eKVw0jmW4pYQvSocuPxL4UCSI56SdKO7m3+Q==
+  dependencies:
+    "@graphql-tools/utils" "8.6.1"
+    resolve-from "5.0.0"
+    tslib "~2.3.0"
+
 "@graphql-tools/json-file-loader@^6.0.0":
   version "6.2.6"
   resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-6.2.6.tgz#830482cfd3721a0799cbf2fe5b09959d9332739a"
@@ -3738,12 +3771,22 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/json-file-loader@^7.0.1", "@graphql-tools/json-file-loader@^7.1.2":
+"@graphql-tools/json-file-loader@^7.1.2":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.2.0.tgz#0d5cdc372a5d925a470c7b2269f26dd659eef841"
   integrity sha512-YMGjYtjYoalmGHUynypSqxm99fSBOXWqoDeDVYTHAZy970yo61yTi72owEtg7dwB4fQndL2wCoh6ZDS5ruiDDg==
   dependencies:
     "@graphql-tools/utils" "^8.2.0"
+    globby "^11.0.3"
+    tslib "~2.3.0"
+    unixify "^1.0.0"
+
+"@graphql-tools/json-file-loader@^7.3.2":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.3.3.tgz#45cfde77b9dc4ab6c21575305ae537d2814d237f"
+  integrity sha512-CN2Qk9rt+Gepa3rb3X/mpxYA5MIYLwZBPj2Njw6lbZ6AaxG+O1ArDCL5ACoiWiBimn1FCOM778uhRM9znd0b3Q==
+  dependencies:
+    "@graphql-tools/utils" "^8.5.1"
     globby "^11.0.3"
     tslib "~2.3.0"
     unixify "^1.0.0"
@@ -3763,13 +3806,23 @@
     unixify "1.0.0"
     valid-url "1.0.9"
 
-"@graphql-tools/load@^7.1.0", "@graphql-tools/load@^7.3.0":
+"@graphql-tools/load@^7.3.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.3.0.tgz#dc4177bb4b7ae537c833a2fcd97ab07b6c789c65"
   integrity sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==
   dependencies:
     "@graphql-tools/schema" "8.2.0"
     "@graphql-tools/utils" "^8.2.0"
+    p-limit "3.1.0"
+    tslib "~2.3.0"
+
+"@graphql-tools/load@^7.4.1":
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.5.1.tgz#8c7f846d2185ddc1d44fdfbf1ed9cb678f69e40b"
+  integrity sha512-j9XcLYZPZdl/TzzqA83qveJmwcCxgGizt5L1+C1/Z68brTEmQHLdQCOR3Ma3ewESJt6DU05kSTu2raKaunkjRg==
+  dependencies:
+    "@graphql-tools/schema" "8.3.1"
+    "@graphql-tools/utils" "^8.6.0"
     p-limit "3.1.0"
     tslib "~2.3.0"
 
@@ -3782,21 +3835,20 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/merge@^6.2.16":
-  version "6.2.17"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.2.17.tgz#4dedf87d8435a5e1091d7cc8d4f371ed1e029f1f"
-  integrity sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==
-  dependencies:
-    "@graphql-tools/schema" "^8.0.2"
-    "@graphql-tools/utils" "8.0.2"
-    tslib "~2.3.0"
-
 "@graphql-tools/merge@^8.1.0":
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.1.2.tgz#50f5763927c51de764d09c5bfd20261671976e24"
   integrity sha512-kFLd4kKNJXYXnKIhM8q9zgGAtbLmsy3WmGdDxYq3YHBJUogucAxnivQYyRIseUq37KGmSAIWu3pBQ23TKGsGOw==
   dependencies:
     "@graphql-tools/utils" "^8.2.2"
+    tslib "~2.3.0"
+
+"@graphql-tools/merge@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.1.tgz#bf83aa06a0cfc6a839e52a58057a84498d0d51ff"
+  integrity sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==
+  dependencies:
+    "@graphql-tools/utils" "^8.5.1"
     tslib "~2.3.0"
 
 "@graphql-tools/optimize@^1.0.1":
@@ -3841,7 +3893,7 @@
     relay-compiler "11.0.2"
     tslib "~2.3.0"
 
-"@graphql-tools/schema@8.2.0", "@graphql-tools/schema@^8.0.2", "@graphql-tools/schema@^8.1.2", "@graphql-tools/schema@^8.2.0":
+"@graphql-tools/schema@8.2.0", "@graphql-tools/schema@^8.1.2", "@graphql-tools/schema@^8.2.0":
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.2.0.tgz#ae75cbb2df6cee9ed6d89fce56be467ab23758dc"
   integrity sha512-ufmI5mJQa8NJczzfkh0pUttKvspqDcT5LLakA3jUmOrrE4d4NVj6onZlazdTzF5sAepSNqanFnwhrxZpCAJMKg==
@@ -3850,6 +3902,16 @@
     "@graphql-tools/utils" "^8.2.0"
     tslib "~2.3.0"
     value-or-promise "1.0.10"
+
+"@graphql-tools/schema@8.3.1", "@graphql-tools/schema@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.1.tgz#1ee9da494d2da457643b3c93502b94c3c4b68c74"
+  integrity sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==
+  dependencies:
+    "@graphql-tools/merge" "^8.2.1"
+    "@graphql-tools/utils" "^8.5.1"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
 
 "@graphql-tools/schema@^7.0.0", "@graphql-tools/schema@^7.1.2":
   version "7.1.2"
@@ -3882,7 +3944,7 @@
     valid-url "1.0.9"
     ws "7.4.1"
 
-"@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.0.3", "@graphql-tools/url-loader@^7.1.0":
+"@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.2.0.tgz#f70f77b9a3cfb8de0460a05a93590d16a68af09a"
   integrity sha512-1HOyt89TlzINko/Sa39oNQCzvbIshAiz+ECaoJKkIfkQZzXWzRkDrU5nEIPGm/FsCHm519OiJeaLwPLbdqnrLw==
@@ -3911,17 +3973,35 @@
     value-or-promise "1.0.10"
     ws "8.2.2"
 
-"@graphql-tools/utils@8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.0.2.tgz#795a8383cdfdc89855707d62491c576f439f3c51"
-  integrity sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==
+"@graphql-tools/url-loader@^7.4.2":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.7.1.tgz#2faabdc1d2c47edc8edc9cc938eee2767189869f"
+  integrity sha512-K/5amdeHtKYI976HVd/AXdSNvLL7vx5QVjMlwN0OHeYyxSgC+UOH+KkS7cshYgL13SekGu0Mxbg9ABfgQ34ECA==
   dependencies:
-    tslib "~2.3.0"
+    "@graphql-tools/delegate" "^8.4.1"
+    "@graphql-tools/utils" "^8.5.1"
+    "@graphql-tools/wrap" "^8.3.1"
+    "@n1ru4l/graphql-live-query" "^0.9.0"
+    "@types/websocket" "^1.0.4"
+    "@types/ws" "^8.0.0"
+    cross-undici-fetch "^0.1.19"
+    dset "^3.1.0"
+    extract-files "^11.0.0"
+    graphql-sse "^1.0.1"
+    graphql-ws "^5.4.1"
+    isomorphic-ws "^4.0.1"
+    meros "^1.1.4"
+    subscriptions-transport-ws "^0.11.0"
+    sync-fetch "^0.3.1"
+    tslib "^2.3.0"
+    valid-url "^1.0.9"
+    value-or-promise "^1.0.11"
+    ws "^8.3.0"
 
-"@graphql-tools/utils@8.2.2", "@graphql-tools/utils@^8.0.1", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.2.0", "@graphql-tools/utils@^8.2.2":
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.2.2.tgz#d29420bf1003d2876cb30f373145be432c7f7c4b"
-  integrity sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==
+"@graphql-tools/utils@8.6.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.1", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.5.3", "@graphql-tools/utils@^8.5.4", "@graphql-tools/utils@^8.6.0":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.1.tgz#52c7eb108f2ca2fd01bdba8eef85077ead1bf882"
+  integrity sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==
   dependencies:
     tslib "~2.3.0"
 
@@ -3942,6 +4022,13 @@
     "@ardatan/aggregate-error" "0.0.6"
     camel-case "4.1.2"
     tslib "~2.0.1"
+
+"@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.2.0", "@graphql-tools/utils@^8.2.2":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.2.2.tgz#d29420bf1003d2876cb30f373145be432c7f7c4b"
+  integrity sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==
+  dependencies:
+    tslib "~2.3.0"
 
 "@graphql-tools/wrap@^7.0.4":
   version "7.0.4"
@@ -3964,6 +4051,17 @@
     "@graphql-tools/utils" "^8.2.0"
     tslib "~2.3.0"
     value-or-promise "1.0.10"
+
+"@graphql-tools/wrap@^8.3.1":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-8.3.3.tgz#014aa04a6cf671ffe477516255d1134777da056a"
+  integrity sha512-TpXN1S4Cv+oMA1Zsg9Nu4N9yrFxLuJkX+CTtSRrrdfETGHIxqfyDkm5slPDCckxP+RILA00g8ny2jzsYyNvX1w==
+  dependencies:
+    "@graphql-tools/delegate" "^8.4.2"
+    "@graphql-tools/schema" "^8.3.1"
+    "@graphql-tools/utils" "^8.5.3"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
 
 "@graphql-typed-document-node/core@^3.0.0":
   version "3.1.0"
@@ -4382,6 +4480,11 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.1.tgz#2d6ca6157dafdc5d122a1aeb623b43e939c4b238"
   integrity sha512-x5SLY+L9/5s07OJprISXx4csNBPF74UZeTI01ZPSaxOtRz2Gljk652kSPf6OjMLtx5uATr35O0M3G0LYhHBLtg==
+
+"@n1ru4l/graphql-live-query@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz#defaebdd31f625bee49e6745934f36312532b2bc"
+  integrity sha512-BTpWy1e+FxN82RnLz4x1+JcEewVdfmUhV1C6/XYD5AjS7PQp9QFF7K8bCD6gzPTr2l+prvqOyVueQhFJxB1vfg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5852,14 +5955,14 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
-"@types/apollo-upload-client@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@types/apollo-upload-client/-/apollo-upload-client-14.1.0.tgz#21a57d7e3f29ff946ba51a53b3d7da46ddd21fbc"
-  integrity sha512-ZLvcEqu+l9qKGdrIpASt/A2WY1ghAC9L3qaoegkiBOccjxvQmWN9liZzVFiuHTuWseWpVbMklqbs/z+KEjll9Q==
+"@types/apollo-upload-client@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/apollo-upload-client/-/apollo-upload-client-17.0.0.tgz#e9ae78c3c3f1a70b5724616c83f5af2ad902f1d0"
+  integrity sha512-S1HUj9g+wn0fM29vLsnD87hTW2h2k/ELlTTJ+mUHTnF6oxmm46KkqxrzFPR7u2rQBjjSiKQEaXLqBn76s8bzBg==
   dependencies:
-    "@apollo/client" "^3.1.3"
+    "@apollo/client" "^3.0.0"
     "@types/extract-files" "*"
-    graphql "^15.3.0"
+    graphql "14 - 16"
 
 "@types/aria-query@^4.2.0":
   version "4.2.0"
@@ -6528,11 +6631,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/ungap__global-this@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"
-  integrity sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==
-
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -6588,7 +6686,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/websocket@1.0.4":
+"@types/websocket@1.0.4", "@types/websocket@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.4.tgz#1dc497280d8049a5450854dd698ee7e6ea9e60b8"
   integrity sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==
@@ -6602,7 +6700,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.2.2":
+"@types/ws@^8.0.0", "@types/ws@^8.2.2":
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.2.tgz#7c5be4decb19500ae6b3d563043cd407bf366c21"
   integrity sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==
@@ -6634,16 +6732,6 @@
   integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
   dependencies:
     "@types/node" "*"
-
-"@types/zen-observable@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
-
-"@types/zen-observable@^0.8.0":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
-  integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
 "@typescript-eslint/eslint-plugin@^5.5.0", "@typescript-eslint/eslint-plugin@^5.9.1":
   version "5.9.1"
@@ -6724,11 +6812,6 @@
   dependencies:
     "@typescript-eslint/types" "5.9.1"
     eslint-visitor-keys "^3.0.0"
-
-"@ungap/global-this@^0.4.2":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.4.tgz#8a1b2cfcd3e26e079a847daba879308c924dd695"
-  integrity sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==
 
 "@vue/compiler-core@3.2.26":
   version "3.2.26"
@@ -7054,13 +7137,6 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wry/context@^0.5.2":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.3.tgz#537db8a5b51f98507dc38f869b3a48c672f48942"
-  integrity sha512-n0uKHiWpf2ArHhmcHcUsKA+Dj0gtye/h56VmsDcoMRuK/ZPFeHKi8ck5L/ftqtF12ZbQR9l8xMPV7y+xybaRDA==
-  dependencies:
-    tslib "^1.14.1"
-
 "@wry/context@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.0.tgz#f903eceb89d238ef7e8168ed30f4511f92d83e06"
@@ -7068,26 +7144,12 @@
   dependencies:
     tslib "^2.1.0"
 
-"@wry/equality@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.1.tgz#81080cdc2e0d8265cd303faa0c64b38a77884e06"
-  integrity sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==
-  dependencies:
-    tslib "^1.14.1"
-
 "@wry/equality@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.1.tgz#b22e4e1674d7bf1439f8ccdccfd6a785f6de68b0"
   integrity sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==
   dependencies:
     tslib "^2.1.0"
-
-"@wry/trie@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.2.1.tgz#4191e1d4a85dd77dfede383d65563138ed82fc47"
-  integrity sha512-sYkuXZqArky2MLQCv4tLW6hX3N8AfTZ5ZMBc8jC6Yy35WYr82UYLLtjS7k/uRGHOA0yTSjuNadG6QQ6a5CS5hQ==
-  dependencies:
-    tslib "^1.14.1"
 
 "@wry/trie@^0.3.0":
   version "0.3.0"
@@ -7116,7 +7178,7 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
-abort-controller@3.0.0:
+abort-controller@3.0.0, abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -7414,14 +7476,12 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-upload-client@^14.1.3:
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-14.1.3.tgz#91f39011897bd08e99c0de0164e77ad2f3402247"
-  integrity sha512-X2T+7pHk5lcaaWnvP9h2tuAAMCzOW6/9juedQ0ZuGp3Ufl81BpDISlCs0o6u29wBV0RRT/QpMU2gbP+3FCfVpQ==
+apollo-upload-client@^17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-17.0.0.tgz#d9baaff8d14e54510de9f2855b487e75ca63b392"
+  integrity sha512-pue33bWVbdlXAGFPkgz53TTmxVMrKeQr0mdRcftNY+PoHIdbGZD0hoaXHvO6OePJAkFz7OiCFUf98p1G/9+Ykw==
   dependencies:
-    "@apollo/client" "^3.2.5"
-    "@babel/runtime" "^7.12.5"
-    extract-files "^9.0.0"
+    extract-files "^11.0.0"
 
 app-root-dir@^1.0.2:
   version "1.0.2"
@@ -9219,12 +9279,7 @@ common-path-prefix@^3.0.0:
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
   integrity sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
 
-common-tags@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
-  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
-
-common-tags@^1.8.0:
+common-tags@1.8.2, common-tags@^1.8.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
@@ -9440,10 +9495,10 @@ cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@7.0.0, cosmiconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
-  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+cosmiconfig@7.0.1, cosmiconfig@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
@@ -9451,10 +9506,10 @@ cosmiconfig@7.0.0, cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cosmiconfig@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
-  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
@@ -9564,6 +9619,18 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-undici-fetch@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/cross-undici-fetch/-/cross-undici-fetch-0.1.19.tgz#1bef41652c33ec812b51cd3b4e1295114cd62d4c"
+  integrity sha512-bNBuesVn09Iy15mAM/hpt97fLWSexblVYpUYa5FjbtLHA7om9w3g1uRGGwrEnmVxy3wouNvZyJwQzAPHXgOrxQ==
+  dependencies:
+    abort-controller "^3.0.0"
+    form-data-encoder "^1.7.1"
+    formdata-node "^4.3.1"
+    node-fetch "^2.6.7"
+    undici "^4.9.3"
+    web-streams-polyfill "^3.2.0"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -10487,6 +10554,11 @@ downshift@^6.0.15:
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+dset@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.1.tgz#07de5af7a8d03eab337ad1a8ba77fe17bba61a8c"
+  integrity sha512-hYf+jZNNqJBD2GiMYb+5mqOIX4R4RRHXU3qWMWYN+rqcR2/YpRL2bUHr8C8fU+5DNvqYjJ8YvMGSLuVPWU1cNg==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -11408,7 +11480,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-files@11.0.0:
+extract-files@11.0.0, extract-files@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-11.0.0.tgz#b72d428712f787eef1f5193aff8ab5351ca8469a"
   integrity sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==
@@ -11815,6 +11887,11 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     semver "^7.3.2"
     tapable "^1.0.0"
 
+form-data-encoder@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.1.tgz#ac80660e4f87ee0d3d3c3638b7da8278ddb8ec96"
+  integrity sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==
+
 form-data@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -11855,6 +11932,14 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formdata-node@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.3.2.tgz#0262e94931e36db7239c2b08bdb6aaf18ec47d21"
+  integrity sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==
+  dependencies:
+    node-domexception "1.0.0"
+    web-streams-polyfill "4.0.0-beta.1"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -12371,19 +12456,19 @@ graphql-config@^3.0.2:
     string-env-interpolation "1.0.1"
     tslib "^2.0.0"
 
-graphql-config@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.0.1.tgz#4ce43cb54f3f39dde5f023d6f8f04064edc16e6e"
-  integrity sha512-JdXxFzBwjujJMGLHUZom9SrmP/M4gF57iTDa3fJVm3Q85+Xw2kj9jZIygaaSLpDKhaPnMQZqfJ5Hmc6afKxS9w==
+graphql-config@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.1.0.tgz#a3b28d3fb537952ebeb69c75e4430605a10695e3"
+  integrity sha512-Myqay6pmdcmX3KqoH+bMbeKZ1cTODpHS2CxF1ZzNnfTE+YUpGTcp01bOw6LpzamRb0T/WTYtGFbZeXGo9Hab2Q==
   dependencies:
     "@endemolshinegroup/cosmiconfig-typescript-loader" "3.0.2"
-    "@graphql-tools/graphql-file-loader" "^7.0.1"
-    "@graphql-tools/json-file-loader" "^7.0.1"
-    "@graphql-tools/load" "^7.1.0"
-    "@graphql-tools/merge" "^6.2.16"
-    "@graphql-tools/url-loader" "^7.0.3"
-    "@graphql-tools/utils" "^8.0.1"
-    cosmiconfig "7.0.0"
+    "@graphql-tools/graphql-file-loader" "^7.3.2"
+    "@graphql-tools/json-file-loader" "^7.3.2"
+    "@graphql-tools/load" "^7.4.1"
+    "@graphql-tools/merge" "^8.2.1"
+    "@graphql-tools/url-loader" "^7.4.2"
+    "@graphql-tools/utils" "^8.5.1"
+    cosmiconfig "7.0.1"
     cosmiconfig-toml-loader "1.0.0"
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
@@ -12435,10 +12520,10 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.0.tgz#79f10248d23d104369eaef93acb9f887276a2c42"
   integrity sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==
 
-graphql@^15.3.0:
-  version "15.4.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
-  integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
+"graphql@14 - 16":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
+  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
 graphql@^15.4.0:
   version "15.5.3"
@@ -13171,26 +13256,7 @@ inline-style-parser@0.1.1:
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
-inquirer@^7.3.3:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
-  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.19"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.6.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
-inquirer@^8.2.0:
+inquirer@^8.0.0, inquirer@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.0.tgz#f44f008dd344bbfc4b30031f45d984e034a3ac3a"
   integrity sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==
@@ -13832,7 +13898,7 @@ isomorphic-form-data@2.0.0:
   dependencies:
     form-data "^2.3.2"
 
-isomorphic-ws@4.0.1:
+isomorphic-ws@4.0.1, isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
@@ -15384,7 +15450,7 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-meros@1.1.4:
+meros@1.1.4, meros@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.1.4.tgz#c17994d3133db8b23807f62bec7f0cb276cfd948"
   integrity sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==
@@ -15805,10 +15871,22 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^1.2.0:
   version "1.2.0"
@@ -16220,14 +16298,6 @@ open@^8.0.9, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
-
-optimism@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.14.0.tgz#256fb079a3428585b40a3a8462f907e0abd2fc49"
-  integrity sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==
-  dependencies:
-    "@wry/context" "^0.5.2"
-    "@wry/trie" "^0.2.1"
 
 optimism@^0.16.1:
   version "0.16.1"
@@ -18837,7 +18907,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.3.3, rxjs@^6.6.0:
+rxjs@^6.3.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -20012,6 +20082,17 @@ subscriptions-transport-ws@^0.10.0:
     symbol-observable "^1.0.4"
     ws "^5.2.0 || ^6.0.0 || ^7.0.0"
 
+subscriptions-transport-ws@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
+  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 sugarss@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-2.0.0.tgz#ddd76e0124b297d40bf3cca31c8b22ecb43bc61d"
@@ -20119,11 +20200,6 @@ symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-symbol-observable@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
-  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
-
 symbol-observable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
@@ -20148,6 +20224,14 @@ sync-fetch@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.3.0.tgz#77246da949389310ad978ab26790bb05f88d1335"
   integrity sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==
+  dependencies:
+    buffer "^5.7.0"
+    node-fetch "^2.6.1"
+
+sync-fetch@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.3.1.tgz#62aa82c4b4d43afd6906bfd7b5f92056458509f0"
+  integrity sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==
   dependencies:
     buffer "^5.7.0"
     node-fetch "^2.6.1"
@@ -20544,6 +20628,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-newlines@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
@@ -20579,19 +20668,10 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-invariant@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.6.0.tgz#44066ecfeb7a806ff1c3b0b283408a337a885412"
-  integrity sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==
-  dependencies:
-    "@types/ungap__global-this" "^0.3.1"
-    "@ungap/global-this" "^0.4.2"
-    tslib "^1.9.3"
-
-ts-invariant@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.0.tgz#4c60e9159a31742ab0103f13d7f63314fb5409c9"
-  integrity sha512-+JqhKqywk+ue5JjAC6eTWe57mOIxYXypMUkBDStkAzvnlfkDJ1KGyeMuNRMwOt6GXzHSC1UT9JecowpZDmgXqA==
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -20627,7 +20707,7 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.14.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -20784,6 +20864,11 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
+
+undici@^4.9.3:
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-4.12.2.tgz#f2fc50ca77a774ed8c0e7067c9361ee18a2f422b"
+  integrity sha512-RZj6SbkQFs5O/pJCboGEo6l5DTCe3Zg4r/8Z/0/2qnIv08+s6zL4akohOPMYWKc3mzwv15WTvsfMWaafZcvYoQ==
 
 unfetch@^4.2.0:
   version "4.2.0"
@@ -21193,6 +21278,11 @@ value-or-promise@1.0.10:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.10.tgz#5bf041f1e9a8e7043911875547636768a836e446"
   integrity sha512-1OwTzvcfXkAfabk60UVr5NdjtjJ0Fg0T5+B1bhxtrOEwSH2fe8y4DnLgoksfCyd8yZCOQQHB0qLMQnwgCjbXLQ==
 
+value-or-promise@1.0.11, value-or-promise@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.11.tgz#3e90299af31dd014fe843fe309cefa7c1d94b140"
+  integrity sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -21312,6 +21402,21 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-streams-polyfill@4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz#3b19b9817374b7cee06d374ba7eeb3aeb80e8c95"
+  integrity sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==
+
+web-streams-polyfill@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -21585,6 +21690,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"
@@ -21918,6 +22031,11 @@ ws@^8.1.0, ws@^8.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.0.tgz#f05e982a0a88c604080e8581576e2a063802bed6"
   integrity sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==
 
+ws@^8.3.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
+  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -22073,15 +22191,14 @@ yup@^0.32.9:
     property-expr "^2.0.4"
     toposort "^2.0.2"
 
-zen-observable-ts@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
-  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
   dependencies:
-    "@types/zen-observable" "0.8.3"
     zen-observable "0.8.15"
 
-zen-observable@0.8.15, zen-observable@^0.8.14:
+zen-observable@0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11,7 +11,25 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apollo/client@3.5.8", "@apollo/client@^3.0.0":
+"@apollo/client@3.4.17":
+  version "3.4.17"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.17.tgz#4972e19a49809e16d17c5adc67f45623a6dac135"
+  integrity sha512-MDt2rwMX1GqodiVEKJqmDmAz8xr0qJmq5PdWeIt0yDaT4GOkKYWZiWkyfhfv3raTk8PyJvbsNG9q2CqmUrlGfg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.0"
+    tslib "^2.3.0"
+    zen-observable-ts "~1.1.0"
+
+"@apollo/client@^3.0.0":
   version "3.5.8"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.8.tgz#7215b974c5988b6157530eb69369209210349fe0"
   integrity sha512-MAm05+I1ullr64VLpZwon/ISnkMuNLf6vDqgo9wiMhHYBGT4yOAbAIseRdjCHZwfSx/7AUuBgaTNOssZPIr6FQ==
@@ -6732,6 +6750,11 @@
   integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
   dependencies:
     "@types/node" "*"
+
+"@types/zen-observable@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
+  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^5.5.0", "@typescript-eslint/eslint-plugin@^5.9.1":
   version "5.9.1"
@@ -20668,7 +20691,7 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-invariant@^0.9.4:
+ts-invariant@^0.9.0, ts-invariant@^0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
   integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
@@ -22196,6 +22219,14 @@ zen-observable-ts@^1.2.0:
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
   integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
   dependencies:
+    zen-observable "0.8.15"
+
+zen-observable-ts@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
+  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+  dependencies:
+    "@types/zen-observable" "0.8.3"
     zen-observable "0.8.15"
 
 zen-observable@0.8.15:


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #2910 

## Changes Proposed

- Upgrade `@apollo/client` to `3.4.17`, the latest `3.4.x`. The latest is `3.5.8`, but upgrading to any `3.5.x` broke our frontend unit tests, and I couldn't for the life of me figure out why. [Changelog](https://github.com/apollographql/apollo-client/releases)
- Upgrade `apollo-upload-client` to `17.0.0`. [Changelog](https://github.com/jaydenseric/apollo-upload-client/releases)
- Upgrade various `@graphql-codegen` packages, all minor version upgrades. Also regenerated the output. [Changelog](https://github.com/dotansimha/graphql-code-generator/releases)
- Upgrade `graphql` to `16.3.0`. Lots of breaking changes, but none seem to affect us. [Changelog](https://github.com/graphql/graphql-js/releases)

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
