### PR TITLE
Add GH workflow to test Liquibase changelogs in CI

### DIFF
--- a/.github/workflows/testDBChangelog.yml
+++ b/.github/workflows/testDBChangelog.yml
@@ -1,0 +1,45 @@
+name: Test Liquibase rollbacks
+
+# Run this on pushes to any branch that changes a Liquibase changelog
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - backend/src/main/resources/db/changelog/db.changelog-master.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - backend/src/main/resources/db/changelog/db.changelog-master.yaml
+
+env:
+  JAVA_VERSION: 11
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  test-db-rollback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{env.JAVA_VERSION}}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{env.JAVA_VERSION}}
+      - name: Cache Java Dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('*.gradle', 'gradle/dependency-locks/*') }}
+      - name: Start DB
+        run: touch ../.env && docker compose -f ../docker-compose.yml up -d db
+      - name: Run forward migrations
+        run: ./gradlew liquibaseUpdate
+      - name: Test rolling back all migrations
+        run: ./gradlew liquibaseRollbackCount -PliquibaseCommandValue=9999

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1003,7 +1003,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: clia_number
-                  type: text # irony
+                  type: text
                   remarks: The CLIA number for the facility that is ordering (and presumably also conducting) the tests.
                   constraints:
                     nullable: false
@@ -1017,7 +1017,6 @@ databaseChangeLog:
               - column:
                   name: ordering_provider_id
                   type: uuid
-                  remarks: at what point does this blow up on me?
                   constraints:
                     nullable: false
                     foreignKeyName: fk__organization__ordering_provider

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -54,7 +54,8 @@ databaseChangeLog:
             sql: CREATE EXTENSION IF NOT EXISTS pgcrypto;
       rollback:
         - sql:
-            sql: DROP EXTENSION pgcrypto;
+            sql: -- DROP EXTENSION IF EXISTS pgcrypto;
+            comment: Dropping the extension requires superuser permissions, and we don't want to give that to the migration user, so we have to do nothing here.
   - changeSet:
       id: define-enum-types
       author: bwarfield@cdc.gov
@@ -903,6 +904,10 @@ databaseChangeLog:
                 ordering_provider_id,
                 default_device_type
               FROM ${database.defaultSchemaName}.organization;
+      rollback:
+        - sql:
+            sql: |
+              TRUNCATE TABLE ${database.defaultSchemaName}.facility;
   - changeSet:
       id: add-facility-relationships
       author: bwarfield@cdc.gov
@@ -992,6 +997,86 @@ databaseChangeLog:
                   name: default_device_type
               - column:
                   name: ordering_provider_id
+      rollback:
+        - addColumn:
+            tableName: organization
+            columns:
+              - column:
+                  name: clia_number
+                  type: text # irony
+                  remarks: The CLIA number for the facility that is ordering (and presumably also conducting) the tests.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: default_device_type
+                  remarks: The default device type (if any) for tests at this facility.
+                  type: uuid
+                  constraints:
+                    foreignKeyName: fk__organization__default_device_type
+                    referencedTableName: device_type
+              - column:
+                  name: ordering_provider_id
+                  type: uuid
+                  remarks: at what point does this blow up on me?
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__organization__ordering_provider
+                    referencedTableName: provider
+        - addColumn:
+            tableName: facility_device_type
+            columns:
+              - column:
+                  name: organization_id
+                  type: uuid
+                  remarks: The organization within which this request was performed (if applicable).
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__api_audit_event__organization
+                    referencedTableName: organization
+        - dropNotNullConstraint:
+            tableName: facility_device_type
+            columnName: facility_id
+        - dropColumn:
+            tableName: facility_device_type
+            columns:
+              - column:
+                  name: facility_id
+        - dropNotNullConstraint:
+            tableName: test_order
+            columnName: facility_id
+        - dropColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: facility_id
+        - dropNotNullConstraint:
+            tableName: test_event
+            columnName: facility_id
+        - dropColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: facility_id
+        - dropColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: facility_id
+        - dropUniqueConstraint:
+            tableName: organization
+            constraintName: uk__organization__organization_name
+            columnNames: organization_name
+        - renameColumn:
+            tableName: organization
+            oldColumnName: organization_name
+            newColumnName: facility_name
+            remarks: The human-readable name for this organization.
+        - addConstraint:
+            tableName: organization
+            constraintName: uk__facility__name
+            constraints:
+              nullable: false
+              unique: true
   - changeSet:
       id: date-tested-backdate
       author: tbest@cdc.gov
@@ -1025,9 +1110,6 @@ databaseChangeLog:
             remarks: Create the enumerations needed for DataHubUpload.
             sql: |
               CREATE TYPE ${database.defaultSchemaName}.DATA_HUB_UPLOAD_STATUS as ENUM('IN_PROGRESS', 'SUCCESS', 'FAIL');
-            rollback:
-              sql: |
-                DROP TYPE ${database.defaultSchemaName}.DATA_HUB_UPLOAD_STATUS;
         - createTable:
             tableName: data_hub_upload
             remarks: Track uploads and results of test_events to the data-hub.
@@ -1087,6 +1169,11 @@ databaseChangeLog:
               - column:
                   name: latest_recorded_timestamp
                   descending: true
+      rollback:
+        dropTable:
+          tableName: data_hub_upload
+        sql: |
+          DROP TYPE ${database.defaultSchemaName}.DATA_HUB_UPLOAD_STATUS;
   - changeSet:
       id: change-test-results-to-MST
       author: neil.s.sharma@omb.eop.gov
@@ -1097,6 +1184,12 @@ databaseChangeLog:
             sql: |
               UPDATE ${database.defaultSchemaName}.test_order
               SET date_tested_backdate = date_tested_backdate + interval '7' HOUR
+              WHERE date_tested_backdate is not null;
+      rollback:
+        - sql:
+          sql: |
+              UPDATE ${database.defaultSchemaName}.test_order
+              SET date_tested_backdate = date_tested_backdate - interval '7' HOUR
               WHERE date_tested_backdate is not null;
 
   - changeSet:
@@ -1133,9 +1226,6 @@ databaseChangeLog:
             remarks: Create the enumerations for corrections_status in test_event table.
             sql: |
               CREATE TYPE ${database.defaultSchemaName}.TEST_CORRECTION_STATUS as ENUM('ORIGINAL', 'CORRECTED', 'REMOVED');
-            rollback:
-              sql: |
-                DROP TYPE ${database.defaultSchemaName}.TEST_CORRECTION_STATUS;
         - addColumn:
             tableName: test_order
             columns:
@@ -1202,6 +1292,32 @@ databaseChangeLog:
         - addNotNullConstraint:
             tableName: test_event
             columnName: test_order_id
+      rollback:
+        - dropColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: correction_status
+              - column:
+                  name: reason_for_correction
+        - dropColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: survey_data
+              - column:
+                  name: date_tested_backdate
+              - column:
+                  name: test_order_id
+              - column:
+                  name: correction_status
+              - column:
+                  name: prior_corrected_test_event_id
+              - column:
+                  name: reason_for_correction
+        - sql:
+          sql: |
+            DROP TYPE ${database.defaultSchemaName}.TEST_CORRECTION_STATUS;
   - changeSet:
       id: add-patient-link-table
       author: nclyde@skylight.digital
@@ -1498,6 +1614,10 @@ databaseChangeLog:
                 gen_random_uuid(), now(), now(), false, null,
                 '${migrations_user_email}', 'Database Migration Process'
               )
+      rollback:
+        - sql:
+            sql: |
+              DELETE FROM ${database.defaultSchemaName}.api_user WHERE last_name='Database Migration Process'
   - changeSet:
       id: populate-specimen-tables
       author: bwarfield@cdc.gov
@@ -1582,6 +1702,12 @@ databaseChangeLog:
               SET device_specimen_type_id = ds.internal_id
               FROM ${database.defaultSchemaName}.device_specimen_type ds
               WHERE ds.device_type_id = t.device_type_id;
+      rollback:
+        - sql:
+            sql: |
+              TRUNCATE TABLE ${database.defaultSchemaName}.specimen_type CASCADE;
+              TRUNCATE TABLE ${database.defaultSchemaName}.device_specimen_type CASCADE;
+              TRUNCATE TABLE ${database.defaultSchemaName}.facility_device_specimen_type CASCADE;
   - changeSet:
       id: test-order-fixup
       author: bwarfield@cdc.gov
@@ -1603,6 +1729,10 @@ databaseChangeLog:
               FROM ${database.defaultSchemaName}.facility f
               WHERE f.internal_id = t.facility_id
               AND t.device_type_id is null
+      rollback:
+        - sql:
+            sql: -- do nothing;
+            comment: This is a one-way UPDATE and can't be rolled back
   - changeSet:
       id: complete-specimen-column-additions
       author: bwarfield@cdc.gov
@@ -1878,6 +2008,10 @@ databaseChangeLog:
               migrations_user_id updated_by
             FROM ${database.defaultSchemaName}.person CROSS JOIN migration_user
             WHERE test_result_delivery IS NOT NULL;
+      rollback:
+        - sql:
+          sql: |
+            TRUNCATE TABLE ${database.defaultSchemaName}.patient_preferences;
   - changeSet:
       id: add-org-verified
       author: jeremy.a.zitomer@omb.eop.gov
@@ -1921,6 +2055,14 @@ databaseChangeLog:
             columns:
               - column:
                   name: test_result_delivery
+      rollback:
+        - addColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: test_result_delivery
+                  type: ${database.defaultSchemaName}.TEST_RESULT_DELIVERY
+                  remarks: Tracks the individual's preference for receiving test results
   - changeSet:
       id: add-no-phi-role
       author: josh@skylight.digital
@@ -1933,8 +2075,9 @@ databaseChangeLog:
             CREATE ROLE ${noPhiUsername} WITH LOGIN NOSUPERUSER ENCRYPTED PASSWORD '${noPhiPassword}';
       rollback:
         - sql:
-          sql: |
-            DROP ROLE ${noPhiUsername};
+            sql: |
+              -- do nothing;
+            comment: We can't actually remove this role because the metabase DB will still be using it.
   - changeSet:
       id: add-no-phi-views
       author: josh@skylight.digital
@@ -2042,6 +2185,9 @@ databaseChangeLog:
         - sql:
             remarks: Add constraint to allow for a facility or an organization.
             sql: ALTER TABLE patient_registration_link ADD CONSTRAINT facility_or_organization CHECK (num_nonnulls(facility_id, organization_id) = 1)
+      rollback:
+        - dropTable:
+            tableName: patient_registration_link
   - changeSet:
         id: add-spring-session-jdbc-support
         author: emma@skylight.digital
@@ -2146,6 +2292,12 @@ databaseChangeLog:
               ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN creation_time TYPE bigint USING EXTRACT(EPOCH FROM creation_time);
               ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN last_access_time TYPE bigint USING EXTRACT(EPOCH FROM last_access_time);
               ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN expiry_time TYPE bigint USING EXTRACT(EPOCH FROM expiry_time);
+        rollback:
+          - sql:
+            sql: |
+              ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN creation_time TYPE TIMESTAMP WITHOUT TIME ZONE USING to_timestamp(creation_time);
+              ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN last_access_time TYPE TIMESTAMP WITHOUT TIME ZONE USING to_timestamp(last_access_time);
+              ALTER TABLE ${database.defaultSchemaName}.spring_session ALTER COLUMN expiry_time TYPE TIMESTAMP WITHOUT TIME ZONE USING to_timestamp(expiry_time);
   - changeSet:
       id: set-null-telephone-to-empty-string
       author: nclyde@skylight.digital
@@ -2175,9 +2327,6 @@ databaseChangeLog:
             remarks: Create the enumerations needed for tracking a phone number's type
             sql: |
               CREATE TYPE ${database.defaultSchemaName}.PHONE_TYPES as ENUM('MOBILE', 'LANDLINE');
-            rollback:
-              sql: |
-                DROP TYPE ${database.defaultSchemaName}.PHONE_TYPES;
           - createTable:
               tableName: phone_number
               remarks: A join table to Person that stores phone numbers with phone type
@@ -2253,6 +2402,17 @@ databaseChangeLog:
                   primary_phone_internal_id = pn.internal_id
                 FROM ${database.defaultSchemaName}.phone_number pn
                 WHERE p.internal_id=pn.person_internal_id;
+      rollback:
+        - dropColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: primary_phone_internal_id
+        - dropTable:
+            tableName: phone_number
+        - sql:
+            sql: |
+              DROP TYPE ${database.defaultSchemaName}.PHONE_TYPES;
   - changeSet:
       id: actually-drop-organization-facility-name-constraint
       author: jeremy.a.zitomer@omb.eop.gov
@@ -2261,6 +2421,22 @@ databaseChangeLog:
         - dropUniqueConstraint:
             tableName: organization
             constraintName: uk__facility__name
+      rollback:
+        - addColumn:
+            tableName: organization
+            columns:
+              - column:
+                  name: facility_name
+                  type: text
+        - addUniqueConstraint:
+            tableName: organization
+            constraintName: uk__facility__name
+            columnNames: facility_name
+        - dropColumn:
+            tableName: organization
+            columns:
+              - column:
+                  name: facility_name
   - changeSet:
       id: add-census-dob-group-function
       author: josh@skylight.digital
@@ -2287,10 +2463,10 @@ databaseChangeLog:
               END;
               $$
               LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-            rollback:
-              - dropProcedure:
-                  procedureName: get_census_dob_group
-                  schemaName: ${database.defaultSchemaName}
+      rollback:
+        - sql:
+            sql: |
+              DROP FUNCTION get_census_dob_group
   - changeSet:
       id: add-census-dob-group-column-to-person-view
       author: josh@skylight.digital
@@ -2302,15 +2478,15 @@ databaseChangeLog:
             replaceIfExists: true
             fullDefinition: false
             selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, is_deleted, organization_id, facility_id, race, gender, ethnicity, county, state, employed_in_healthcare, role, resident_congregate_setting, tribal_affiliation, get_census_dob_group(person.birth_date) AS census_dob_group FROM ${database.defaultSchemaName}.person
-            rollback:
-              - dropView:
-                  viewName: person_no_phi_view
-              - createView:
-                  viewName: person_no_phi_view
-                  remarks: A subset of the person table with columns containing PHI removed.
-                  replaceIfExists: true
-                  fullDefinition: false
-                  selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, is_deleted, organization_id, facility_id, race, gender, ethnicity, county, state, employed_in_healthcare, role, resident_congregate_setting, tribal_affiliation FROM ${database.defaultSchemaName}.person
+      rollback:
+        - dropView:
+            viewName: person_no_phi_view
+        - createView:
+            viewName: person_no_phi_view
+            remarks: A subset of the person table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, is_deleted, organization_id, facility_id, race, gender, ethnicity, county, state, employed_in_healthcare, role, resident_congregate_setting, tribal_affiliation FROM ${database.defaultSchemaName}.person
   - changeSet:
       id: add-email-back-to-api-user-view
       author: josh@skylight.digital
@@ -2322,15 +2498,15 @@ databaseChangeLog:
             replaceIfExists: true
             fullDefinition: false
             selectQuery: SELECT internal_id, created_at, updated_at, last_seen, is_deleted, login_email FROM ${database.defaultSchemaName}.api_user
-            rollback:
-              - dropView:
-                  viewName: api_user_no_phi_view
-              - createView:
-                  viewName: api_user_no_phi_view
-                  remarks: A subset of the api_user table with columns containing PHI removed.
-                  replaceIfExists: true
-                  fullDefinition: false
-                  selectQuery: SELECT internal_id, created_at, updated_at, last_seen, is_deleted FROM ${database.defaultSchemaName}.api_user
+      rollback:
+        - dropView:
+            viewName: api_user_no_phi_view
+        - createView:
+            viewName: api_user_no_phi_view
+            remarks: A subset of the api_user table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, updated_at, last_seen, is_deleted FROM ${database.defaultSchemaName}.api_user
   - changeSet:
       id: drop-person-phone
       author: adam@skylight.digital
@@ -2341,6 +2517,14 @@ databaseChangeLog:
             columns:
               - column:
                   name: telephone
+      rollback:
+        - addColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: telephone
+                  remarks: The provider's contact phone number.
+                  type: text
   - changeSet:
       id: add-patient-reg-link-to-metabase
       author: adam@skylight.digital
@@ -2348,6 +2532,9 @@ databaseChangeLog:
       changes:
         sql: |
           GRANT SELECT ON TABLE ${database.defaultSchemaName}.patient_registration_link TO ${noPhiUsername};
+      rollback:
+        sql: |
+          REVOKE SELECT ON TABLE ${database.defaultSchemaName}.patient_registration_link FROM ${noPhiUsername};
   - changeSet:
       id: add-patient-preferences-to-person-view
       author: nathan@skylight.digital
@@ -2481,6 +2668,11 @@ databaseChangeLog:
                     nullable: false
         - sql: |
             GRANT SELECT ON TABLE ${database.defaultSchemaName}.tenant_data_access TO ${noPhiUsername};
+      rollback:
+        - sql: |
+            REVOKE SELECT ON TABLE ${database.defaultSchemaName}.tenant_data_access FROM ${noPhiUsername};
+        - dropTable:
+            tableName: tenant_data_access
   - changeSet:
       id: add-text-message-sent-table
       author: nicholas.a.scialli@omb.eop.gov
@@ -2518,6 +2710,11 @@ databaseChangeLog:
               - column: *updated_by_column
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.text_message_sent TO ${noPhiUsername};
+      rollback:
+        - sql: |
+            REVOKE SELECT ON ${database.defaultSchemaName}.text_message_sent FROM ${noPhiUsername};
+        - dropTable:
+            tableName: text_message_sent
   - changeSet:
       id: add-columns-to-provider-view
       author: josh@skylight.digital
@@ -3066,6 +3263,11 @@ databaseChangeLog:
               - column: *created_at_column
         - sql: |
             GRANT SELECT ON TABLE ${database.defaultSchemaName}.report_stream_response TO ${noPhiUsername};
+      rollback:
+        - sql: |
+            REVOKE SELECT ON TABLE ${database.defaultSchemaName}.report_stream_response FROM ${noPhiUsername};
+        - dropTable:
+            tableName: report_stream_response
   - changeSet:
       id: add-index-patient_link-test_order
       author: adam@skylight.digital
@@ -3156,13 +3358,6 @@ databaseChangeLog:
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
       rollback:
-        - dropColumn:
-            tableName: person
-            columns:
-              - column:
-                  name: country
-                  type: text
-                  remarks: The country of a person's address
         - dropView:
             viewName: person_no_phi_view
         - createView:
@@ -3196,6 +3391,13 @@ databaseChangeLog:
               FROM ${database.defaultSchemaName}.person p
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
+        - dropColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: country
+                  type: text
+                  remarks: The country of a person's address
   - changeSet:
       id: add-email-all-to-test-result-delivery
       author: zedd@skylight.digital
@@ -3278,6 +3480,10 @@ databaseChangeLog:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
               UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+      rollback:
+        - sql:
+            sql: |
+              -- do nothing;
   - changeSet:
       id: add-specimen_type_id-to-test_event
       author: zedd@skylight.digital


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- We've been playing with fire by not testing migrations - this fixes that.

## Changes Proposed

- Add missing rollback steps for changeSets that didn't have them
- Add GH workflow that runs all migrations against an empty DB, then tests a complete rollback of all changeSets

## Additional Information

- Some rollbacks are a bit messy. The problem is that once you have a raw SQL migration in a changeset you can't automatically generate a rollback, even if the rest of the changes aren't raw SQL. These rollbacks have to be reversed manually.
- Some migrations can't be reversed. This shouldn't be a big issue but that's an exercise for the reviewer.

## Testing

- The action was tested both locally and via the workflow itself - you can see a passing run [here](https://github.com/CDCgov/prime-simplereport/runs/5633512129?check_suite_focus=true).

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
