### PR TITLE
Raise ReportStream upload function alert threshold to 5

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -325,7 +325,7 @@ ${local.skip_on_weekends}
 
   trigger {
     operator  = "Equal"
-    threshold = 0
+    threshold = 4
   }
 
   action {


### PR DESCRIPTION
## Related Issue or Background Info

#3495

## Changes Proposed

- Raise alert threshold for ReportStream uploader failures to 5 (previously 1)

## Additional Information

- Single failures aren't actionable and often occur in the middle of the night. We should only be alerted for sustained outages outside of business hours. Alerts during business hours will be rolled into the work in #3508.

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**
