### PR TITLE
increase graphql variable length

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlSchemaDirectiveConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlSchemaDirectiveConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class GraphQlSchemaDirectiveConfig {
   public static final String REQUIRED_PERMISSIONS_DIRECTIVE_NAME = "requiredPermissions";
-  public static final int MAXIMUM_SIZE = 256;
+  public static final int MAXIMUM_SIZE = 4096;
 
   @Bean
   public SchemaDirective getRequiredPermissionsWiring() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -468,8 +468,8 @@ class PatientManagementTest extends BaseGraphqlTest {
             "patientId", "x".repeat(35), "/updatePatient/patientId size must be between 36 and 36"),
         Arguments.of(
             "firstName",
-            "x".repeat(500),
-            "/updatePatient/firstName size must be between 0 and 256"));
+            "x".repeat(5000),
+            "/updatePatient/firstName size must be between 0 and 4096"));
   }
 
   private JsonNode doCreateAndFetch(


### PR DESCRIPTION
increase graphql variable length to accommodate for bigger query variables

## Related Issue or Background Info

- link to issue, or a few sentences describing why this PR exists


## Additional Information
report stream requested to resend 3534 events, however our resend graphql endpoint is subject to a limit of 256 events, this will increase the limit to 4096

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [X] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes (including new error messages) have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Testing
- [X] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [X] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
