### PR TITLE
Modify GraphQL validation query to fire on more than 2 errors.

### DIFF
--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -24,7 +24,7 @@ resource "azurerm_monitor_diagnostic_setting" "collect_appserviceconsolelogs" {
   }
 }
 
-# Add an alert for GraphQL query validation failures (more than 3 in a 5-minute window)
+# Add an alert for GraphQL query validation failures (more than 2 in a 5-minute window)
 data "azurerm_resource_group" "app" {
   name = var.rg_name
 }
@@ -52,7 +52,7 @@ AppServiceConsoleLogs
   time_window = 5
   trigger {
     operator  = "GreaterThan"
-    threshold = 0
+    threshold = 2
   }
 }
 


### PR DESCRIPTION
## Related Issue or Background Info

- Resolves #3523 .

## Changes Proposed

- Raise threshold of GraphQL validation exceptions to 3 or more failures in a 5-minute span.

## Additional Information

- It looks like this was originally supposed to fire at a higher threshold, based on the original code comment.
- I deliberately chose a threshold of 3 failures for firing the alert. 2 seems like it is still achievable due to pure coincidence during periods of high traffic; if there is a compatibility issue, we should get more than this fairly quickly. That said, I am happy to modify this threshold down upon request!

## Screenshots / Demos

## Checklist for Author and Reviewer

### Infrastructure
- [ ] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
