### PR TITLE
add header value to the maintenance page

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -6,7 +6,11 @@ on:
       active:
         description: "Active outage? (true/false)"
         required: true
-        default: true
+        default: "true"
+      header:
+        description: "Header to display"
+        required: true
+        default: "SimpleReport alert:"
       message:
         description: "Message to display"
         required: true
@@ -34,7 +38,8 @@ jobs:
         shell: bash
         run: |
           export MAINTENANCE_BOOLEAN=$( if [ "${{ github.event.inputs.active }}" = "true" ]; then echo true; else echo false; fi )
+          export MAINTENANCE_HEADER="${{ github.event.inputs.header }}"
           export MAINTENANCE_MESSAGE="${{ github.event.inputs.message }}"
           export MAINTENANCE_ENV=${{ github.event.inputs.env }}
-          echo "{\"active\": $MAINTENANCE_BOOLEAN, \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
+          echo "{\"active\": $MAINTENANCE_BOOLEAN, \"header\": \"$MAINTENANCE_HEADER\", \"message\": \"$MAINTENANCE_MESSAGE\"}" > maintenance.json
           yarn run maintenance:deploy


### PR DESCRIPTION
## Related Issue or Background Info

- resolves #3366

## Changes Proposed

- add header value to maintenance page

## Screenshots / Demos
![Screenshot from 2022-02-17 06-37-02](https://user-images.githubusercontent.com/94012653/154504162-147227dc-5f0a-400d-9b59-074ea767c468.png)

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
