### PR TITLE
Increase threshold for 4xx errors to 50.

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -126,7 +126,7 @@ ${local.skip_on_weekends}
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
   name                = "${var.env}-api-4xx-errors"
-  description         = "${local.env_title} HTTP Server 4xx Errors (excluding 401s and 410s) >= 25"
+  description         = "${local.env_title} HTTP Server 4xx Errors (excluding 401s and 410s) >= 50"
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
@@ -154,7 +154,7 @@ ${local.skip_on_weekends}
 
   trigger {
     operator  = "GreaterThan"
-    threshold = 24
+    threshold = 49
   }
 
   action {


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #3524 .

## Changes Proposed

- Increase threshold for 4xx alert to 50, from 25.

## Additional Information

- Please note that the threshold is evaluated on a "GreaterThan" operation, instead of greater than or equal to. The numbers look a little weird because of this.

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
