### PR TITLE
include an optional --overwrite flag if the initial storage blob fail…

### DIFF
--- a/.github/actions/deploy-application/action.yml
+++ b/.github/actions/deploy-application/action.yml
@@ -34,5 +34,9 @@ runs:
         echo "::group::Deploy frontend app"
         az storage blob upload-batch -s client-build/ -d '$web' \
           --account-name simplereport${{ inputs.deploy-env }}app \
-          --destination-path '/app'
+          --destination-path '/app' || \
+        az storage blob upload-batch -s client-build/ -d '$web' \
+        --account-name simplereport${{ inputs.deploy-env }}app \
+        --destination-path '/app' \
+        --overwrite
         echo "::endgroup::"


### PR DESCRIPTION
This addresses a breaking change that was pushed in the Azure CLI. The change has been inconsistent in our deploys so here we are accounting for both possibilities until a better fix comes up.

## Related Issue or Background Info

No issue currently exists.

## Changes Proposed

- include an optional --overwrite flag if the initial storage blob fails to update during a deploy

## Additional Information

- For context: https://github.com/Azure/azure-cli/issues/21477
- https://github.com/CDCgov/prime-simplereport/pull/3545
- https://github.com/CDCgov/prime-simplereport/pull/3548

## Checklist for Author and Reviewer

### Infrastructure
- [x] **Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!**

