### PR TITLE
Add test correction workflow (backend)

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -282,7 +282,7 @@ public class TestEventExport {
   public String getTestResultStatus() {
     // F Final results
     // W Post original as wrong, e.g., transmitted for wrong patient
-    // C Corrected, final (not yet supported
+    // C Corrected, final
     switch (testEvent.getCorrectionStatus()) {
       case REMOVED:
         return "W";
@@ -312,7 +312,7 @@ public class TestEventExport {
   public String getObservationResultStatus() {
     // F Final results
     // W Post original as wrong, e.g., transmitted for wrong patient
-    // C Corrected, final (not yet supported
+    // C Corrected, final
     switch (testEvent.getCorrectionStatus()) {
       case REMOVED:
         return "W";

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -294,6 +294,37 @@ public class TestEventExport {
     }
   }
 
+  @JsonProperty("Order_result_status")
+  public String getOrderResultStatus() {
+    // F Final results
+    // C Corrected to results (includes removal)
+    switch (testEvent.getCorrectionStatus()) {
+      case REMOVED:
+      case CORRECTED:
+        return "C";
+      case ORIGINAL:
+      default:
+        return "F";
+    }
+  }
+
+  // TODO: duplicate of Test_result_status for now
+  @JsonProperty("Observation_result_status")
+  public String getObservationResultStatus() {
+    // F Final results
+    // W Post original as wrong, e.g., transmitted for wrong patient
+    // C Corrected, final (not yet supported
+    switch (testEvent.getCorrectionStatus()) {
+      case REMOVED:
+        return "W";
+      case CORRECTED:
+        return "C";
+      case ORIGINAL:
+      default:
+        return "F";
+    }
+  }
+
   @JsonProperty("Test_result_code")
   public String getTestResult() {
     return testResultMap.get(testEvent.getResult());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -308,7 +308,6 @@ public class TestEventExport {
     }
   }
 
-  // TODO: duplicate of Test_result_status for now
   @JsonProperty("Observation_result_status")
   public String getObservationResultStatus() {
     // F Final results

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.api.testresult;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
@@ -59,13 +58,11 @@ public class TestResultResolver implements GraphQLQueryResolver, GraphQLMutation
         endDate);
   }
 
-  public TestEvent correctTestMarkAsError(UUID id, String reasonForCorrection)
-      throws JsonProcessingException {
+  public TestEvent correctTestMarkAsError(UUID id, String reasonForCorrection) {
     return tos.correctTestMarkAsError(id, TestCorrectionStatus.REMOVED, reasonForCorrection);
   }
 
-  public TestEvent correctTestMarkAsCorrection(UUID id, String reasonForCorrection)
-      throws JsonProcessingException {
+  public TestEvent correctTestMarkAsCorrection(UUID id, String reasonForCorrection) {
     return tos.correctTestMarkAsError(id, TestCorrectionStatus.CORRECTED, reasonForCorrection);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -1,9 +1,11 @@
 package gov.cdc.usds.simplereport.api.testresult;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
@@ -57,8 +59,14 @@ public class TestResultResolver implements GraphQLQueryResolver, GraphQLMutation
         endDate);
   }
 
-  public TestEvent correctTestMarkAsError(UUID id, String reasonForCorrection) {
-    return tos.correctTestMarkAsError(id, reasonForCorrection);
+  public TestEvent correctTestMarkAsError(UUID id, String reasonForCorrection)
+      throws JsonProcessingException {
+    return tos.correctTestMarkAsError(id, TestCorrectionStatus.REMOVED, reasonForCorrection);
+  }
+
+  public TestEvent correctTestMarkAsCorrection(UUID id, String reasonForCorrection)
+      throws JsonProcessingException {
+    return tos.correctTestMarkAsError(id, TestCorrectionStatus.CORRECTED, reasonForCorrection);
   }
 
   public TestEvent getTestResult(UUID id) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -4,7 +4,6 @@ import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
-import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
@@ -59,11 +58,11 @@ public class TestResultResolver implements GraphQLQueryResolver, GraphQLMutation
   }
 
   public TestEvent correctTestMarkAsError(UUID id, String reasonForCorrection) {
-    return tos.correctTestMarkAsError(id, TestCorrectionStatus.REMOVED, reasonForCorrection);
+    return tos.markAsError(id, reasonForCorrection);
   }
 
   public TestEvent correctTestMarkAsCorrection(UUID id, String reasonForCorrection) {
-    return tos.correctTestMarkAsError(id, TestCorrectionStatus.CORRECTED, reasonForCorrection);
+    return tos.markAsCorrection(id, reasonForCorrection);
   }
 
   public TestEvent getTestResult(UUID id) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -87,7 +87,6 @@ public class TestEvent extends BaseTestInfo {
     this.priorCorrectedTestEventId = event.getInternalId();
   }
 
-  // TODO: is there a better way of doing this?
   public TestEvent(
       TestOrder order, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
     super(order, correctionStatus, reasonForCorrection);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -87,6 +87,21 @@ public class TestEvent extends BaseTestInfo {
     this.priorCorrectedTestEventId = event.getInternalId();
   }
 
+  // TODO: is there a better way of doing this?
+  public TestEvent(
+      TestOrder order, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
+    super(order, correctionStatus, reasonForCorrection);
+
+    TestEvent event = order.getTestEvent();
+
+    this.patientData = event.getPatientData();
+    this.providerData = event.getProviderData();
+    this.order = order;
+    this.surveyData = event.getSurveyData();
+    setDateTestedBackdate(order.getDateTestedBackdate());
+    this.priorCorrectedTestEventId = event.getInternalId();
+  }
+
   public UUID getPatientInternalID() {
     return getPatient().getInternalId();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -84,6 +84,10 @@ public class TestOrder extends BaseTestInfo {
     orderStatus = OrderStatus.COMPLETED;
   }
 
+  public void markPending() {
+    orderStatus = OrderStatus.PENDING;
+  }
+
   public void cancelOrder() {
     orderStatus = OrderStatus.CANCELED;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -238,8 +238,7 @@ public class TestOrderService {
   @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
   @Transactional(noRollbackFor = {TwilioException.class, ApiException.class})
   public AddTestResultResponse addTestResult(
-      UUID deviceSpecimenTypeId, TestResult result, UUID patientId, Date dateTested)
-      {
+      UUID deviceSpecimenTypeId, TestResult result, UUID patientId, Date dateTested) {
     Organization org = _os.getCurrentOrganization();
     Person person = _ps.getPatientNoPermissionsCheck(patientId, org);
     TestOrder order =
@@ -260,8 +259,7 @@ public class TestOrderService {
       TestEvent testEvent =
           order.getCorrectionStatus() == TestCorrectionStatus.ORIGINAL
               ? new TestEvent(order, hasPriorTests)
-              : new TestEvent(
-                  order, order.getCorrectionStatus(), order.getReasonForCorrection());
+              : new TestEvent(order, order.getCorrectionStatus(), order.getReasonForCorrection());
 
       _terepo.save(testEvent);
 
@@ -405,8 +403,7 @@ public class TestOrderService {
   @Transactional
   @AuthorizationConfiguration.RequirePermissionUpdateTestForTestEvent
   public TestEvent correctTestMarkAsError(
-      UUID testEventId, TestCorrectionStatus status, String reasonForCorrection)
-      {
+      UUID testEventId, TestCorrectionStatus status, String reasonForCorrection) {
     Organization org = _os.getCurrentOrganization(); // always check against org
     // The client sends us a TestEvent, we need to map back to the Order.
     TestEvent event = _terepo.findByOrganizationAndInternalId(org, testEventId);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -402,7 +402,7 @@ public class TestOrderService {
 
   @Transactional
   @AuthorizationConfiguration.RequirePermissionUpdateTestForTestEvent
-  public TestEvent correctTestMarkAsError(
+  public TestEvent correctTest(
       UUID testEventId, TestCorrectionStatus status, String reasonForCorrection) {
     Organization org = _os.getCurrentOrganization(); // always check against org
     // The client sends us a TestEvent, we need to map back to the Order.
@@ -443,32 +443,26 @@ public class TestOrderService {
     _terepo.save(newRemoveEvent);
     _testEventReportingService.report(newRemoveEvent);
 
-    // order having reason text is way more useful when we allow actual corrections
-    // not just
-    // deletes.
     order.setReasonForCorrection(reasonForCorrection);
     order.setTestEventRef(newRemoveEvent);
 
-    // order.setOrderStatus(OrderStatus.CANCELED); NO: this makes it disappear.
-
-    // We currently don't do anything special with this CorrectionStatus on the
-    // order, but in the
-    // next
-    // refactor, we will set this to TestCorrectionStatus.CORRECTED and it will go
-    // back into the
-    // queue to
-    // be corrected.
     order.setCorrectionStatus(TestCorrectionStatus.REMOVED);
 
-    // NOTE: WHEN we support actual corrections (versus just deleting). Make sure to
-    // think about the
-    // TestOrder.dateTestedBackdate field.
-    // For example: when viewing the list of past TestEvents, and you see a
-    // correction,
-    // what date should be shown if the original test being corrected was backdated?
     _repo.save(order);
 
     return newRemoveEvent;
+  }
+
+  @Transactional
+  @AuthorizationConfiguration.RequirePermissionUpdateTestForTestEvent
+  public TestEvent markAsError(UUID testEventId, String reasonForCorrection) {
+    return correctTest(testEventId, TestCorrectionStatus.REMOVED, reasonForCorrection);
+  }
+
+  @Transactional
+  @AuthorizationConfiguration.RequirePermissionUpdateTestForTestEvent
+  public TestEvent markAsCorrection(UUID testEventId, String reasonForCorrection) {
+    return correctTest(testEventId, TestCorrectionStatus.CORRECTED, reasonForCorrection);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -31,7 +31,8 @@ type Facility {
   email: String
   deviceTypes: [DeviceType]
   defaultDeviceSpecimen: ID
-  deviceSpecimenTypes: [DeviceSpecimenType] @deprecated(reason: "kept for compatibility")
+  deviceSpecimenTypes: [DeviceSpecimenType]
+    @deprecated(reason: "kept for compatibility")
   defaultDeviceType: DeviceType @deprecated(reason: "kept for compatibility")
   orderingProvider: Provider
   patientSelfRegistrationLink: String
@@ -502,7 +503,8 @@ type Mutation {
   ): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   resetUserPassword(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   resetUserMfa(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
-  updateUserEmail(id: ID!, email: String): User @requiredPermissions(allOf: ["MANAGE_USERS"])
+  updateUserEmail(id: ID!, email: String): User
+    @requiredPermissions(allOf: ["MANAGE_USERS"])
   setUserIsDeleted(id: ID!, deleted: Boolean!): User
     @requiredPermissions(allOf: ["MANAGE_USERS"])
   reactivateUser(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
@@ -594,6 +596,8 @@ type Mutation {
   ): TestOrder @requiredPermissions(allOf: ["UPDATE_TEST"])
   correctTestMarkAsError(id: ID!, reason: String): TestResult
     @requiredPermissions(allOf: ["UPDATE_TEST"])
+  correctTestMarkAsCorrection(id: ID!, reason: String): TestResult
+    @requiredPermissions(allOf: ["UPDATE_TEST"])
   addPatientToQueue(
     facilityId: ID!
     patientId: ID!
@@ -616,7 +620,7 @@ type Mutation {
   sendPatientLinkSms(internalId: ID!): Boolean
     @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkSmsByTestEventId(testEventId: ID!): Boolean
-  @requiredPermissions(allOf: ["UPDATE_TEST"])
+    @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkEmail(internalId: ID!): Boolean
   sendPatientLinkEmailByTestEventId(testEventId: ID!): Boolean
   updateOrganization(type: String!): String

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -194,7 +194,6 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + testEvent.getInternalId().toString()
             + "\","
             + "\"Test_correction_reason\":\"Cold feet\","
-            // + "\"Test_result_status\":\"W\","
             + "\"Order_result_status\":\"C\","
             + "\"Observation_result_status\":\"C\","
             + "\"Test_result_code\":\"260415000\","
@@ -296,7 +295,6 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + testEvent.getInternalId().toString()
             + "\","
             + "\"Test_correction_reason\":\"Cold feet\","
-            // + "\"Test_result_status\":\"W\","
             + "\"Order_result_status\":\"C\","
             + "\"Observation_result_status\":\"W\","
             + "\"Test_result_code\":\"260415000\","

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -156,6 +156,108 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
 
   @Test
   void testCorrectedEventSerialization() throws Exception {
+    TestEvent correctedTestEvent = _dataFactory.createTestEventCorrected(testEvent);
+    TestEventExport correctedTestEventExport = new TestEventExport(correctedTestEvent);
+
+    String actualStr = objectMapper.writeValueAsString(correctedTestEventExport);
+    JSONAssert.assertEquals(
+        "{"
+            + "\"Patient_last_name\":\"Astaire\","
+            + "\"Patient_first_name\":\"Fred\","
+            + "\"Patient_middle_name\":\"M\","
+            + "\"Patient_suffix\":null,"
+            + "\"Patient_race\":\"2106-3\","
+            + "\"Patient_DOB\":\"18990510\","
+            + "\"Patient_gender\":\"M\","
+            + "\"Patient_ethnicity\":\"N\","
+            + "\"Patient_street\":\"736 Jackson PI NW\","
+            + "\"Patient_street_2\":\"APT. 123\","
+            + "\"Patient_city\":\"Washington\","
+            + "\"Patient_county\":\"Washington\","
+            + "\"Patient_state\":\"DC\","
+            + "\"Patient_zip_code\":\"20503\","
+            + "\"Patient_country\":\"USA\","
+            + "\"Patient_phone_number\":\"202-123-4567\","
+            + "\"Patient_email\":\"fred@astaire.com\","
+            + "\"Patient_ID\":"
+            + correctedTestEventExport.getPatientId()
+            + ","
+            + "\"Patient_role\":\"RESIDENT\","
+            + "\"Patient_tribal_affiliation\":\"\","
+            + "\"Patient_preferred_language\":\"English\","
+            + "\"Employed_in_healthcare\":\"N\","
+            + "\"Resident_congregate_setting\":\"N\","
+            + "\"Result_ID\":"
+            + correctedTestEventExport.getResultID()
+            + ","
+            + "\"Corrected_result_ID\":\""
+            + testEvent.getInternalId().toString()
+            + "\","
+            + "\"Test_correction_reason\":\"Cold feet\","
+            // + "\"Test_result_status\":\"W\","
+            + "\"Order_result_status\":\"C\","
+            + "\"Observation_result_status\":\"C\","
+            + "\"Test_result_code\":\"260415000\","
+            + "\"Specimen_collection_date_time\":\""
+            + correctedTestEventExport.getSpecimenCollectionDateTime()
+            + "\","
+            + "\"Ordering_provider_ID\":\"PEBBLES\","
+            + "\"First_test\":\"UNK\","
+            + "\"Symptomatic_for_disease\":\"UNK\","
+            + "\"Illness_onset_date\":\"\","
+            + "\"Testing_lab_name\":\"Injection Site\","
+            + "\"Testing_lab_CLIA\":\"000111222-3\","
+            + "\"Testing_lab_state\":null,"
+            + "\"Testing_lab_street\":\"2797 N Cerrada de Beto\","
+            + "\"Testing_lab_street_2\":\"\","
+            + "\"Testing_lab_zip_code\":null,"
+            + "\"Testing_lab_county\":null,"
+            + "\"Testing_lab_phone_number\":null,"
+            + "\"Testing_lab_city\":null,"
+            + "\"Processing_mode_code\":\"P\","
+            + "\"Ordering_facility_city\":null,"
+            + "\"Ordering_facility_county\":null,"
+            + "\"Ordering_facility_name\":\"Injection Site\","
+            + "\"Organization_name\":\"Dis Organization\","
+            + "\"Ordering_facility_phone_number\":null,"
+            + "\"Ordering_facility_email\":null,"
+            + "\"Ordering_facility_state\":null,"
+            + "\"Ordering_facility_street\":\"2797 N Cerrada de Beto\","
+            + "\"Ordering_facility_street_2\":\"\","
+            + "\"Ordering_facility_zip_code\":null,"
+            + "\"Ordering_provider_last_name\":\"Flintstone\","
+            + "\"Ordering_provider_first_name\":\"Fred\","
+            + "\"Ordering_provider_street\":\"123 Main Street\","
+            + "\"Ordering_provider_street_2\":\"\","
+            + "\"Ordering_provider_city\":\"Oz\","
+            + "\"Ordering_provider_state\":\"KS\","
+            + "\"Ordering_provider_zip_code\":null,"
+            + "\"Ordering_provider_county\":null,"
+            + "\"Ordering_provider_phone_number\":\"(202) 555-1212\","
+            + "\"Ordered_test_code\":\"95209-3\","
+            + "\"Specimen_source_site_code\":\"71836000\","
+            + "\"Specimen_type_code\":\"445297001\","
+            + "\"Instrument_ID\":"
+            + correctedTestEventExport.getInstrumentID()
+            + ","
+            + "\"Device_ID\":\"LumiraDx SARS-CoV-2 Ag Test*\","
+            + "\"Test_date\":\""
+            + correctedTestEventExport.getTestDate()
+            + "\","
+            + "\"Date_result_released\":\""
+            + correctedTestEventExport.getDateResultReleased()
+            + "\","
+            + "\"Order_test_date\":\""
+            + correctedTestEventExport.getOrderTestDate()
+            + "\","
+            + "\"Site_of_care\":\"university\""
+            + "}",
+        actualStr,
+        false);
+  }
+
+  @Test
+  void testRemovedEventSerialization() throws Exception {
     TestEvent correctedTestEvent = _dataFactory.createTestEventRemoval(testEvent);
     TestEventExport correctedTestEventExport = new TestEventExport(correctedTestEvent);
 
@@ -194,7 +296,9 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + testEvent.getInternalId().toString()
             + "\","
             + "\"Test_correction_reason\":\"Cold feet\","
-            + "\"Test_result_status\":\"W\","
+            // + "\"Test_result_status\":\"W\","
+            + "\"Order_result_status\":\"C\","
+            + "\"Observation_result_status\":\"W\","
             + "\"Test_result_code\":\"260415000\","
             + "\"Specimen_collection_date_time\":\""
             + correctedTestEventExport.getSpecimenCollectionDateTime()

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -561,8 +561,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // Mark existing test order as "corrected", re-open as "pending" order status
     TestEvent originalTestEvent = testEvents.get(0);
-    _service.correctTestMarkAsError(
-        originalTestEvent.getInternalId(), TestCorrectionStatus.CORRECTED, "Cold feet");
+    _service.markAsCorrection(originalTestEvent.getInternalId(), "Cold feet");
 
     // Issue test correction
     _service.addTestResult(devA.getInternalId(), TestResult.NEGATIVE, p.getInternalId(), null);
@@ -1111,9 +1110,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder _o = _e.getTestOrder();
 
     String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    TestEvent deleteMarkerEvent =
-        _service.correctTestMarkAsError(
-            _e.getInternalId(), TestCorrectionStatus.REMOVED, reasonMsg);
+    TestEvent deleteMarkerEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
     assertNotNull(deleteMarkerEvent);
 
     assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
@@ -1162,9 +1159,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
 
     // A test correction call just returns the original TestEvent...
-    TestEvent originalEvent =
-        _service.correctTestMarkAsError(
-            e.getInternalId(), TestCorrectionStatus.CORRECTED, reasonMsg);
+    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
 
     // ...but re-opens the original TestOrder and updates correction status
     TestOrder updatedOrder = originalEvent.getTestOrder();
@@ -1497,10 +1492,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
     assertThrows(
-        AccessDeniedException.class,
-        () ->
-            _service.correctTestMarkAsError(
-                _e.getInternalId(), TestCorrectionStatus.REMOVED, reasonMsg));
+        AccessDeniedException.class, () -> _service.markAsError(_e.getInternalId(), reasonMsg));
     assertThrows(
         AccessDeniedException.class,
         () ->
@@ -1514,9 +1506,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     verifyNoInteractions(testEventReportingService);
 
     TestUserIdentities.setFacilityAuthorities(facility);
-    TestEvent correctedTestEvent =
-        _service.correctTestMarkAsError(
-            _e.getInternalId(), TestCorrectionStatus.REMOVED, reasonMsg);
+    TestEvent correctedTestEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
     _service.getTestEventsResults(facility.getInternalId(), null, null, null, null, null, 0, 10);
     _service.getTestResult(_e.getInternalId()).getTestOrder();
     // make sure the corrected event is sent to storage queue

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -43,6 +43,7 @@ import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -579,7 +580,10 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertEquals("Cold feet", correctionTestEvent.getReasonForCorrection());
     assertEquals(TestResult.NEGATIVE, correctionTestEvent.getResult());
     // Date of original test is overwritten by the new correction event
-    assertNotEquals(LocalDate.of(1865, 12, 25), correctionTestEvent.getDateTested());
+    assertNotEquals(
+        LocalDate.of(1865, 12, 25),
+        LocalDate.ofInstant(
+            correctionTestEvent.getDateTested().toInstant(), ZoneId.systemDefault()));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1070,7 +1070,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder _o = _e.getTestOrder();
 
     String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    TestEvent deleteMarkerEvent = _service.correctTestMarkAsError(_e.getInternalId(), reasonMsg);
+    TestEvent deleteMarkerEvent = _service.correctTestMarkAsError(_e.getInternalId(), TestCorrectionStatus.REMOVED, reasonMsg);
     assertNotNull(deleteMarkerEvent);
 
     assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
@@ -1421,7 +1421,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
     assertThrows(
         AccessDeniedException.class,
-        () -> _service.correctTestMarkAsError(_e.getInternalId(), reasonMsg));
+        () -> _service.correctTestMarkAsError(_e.getInternalId(), TestCorrectionStatus.REMOVED, reasonMsg));
     assertThrows(
         AccessDeniedException.class,
         () ->
@@ -1435,7 +1435,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     verifyNoInteractions(testEventReportingService);
 
     TestUserIdentities.setFacilityAuthorities(facility);
-    TestEvent correctedTestEvent = _service.correctTestMarkAsError(_e.getInternalId(), reasonMsg);
+    TestEvent correctedTestEvent = _service.correctTestMarkAsError(_e.getInternalId(), TestCorrectionStatus.REMOVED, reasonMsg);
     _service.getTestEventsResults(facility.getInternalId(), null, null, null, null, null, 0, 10);
     _service.getTestResult(_e.getInternalId()).getTestOrder();
     // make sure the corrected event is sent to storage queue

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -578,7 +578,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertEquals(TestCorrectionStatus.CORRECTED, correctionTestEvent.getCorrectionStatus());
     assertEquals("Cold feet", correctionTestEvent.getReasonForCorrection());
     assertEquals(TestResult.NEGATIVE, correctionTestEvent.getResult());
-    // think about the dates here - how's backdating look?
+    // Date of original test is overwritten by the new correction event
+    assertNotEquals(LocalDate.of(1865, 12, 25), correctionTestEvent.getDateTested());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -383,6 +383,11 @@ public class TestDataFactory {
     return e;
   }
 
+  public TestEvent createTestEventCorrected(TestEvent originalTestEvent) {
+    return _testEventRepo.save(
+        new TestEvent(originalTestEvent, TestCorrectionStatus.CORRECTED, "Cold feet"));
+  }
+
   public TestEvent createTestEventRemoval(TestEvent originalTestEvent) {
     return _testEventRepo.save(
         new TestEvent(originalTestEvent, TestCorrectionStatus.REMOVED, "Cold feet"));

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -135,6 +135,7 @@ export type Mutation = {
   addUser?: Maybe<User>;
   addUserToCurrentOrg?: Maybe<User>;
   adminUpdateOrganization?: Maybe<Scalars["String"]>;
+  correctTestMarkAsCorrection?: Maybe<TestResult>;
   correctTestMarkAsError?: Maybe<TestResult>;
   createDeviceType?: Maybe<DeviceType>;
   createFacilityRegistrationLink?: Maybe<Scalars["String"]>;
@@ -294,6 +295,11 @@ export type MutationAddUserToCurrentOrgArgs = {
 export type MutationAdminUpdateOrganizationArgs = {
   name: Scalars["String"];
   type: Scalars["String"];
+};
+
+export type MutationCorrectTestMarkAsCorrectionArgs = {
+  id: Scalars["ID"];
+  reason?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationCorrectTestMarkAsErrorArgs = {


### PR DESCRIPTION
## Related Issue
- #3417 
- Currently, "correcting" a test is a piecemeal process:
    - First, the original test is submitted as usual and a `test_event` is created in the database
    - When the user marks that test as an error, a _second_ `test_event` is created, signaling to ReportStream that the previous test should be ignored
    - The user can then submit another, entirely different test for the patient, which acts as the replacement.
- This is a grand total of three `test_events` created to issue a single correction!
- Fortunately, ReportStream supports issuing true corrections using only _two_ messages: the original, and a second `CORRECTED` event that fully replaces the original
- This is done by adding two more fields to SimpleReport's exported test events:
    - `order_result_status` ([reference](https://hl7-definition.caristix.com/v2/HL7v2.6/Tables/0123))
    - `observation_result_status` ([reference](https://hl7-definition.caristix.com/v2/HL7v2.6/Tables/0085))
        - This is identical to the field we are currently sending as `Test_result_status`
   - ReportStream uses the `Corrected_result_ID` value from the message to know which test to replace
   - <img width="473" alt="Screen Shot 2022-03-29 at 2 05 16 PM" src="https://user-images.githubusercontent.com/27730981/161806265-4ee3d78a-4a0d-4e8c-87f7-c81e4bb101ef.png">

## Changes Proposed
- Adds a `correctTestMarkAsCorrected` GraphQL mutation that re-opens the specified test and prepares for a new correction event to be created
- Exports new `Order_result_status` and `Observation_result_status` in events sent to ReportStream
- Adds a new `TestEvent` constructor that accepts a _test order_ and a correction status and reason
    - Since `TestEvent`s are immutable by design (via protected setters), any test corrections must be made _on the test order_ and a new event created from those changes

## Additional Information
- This **should not** introduce any changes to the user experience. This is a backend-only patch. The new mutation will not be accessible to users via the UI or other means.
    - If you see something that may affect the user experience, please shout it out!
- Test corrections do not appear as rows in the Results list view
    - My understanding is that this is desired, but please let me know if you feel otherwise

## Testing
- Please verify that the `date_tested_backdate` column is correctly populated for removed or corrected test events
- Please verify that no UI changes could result from this patch

## Acceptance validation
### Mark as error (existing functionality)
1. Submit a test result in the ordinary fashion
    - <img width="489" alt="Screen Shot 2022-04-05 at 12 13 07 PM" src="https://user-images.githubusercontent.com/27730981/161800255-26133d14-18a8-4974-8540-42dd0c49b1f2.png">
    - <img width="806" alt="Screen Shot 2022-04-05 at 12 13 33 PM" src="https://user-images.githubusercontent.com/27730981/161800257-986dcef8-e1be-43f3-8705-ba067286ad2d.png">
    - <img width="569" alt="Screen Shot 2022-04-05 at 12 14 18 PM" src="https://user-images.githubusercontent.com/27730981/161800260-443d8c22-4136-4a4a-91d9-98470aa8c261.png">
2. Mark completed test as error
    - <img width="1" alt="Screen Shot 2022-04-05 at 12 14 26 PM" src="https://user-images.githubusercontent.com/27730981/161800262-f4d8427f-0a21-49dc-a164-25246ca790c2.png">
    - <img width="830" alt="Screen Shot 2022-04-05 at 12 14 36 PM" src="https://user-images.githubusercontent.com/27730981/161800263-24cc761c-dac6-4565-a890-ebaa1e151d46.png">
     - <img width="762" alt="Screen Shot 2022-04-05 at 12 14 53 PM" src="https://user-images.githubusercontent.com/27730981/161800266-0c1b9f44-d86f-49ff-8775-d23593485986.png">
 3. Verify that a `REMOVED` test event was created, and verify that is correctly points to the original test 
    - <img width="760" alt="Screen Shot 2022-04-05 at 12 26 05 PM" src="https://user-images.githubusercontent.com/27730981/161801304-d05136f5-e2e7-4f69-8771-e19c6029b341.png">

### Mark as correction (new functionality)
1. Submit a test result in the normal fashion
    - <img width="581" alt="Screen Shot 2022-04-05 at 12 16 20 PM" src="https://user-images.githubusercontent.com/27730981/161800275-59a1cc67-32ef-4da3-8cb2-c644be20b92f.png">
2. Re-open the original test as a correction
    - Hitting the GraphQL endpoint directly for this until the UI is implemented
    - <img width="1033" alt="Screen Shot 2022-04-05 at 12 17 19 PM" src="https://user-images.githubusercontent.com/27730981/161800276-e815568f-7183-416c-accd-7d4372772074.png">
3. Verify that a second test event was _not_ created by this action
   - Marking a test as an error _does_ cause a second `REMOVED` test event to be created immediately
   - <img width="578" alt="Screen Shot 2022-04-05 at 12 17 31 PM" src="https://user-images.githubusercontent.com/27730981/161800277-dbeafdb6-29f1-4a73-b88a-044d9d57ee1e.png">
4. Verify that the original test re-appears in the queue, having been marked as `PENDING`
    - <img width="821" alt="Screen Shot 2022-04-05 at 12 18 30 PM" src="https://user-images.githubusercontent.com/27730981/161800280-c8908ad1-89d2-4b06-b840-0abf66c4a83b.png">
5. Re-submit the test using updated values
    - <img width="540" alt="Screen Shot 2022-04-05 at 12 18 39 PM" src="https://user-images.githubusercontent.com/27730981/161800282-b2289e5c-5b7d-476f-aa4d-6ae906aa6519.png">
6. Verify that a `CORRECTED` test event was created, and that it points to the original test event
    - <img width="760" alt="Screen Shot 2022-04-05 at 12 25 03 PM" src="https://user-images.githubusercontent.com/27730981/161821434-b4ef24dc-a3c6-4e0c-aa87-b90fc05beb3b.png">

8. Verify that the corrected test appears in the Results list and is indicated as having been successfully completed
<img width="771" alt="Screen Shot 2022-04-05 at 12 19 16 PM" src="https://user-images.githubusercontent.com/27730981/161800289-ad4008cd-b252-4c43-80a3-9da0fe118bf1.png">

## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed