### PR TITLE
Add info icon with tooltip to test card device dropdown

### DIFF
--- a/frontend/src/app/commonComponents/TextWithTooltip.scss
+++ b/frontend/src/app/commonComponents/TextWithTooltip.scss
@@ -1,7 +1,8 @@
 .usa-text-with-tooltip {
   .usa-tooltip__body {
-    margin-left: -240px !important;
-    margin-top: -60px !important;
+    white-space: pre-wrap;
+    min-width: 300px;
+    padding: 1em;
   }
 
   .info-circle-icon {

--- a/frontend/src/app/commonComponents/TextWithTooltip.tsx
+++ b/frontend/src/app/commonComponents/TextWithTooltip.tsx
@@ -2,7 +2,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { Tooltip } from "@trussworks/react-uswds";
 import React from "react";
-
 import "./TextWithTooltip.scss";
 
 type CustomButtonProps = React.PropsWithChildren<{
@@ -12,16 +11,16 @@ type CustomButtonProps = React.PropsWithChildren<{
   React.RefAttributes<HTMLButtonElement>;
 
 interface Props {
-  text: string;
   tooltip: string;
   position?: "top" | "bottom" | "left" | "right";
+  text?: string;
   className?: string;
 }
 
 export const TextWithTooltip = ({
-  text,
   tooltip,
   position,
+  text,
   className,
 }: Props) => {
   const CustomButton: React.ForwardRefExoticComponent<CustomButtonProps> = React.forwardRef(
@@ -47,12 +46,7 @@ export const TextWithTooltip = ({
       wrapperclasses="usa-text-with-tooltip"
     >
       {text}
-      <FontAwesomeIcon
-        className="info-circle-icon"
-        icon={faInfoCircle}
-        color="black"
-        size="xs"
-      />
+      <FontAwesomeIcon className="info-circle-icon" icon={faInfoCircle} />
     </Tooltip>
   );
 };

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -183,6 +183,7 @@ const OrganizationForm = () => {
                   <TextWithTooltip
                     tooltip="Can be anyone that works at your organization. Adds testing facility locations; manages the account and user access."
                     text="Organization administrator"
+                    position="right"
                   />
                 </strong>
               </label>

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -40,7 +40,7 @@ export const organizationFields = [
     <TextWithTooltip
       text="Organization name"
       tooltip="Organizations have multiple testing facilities or locations as part of their network."
-      position="top"
+      position="right"
     />,
     true,
     "",

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -141,7 +141,10 @@ describe("QueueItem", () => {
       </MockedProvider>
     );
 
-    userEvent.type(screen.getByLabelText("Device", { exact: false }), "lumira");
+    userEvent.type(
+      screen.getAllByLabelText("Device", { exact: false })[1],
+      "lumira"
+    );
 
     expect(await screen.findByTestId("timer")).toHaveTextContent("10:00");
   });
@@ -171,7 +174,9 @@ describe("QueueItem", () => {
       </MockedProvider>
     );
 
-    const deviceDropdown = await screen.findByLabelText("Device");
+    const deviceDropdown = (
+      await screen.findAllByLabelText("Device", { exact: false })
+    )[1];
 
     userEvent.selectOptions(deviceDropdown, "Access Bio CareStart");
 
@@ -299,7 +304,9 @@ describe("QueueItem", () => {
       </>
     );
 
-    const deviceDropdown = await screen.findByLabelText("Device");
+    const deviceDropdown = (
+      await screen.findAllByLabelText("Device", { exact: false })
+    )[1];
 
     // Change device type
     userEvent.selectOptions(deviceDropdown, "LumiraDX");

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -21,6 +21,7 @@ import { displayFullName, showNotification } from "../utils";
 import { RootState } from "../store";
 import { getAppInsights } from "../TelemetryService";
 import { formatDate } from "../utils/date";
+import { TextWithTooltip } from "../commonComponents/TextWithTooltip";
 
 import { ALERT_CONTENT, QUEUE_NOTIFICATION_TYPES } from "./constants";
 import AskOnEntryTag, { areAnswersComplete } from "./AskOnEntryTag";
@@ -803,7 +804,16 @@ const QueueItem = ({
                           label: d.name,
                           value: d.internalId,
                         }))}
-                      label="Device"
+                      label={
+                        <>
+                          <span>Device</span>
+
+                          <TextWithTooltip
+                            tooltip="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                            position="right"
+                          />
+                        </>
+                      }
                       name="testDevice"
                       selectedValue={deviceId}
                       onChange={onDeviceChange}

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -26,6 +26,8 @@ describe("TestQueue", () => {
   const mockStore = configureStore([]);
 
   beforeEach(() => {
+    jest.spyOn(global.Math, "random").mockReturnValue(0.123456789);
+
     store = mockStore({
       organization: {
         name: "Organization Name",
@@ -37,6 +39,10 @@ describe("TestQueue", () => {
         },
       ],
     });
+  });
+
+  afterEach(() => {
+    jest.spyOn(global.Math, "random").mockRestore();
   });
 
   it("should render the test queue", async () => {

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -261,7 +261,49 @@ exports[`TestQueue should render the test queue 1`] = `
                         class="usa-label"
                         for="1"
                       >
-                        Device
+                        <span>
+                          Device
+                        </span>
+                        <span
+                          class="usa-tooltip usa-text-with-tooltip"
+                          data-testid="tooltipWrapper"
+                        >
+                          <button
+                            aria-describedby="tooltip-996653"
+                            class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                            data-testid="triggerElement"
+                            position="right"
+                            tabindex="0"
+                            title=""
+                            wrapperclasses="usa-text-with-tooltip"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-info-circle fa-w-16 info-circle-icon"
+                              data-icon="info-circle"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 512 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            aria-hidden="true"
+                            class="usa-tooltip__body"
+                            data-testid="tooltipBody"
+                            id="tooltip-996653"
+                            role="tooltip"
+                            title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                          >
+                            Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                          </span>
+                        </span>
                       </label>
                       <select
                         aria-required="false"
@@ -625,7 +667,49 @@ exports[`TestQueue should render the test queue 1`] = `
                         class="usa-label"
                         for="4"
                       >
-                        Device
+                        <span>
+                          Device
+                        </span>
+                        <span
+                          class="usa-tooltip usa-text-with-tooltip"
+                          data-testid="tooltipWrapper"
+                        >
+                          <button
+                            aria-describedby="tooltip-198081"
+                            class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                            data-testid="triggerElement"
+                            position="right"
+                            tabindex="0"
+                            title=""
+                            wrapperclasses="usa-text-with-tooltip"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-info-circle fa-w-16 info-circle-icon"
+                              data-icon="info-circle"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 512 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            aria-hidden="true"
+                            class="usa-tooltip__body"
+                            data-testid="tooltipBody"
+                            id="tooltip-198081"
+                            role="tooltip"
+                            title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                          >
+                            Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                          </span>
+                        </span>
                       </label>
                       <select
                         aria-required="false"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           data-testid="tooltipWrapper"
                         >
                           <button
-                            aria-describedby="tooltip-996653"
+                            aria-describedby="tooltip-734032"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -297,7 +297,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             aria-hidden="true"
                             class="usa-tooltip__body"
                             data-testid="tooltipBody"
-                            id="tooltip-996653"
+                            id="tooltip-734032"
                             role="tooltip"
                             title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
                           >
@@ -675,7 +675,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           data-testid="tooltipWrapper"
                         >
                           <button
-                            aria-describedby="tooltip-198081"
+                            aria-describedby="tooltip-323564"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -703,7 +703,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             aria-hidden="true"
                             class="usa-tooltip__body"
                             data-testid="tooltipBody"
-                            id="tooltip-198081"
+                            id="tooltip-323564"
                             role="tooltip"
                             title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
                           >

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           data-testid="tooltipWrapper"
                         >
                           <button
-                            aria-describedby="tooltip-734032"
+                            aria-describedby="tooltip-211111"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -297,7 +297,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             aria-hidden="true"
                             class="usa-tooltip__body"
                             data-testid="tooltipBody"
-                            id="tooltip-734032"
+                            id="tooltip-211111"
                             role="tooltip"
                             title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
                           >
@@ -675,7 +675,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           data-testid="tooltipWrapper"
                         >
                           <button
-                            aria-describedby="tooltip-323564"
+                            aria-describedby="tooltip-211111"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -703,7 +703,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             aria-hidden="true"
                             class="usa-tooltip__body"
                             data-testid="tooltipBody"
-                            id="tooltip-323564"
+                            id="tooltip-211111"
                             role="tooltip"
                             title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
                           >


### PR DESCRIPTION
## Related Issue or Background Info
- Closes #3088 

## Changes Proposed
- Using the existing `TextWithTooltip` component, adds an info icon with tooltip to the device dropdown on a test card
 
## Additional Information
- As mentioned above, we already had a `TextWithTooltip` component that was well-suited to this use case
    - However, this component was only used by a single component: namely, the organization sign-up form
    - Owing to some deep CSS weirdness, the tooltip component had to be manually positioned (through `!important` negative margins) on the organization form in order to appear correctly
    - This position override did _not_ work for the test card, however
    - Therefore, I made some changes to the stylesheet so that the tooltip can appear in the correct position across different containers
    - This has the side effect of slightly changing the appearance of the tooltips as they appear on the sign-up form (for the better, imo) 
    - @vz3 check out the screenshots in my comment below and let me know if this 1) makes sense and 2) looks OK

## Screenshots / Demos
https://user-images.githubusercontent.com/27730981/156462871-73a20fdf-2372-41b5-9a45-36617d40266e.mov

## Checklist for Author and Reviewer
- @kenieh it looks like you did the designs for this work? Let me know if everything is to spec! 

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes (including new error messages) have been approved by content team
    - See: https://app.zenhub.com/workspaces/simplereport-better-data-team-605b43d51ea9f700119a48ee/issues/cdcgov/prime-simplereport/3088#issuecomment-990523075 

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Changes are Backwards Compatible
- [x] Database changes are submitted as a separate PR
  - [x] Any new tables that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
  - [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views
        (including re-granting permission to the no-PHI user if need be)
  - [x] Liquibase rollback has been tested locally using `./gradlew liquibaseRollbackSQL` or `liquibaseRollback`
  - [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] GraphQL schema changes are backward compatible with older version of the front-end

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] DevOps team has been notified if PR requires ops support
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
