### PR TITLE
Refactor TestEvent constructors (prep for multiplex)

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -100,7 +100,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     _repo.save(secondEvent);
     flush();
     TestEvent found = _repo.findFirst1ByPatientOrderByCreatedAtDesc(patient);
-    assertEquals(secondEvent.getResult(), TestResult.UNDETERMINED);
+    assertEquals(TestResult.UNDETERMINED, secondEvent.getResult());
     List<TestEvent> foundTestReports2 =
         _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE, Pageable.unpaged());
     assertEquals(2, foundTestReports2.size() - foundTestReports1.size());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -68,12 +68,10 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Facility place = _dataFactory.createValidFacility(org);
     Person patient = _dataFactory.createMinimalPerson(org);
     TestOrder order = _dataFactory.createTestOrder(patient, place);
-    _repo.save(
-        new TestEvent(
-            TestResult.POSITIVE, place.getDefaultDeviceSpecimen(), patient, place, order));
-    _repo.save(
-        new TestEvent(
-            TestResult.UNDETERMINED, place.getDefaultDeviceSpecimen(), patient, place, order));
+    order.setResult(TestResult.POSITIVE);
+    _repo.save(new TestEvent(order, false));
+    order.setResult(TestResult.NEGATIVE);
+    _repo.save(new TestEvent(order, false));
     flush();
     List<TestEvent> found = _repo.findAllByPatientAndFacilities(patient, Set.of(place));
     assertEquals(2, found.size());
@@ -89,23 +87,26 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Organization org = _dataFactory.createValidOrg();
     Facility place = _dataFactory.createValidFacility(org);
     Person patient = _dataFactory.createMinimalPerson(org);
-    TestOrder order = _dataFactory.createTestOrder(patient, place);
-    TestEvent first =
-        new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceSpecimen(), patient, place, order);
-    TestEvent second =
-        new TestEvent(
-            TestResult.UNDETERMINED, place.getDefaultDeviceSpecimen(), patient, place, order);
-    _repo.save(first);
-    _repo.save(second);
+
+    TestOrder firstOrder =
+        _dataFactory.createCompletedTestOrder(patient, place, TestResult.POSITIVE);
+    TestEvent firstEvent = new TestEvent(firstOrder);
+    _repo.save(firstEvent);
+
+    TestOrder secondOrder =
+        _dataFactory.createCompletedTestOrder(patient, place, TestResult.UNDETERMINED);
+    TestEvent secondEvent = new TestEvent(secondOrder);
+
+    _repo.save(secondEvent);
     flush();
     TestEvent found = _repo.findFirst1ByPatientOrderByCreatedAtDesc(patient);
-    assertEquals(second.getResult(), TestResult.UNDETERMINED);
+    assertEquals(secondEvent.getResult(), TestResult.UNDETERMINED);
     List<TestEvent> foundTestReports2 =
         _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE, Pageable.unpaged());
     assertEquals(2, foundTestReports2.size() - foundTestReports1.size());
 
     testTestEventUnitTests(
-        order, first); // just leverage existing order, event to test on newer columns
+        firstOrder, firstEvent); // just leverage existing order, event to test on newer columns
   }
 
   @Test
@@ -223,35 +224,31 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Facility place = _dataFactory.createValidFacility(org);
     Person patient = _dataFactory.createMinimalPerson(org);
 
-    TestOrder order = _dataFactory.createTestOrder(patient, place);
-    TestEvent first =
-        new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceSpecimen(), patient, place, order);
-    TestEvent second =
-        new TestEvent(
-            TestResult.UNDETERMINED, place.getDefaultDeviceSpecimen(), patient, place, order);
-    _repo.save(first);
-    _repo.save(second);
+    TestOrder firstOrder =
+        _dataFactory.createCompletedTestOrder(patient, place, TestResult.POSITIVE);
+    TestEvent firstEvent = new TestEvent(firstOrder);
+
+    TestOrder secondOrder =
+        _dataFactory.createCompletedTestOrder(patient, place, TestResult.UNDETERMINED);
+    TestEvent secondEvent = new TestEvent(secondOrder);
+
+    _repo.save(firstEvent);
+    _repo.save(secondEvent);
 
     Facility otherPlace = _dataFactory.createValidFacility(org, "Other Place");
     Person otherPatient =
         _dataFactory.createMinimalPerson(org, otherPlace, "First", "Middle", "Last", "");
-    TestOrder order2 = _dataFactory.createTestOrder(otherPatient, otherPlace);
-    TestEvent third =
-        new TestEvent(
-            TestResult.NEGATIVE,
-            otherPlace.getDefaultDeviceSpecimen(),
-            otherPatient,
-            otherPlace,
-            order2);
-    TestEvent fourth =
-        new TestEvent(
-            TestResult.POSITIVE,
-            otherPlace.getDefaultDeviceSpecimen(),
-            otherPatient,
-            otherPlace,
-            order2);
-    _repo.save(third);
-    _repo.save(fourth);
+
+    TestOrder firstOrderOtherPlace =
+        _dataFactory.createCompletedTestOrder(otherPatient, otherPlace, TestResult.NEGATIVE);
+    TestEvent firstEventOtherPlace = new TestEvent(firstOrderOtherPlace);
+
+    TestOrder secondOrderOtherPlace =
+        _dataFactory.createCompletedTestOrder(otherPatient, otherPlace, TestResult.POSITIVE);
+    TestEvent secondEventOtherPlace = new TestEvent(secondOrderOtherPlace);
+
+    _repo.save(firstEventOtherPlace);
+    _repo.save(secondEventOtherPlace);
 
     return place;
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -112,9 +112,13 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
     TestOrder order = _repo.save(new TestOrder(hoya, site));
     assertNotNull(order);
     flush();
-    TestEvent ev =
-        _events.save(
-            new TestEvent(TestResult.POSITIVE, site.getDefaultDeviceSpecimen(), hoya, site, order));
+    order.setResult(TestResult.POSITIVE);
+    TestEvent ev = _events.save(new TestEvent(order));
+
+    //    TestEvent ev =
+    //        _events.save(
+    //            new TestEvent(TestResult.POSITIVE, site.getDefaultDeviceSpecimen(), hoya, site,
+    // order));
     assertNotNull(ev);
     order.setTestEventRef(ev);
     _repo.save(order);
@@ -180,12 +184,9 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
     TestOrder order1 = new TestOrder(patient0, site);
     _repo.save(order1);
     flush();
-    TestEvent didit =
-        _events.save(
-            new TestEvent(
-                TestResult.NEGATIVE, site.getDefaultDeviceSpecimen(), patient0, site, order1));
+    order1.setResult(TestResult.NEGATIVE);
+    TestEvent didit = _events.save(new TestEvent(order1));
     order1.setTestEventRef(didit);
-    order1.setResult(didit.getResult());
     order1.markComplete();
     _repo.save(order1);
     flush();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -114,11 +114,6 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
     flush();
     order.setResult(TestResult.POSITIVE);
     TestEvent ev = _events.save(new TestEvent(order));
-
-    //    TestEvent ev =
-    //        _events.save(
-    //            new TestEvent(TestResult.POSITIVE, site.getDefaultDeviceSpecimen(), hoya, site,
-    // order));
     assertNotNull(ev);
     order.setTestEventRef(ev);
     _repo.save(order);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -357,7 +357,7 @@ public class TestDataFactory {
     o.setDateTestedBackdate(d);
     o.setResult(r);
 
-    TestEvent e = _testEventRepo.save(new TestEvent(o, false));
+    TestEvent e = _testEventRepo.save(new TestEvent(o));
     o.setTestEventRef(e);
     o.markComplete();
     _testOrderRepo.save(o);
@@ -387,7 +387,7 @@ public class TestDataFactory {
 
   public TestEvent doTest(TestOrder order, TestResult result) {
     order.setResult(result);
-    TestEvent event = _testEventRepo.save(new TestEvent(order, false));
+    TestEvent event = _testEventRepo.save(new TestEvent(order));
     order.setTestEventRef(event);
     order.markComplete();
     _testOrderRepo.save(order);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -316,18 +316,36 @@ public class TestDataFactory {
   }
 
   public TestOrder createTestOrder(Person p, Facility f) {
-    AskOnEntrySurvey survey = AskOnEntrySurvey.builder().symptoms(Collections.emptyMap()).build();
-    return createTestOrder(p, f, survey);
+    return createTestOrder(p, f, createEmptySurvey());
   }
 
   public TestOrder createTestOrder(Person p, Facility f, AskOnEntrySurvey s) {
-    PatientAnswers answers = new PatientAnswers(s);
-    _patientAnswerRepo.save(answers);
     TestOrder o = new TestOrder(p, f);
-    o.setAskOnEntrySurvey(answers);
+    o.setAskOnEntrySurvey(savePatientAnswers(s));
     var savedOrder = _testOrderRepo.save(o);
     _patientLinkRepository.save(new PatientLink(savedOrder));
     return savedOrder;
+  }
+
+  public TestOrder createCompletedTestOrder(Person patient, Facility facility, TestResult result) {
+    TestOrder order = new TestOrder(patient, facility);
+    order.setAskOnEntrySurvey(savePatientAnswers(createEmptySurvey()));
+    order.setDeviceSpecimen(facility.getDefaultDeviceSpecimen());
+    order.setResult(result);
+    order.markComplete();
+    TestOrder savedOrder = _testOrderRepo.save(order);
+    _patientLinkRepository.save(new PatientLink(savedOrder));
+    return order;
+  }
+
+  private AskOnEntrySurvey createEmptySurvey() {
+    return AskOnEntrySurvey.builder().symptoms(Collections.emptyMap()).build();
+  }
+
+  private PatientAnswers savePatientAnswers(AskOnEntrySurvey survey) {
+    PatientAnswers answers = new PatientAnswers(survey);
+    _patientAnswerRepo.save(answers);
+    return answers;
   }
 
   public TestEvent createTestEvent(Person p, Facility f) {
@@ -339,7 +357,7 @@ public class TestDataFactory {
     o.setDateTestedBackdate(d);
     o.setResult(r);
 
-    TestEvent e = _testEventRepo.save(new TestEvent(o));
+    TestEvent e = _testEventRepo.save(new TestEvent(o, false));
     o.setTestEventRef(e);
     o.markComplete();
     _testOrderRepo.save(o);
@@ -369,7 +387,7 @@ public class TestDataFactory {
 
   public TestEvent doTest(TestOrder order, TestResult result) {
     order.setResult(result);
-    TestEvent event = _testEventRepo.save(new TestEvent(order));
+    TestEvent event = _testEventRepo.save(new TestEvent(order, false));
     order.setTestEventRef(event);
     order.markComplete();
     _testOrderRepo.save(order);


### PR DESCRIPTION
## Related Issue

Prelude to #3456. We currently support two ways to create a TestEvent - by pulling all the relevant data from the associated TestOrder (this is how it's done in prod) and by directly passing in a TestResult in addition to the TestOrder. This makes moving away from the results column to the results table in the multiplex effort overly complex, because there's no single source of truth around where results come from! Since the results-passed constructor was only used as a testing crutch, I removed it and refactored the relevant tests to be created from a TestOrder (closer to how it's done in prod).

## Changes Proposed

- Remove a testing-only constructor from `TestEvent`
- Refactor tests that used the constructor to read from a completed `TestOrder` instead
- Added a method to create completed test orders in `TestDataFactory`, along with some helper methods to DRY out that portion of the codebase

## Additional Information

- Split this out into a separate PR for ease of review, but it's purely a multiplex-required change

## Testing

- Verify that TestResult-related mutations still work as expected

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Any content updates (user-facing error messages, etc) have been approved by content team
- [x] Any changes that might generate questions in the support inbox have been flagged to the support team
- [x] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed