### PR TITLE
Add alert for DB connection exhaustion

### DIFF
--- a/ops/demo/alerts.tf
+++ b/ops/demo/alerts.tf
@@ -22,4 +22,5 @@ module "metric_alerts" {
     data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
 
+  database_id = data.terraform_remote_state.persistent_demo.outputs.postgres_server_id
 }

--- a/ops/demo/persistent/_output.tf
+++ b/ops/demo/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }

--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -20,6 +20,7 @@ module "metric_alerts" {
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",
+    "db_connection_exhaustion",
     "batched_uploader_single_failure_detected",
     "batched_uploader_function_not_triggering"
   ]
@@ -28,4 +29,5 @@ module "metric_alerts" {
     data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
 
+  database_id = data.terraform_remote_state.persistent_dev.outputs.postgres_server_id
 }

--- a/ops/dev/persistent/_output.tf
+++ b/ops/dev/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }

--- a/ops/pentest/persistent/_output.tf
+++ b/ops/pentest/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }

--- a/ops/prod/alerts.tf
+++ b/ops/prod/alerts.tf
@@ -26,4 +26,5 @@ module "metric_alerts" {
     data.terraform_remote_state.global.outputs.pagerduty_prod_action_id
   ]
 
+  database_id = data.terraform_remote_state.persistent_prod.outputs.postgres_server_id
 }

--- a/ops/prod/persistent/_output.tf
+++ b/ops/prod/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -29,6 +29,7 @@ variable "disabled_alerts" {
       "frontend_error_boundary",
       "db_query_duration",
       "db_query_duration_over_time_window",
+      "db_connection_exhaustion",
       "batched_uploader_single_failure_detected",
       "batched_uploader_function_not_triggering"
     ])) == 0
@@ -82,3 +83,5 @@ variable "additional_uptime_test_urls" {
   type    = map(string)
   default = {}
 }
+
+variable "database_id" {}

--- a/ops/services/alerts/app_service_metrics/data.tf
+++ b/ops/services/alerts/app_service_metrics/data.tf
@@ -1,0 +1,12 @@
+data "azurerm_resource_group" "management" {
+  name = "prime-simple-report-management"
+}
+
+data "azurerm_resource_group" "app" {
+  name = var.rg_name
+}
+
+data "azurerm_log_analytics_workspace" "global" {
+  name                = "simple-report-log-workspace-global"
+  resource_group_name = data.azurerm_resource_group.management.name
+}

--- a/ops/services/alerts/app_service_metrics/database.tf
+++ b/ops/services/alerts/app_service_metrics/database.tf
@@ -1,0 +1,83 @@
+resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration" {
+  name                = "${var.env}-db-query-duration"
+  description         = "${local.env_title} DB query durations >= 10s"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+  severity            = var.severity
+  frequency           = 5
+  time_window         = 5
+  enabled             = contains(var.disabled_alerts, "db_query_duration") ? false : true
+
+  data_source_id = var.app_insights_id
+
+  query = <<-QUERY
+dependencies
+${local.skip_on_weekends}
+| where timestamp >= ago(5m) and name has "SQL:" and duration >= 10000
+  QUERY
+
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 0
+  }
+
+  action {
+    action_group = var.action_group_ids
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_time_window" {
+  name                = "${var.env}-db-query-duration-over-time-window"
+  description         = "10+ DB queries with durations over 1.25s in the past 5 minutes"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+  severity            = var.severity
+  frequency           = 5
+  time_window         = 5
+  enabled             = contains(var.disabled_alerts, "db_query_duration_over_time_window") ? false : true
+
+  data_source_id = var.app_insights_id
+
+  query = <<-QUERY
+dependencies
+${local.skip_on_weekends}
+| where timestamp >= ago(5m) and name startswith "SQL:" and duration > 1250 and data !startswith "insert into public.api_audit_event"
+  QUERY
+
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 25
+  }
+
+  action {
+    action_group = var.action_group_ids
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "db_connection_exhaustion" {
+  name                = "${var.env}-db-connection-exhaustion"
+  description         = "${local.env_title} instances of DB connection exhaustion"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+
+  action {
+    action_group = var.action_group_ids
+  }
+
+  data_source_id = var.database_id
+  enabled        = contains(var.disabled_alerts, "db_connection_exhaustion") ? false : true
+
+  query = <<-QUERY
+ AzureDiagnostics
+ ${local.skip_on_weekends}
+ | where errorLevel_s == "FATAL" and Message startswith "remaining connection slots are reserved"
+  QUERY
+
+  severity    = 1
+  frequency   = 5
+  time_window = 5
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 5
+  }
+}

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -1,13 +1,4 @@
 # To do log-based alerts, we need to make sure we're actually collecting AppServiceConsoleLogs from the API
-data "azurerm_resource_group" "management" {
-  name = "prime-simple-report-management"
-}
-
-data "azurerm_log_analytics_workspace" "global" {
-  name                = "simple-report-log-workspace-global"
-  resource_group_name = data.azurerm_resource_group.management.name
-}
-
 resource "azurerm_monitor_diagnostic_setting" "collect_appserviceconsolelogs" {
   name                       = "${local.env_title} API App Service console logs"
   target_resource_id         = var.app_service_id
@@ -25,10 +16,6 @@ resource "azurerm_monitor_diagnostic_setting" "collect_appserviceconsolelogs" {
 }
 
 # Add an alert for GraphQL query validation failures (more than 2 in a 5-minute window)
-data "azurerm_resource_group" "app" {
-  name = var.rg_name
-}
-
 resource "azurerm_monitor_scheduled_query_rules_alert" "graphql_query_validation_failures" {
   name                = "${var.env}-graphql-query-validation-failures"
   description         = "${local.env_title} GraphQL query validation failures"

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -192,62 +192,6 @@ ${local.skip_on_weekends}
   }
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration" {
-  name                = "${var.env}-db-query-duration"
-  description         = "${local.env_title} DB query durations >= 10s"
-  location            = data.azurerm_resource_group.app.location
-  resource_group_name = var.rg_name
-  severity            = var.severity
-  frequency           = 5
-  time_window         = 5
-  enabled             = contains(var.disabled_alerts, "db_query_duration") ? false : true
-
-  data_source_id = var.app_insights_id
-
-  query = <<-QUERY
-dependencies
-${local.skip_on_weekends}
-| where timestamp >= ago(5m) and name has "SQL:" and duration >= 10000
-  QUERY
-
-  trigger {
-    operator  = "GreaterThan"
-    threshold = 0
-  }
-
-  action {
-    action_group = var.action_group_ids
-  }
-}
-
-resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_time_window" {
-  name                = "${var.env}-db-query-duration-over-time-window"
-  description         = "10+ DB queries with durations over 1.25s in the past 5 minutes"
-  location            = data.azurerm_resource_group.app.location
-  resource_group_name = var.rg_name
-  severity            = var.severity
-  frequency           = 5
-  time_window         = 5
-  enabled             = contains(var.disabled_alerts, "db_query_duration_over_time_window") ? false : true
-
-  data_source_id = var.app_insights_id
-
-  query = <<-QUERY
-dependencies
-${local.skip_on_weekends}
-| where timestamp >= ago(5m) and name startswith "SQL:" and duration > 1250 and data !startswith "insert into public.api_audit_event"
-  QUERY
-
-  trigger {
-    operator  = "GreaterThan"
-    threshold = 25
-  }
-
-  action {
-    action_group = var.action_group_ids
-  }
-}
-
 resource "azurerm_monitor_scheduled_query_rules_alert" "batched_uploader_single_failure_detected" {
   name                = "${var.env}-batched-uploader-single-failure-detected"
   description         = "QueueBatchedReportStreamUploader failed to successfully complete"

--- a/ops/stg/alerts.tf
+++ b/ops/stg/alerts.tf
@@ -24,4 +24,5 @@ module "metric_alerts" {
     data.terraform_remote_state.global.outputs.pagerduty_prod_action_id
   ]
 
+  database_id = data.terraform_remote_state.persistent_stg.outputs.postgres_server_id
 }

--- a/ops/stg/persistent/_output.tf
+++ b/ops/stg/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -20,6 +20,7 @@ module "metric_alerts" {
     "frontend_error_boundary",
     "db_query_duration",
     "db_query_duration_over_time_window",
+    "db_connection_exhaustion",
     "batched_uploader_single_failure_detected",
     "batched_uploader_function_not_triggering"
   ]
@@ -31,4 +32,5 @@ module "metric_alerts" {
 
   mem_threshold = 85
   cpu_threshold = 85
+  database_id   = data.terraform_remote_state.persistent_test.outputs.postgres_server_id
 }

--- a/ops/test/persistent/_output.tf
+++ b/ops/test/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }

--- a/ops/training/alerts.tf
+++ b/ops/training/alerts.tf
@@ -20,4 +20,6 @@ module "metric_alerts" {
   action_group_ids = [
     data.terraform_remote_state.global.outputs.pagerduty_non_prod_action_id
   ]
+
+  database_id = data.terraform_remote_state.persistent_training.outputs.postgres_server_id
 }

--- a/ops/training/persistent/_output.tf
+++ b/ops/training/persistent/_output.tf
@@ -27,6 +27,10 @@ output "postgres_server_fqdn" {
   value = module.db.server_fqdn
 }
 
+output "postgres_server_id" {
+  value = module.db.server_id
+}
+
 output "network_profile_id" {
   value = module.vnet.network_profile_id
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Postmortem item. We decided that we needed better insight into connection pooling issues, and connection exhaustion in particular.

## Changes Proposed

- Added an alert that triggers on >= 5 instances of connection exhaustion over a 5 minute window.
- Moved the various `data`s in `services/alerts/app_service_metrics` to a `data.tf` file for better organization

## Testing

- Deploying the branch to a dev environment should deploy the new alert (or locally if you have local Terraform set up).
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification