### PR TITLE
Patient upload service supports `PhoneNumberType` column in input CSV

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PhoneNumberRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PhoneNumberRepository.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.UUID;
 
 public interface PhoneNumberRepository extends AuditedEntityRepository<PhoneNumber> {
+  List<PhoneNumber> findAllByPersonInternalId(UUID personId);
+
   List<List<PhoneNumber>> findAllByPersonInternalIdIn(Collection<UUID> personIds);
 
   List<PhoneNumber> findAllByInternalIdIn(Collection<UUID> phoneIds);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UploadService.java
@@ -4,7 +4,6 @@ import static gov.cdc.usds.simplereport.api.Translators.parseEmails;
 import static gov.cdc.usds.simplereport.api.Translators.parseEthnicity;
 import static gov.cdc.usds.simplereport.api.Translators.parseGender;
 import static gov.cdc.usds.simplereport.api.Translators.parsePersonRole;
-import static gov.cdc.usds.simplereport.api.Translators.parsePhoneNumber;
 import static gov.cdc.usds.simplereport.api.Translators.parsePhoneNumbers;
 import static gov.cdc.usds.simplereport.api.Translators.parseRaceDisplayValue;
 import static gov.cdc.usds.simplereport.api.Translators.parseString;
@@ -157,7 +156,7 @@ public class UploadService {
             parsePhoneNumbers(
                 List.of(
                     new PhoneNumberInput(
-                        null, parsePhoneNumber((getRow(row, "PhoneNumber", true)))))),
+                        getRow(row, "PhoneNumberType", false), getRow(row, "PhoneNumber", true)))),
             parsePersonRole(getRow(row, "Role", false), false),
             parseEmails(List.of(getRow(row, "Email", false))),
             parseRaceDisplayValue(getRow(row, "Race", true)),
@@ -214,6 +213,7 @@ public class UploadService {
           .addColumn("ZipCode", CsvSchema.ColumnType.STRING)
           .addColumn("Country", CsvSchema.ColumnType.STRING)
           .addColumn("PhoneNumber", CsvSchema.ColumnType.STRING)
+          .addColumn("PhoneNumberType", CsvSchema.ColumnType.STRING)
           .addColumn("employedInHealthcare", CsvSchema.ColumnType.STRING)
           .addColumn("residentCongregateSetting", CsvSchema.ColumnType.STRING)
           .addColumn("Role", CsvSchema.ColumnType.STRING)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -33,7 +33,7 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   public static final int PATIENT_PAGE_SIZE = 1000;
 
   @Autowired private PersonService personService;
-  @Autowired private PhoneNumberRepository _pnRepo;
+  @Autowired private PhoneNumberRepository phoneNumberRepository;
   @MockBean protected AddressValidationService addressValidationService;
   private StreetAddress address;
 
@@ -77,7 +77,8 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
     Person p = getPatients().get(0);
     assertThat(p.getLastName()).isEqualTo("Best");
     assertThat(p.getAddress()).isEqualTo(address);
-    List<PhoneNumber> phoneNumbers = _pnRepo.findAllByPersonInternalId(p.getInternalId());
+    List<PhoneNumber> phoneNumbers =
+        phoneNumberRepository.findAllByPersonInternalId(p.getInternalId());
     assertThat(phoneNumbers).hasSize(1);
     PhoneNumber pn = phoneNumbers.get(0);
     assertThat(pn.getNumber()).isEqualTo("(565) 666-7777");
@@ -125,7 +126,8 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
     // THEN
     assertThat(getPatients()).hasSize(1);
     Person p = getPatients().get(0);
-    List<PhoneNumber> phoneNumbers = _pnRepo.findAllByPersonInternalId(p.getInternalId());
+    List<PhoneNumber> phoneNumbers =
+        phoneNumberRepository.findAllByPersonInternalId(p.getInternalId());
     assertThat(phoneNumbers).hasSize(1);
     PhoneNumber pn = phoneNumbers.get(0);
     assertThat(pn.getNumber()).isEqualTo("(565) 666-7777");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -100,6 +100,39 @@ class UploadServiceTest extends BaseServiceTest<UploadService> {
   }
 
   @Test
+  void testInvalidPhoneType() {
+    // GIVEN
+    InputStream inputStream = loadCsv("test-upload-invalid-phone-type.csv");
+
+    // WHEN
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> this._service.processPersonCSV(inputStream));
+
+    // THEN
+    assertThat(error.getMessage()).isEqualTo("Error on row 1; Invalid PhoneType received");
+    assertThat(getPatients()).isEmpty();
+  }
+
+  @Test
+  void testNoPhoneType() {
+    // GIVEN
+    InputStream inputStream = loadCsv("test-upload-no-phone-type.csv");
+
+    // WHEN
+    this._service.processPersonCSV(inputStream);
+
+    // THEN
+    assertThat(getPatients()).hasSize(1);
+    Person p = getPatients().get(0);
+    List<PhoneNumber> phoneNumbers = _pnRepo.findAllByPersonInternalId(p.getInternalId());
+    assertThat(phoneNumbers).hasSize(1);
+    PhoneNumber pn = phoneNumbers.get(0);
+    assertThat(pn.getNumber()).isEqualTo("(565) 666-7777");
+    assertThat(pn.getType()).isNull();
+  }
+
+  @Test
   void testInsertNoCountry() {
     // GIVEN
     InputStream inputStream = loadCsv("test-upload-no-country.csv");

--- a/backend/src/test/resources/test-upload-invalid-ethnicity.csv
+++ b/backend/src/test/resources/test-upload-invalid-ethnicity.csv
@@ -1,2 +1,2 @@
-LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
-Best,Tim,,,White,5/11/1933,Male,InvalidEthnicity,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,InvalidEthnicity,123 Main Street,,Washington,,DC,20008,USA,5656667777,MOBILE,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-invalid-phone-type.csv
+++ b/backend/src/test/resources/test-upload-invalid-phone-type.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,junk,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-invalid-phone.csv
+++ b/backend/src/test/resources/test-upload-invalid-phone.csv
@@ -1,2 +1,2 @@
-LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City ,County,State,ZipCode,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
-Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,not a phone number,Yes,No,Staff,foo@example.com,
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,not a phone number,MOBILE,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-invalid-race.csv
+++ b/backend/src/test/resources/test-upload-invalid-race.csv
@@ -1,2 +1,2 @@
-LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
-Best,Tim,,,InvalidRace,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,InvalidRace,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,MOBILE,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-invalid-zipcode.csv
+++ b/backend/src/test/resources/test-upload-invalid-zipcode.csv
@@ -1,2 +1,2 @@
-LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City ,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
-Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Lyndonville,,VT,5851,USA,5656667777,Yes,No,Staff,foo@example.com,
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Lyndonville,,VT,5851,USA,5656667777,MOBILE,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-no-phone-type.csv
+++ b/backend/src/test/resources/test-upload-no-phone-type.csv
@@ -1,0 +1,2 @@
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload-valid-no-header.csv
+++ b/backend/src/test/resources/test-upload-valid-no-header.csv
@@ -1,1 +1,1 @@
-Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,MOBILE,Yes,No,Staff,foo@example.com,

--- a/backend/src/test/resources/test-upload.csv
+++ b/backend/src/test/resources/test-upload.csv
@@ -1,2 +1,2 @@
-LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City ,County,State,ZipCode,Country,PhoneNumber,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
-Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,Yes,No,Staff,foo@example.com,
+LastName,FirstName,MiddleName,Suffix,Race,DOB,biologicalSex,Ethnicity,Street,Street2,City,County,State,ZipCode,Country,PhoneNumber,PhoneNumberType,employedInHealthcare,residentCongregateSetting,Role,Email,facilityId
+Best,Tim,,,White,5/11/1933,Male,Not_Hispanic,123 Main Street,,Washington,,DC,20008,USA,5656667777,MOBILE,Yes,No,Staff,foo@example.com,


### PR DESCRIPTION
## Related Issue or Background Info

- Closes #3360 

## Changes Proposed
- Get and parse `PhoneNumberType` values from input CSV and set patient phone number type  using the value

## Additional Information
- See [prime-simplereport-site PR #276](https://github.com/CDCgov/prime-simplereport-site/pull/276) for updates to bulk upload PDF

## Screenshots / Demos
### Upload success
<img width="496" alt="Screen Shot 2022-02-15 at 12 08 54 PM" src="https://user-images.githubusercontent.com/27730981/154113062-a196fa48-3877-443e-aa0c-f98a5ad9fff2.png">

* `PhoneNumberType` - `MOBILE`

<img width="468" alt="Screen Shot 2022-02-15 at 12 09 10 PM" src="https://user-images.githubusercontent.com/27730981/154113105-c3158cf3-c52a-4b9b-87e4-4a4a6f2f9a2a.png">

### Upload failure
<img width="970" alt="Screen Shot 2022-02-15 at 12 10 06 PM" src="https://user-images.githubusercontent.com/27730981/154113132-3725548a-2dee-46e0-93bf-ffcb62b4b0d5.png">

* `PhoneNumberType` - `junk`
 
<img width="880" alt="Screen Shot 2022-02-15 at 12 09 57 PM" src="https://user-images.githubusercontent.com/27730981/154113131-b0043254-8685-4ed3-aa83-d0665bd820fc.png">

## Checklist for Author and Reviewer
- [ ] The ticket mentions supporting an `Unknown` type, but that would require some additional logic in the upload service and seems to be redundant with simply leaving the `PhoneNumberType` cell blank. If anyone feels otherwise, I can include that as an allowable value

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
