### PR TITLE
Annotate TF-managed Okta Trusted Origins.

### DIFF
--- a/ops/prod/persistent/okta.tf
+++ b/ops/prod/persistent/okta.tf
@@ -5,12 +5,12 @@ module "okta" {
   logout_redirect_uris = ["https://simplereport.cdc.gov", "https://www.simplereport.gov"]
   trusted_origins = [
     {
-      name   = "SimpleReport Prod Env",
+      name   = "SimpleReport Prod Env [TF]",
       url    = "https://simplereport.gov",
       scopes = ["CORS", "REDIRECT"]
     },
     {
-      name   = "SimpleReport Prod Env (www)",
+      name   = "SimpleReport Prod Env (www) [TF]",
       url    = "https://www.simplereport.gov",
       scopes = ["CORS", "REDIRECT"]
     }

--- a/ops/stg/persistent/okta.tf
+++ b/ops/stg/persistent/okta.tf
@@ -6,7 +6,7 @@ module "okta" {
   redirect_urls        = []
   trusted_origins = [
     {
-      name   = "SimpleReport Staging Env",
+      name   = "SimpleReport Staging Env [TF]",
       url    = "https://stg.simplereport.gov",
       scopes = ["CORS", "REDIRECT"]
     }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Provides an additional fix that should unblock deployments from `main` without the need to introduce downtime.

## Changes Proposed

- Deployments now fail on the `apply` stage due to an identical name of an origin that has already been created in Okta. This change adds a `[TF]` annotation to origins that are created by/managed from Terraform, to preserve unique names and allow for the manual deletion of the obsolete origin after a successful deployment.

## Additional Information

- This change isn't strictly necessary, but the main alternatives right now are to either delete the existing origins manually before deployment, which can result in downtime for end users, or work with local Terraform to leverage an API key for the Okta API to perform an import. This way gives us the benefit of seeing which of the origins have been converted to Terraform, which is more important on our existing PRIME-shared instance.

## Testing

- Again, no testing is really possible outside of running a manual `apply`. `Plan` thinks everything is just fine, and happily spits back results without an issue.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
