### PR TITLE
Add facility name and phone number to date of birth verification page

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpTestResultUnauthenticatedResponse.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpTestResultUnauthenticatedResponse.java
@@ -5,6 +5,7 @@ import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 public class PxpTestResultUnauthenticatedResponse {
   private Person person;
@@ -17,7 +18,7 @@ public class PxpTestResultUnauthenticatedResponse {
     this.pl = pl;
   }
 
-  public HashMap<String, String> getPatient() {
+  public Map<String, String> getPatient() {
     HashMap<String, String> patientMap = new HashMap<>();
     patientMap.put("firstName", person.getFirstName());
     patientMap.put("lastName", person.getLastName().charAt(0) + ".");
@@ -25,7 +26,7 @@ public class PxpTestResultUnauthenticatedResponse {
     return patientMap;
   }
 
-  public HashMap<String, String> getFacility() {
+  public Map<String, String> getFacility() {
     HashMap<String, String> facilityMap = new HashMap<>();
     facilityMap.put("name", facility.getFacilityName());
     facilityMap.put("phone", facility.getTelephone());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpTestResultUnauthenticatedResponse.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpTestResultUnauthenticatedResponse.java
@@ -1,0 +1,39 @@
+package gov.cdc.usds.simplereport.api.model.pxp;
+
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.PatientLink;
+import gov.cdc.usds.simplereport.db.model.Person;
+import java.util.Date;
+import java.util.HashMap;
+
+public class PxpTestResultUnauthenticatedResponse {
+  private Person person;
+  private Facility facility;
+  private PatientLink pl;
+
+  public PxpTestResultUnauthenticatedResponse(Person person, Facility facility, PatientLink pl) {
+    this.person = person;
+    this.facility = facility;
+    this.pl = pl;
+  }
+
+  public HashMap<String, String> getPatient() {
+    HashMap<String, String> patientMap = new HashMap<>();
+    patientMap.put("firstName", person.getFirstName());
+    patientMap.put("lastName", person.getLastName().charAt(0) + ".");
+
+    return patientMap;
+  }
+
+  public HashMap<String, String> getFacility() {
+    HashMap<String, String> facilityMap = new HashMap<>();
+    facilityMap.put("name", facility.getFacilityName());
+    facilityMap.put("phone", facility.getTelephone());
+
+    return facilityMap;
+  }
+
+  public Date getExpiresAt() {
+    return pl.getExpiresAt();
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -9,6 +9,7 @@ public final class ResourceLinks {
   public static final String SELF_REGISTER = "/pxp/register";
   public static final String EXISTING_PATIENT = "/pxp/register/existing-patient";
   public static final String GET_OBFUSCATED_PATIENT_NAME = "/pxp/patient-name";
+  public static final String GET_TEST_RESULT_UNAUTHENTICATED = "/pxp/entity";
   public static final String ENTITY_NAME = "/pxp/register/entity-name";
 
   public static final String WAITLIST_REQUEST = "/account-request/waitlist";

--- a/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -28,7 +28,7 @@ describe("Getting a test result from a patient link", () => {
     // library interpolates the patient name variable
     cy.contains("Enter ");
     cy.contains(`${patientObfuscatedName}'s`);
-    cy.contains("date of birth to access your COVID-19 testing portal.");
+    cy.contains("date of birth to access your COVID-19 testing results.");
     const dob = dayjs(patientDOB, "MM/DD/YYYY");
     // Month is zero-indexed, so add 1
     const birthMonth = dob.month() + 1;

--- a/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -27,8 +27,8 @@ describe("Getting a test result from a patient link", () => {
     // This sentence is broken into multiple lines due to how the i18n
     // library interpolates the patient name variable
     cy.contains("Enter ");
-    cy.contains(patientObfuscatedName);
-    cy.contains("'s date of birth to access your COVID-19 testing portal.");
+    cy.contains(`${patientObfuscatedName}'s`);
+    cy.contains("date of birth to access your COVID-19 testing portal.");
     const dob = dayjs(patientDOB, "MM/DD/YYYY");
     // Month is zero-indexed, so add 1
     const birthMonth = dob.month() + 1;

--- a/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -28,7 +28,7 @@ describe("Getting a test result from a patient link", () => {
     // library interpolates the patient name variable
     cy.contains("Enter ");
     cy.contains(`${patientObfuscatedName}'s`);
-    cy.contains("date of birth to access your COVID-19 testing results.");
+    cy.contains("date of birth to access your COVID-19 test results.");
     const dob = dayjs(patientDOB, "MM/DD/YYYY");
     // Month is zero-indexed, so add 1
     const birthMonth = dob.month() + 1;

--- a/frontend/src/app/commonComponents/DateInput.tsx
+++ b/frontend/src/app/commonComponents/DateInput.tsx
@@ -3,6 +3,7 @@ import {
   DateInput as TrussworksDateInput,
   DateInputGroup,
 } from "@trussworks/react-uswds";
+import { useTranslation } from "react-i18next";
 
 export type HTMLInputElementType =
   | "date"
@@ -61,6 +62,8 @@ export const DateInput = ({
   defaultValue,
   noHint,
 }: Props) => {
+  const { t } = useTranslation();
+
   return (
     <div
       className={classnames("usa-form-group", className, {
@@ -76,7 +79,9 @@ export const DateInput = ({
       >
         {label}
       </label>
-      {noHint ? null : <span className="usa-hint">For example: 4 28 1986</span>}
+      {noHint ? null : (
+        <span className="usa-hint">{t("testResult.dob.exampleText")}</span>
+      )}
       {validationStatus === "error" && (
         <span className="usa-error-message" id={`error_${name}`} role="alert">
           <span className="usa-sr-only">Error: </span>
@@ -90,7 +95,7 @@ export const DateInput = ({
           value={monthValue}
           required={true}
           defaultValue={defaultValue}
-          label={"Month"}
+          label={t("constants.date.month")}
           unit={"month"}
           maxLength={2}
           type={type || "text"}
@@ -102,7 +107,7 @@ export const DateInput = ({
           value={dayValue}
           required={true}
           defaultValue={defaultValue}
-          label={"Day"}
+          label={t("constants.date.day")}
           unit={"day"}
           maxLength={2}
           type={type || "text"}
@@ -114,7 +119,7 @@ export const DateInput = ({
           value={yearValue}
           required={true}
           defaultValue={defaultValue}
-          label={"Year"}
+          label={t("constants.date.year")}
           unit={"year"}
           maxLength={4}
           type={type || "text"}

--- a/frontend/src/app/utils/date.ts
+++ b/frontend/src/app/utils/date.ts
@@ -27,8 +27,8 @@ export const formatDateTime = (dateFormat: string, timeFormat: string) => (
 
 export const formatDateWithTimeOption = formatDateTime("MM/DD/yyyy", "h:mma");
 export const formatShortDateWithTimeOption = formatDateTime(
-  "M/DD/yyyy",
-  "h:mma"
+  "M/D/yyyy",
+  "h:mm a"
 );
 
 export const daysSince = (date: moment.Moment): String => {

--- a/frontend/src/app/utils/date.ts
+++ b/frontend/src/app/utils/date.ts
@@ -17,15 +17,19 @@ export const formatDateLong = (date: string | undefined) => {
   return moment(date)?.format("MMMM Do, YYYY");
 };
 
-export const formatDateWithTimeOption = (
+export const formatDateTime = (dateFormat: string, timeFormat: string) => (
   date: string | Date | null | undefined,
   withTime?: boolean
 ) => {
-  const dateFormat = "MM/DD/yyyy";
-  const timeFormat = "h:mma";
   const format = withTime ? `${dateFormat} ${timeFormat}` : dateFormat;
   return moment(date)?.format(format);
 };
+
+export const formatDateWithTimeOption = formatDateTime("MM/DD/yyyy", "h:mma");
+export const formatShortDateWithTimeOption = formatDateTime(
+  "M/DD/yyyy",
+  "h:mma"
+);
 
 export const daysSince = (date: moment.Moment): String => {
   const now = moment();

--- a/frontend/src/app/utils/date.ts
+++ b/frontend/src/app/utils/date.ts
@@ -1,11 +1,11 @@
 import moment from "moment";
 
+type DateInputFormat = Date | string | undefined | null;
+
 export function formatDate(date: string | Date): ISODate;
 export function formatDate(date: undefined | null): null;
-export function formatDate(
-  date: string | undefined | null | Date
-): ISODate | null;
-export function formatDate(date: string | undefined | null | Date) {
+export function formatDate(date: DateInputFormat): ISODate | null;
+export function formatDate(date: DateInputFormat) {
   if (!date) {
     return null;
   }
@@ -18,7 +18,7 @@ export const formatDateLong = (date: string | undefined) => {
 };
 
 export const formatDateTime = (dateFormat: string, timeFormat: string) => (
-  date: string | Date | null | undefined,
+  date: DateInputFormat,
   withTime?: boolean
 ) => {
   const format = withTime ? `${dateFormat} ${timeFormat}` : dateFormat;

--- a/frontend/src/app/utils/date.ts
+++ b/frontend/src/app/utils/date.ts
@@ -18,7 +18,7 @@ export const formatDateLong = (date: string | undefined) => {
 };
 
 export const formatDateWithTimeOption = (
-  date: string | undefined,
+  date: string | Date | null | undefined,
   withTime?: boolean
 ) => {
   const dateFormat = "MM/DD/yyyy";

--- a/frontend/src/app/utils/text.ts
+++ b/frontend/src/app/utils/text.ts
@@ -92,6 +92,22 @@ export function formatPhoneNumber(str: string) {
   return null;
 }
 
+/**
+ * Formats a US phone number to include dashes and parentheses,
+ * e.g. (123) 456-7890
+ *
+ * @param str a 10 digit phone number
+ * @returns formatted phone number
+ */
+export function formatPhoneNumberParens(str: string) {
+  var cleaned = ("" + str).replace(/\D/g, "");
+  var match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/);
+  if (match) {
+    return "(" + match[1] + ") " + match[2] + "-" + match[3];
+  }
+  return null;
+}
+
 export function formatUserStatus(status?: string | null) {
   if (!status) {
     return "Unknown";

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -564,11 +564,11 @@ export const en = {
         dateOfBirth: "Date of birth",
         enterDOB: "Enter your date of birth",
         enterDOB2:
-          "Enter <0>{{personName}}</0>'s date of birth to access your COVID-19 testing portal.",
+          "Enter <0>{{personName}}'s</0> date of birth to access your COVID-19 testing results.",
         linkExpirationNotice:
           "Note: this link will expire on <0>{{expirationDate}}</0>. ",
         testingFacilityContact:
-          "Please reach out to <0>{{facilityName}}</0> at <1>{{facilityPhone}}</1> if you have  issues accessing your result.",
+          "Please reach out to <0>{{facilityName}}</0> at <1>{{facilityPhone}}</1> if you have issues accessing your result.",
         format: "MM/DD/YYYY",
         invalidFormat: "Date of birth must be in MM/DD/YYYY format",
         invalidYear:

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -6,7 +6,7 @@ const UNKNOWN = "Unknown";
 
 export const en = {
   translation: {
-    header: "COVID-19 Testing Portal",
+    header: "COVID-19 testing portal",
     banner: {
       dotGov: "The .gov means it’s official.",
       dotGovHelper:

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -566,6 +566,7 @@ export const en = {
         },
       },
       dob: {
+        header: "Verify date of birth",
         dateOfBirth: "Date of birth",
         enterDOB: "Enter your date of birth",
         enterDOB2:
@@ -573,7 +574,7 @@ export const en = {
         linkExpirationNotice:
           "Note: this link will expire on <0>{{expirationDate}}</0>. ",
         testingFacilityContact:
-          "Please reach out to <0>{{facilityName}}</0> at <1>{{facilityPhone}}</1> if you have issues accessing your result.",
+          "Please reach out to <0>{{facilityName}}</0> <1>{{facilityPhone}}</1> if you have issues accessing your result.",
         format: "MM/DD/YYYY",
         invalidFormat: "Date of birth must be in MM/DD/YYYY format",
         invalidYear:

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -566,7 +566,9 @@ export const en = {
         enterDOB2:
           "Enter <0>{{personName}}</0>'s date of birth to access your COVID-19 testing portal.",
         linkExpirationNotice:
-          "Note: this link will expire 10 days after the test result was recorded.",
+          "Note: this link will expire on <0>{{expirationDate}}</0>. ",
+        testingFacilityContact:
+          "Please reach out to <0>{{facilityName}}</0> at <1>{{facilityPhone}}</1> if you have  issues accessing your result.",
         format: "MM/DD/YYYY",
         invalidFormat: "Date of birth must be in MM/DD/YYYY format",
         invalidYear:

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -59,6 +59,11 @@ export const en = {
         NO,
         UNKNOWN,
       },
+      date: {
+        month: "Month",
+        day: "Day",
+        year: "Year",
+      },
     },
     languages: {
       English: "English",
@@ -580,6 +585,7 @@ export const en = {
           "This link has expired. Please contact your test provider to generate a new link.",
         linkNotFound:
           "This test result link is invalid. Please double check the URL or contact your test provider for the correct link.",
+        exampleText: "For example: 4 28 1986",
         submit: "Continue",
       },
     },

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -564,7 +564,7 @@ export const en = {
         dateOfBirth: "Date of birth",
         enterDOB: "Enter your date of birth",
         enterDOB2:
-          "Enter <0>{{personName}}'s</0> date of birth to access your COVID-19 testing results.",
+          "Enter <0>{{personName}}'s</0> date of birth to access your COVID-19 test results.",
         linkExpirationNotice:
           "Note: this link will expire on <0>{{expirationDate}}</0>. ",
         testingFacilityContact:

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -482,12 +482,11 @@ export const es: LanguageConfig = {
         dateOfBirth: "Fecha de nacimiento",
         enterDOB: "Ingrese su fecha de nacimiento",
         enterDOB2:
-          "Ingrese su fecha de nacimiento para acceder a su portal de pruebas de COVID-19.",
+          "Ingrese la fecha de nacimiento de <0>{{personName}}</0> para acceder a su resultado de pruebas de COVID-19.",
         linkExpirationNotice:
-          "Nota: este enlace caducará 10 días después de que se registró el resultado de la prueba.",
-        // TODO: TRANSLATION REQ'D
+          "Nota: este enlace vencerá el <0>{{expirationDate}}</0>. ",
         testingFacilityContact:
-          "Please reach out to <0>{{facilityName}}</0> at <1>{{facilityPhone}}</1> if you have  issues accessing your result",
+          "Por favor comuníquese con <0>{{facilityName}}</0> al <1>{{facilityPhone}}</1> si tiene problemas para acceder a su resultado.",
         format: "MM/DD/AAAA",
         invalidFormat:
           "La fecha de nacimiento debe estar en formato MM/DD/AAAA",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -484,6 +484,7 @@ export const es: LanguageConfig = {
         },
       },
       dob: {
+        header: "Verificar fecha de nacimiento",
         dateOfBirth: "Fecha de nacimiento",
         enterDOB: "Ingrese su fecha de nacimiento",
         enterDOB2:

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -485,6 +485,9 @@ export const es: LanguageConfig = {
           "Ingrese su fecha de nacimiento para acceder a su portal de pruebas de COVID-19.",
         linkExpirationNotice:
           "Nota: este enlace caducará 10 días después de que se registró el resultado de la prueba.",
+        // TODO: TRANSLATION REQ'D
+        testingFacilityContact:
+          "Please reach out to <0>{{facilityName}}</0> at <1>{{facilityPhone}}</1> if you have  issues accessing your result",
         format: "MM/DD/AAAA",
         invalidFormat:
           "La fecha de nacimiento debe estar en formato MM/DD/AAAA",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -65,6 +65,11 @@ export const es: LanguageConfig = {
         NO,
         UNKNOWN,
       },
+      date: {
+        month: "Mes",
+        day: "Fecha",
+        year: "Año",
+      },
     },
     languages: {
       English: "Inglés",
@@ -499,6 +504,7 @@ export const es: LanguageConfig = {
           "Este enlace ha caducado. Comuníquese con su proveedor de prueba para generar un nuevo enlace.",
         linkNotFound:
           "Este enlace de resultado de la prueba no es válido. Vuelva a verificar el enlace o comuníquese con su proveedor de prueba para obtener el enlace correcto.",
+        exampleText: "Por ejemplo: 4 28 1986",
         submit: "Continuar",
       },
     },

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -79,6 +79,18 @@ export type VerifyV2Response = {
   };
 };
 
+export type TestResultUnauthenticated = {
+  patient: {
+    firstName: string;
+    lastName: string;
+  };
+  facility: {
+    name: string;
+    phone: string;
+  };
+  expiresAt: Date;
+};
+
 export class PxpApi {
   static validateDateOfBirth(
     patientLinkId: string,
@@ -126,6 +138,12 @@ export class PxpApi {
     patientLink: string
   ): Promise<string> => {
     return api.getRequest(`/patient-name?patientLink=${patientLink}`);
+  };
+
+  static getTestResultUnauthenticated = async (
+    patientLink: string
+  ): Promise<TestResultUnauthenticated> => {
+    return api.request(`/entity?patientLink=${patientLink}`, null, "GET");
   };
 
   static selfRegister = async (person: SelfRegistrationData): Promise<void> => {

--- a/frontend/src/patientApp/timeOfTest/DOB.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.test.tsx
@@ -27,21 +27,33 @@ const validateDateOfBirthSpy = jest
   .mockImplementation(jest.fn());
 
 describe("DOB (valid UUID)", () => {
-  let getObfuscatedPatientNameSpy: jest.SpyInstance;
+  let getTestResultUnauthenticatedSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     const store = mockStore({ plid });
 
-    getObfuscatedPatientNameSpy = jest
-      .spyOn(PxpApi, "getObfuscatedPatientName")
-      .mockImplementation((_plid) => Promise.resolve("John D."));
+    getTestResultUnauthenticatedSpy = jest
+      .spyOn(PxpApi, "getTestResultUnauthenticated")
+      .mockImplementation((_plid) =>
+        Promise.resolve({
+          patient: {
+            firstName: "John",
+            lastName: "D.",
+          },
+          facility: {
+            name: "Testing Facility",
+            phone: "6318675309",
+          },
+          expiresAt: new Date("3000-01-01"),
+        })
+      );
 
     render(mockContainer(store));
     expect(await screen.findByText("John D.")).toBeInTheDocument();
   });
 
-  it("fetches obfuscated patient name from server on render", async () => {
-    expect(getObfuscatedPatientNameSpy).toBeCalledWith(plid);
+  it("fetches unauthenticated test result data from server on render", async () => {
+    expect(getTestResultUnauthenticatedSpy).toBeCalledWith(plid);
   });
 
   it("shows obfuscated patient name on verification screen", async () => {
@@ -52,6 +64,26 @@ describe("DOB (valid UUID)", () => {
         "'s date of birth to access your COVID-19 testing portal",
         { exact: false }
       )
+    ).toBeInTheDocument();
+  });
+
+  it("shows facility name and phone number on verification screen", async () => {
+    expect(
+      await screen.findByText("Testing Facility", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("631-867-5309", { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("shows patient link expiration date on verification screen", async () => {
+    expect(
+      await screen.findByText("Note: this link will expire on ", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("01/01/3000 12:00am", { exact: false })
     ).toBeInTheDocument();
   });
 
@@ -210,8 +242,20 @@ describe("DOB (invalid UUID)", () => {
       plid: "this is totally not a valid UUID",
     });
     jest
-      .spyOn(PxpApi, "getObfuscatedPatientName")
-      .mockImplementation((_id) => Promise.resolve("J Doe"));
+      .spyOn(PxpApi, "getTestResultUnauthenticated")
+      .mockImplementation((_plid) =>
+        Promise.resolve({
+          patient: {
+            firstName: "John",
+            lastName: "D.",
+          },
+          facility: {
+            name: "Testing Facility",
+            phone: "6318675309",
+          },
+          expiresAt: new Date("3000-01-01"),
+        })
+      );
 
     render(mockContainer(store));
 

--- a/frontend/src/patientApp/timeOfTest/DOB.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.test.tsx
@@ -72,7 +72,7 @@ describe("DOB (valid UUID)", () => {
       await screen.findByText("Testing Facility", { exact: false })
     ).toBeInTheDocument();
     expect(
-      await screen.findByText("631-867-5309", { exact: false })
+      await screen.findByText("(631) 867-5309", { exact: false })
     ).toBeInTheDocument();
   });
 
@@ -83,7 +83,7 @@ describe("DOB (valid UUID)", () => {
       })
     ).toBeInTheDocument();
     expect(
-      await screen.findByText("1/01/3000 12:00am", { exact: false })
+      await screen.findByText("1/1/3000 12:00 am", { exact: false })
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/patientApp/timeOfTest/DOB.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.test.tsx
@@ -61,7 +61,7 @@ describe("DOB (valid UUID)", () => {
     expect(await screen.findByText("John D.'s")).toBeInTheDocument();
     expect(
       await screen.findByText(
-        "date of birth to access your COVID-19 testing results.",
+        "date of birth to access your COVID-19 test results.",
         { exact: false }
       )
     ).toBeInTheDocument();

--- a/frontend/src/patientApp/timeOfTest/DOB.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.test.tsx
@@ -49,7 +49,7 @@ describe("DOB (valid UUID)", () => {
       );
 
     render(mockContainer(store));
-    expect(await screen.findByText("John D.")).toBeInTheDocument();
+    expect(await screen.findByText("John D.'s")).toBeInTheDocument();
   });
 
   it("fetches unauthenticated test result data from server on render", async () => {
@@ -58,10 +58,10 @@ describe("DOB (valid UUID)", () => {
 
   it("shows obfuscated patient name on verification screen", async () => {
     // Text is broken up by multiple HTML elements
-    expect(await screen.findByText("John D.")).toBeInTheDocument();
+    expect(await screen.findByText("John D.'s")).toBeInTheDocument();
     expect(
       await screen.findByText(
-        "'s date of birth to access your COVID-19 testing portal",
+        "date of birth to access your COVID-19 testing results.",
         { exact: false }
       )
     ).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe("DOB (valid UUID)", () => {
       })
     ).toBeInTheDocument();
     expect(
-      await screen.findByText("01/01/3000 12:00am", { exact: false })
+      await screen.findByText("1/01/3000 12:00am", { exact: false })
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -184,10 +184,8 @@ const DOB = () => {
               }}
             </Trans>
             <Trans t={t} i18nKey="testResult.dob.testingFacilityContact">
-              {{
-                facilityName: facility?.name,
-                facilityPhone: formatPhoneNumber(facility?.phone as string),
-              }}
+              {{ facilityName: facility?.name }}
+              {{ facilityPhone: formatPhoneNumber(facility?.phone as string) }}
             </Trans>
           </p>
           <DateInput

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -15,7 +15,7 @@ import {
   formatShortDateWithTimeOption,
 } from "../../app/utils/date";
 import { LoadingCard } from "../../app/commonComponents/LoadingCard/LoadingCard";
-import { formatPhoneNumber } from "../../app/utils/text";
+import { formatPhoneNumberParens } from "../../app/utils/text";
 
 const DOB = () => {
   const { t } = useTranslation();
@@ -171,22 +171,37 @@ const DOB = () => {
     return (
       <main>
         <div className="grid-container maxw-tablet">
-          <h1 className="font-heading-lg margin-top-3">Verify date of birth</h1>
+          <h1 className="font-heading-lg margin-top-3">
+            {t("testResult.dob.header")}
+          </h1>
           <Trans t={t} parent="p" i18nKey="testResult.dob.enterDOB2">
             <span className="text-bold">
               {{ personName: patientObfuscatedName }}
             </span>
           </Trans>
-          <p>
-            <Trans t={t} i18nKey="testResult.dob.linkExpirationNotice">
-              {{
-                expirationDate: formatShortDateWithTimeOption(expiresAt, true),
-              }}
-            </Trans>
-            <Trans t={t} i18nKey="testResult.dob.testingFacilityContact">
-              {{ facilityName: facility?.name }}
-              {{ facilityPhone: formatPhoneNumber(facility?.phone as string) }}
-            </Trans>
+          <p className="usa-hint font-ui-2xs">
+            <em>
+              <Trans t={t} i18nKey="testResult.dob.linkExpirationNotice">
+                {{
+                  expirationDate: formatShortDateWithTimeOption(
+                    expiresAt,
+                    true
+                  ),
+                }}
+              </Trans>
+              <Trans t={t} i18nKey="testResult.dob.testingFacilityContact">
+                {{ facilityName: facility?.name }}
+                {facility?.phone && (
+                  <span style={{ whiteSpace: "nowrap" }}>
+                    {{
+                      facilityPhone:
+                        "at " +
+                        formatPhoneNumberParens(facility?.phone as string),
+                    }}
+                  </span>
+                )}
+              </Trans>
+            </em>
           </p>
           <DateInput
             className="width-mobile"

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -12,7 +12,7 @@ import Alert from "../../app/commonComponents/Alert";
 import { DateInput } from "../../app/commonComponents/DateInput";
 import {
   dateFromStrings,
-  formatDateWithTimeOption,
+  formatShortDateWithTimeOption,
 } from "../../app/utils/date";
 import { LoadingCard } from "../../app/commonComponents/LoadingCard/LoadingCard";
 import { formatPhoneNumber } from "../../app/utils/text";
@@ -177,7 +177,9 @@ const DOB = () => {
           </Trans>
           <p>
             <Trans t={t} i18nKey="testResult.dob.linkExpirationNotice">
-              {{ expirationDate: formatDateWithTimeOption(expiresAt, true) }}
+              {{
+                expirationDate: formatShortDateWithTimeOption(expiresAt, true),
+              }}
             </Trans>
             <Trans t={t} i18nKey="testResult.dob.testingFacilityContact">
               {{

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -24,10 +24,12 @@ const DOB = () => {
 
   useEffect(() => {
     PxpApi.getTestResultUnauthenticated(plid)
-      .then(({ patient, facility, expiresAt }) => {
-        setPatientObfuscatedName(patient.firstName + " " + patient.lastName);
-        setFacility(facility);
-        setExpiresAt(expiresAt);
+      .then((response) => {
+        setPatientObfuscatedName(
+          `${response.patient.firstName} ${response.patient.lastName}`
+        );
+        setFacility(response.facility);
+        setExpiresAt(response.expiresAt);
         setIsLoading(false);
       })
       .catch(() => {

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -10,8 +10,12 @@ import { setTestResult, updateOrganization } from "../../app/store";
 import { PxpApi } from "../PxpApiService";
 import Alert from "../../app/commonComponents/Alert";
 import { DateInput } from "../../app/commonComponents/DateInput";
-import { dateFromStrings } from "../../app/utils/date";
+import {
+  dateFromStrings,
+  formatDateWithTimeOption,
+} from "../../app/utils/date";
 import { LoadingCard } from "../../app/commonComponents/LoadingCard/LoadingCard";
+import { formatPhoneNumber } from "../../app/utils/text";
 
 const DOB = () => {
   const { t } = useTranslation();
@@ -19,9 +23,11 @@ const DOB = () => {
   const plid = useSelector((state: any) => state.plid);
 
   useEffect(() => {
-    PxpApi.getObfuscatedPatientName(plid)
-      .then((name) => {
-        setPatientObfuscatedName(name);
+    PxpApi.getTestResultUnauthenticated(plid)
+      .then(({ patient, facility, expiresAt }) => {
+        setPatientObfuscatedName(patient.firstName + " " + patient.lastName);
+        setFacility(facility);
+        setExpiresAt(expiresAt);
         setIsLoading(false);
       })
       .catch(() => {
@@ -31,6 +37,11 @@ const DOB = () => {
 
   const dispatch = useDispatch();
   const [patientObfuscatedName, setPatientObfuscatedName] = useState("");
+  const [facility, setFacility] = useState<Pick<
+    Facility,
+    "name" | "phone"
+  > | null>(null);
+  const [expiresAt, setExpiresAt] = useState<Date | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [birthMonth, setBirthMonth] = useState("");
   const [birthDay, setBirthDay] = useState("");
@@ -159,13 +170,21 @@ const DOB = () => {
       <main>
         <div className="grid-container maxw-tablet">
           <h1 className="font-heading-lg margin-top-3">Verify date of birth</h1>
-          <Trans t={t} i18nKey="testResult.dob.enterDOB2">
+          <Trans t={t} parent="p" i18nKey="testResult.dob.enterDOB2">
             <span className="text-bold">
               {{ personName: patientObfuscatedName }}
             </span>
           </Trans>
-          <p className="usa-hint">
-            <em>{t("testResult.dob.linkExpirationNotice")}</em>
+          <p>
+            <Trans t={t} i18nKey="testResult.dob.linkExpirationNotice">
+              {{ expirationDate: formatDateWithTimeOption(expiresAt, true) }}
+            </Trans>
+            <Trans t={t} i18nKey="testResult.dob.testingFacilityContact">
+              {{
+                facilityName: facility?.name,
+                facilityPhone: formatPhoneNumber(facility?.phone as string),
+              }}
+            </Trans>
           </p>
           <DateInput
             className="width-mobile"


### PR DESCRIPTION
## Related Issue

Closes #3332.

## Changes Proposed
- Adds facility name and facility phone number to date of birth verification page
    - Adds unauthenticated `GET /entity` PXP endpoint to return certain test result data

## Additional Information
- Previously, the only unauthenticated data from the server that we displayed on the DOB verification page was the patient's name, obfuscated.
- A new endpoint was added to return this information
    - This replaces the now-deprecated `GET /patient-name` PXP endpoint

## Testing
- Add and complete a new test for a patient
- Follow the patient link for the completed test
- Verify that the date of birth verification screen includes the facility name and facility phone number

## Acceptance Validation
<img width="597" alt="Screen Shot 2022-03-22 at 2 57 13 PM" src="https://user-images.githubusercontent.com/27730981/159561838-94194968-3649-45fe-a68e-a32515d58d33.png">

<img width="526" alt="Screen Shot 2022-03-24 at 3 40 00 PM" src="https://user-images.githubusercontent.com/27730981/159996988-0bc51dc2-2308-431e-ba63-8fef86b4a326.png">

## Checklist for reviewers
- [x] @emmastephenson congratulations, you've drawn the reviewer short straw :)
- [ ] @vz3 I suspect we will want to tweak the design of this page a bit for readability - please review & reach out with any changes you'd like to make
- [ ] @Rebecca-LM I've sent the (very) small batch of translation requests to the CDC office but I haven't heard back yet - if you have time, would you be able to take a look at [these two sentences](https://app.zenhub.com/workspaces/simplereport-better-data-team-605b43d51ea9f700119a48ee/issues/cdcgov/prime-simplereport/3332#issuecomment-1071071846) for translation?

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] ~Any changes that might generate new support requests have been flagged to the support team~
- [x] ~Any changes to support infrastructure have been demo'd to support team~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~
