### PR TITLE
make banner header customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ To do so manually:
 Example:
 
 ```Shell
-MAINTENANCE_MESSAGE='{"active": true, "message": "SimpleReport is currently experiencing service degradation"}' MAINTENANCE_ENV=dev yarn run maintenance:start
+MAINTENANCE_MESSAGE='{"active": true, "header" : "SimpleReport is currently experiencing an outage.", "message": "SimpleReport is currently experiencing service degradation"}' MAINTENANCE_ENV=dev yarn run maintenance:start
 ```
 
 Possible values for `MAINTENANCE_ENV`: `dev`, `test`, `pentest`, `training`, `demo`, `stg`, `prod`

--- a/frontend/src/app/commonComponents/MaintenanceBanner.tsx
+++ b/frontend/src/app/commonComponents/MaintenanceBanner.tsx
@@ -4,12 +4,14 @@ import Alert from "./Alert";
 
 interface MaintenanceMode {
   active: boolean;
+  header: string;
   message: string;
 }
 
 export const MaintenanceBanner: React.FC = () => {
   const [maintenanceMode, setMaintenanceMode] = useState<MaintenanceMode>({
     active: false,
+    header: "SimpleReport alert.",
     message: "",
   });
   useEffect(() => {
@@ -32,8 +34,7 @@ export const MaintenanceBanner: React.FC = () => {
       {maintenanceMode.active ? (
         <div className="usa-site-alert usa-site-alert--emergency usa-site-alert--no-heading border-top border-base-lighter">
           <Alert type="emergency" role="alert">
-            <strong>SimpleReport is currently experiencing an outage.</strong>{" "}
-            {maintenanceMode.message}
+            <strong>{maintenanceMode.header}</strong> {maintenanceMode.message}
           </Alert>
         </div>
       ) : null}

--- a/frontend/src/app/commonComponents/MaintenanceBanner.tsx
+++ b/frontend/src/app/commonComponents/MaintenanceBanner.tsx
@@ -11,7 +11,7 @@ interface MaintenanceMode {
 export const MaintenanceBanner: React.FC = () => {
   const [maintenanceMode, setMaintenanceMode] = useState<MaintenanceMode>({
     active: false,
-    header: "SimpleReport alert.",
+    header: "SimpleReport alert:",
     message: "",
   });
   useEffect(() => {

--- a/frontend/src/app/commonComponents/MaintenanceBanner.tsx
+++ b/frontend/src/app/commonComponents/MaintenanceBanner.tsx
@@ -11,7 +11,7 @@ interface MaintenanceMode {
 export const MaintenanceBanner: React.FC = () => {
   const [maintenanceMode, setMaintenanceMode] = useState<MaintenanceMode>({
     active: false,
-    header: "SimpleReport alert:",
+    header: "",
     message: "",
   });
   useEffect(() => {
@@ -34,7 +34,8 @@ export const MaintenanceBanner: React.FC = () => {
       {maintenanceMode.active ? (
         <div className="usa-site-alert usa-site-alert--emergency usa-site-alert--no-heading border-top border-base-lighter">
           <Alert type="emergency" role="alert">
-            <strong>{maintenanceMode.header}</strong> {maintenanceMode.message}
+            <strong>{maintenanceMode.header || "SimpleReport alert:"}</strong>{" "}
+            {maintenanceMode.message}
           </Alert>
         </div>
       ) : null}


### PR DESCRIPTION
## Related Issue or Background Info

- removing hardcoded `SimpleReport is currently experiencing an outage.` from the banner message
- changed the default to `SimpleReport alert.`

## Changes Proposed

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
