### PR TITLE
Disable daily training DB reset

### DIFF
--- a/.github/workflows/resetTrainingDB.yml
+++ b/.github/workflows/resetTrainingDB.yml
@@ -2,9 +2,6 @@ name: Reset Training Database
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run this on a daily timer as well in order to reset the training DB
-    - cron: '0 9 * * *'
 
 env:
   DEPLOY_ENV: training


### PR DESCRIPTION
## Related Issue or Background Info

With the #3180 changes, we moved creating the `simple_report_no_phi` user into Liquibase rather than managing it via TF. This works great except for the fact that we currently reset the training DB by dropping the DB and restarting the app 
 and just letting Liquibase recreate everything. That drop doesn't remove the existing `simple_report_no_phi` user though, so every reset now causes a migration conflict.

The bigger issue is that once we move to Azure Flexible DBs, we have to entirely change this workflow - there's no more public access, even temporarily. The fix for both issues is to move this functionality into the app in #3443.

In the meantime, the workaround is to disable the daily scheduled reset.

## Changes Proposed

- Disable the cron schedule for the reset training DB workflow