### PR TITLE
Revert App Service Plan changes

### DIFF
--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -15,11 +15,8 @@ locals {
 }
 
 resource "azurerm_app_service_plan" "service_plan" {
-  name = "${var.az_account}-appserviceplan-${var.env}"
-  // This is hard-coded for stg due to a specific issue with the combination of our stg RG and East US
-  // not supporting V3 SKUs - other regions seem to work fine. This needs an Azure support ticket
-  // to get back to the correct region.
-  location            = var.env == "stg" ? "centralus" : var.resource_group_location
+  name                = "${var.az_account}-appserviceplan-${var.env}"
+  location            = var.resource_group_location
   resource_group_name = var.resource_group_name
 
   # Define Linux as Host OS

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,8 +4,8 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_tier  = "PremiumV3"
-  instance_size  = "P2v3"
+  instance_tier  = "PremiumV2"
+  instance_size  = "P2v2"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #3370
- Briefly: none of this actually works and we'll need to fully revert and file a support ticket.
- Interestingly, I can create a Windows App Service Plan in East US, just not a Linux/Docker one. One theory I came up with after poking around is that `stg` was the only environment that at one point had a non-Premium Linux App Service Plan in East US. Supposedly that will interfere with creating a Premium plan in the same location later. The easy fix would be to recreate the resource group but we don't have permission. So, back to filing a support ticket.

## Changes Proposed

- Revert previous attempts to move locations
