### PR TITLE
Create alert for ReportStream uploader function app failures.

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -13,6 +13,7 @@ module "metric_alerts" {
   skip_on_weekends               = true
   disabled_alerts = [
     "frontend_error_boundary",
+    "batched_uploader_single_failure_detected"
   ]
 
   action_group_ids = [

--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -13,7 +13,8 @@ module "metric_alerts" {
   skip_on_weekends               = true
   disabled_alerts = [
     "frontend_error_boundary",
-    "batched_uploader_single_failure_detected"
+    "batched_uploader_single_failure_detected",
+    "batched_uploader_function_not_triggering"
   ]
 
   action_group_ids = [

--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -20,7 +20,8 @@ module "metric_alerts" {
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",
-    "batched_uploader_single_failure_detected"
+    "batched_uploader_single_failure_detected",
+    "batched_uploader_function_not_triggering"
   ]
 
   action_group_ids = [

--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -20,6 +20,7 @@ module "metric_alerts" {
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",
+    "batched_uploader_single_failure_detected"
   ]
 
   action_group_ids = [

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -30,6 +30,7 @@ variable "disabled_alerts" {
       "frontend_error_boundary",
       "db_query_duration",
       "db_query_duration_over_time_window",
+      "batched_uploader_single_failure_detected"
     ])) == 0
     error_message = "One or more disabled_alert values are invalid."
   }

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -30,7 +30,8 @@ variable "disabled_alerts" {
       "frontend_error_boundary",
       "db_query_duration",
       "db_query_duration_over_time_window",
-      "batched_uploader_single_failure_detected"
+      "batched_uploader_single_failure_detected",
+      "batched_uploader_function_not_triggering"
     ])) == 0
     error_message = "One or more disabled_alert values are invalid."
   }

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -303,3 +303,32 @@ ${local.skip_on_weekends}
     action_group = var.action_group_ids
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_function_not_triggering" {
+  name                = "${var.env}-batched-uploader-function-not-triggering"
+  description         = "QueueBatchedReportStreamUploader is not triggering on schedule"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+  severity            = var.severity
+  frequency           = 5
+  time_window         = 5
+  enabled             = contains(var.disabled_alerts, "batched_uploader_function_not_triggering") ? false : true
+
+  data_source_id = var.app_insights_id
+
+  query = <<-QUERY
+dependencies
+${local.skip_on_weekends}
+| where timestamp >= ago(6m) 
+    and operation_Name =~ 'QueueBatchedReportStreamUploader'
+  QUERY
+
+  trigger {
+    operator  = "Equal"
+    threshold = 0
+  }
+
+  action {
+    action_group = var.action_group_ids
+  }
+}

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -281,7 +281,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   resource_group_name = var.rg_name
   severity            = var.severity
   frequency           = 5
-  time_window         = 5
+  time_window         = 7
   enabled             = contains(var.disabled_alerts, "batched_uploader_single_failure_detected") ? false : true
 
   data_source_id = var.app_insights_id
@@ -311,7 +311,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_functio
   resource_group_name = var.rg_name
   severity            = var.severity
   frequency           = 5
-  time_window         = 5
+  time_window         = 7
   enabled             = contains(var.disabled_alerts, "batched_uploader_function_not_triggering") ? false : true
 
   data_source_id = var.app_insights_id

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -280,8 +280,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
-  frequency           = 1
-  time_window         = 1
+  frequency           = 5
+  time_window         = 5
   enabled             = contains(var.disabled_alerts, "batched_uploader_single_failure_detected") ? false : true
 
   data_source_id = var.app_insights_id

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -289,7 +289,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   query = <<-QUERY
 dependencies
 ${local.skip_on_weekends}
-| where timestamp >= ago(5m) 
+| where timestamp >= ago(7m) 
     and operation_Name =~ 'QueueBatchedReportStreamUploader' 
     and success != true
   QUERY

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -287,7 +287,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   data_source_id = var.app_insights_id
 
   query = <<-QUERY
-dependencies
+requests
 ${local.skip_on_weekends}
 | where timestamp >= ago(7m) 
     and operation_Name =~ 'QueueBatchedReportStreamUploader' 
@@ -317,7 +317,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_functio
   data_source_id = var.app_insights_id
 
   query = <<-QUERY
-dependencies
+requests
 ${local.skip_on_weekends}
 | where timestamp >= ago(7m) 
     and operation_Name =~ 'QueueBatchedReportStreamUploader'

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -319,7 +319,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_functio
   query = <<-QUERY
 dependencies
 ${local.skip_on_weekends}
-| where timestamp >= ago(6m) 
+| where timestamp >= ago(7m) 
     and operation_Name =~ 'QueueBatchedReportStreamUploader'
   QUERY
 

--- a/ops/stg/alerts.tf
+++ b/ops/stg/alerts.tf
@@ -15,6 +15,7 @@ module "metric_alerts" {
     "account_request_failures",
     "experian_auth_failures",
     "frontend_error_boundary",
+    "batched_uploader_single_failure_detected"
   ]
 
   action_group_ids = [

--- a/ops/stg/alerts.tf
+++ b/ops/stg/alerts.tf
@@ -15,7 +15,8 @@ module "metric_alerts" {
     "account_request_failures",
     "experian_auth_failures",
     "frontend_error_boundary",
-    "batched_uploader_single_failure_detected"
+    "batched_uploader_single_failure_detected",
+    "batched_uploader_function_not_triggering"
   ]
 
   action_group_ids = [

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -20,7 +20,8 @@ module "metric_alerts" {
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",
-    "batched_uploader_single_failure_detected"
+    "batched_uploader_single_failure_detected",
+    "batched_uploader_function_not_triggering"
   ]
 
   action_group_ids = [

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -20,6 +20,7 @@ module "metric_alerts" {
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",
+    "batched_uploader_single_failure_detected"
   ]
 
   action_group_ids = [

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -12,6 +12,7 @@ module "metric_alerts" {
   skip_on_weekends               = true
   disabled_alerts = [
     "frontend_error_boundary",
+    "batched_uploader_single_failure_detected"
   ]
 
   action_group_ids = [

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -12,7 +12,8 @@ module "metric_alerts" {
   skip_on_weekends               = true
   disabled_alerts = [
     "frontend_error_boundary",
-    "batched_uploader_single_failure_detected"
+    "batched_uploader_single_failure_detected",
+    "batched_uploader_function_not_triggering"
   ]
 
   action_group_ids = [


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #3319 .

## Changes Proposed

- Add alert that detects when `QueueBatchedReportStreamUploader` has one or more failed results within a 7-minute window.
- Add alert that detects when `QueueBatchedReportStreamUploader` has not functioned within a 7-minute window.

## Additional Information

- 7 minutes was selected for these intervals to account for the 5-minute Insights frequency, and catch any runs that may happen on the very edge of the detection window (2 minutes between runs). Experiments showed that setting the value to 6 minutes could result in false triggers of the alert that fires when the uploader function is completely missing.