### PR TITLE
Upgrade app service plans to Premium v3

### DIFF
--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -4,7 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 4
-  instance_size  = "P2v2"
+  instance_size  = "P2v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -4,7 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 4
-  instance_size  = "P2v3"
+  instance_size  = "P3v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/services/app_service/_var.tf
+++ b/ops/services/app_service/_var.tf
@@ -23,11 +23,11 @@ variable "tenant_id" {}
 
 # https://azure.microsoft.com/en-us/pricing/details/app-service/windows/
 variable "instance_tier" {
-  default = "PremiumV2"
+  default = "PremiumV3"
 }
 
 variable "instance_size" {
-  default = "P1v2"
+  default = "P1v3"
 }
 
 variable "instance_count" {

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,7 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_size  = "P2v3"
+  instance_size  = "P1v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,7 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_size  = "P1v3"
+  instance_size  = "P3v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,7 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_size  = "P2v2"
+  instance_size  = "P2v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
## Related Issue or Background Info

- After deploying #3312, we discovered an out of memory error. We are still looking into that issue, but we noticed that there is a new version of the app service plans, V3 ([released in July 2021](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/announcing-app-service-environment-v3-ga/ba-p/2517990)). By upgrading all of our app services to this version, we can potentially save money and also have faster CPUs and more memory. [Pricing page here](https://azure.microsoft.com/en-us/pricing/details/app-service/linux/#pricing)
## Changes Proposed

- Change all app service plans to V3
- Prod and stg use tier 2 `P3v3`, the rest use tier 1 `P1v3`

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
