### PR TITLE
Raise ReportStream upload function alert threshold to 5, correctly this time

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -281,7 +281,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   resource_group_name = var.rg_name
   severity            = var.severity
   frequency           = 5
-  time_window         = 10
+  time_window         = 11
   enabled             = contains(var.disabled_alerts, "batched_uploader_single_failure_detected") ? false : true
 
   data_source_id = var.app_insights_id
@@ -289,7 +289,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   query = <<-QUERY
 requests
 ${local.skip_on_weekends}
-| where timestamp >= ago(10m) 
+| where timestamp >= ago(11m) 
     and operation_Name =~ 'QueueBatchedReportStreamUploader' 
     and success != true
   QUERY

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -281,7 +281,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   resource_group_name = var.rg_name
   severity            = var.severity
   frequency           = 5
-  time_window         = 7
+  time_window         = 10
   enabled             = contains(var.disabled_alerts, "batched_uploader_single_failure_detected") ? false : true
 
   data_source_id = var.app_insights_id
@@ -289,14 +289,14 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_
   query = <<-QUERY
 requests
 ${local.skip_on_weekends}
-| where timestamp >= ago(7m) 
+| where timestamp >= ago(10m) 
     and operation_Name =~ 'QueueBatchedReportStreamUploader' 
     and success != true
   QUERY
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 0
+    threshold = 4
   }
 
   action {
@@ -325,7 +325,7 @@ ${local.skip_on_weekends}
 
   trigger {
     operator  = "Equal"
-    threshold = 4
+    threshold = 0
   }
 
   action {


### PR DESCRIPTION
## Related Issue or Background Info

#3495

## Changes Proposed

- Raise alert threshold for ReportStream uploader failures to 5 (previously 1)

## Additional Information

- Single failures aren't actionable and often occur in the middle of the night. We should only be alerted for sustained outages outside of business hours. Alerts during business hours will be rolled into the work in #3508.

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**