### PR TITLE
Capture existing App Service state not in TF

### DIFF
--- a/ops/services/app_service/_data.tf
+++ b/ops/services/app_service/_data.tf
@@ -7,3 +7,8 @@ data "terraform_remote_state" "global" {
     key                  = "global/terraform.tfstate"
   }
 }
+
+data "azurerm_key_vault_certificate" "wildcard_simplereport_gov" {
+  key_vault_id = var.key_vault_id
+  name         = "wildcard-simplereport-gov"
+}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- In the process of fixing #3370, we discovered some additional App Service state not managed by Terraform.

## Changes Proposed

Added Terraform resources to capture existing config for the following:
- Associating the App Service with that environment's VNet (strangely, this was already present for the staging slot)
- The process of importing our certs into an App Service, creating a custom domain, and binding the cert to that domain (required for proper HTTPS when using a non-Azure-provided domain).
- Added some comments to capture what we learned trying to restore all of this to `stg`.

## Additional Information

- This config already exists in all envs, and this was tested when re-introducing this config into the new `stg` (where it wasn't already present)
- So, this PR will require a scripted series of `terraform import` statements to bring the existing resources into Terraform prior to merge. This means that the `terraform plan` will be wrong.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
