### PR TITLE
Fix Docker DB rollback action

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker compose run --rm backend gradle liquibaseRollbackCount -PliquibaseCommand
 To roll back to a certain tag:
 
 ```
-docker compose run --rm backend gradle liquibaseUpdateToTag -PliquibaseCommandValue=${TAG}
+docker compose run --rm backend gradle liquibaseRollback -PliquibaseCommandValue=${TAG}
 ```
 
 If you are required to roll back a non-local database, you may generate the required SQL to execute elsewhere. Use `liquibaseRollbackToDateSQL` or `liquibaseRollbackCountSQL` in the manner described above to write the rollback SQL to stdout.

--- a/backend/Dockerfile.db-rollback
+++ b/backend/Dockerfile.db-rollback
@@ -1,15 +1,16 @@
 FROM gradle:6.9.1-jdk11-hotspot AS build
 
+USER gradle
+
 WORKDIR /home/gradle/graphql-api
-COPY --chown=gradle:gradle ./.git ./.git
+COPY ./.git ./.git
 
 WORKDIR /home/gradle/graphql-api/backend
-COPY --chown=gradle:gradle backend/gradle ./gradle
-COPY --chown=gradle:gradle backend/*.gradle ./
-COPY --chown=gradle:gradle ./backend/config ./config
-COPY --chown=gradle:gradle ./backend/src ./src
-COPY --chown=gradle:gradle ./backend/gradle.properties gradle.properties
-COPY --chown=gradle:gradle ./backend/db_rollback_to_tag.sh ./db_rollback_to_tag.sh
+COPY backend/gradle ./gradle
+COPY backend/*.gradle ./
+COPY ./backend/config ./config
+COPY ./backend/src ./src
+COPY ./backend/gradle.properties gradle.properties
+COPY ./backend/db_rollback_to_tag.sh ./db_rollback_to_tag.sh
 
-# Indefinite keep-alive
 ENTRYPOINT ["./db_rollback_to_tag.sh"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -149,10 +149,11 @@ jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
 }
 
-// Prefer SPRING_DATASOURCE_URL if provided, otherwise assume local Docker
-def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://db:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
-// If SPRING_DATASOURCE_URL is provided, assume target DB is non-local and schema is "public"
-def defaultSchema = System.getenv("SPRING_DATASOURCE_URL") ? "public" : "simple_report"
+// Prefer SPRING_DATASOURCE_URL if provided, otherwise assume localhost
+def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://127.0.0.1:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
+def isLocalDB = dbConnectionString.contains("postgresql://db") || dbConnectionString.contains("postgresql://127")
+// Use "simple_report" schema for local DBs, and "public" for non-local
+def defaultSchema = isLocalDB ? "simple_report" : "public"
 def noPhiPassword = System.getenv("DB_PASSWORD_NO_PHI") ?: "nophi789"
 
 liquibase {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -149,8 +149,8 @@ jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
 }
 
-// Prefer SPRING_DATASOURCE_URL if provided
-def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://127.0.0.1:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
+// Prefer SPRING_DATASOURCE_URL if provided, otherwise assume local Docker
+def dbConnectionString = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://db:${System.getenv("SR_DB_PORT") ?: 5432}/simple_report"
 // If SPRING_DATASOURCE_URL is provided, assume target DB is non-local and schema is "public"
 def defaultSchema = System.getenv("SPRING_DATASOURCE_URL") ? "public" : "simple_report"
 def noPhiPassword = System.getenv("DB_PASSWORD_NO_PHI") ?: "nophi789"

--- a/backend/docker-compose.db-rollback.yml
+++ b/backend/docker-compose.db-rollback.yml
@@ -9,9 +9,11 @@ services:
     container_name: db_rollback
     environment:
       LIQUIBASE_ROLLBACK_TAG: ${LIQUIBASE_ROLLBACK_TAG:-}
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://db:5432/simple_report}
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-}
+      GRADLE_USER_HOME: /home/gradle
     networks:
-      - dev-net
+      - default
 networks:
-  dev-net:
-    name: dev-net
+  default:
+    external: true
+    name: prime-simplereport_default

--- a/backend/docker-compose.db-rollback.yml
+++ b/backend/docker-compose.db-rollback.yml
@@ -9,7 +9,7 @@ services:
     container_name: db_rollback
     environment:
       LIQUIBASE_ROLLBACK_TAG: ${LIQUIBASE_ROLLBACK_TAG:-}
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-}
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://db:5432/simple_report}
       GRADLE_USER_HOME: /home/gradle
     networks:
       - default


### PR DESCRIPTION
## Related Issue or Background Info

#3500

## Changes Proposed

- Fix rollback command in `README.md`
- Fix `SPRING_DATASOURCE_URL` in `backend/build.gradle` and the network in `backend/docker-compose.db-rollback.yml` to match latest local dev changes.
- The official Gradle image already has a non-root `gradle` user built in, so the fix is to just use that user and properly set `GRADLE_USER_HOME`.

## Screenshots / Demos

## Checklist for Author and Reviewer

### Testing
- [x] You can verify this locally by running `LIQUIBASE_ROLLBACK_TAG=tag_goes_here compose -f docker-compose.db-rollback.yml up --build` from `/backend`. You should no longer see a crash with the message `Failed to load native library 'libnative-platform.so' for Linux amd64.`.
