### PR TITLE
Add additional README step for installation of yarn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To use this, you'll need to install the following:
 1. Install [mkcert](https://github.com/FiloSottile/mkcert#installation)
 1. Install Node.js 14, either using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) or your preferred method. This is used for yarn scripts and pre-commit hooks.
 1. Install AdoptOpenJDK 11, either using [jabba](https://github.com/shyiko/jabba) or your preferred method. This is useful for IDE integration (IntelliJ, VS Code, etc.)
+1. Install yarn by running `npm install --global yarn`.
 
 Once those dependencies are installed, follow these steps to get the app up and running:
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- After setting my environment back up (yay, failed hard drives!), I noticed that a step to install `yarn` seemed to be missing. I had to go look up what the proper command was. To help onboard new developers (or people like me who don't do much with frontend tools), I would like to explicitly add this to our instructions.

## Changes Proposed

- One-line addition to the README that lists the command for installing `yarn`.

## Testing

- Documentation only, so no explicit verification needed. If anyone wants to test what I wrote, though, I would always appreciate a second look!
