### PR TITLE
Update TF version for rollback workflow

### DIFF
--- a/.github/workflows/rollbackDB.yml
+++ b/.github/workflows/rollbackDB.yml
@@ -56,7 +56,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.15.1
+          terraform_version: 1.1.4
       - name: Terraform init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Launch DB Rollback Container Instance


### PR DESCRIPTION
## Related Issue or Background Info

We missed a Terraform version change in a workflow in #3218.

## Changes Proposed

- Update the Rollback DB workflow to the correct Terraform version (1.1.4).