### PR TITLE
add noPhiPassword as a parameter for rollback

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -153,7 +153,7 @@ jacocoTestReport {
 def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://127.0.0.1:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
 // If SPRING_DATASOURCE_URL is provided, assume target DB is non-local and schema is "public"
 def defaultSchema = System.getenv("SPRING_DATASOURCE_URL") ? "public" : "simple_report"
-def noPhiPassword = System.getenv("DB_PASSWORD_NO_PHI") ? System.getenv("DB_PASSWORD_NO_PHI") : "nophi789"
+def noPhiPassword = System.getenv("DB_PASSWORD_NO_PHI") ?: "nophi789"
 
 liquibase {
     activities {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -153,6 +153,7 @@ jacocoTestReport {
 def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://127.0.0.1:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
 // If SPRING_DATASOURCE_URL is provided, assume target DB is non-local and schema is "public"
 def defaultSchema = System.getenv("SPRING_DATASOURCE_URL") ? "public" : "simple_report"
+def noPhiPassword = System.getenv("DB_PASSWORD_NO_PHI") ? System.getenv("DB_PASSWORD_NO_PHI") : "nophi789"
 
 liquibase {
     activities {
@@ -165,7 +166,7 @@ liquibase {
             defaultSchemaName defaultSchema
             classpath "src/main/resources"
             // this shadows application.yaml: should probably be in a shared properties file
-            changeLogParameters noPhiUsername: "simple_report_no_phi"
+            changeLogParameters ([noPhiUsername: "simple_report_no_phi", noPhiPassword: noPhiPassword])
         }
     }
 }


### PR DESCRIPTION
## Related Issue or Background Info
## Changes Proposed

- add noPhiPassword as a parameter for rollback

## Additional Information

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [ ] Database changes are submitted as a separate PR
  - [ ] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [ ] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] DevOps team has been notified if PR requires ops support
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
