### PR TITLE
separate out twilio monitor action group

### DIFF
--- a/ops/services/pagerduty/main.tf
+++ b/ops/services/pagerduty/main.tf
@@ -6,7 +6,7 @@ resource "pagerduty_service_integration" "az" {
 }
 
 resource "pagerduty_service_integration" "twilio" {
-  name    = "Terraformed Integration"
+  name    = "Terraformed Twilio Integration"
   service = data.pagerduty_service.service.id
   vendor  = data.pagerduty_vendor.twilio.id
 }
@@ -19,12 +19,6 @@ resource "azurerm_monitor_action_group" "pd" {
   webhook_receiver {
     name                    = "PagerDuty - ${data.pagerduty_service.service.name}"
     service_uri             = "https://events.pagerduty.com/integration/${pagerduty_service_integration.az.integration_key}/enqueue"
-    use_common_alert_schema = true
-  }
-
-  webhook_receiver {
-    name                    = "PagerDuty - ${data.pagerduty_service.service.name}"
-    service_uri             = "https://events.pagerduty.com/integration/${pagerduty_service_integration.twilio.integration_key}/enqueue"
     use_common_alert_schema = true
   }
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #3678

## Changes Proposed

- remove the webhook receiver from the azure monitor action group. 

## Additional Information

- The important part of this terraform is the `pagerduty_service_integration` as it creates the integration key that we can use in our Twilio webhook.
- The webhook receiver isn't needed on this azure resource, we only need the integration key in order for the Twilio webhooks we create in their dashboard.
 
![Screenshot from 2022-04-25 16-15-57](https://user-images.githubusercontent.com/94012653/165189683-8dafe7bf-b52e-4a2c-b3dd-a2566fa62d16.png)

## Checklist for Primary Reviewer

### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

## Cloud
- [x] Oncall has been notified if this change is going in after-hours
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

----