### PR TITLE
specifying the schema to be compatible with liquibase core 4.5

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2041,7 +2041,7 @@ databaseChangeLog:
                     nullable: false
         - sql:
             remarks: Add constraint to allow for a facility or an organization.
-            sql: ALTER TABLE patient_registration_link ADD CONSTRAINT facility_or_organization CHECK (num_nonnulls(facility_id, organization_id) = 1)
+            sql: ALTER TABLE ${database.defaultSchemaName}.patient_registration_link ADD CONSTRAINT facility_or_organization CHECK (num_nonnulls(facility_id, organization_id) = 1)
   - changeSet:
         id: add-spring-session-jdbc-support
         author: emma@skylight.digital
@@ -2383,7 +2383,7 @@ databaseChangeLog:
                 pp.preferred_language,
                 pp.test_result_delivery
               FROM ${database.defaultSchemaName}.person p
-              JOIN patient_preferences pp on pp.internal_id=p.internal_id
+              JOIN ${database.defaultSchemaName}.patient_preferences pp on pp.internal_id=p.internal_id
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
       rollback:
@@ -2560,7 +2560,7 @@ databaseChangeLog:
                   SELECT
                     o.internal_id AS organization_id, f.internal_id AS facility_id, m.migrations_user_id AS migrations_user_id
                   FROM
-                    facility AS f 
+                    ${database.defaultSchemaName}.facility AS f 
                     FULL OUTER JOIN ${database.defaultSchemaName}.patient_registration_link AS p ON f.internal_id = p.facility_id 
                     FULL OUTER JOIN ${database.defaultSchemaName}.organization AS o ON o.internal_id = p.organization_id
                     CROSS JOIN migration_user AS m
@@ -2694,7 +2694,7 @@ databaseChangeLog:
                 pp.preferred_language,
                 pp.test_result_delivery
               FROM ${database.defaultSchemaName}.person p
-              JOIN patient_preferences pp on pp.internal_id=p.internal_id
+              JOIN ${database.defaultSchemaName}.patient_preferences pp on pp.internal_id=p.internal_id
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
       rollback:
@@ -3262,7 +3262,7 @@ databaseChangeLog:
         - sql:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
-              UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+              UPDATE ${database.defaultSchemaName}.person SET emails = ARRAY[email] WHERE email IS NOT NULL;
       rollback:
         - dropColumn:
             tableName: person
@@ -3277,7 +3277,7 @@ databaseChangeLog:
         - sql:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
-              UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+              UPDATE ${database.defaultSchemaName}.person SET emails = ARRAY[email] WHERE email IS NOT NULL;
   - changeSet:
       id: add-specimen_type_id-to-test_event
       author: zedd@skylight.digital


### PR DESCRIPTION
Specify the db schema in all table references
liquibase version (managed by spring) has been updated from 3.10 to 4.5 in the 2.4.6 spring release, the new version of liquibase is stricter when running the old migrations, and it require you to specify the schema every time you reference a table, meaning if you blow away your local db, you will not be able to put it back together when using a newer version of liquibase
however that changes the checksum for the migrations which causes it not to work on an azure env

I recommend merging these migration changes before this is merged and we have to do it env by env and recalculate the checksums as they deploy. hoping @jdorothy has a better solution