### PR TITLE
Remove db_query_duration alert from all envs.

### DIFF
--- a/ops/dev/alerts.tf
+++ b/ops/dev/alerts.tf
@@ -18,7 +18,6 @@ module "metric_alerts" {
     "account_request_failures",
     "experian_auth_failures",
     "frontend_error_boundary",
-    "db_query_duration",
     "db_query_duration_over_time_window",
     "db_connection_exhaustion",
     "batched_uploader_single_failure_detected",

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -27,7 +27,6 @@ variable "disabled_alerts" {
       "account_request_failures",
       "experian_auth_failures",
       "frontend_error_boundary",
-      "db_query_duration",
       "db_query_duration_over_time_window",
       "db_connection_exhaustion",
       "batched_uploader_single_failure_detected",

--- a/ops/services/alerts/app_service_metrics/database.tf
+++ b/ops/services/alerts/app_service_metrics/database.tf
@@ -1,31 +1,3 @@
-resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration" {
-  name                = "${var.env}-db-query-duration"
-  description         = "${local.env_title} DB query durations >= 10s"
-  location            = data.azurerm_resource_group.app.location
-  resource_group_name = var.rg_name
-  severity            = var.severity
-  frequency           = 5
-  time_window         = 5
-  enabled             = contains(var.disabled_alerts, "db_query_duration") ? false : true
-
-  data_source_id = var.app_insights_id
-
-  query = <<-QUERY
-dependencies
-${local.skip_on_weekends}
-| where timestamp >= ago(5m) and name has "SQL:" and duration >= 10000
-  QUERY
-
-  trigger {
-    operator  = "GreaterThan"
-    threshold = 0
-  }
-
-  action {
-    action_group = var.action_group_ids
-  }
-}
-
 resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_time_window" {
   name                = "${var.env}-db-query-duration-over-time-window"
   description         = "10+ DB queries with durations over 1.25s in the past 5 minutes"

--- a/ops/test/alerts.tf
+++ b/ops/test/alerts.tf
@@ -18,7 +18,6 @@ module "metric_alerts" {
     "account_request_failures",
     "experian_auth_failures",
     "frontend_error_boundary",
-    "db_query_duration",
     "db_query_duration_over_time_window",
     "db_connection_exhaustion",
     "batched_uploader_single_failure_detected",


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- This deletes a DB alert made irrelevant by the completion of #3577.

## Changes Proposed

- Remove the `db_query_duration` alert from TF, and all environments.

## Additional Information

- This leaves the alert for 10+ queries lasting more than 1.25 seconds in place, per team consensus. That alert can be removed at any time, if desired.

## Testing

- Verification of the results of `terraform plan` is the primary way to test this. 

## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

## Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

