### PR TITLE
Move stg App Service Plan to V3

### DIFF
--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,10 +4,13 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_tier  = "PremiumV2"
-  instance_size  = "P2v2"
+  instance_tier  = "PremiumV3"
+  instance_size  = "P2v3"
 
-  resource_group_location = data.azurerm_resource_group.rg.location
+  // This is hard-coded due to a specific issue with the combination of our stg RG and East US
+  // not supporting V3 SKUs - other regions seem to work fine. This needs an Azure support ticket
+  // to get back to the correct region.
+  resource_group_location = "centralus"
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   webapp_subnet_id = data.terraform_remote_state.persistent_stg.outputs.subnet_webapp_id


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

#3370

## Changes Proposed

- Move `stg` App Service Plan to Premium V3

## Additional Information

- Per the comment in the code, I think we have an issue on the Azure side. The `stg` resource group doesn't seem to support V3 when using East US - any other region seems to work fine. We need to hard-code the region for now to get this to work, and file a support ticket to see if we can resolve the actual issue.

## Testing
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!