### PR TITLE
add org mutation and test

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -410,6 +410,11 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
   }
 
   /** Support-only mutation to mark a facility as deleted. This is a soft deletion only. */
+  public Organization markOrganizationAsDeleted(UUID organizationId, boolean deleted) {
+    return organizationService.markOrganizationAsDeleted(organizationId, deleted);
+  }
+
+  /** Support-only mutation to mark a facility as deleted. This is a soft deletion only. */
   public Facility markFacilityAsDeleted(UUID facilityId, boolean deleted) {
     return organizationService.markFacilityAsDeleted(facilityId, deleted);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -409,7 +409,7 @@ public class OrganizationMutationResolver implements GraphQLMutationResolver {
     return organizationQueueService.markPendingOrganizationAsDeleted(orgExternalId, deleted);
   }
 
-  /** Support-only mutation to mark a facility as deleted. This is a soft deletion only. */
+  /** Support-only mutation to mark an organization as deleted. This is a soft deletion only. */
   public Organization markOrganizationAsDeleted(UUID organizationId, boolean deleted) {
     return organizationService.markOrganizationAsDeleted(organizationId, deleted);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -387,4 +387,17 @@ public class OrganizationService {
     facility.setIsDeleted(deleted);
     return facilityRepository.save(facility);
   }
+
+  @Transactional(readOnly = false)
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public Organization markOrganizationAsDeleted(UUID organizationId, boolean deleted) {
+    Optional<Organization> optionalOrganization = organizationRepository.findById(organizationId);
+    if (optionalOrganization.isEmpty()) {
+      throw new IllegalGraphqlArgumentException("Organization not found.");
+    }
+
+    Organization organization = optionalOrganization.get();
+    organization.setIsDeleted(deleted);
+    return organizationRepository.save(organization);
+  }
 }

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -87,4 +87,5 @@ extend type Mutation {
   setRegistrationLinkIsDeleted(link: String, deleted: Boolean!): String
   adminUpdateOrganization(name: String!, type: String!): String
   markFacilityAsDeleted(facilityId: ID!, deleted: Boolean!): String
+  markOrganizationAsDeleted(organizationId: ID!, deleted: Boolean!): String
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
@@ -45,12 +45,15 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
 
   private Facility facility;
   private StreetAddress address;
+  private Organization organization;
+
   private OrganizationQueueItem pendingOrg;
   private final UUID deviceId = UUID.randomUUID();
 
   @BeforeEach
   void setup() {
     Organization org = _dataFactory.createValidOrg();
+    organization = org;
     facility = _dataFactory.createValidFacility(org);
     pendingOrg = _dataFactory.createOrganizationQueueItem();
     address = facility.getAddress();
@@ -302,6 +305,25 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
 
     // THEN
     verify(mockedOrganizationService).markFacilityAsDeleted(facility.getInternalId(), false);
+  }
+
+  @Test
+  void markOrganizationAsDeleted_true() {
+    // WHEN
+    organizationMutationResolver.markOrganizationAsDeleted(organization.getInternalId(), true);
+
+    // THEN
+    verify(mockedOrganizationService).markOrganizationAsDeleted(organization.getInternalId(), true);
+  }
+
+  @Test
+  void markOrganizationAsDeleted_false() {
+    // WHEN
+    organizationMutationResolver.markOrganizationAsDeleted(organization.getInternalId(), false);
+
+    // THEN
+    verify(mockedOrganizationService)
+        .markOrganizationAsDeleted(organization.getInternalId(), false);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -194,6 +194,31 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   }
 
   @Test
+  @DisplayName("it should allow global admins to mark organizations as deleted")
+  @WithSimpleReportSiteAdminUser
+  void deleteOrganizationTest_successful() {
+    // GIVEN
+    Organization verifiedOrg = testDataFactory.createValidOrg();
+    // WHEN
+    Organization deletedOrganization =
+        _service.markOrganizationAsDeleted(verifiedOrg.getInternalId(), true);
+    // THEN
+    assertThat(deletedOrganization.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("it should not delete nonexistent organizations")
+  @WithSimpleReportSiteAdminUser
+  void deletedOrganizationTest_throwsErrorWhenOrganizationyNotFound() {
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            // fake UUID
+            () -> _service.markOrganizationAsDeleted(UUID.randomUUID(), true));
+    assertEquals("Organization not found.", caught.getMessage());
+  }
+
+  @Test
   @WithSimpleReportOrgAdminUser
   void adminUpdateOrganization_not_allowed() {
     AccessDeniedException caught =

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -144,6 +144,7 @@ export type Mutation = {
   editPendingOrganization?: Maybe<Scalars["String"]>;
   editQueueItem?: Maybe<TestOrder>;
   markFacilityAsDeleted?: Maybe<Scalars["String"]>;
+  markOrganizationAsDeleted?: Maybe<Scalars["String"]>;
   markPendingOrganizationAsDeleted?: Maybe<Scalars["String"]>;
   reactivateUser?: Maybe<User>;
   removePatientFromQueue?: Maybe<Scalars["String"]>;
@@ -379,6 +380,11 @@ export type MutationEditQueueItemArgs = {
 export type MutationMarkFacilityAsDeletedArgs = {
   deleted: Scalars["Boolean"];
   facilityId: Scalars["ID"];
+};
+
+export type MutationMarkOrganizationAsDeletedArgs = {
+  deleted: Scalars["Boolean"];
+  organizationId: Scalars["ID"];
 };
 
 export type MutationMarkPendingOrganizationAsDeletedArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
https://github.com/CDCgov/prime-simplereport/issues/3683 

Adding an organization soft deletion mutation to respond to some support escalations. Similar to the pending organzations and facility mutations added in previous sprints

## Changes Proposed
- Add relevant deletion methods into the organization repository, service, and mutation resolver classes
- Add tests / relevant GraphQL additions

## Testing

- Smoke tested in dev and it works.

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Any content updates (user-facing error messages, etc) have been approved by content team
- [x] Any changes that might generate questions in the support inbox have been flagged to the support team
