### PR TITLE
Remove facility backward compatibility code

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -30,10 +30,6 @@ public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapp
     return getWrapped().getEmail();
   }
 
-  public List<DeviceSpecimenType> getDeviceSpecimenTypes() {
-    return getWrapped().getDeviceSpecimenTypes();
-  }
-
   public List<DeviceType> getDeviceTypes() {
     return getWrapped().getDeviceTypes();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -47,13 +47,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
 
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
-      name = "facility_device_specimen_type",
-      joinColumns = @JoinColumn(name = "facility_id"),
-      inverseJoinColumns = @JoinColumn(name = "device_specimen_type_id"))
-  private Set<DeviceSpecimenType> configuredDeviceSpecimenTypes = new HashSet<>();
-
-  @ManyToMany(fetch = FetchType.EAGER)
-  @JoinTable(
       name = "facility_device_type",
       joinColumns = @JoinColumn(name = "facility_id"),
       inverseJoinColumns = @JoinColumn(name = "device_type_id"))
@@ -116,41 +109,11 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
   }
 
   public void addDeviceType(DeviceType device) {
-    initializeDeviceTypesSet();
     configuredDeviceTypes.add(device);
   }
 
   public List<DeviceType> getDeviceTypes() {
-    initializeDeviceTypesSet();
     return configuredDeviceTypes.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
-  }
-
-  public List<DeviceSpecimenType> getDeviceSpecimenTypes() {
-    return configuredDeviceSpecimenTypes.stream()
-        .filter(
-            e ->
-                !(e.isDeleted()
-                    || e.getSpecimenType().isDeleted()
-                    || e.getDeviceType().isDeleted()))
-        .collect(Collectors.toList());
-  }
-
-  private void initializeDeviceTypesSet() {
-    if (this.configuredDeviceTypes.isEmpty()) {
-      Set<DeviceType> deviceTypesFromFacilityDeviceSpecimenTypes =
-          this.configuredDeviceSpecimenTypes.stream()
-              .map(DeviceSpecimenType::getDeviceType)
-              .filter(e -> !e.isDeleted())
-              .collect(Collectors.toSet());
-      if (!deviceTypesFromFacilityDeviceSpecimenTypes.isEmpty()) {
-        this.configuredDeviceTypes = deviceTypesFromFacilityDeviceSpecimenTypes;
-        this.configuredDeviceSpecimenTypes.clear();
-      }
-    }
-  }
-
-  public void addDeviceSpecimenType(DeviceSpecimenType ds) {
-    configuredDeviceSpecimenTypes.add(ds);
   }
 
   public DeviceSpecimenType getDefaultDeviceSpecimen() {
@@ -172,7 +135,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
   }
 
   public void removeDeviceType(DeviceType deletedDevice) {
-    initializeDeviceTypesSet();
     this.configuredDeviceTypes.remove(deletedDevice);
 
     // If the corresponding device to a facility's default device swab type is removed,

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -31,8 +31,6 @@ type Facility {
   email: String
   deviceTypes: [DeviceType]
   defaultDeviceSpecimen: ID
-  deviceSpecimenTypes: [DeviceSpecimenType]
-    @deprecated(reason: "kept for compatibility")
   defaultDeviceType: DeviceType @deprecated(reason: "kept for compatibility")
   orderingProvider: Provider
   patientSelfRegistrationLink: String

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.db.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,63 +63,5 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
     found = _repo.findById(saved.getInternalId()).get();
     assertNull(found.getDefaultDeviceType());
     assertEquals(1, found.getDeviceTypes().size());
-  }
-
-  @Test
-  void facilityAddDeviceType_backwardCompatibleWithFacilityDeviceSpecimenType() {
-    // GIVEN
-    var facilityDeviceSpecimenType = _dataFactory.getGenericDeviceSpecimen();
-    var org = _dataFactory.createValidOrg();
-    var facility = _dataFactory.createValidFacility(org);
-    facility.getDeviceTypes().forEach(facility::removeDeviceType);
-    assertThat(facility.getDeviceTypes()).isEmpty();
-
-    // WHEN only a facility device specimen type is configured
-    facility.addDeviceSpecimenType(facilityDeviceSpecimenType);
-    _repo.save(facility);
-
-    // THEN
-    assertThat(facility.getDeviceTypes()).hasSize(1);
-    assertThat(facility.getDeviceTypes()).contains(facilityDeviceSpecimenType.getDeviceType());
-
-    // WHEN adding a new device
-    facility.addDeviceType(new DeviceType("New Shiny Device", "Nue Inc", "Shiny", "123", null, 15));
-
-    // THEN
-    assertThat(facility.getDeviceTypes()).hasSize(2);
-
-    // WHEN Deleting a device
-    facility.removeDeviceType(facilityDeviceSpecimenType.getDeviceType());
-
-    // THEN
-    assertThat(facility.getDeviceTypes()).hasSize(1);
-    DeviceType device = facility.getDeviceTypes().get(0);
-    assertThat(device.getName()).isEqualTo("New Shiny Device");
-    assertThat(device.getManufacturer()).isEqualTo("Nue Inc");
-    assertThat(device.getModel()).isEqualTo("Shiny");
-  }
-
-  @Test
-  void facilityRemoveDeviceType_backwardCompatibleWithFacilityDeviceSpecimenType() {
-    // GIVEN
-    var facilityDeviceSpecimenType = _dataFactory.getGenericDeviceSpecimen();
-    var org = _dataFactory.createValidOrg();
-    var facility = _dataFactory.createValidFacility(org);
-    facility.getDeviceTypes().forEach(facility::removeDeviceType);
-    assertThat(facility.getDeviceTypes()).isEmpty();
-
-    // WHEN only a facility device specimen type is configured
-    facility.addDeviceSpecimenType(facilityDeviceSpecimenType);
-    _repo.save(facility);
-
-    // THEN
-    assertThat(facility.getDeviceTypes()).hasSize(1);
-    assertThat(facility.getDeviceTypes()).contains(facilityDeviceSpecimenType.getDeviceType());
-
-    // WHEN Deleting a device
-    facility.removeDeviceType(facilityDeviceSpecimenType.getDeviceType());
-
-    // THEN
-    assertThat(facility.getDeviceTypes()).isEmpty();
   }
 }


### PR DESCRIPTION
remove backward compatibility code used to migrate from facility_device_specimen_type to facility_device_type

# BACKEND PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
