### PR TITLE
route to queue when starting a correction

### DIFF
--- a/frontend/src/app/testResults/TestResultCorrectionModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.test.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
+import { Provider } from "react-redux";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import "./TestResultCorrectionModal.scss";
 import userEvent from "@testing-library/user-event";
+import configureStore from "redux-mock-store";
 
 import { TestResult } from "../testQueue/QueueItem";
 
@@ -46,6 +48,12 @@ const testResult = {
     },
   },
 };
+const mockFacilityID = "b0d2041f-93c9-4192-b19a-dd99c0044a7e";
+const mockStore = configureStore([]);
+const store = mockStore({
+  facilities: [{ id: mockFacilityID, name: "123" }],
+  organization: { name: "Test Organization" },
+});
 
 const mockedNavigate = jest.fn();
 jest.mock("react-router-dom", () => {
@@ -66,15 +74,17 @@ describe("TestResultCorrectionModal", () => {
 
   it("renders the correction reason dropdown menu", async () => {
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
-        <MemoryRouter>
-          <DetachedTestResultCorrectionModal
-            data={testResult}
-            testResultId={internalId}
-            closeModal={() => {}}
-          />
-        </MemoryRouter>
-      </MockedProvider>
+      <Provider store={store}>
+        <MockedProvider mocks={[]} addTypename={false}>
+          <MemoryRouter>
+            <DetachedTestResultCorrectionModal
+              data={testResult}
+              testResultId={internalId}
+              closeModal={() => {}}
+            />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
     );
 
     const expectedCorrectionReasons = Object.values(TestCorrectionReasons);
@@ -92,15 +102,17 @@ describe("TestResultCorrectionModal", () => {
 
   it("matches snapshot", () => {
     component = render(
-      <MockedProvider mocks={[]} addTypename={false}>
-        <MemoryRouter>
-          <DetachedTestResultCorrectionModal
-            data={testResult}
-            testResultId={internalId}
-            closeModal={() => {}}
-          />
-        </MemoryRouter>
-      </MockedProvider>
+      <Provider store={store}>
+        <MockedProvider mocks={[]} addTypename={false}>
+          <MemoryRouter>
+            <DetachedTestResultCorrectionModal
+              data={testResult}
+              testResultId={internalId}
+              closeModal={() => {}}
+            />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
     );
 
     expect(component).toMatchSnapshot();
@@ -131,15 +143,17 @@ describe("TestResultCorrectionModal", () => {
 
     beforeEach(() => {
       render(
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <MemoryRouter>
-            <DetachedTestResultCorrectionModal
-              data={testResult}
-              testResultId={internalId}
-              closeModal={() => {}}
-            />
-          </MemoryRouter>
-        </MockedProvider>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <MemoryRouter>
+              <DetachedTestResultCorrectionModal
+                data={testResult}
+                testResultId={internalId}
+                closeModal={() => {}}
+              />
+            </MemoryRouter>
+          </MockedProvider>
+        </Provider>
       );
     });
 
@@ -177,15 +191,19 @@ describe("TestResultCorrectionModal", () => {
 
     beforeEach(() => {
       render(
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <MemoryRouter>
-            <DetachedTestResultCorrectionModal
-              data={testResult}
-              testResultId={internalId}
-              closeModal={() => {}}
-            />
-          </MemoryRouter>
-        </MockedProvider>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <MemoryRouter
+              initialEntries={[`/results/1?facility=${mockFacilityID}`]}
+            >
+              <DetachedTestResultCorrectionModal
+                data={testResult}
+                testResultId={internalId}
+                closeModal={() => {}}
+              />
+            </MemoryRouter>
+          </MockedProvider>
+        </Provider>
       );
     });
 
@@ -201,7 +219,9 @@ describe("TestResultCorrectionModal", () => {
         expect(markAsCorrectMockDidComplete).toBe(true);
       });
       await waitFor(() => {
-        expect(mockedNavigate).toHaveBeenCalledWith("/queue");
+        expect(mockedNavigate).toHaveBeenCalledWith(
+          `/queue?facility=${mockFacilityID}`
+        );
       });
     });
   });
@@ -249,15 +269,17 @@ describe("TestResultCorrectionModal", () => {
     ];
     beforeEach(async () => {
       render(
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <MemoryRouter>
-            <DetachedTestResultCorrectionModal
-              data={testResult}
-              testResultId={internalId}
-              closeModal={() => {}}
-            />
-          </MemoryRouter>
-        </MockedProvider>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <MemoryRouter>
+              <DetachedTestResultCorrectionModal
+                data={testResult}
+                testResultId={internalId}
+                closeModal={() => {}}
+              />
+            </MemoryRouter>
+          </MockedProvider>
+        </Provider>
       );
 
       const dropdown = await screen.findByLabelText(

--- a/frontend/src/app/testResults/TestResultCorrectionModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import "./TestResultCorrectionModal.scss";
@@ -46,6 +47,14 @@ const testResult = {
   },
 };
 
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  return {
+    ...jest.requireActual("react-router-dom"),
+    useNavigate: () => mockedNavigate,
+  };
+});
+
 describe("TestResultCorrectionModal", () => {
   let component: any;
 
@@ -58,11 +67,13 @@ describe("TestResultCorrectionModal", () => {
   it("renders the correction reason dropdown menu", async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
-        <DetachedTestResultCorrectionModal
-          data={testResult}
-          testResultId={internalId}
-          closeModal={() => {}}
-        />
+        <MemoryRouter>
+          <DetachedTestResultCorrectionModal
+            data={testResult}
+            testResultId={internalId}
+            closeModal={() => {}}
+          />
+        </MemoryRouter>
       </MockedProvider>
     );
 
@@ -82,11 +93,13 @@ describe("TestResultCorrectionModal", () => {
   it("matches snapshot", () => {
     component = render(
       <MockedProvider mocks={[]} addTypename={false}>
-        <DetachedTestResultCorrectionModal
-          data={testResult}
-          testResultId={internalId}
-          closeModal={() => {}}
-        />
+        <MemoryRouter>
+          <DetachedTestResultCorrectionModal
+            data={testResult}
+            testResultId={internalId}
+            closeModal={() => {}}
+          />
+        </MemoryRouter>
       </MockedProvider>
     );
 
@@ -119,11 +132,13 @@ describe("TestResultCorrectionModal", () => {
     beforeEach(() => {
       render(
         <MockedProvider mocks={mocks} addTypename={false}>
-          <DetachedTestResultCorrectionModal
-            data={testResult}
-            testResultId={internalId}
-            closeModal={() => {}}
-          />
+          <MemoryRouter>
+            <DetachedTestResultCorrectionModal
+              data={testResult}
+              testResultId={internalId}
+              closeModal={() => {}}
+            />
+          </MemoryRouter>
         </MockedProvider>
       );
     });
@@ -163,11 +178,13 @@ describe("TestResultCorrectionModal", () => {
     beforeEach(() => {
       render(
         <MockedProvider mocks={mocks} addTypename={false}>
-          <DetachedTestResultCorrectionModal
-            data={testResult}
-            testResultId={internalId}
-            closeModal={() => {}}
-          />
+          <MemoryRouter>
+            <DetachedTestResultCorrectionModal
+              data={testResult}
+              testResultId={internalId}
+              closeModal={() => {}}
+            />
+          </MemoryRouter>
         </MockedProvider>
       );
     });
@@ -182,6 +199,9 @@ describe("TestResultCorrectionModal", () => {
       userEvent.click(submitButton);
       await waitFor(() => {
         expect(markAsCorrectMockDidComplete).toBe(true);
+      });
+      await waitFor(() => {
+        expect(mockedNavigate).toHaveBeenCalledWith("/queue");
       });
     });
   });
@@ -230,11 +250,13 @@ describe("TestResultCorrectionModal", () => {
     beforeEach(async () => {
       render(
         <MockedProvider mocks={mocks} addTypename={false}>
-          <DetachedTestResultCorrectionModal
-            data={testResult}
-            testResultId={internalId}
-            closeModal={() => {}}
-          />
+          <MemoryRouter>
+            <DetachedTestResultCorrectionModal
+              data={testResult}
+              testResultId={internalId}
+              closeModal={() => {}}
+            />
+          </MemoryRouter>
         </MockedProvider>
       );
 

--- a/frontend/src/app/testResults/TestResultCorrectionModal.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
+import { useNavigate } from "react-router-dom";
 
 import Button from "../commonComponents/Button/Button";
 import { displayFullName, showNotification } from "../utils";
@@ -121,6 +122,8 @@ export const DetachedTestResultCorrectionModal = ({
   const [action, setAction] = useState<TestCorrectionAction>();
   const [correctionDetails, setCorrectionDetails] = useState("");
 
+  const navigate = useNavigate();
+
   const markAsError = () => {
     markTestAsError({
       variables: {
@@ -155,7 +158,9 @@ export const DetachedTestResultCorrectionModal = ({
         showNotification(alert);
       })
       .finally(() => {
-        closeModal();
+        setTimeout(() => {
+          navigate(`/queue`);
+        }, 1000);
       });
   };
 

--- a/frontend/src/app/testResults/TestResultCorrectionModal.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.tsx
@@ -14,6 +14,7 @@ import Alert from "../commonComponents/Alert";
 import Dropdown from "../commonComponents/Dropdown";
 import RadioGroup from "../commonComponents/RadioGroup";
 import Required from "../commonComponents/Required";
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 export enum TestCorrectionReason {
   DUPLICATE_TEST = "DUPLICATE_TEST",
@@ -123,6 +124,8 @@ export const DetachedTestResultCorrectionModal = ({
   const [correctionDetails, setCorrectionDetails] = useState("");
 
   const navigate = useNavigate();
+  const [activeFacility] = useSelectedFacility();
+  const activeFacilityId = activeFacility?.id;
 
   const markAsError = () => {
     markTestAsError({
@@ -159,7 +162,7 @@ export const DetachedTestResultCorrectionModal = ({
       })
       .finally(() => {
         setTimeout(() => {
-          navigate(`/queue`);
+          navigate(`/queue?facility=${activeFacilityId}`);
         }, 1000);
       });
   };


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- route to test queue when starting a correction


## Testing

- start a correction
- choose a reason other than duplicate
- notice how you're routed to the queue once you confirm
