### PR TITLE
Don't include Okta module in TF plan/apply for now

### DIFF
--- a/ops/Makefile
+++ b/ops/Makefile
@@ -47,11 +47,11 @@ init-%: .valid-env-%
 	terraform -chdir=$* init
 
 plan-%: .valid-env-% api.tfvars
-	terraform -chdir=$*/persistent plan -lock-timeout=30m
+	terraform -chdir=$*/persistent plan -lock-timeout=30m --target=module.bastion --target=module.vnet --target=module.db --target=module.monitoring
 	terraform -chdir=$* plan -var-file=../api.tfvars -lock-timeout=30m
 
 deploy-%: .valid-env-% api.tfvars
-	terraform -chdir=$*/persistent apply -auto-approve -lock-timeout=30m
+	terraform -chdir=$*/persistent apply -auto-approve -lock-timeout=30m --target=module.bastion --target=module.vnet --target=module.db --target=module.monitoring
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=30m
 
 promote-%: .be-logged-in .valid-env-%


### PR DESCRIPTION
## Related Issue or Background Info

The TF Okta provider has started causing us issues. It's unclear what the issue is exactly (rate limiting? too many things in Okta?) but it's blocking all pipeline activity.

## Changes proposed

For now, change the `Makefile` in `ops` to `-target` every module in `ops/ENV/persistent` other than `okta` individually. This is a workaround until we can find the actual fix.