### PR TITLE
disable open in view

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
@@ -3,11 +3,8 @@ package gov.cdc.usds.simplereport.config;
 import gov.cdc.usds.simplereport.logging.PatientExperienceLoggingInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -34,19 +31,5 @@ public class WebConfiguration implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(_loggingInterceptor);
-  }
-
-  /**
-   * We want (at least for now) to be able to lazy-load JPA relationships in the graphql resolver,
-   * even after exiting service-layer transactions.
-   *
-   * <p>Since the graphql servlet does not register a handler with Spring, the Spring
-   * HandlerInterceptor does not work: instead, register a servlet filter with the same effect.
-   *
-   * @return
-   */
-  @Bean
-  public FilterRegistrationBean<OpenEntityManagerInViewFilter> openInViewFilter() {
-    return new FilterRegistrationBean<>(new OpenEntityManagerInViewFilter());
   }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -22,9 +22,10 @@ spring:
   jpa:
     database: POSTGRESQL
     hibernate.ddl-auto: validate
-    open-in-view: false # this is misleading: we actually have a filter that does this instead
+    open-in-view: false
     properties:
       hibernate:
+        enable_lazy_load_no_trans: true # removing in no session issues
         default_schema: public # Using the public schema for now, so we don't have to add a manual step to the deploy process
   liquibase:
     simplereport:


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- My hypothesis is that this setting is causing a massive mismanagement of the db connections and turning it off will improve our db connection utilization.
- It causes connections to be started for every request and kept alive for the duration of that request, as apposed to the db interaction portion of the request
- It causes few more necessary queries and possible n+1 issues.

## Changes Proposed

- This PR disables the `open-in-view` jpa option, this setting keeps a session open for the duration of the request to allow lazy loading.
- sets `enable_lazy_load_no_trans` to open a temporary session when lazy loading  https://www.baeldung.com/hibernate-lazy-loading-workaround

## Additional Information

> 4.2. Exhausting the Connection Pool
> When OSIV is active, there is always a Session in the current request scope, even if we remove @Transactional. Although this Session is not connected initially, after our first database IO, it gets connected and remains so until the end of the request.
source: https://www.baeldung.com/spring-open-session-in-view



> If OSIV flag is enabled (default), OSIV enables OpenEntityManagerInViewInterceptor to register EntityManager to the current thread. So EntityManager is available throughout the lifespan of the web request. A database connection is created for each web request and stays untill the web request is completed.
source: https://www.yawintutor.com/warn-3840-spring-jpa-open-in-view-is-enabled-default/


https://medium.com/@rafaelralf90/open-session-in-view-is-evil-fd9a21645f8e
