### PR TITLE
Add supported disease table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3335,14 +3335,14 @@ databaseChangeLog:
                     foreignKeyName: fk__facility__default_specimen_type
                     references: specimen_type(internal_id)
   - changeSet:
-      id: add-disease-table
+      id: add-supported-disease-table
       author: emma@skylight.digital
       comment: Adds a non-audited table to track which diseases SimpleReport supports
       changes:
         - tagDatabase:
             tag: add-supported-disease-table
         - createTable:
-            tableName: supported_diseases
+            tableName: supported_disease
             columns:
               - column:
                   name: internal_id
@@ -3364,12 +3364,12 @@ databaseChangeLog:
                   constraints:
                     nullable: false
         - sql: |
-            GRANT SELECT ON ${database.defaultSchemaName}.supported_diseases TO ${noPhiUsername};
+            GRANT SELECT ON ${database.defaultSchemaName}.supported_disease TO ${noPhiUsername};
       rollback:
           sql: |
-            DROP TABLE ${database.defaultSchemaName}.supported_diseases;
+            DROP TABLE ${database.defaultSchemaName}.supported_disease;
   - changeSet:
-      id: populate-supported-diseases-table
+      id: populate-supported-disease-table
       author: emma@skylight.digital
       comment: Populate the diseases that SimpleReport currently supports.
       changes:
@@ -3378,7 +3378,7 @@ databaseChangeLog:
         - sql:
             comment: Add COVID-19, Flu A, and Flu B to the supported disease table
             sql: |
-              INSERT INTO ${database.defaultSchemaName}.supported_diseases (
+              INSERT INTO ${database.defaultSchemaName}.supported_disease (
                    internal_id,
                    name,
                    loinc)
@@ -3388,4 +3388,4 @@ databaseChangeLog:
                    (gen_random_uuid(), 'Flu B', 'LP14240-3');
       rollback:
         sql: |
-          TRUNCATE TABLE ${database.defaultSchemaName}.supported_diseases;
+          TRUNCATE TABLE ${database.defaultSchemaName}.supported_disease;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3339,6 +3339,8 @@ databaseChangeLog:
       author: emma@skylight.digital
       comment: Add table to track which diseases SimpleReport supports
       changes:
+        - tagDatabase:
+            tag: add-supported-disease-table
         - createTable:
             tableName: supported_diseases
             columns:
@@ -3355,11 +3357,18 @@ databaseChangeLog:
                   name: loinc
                   type: text
                   remarks: Tracks the LOINC code for this disease
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.supported_diseases TO ${noPhiUsername};
+      rollback:
+          sql: |
+          DROP TABLE ${database.defaultSchemaName}.supported_diseases;
   - changeSet:
       id: populate-supported-diseases-table
       author: emma@skylight.digital
       comment: Populate the diseases that SimpleReport currently supports.
       changes:
+        - tagDatabase:
+            tag: populate-supported-disease-table
         - sql:
             comment: Add COVID-19, Flu A, and Flu B to the supported disease table
             sql: |
@@ -3380,3 +3389,6 @@ databaseChangeLog:
                    (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'COVID-19', '96741-4'),
                    (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu A', 'LP14239-5'),
                    (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu B', 'LP14240-3');
+      rollback:
+        sql: |
+          TRUNCATE TABLE ${database.defaultSchemaName}.supported_diseases;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3337,58 +3337,55 @@ databaseChangeLog:
   - changeSet:
       id: add-disease-table
       author: emma@skylight.digital
-      comment: Add table to track which diseases SimpleReport supports
+      comment: Adds a non-audited table to track which diseases SimpleReport supports
       changes:
         - tagDatabase:
             tag: add-supported-disease-table
         - createTable:
             tableName: supported_diseases
             columns:
-              - - column: *pk_column
-                - column: *created_at_column
-                - column: *created_by_column
-                - column: *updated_at_column
-                - column: *updated_by_column
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity
+                  constraints:
+                    primaryKey: true
+                    nullable: false
               - column:
                   name: name
                   type: text
                   remarks: Tracks the human-readable name for the disease
+                  constraints:
+                    nullable: false
               - column:
                   name: loinc
                   type: text
                   remarks: Tracks the LOINC code for this disease
+                  constraints:
+                    nullable: false
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.supported_diseases TO ${noPhiUsername};
       rollback:
           sql: |
             DROP TABLE ${database.defaultSchemaName}.supported_diseases;
-#  - changeSet:
-#      id: populate-supported-diseases-table
-#      author: emma@skylight.digital
-#      comment: Populate the diseases that SimpleReport currently supports.
-#      changes:
-#        - tagDatabase:
-#            tag: populate-supported-disease-table
-#        - sql:
-#            comment: Add COVID-19, Flu A, and Flu B to the supported disease table
-#            sql: |
-#              WITH migration_user as (
-#                   SELECT internal_id as migrations_user_id
-#                   FROM ${database.defaultSchemaName}.api_user
-#                   WHERE login_email = '${migrations_user_email}')
-#
-#              INSERT INTO ${database.defaultSchemaName}.supported_diseases (
-#                   internal_id,
-#                   created_at,
-#                   created_by,
-#                   updated_at,
-#                   updated_by,
-#                   name,
-#                   loinc)
-#              VALUES
-#                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'COVID-19', '96741-4'),
-#                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu A', 'LP14239-5'),
-#                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu B', 'LP14240-3');
-#      rollback:
-#        sql: |
-#          TRUNCATE TABLE ${database.defaultSchemaName}.supported_diseases;
+  - changeSet:
+      id: populate-supported-diseases-table
+      author: emma@skylight.digital
+      comment: Populate the diseases that SimpleReport currently supports.
+      changes:
+        - tagDatabase:
+            tag: populate-supported-disease-table
+        - sql:
+            comment: Add COVID-19, Flu A, and Flu B to the supported disease table
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.supported_diseases (
+                   internal_id,
+                   name,
+                   loinc)
+              VALUES
+                   (gen_random_uuid(), 'COVID-19', '96741-4'),
+                   (gen_random_uuid(), 'Flu A', 'LP14239-5'),
+                   (gen_random_uuid(), 'Flu B', 'LP14240-3');
+      rollback:
+        sql: |
+          TRUNCATE TABLE ${database.defaultSchemaName}.supported_diseases;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3361,34 +3361,34 @@ databaseChangeLog:
             GRANT SELECT ON ${database.defaultSchemaName}.supported_diseases TO ${noPhiUsername};
       rollback:
           sql: |
-          DROP TABLE ${database.defaultSchemaName}.supported_diseases;
-  - changeSet:
-      id: populate-supported-diseases-table
-      author: emma@skylight.digital
-      comment: Populate the diseases that SimpleReport currently supports.
-      changes:
-        - tagDatabase:
-            tag: populate-supported-disease-table
-        - sql:
-            comment: Add COVID-19, Flu A, and Flu B to the supported disease table
-            sql: |
-              WITH migration_user as (
-                   SELECT internal_id as migrations_user_id
-                   FROM ${database.defaultSchemaName}.api_user
-                   WHERE login_email = '${migrations_user_email}')
-                   
-              INSERT INTO ${database.defaultSchemaName}.supported_diseases (
-                   internal_id, 
-                   created_at, 
-                   created_by, 
-                   updated_at,
-                   updated_by,
-                   name,
-                   loinc)
-              VALUES 
-                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'COVID-19', '96741-4'),
-                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu A', 'LP14239-5'),
-                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu B', 'LP14240-3');
-      rollback:
-        sql: |
-          TRUNCATE TABLE ${database.defaultSchemaName}.supported_diseases;
+            DROP TABLE ${database.defaultSchemaName}.supported_diseases;
+#  - changeSet:
+#      id: populate-supported-diseases-table
+#      author: emma@skylight.digital
+#      comment: Populate the diseases that SimpleReport currently supports.
+#      changes:
+#        - tagDatabase:
+#            tag: populate-supported-disease-table
+#        - sql:
+#            comment: Add COVID-19, Flu A, and Flu B to the supported disease table
+#            sql: |
+#              WITH migration_user as (
+#                   SELECT internal_id as migrations_user_id
+#                   FROM ${database.defaultSchemaName}.api_user
+#                   WHERE login_email = '${migrations_user_email}')
+#
+#              INSERT INTO ${database.defaultSchemaName}.supported_diseases (
+#                   internal_id,
+#                   created_at,
+#                   created_by,
+#                   updated_at,
+#                   updated_by,
+#                   name,
+#                   loinc)
+#              VALUES
+#                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'COVID-19', '96741-4'),
+#                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu A', 'LP14239-5'),
+#                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu B', 'LP14240-3');
+#      rollback:
+#        sql: |
+#          TRUNCATE TABLE ${database.defaultSchemaName}.supported_diseases;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3367,7 +3367,7 @@ databaseChangeLog:
             GRANT SELECT ON ${database.defaultSchemaName}.supported_disease TO ${noPhiUsername};
       rollback:
           sql: |
-            DROP TABLE ${database.defaultSchemaName}.supported_disease;
+            DROP TABLE ${database.defaultSchemaName}.supported_disease CASCADE;
   - changeSet:
       id: populate-supported-disease-table
       author: emma@skylight.digital
@@ -3388,4 +3388,4 @@ databaseChangeLog:
                    (gen_random_uuid(), 'Flu B', 'LP14240-3');
       rollback:
         sql: |
-          TRUNCATE TABLE ${database.defaultSchemaName}.supported_disease;
+          TRUNCATE TABLE ${database.defaultSchemaName}.supported_disease CASCADE;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3334,3 +3334,49 @@ databaseChangeLog:
                     nullable: true
                     foreignKeyName: fk__facility__default_specimen_type
                     references: specimen_type(internal_id)
+  - changeSet:
+      id: add-disease-table
+      author: emma@skylight.digital
+      comment: Add table to track which diseases SimpleReport supports
+      changes:
+        - createTable:
+            tableName: supported_diseases
+            columns:
+              - - column: *pk_column
+                - column: *created_at_column
+                - column: *created_by_column
+                - column: *updated_at_column
+                - column: *updated_by_column
+              - column:
+                  name: name
+                  type: text
+                  remarks: Tracks the human-readable name for the disease
+              - column:
+                  name: loinc
+                  type: text
+                  remarks: Tracks the LOINC code for this disease
+  - changeSet:
+      id: populate-supported-diseases-table
+      author: emma@skylight.digital
+      comment: Populate the diseases that SimpleReport currently supports.
+      changes:
+        - sql:
+            comment: Add COVID-19, Flu A, and Flu B to the supported disease table
+            sql: |
+              WITH migration_user as (
+                   SELECT internal_id as migrations_user_id
+                   FROM ${database.defaultSchemaName}.api_user
+                   WHERE login_email = '${migrations_user_email}')
+                   
+              INSERT INTO ${database.defaultSchemaName}.supported_diseases (
+                   internal_id, 
+                   created_at, 
+                   created_by, 
+                   updated_at,
+                   updated_by,
+                   name,
+                   loinc)
+              VALUES 
+                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'COVID-19', '96741-4'),
+                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu A', 'LP14239-5'),
+                   (gen_random_uuid(), migrations_user_id, now(), migrations_user_id, now(), 'Flu B', 'LP14240-3');


### PR DESCRIPTION
## Related Issue or Background Info

- Fixes #3411 

## Changes Proposed

- Add a new supported disease table
- Add COVID-19, Flu A, and Flu B to the table

## Additional Information

- This is a non-audited table as it should only ever be updated internally (users will never have write access)

This is the result of running the migrations locally:
<img width="571" alt="Screen Shot 2022-02-23 at 4 06 17 PM" src="https://user-images.githubusercontent.com/80282552/155431873-496aba0a-ff1d-42d1-acd9-c3ea36b2c566.png">

- We need to check with someone(?) who is a LOINC expert that these are the right values to store

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
