### PR TITLE
remove old pxp verify endpoint

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
@@ -78,27 +78,6 @@ public class PatientExperienceController {
     log.info("Patient Experience REST endpoints enabled");
   }
 
-  /**
-   * Verify that the patient-provided DOB matches the patient on file for the patient link id. It
-   * returns the full patient object if so, otherwise it throws an exception
-   */
-  @PreAuthorize(
-      "@patientLinkService.verifyPatientLink(#body.getPatientLinkId(), #body.getDateOfBirth())")
-  @PostMapping("/link/verify")
-  public PxpVerifyResponse getPatientLinkVerify(
-      @RequestBody PxpRequestWrapper<Void> body, HttpServletRequest request) {
-    PatientLink pl = _contextHolder.getPatientLink();
-    OrderStatus os = _contextHolder.getLinkedOrder().getOrderStatus();
-    Person p = _contextHolder.getPatient();
-    TestEvent te =
-        os == OrderStatus.COMPLETED
-            ? _contextHolder.getLinkedOrder().getTestEvent()
-            : _tes.getLastTestResultsForPatient(p);
-    _tocs.storeTimeOfConsent(pl);
-
-    return new PxpVerifyResponse(p, os, te);
-  }
-
   /** Verify that the patient-provided DOB matches the patient on file for the patient link id. */
   @PreAuthorize(
       "@patientLinkService.verifyPatientLink(#body.getPatientLinkId(), #body.getDateOfBirth())")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -2,7 +2,6 @@ package gov.cdc.usds.simplereport.api;
 
 /** Container class for test constants related to REST handler testing */
 public final class ResourceLinks {
-  public static final String VERIFY_LINK = "/pxp/link/verify";
   public static final String VERIFY_LINK_V2 = "/pxp/link/verify/v2";
   public static final String UPDATE_PATIENT = "/pxp/patient";
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -68,20 +67,20 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
   @MockBean private TimeOfConsentService _consentService;
   @Captor private ArgumentCaptor<ApiAuditEvent> _eventCaptor;
 
-  private Facility _base;
-  private Person _patient;
-  private PatientLink _link;
+  private Facility facility;
+  private Person patient;
+  private PatientLink patientLink;
 
   @BeforeEach
   void init() {
     TestUserIdentities.withStandardUser(
         () -> {
           Organization org = _orgService.getCurrentOrganizationNoCache();
-          _base = _orgService.getFacilities(org).get(0);
-          _base.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
-          _patient = _dataFactory.createFullPerson(org);
-          TestOrder order = _dataFactory.createTestOrder(_patient, _base);
-          _link = _dataFactory.createPatientLink(order);
+          facility = _orgService.getFacilities(org).get(0);
+          facility.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+          patient = _dataFactory.createFullPerson(org);
+          TestOrder order = _dataFactory.createTestOrder(patient, facility);
+          patientLink = _dataFactory.createPatientLink(order);
         });
   }
 
@@ -91,7 +90,7 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     useOrgUserAllFacilityAccess();
     ObjectNode args =
         patientArgs()
-            .put("deviceId", _base.getDefaultDeviceType().getInternalId().toString())
+            .put("deviceId", facility.getDefaultDeviceType().getInternalId().toString())
             .put("result", "NEGATIVE");
     runQuery("submit-test", args, "ewww");
     verify(_auditRepo).save(_eventCaptor.capture());
@@ -120,40 +119,40 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     HttpEntity<JsonNode> requestEntity = new HttpEntity<JsonNode>(makeVerifyLinkArgs());
     ResponseEntity<String> resp =
         _restTemplate.exchange(
-            ResourceLinks.VERIFY_LINK, HttpMethod.POST, requestEntity, String.class);
+            ResourceLinks.VERIFY_LINK_V2, HttpMethod.POST, requestEntity, String.class);
     log.info("Response body is {}", resp.getBody());
     verify(_auditRepo).save(_eventCaptor.capture());
     assertThat(_eventCaptor.getValue())
         .as("Saved audit event")
-        .matches(e -> e.getHttpRequestDetails().getRequestUri().equals(ResourceLinks.VERIFY_LINK))
+        .matches(
+            e -> e.getHttpRequestDetails().getRequestUri().equals(ResourceLinks.VERIFY_LINK_V2))
         .hasFieldOrPropertyWithValue("responseCode", 500);
   }
 
   @Test
-  void restQuery_auditFailure_noDataReturned()
-      throws JsonMappingException, JsonProcessingException {
+  void restQuery_auditFailure_noDataReturned() throws JsonProcessingException {
     when(_auditRepo.save(_eventCaptor.capture())).thenThrow(HibernateException.class);
     HttpEntity<JsonNode> requestEntity = new HttpEntity<JsonNode>(makeVerifyLinkArgs());
     ResponseEntity<String> resp =
         _restTemplate.exchange(
-            ResourceLinks.VERIFY_LINK, HttpMethod.POST, requestEntity, String.class);
-    assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+            ResourceLinks.VERIFY_LINK_V2, HttpMethod.POST, requestEntity, String.class);
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
     JsonNode responseJson = new ObjectMapper().readTree(resp.getBody());
-    assertEquals(400, responseJson.get("status").asInt());
-    assertEquals("Bad Request", responseJson.get("error").asText());
-    assertEquals(ResourceLinks.VERIFY_LINK, responseJson.get("path").asText());
+    assertEquals(500, responseJson.get("status").asInt());
+    assertEquals("Internal Server Error", responseJson.get("error").asText());
+    assertEquals(ResourceLinks.VERIFY_LINK_V2, responseJson.get("path").asText());
   }
 
   private ObjectNode makeVerifyLinkArgs() {
     return JsonNodeFactory.instance
         .objectNode()
-        .put("patientLinkId", _link.getInternalId().toString())
-        .put("dateOfBirth", _patient.getBirthDate().toString());
+        .put("patientLinkId", patientLink.getInternalId().toString())
+        .put("dateOfBirth", patient.getBirthDate().toString());
   }
 
   private ObjectNode patientArgs() {
     return JsonNodeFactory.instance
         .objectNode()
-        .put("patientId", _patient.getInternalId().toString());
+        .put("patientId", patient.getInternalId().toString());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -14,7 +14,7 @@ import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.HttpRequestDetails;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
@@ -120,10 +120,10 @@ class AuditLoggingTest extends BaseGraphqlTest {
             .put("dateOfBirth", TestDataFactory.DEFAULT_BDAY.toString())
             .toString();
     _mockMvc
-        .perform(withJsonContent(post(ResourceLinks.VERIFY_LINK), requestBody))
+        .perform(withJsonContent(post(ResourceLinks.VERIFY_LINK_V2), requestBody))
         .andExpect(status().isOk());
 
-    ApiAuditEvent event = assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, null);
+    ApiAuditEvent event = assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, null);
     assertEquals(link.getInternalId(), event.getPatientLink().getInternalId(), "patient link");
     assertEquals(TestDataFactory.DEFAULT_ORG_ID, event.getOrganization().getExternalId());
 
@@ -144,8 +144,8 @@ class AuditLoggingTest extends BaseGraphqlTest {
           Organization org = _dataFactory.createValidOrg();
           Facility site = _dataFactory.createValidFacility(org);
           Person person = _dataFactory.createFullPerson(org);
-          TestOrder testOrder = _dataFactory.createTestOrder(person, site);
-          linkHolder.setValue(_dataFactory.createPatientLink(testOrder));
+          TestEvent testEvent = _dataFactory.createTestEvent(person, site);
+          linkHolder.setValue(_dataFactory.createPatientLink(testEvent.getTestOrder()));
         });
     return linkHolder.getValue();
   }
@@ -160,12 +160,12 @@ class AuditLoggingTest extends BaseGraphqlTest {
             .put("dateOfBirth", TestDataFactory.DEFAULT_BDAY.toString())
             .toString();
     MockHttpServletRequestBuilder req =
-        withJsonContent(post(ResourceLinks.VERIFY_LINK), requestBody)
+        withJsonContent(post(ResourceLinks.VERIFY_LINK_V2), requestBody)
             .header("X-forwarded-PROTO", "gopher")
             .header("x-ORIGINAL-HOST", "simplereport.simple")
             .header("x-forwarded-for", "192.168.153.128:80, 10.3.1.1:443");
     _mockMvc.perform(req).andExpect(status().isOk());
-    ApiAuditEvent event = assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, null);
+    ApiAuditEvent event = assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, null);
     assertEquals(link.getInternalId(), event.getPatientLink().getInternalId(), "patient link");
     assertEquals(TestDataFactory.DEFAULT_ORG_ID, event.getOrganization().getExternalId());
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -70,26 +70,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   }
 
   @Test
-  void preAuthorizerThrows403() throws Exception {
-    String dob = "1900-01-01";
-    String requestBody =
-        "{\"patientLinkId\":\"" + UUID.randomUUID() + "\",\"dateOfBirth\":\"" + dob + "\"}";
-
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.VERIFY_LINK)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(requestBody);
-
-    this.mockMvc
-        .perform(builder)
-        .andExpect(status().isForbidden())
-        .andExpect(header().exists(LoggingConstants.REQUEST_ID_HEADER));
-    assertNoAuditEvent();
-  }
-
-  @Test
   void preAuthorizerThrows403V2() throws Exception {
     String dob = "1900-01-01";
     String requestBody =
@@ -107,30 +87,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
         .andExpect(status().isForbidden())
         .andExpect(header().exists(LoggingConstants.REQUEST_ID_HEADER));
     assertNoAuditEvent();
-  }
-
-  @Test
-  void preAuthorizerSucceeds() throws Exception {
-    // GIVEN
-    String dob = person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-    String requestBody =
-        "{\"patientLinkId\":\""
-            + patientLink.getInternalId()
-            + "\",\"dateOfBirth\":\""
-            + dob
-            + "\"}";
-
-    // WHEN
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.VERIFY_LINK)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(requestBody);
-
-    // THEN
-    String requestId = runBuilderReturningRequestId(mockMvc, builder, status().isOk());
-    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, requestId);
   }
 
   @Test
@@ -155,41 +111,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
     // THEN
     String requestId = runBuilderReturningRequestId(mockMvc, builder, status().isOk());
     assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, requestId);
-  }
-
-  @Test
-  void verifyLinkReturnsPerson() throws Exception {
-    // GIVEN
-    String dob = person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-    String requestBody =
-        "{\"patientLinkId\":\""
-            + patientLink.getInternalId()
-            + "\",\"dateOfBirth\":\""
-            + dob
-            + "\"}";
-
-    // WHEN
-    MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.VERIFY_LINK)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .characterEncoding("UTF-8")
-            .content(requestBody);
-
-    // THEN
-    String requestId =
-        mockMvc
-            .perform(builder)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.firstName", is(person.getFirstName())))
-            .andExpect(jsonPath("$.lastName", is(person.getLastName())))
-            .andExpect(jsonPath("$.lastTest.deviceTypeName", is("Acme SuperFine")))
-            .andExpect(jsonPath("$.lastTest.deviceTypeModel", is("SFN")))
-            .andReturn()
-            .getResponse()
-            .getHeader(LoggingConstants.REQUEST_ID_HEADER);
-
-    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK, requestId);
   }
 
   @Test
@@ -261,7 +182,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK_V2)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
@@ -269,7 +190,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // THEN
     String requestId = runBuilderReturningRequestId(mockMvc, builder, status().isGone());
-    assertLastAuditEntry(HttpStatus.GONE, ResourceLinks.VERIFY_LINK, requestId);
+    assertLastAuditEntry(HttpStatus.GONE, ResourceLinks.VERIFY_LINK_V2, requestId);
   }
 
   @Test
@@ -288,7 +209,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   }
 
   @Test
-  void getObfuscatedPatientName_thowsOnExpiredLink() throws Exception {
+  void getObfuscatedPatientName_throwsOnExpiredLink() throws Exception {
     // GIVEN
     TestUserIdentities.withStandardUser(
         () -> patientLink = _dataFactory.expirePatientLink(patientLink));
@@ -333,7 +254,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   }
 
   @Test
-  void getTestResultUnauthenticated_thowsOnExpiredLink() throws Exception {
+  void getTestResultUnauthenticated_throwsOnExpiredLink() throws Exception {
     // GIVEN
     TestUserIdentities.withStandardUser(
         () -> patientLink = _dataFactory.expirePatientLink(patientLink));
@@ -361,7 +282,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
 
     // WHEN
     MockHttpServletRequestBuilder builder =
-        post(ResourceLinks.VERIFY_LINK)
+        post(ResourceLinks.VERIFY_LINK_V2)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- remove unused `pxp/link/verify` endpoint

## Testing
- Tested on `test` and was able to access results link correctly




