### PR TITLE
Fix hard-coding of stg App Service Plan location

### DIFF
--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 resource "azurerm_app_service_plan" "service_plan" {
-  name                = "${var.az_account}-appserviceplan-${var.env}"
+  name = "${var.az_account}-appserviceplan-${var.env}"
   // This is hard-coded for stg due to a specific issue with the combination of our stg RG and East US
   // not supporting V3 SKUs - other regions seem to work fine. This needs an Azure support ticket
   // to get back to the correct region.

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -16,7 +16,10 @@ locals {
 
 resource "azurerm_app_service_plan" "service_plan" {
   name                = "${var.az_account}-appserviceplan-${var.env}"
-  location            = var.resource_group_location
+  // This is hard-coded for stg due to a specific issue with the combination of our stg RG and East US
+  // not supporting V3 SKUs - other regions seem to work fine. This needs an Azure support ticket
+  // to get back to the correct region.
+  location            = var.env == "stg" ? "centralus" : var.resource_group_location
   resource_group_name = var.resource_group_name
 
   # Define Linux as Host OS

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -7,10 +7,7 @@ module "simple_report_api" {
   instance_tier  = "PremiumV3"
   instance_size  = "P2v3"
 
-  // This is hard-coded due to a specific issue with the combination of our stg RG and East US
-  // not supporting V3 SKUs - other regions seem to work fine. This needs an Azure support ticket
-  // to get back to the correct region.
-  resource_group_location = "centralus"
+  resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name
 
   webapp_subnet_id = data.terraform_remote_state.persistent_stg.outputs.subnet_webapp_id


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

#3370, fixes issue in #3589

## Changes Proposed

- We need to hardcode the location value inside the `app_service` module rather than in `stg`, otherwise the App Service itself will also be moved to Central US. We only want the App Service Plan to move.