### PR TITLE
disable azure rs function through azure configs

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/ReportStreamExceptionHandler/function.json
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/ReportStreamExceptionHandler/function.json
@@ -1,5 +1,4 @@
 {
-  "disabled": true,
   "bindings": [
     {
       "name": "body",

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -87,6 +87,7 @@ resource "azurerm_function_app" "functions" {
     REPORT_STREAM_BATCH_MAXIMUM    = var.report_stream_batch_maximum
     SIMPLE_REPORT_CB_URL           = local.simple_report_callback_url
     SIMPLE_REPORT_CB_TOKEN         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
+    AzureWebJobs.ReportStreamExceptionHandler.Disabled = 1
   }
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -68,26 +68,26 @@ resource "azurerm_function_app" "functions" {
   }
 
   app_settings = {
-    https_only                                         = true
-    FUNCTIONS_WORKER_RUNTIME                           = "node"
-    WEBSITE_NODE_DEFAULT_VERSION                       = "~14"
-    FUNCTION_APP_EDIT_MODE                             = "readonly"
-    HASH                                               = "${base64encode(filesha256("${local.function_app_source}"))}"
-    WEBSITE_RUN_FROM_PACKAGE                           = "https://${data.azurerm_storage_account.app.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
-    APPINSIGHTS_INSTRUMENTATIONKEY                     = data.azurerm_application_insights.app.instrumentation_key
-    AZ_STORAGE_QUEUE_SVC_URL                           = "https://${data.azurerm_storage_account.app.name}.queue.core.windows.net/"
-    AZ_STORAGE_ACCOUNT_NAME                            = data.azurerm_storage_account.app.name
-    AZ_STORAGE_ACCOUNT_KEY                             = data.azurerm_storage_account.app.primary_access_key
-    AZ_STORAGE_QUEUE_CXN_STRING                        = data.azurerm_storage_account.app.primary_connection_string
-    TEST_EVENT_QUEUE_NAME                              = var.test_event_queue_name
-    REPORTING_EXCEPTION_QUEUE_NAME                     = var.reporting_exception_queue_name
-    REPORT_STREAM_URL                                  = local.report_stream_url
-    REPORT_STREAM_TOKEN                                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
-    REPORT_STREAM_BATCH_MINIMUM                        = var.report_stream_batch_minimum
-    REPORT_STREAM_BATCH_MAXIMUM                        = var.report_stream_batch_maximum
-    SIMPLE_REPORT_CB_URL                               = local.simple_report_callback_url
-    SIMPLE_REPORT_CB_TOKEN                             = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
-    AzureWebJobs.ReportStreamExceptionHandler.Disabled = "1"
+    https_only                                           = true
+    FUNCTIONS_WORKER_RUNTIME                             = "node"
+    WEBSITE_NODE_DEFAULT_VERSION                         = "~14"
+    FUNCTION_APP_EDIT_MODE                               = "readonly"
+    HASH                                                 = "${base64encode(filesha256("${local.function_app_source}"))}"
+    WEBSITE_RUN_FROM_PACKAGE                             = "https://${data.azurerm_storage_account.app.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
+    APPINSIGHTS_INSTRUMENTATIONKEY                       = data.azurerm_application_insights.app.instrumentation_key
+    AZ_STORAGE_QUEUE_SVC_URL                             = "https://${data.azurerm_storage_account.app.name}.queue.core.windows.net/"
+    AZ_STORAGE_ACCOUNT_NAME                              = data.azurerm_storage_account.app.name
+    AZ_STORAGE_ACCOUNT_KEY                               = data.azurerm_storage_account.app.primary_access_key
+    AZ_STORAGE_QUEUE_CXN_STRING                          = data.azurerm_storage_account.app.primary_connection_string
+    TEST_EVENT_QUEUE_NAME                                = var.test_event_queue_name
+    REPORTING_EXCEPTION_QUEUE_NAME                       = var.reporting_exception_queue_name
+    REPORT_STREAM_URL                                    = local.report_stream_url
+    REPORT_STREAM_TOKEN                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
+    REPORT_STREAM_BATCH_MINIMUM                          = var.report_stream_batch_minimum
+    REPORT_STREAM_BATCH_MAXIMUM                          = var.report_stream_batch_maximum
+    SIMPLE_REPORT_CB_URL                                 = local.simple_report_callback_url
+    SIMPLE_REPORT_CB_TOKEN                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
+    "AzureWebJobs.ReportStreamExceptionHandler.Disabled" = "1"
   }
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_function_app" "functions" {
     REPORT_STREAM_BATCH_MAXIMUM    = var.report_stream_batch_maximum
     SIMPLE_REPORT_CB_URL           = local.simple_report_callback_url
     SIMPLE_REPORT_CB_TOKEN         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
-    "AzureWebJobs.ReportStreamExceptionHandler.Disabled" = 1
+    "AzureWebJobs.ReportStreamExceptionHandler.Disabled" = "1"
   }
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -68,26 +68,26 @@ resource "azurerm_function_app" "functions" {
   }
 
   app_settings = {
-    https_only                     = true
-    FUNCTIONS_WORKER_RUNTIME       = "node"
-    WEBSITE_NODE_DEFAULT_VERSION   = "~14"
-    FUNCTION_APP_EDIT_MODE         = "readonly"
-    HASH                           = "${base64encode(filesha256("${local.function_app_source}"))}"
-    WEBSITE_RUN_FROM_PACKAGE       = "https://${data.azurerm_storage_account.app.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
-    APPINSIGHTS_INSTRUMENTATIONKEY = data.azurerm_application_insights.app.instrumentation_key
-    AZ_STORAGE_QUEUE_SVC_URL       = "https://${data.azurerm_storage_account.app.name}.queue.core.windows.net/"
-    AZ_STORAGE_ACCOUNT_NAME        = data.azurerm_storage_account.app.name
-    AZ_STORAGE_ACCOUNT_KEY         = data.azurerm_storage_account.app.primary_access_key
-    AZ_STORAGE_QUEUE_CXN_STRING    = data.azurerm_storage_account.app.primary_connection_string
-    TEST_EVENT_QUEUE_NAME          = var.test_event_queue_name
-    REPORTING_EXCEPTION_QUEUE_NAME = var.reporting_exception_queue_name
-    REPORT_STREAM_URL              = local.report_stream_url
-    REPORT_STREAM_TOKEN            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
-    REPORT_STREAM_BATCH_MINIMUM    = var.report_stream_batch_minimum
-    REPORT_STREAM_BATCH_MAXIMUM    = var.report_stream_batch_maximum
-    SIMPLE_REPORT_CB_URL           = local.simple_report_callback_url
-    SIMPLE_REPORT_CB_TOKEN         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
-    "AzureWebJobs.ReportStreamExceptionHandler.Disabled" = "1"
+    https_only                                         = true
+    FUNCTIONS_WORKER_RUNTIME                           = "node"
+    WEBSITE_NODE_DEFAULT_VERSION                       = "~14"
+    FUNCTION_APP_EDIT_MODE                             = "readonly"
+    HASH                                               = "${base64encode(filesha256("${local.function_app_source}"))}"
+    WEBSITE_RUN_FROM_PACKAGE                           = "https://${data.azurerm_storage_account.app.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
+    APPINSIGHTS_INSTRUMENTATIONKEY                     = data.azurerm_application_insights.app.instrumentation_key
+    AZ_STORAGE_QUEUE_SVC_URL                           = "https://${data.azurerm_storage_account.app.name}.queue.core.windows.net/"
+    AZ_STORAGE_ACCOUNT_NAME                            = data.azurerm_storage_account.app.name
+    AZ_STORAGE_ACCOUNT_KEY                             = data.azurerm_storage_account.app.primary_access_key
+    AZ_STORAGE_QUEUE_CXN_STRING                        = data.azurerm_storage_account.app.primary_connection_string
+    TEST_EVENT_QUEUE_NAME                              = var.test_event_queue_name
+    REPORTING_EXCEPTION_QUEUE_NAME                     = var.reporting_exception_queue_name
+    REPORT_STREAM_URL                                  = local.report_stream_url
+    REPORT_STREAM_TOKEN                                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
+    REPORT_STREAM_BATCH_MINIMUM                        = var.report_stream_batch_minimum
+    REPORT_STREAM_BATCH_MAXIMUM                        = var.report_stream_batch_maximum
+    SIMPLE_REPORT_CB_URL                               = local.simple_report_callback_url
+    SIMPLE_REPORT_CB_TOKEN                             = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
+    AzureWebJobs.ReportStreamExceptionHandler.Disabled = "1"
   }
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_function_app" "functions" {
     REPORT_STREAM_BATCH_MAXIMUM    = var.report_stream_batch_maximum
     SIMPLE_REPORT_CB_URL           = local.simple_report_callback_url
     SIMPLE_REPORT_CB_TOKEN         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
-    AzureWebJobs.ReportStreamExceptionHandler.Disabled = 1
+    "AzureWebJobs.ReportStreamExceptionHandler.Disabled" = 1
   }
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

- Looks like the way to disable the azure cloud function is via app config

this is auto generated from the Azure portal
![image](https://user-images.githubusercontent.com/4952042/154535213-4fe137d9-ca4d-4544-a024-83b594af3bcd.png)

reference:
https://docs.microsoft.com/en-us/azure/azure-functions/disable-function?tabs=portal

## Changes Proposed

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
