### PR TITLE
Remove OWASP managed WAF rules, and activate WAF prevention.

### DIFF
--- a/ops/demo/main.tf
+++ b/ops/demo/main.tf
@@ -112,7 +112,7 @@ module "nat_gateway" {
   tags                    = local.management_tags
 }
 
-/* module "web_application_firewall" {
+module "web_application_firewall" {
   source                  = "../services/web_application_firewall"
   name                    = local.name
   env                     = local.env
@@ -120,7 +120,7 @@ module "nat_gateway" {
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   tags = local.management_tags
-} */
+}
 
 module "app_service_autoscale" {
   source                  = "../services/app_service_autoscale"

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -58,7 +58,7 @@ module "nat_gateway" {
   tags                    = local.management_tags
 }
 
-/* module "web_application_firewall" {
+module "web_application_firewall" {
   source                  = "../services/web_application_firewall"
   name                    = local.name
   env                     = local.env
@@ -66,7 +66,7 @@ module "nat_gateway" {
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   tags = local.management_tags
-} */
+}
 
 module "app_service_autoscale" {
   source                  = "../services/app_service_autoscale"

--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -19,16 +19,9 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
     action = "Block"
   }
 
-  managed_rules {
-    managed_rule_set {
-      type    = "OWASP"
-      version = "3.1"
-    }
-  }
-
   policy_settings {
     enabled                     = true
-    mode                        = "Detection" //Can use "Detection" for testing, to see which requests would be blocked. "Prevention" turns on active blocking.
+    mode                        = "Prevention" //Can use "Detection" for testing, to see which requests would be blocked. "Prevention" turns on active blocking.
     request_body_check          = true
     file_upload_limit_in_mb     = 100
     max_request_body_size_in_kb = 128 //Can go to 2000 in modern provider version. Proposed is 1024.

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -111,7 +111,7 @@ module "nat_gateway" {
   tags                    = local.management_tags
 }
 
-/* module "web_application_firewall" {
+module "web_application_firewall" {
   source                  = "../services/web_application_firewall"
   name                    = local.name
   env                     = local.env
@@ -119,4 +119,4 @@ module "nat_gateway" {
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   tags = local.management_tags
-} */
+}

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -69,7 +69,7 @@ module "nat_gateway" {
   tags                    = local.management_tags
 }
 
-/* module "web_application_firewall" {
+module "web_application_firewall" {
   source                  = "../services/web_application_firewall"
   name                    = local.name
   env                     = local.env
@@ -77,7 +77,7 @@ module "nat_gateway" {
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   tags = local.management_tags
-} */
+}
 
 module "app_service_autoscale" {
   source                  = "../services/app_service_autoscale"

--- a/ops/training/main.tf
+++ b/ops/training/main.tf
@@ -111,7 +111,7 @@ module "nat_gateway" {
   tags                    = local.management_tags
 }
 
-/* module "web_application_firewall" {
+module "web_application_firewall" {
   source                  = "../services/web_application_firewall"
   name                    = local.name
   env                     = local.env
@@ -119,7 +119,7 @@ module "nat_gateway" {
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   tags = local.management_tags
-} */
+}
 
 module "app_service_autoscale" {
   source                  = "../services/app_service_autoscale"


### PR DESCRIPTION
This commit also activates full "Prevention" mode for the WAF across all environments, which addresses intrusion attempts outside the United States and Canada against our IP addresses.

# DEVOPS PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
