### PR TITLE
Track md5 of RS function source bundle to ensure updates on changes

### DIFF
--- a/.github/actions/build-reportstream-functions/action.yml
+++ b/.github/actions/build-reportstream-functions/action.yml
@@ -14,18 +14,9 @@ runs:
         echo "::group::Install dependencies"
         npm ci
         echo "::endgroup::"
-    - name: Build function
+    - name: Build function source bundle
       shell: bash
       working-directory: ./ops/services/app_functions/report_stream_batched_publisher/functions
       run: |
         echo "::group::Build function"
-        yarn prestart
-        npm prune --production
-        echo "::endgroup::"
-    - name: Build function .zip
-      shell: bash
-      working-directory: ./ops/services/app_functions/report_stream_batched_publisher/functions
-      run: |
-        echo "::group::Build function .zip"
-        yarn build:zip
-        echo "::endgroup::"
+        yarn build:production

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/package.json
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/package.json
@@ -12,7 +12,6 @@
     "build:zip": "zip -r build/batched-rs-publisher.zip . -x \"*.zip\" -x \".terraform\" -x \"terraform.*\" -x \"*.tf\" -x \"local.settings.json\" -x \"*.map\"",
     "build": "npm run clean && npm run build:compile",
     "predeploy": "npm run build:production",
-    "deploy": "terraform apply",
     "prestart": "npm run build && func extensions install",
     "start": "func start",
     "test": "jest --watch"


### PR DESCRIPTION
## Related Issue or Background Info

Bug fix for changes made in #3313 

## Changes Proposed

- `azurerm_storage_blob` wasn't tracking the md5sum of the source bundle,
  and so it was never tracking whether the remote source bundle needed
  to be updated to match the updated local code

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**
