### PR TITLE
Purge ${env}_network_response alert.

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -19,7 +19,6 @@ variable "disabled_alerts" {
     condition = length(setsubtract(var.disabled_alerts, [
       "cpu_util",
       "mem_util",
-      "http_response_time",
       "http_2xx_failed_requests",
       "http_4xx_errors",
       "http_401_410_errors",

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -56,32 +56,6 @@ resource "azurerm_monitor_metric_alert" "mem_util" {
   }
 }
 
-resource "azurerm_monitor_metric_alert" "http_response_time" {
-  name                = "${var.env}-api-http-response"
-  description         = "${local.env_title} network response >= 1000ms(1s)"
-  resource_group_name = var.rg_name
-  scopes              = [var.app_service_id]
-  frequency           = "PT1M"
-  window_size         = "PT15M"
-  severity            = var.severity
-  enabled             = contains(var.disabled_alerts, "http_response_time") ? false : true
-
-  criteria {
-    aggregation      = var.http_response_time_aggregation
-    metric_name      = "HttpResponseTime"
-    metric_namespace = "Microsoft.Web/sites"
-    operator         = "GreaterThanOrEqual"
-    threshold        = 1.000 #(1s/1000ms)
-  }
-
-  dynamic "action" {
-    for_each = var.action_group_ids
-    content {
-      action_group_id = action.value
-    }
-  }
-}
-
 resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
   name                = "${var.env}-failure-anomalies"
   description         = "${local.env_title} Failure Anomalies notifies you of an unusual rise in the rate of failed HTTP requests or dependency calls."


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #3519 .

## Changes Proposed

- Delete the http_network_response alert from TF.

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
