### PR TITLE
Remove symptoms column from results table

### DIFF
--- a/frontend/src/app/testResults/DownloadResultsCsvButton.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvButton.tsx
@@ -15,7 +15,6 @@ import { GetFacilityResultsForCsvDocument } from "../../generated/graphql";
 import {
   byDateTested,
   FilterParams,
-  hasSymptoms,
   Results,
   ResultsQueryVariables,
 } from "./TestResultsList";
@@ -24,6 +23,19 @@ interface Props {
   filterParams: FilterParams;
   totalEntries: number;
   facilityId: string;
+}
+
+function hasSymptoms(noSymptoms: boolean, symptoms: string) {
+  if (noSymptoms) {
+    return "No";
+  }
+  const symptomsList: Record<string, string> = JSON.parse(symptoms);
+  for (let key in symptomsList) {
+    if (symptomsList[key] === "true") {
+      return "Yes";
+    }
+  }
+  return "Unknown";
 }
 
 const DownloadResultsCSVButton = ({

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -51,19 +51,6 @@ import DownloadResultsCSVButton from "./DownloadResultsCsvButton";
 
 export type Results = keyof typeof TEST_RESULT_DESCRIPTIONS;
 
-export function hasSymptoms(noSymptoms: boolean, symptoms: string) {
-  if (noSymptoms) {
-    return "No";
-  }
-  const symptomsList: Record<string, string> = JSON.parse(symptoms);
-  for (let key in symptomsList) {
-    if (symptomsList[key] === "true") {
-      return "Yes";
-    }
-  }
-  return "Unknown";
-}
-
 export const byDateTested = (a: any, b: any) => {
   // ISO string dates sort nicely
   if (a.dateTested === b.dateTested) return 0;

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -143,7 +143,6 @@ function testResultRows(
         <td>{formatDateWithTimeOption(r.dateTested, true)}</td>
         <td>{TEST_RESULT_DESCRIPTIONS[r.result as Results]}</td>
         <td>{r.deviceType.name}</td>
-        <td>{hasSymptoms(r.noSymptoms, r.symptoms)}</td>
         <td>
           {displayFullName(
             r.createdBy.nameInfo.firstName,
@@ -528,7 +527,6 @@ export const DetachedTestResultsList = ({
                     <th scope="col">Test date</th>
                     <th scope="col">Result</th>
                     <th scope="col">Device</th>
-                    <th scope="col">Symptoms</th>
                     <th scope="col">Submitter</th>
                     <th scope="col">Actions</th>
                   </tr>
@@ -624,8 +622,6 @@ export const testResultQuery = gql`
       patientLink {
         internalId
       }
-      symptoms
-      noSymptoms
     }
   }
 `;

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -342,11 +342,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   <th
                     scope="col"
                   >
-                    Symptoms
-                  </th>
-                  <th
-                    scope="col"
-                  >
                     Submitter
                   </th>
                   <th
@@ -381,9 +376,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   </td>
                   <td>
                     Abbott IDNow
-                  </td>
-                  <td>
-                    Yes
                   </td>
                   <td>
                     Entry, Ethan
@@ -447,9 +439,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                     Abbott IDNow
                   </td>
                   <td>
-                    Unknown
-                  </td>
-                  <td>
                     User, Ursula
                   </td>
                   <td>
@@ -509,9 +498,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   </td>
                   <td>
                     Abbott IDNow
-                  </td>
-                  <td>
-                    No
                   </td>
                   <td>
                     Admin, Arthur A

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2247,8 +2247,6 @@ export type GetFacilityResultsQuery = {
             dateTested?: any | null | undefined;
             result?: string | null | undefined;
             correctionStatus?: string | null | undefined;
-            symptoms?: string | null | undefined;
-            noSymptoms?: boolean | null | undefined;
             deviceType?:
               | { __typename?: "DeviceType"; internalId: string; name: string }
               | null
@@ -6227,8 +6225,6 @@ export const GetFacilityResultsDocument = gql`
       patientLink {
         internalId
       }
-      symptoms
-      noSymptoms
     }
   }
 `;


### PR DESCRIPTION
## Related Issue

- Resolves #3489 

## Changes Proposed

- Removes the symptoms column from the results table
- Alters the GraphQL query to no longer request the symptoms data

## Testing

- Visit dev, view table without symptoms column
 
## Screenshots / Demos

<img width="1477" alt="Screen Shot 2022-04-01 at 12 38 03 PM" src="https://user-images.githubusercontent.com/9121162/161330445-9d68dace-1c45-4ba3-a94f-a20db66d33a5.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
