### PR TITLE
Re-enable stg in CI and move it to App Service V3

### DIFF
--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -12,116 +12,110 @@ concurrency:
   group: stg-deploy
 
 jobs:
-  # Remove this job and re-enable the old ones after stg is recreated
-  bypass-stg:
+  build-docker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ACR
+        run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
+      - name: Build and push Docker images
+        run: ./build_and_push.sh
+  prerelease-backend:
+    runs-on: ubuntu-latest
+    needs: build-docker
+    defaults:
+      run:
+        working-directory: ./ops
+    env: # all Azure interaction is through terraform
+      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+      OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.1.4
+      - name: Terraform Init
+        run: make init-${{ env.DEPLOY_ENV }}
+      - name: Terraform deploy (infrastructure and staging slot)
+        run: make deploy-${{ env.DEPLOY_ENV }}
+      - name: Wait for correct release to be deployed in staging slot
+        timeout-minutes: 5
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
+      - name: Wait for staging deploy to be ready
+        timeout-minutes: 1
+        run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - name: bypass-stg
-        run: echo Bypassing stg
-  # build-docker:
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       working-directory: ./backend
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v1
-  #     - name: Login to ACR
-  #       run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
-  #     - name: Build and push Docker images
-  #       run: ./build_and_push.sh
-  # prerelease-backend:
-  #   runs-on: ubuntu-latest
-  #   needs: build-docker
-  #   defaults:
-  #     run:
-  #       working-directory: ./ops
-  #   env: # all Azure interaction is through terraform
-  #     ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-  #     ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-  #     ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-  #     ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-  #     OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #     - uses: hashicorp/setup-terraform@v1
-  #       with:
-  #         terraform_version: 1.1.4
-  #     - name: Terraform Init
-  #       run: make init-${{ env.DEPLOY_ENV }}
-  #     - name: Terraform deploy (infrastructure and staging slot)
-  #       run: make deploy-${{ env.DEPLOY_ENV }}
-  #     - name: Wait for correct release to be deployed in staging slot
-  #       timeout-minutes: 5
-  #       run: make wait-for-${{ env.DEPLOY_ENV }}-slot-commit
-  #     - name: Wait for staging deploy to be ready
-  #       timeout-minutes: 1
-  #       run: make wait-for-${{ env.DEPLOY_ENV }}-slot-readiness
-  # build-frontend:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2.1.5
-  #       with:
-  #         node-version: ${{env.NODE_VERSION}}
-  #     - name: Use cache for node_modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ./frontend/node_modules
-  #         key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
-  #     - uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #     - uses: ./.github/actions/build-frontend
-  #       name: Build front-end application
-  #       with:
-  #         deploy-env: ${{env.DEPLOY_ENV}}
-  #         smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
-  #         client-tarball: ./client.tgz
-  #         okta-enabled: true
-  #         okta-url: https://hhs-prime.okta.com
-  #         okta-client-id: 0oa62qncijWSeQMuc4h6
-  #     - name: Save compiled frontend application
-  #       uses: actions/upload-artifact@v2
-  #       if: success()
-  #       with:
-  #         name: frontend-tarball
-  #         path: client.tgz
-  #         retention-days: 1
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: Staging
-  #     url: https://stg.simplereport.gov
-  #   needs: [build-frontend, prerelease-backend]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #     - name: Retrieve frontend build
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: frontend-tarball
-  #     - name: Promote and deploy
-  #       uses: ./.github/actions/deploy-application
-  #       with:
-  #         client-tarball: client.tgz
-  #         deploy-env: ${{env.DEPLOY_ENV}}
-  # verify-release:
-  #   runs-on: ubuntu-latest
-  #   needs: [deploy]
-  #   defaults:
-  #     run:
-  #       working-directory: ./ops
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Run health checks
-  #       uses: ./.github/actions/health-checks
-  #       with:
-  #         deploy-env: ${{env.DEPLOY_ENV}}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{env.NODE_VERSION}}
+      - name: Use cache for node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./frontend/node_modules
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/yarn.lock', 'frontend/package.json') }}
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - uses: ./.github/actions/build-frontend
+        name: Build front-end application
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}
+          smarty-streets-key: ${{ secrets.SMARTY_STREETS_KEY }}
+          client-tarball: ./client.tgz
+          okta-enabled: true
+          okta-url: https://hhs-prime.okta.com
+          okta-client-id: 0oa62qncijWSeQMuc4h6
+      - name: Save compiled frontend application
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: frontend-tarball
+          path: client.tgz
+          retention-days: 1
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Staging
+      url: https://stg.simplereport.gov
+    needs: [build-frontend, prerelease-backend]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Retrieve frontend build
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend-tarball
+      - name: Promote and deploy
+        uses: ./.github/actions/deploy-application
+        with:
+          client-tarball: client.tgz
+          deploy-env: ${{env.DEPLOY_ENV}}
+  verify-release:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    defaults:
+      run:
+        working-directory: ./ops
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run health checks
+        uses: ./.github/actions/health-checks
+        with:
+          deploy-env: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -24,13 +24,9 @@ jobs:
   check-terraform-validity:
     runs-on: ubuntu-latest
     env:
-      # TODO: re-enable once stg is recreated
-      # dev dev/persistent test test/persistent demo demo/persistent training training/persistent
-      # stg stg/persistent pentest pentest/persistent prod prod/persistent
-      # global
       TERRAFORM_DIRS: |
           dev dev/persistent test test/persistent demo demo/persistent training training/persistent
-          pentest pentest/persistent prod prod/persistent
+          stg stg/persistent pentest pentest/persistent prod prod/persistent
           global
     steps:
       - uses: actions/checkout@v2

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -4,8 +4,8 @@ module "simple_report_api" {
   env    = local.env
 
   instance_count = 3
-  instance_tier  = "PremiumV2"
-  instance_size  = "P2v2"
+  instance_tier  = "PremiumV3"
+  instance_size  = "P2v3"
 
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #3370. Now that we've recreated the `stg` resource group, we're finally able to move `stg` to the V3 App Service Plan, meaning every env is now fully migrated to V3.

## Changes Proposed

- Re-enables `stg` in CI
- Moves the `stg` App Service Plan to V3

## Testing

- This is already applied and live in `stg` (safe to do in this case since `stg` isn't back in CI yet).
 
## Checklist for Primary Reviewer

### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification