### PR TITLE
Add test correction workflow (migration)

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3733,6 +3733,10 @@ databaseChangeLog:
       changes:
         - tagDatabase:
             tag: add-test-correction-columns
+        - sql:
+            remarks: Create the enumerations needed for tracking test order correction reasons
+            sql: |
+              CREATE TYPE ${database.defaultSchemaName}.TEST_CORRECTION_REASON as ENUM('DUPLICATE_TEST', 'INCORRECT_RESULT', 'INCORRECT_TEST_DATE', 'OTHER');
         - addColumn:
             tableName: test_order
             columns:
@@ -3749,8 +3753,8 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  name: additional_correction_information
-                  type: text
+                  name: correction_reason
+                  type: ${database.defaultSchemaName}.TEST_CORRECTION_REASON
                   constraints:
                     nullable: true
         - addColumn:
@@ -3769,7 +3773,17 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  name: additional_correction_information
-                  type: text
+                  name: correction_reason
+                  type: ${database.defaultSchemaName}.TEST_CORRECTION_REASON
                   constraints:
                     nullable: true
+        - sql:
+            remarks: 
+            sql: |
+              UPDATE ${database.defaultSchemaName}.test_order SET correction_reason='OTHER' WHERE reason_for_correction IS NOT NULL;
+              GRANT SELECT ON ${database.defaultSchemaName}.result TO ${noPhiUsername};
+      rollback:
+          sql: |
+            ALTER TABLE ${database.defaultSchemaName}.test_order DROP COLUMN corrected_by, DROP COLUMN corrected_at, DROP COLUMN correction_reason;
+            ALTER TABLE ${database.defaultSchemaName}.test_event DROP COLUMN corrected_by, DROP COLUMN corrected_at, DROP COLUMN correction_reason;
+            DROP TYPE ${database.defaultSchemaName}.TEST_CORRECTION_REASON;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3726,3 +3726,50 @@ databaseChangeLog:
       rollback:
         sql: |
           ALTER TABLE ${database.defaultSchemaName}.result DROP COLUMN test_result;
+  - changeSet:
+      id: add-test-correction-columns
+      author: nathan@skylight.digital
+      comment: Adds columns in support of test correction workflow
+      changes:
+        - tagDatabase:
+            tag: add-test-correction-columns
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: corrected_by
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__test_order__api_user
+                    references: api_user(internal_id)
+              - column:
+                  name: corrected_at
+                  type: DATETIME
+                  constraints:
+                    nullable: true
+              - column:
+                  name: additional_correction_information
+                  type: text
+                  constraints:
+                    nullable: true
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: corrected_by
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__test_event__api_user
+                    references: api_user(internal_id)
+              - column:
+                  name: corrected_at
+                  type: DATETIME
+                  constraints:
+                    nullable: true
+              - column:
+                  name: additional_correction_information
+                  type: text
+                  constraints:
+                    nullable: true

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3736,7 +3736,7 @@ databaseChangeLog:
         - sql:
             remarks: Create the enumerations needed for tracking test order correction reasons
             sql: |
-              CREATE TYPE ${database.defaultSchemaName}.TEST_CORRECTION_REASON as ENUM('DUPLICATE_TEST', 'INCORRECT_RESULT', 'INCORRECT_TEST_DATE', 'OTHER');
+              CREATE TYPE ${database.defaultSchemaName}.TEST_CORRECTION_TYPE as ENUM('DUPLICATE_TEST', 'INCORRECT_RESULT', 'INCORRECT_TEST_DATE', 'OTHER');
         - addColumn:
             tableName: test_order
             columns:
@@ -3753,8 +3753,8 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  name: correction_reason
-                  type: ${database.defaultSchemaName}.TEST_CORRECTION_REASON
+                  name: correction_type
+                  type: ${database.defaultSchemaName}.TEST_CORRECTION_TYPE
                   constraints:
                     nullable: true
         - addColumn:
@@ -3773,17 +3773,18 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  name: correction_reason
-                  type: ${database.defaultSchemaName}.TEST_CORRECTION_REASON
+                  name: correction_type
+                  type: ${database.defaultSchemaName}.TEST_CORRECTION_TYPE
                   constraints:
                     nullable: true
         - sql:
             remarks: 
             sql: |
-              UPDATE ${database.defaultSchemaName}.test_order SET correction_reason='OTHER' WHERE reason_for_correction IS NOT NULL;
+              UPDATE ${database.defaultSchemaName}.test_order SET correction_type='OTHER' WHERE reason_for_correction IS NOT NULL;
+              UPDATE ${database.defaultSchemaName}.test_event SET correction_type='OTHER' WHERE reason_for_correction IS NOT NULL;
               GRANT SELECT ON ${database.defaultSchemaName}.result TO ${noPhiUsername};
       rollback:
           sql: |
-            ALTER TABLE ${database.defaultSchemaName}.test_order DROP COLUMN corrected_by, DROP COLUMN corrected_at, DROP COLUMN correction_reason;
-            ALTER TABLE ${database.defaultSchemaName}.test_event DROP COLUMN corrected_by, DROP COLUMN corrected_at, DROP COLUMN correction_reason;
-            DROP TYPE ${database.defaultSchemaName}.TEST_CORRECTION_REASON;
+            ALTER TABLE ${database.defaultSchemaName}.test_order DROP COLUMN corrected_by, DROP COLUMN corrected_at, DROP COLUMN correction_type;
+            ALTER TABLE ${database.defaultSchemaName}.test_event DROP COLUMN corrected_by, DROP COLUMN corrected_at, DROP COLUMN correction_type;
+            DROP TYPE ${database.defaultSchemaName}.TEST_CORRECTION_TYPE;


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue
- #3417 

## Changes Proposed
- Adds the following columns to both `test_order` and `test_event` tables:
    - `corrected_at`
    - `corrected_by`
        - Required to implement the `requested by {name} on {date}` part of the following design:
        - <img width="1026" alt="Screen Shot 2022-04-12 at 3 28 19 PM" src="https://user-images.githubusercontent.com/27730981/163038913-666c2a68-2173-47df-bbaf-e4eb24381fa0.png">
    - `correction_type`
        - This holds a member of an enum of valid test correction reasons
- We will maintain the existing `reason_for_correction` column for now, which will be populated by the "Additional details" field in the test correction form
    - <img width="465" alt="Screen Shot 2022-04-12 at 3 28 02 PM" src="https://user-images.githubusercontent.com/27730981/163039097-c8fd44f9-8206-4026-8082-ba1fea21470d.png">
    - Longer-term we would like to migrate that column to, e.g. `additional_correction_information` to be more descriptive of its contents

## Additional Information
- Please see https://github.com/CDCgov/prime-simplereport/pull/3650#discussion_r849864098 and [3d3a348](https://github.com/CDCgov/prime-simplereport/pull/3650/commits/3d3a3481f5d7b03dcbe71339b33617615db212d8) for the proposed approach to migrating existing data

## Testing
* Create or establish any number of test result removals
    * <img width="470" alt="Screen Shot 2022-04-13 at 6 11 06 PM" src="https://user-images.githubusercontent.com/27730981/163278916-fc751c1b-2287-41cd-93a1-4955cb284f1a.png">
* Perform the migration
* Verify the post-migration state of the database
    * <img width="472" alt="Screen Shot 2022-04-13 at 6 11 50 PM" src="https://user-images.githubusercontent.com/27730981/163278953-92b62179-7639-4aeb-8050-afa45c4eccec.png">

    * All pre-existing test orders/events should have a correction reason of "OTHER" since we have no way of parsing the plaintext correction reasons

## Checklist for Primary Reviewer
- [x] Only database changes are included in this PR
- [x] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] Rollback has been verifed locally and in a deployed environment
