### PR TITLE
Add "save and start test" button to Edit Patient form

### DIFF
--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -480,11 +480,13 @@ describe("AddPatient", () => {
         await waitForElementToBeRemoved(() =>
           screen.queryAllByText("Saving...")
         );
+
         expect(
-          screen.getByText("Testing Queue!", { exact: false })
+          await screen.findByText("Testing Queue!", { exact: false })
         ).toBeInTheDocument();
+
         expect(
-          screen.getByText("facility-id-001", { exact: false })
+          await screen.findByText("facility-id-001", { exact: false })
         ).toBeInTheDocument();
       });
     });

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -230,10 +230,6 @@ const AddPatient = () => {
     string | { pathname: string; search: string; state?: any } | undefined
   >(undefined);
 
-  if (redirect) {
-    return <Navigate to={redirect} />;
-  }
-
   if (!activeFacilityId) {
     return <div>No facility selected</div>;
   }
@@ -242,10 +238,6 @@ const AddPatient = () => {
     person: Nullable<PersonFormData>,
     startTest?: boolean
   ) => {
-    console.log("==============================");
-    console.log("startTest");
-    console.log(startTest);
-    console.log("==============================");
     const { data } = await addPatient({
       variables: {
         ...person,
@@ -277,6 +269,19 @@ const AddPatient = () => {
       setRedirect(personPath);
     }
   };
+
+  if (redirect) {
+    const navProps: any = {};
+
+    if (typeof redirect === "string") {
+      navProps.to = redirect;
+    } else {
+      navProps.to = redirect.pathname + redirect.search;
+      navProps.state = redirect.state;
+    }
+
+    return <Navigate {...navProps} />;
+  }
 
   const getSaveButtons = (
     formChanged: boolean,

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { gql, useLazyQuery, useMutation } from "@apollo/client";
-import { Navigate } from "react-router-dom";
+import { useNavigate, NavigateOptions } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import moment from "moment";
 import { useSelector } from "react-redux";
@@ -219,10 +219,9 @@ const AddPatient = () => {
     }
   }, [identifyingData, getPatientExists]);
 
+  const navigate = useNavigate();
   const [activeFacility] = useSelectedFacility();
   const activeFacilityId = activeFacility?.id;
-
-  //const [startTest, setStartTest] = useState(false);
 
   const personPath = `/patients/?facility=${activeFacilityId}`;
 
@@ -249,6 +248,7 @@ const AddPatient = () => {
         emails: dedupeAndCompactStrings(person.emails || []),
       },
     });
+
     showNotification(
       <Alert
         type="success"
@@ -256,8 +256,10 @@ const AddPatient = () => {
         body="New information record has been created."
       />
     );
+
     if (startTest) {
       const facility = data?.addPatient?.facility?.id || activeFacilityId;
+
       setRedirect({
         pathname: "/queue",
         search: `?facility=${facility}`,
@@ -271,16 +273,18 @@ const AddPatient = () => {
   };
 
   if (redirect) {
-    const navProps: any = {};
+    const redirectTo =
+      typeof redirect === "string"
+        ? redirect
+        : redirect.pathname + redirect.search;
 
-    if (typeof redirect === "string") {
-      navProps.to = redirect;
-    } else {
-      navProps.to = redirect.pathname + redirect.search;
-      navProps.state = redirect.state;
+    const navOptions: NavigateOptions = {};
+
+    if (typeof redirect !== "string") {
+      navOptions.state = redirect.state;
     }
 
-    return <Navigate {...navProps} />;
+    navigate(redirectTo, navOptions);
   }
 
   const getSaveButtons = (

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -222,7 +222,7 @@ const AddPatient = () => {
   const [activeFacility] = useSelectedFacility();
   const activeFacilityId = activeFacility?.id;
 
-  const [startTest, setStartTest] = useState(false);
+  //const [startTest, setStartTest] = useState(false);
 
   const personPath = `/patients/?facility=${activeFacilityId}`;
 
@@ -238,7 +238,14 @@ const AddPatient = () => {
     return <div>No facility selected</div>;
   }
 
-  const savePerson = async (person: Nullable<PersonFormData>) => {
+  const savePerson = async (
+    person: Nullable<PersonFormData>,
+    startTest?: boolean
+  ) => {
+    console.log("==============================");
+    console.log("startTest");
+    console.log(startTest);
+    console.log("==============================");
     const { data } = await addPatient({
       variables: {
         ...person,
@@ -271,15 +278,17 @@ const AddPatient = () => {
     }
   };
 
-  const getSaveButtons = (formChanged: boolean, onSave: () => void) => (
+  const getSaveButtons = (
+    formChanged: boolean,
+    onSave: (startTest?: boolean) => void
+  ) => (
     <>
       <Button
         id="edit-patient-save-lower"
         className="prime-save-patient-changes-start-test"
         disabled={loading || !formChanged}
         onClick={() => {
-          setStartTest(true);
-          onSave();
+          onSave(true);
         }}
         variant="outline"
         label={
@@ -291,8 +300,7 @@ const AddPatient = () => {
         className="prime-save-patient-changes"
         disabled={loading || !formChanged}
         onClick={() => {
-          setStartTest(false);
-          onSave();
+          onSave(false);
         }}
         label={
           loading ? `${t("common.button.saving")}...` : t("common.button.save")

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -101,6 +101,7 @@ interface Props {
 
 const PersonForm = (props: Props) => {
   const [formChanged, setFormChanged] = useState(false);
+  const [startTest, setStartTest] = useState(false);
   const [patient, setPatient] = useState(props.patient);
   // Default country to USA if it's not set
   if (patient.country === null) {
@@ -237,7 +238,7 @@ const PersonForm = (props: Props) => {
     const originalAddress = getAddress(patient);
     const suggestedAddress = await getBestSuggestion(originalAddress);
     if (suggestionIsCloseEnough(originalAddress, suggestedAddress)) {
-      onSave(suggestedAddress);
+      onSave(suggestedAddress, startTest);
     } else {
       setAddressSuggestion(suggestedAddress);
       setAddressModalOpen(true);
@@ -245,6 +246,10 @@ const PersonForm = (props: Props) => {
   };
 
   const validateForm = async (startTest?: boolean) => {
+    if (startTest) {
+      setStartTest(true);
+    }
+
     try {
       phoneNumberValidator.current?.();
       await schema.validate(patient, { abortEarly: false });
@@ -642,7 +647,7 @@ const PersonForm = (props: Props) => {
           },
         ]}
         showModal={addressModalOpen}
-        onConfirm={(data) => onSave(data.person)}
+        onConfirm={(data) => onSave(data.person, startTest)}
         onClose={() => setAddressModalOpen(false)}
       />
     </>

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -84,15 +84,18 @@ const yesNoUnknownToBool = (
 interface Props {
   patient: Nullable<PersonFormData>;
   patientId?: string;
-  savePerson: (person: Nullable<PersonFormData>) => void;
+  savePerson: (person: Nullable<PersonFormData>, startTest?: boolean) => void;
   onBlur?: (person: Nullable<PersonFormData>) => void;
   hideFacilitySelect?: boolean;
   getHeader?: (
     person: Nullable<PersonFormData>,
-    onSave: () => void,
+    onSave: (startTest?: boolean) => void,
     formChanged: boolean
   ) => React.ReactNode;
-  getFooter: (onSave: () => void, formChanged: boolean) => React.ReactNode;
+  getFooter: (
+    onSave: (startTest?: boolean) => void,
+    formChanged: boolean
+  ) => React.ReactNode;
   view?: PersonFormView;
 }
 
@@ -241,7 +244,7 @@ const PersonForm = (props: Props) => {
     }
   };
 
-  const validateForm = async () => {
+  const validateForm = async (startTest?: boolean) => {
     try {
       phoneNumberValidator.current?.();
       await schema.validate(patient, { abortEarly: false });
@@ -276,18 +279,18 @@ const PersonForm = (props: Props) => {
         JSON.stringify(getAddress(props.patient)) ||
       patient.country !== "USA"
     ) {
-      onSave();
+      onSave(undefined, startTest);
     } else {
       validatePatientAddress();
     }
   };
 
-  const onSave = (address?: AddressWithMetaData) => {
+  const onSave = (address?: AddressWithMetaData, startTest?: boolean) => {
     const person = address ? { ...patient, ...address } : patient;
     setPatient(person);
     setAddressModalOpen(false);
     setFormChanged(false);
-    props.savePerson(person);
+    props.savePerson(person, startTest);
   };
 
   const commonInputProps = {

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -187,7 +187,6 @@ const EditPatient = (props: Props) => {
   >(UPDATE_PATIENT);
   const [activeFacility] = useSelectedFacility();
   const activeFacilityId = activeFacility?.id;
-  const [startTest, setStartTest] = useState(false);
   const [redirect, setRedirect] = useState<
     string | { pathname: string; search: string; state?: any } | undefined
   >(undefined);
@@ -200,21 +199,15 @@ const EditPatient = (props: Props) => {
   if (loading) {
     return <p>Loading...</p>;
   }
+
   if (error || data === undefined) {
     return <p>error loading patient with id {props.patientId}...</p>;
   }
-  if (startTest) {
-    const facility = data?.patient.facility?.id || activeFacilityId;
-    setRedirect({
-      pathname: "/queue",
-      search: `?facility=${facility}`,
-      state: {
-        patientId: props.patientId,
-      } as StartTestProps,
-    });
-  }
 
-  const savePerson = async (person: Nullable<PersonFormData>) => {
+  const savePerson = async (
+    person: Nullable<PersonFormData>,
+    startTest?: boolean
+  ) => {
     await updatePatient({
       variables: {
         patientId: props.patientId,
@@ -243,7 +236,18 @@ const EditPatient = (props: Props) => {
       />
     );
 
-    setRedirect(personPath);
+    if (startTest) {
+      const facility = data?.patient.facility?.id || activeFacilityId;
+      setRedirect({
+        pathname: "/queue",
+        search: `?facility=${facility}`,
+        state: {
+          patientId: props.patientId,
+        } as StartTestProps,
+      });
+    } else {
+      setRedirect(personPath);
+    }
   };
 
   const getTitle = (person: Nullable<PersonFormData>) =>
@@ -310,8 +314,7 @@ const EditPatient = (props: Props) => {
                       className="prime-save-patient-changes-start-test"
                       disabled={loading || !formChanged}
                       onClick={() => {
-                        setStartTest(true);
-                        onSave();
+                        onSave(true);
                       }}
                       variant="outline"
                       label={
@@ -323,7 +326,7 @@ const EditPatient = (props: Props) => {
                     <button
                       className="prime-save-patient-changes usa-button margin-right-0"
                       disabled={editPersonLoading || !formChanged}
-                      onClick={onSave}
+                      onClick={() => onSave(false)}
                     >
                       {editPersonLoading
                         ? `${t("common.button.saving")}...`
@@ -338,7 +341,7 @@ const EditPatient = (props: Props) => {
                     id="edit-patient-save-lower"
                     className="prime-save-patient-changes"
                     disabled={editPersonLoading || !formChanged}
-                    onClick={onSave}
+                    onClick={() => onSave(false)}
                     label={
                       editPersonLoading
                         ? `${t("common.button.saving")}...`

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -169,6 +169,12 @@ interface EditPatientResponse {
   internalId: string;
 }
 
+interface RedirectSettings {
+  pathname: string;
+  search: string;
+  state?: any;
+}
+
 const EditPatient = (props: Props) => {
   useDocumentTitle("Edit Patient");
 
@@ -188,12 +194,21 @@ const EditPatient = (props: Props) => {
   const [activeFacility] = useSelectedFacility();
   const activeFacilityId = activeFacility?.id;
   const [redirect, setRedirect] = useState<
-    string | { pathname: string; search: string; state?: any } | undefined
+    string | RedirectSettings | undefined
   >(undefined);
   const personPath = `/patients/?facility=${props.facilityId}`;
 
   if (redirect) {
-    return <Navigate to={redirect} />;
+    const navProps: any = {};
+
+    if (typeof redirect === "string") {
+      navProps.to = redirect;
+    } else {
+      navProps.to = redirect.pathname + redirect.search;
+      navProps.state = redirect.state;
+    }
+
+    return <Navigate {...navProps} />;
   }
 
   if (loading) {

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -14,6 +14,8 @@ import Alert from "../commonComponents/Alert";
 import Button from "../commonComponents/Button/Button";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { useDocumentTitle } from "../utils/hooks";
+import { StartTestProps } from "../testQueue/addToQueue/AddToQueueSearch";
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 import { TestResultDeliveryPreference } from "./TestResultDeliveryPreference";
 import PersonForm from "./Components/PersonForm";
@@ -183,7 +185,12 @@ const EditPatient = (props: Props) => {
     EditPatientResponse,
     EditPatientParams
   >(UPDATE_PATIENT);
-  const [redirect, setRedirect] = useState<string | undefined>(undefined);
+  const [activeFacility] = useSelectedFacility();
+  const activeFacilityId = activeFacility?.id;
+  const [startTest, setStartTest] = useState(false);
+  const [redirect, setRedirect] = useState<
+    string | { pathname: string; search: string; state?: any } | undefined
+  >(undefined);
   const personPath = `/patients/?facility=${props.facilityId}`;
 
   if (redirect) {
@@ -195,6 +202,16 @@ const EditPatient = (props: Props) => {
   }
   if (error || data === undefined) {
     return <p>error loading patient with id {props.patientId}...</p>;
+  }
+  if (startTest) {
+    const facility = data?.patient.facility?.id || activeFacilityId;
+    setRedirect({
+      pathname: "/queue",
+      search: `?facility=${facility}`,
+      state: {
+        patientId: props.patientId,
+      } as StartTestProps,
+    });
   }
 
   const savePerson = async (person: Nullable<PersonFormData>) => {
@@ -288,6 +305,21 @@ const EditPatient = (props: Props) => {
                     </div>
                   </div>
                   <div className="display-flex flex-align-center">
+                    <Button
+                      id="edit-patient-save-lower"
+                      className="prime-save-patient-changes-start-test"
+                      disabled={loading || !formChanged}
+                      onClick={() => {
+                        setStartTest(true);
+                        onSave();
+                      }}
+                      variant="outline"
+                      label={
+                        loading
+                          ? `${t("common.button.saving")}...`
+                          : "Save and start test"
+                      }
+                    />
                     <button
                       className="prime-save-patient-changes usa-button margin-right-0"
                       disabled={editPersonLoading || !formChanged}

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { Navigate } from "react-router-dom";
+import { NavigateOptions, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
@@ -191,6 +191,7 @@ const EditPatient = (props: Props) => {
     EditPatientResponse,
     EditPatientParams
   >(UPDATE_PATIENT);
+  const navigate = useNavigate();
   const [activeFacility] = useSelectedFacility();
   const activeFacilityId = activeFacility?.id;
   const [redirect, setRedirect] = useState<
@@ -199,16 +200,18 @@ const EditPatient = (props: Props) => {
   const personPath = `/patients/?facility=${props.facilityId}`;
 
   if (redirect) {
-    const navProps: any = {};
+    const redirectTo =
+      typeof redirect === "string"
+        ? redirect
+        : redirect.pathname + redirect.search;
 
-    if (typeof redirect === "string") {
-      navProps.to = redirect;
-    } else {
-      navProps.to = redirect.pathname + redirect.search;
-      navProps.state = redirect.state;
+    const navOptions: NavigateOptions = {};
+
+    if (typeof redirect !== "string") {
+      navOptions.state = redirect.state;
     }
 
-    return <Navigate {...navProps} />;
+    navigate(redirectTo, navOptions);
   }
 
   if (loading) {

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -58,6 +58,14 @@ Object {
                     class="display-flex flex-align-center"
                   >
                     <button
+                      class="usa-button usa-button--outline usa-button-disabled prime-save-patient-changes-start-test"
+                      disabled=""
+                      id="edit-patient-save-lower"
+                      type="button"
+                    >
+                      Save and start test
+                    </button>
+                    <button
                       class="prime-save-patient-changes usa-button margin-right-0"
                       disabled=""
                     >
@@ -2636,6 +2644,14 @@ Object {
                 <div
                   class="display-flex flex-align-center"
                 >
+                  <button
+                    class="usa-button usa-button--outline usa-button-disabled prime-save-patient-changes-start-test"
+                    disabled=""
+                    id="edit-patient-save-lower"
+                    type="button"
+                  >
+                    Save and start test
+                  </button>
                   <button
                     class="prime-save-patient-changes usa-button margin-right-0"
                     disabled=""

--- a/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistrationForm.tsx
@@ -92,7 +92,7 @@ export const SelfRegistrationForm = ({
         getFooter={(onSave) => (
           <Button
             className="self-registration-button margin-top-3"
-            onClick={onSave}
+            onClick={() => onSave()}
           >
             {t("common.button.submit")}
           </Button>

--- a/frontend/src/patientApp/timeOfTest/PatientFormContainer.tsx
+++ b/frontend/src/patientApp/timeOfTest/PatientFormContainer.tsx
@@ -93,7 +93,7 @@ const PatientFormContainer = () => {
                 <Button
                   id="edit-patient-save-lower"
                   disabled={!formChanged}
-                  onClick={onSave}
+                  onClick={() => onSave()}
                   label="Save and continue"
                 />
                 <Button


### PR DESCRIPTION
## Related Issue or Background Info
* Closes #2871 
* Closes #3450

## Changes Proposed
- Add "save and start test" button to Edit Patient form
- Update person form -> test queue redirect logic to be consistent with React Router 6
    - This restores the functionality of the same button on the Add Patient form

## Additional Information
- Asynchronous state-setting of the `startTest` flag was brittle and hard to rely on. That flag is now being passed in directly into the on-save callbacks

## Screenshots / Demos
### Add Patient
https://user-images.githubusercontent.com/27730981/156054058-71d709a9-7b80-4837-9223-faea3aced2d5.mov

### Edit Patient
https://user-images.githubusercontent.com/27730981/156054084-8a4dd745-561c-4804-8c83-4d79669db660.mov

## Checklist for Author and Reviewer
- [ ] Just a general review, please!

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
