### PR TITLE
disable rs error reporting function

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/ReportStreamExceptionHandler/function.json
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/ReportStreamExceptionHandler/function.json
@@ -1,4 +1,5 @@
 {
+  "disabled": true,
   "bindings": [
     {
       "name": "body",


### PR DESCRIPTION
## Related Issue or Background Info

- disable ReportStreamExceptionHandler azure function since now is part of the prod pipeline and we have a ticket to re-enable it #3081
## Changes Proposed

- disable ReportStreamExceptionHandler

## Additional Information

deploying to `test` to verify functionality correctly.
https://docs.microsoft.com/en-us/azure/azure-functions/disable-function?tabs=portal

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [X] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes (including new error messages) have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Testing
- [X] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [X] Database changes are submitted as a separate PR
  - [X] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [X] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

## Cloud
- [X] DevOps team has been notified if PR requires ops support
- [X] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
