### PR TITLE
Fix broken dates in TestOrderServiceTest

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1364,7 +1364,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     OrganizationLevelDashboardMetrics metrics =
         _service.getOrganizationLevelDashboardMetrics(startDate, endDate);
-    // these will need to be adjusted once the Date bug in makedata is fixed.
     assertEquals(3, metrics.getOrganizationPositiveTestCount());
     assertEquals(12, metrics.getOrganizationTotalTestCount());
     assertEquals(5, metrics.getOrganizationNegativeTestCount());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1229,13 +1229,20 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null,
             null,
             null,
-            new Date(2021, 6, 1, 0, 0, 0),
-            new Date(2021, 6, 3, 23, 59, 59),
+            convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
+            convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59)),
             0,
             10);
     List<TestEvent> priorToJune2Noon =
         _service.getTestEventsResults(
-            _site.getInternalId(), null, null, null, null, new Date(2021, 6, 2, 11, 59, 59), 0, 10);
+            _site.getInternalId(),
+            null,
+            null,
+            null,
+            null,
+            convertDate(LocalDateTime.of(2021, 6, 2, 11, 59, 59)),
+            0,
+            10);
     List<TestEvent> positivesAmos =
         _service.getTestEventsResults(
             _site.getInternalId(),
@@ -1262,8 +1269,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             _dataFactory.getPersonByName(CHARLES).getInternalId(),
             TestResult.POSITIVE,
             PersonRole.RESIDENT,
-            new Date(2021, 6, 1, 0, 0, 0),
-            new Date(2021, 6, 1, 23, 59, 59),
+            convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
+            convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59)),
             0,
             10);
 
@@ -1299,13 +1306,15 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         testEvents.stream()
             .filter(
                 t ->
-                    !t.getDateTested().before(new Date(2021, 6, 1, 0, 0, 0))
-                        && !t.getDateTested().after(new Date(2021, 6, 3, 23, 59, 59)))
+                    !t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
+                        && !t.getDateTested()
+                            .after(convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59))))
             .collect(Collectors.toList()));
     assertTestResultsList(
         priorToJune2Noon,
         testEvents.stream()
-            .filter(t -> t.getDateTested().before(new Date(2021, 6, 2, 12, 0, 0)))
+            .filter(
+                t -> t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0))))
             .collect(Collectors.toList()));
     assertTestResultsList(
         positivesAmos,
@@ -1331,8 +1340,10 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                     t.getPatient().getNameInfo().equals(CHARLES)
                         && t.getResult() == TestResult.POSITIVE
                         && t.getPatient().getRole() == PersonRole.RESIDENT
-                        && !t.getDateTested().before(new Date(2021, 6, 1, 0, 0, 0))
-                        && !t.getDateTested().after(new Date(2021, 6, 1, 23, 59, 59)))
+                        && !t.getDateTested()
+                            .before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
+                        && !t.getDateTested()
+                            .after(convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59))))
             .collect(Collectors.toList()));
   }
 
@@ -1354,9 +1365,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     OrganizationLevelDashboardMetrics metrics =
         _service.getOrganizationLevelDashboardMetrics(startDate, endDate);
     // these will need to be adjusted once the Date bug in makedata is fixed.
-    assertEquals(0, metrics.getOrganizationPositiveTestCount());
-    assertEquals(1, metrics.getOrganizationTotalTestCount());
-    assertEquals(1, metrics.getOrganizationNegativeTestCount());
+    assertEquals(3, metrics.getOrganizationPositiveTestCount());
+    assertEquals(12, metrics.getOrganizationTotalTestCount());
+    assertEquals(5, metrics.getOrganizationNegativeTestCount());
     assertEquals(4, metrics.getFacilityMetrics().size());
   }
 
@@ -1383,8 +1394,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     TopLevelDashboardMetrics metrics =
         _service.getTopLevelDashboardMetrics(null, startDate, endDate);
-    assertEquals(0, metrics.getPositiveTestCount());
-    assertEquals(1, metrics.getTotalTestCount());
+    assertEquals(3, metrics.getPositiveTestCount());
+    assertEquals(12, metrics.getTotalTestCount());
   }
 
   @Test
@@ -1418,17 +1429,17 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     patientsToResults.put(LEELOO, TestResult.UNDETERMINED);
 
     Map<PersonName, Date> patientsToDates = new HashMap<>();
-    patientsToDates.put(AMOS, new Date(2021, 6, 1, 0, 0, 0));
-    patientsToDates.put(CHARLES, new Date(2021, 6, 1, 12, 0, 0));
-    patientsToDates.put(DEXTER, new Date(2021, 6, 2, 0, 0, 0));
-    patientsToDates.put(ELIZABETH, new Date(2021, 6, 2, 12, 0, 0));
-    patientsToDates.put(FRANK, new Date(2021, 6, 3, 0, 0, 0));
-    patientsToDates.put(GALE, new Date(2021, 6, 3, 12, 0, 0));
-    patientsToDates.put(HEINRICK, new Date(2021, 6, 4, 0, 0, 0));
-    patientsToDates.put(IAN, new Date(2021, 6, 4, 12, 0, 0));
-    patientsToDates.put(JANNELLE, new Date(2021, 6, 5, 0, 0, 0));
-    patientsToDates.put(KACEY, new Date(2021, 6, 5, 12, 0, 0));
-    patientsToDates.put(LEELOO, new Date(2021, 6, 6, 0, 0, 0));
+    patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
+    patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
+    patientsToDates.put(DEXTER, convertDate(LocalDateTime.of(2021, 6, 2, 0, 0, 0)));
+    patientsToDates.put(ELIZABETH, convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0)));
+    patientsToDates.put(FRANK, convertDate(LocalDateTime.of(2021, 6, 3, 0, 0, 0)));
+    patientsToDates.put(GALE, convertDate(LocalDateTime.of(2021, 6, 3, 12, 0, 0)));
+    patientsToDates.put(HEINRICK, convertDate(LocalDateTime.of(2021, 6, 4, 0, 0, 0)));
+    patientsToDates.put(IAN, convertDate(LocalDateTime.of(2021, 6, 4, 12, 0, 0)));
+    patientsToDates.put(JANNELLE, convertDate(LocalDateTime.of(2021, 6, 5, 0, 0, 0)));
+    patientsToDates.put(KACEY, convertDate(LocalDateTime.of(2021, 6, 5, 12, 0, 0)));
+    patientsToDates.put(LEELOO, convertDate(LocalDateTime.of(2021, 6, 6, 0, 0, 0)));
 
     Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
     patientsToRoles.put(AMOS, PersonRole.RESIDENT);
@@ -1486,6 +1497,10 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     if (expected.size() != found.size()) {
       fail("Expected " + expected.size() + " items but found " + found.size());
     }
+  }
+
+  private static Date convertDate(LocalDateTime dateTime) {
+    return Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixes #2692

## Changes Proposed

- Removes deprecated `Date` constructors in this test in favor of `LocalDateTime`

## Additional Information

- This was affecting the multiplex results changes; I started making changes to the file in that PR (#3702) but that PR is _already_ gargantuan so split this out for ease of review!

## Testing

- Do tests still pass? 

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Any content updates (user-facing error messages, etc) have been approved by content team
- [x] Any changes that might generate questions in the support inbox have been flagged to the support team
- [x] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed
