### PR TITLE
Increase max width of Results table

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.scss
+++ b/frontend/src/app/testResults/TestResultsList.scss
@@ -87,3 +87,7 @@
     border: 1px solid rgb(86, 92, 101);
   }
 }
+
+.grid-container.results-wide-container {
+  max-width: 1400px;
+}

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -18,7 +18,7 @@ import { DatePicker, Label } from "@trussworks/react-uswds";
 
 import { PATIENT_TERM_CAP } from "../../config/constants";
 import { displayFullName } from "../utils";
-import { isValidDate, formatDateWithTimeOption } from "../utils/date";
+import { formatDateWithTimeOption, isValidDate } from "../utils/date";
 import { ActionsMenu } from "../commonComponents/ActionsMenu";
 import { getParameterFromUrl, getUrl } from "../utils/url";
 import { useDocumentTitle, useOutsideClick } from "../utils/hooks";
@@ -387,7 +387,7 @@ export const DetachedTestResultsList = ({
           }}
         />
       )}
-      <div className="grid-container">
+      <div className="grid-container results-wide-container">
         <div className="grid-row">
           <div className="prime-container card-container sr-test-results-list">
             <div className="usa-card__header">

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
     class="prime-home"
   >
     <div
-      class="grid-container"
+      class="grid-container results-wide-container"
     >
       <div
         class="grid-row"


### PR DESCRIPTION
## Related Issue

- Resolves #3487 

## Changes Proposed

- Changes max width of test results table to 1400px

## Testing

- Visit dev (currently deployed), go to results table, see how wide it is! https://dev.simplereport.gov/app/results
 
## Screenshots / Demos

<img width="1840" alt="Screen Shot 2022-03-31 at 1 35 42 PM" src="https://user-images.githubusercontent.com/9121162/161144823-d3bde94f-c87b-4274-98b6-3d34065ed011.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
