### PR TITLE
Default to overwrite when deploying frontend

### DIFF
--- a/.github/actions/deploy-application/action.yml
+++ b/.github/actions/deploy-application/action.yml
@@ -33,9 +33,6 @@ runs:
       run: |
         echo "::group::Deploy frontend app"
         az storage blob upload-batch -s client-build/ -d '$web' \
-          --account-name simplereport${{ inputs.deploy-env }}app \
-          --destination-path '/app' || \
-        az storage blob upload-batch -s client-build/ -d '$web' \
         --account-name simplereport${{ inputs.deploy-env }}app \
         --destination-path '/app' \
         --overwrite


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

If there are conflicts when uploading the source bundle, you'll receive the following error message from the CLI:

```
  ERROR: The specified blob already exists.
  RequestId:764fa903-b01e-000e-6447-50f215000000
  Time:2022-04-14T21:32:00.6061954Z
  ErrorCode:BlobAlreadyExists
  If you want to overwrite the existing one, please add --overwrite in your command.
```

Currently we run the CLI command joined with an `||` and then the same command using an `--overwrite` flag - in short, if it fails without the flag, try it again with the flag.

We learned today that the first command can mostly fail (uploading 3/90 items) and still return an exit code of `0`. This prevents the command with the flag from running, and the frontend doesn't update. It's still unclear why this hasn't affected us until now.

## Changes Proposed

- We don't parameterize the source bundle upload, so let's just default to the `--overwrite` flag. The current workflow assumes this is being done anyway.

## Testing

- Running correctly here (the log group issue was fixed post deploying this): https://github.com/CDCgov/prime-simplereport/runs/6031542037?check_suite_focus=true