### PR TITLE
Add --overwrite to maintance banner upload

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     "storybook": "yarn create-storybook-public && yarn watch-css & start-storybook -p 6006 -s storybook_public",
     "build-storybook": "yarn create-storybook-public && yarn compile-scss && REACT_APP_BACKEND_URL=http://localhost:8080 build-storybook -s storybook_public",
     "maintenance:start": "[ -z \"$MAINTENANCE_MESSAGE\" ] && echo \"MAINTENANCE_MESSAGE must be set!\" || (echo $MAINTENANCE_MESSAGE > maintenance.json && yarn maintenance:deploy && rm maintenance.json)",
-    "maintenance:deploy": "[ -z \"$MAINTENANCE_ENV\" ] && echo \"MAINTENANCE_ENV must be set!\" || az storage blob upload -f maintenance.json -n maintenance.json -c '$web' --account-name simplereport${MAINTENANCE_ENV}app"
+    "maintenance:deploy": "[ -z \"$MAINTENANCE_ENV\" ] && echo \"MAINTENANCE_ENV must be set!\" || az storage blob upload -f maintenance.json -n maintenance.json -c '$web' --account-name simplereport${MAINTENANCE_ENV}app --overwrite"
   },
   "prettier": {
     "singleQuote": false


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

We missed a spot when adding the `--overwrite` flag to storage blob uploads and the maintenance banner workflow is broken as a result.

## Changes Proposed

- Add the `--overwrite` flag to the yarn script used in the maintenance banner workflow.

Working here: https://github.com/CDCgov/prime-simplereport/actions/runs/2193537835