### PR TITLE
Bob/fix confirmation modals

### DIFF
--- a/frontend/cypress/integration/01-organization_sign_up_spec.js
+++ b/frontend/cypress/integration/01-organization_sign_up_spec.js
@@ -38,6 +38,7 @@ describe("Organization sign up", () => {
   it("verifies the org", () => {
     cy.get(".sr-pending-org-edit-verify").first().click();
     cy.get("#verify-button").click();
+    cy.get("#verify-confirmation").click();
     cy.contains("Identity verified for Beach Camp", { timeout: 30000 });
   });
   it("spoofs into the org", () => {

--- a/frontend/cypress/integration/01-organization_sign_up_spec.js
+++ b/frontend/cypress/integration/01-organization_sign_up_spec.js
@@ -47,7 +47,7 @@ describe("Organization sign up", () => {
     cy.get("#org-dropdown-select--list--option-0").click();
     cy.get('input[name="justification"]').type("I am a test user").blur();
     cy.contains("Access data").click();
-    cy.contains("Support Admin");
+    cy.contains("Support admin");
   });
   it("navigates to the manage facilities page", () => {
     cy.visit("/settings/facilities");

--- a/frontend/src/app/Settings/Users/DeleteUserModal.tsx
+++ b/frontend/src/app/Settings/Users/DeleteUserModal.tsx
@@ -50,7 +50,10 @@ const DeleteUserModal: React.FC<Props> = ({ onClose, onDeleteUser, user }) => {
             </strong>
             ?
           </p>
-          <p> Doing so will remove this person's access to SimpleReport.</p>
+          <p>
+            Doing so will remove this person's access to SimpleReport. It
+            doesn't reset their account settings or password.
+          </p>
         </div>
         <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
           <div className="display-flex flex-justify-end">

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
@@ -297,7 +297,7 @@ describe("PendingOrganizationsContainer", () => {
       expect(
         screen.getByLabelText("Organization name", { exact: false })
       ).toBeDisabled();
-      expect(screen.getByText("Update only", { exact: false })).toBeDisabled();
+      expect(screen.getByText("Edit only", { exact: false })).toBeDisabled();
       expect(screen.getByText("Verify", { exact: true })).toBeInTheDocument();
       expect(screen.getByText("Verify", { exact: true })).toBeEnabled();
       expect(
@@ -312,7 +312,7 @@ describe("PendingOrganizationsContainer", () => {
       expect(
         screen.getByLabelText("Organization name", { exact: false })
       ).toBeDisabled();
-      expect(screen.getByText("Update only", { exact: false })).toBeDisabled();
+      expect(screen.getByText("Edit only", { exact: false })).toBeDisabled();
       expect(screen.getByText("Verify", { exact: true })).toBeInTheDocument();
       expect(screen.getByText("Verify", { exact: true })).toBeEnabled();
       expect(
@@ -336,10 +336,12 @@ describe("PendingOrganizationsContainer", () => {
       expect(
         screen.getByLabelText("Organization name", { exact: false })
       ).toBeDisabled();
-      expect(screen.getByText("Update only", { exact: false })).toBeDisabled();
+      expect(screen.getByText("Edit only", { exact: false })).toBeDisabled();
       userEvent.click(screen.getByText("Verify", { exact: true }));
+      userEvent.click(screen.getByText("Yes, I'm sure"));
+
       await waitForElementToBeRemoved(
-        screen.queryByText("Organization details")
+        screen.queryByText("Verify organization")
       );
       expect(
         await screen.findByText("An Old Schema Org with Date", {
@@ -479,7 +481,7 @@ describe("PendingOrganizationsContainer", () => {
           expect(
             screen.getByLabelText("Organization name", { exact: false })
           ).toHaveValue("DC Space Camp");
-          userEvent.click(screen.getByText("Update only", { exact: false }));
+          userEvent.click(screen.getByText("Edit only", { exact: false }));
           expect(
             screen.getByLabelText("Organization name", { exact: false })
           ).toHaveValue("DC Space Camp");
@@ -520,8 +522,10 @@ describe("PendingOrganizationsContainer", () => {
           Array.from(await screen.findAllByText("Edit/Verify"))[1]
         );
         userEvent.click(screen.getByText("Verify"));
+        userEvent.click(screen.getByText("Yes, I'm sure"));
+
         await waitForElementToBeRemoved(
-          screen.queryByLabelText("Organization name", {
+          screen.queryByLabelText("Verify organization", {
             exact: false,
           })
         );
@@ -580,12 +584,14 @@ describe("PendingOrganizationsContainer", () => {
         })
       ).toHaveValue("DC Space Camp");
       userEvent.click(screen.getByText("Verify"));
-      await waitForElementToBeRemoved(() =>
+      userEvent.click(screen.getByText("Yes, I'm sure"));
+
+      await waitForElementToBeRemoved(
+        screen.queryByText("Verify organization")
+      );
+      await waitForElementToBeRemoved(
         screen.queryByText("DC-Space-Camp-f34183c4-b4c5-449f-98b0-2e02abb7aae0")
       );
-      expect(
-        screen.queryByText("DC-Space-Camp-f34183c4-b4c5-449f-98b0-2e02abb7aae0")
-      ).not.toBeInTheDocument();
     });
   });
   describe("deleting organizations", () => {

--- a/frontend/src/app/supportAdmin/PendingOrganizations/modals/ConfirmOrgVerificationModal.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/modals/ConfirmOrgVerificationModal.tsx
@@ -143,7 +143,8 @@ const ConfirmOrgVerificationModal: React.FC<VerficationModalProps> = ({
               label="No, go back"
             />
             <Button
-              className="margin-right-205 verify-confirmation"
+              className="margin-right-205"
+              id="verify-confirmation"
               label="Yes, I'm sure"
               onClick={onVerify}
             />

--- a/frontend/src/app/supportAdmin/PendingOrganizations/modals/ConfirmOrgVerificationModal.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/modals/ConfirmOrgVerificationModal.tsx
@@ -40,6 +40,7 @@ const ConfirmOrgVerificationModal: React.FC<VerficationModalProps> = ({
     adminLastName: "",
     adminPhone: "",
   });
+  const [verifyConfirmation, setVerifyConfirmation] = useState(false);
 
   const validateField = async (field: keyof PendingOrganizationFormValues) => {
     setErrors(
@@ -94,7 +95,63 @@ const ConfirmOrgVerificationModal: React.FC<VerficationModalProps> = ({
     getValidationStatus,
   };
 
-  return (
+  return verifyConfirmation ? (
+    <Modal
+      isOpen={true}
+      style={{
+        content: {
+          maxHeight: "90vh",
+          width: "40em",
+          position: "initial",
+        },
+      }}
+      overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
+      contentLabel="Verify organization"
+    >
+      <div className="border-0 card-container">
+        <div className="display-flex flex-justify">
+          <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
+            Verify organization
+          </h1>
+          <button
+            onClick={handleClose}
+            className="close-button"
+            aria-label="Close"
+          >
+            <span className="fa-layers">
+              <FontAwesomeIcon icon={"circle"} size="2x" inverse />
+              <FontAwesomeIcon icon={"times-circle"} size="2x" />
+            </span>
+          </button>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
+        <div className="grid-row grid-gap">
+          <p>
+            Are you sure you want to verify <strong>{org.name}</strong>?
+          </p>
+          <p>
+            Doing so will allow the organization to create an account and
+            conduct and submit tests.
+          </p>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
+          <div className="display-flex flex-justify-end">
+            <Button
+              className="margin-right-2"
+              onClick={() => setVerifyConfirmation(false)}
+              variant="unstyled"
+              label="No, go back"
+            />
+            <Button
+              className="margin-right-205 verify-confirmation"
+              label="Yes, I'm sure"
+              onClick={onVerify}
+            />
+          </div>
+        </div>
+      </div>
+    </Modal>
+  ) : (
     <Modal
       isOpen={true}
       style={{
@@ -172,13 +229,13 @@ const ConfirmOrgVerificationModal: React.FC<VerficationModalProps> = ({
               className="margin-right-2"
               variant="outline"
               onClick={onSave}
-              label={isUpdating ? "Updating..." : "Update only"}
+              label={isUpdating ? "Updating..." : "Edit only"}
               disabled={isVerifying || isUpdating || orgUsingOldSchema}
             />
             <Button
               className="margin-right-205"
               id="verify-button"
-              onClick={onVerify}
+              onClick={() => setVerifyConfirmation(true)}
               label={isVerifying ? "Verifying..." : "Verify"}
               disabled={isVerifying || isUpdating}
             />

--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -8,7 +8,7 @@ const SupportAdmin = () => {
           <div className="prime-container card-container">
             <div className="usa-card__header">
               <div>
-                <h2>Support Admin</h2>
+                <h2>Support admin</h2>
               </div>
             </div>
             <div className="usa-card__body">
@@ -24,12 +24,12 @@ const SupportAdmin = () => {
               </div>
               <div>
                 <LinkWithQuery to="/admin/create-device-type">
-                  Create new device type
+                  Add a new testing device
                 </LinkWithQuery>
               </div>
               <div>
                 <LinkWithQuery to="/admin/manage-devices">
-                  Manage devices
+                  Edit existing testing device
                 </LinkWithQuery>
               </div>
               <div>


### PR DESCRIPTION
## Related Issue or Background Info

Some changes to various modals around the app as requested [here](https://github.com/CDCgov/prime-simplereport/issues/2963) and [here](https://github.com/CDCgov/prime-simplereport/issues/3391)

## Changes Proposed

- Add confirmation modals in the correct place/changed copy on one of the modals
- Change relevant e2e/testing selectors

## Screenshots / Demos

https://user-images.githubusercontent.com/29645040/155384456-5b634464-ce4b-4e23-96ff-98dd32b4a402.mov

b-fb11531a21aa.png">

<img width="916" alt="image" src="https://user-images.githubusercontent.com/29645040/155384235-52fc03b7-433f-4ccb-9207-4c3f80b3eec4.png">

## Checklist for Author and Reviewer
- [ ] Verify copy/interaction changes look ok

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team
