### PR TITLE
Hides 'Add new patient' button from entry-only users

### DIFF
--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -32,6 +32,9 @@ describe("TestQueue", () => {
       organization: {
         name: "Organization Name",
       },
+      user: {
+        roleDescription: "Standard user",
+      },
       facilities: [
         {
           id: "a1",

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Provider } from "react-redux";
 import {
   fireEvent,
   render,
@@ -7,8 +8,16 @@ import {
 } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
+import createMockStore from "redux-mock-store";
 
 import AddToQueueSearch, { QUERY_PATIENT } from "./AddToQueueSearch";
+
+const mockStore = createMockStore([]);
+const store = mockStore({
+  user: {
+    roleDescription: "Standard user",
+  },
+});
 
 let refetchQueueMock;
 let setStartTestPatientIdMock;
@@ -74,17 +83,19 @@ describe("AddToSearchQueue", () => {
     setStartTestPatientIdMock = jest.fn();
 
     render(
-      <MemoryRouter>
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <AddToQueueSearch
-            refetchQueue={refetchQueueMock}
-            facilityId={facilityId}
-            patientsInQueue={[patientInQueue.internalId]}
-            startTestPatientId=""
-            setStartTestPatientId={setStartTestPatientIdMock}
-          />
-        </MockedProvider>
-      </MemoryRouter>
+      <Provider store={store}>
+        <MemoryRouter>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <AddToQueueSearch
+              refetchQueue={refetchQueueMock}
+              facilityId={facilityId}
+              patientsInQueue={[patientInQueue.internalId]}
+              startTestPatientId=""
+              setStartTestPatientId={setStartTestPatientIdMock}
+            />
+          </MockedProvider>
+        </MemoryRouter>
+      </Provider>
     );
   });
 

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import moment from "moment";
 import { Navigate, useLocation } from "react-router-dom";
+import { useSelector } from "react-redux";
 
 import Button from "../../commonComponents/Button/Button";
 import AoEModalForm from "../AoEForm/AoEModalForm";
@@ -8,6 +9,7 @@ import { displayFullName } from "../../utils";
 import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
 import { getFacilityIdFromUrl } from "../../utils/url";
+import { hasPermission, appPermissions } from "../../permissions";
 
 interface SearchResultsProps {
   patients: Patient[];
@@ -41,6 +43,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
     selectedPatient,
   } = props;
 
+  const user = useSelector((state) => (state as any).user as User);
   const [dialogPatient, setDialogPatient] = useState<Patient | null>(null);
   const [canAddToQueue, setCanAddToQueue] = useState(false);
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
@@ -53,6 +56,11 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       setCanAddToQueue(true);
     }
   }, [selectedPatient]);
+
+  const canEditPeople = hasPermission(
+    user.permissions,
+    appPermissions.people.canEdit
+  );
 
   if (redirect) {
     return <Navigate to={redirect} />;
@@ -101,14 +109,20 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       >
         <div className="margin-bottom-105">No results found.</div>
         <div>
-          Check for spelling errors or
-          <Button
-            className="margin-left-1"
-            label="Add new patient"
-            onClick={() => {
-              setRedirect(`/add-patient?facility=${activeFacilityId}`);
-            }}
-          />
+          Check for spelling errors
+          {canEditPeople ? (
+            <>
+              {" "}
+              or
+              <Button
+                className="margin-left-1"
+                label="Add new patient"
+                onClick={() => {
+                  setRedirect(`/add-patient?facility=${activeFacilityId}`);
+                }}
+              />
+            </>
+          ) : null}
         </div>
       </div>
     );


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #2920 

## Changes Proposed

Conditionally hides the "Add new patient" button in SearchResults if the logged in user is not authorized to add new patients.

## Additional Information

Uses the `EDIT_PATIENT` UserPermission to determine if a user is allowed to add new patients.

## Testing

1. Spoof an entry-only user (can do on local)
1. Look up someone who isn't in the org
1. Verify "Add new patient" button does not show up

For regression testing:

1. Spoof a standard user
1. Look up someone who isn't in the org
1. Verify "Add new patient" button shows up
1. Click "Add new patient" button, and verify you are redirected to the "Add new person" page
 
## Screenshots / Demos

As entry-only user:

<img width="1547" alt="Screen Shot 2022-04-28 at 7 25 06 PM" src="https://user-images.githubusercontent.com/11892841/165877527-8c7cf85b-97ec-4781-abd9-25b3efa05a9f.png">

As standard user:

<img width="1549" alt="Screen Shot 2022-04-28 at 7 28 05 PM" src="https://user-images.githubusercontent.com/11892841/165877550-f5b38ef5-727d-4dea-ad14-321b1732f496.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
