### PR TITLE
Change app gateway to redirect self-registration links to /app

### DIFF
--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -216,6 +216,20 @@ resource "azurerm_application_gateway" "load_balancer" {
       backend_address_pool_name  = local.static_backend_pool
       backend_http_settings_name = local.static_backend_https_setting
     }
+
+    path_rule {
+      name                        = "self-registration"
+      paths                       = ["/register/*"]
+      redirect_configuration_name = local.redirect_self_registration_rule
+    }
+  }
+  redirect_configuration {
+    name = local.redirect_self_registration_rule
+
+    include_path         = true
+    include_query_string = true
+    redirect_type        = "Permanent"
+    target_url           = "https://${var.env}.simplereport.gov/app"
   }
 
   rewrite_rule_set {
@@ -259,24 +273,7 @@ resource "azurerm_application_gateway" "load_balancer" {
         reroute      = true
       }
     }
-    rewrite_rule {
-      name          = "registration-link"
-      rule_sequence = 102
 
-      condition {
-        ignore_case = true
-        pattern     = "^/register/"
-        variable    = "var_uri_path"
-      }
-
-      url {
-        path = "/app"
-        # This is probably excessive, but it was happening anyway: see
-        # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11563
-        query_string = ""
-        reroute      = true
-      }
-    }
     rewrite_rule {
       name          = "HSTS"
       rule_sequence = 101

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -10,6 +10,8 @@ locals {
   frontend_config                 = "${var.name}-config"
   redirect_rule                   = "${var.name}-redirect"
   redirect_self_registration_rule = "${var.name}-redirect-self-registration"
+  url_prefix                      = var.env == "prod" ? "www" : var.env
+  app_url                         = "https://${local.url_prefix}.simplereport.gov/app"
 }
 
 resource "azurerm_public_ip" "static_gateway" {
@@ -230,7 +232,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     include_path         = true
     include_query_string = true
     redirect_type        = "Permanent"
-    target_url           = "https://${var.env}.simplereport.gov/app"
+    target_url           = local.app_url
   }
 
   rewrite_rule_set {

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -1,14 +1,15 @@
 locals {
-  static_backend_pool          = "${var.name}-${var.env}-fe-static"
-  static_backend_http_setting  = "${var.name}-${var.env}-fe-static-http"
-  static_backend_https_setting = "${var.name}-${var.env}-fe-static-https"
-  api_backend_pool             = "${var.name}-${var.env}-be-api"
-  api_backend_http_setting     = "${var.name}-${var.env}-be-api-http"
-  api_backend_https_setting    = "${var.name}-${var.env}-be-api-https"
-  http_listener                = "${var.name}-http"
-  https_listener               = "${var.name}-https"
-  frontend_config              = "${var.name}-config"
-  redirect_rule                = "${var.name}-redirect"
+  static_backend_pool             = "${var.name}-${var.env}-fe-static"
+  static_backend_http_setting     = "${var.name}-${var.env}-fe-static-http"
+  static_backend_https_setting    = "${var.name}-${var.env}-fe-static-https"
+  api_backend_pool                = "${var.name}-${var.env}-be-api"
+  api_backend_http_setting        = "${var.name}-${var.env}-be-api-http"
+  api_backend_https_setting       = "${var.name}-${var.env}-be-api-https"
+  http_listener                   = "${var.name}-http"
+  https_listener                  = "${var.name}-https"
+  frontend_config                 = "${var.name}-config"
+  redirect_rule                   = "${var.name}-redirect"
+  redirect_self_registration_rule = "${var.name}-redirect-self-registration"
 }
 
 resource "azurerm_public_ip" "static_gateway" {


### PR DESCRIPTION
## Related Issue or Background Info

- When #3261 was merged, a bug was discovered where self registration links (`/register/foo`) would render a blank white page. Our app gateway is currently configured to catch any `/register/*` requests and rewrite them as `/app/register/*`. React router v5 seemed to handle this just fine, but v6 does not. We can alter the app to pass out links prefixed with `/app`, but we need to support the old links too in case orgs have them saved outside of the app. One way to support this is to change the configuration of our app gateway to redirect `/register/*` requests to `/app/register/*` instead of rewriting.

## Changes Proposed

- change the configuration of our app gateway to redirect `/register/*` requests to `/app/register/*` instead of rewriting.

## Additional Information

- I already made this change in the Azure console for our dev gateway and confirmed that it works with router v6!

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
