### PR TITLE
Revert "Add overwrite flag to frontend deploy."

### DIFF
--- a/.github/actions/deploy-application/action.yml
+++ b/.github/actions/deploy-application/action.yml
@@ -34,5 +34,5 @@ runs:
         echo "::group::Deploy frontend app"
         az storage blob upload-batch -s client-build/ -d '$web' \
           --account-name simplereport${{ inputs.deploy-env }}app \
-          --destination-path '/app' --overwrite
+          --destination-path '/app'
         echo "::endgroup::"


### PR DESCRIPTION
Reverts CDCgov/prime-simplereport#3545

It seems like GitHub has now made some sort of change that rolls back the current version of the Azure CLI, so that this flag is no longer recognized. I would like to see if rolling back restores our original functionality.

The older workflow has been tested to work on lower branches. This is semi-urgent, as we cannot currently deploy to production.