### PR TITLE
Fix for self-registration link bug

### DIFF
--- a/frontend/src/app/Settings/ManageSelfRegistrationLinksContainer.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinksContainer.tsx
@@ -1,5 +1,7 @@
 import { useQuery, gql } from "@apollo/client";
 
+import { getUrl } from "../utils/url";
+
 import { ManageSelfRegistrationLinks } from "./ManageSelfRegistrationLinks";
 
 type Data = {
@@ -55,7 +57,7 @@ export const ManageSelfRegistrationLinksContainer = () => {
 
   return (
     <ManageSelfRegistrationLinks
-      baseUrl={process.env.REACT_APP_BASE_URL || ""}
+      baseUrl={getUrl() || ""}
       organizationSlug={organizationSlug}
       facilitySlugs={facilitySlugs}
       howItWorksPath="/using-simplereport/manage-people-you-test/self-registration"


### PR DESCRIPTION
## Related Issue or Background Info

- The self-registration links have never included `PUBLIC_URL`, which they need to be valid in deployed envs. Right now they are missing `/app`. This will fix that

## Changes Proposed

- Use the `getUrl` util to get baseUrl for self reg links

## Additional Information

- decisions that were made
- discussion of tradeoffs / future work
- complaints about how bad the code is

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
