### PR TITLE
Update validation error messages on the person form

### DIFF
--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -37,7 +37,12 @@ export const EMPTY_PERSON: Nullable<PersonFormData> = {
   tribalAffiliation: undefined,
   birthDate: "",
   telephone: null,
-  phoneNumbers: [],
+  phoneNumbers: [
+    {
+      number: "",
+      type: "",
+    },
+  ],
   county: null,
   emails: null,
   street: "",

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -37,7 +37,7 @@ export const EMPTY_PERSON: Nullable<PersonFormData> = {
   tribalAffiliation: undefined,
   birthDate: "",
   telephone: null,
-  phoneNumbers: null,
+  phoneNumbers: [],
   county: null,
   emails: null,
   street: "",

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -594,6 +594,7 @@ const PersonForm = (props: Props) => {
           hintText={t("patient.form.demographics.genderHelpText")}
           name="gender"
           required={view !== PersonFormView.PXP}
+          validationStatus={validationStatus("gender")}
           buttons={GENDER_VALUES}
           selectedRadio={patient.gender}
           onChange={onPersonChange("gender")}

--- a/frontend/src/app/patients/personSchema.ts
+++ b/frontend/src/app/patients/personSchema.ts
@@ -252,8 +252,7 @@ const updateFieldSchemata: (
     .oneOf(getValues(ETHNICITY_VALUES), t("patient.form.errors.ethnicity")),
   gender: yup
     .mixed()
-    .oneOf(getValues(GENDER_VALUES))
-    .required(t("Sex assigned at birth is required")),
+    .oneOf(getValues(GENDER_VALUES), t("patient.form.errors.gender")),
   residentCongregateSetting: yup.boolean().nullable(),
   employedInHealthcare: yup.boolean().nullable(),
   tribalAffiliation: yup

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -191,7 +191,7 @@ export const en = {
           race: "Race is required",
           tribalAffiliation: "Tribal affiliation is incorrectly formatted",
           ethnicity: "Ethnicity is required",
-          gender: "Sex assigned at birth is incorrectly formatted",
+          gender: "Sex assigned at birth is required",
           residentCongregateSetting:
             "Are you a resident in a congregate living setting? is required",
           employedInHealthcare: "Are you a health care worker? is required",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -202,7 +202,7 @@ export const es: LanguageConfig = {
           race: "La raza es obligatoria",
           tribalAffiliation: "La afiliación tribal tiene un formato incorrecto",
           ethnicity: "La etnia es obligatoria",
-          gender: "El sexo asignado al nacer tiene un formato incorrecto",
+          gender: "El sexo asignado al nacer es obligatoria",
           residentCongregateSetting:
             "¿Reside usted en un entorno compartido por muchas personas?  Se requiere una respuesta",
           employedInHealthcare:


### PR DESCRIPTION
## Related Issue or Background Info
- Closes #3330 

## Changes Proposed
- Attempting to submit a new patient with a null primary phone number results in the correct validation error message is displayed in the UI
- Attempting to submit a new patient with a null `gender` results in the correct validation error message is displayed in the UI
- In addition, the fields for phone numbers and gender were not highlighted in red upon validation failure as expected. This is fixed as well.

## Additional Information
- N/A

## Screenshots / Demos
### Phone numbers
#### Before
<img width="435" alt="3330-phone-numbers" src="https://user-images.githubusercontent.com/27730981/154328560-826a3a46-d01b-42d0-abb8-db5c040ba16e.png">


#### After
<img width="493" alt="Screen Shot 2022-02-16 at 3 45 20 PM" src="https://user-images.githubusercontent.com/27730981/154354171-3586d16d-0c24-48e3-a19c-f5ff9fdd6959.png">

### Gender
#### Before
<img width="495" alt="3330-gender" src="https://user-images.githubusercontent.com/27730981/154328559-2d36b1ab-e6eb-4e33-b6ed-2ee0dceedf65.png">

#### After
<img width="864" alt="Screen Shot 2022-02-16 at 1 15 03 PM" src="https://user-images.githubusercontent.com/27730981/154329489-9184d02c-496e-4f0d-a965-cda1a346af32.png">

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
