### PR TITLE
Revert "increase graphql variable length"

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlSchemaDirectiveConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlSchemaDirectiveConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class GraphQlSchemaDirectiveConfig {
   public static final String REQUIRED_PERMISSIONS_DIRECTIVE_NAME = "requiredPermissions";
-  public static final int MAXIMUM_SIZE = 4096;
+  public static final int MAXIMUM_SIZE = 256;
 
   @Bean
   public SchemaDirective getRequiredPermissionsWiring() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -468,8 +468,8 @@ class PatientManagementTest extends BaseGraphqlTest {
             "patientId", "x".repeat(35), "/updatePatient/patientId size must be between 36 and 36"),
         Arguments.of(
             "firstName",
-            "x".repeat(5000),
-            "/updatePatient/firstName size must be between 0 and 4096"));
+            "x".repeat(500),
+            "/updatePatient/firstName size must be between 0 and 256"));
   }
 
   private JsonNode doCreateAndFetch(


### PR DESCRIPTION
Reverts CDCgov/prime-simplereport#3318

This is to restore the original argument length filter removed by the initial PR. This should be merged immediately after resends to ReportStream are completed.