### PR TITLE
Remove stg from CI

### DIFF
--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -12,110 +12,116 @@ concurrency:
   group: stg-deploy
 
 jobs:
-  build-docker:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./backend
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to ACR
-        run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
-      - name: Build and push Docker images
-        run: ./build_and_push.sh
-  prerelease-backend:
-    runs-on: ubuntu-latest
-    needs: build-docker
-    defaults:
-      run:
-        working-directory: ./ops
-    env: # all Azure interaction is through terraform
-      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-      OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 1.1.4
-      - name: Terraform Init
-        run: make init-${{ env.DEPLOY_ENV }}
-      - name: Terraform deploy (infrastructure and staging slot)
-        run: make deploy-${{ env.DEPLOY_ENV }}
-      - name: Wait for correct release to be deployed in staging slot
-        timeout-minutes: 5
-        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
-      - name: Wait for staging deploy to be ready
-        timeout-minutes: 1
-        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-  build-frontend:
+  # Remove this job and re-enable the old ones after stg is recreated
+  bypass-stg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.1.5
-        with:
-          node-version: ${{env.NODE_VERSION}}
-      - name: Use cache for node_modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./frontend/node_modules
-          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/build-frontend
-        name: Build front-end application
-        with:
-          deploy-env: ${{env.DEPLOY_ENV}}
-          smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
-          client-tarball: ./client.tgz
-          okta-enabled: true
-          okta-url: https://hhs-prime.okta.com
-          okta-client-id: 0oa62qncijWSeQMuc4h6
-      - name: Save compiled frontend application
-        uses: actions/upload-artifact@v2
-        if: success()
-        with:
-          name: frontend-tarball
-          path: client.tgz
-          retention-days: 1
-  deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: Staging
-      url: https://stg.simplereport.gov
-    needs: [build-frontend, prerelease-backend]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Retrieve frontend build
-        uses: actions/download-artifact@v2
-        with:
-          name: frontend-tarball
-      - name: Promote and deploy
-        uses: ./.github/actions/deploy-application
-        with:
-          client-tarball: client.tgz
-          deploy-env: ${{env.DEPLOY_ENV}}
-  verify-release:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    defaults:
-      run:
-        working-directory: ./ops
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run health checks
-        uses: ./.github/actions/health-checks
-        with:
-          deploy-env: ${{env.DEPLOY_ENV}}
+      - name: bypass-stg
+        run: echo Bypassing stg
+  # build-docker:
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       working-directory: ./backend
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v1
+  #     - name: Login to ACR
+  #       run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
+  #     - name: Build and push Docker images
+  #       run: ./build_and_push.sh
+  # prerelease-backend:
+  #   runs-on: ubuntu-latest
+  #   needs: build-docker
+  #   defaults:
+  #     run:
+  #       working-directory: ./ops
+  #   env: # all Azure interaction is through terraform
+  #     ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+  #     ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+  #     ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+  #     ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+  #     OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: azure/login@v1
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #     - uses: hashicorp/setup-terraform@v1
+  #       with:
+  #         terraform_version: 1.1.4
+  #     - name: Terraform Init
+  #       run: make init-${{ env.DEPLOY_ENV }}
+  #     - name: Terraform deploy (infrastructure and staging slot)
+  #       run: make deploy-${{ env.DEPLOY_ENV }}
+  #     - name: Wait for correct release to be deployed in staging slot
+  #       timeout-minutes: 5
+  #       run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+  #     - name: Wait for staging deploy to be ready
+  #       timeout-minutes: 1
+  #       run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
+  # build-frontend:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2.1.5
+  #       with:
+  #         node-version: ${{env.NODE_VERSION}}
+  #     - name: Use cache for node_modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ./frontend/node_modules
+  #         key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
+  #     - uses: azure/login@v1
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #     - uses: ./.github/actions/build-frontend
+  #       name: Build front-end application
+  #       with:
+  #         deploy-env: ${{env.DEPLOY_ENV}}
+  #         smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+  #         client-tarball: ./client.tgz
+  #         okta-enabled: true
+  #         okta-url: https://hhs-prime.okta.com
+  #         okta-client-id: 0oa62qncijWSeQMuc4h6
+  #     - name: Save compiled frontend application
+  #       uses: actions/upload-artifact@v2
+  #       if: success()
+  #       with:
+  #         name: frontend-tarball
+  #         path: client.tgz
+  #         retention-days: 1
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: Staging
+  #     url: https://stg.simplereport.gov
+  #   needs: [build-frontend, prerelease-backend]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: azure/login@v1
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #     - name: Retrieve frontend build
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: frontend-tarball
+  #     - name: Promote and deploy
+  #       uses: ./.github/actions/deploy-application
+  #       with:
+  #         client-tarball: client.tgz
+  #         deploy-env: ${{env.DEPLOY_ENV}}
+  # verify-release:
+  #   runs-on: ubuntu-latest
+  #   needs: [deploy]
+  #   defaults:
+  #     run:
+  #       working-directory: ./ops
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Run health checks
+  #       uses: ./.github/actions/health-checks
+  #       with:
+  #         deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -24,9 +24,13 @@ jobs:
   check-terraform-validity:
     runs-on: ubuntu-latest
     env:
+      # TODO: re-enable once stg is recreated
+      # dev dev/persistent test test/persistent demo demo/persistent training training/persistent
+      # stg stg/persistent pentest pentest/persistent prod prod/persistent
+      # global
       TERRAFORM_DIRS: |
           dev dev/persistent test test/persistent demo demo/persistent training training/persistent
-          stg stg/persistent pentest pentest/persistent prod prod/persistent
+          pentest pentest/persistent prod prod/persistent
           global
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- See comment in #3370. Removing `stg` from CI is the first step in re-creating the `stg` resource group.

## Changes Proposed

- Change the pipeline so `stg` runs a no-op `echo` statement. This seems easier to revert than re-arranging the pipeline stage dependencies.
- Remove `stg` and `stg/persistent` from CI Terraform checks
