### PR TITLE
remove unused patient-name endpoint

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceController.java
@@ -92,33 +92,6 @@ public class PatientExperienceController {
   }
 
   /**
-   * Given a patient link ID, returns the name of the patient for whom the test was conducted, in
-   * lightly-obfuscated form (e.g. "John Doe" -> "John D").
-   *
-   * <p>This endpoint is unauthorized and therefore does not return fully identifying data.
-   *
-   * @param request
-   * @return an obfuscated patient name
-   */
-  @GetMapping("/patient-name")
-  public String getObfuscatedPatientNameFromLink(
-      @RequestParam("patientLink") UUID patientLink, HttpServletRequest request)
-      throws ExpiredPatientLinkException {
-    var link = _pls.getPatientLink(patientLink);
-
-    if (link.isExpired()) {
-      throw new ExpiredPatientLinkException();
-    }
-
-    TestOrder to = link.getTestOrder();
-    Person p = to.getPatient();
-
-    _contextHolder.setContext(link, to, p);
-
-    return p.getFirstName() + " " + p.getLastName().charAt(0) + ".";
-  }
-
-  /**
    * Given a patient link ID, returns a minimum of information about the patient (obfuscated name)
    * and facility (name and phone number) that may aid the end user in identify verification.
    *

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -7,7 +7,6 @@ public final class ResourceLinks {
 
   public static final String SELF_REGISTER = "/pxp/register";
   public static final String EXISTING_PATIENT = "/pxp/register/existing-patient";
-  public static final String GET_OBFUSCATED_PATIENT_NAME = "/pxp/patient-name";
   public static final String GET_TEST_RESULT_UNAUTHENTICATED = "/pxp/entity";
   public static final String ENTITY_NAME = "/pxp/register/entity-name";
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -194,37 +194,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   }
 
   @Test
-  void getObfuscatedPatientName_returnsName() throws Exception {
-    // WHEN
-    MockHttpServletRequestBuilder builder =
-        get(ResourceLinks.GET_OBFUSCATED_PATIENT_NAME)
-            .characterEncoding("UTF-8")
-            .param("patientLink", patientLink.getInternalId().toString());
-
-    // THEN
-    this.mockMvc
-        .perform(builder)
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", is("Fred A.")));
-  }
-
-  @Test
-  void getObfuscatedPatientName_throwsOnExpiredLink() throws Exception {
-    // GIVEN
-    TestUserIdentities.withStandardUser(
-        () -> patientLink = _dataFactory.expirePatientLink(patientLink));
-
-    // WHEN
-    MockHttpServletRequestBuilder builder =
-        get(ResourceLinks.GET_OBFUSCATED_PATIENT_NAME)
-            .characterEncoding("UTF-8")
-            .param("patientLink", patientLink.getInternalId().toString());
-
-    // THEN
-    this.mockMvc.perform(builder).andExpect(status().isGone());
-  }
-
-  @Test
   void getTestResultUnauthenticated_returnsPartialTestResultData() throws Exception {
     // WHEN
     MockHttpServletRequestBuilder builder =

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -134,12 +134,6 @@ export class PxpApi {
     );
   };
 
-  static getObfuscatedPatientName = async (
-    patientLink: string
-  ): Promise<string> => {
-    return api.getRequest(`/patient-name?patientLink=${patientLink}`);
-  };
-
   static getTestResultUnauthenticated = async (
     patientLink: string
   ): Promise<TestResultUnauthenticated> => {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- remove unused `/pxp//patient-name` endpoint

## Testing

- Tested on `test` and was able to access results link correctly


