### PR TITLE
Move stg App Service Plan tier to v3 and size to P2v3

### DIFF
--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,8 +4,7 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_tier  = "PremiumV2"
-  instance_size  = "P2v2"
+  instance_size  = "P2v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
## Related Issue or Background Info

#3370

## Changes Proposed

- Update TF code for `stg`'s App Service Plan to set `tier` to `PremiumV3` and `size` to `P2v3`
 
## Additional Information

- It doesn't look like we can move `stg` to `PremiumV3` without recreating the entire thing, so the best way to do this is to let Terraform figure out what needs to get recreated/updated. To do this, we need this PR to make sure subsequent commits don't try to reverse it just in case we need to do some manual Terraform commands.

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**
