### PR TITLE
Add test_result column to results database and make test_event column nullable

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3487,3 +3487,37 @@ databaseChangeLog:
       rollback:
         sql: |
           DROP TABLE ${database.defaultSchemaName}.result;
+  - changeSet:
+      id: make-test-event-nullable-on-results-table
+      author: emma@skylight.digital
+      comment: Make test event column on results table nullable.
+      changes:
+        - tagDatabase:
+            tag: make-test-event-nullable-on-results-table
+        - dropNotNullConstraint:
+            tableName: result
+            columnName: test_event_id
+  - changeSet:
+      id: add-test-result-column-to-result-table
+      author: emma@skylight.digital
+      comment: Add another test result column to result table to store results as enum. This preserves the original result even if the associated LOINC changes
+      changes:
+        - tagDatabase:
+          tag: add-test-result-column-to-result-table
+        - addColumn:
+            tableName: result
+            columns:
+              - column:
+                  name: test_result
+                  type: ${database.defaultSchemaName}.TEST_RESULT
+                  constraints:
+                    nullable: false
+              - addUniqueConstraint:
+                  tableName: result
+                  constraintName: uk__test_result
+                  columnNames: test_event_id, test_order_id, disease_id
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.result TO ${noPhiUsername};
+      rollback:
+        sql: |
+          ALTER TABLE ${database.defaultSchemaName}.result DROP COLUMN test_result;


### PR DESCRIPTION
## Related Issue

- Part of #3430 
- Response to comments on #3529 

## Changes Proposed

1. Makes the test_event column nullable within the results table
2. Adds a new column for storing results as a TEST_RESULT

## Additional Information

1. The test_event column needs to be nullable because test_events are created *after* test_orders, and it's entirely possible  for a test_order to have a result marked but not be submitted yet (and therefore no test_event to be created.) 
2. As [Zedd pointed out](https://github.com/CDCgov/prime-simplereport/pull/3529#discussion_r824913901) on the original PR for #3430, the LIVD table changes all the time and it's possible that a result was recorded with a LOINC code that no longer has the same meaning. This database change adds another column to the result table to track what the result was at the time of recording, re-using our existing TEST_RESULT enum.

There's no rollback for the first change because the `dropNotNullConstraint` command supports auto-rollbacks: https://docs.liquibase.com/change-types/drop-not-null-constraint.html#:~:text=Supported-,Yes,-SQL%20Server

## Testing

- Verify that rollbacks work as expected

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment