### PR TITLE
Use consistent Facility header on Admin dashboard

### DIFF
--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -316,4 +316,13 @@ describe("Analytics", () => {
     ]);
     expect(await screen.findByText("0.0%")).toBeInTheDocument();
   });
+  it("displays org and facility in subheader", async () => {
+    await screen.findByText("Central Schools: All facilities");
+    userEvent.selectOptions(screen.getByLabelText("Testing facility"), [
+      "Lincoln Middle School",
+    ]);
+    expect(
+      await screen.findByText("Central Schools: Lincoln Middle School")
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -61,7 +61,7 @@ export const Analytics = (props: Props) => {
     (state) => ((state as any).facilities as Facility[]) || []
   );
   const [facilityId, setFacilityId] = useState<string>("");
-  const [facilityName, setFacilityName] = useState<string>(organization.name);
+  const [facilityName, setFacilityName] = useState<string>("All facilities");
   const [dateRange, setDateRange] = useState<string>("week");
   const [startDate, setStartDate] = useState<string>(
     props.startDate || getStartDateStringFromDaysAgo(7)
@@ -232,7 +232,9 @@ export const Analytics = (props: Props) => {
                   </div>
                 </div>
               )}
-              <h3>{facilityName}</h3>
+              <h3>
+                {organization.name}: {facilityName}
+              </h3>
               <p className="margin-bottom-0">All people tested</p>
               <p className="padding-top-1">{`${startDate} \u2013 ${endDate}`}</p>
               <div className="grid-row grid-gap">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #3640

## Changes Proposed

This PR updates the facility header on the Admin dashboard to be consistent, on page load and when the testing facility is changed.

The new format (as suggested by @emmastephenson) is: `[Organization Name]: [Testing facility name]`

## Additional Information

N/A

## Testing

This can be tested by visiting the Dashboard page, and then selecting a specific Testing facility from the dropdown menu, and then switching back to "All facilities". This can be done locally or via Storybook (the Storybook component is inside APP > Analytics).
 
## Screenshots / Demos

On page load:

<img width="1074" alt="Screen Shot 2022-04-28 at 5 55 51 PM" src="https://user-images.githubusercontent.com/11892841/165870773-00b00666-96e1-49a3-abf9-61fc1aa29b49.png">

After selecting a specific testing facility:

<img width="1074" alt="Screen Shot 2022-04-28 at 5 56 00 PM" src="https://user-images.githubusercontent.com/11892841/165870786-30ff14c7-5a45-41d6-938b-c7b399de251c.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
