### PR TITLE
Content updates in the add person flow

### DIFF
--- a/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.stories.tsx
+++ b/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.stories.tsx
@@ -1,0 +1,46 @@
+import { Story, Meta } from "@storybook/react";
+
+import YesNoNotSureRadioGroup from "./YesNoNotSureRadioGroup";
+
+export default {
+  title: "Components/Yes, No, Not Sure Radio Group",
+  component: YesNoNotSureRadioGroup,
+  argTypes: {},
+  args: {
+    legend: "Question with a Yes/No/Not Sure answer?",
+    name: "radioGroup1",
+    value: undefined,
+    onChange: () => {},
+    onBlur: () => {},
+    validationStatus: undefined,
+    errorMessage: "This is an error message.",
+    hintText: undefined,
+  },
+} as Meta;
+
+type Props = React.ComponentProps<typeof YesNoNotSureRadioGroup>;
+
+const RadioGroupTemplate: Story<Props> = (args) => (
+  <div className="margin-9">
+    <YesNoNotSureRadioGroup {...args} />
+  </div>
+);
+
+export const Default = RadioGroupTemplate.bind({});
+Default.args = {};
+
+export const WithHint = RadioGroupTemplate.bind({});
+WithHint.args = {
+  hintText: "more context for the question",
+};
+
+export const PreSelectedAnswer = RadioGroupTemplate.bind({});
+PreSelectedAnswer.args = {
+  value: "YES",
+};
+
+export const onError = RadioGroupTemplate.bind({});
+onError.args = {
+  validationStatus: "error",
+  errorMessage: "Oops something went wrong!",
+};

--- a/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.test.tsx
+++ b/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import YesNoNotSureRadioGroup from "./YesNoNotSureRadioGroup";
+
+describe("Yes/No/Not Sure RadioGroup", () => {
+  const onChangeFn = jest.fn(() => {});
+  const onBlurFn = jest.fn(() => {});
+
+  const defaultArgs = {
+    legend: "Question with a Yes/No/Not Sure answer?",
+    name: "radioGroup1",
+    value: undefined,
+    onChange: onChangeFn,
+    onBlur: onBlurFn,
+    validationStatus: undefined,
+    errorMessage: "This is an error message.",
+    hintText: undefined,
+  };
+
+  it("renders component with a hint text", () => {
+    render(
+      <YesNoNotSureRadioGroup {...defaultArgs} hintText="This is a hint" />
+    );
+    expect(screen.getByText("This is a hint")).toBeInTheDocument();
+  });
+
+  it("renders with an error", () => {
+    render(
+      <YesNoNotSureRadioGroup {...defaultArgs} validationStatus="error" />
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      defaultArgs.errorMessage
+    );
+  });
+
+  it("calls function on changed", () => {
+    render(<YesNoNotSureRadioGroup {...defaultArgs} />);
+
+    userEvent.click(screen.getByLabelText("Yes"));
+
+    expect(onChangeFn).toHaveBeenCalledWith("YES");
+    expect(onBlurFn).not.toHaveBeenCalled();
+  });
+
+  it("calls function on blur", () => {
+    render(<YesNoNotSureRadioGroup {...defaultArgs} />);
+
+    userEvent.click(screen.getByLabelText("Yes"));
+    userEvent.click(screen.getByLabelText("No"));
+
+    expect(onBlurFn).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.test.tsx
+++ b/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.test.tsx
@@ -8,21 +8,20 @@ describe("Yes/No/Not Sure RadioGroup", () => {
   const onBlurFn = jest.fn(() => {});
 
   const defaultArgs = {
-    legend: "Question with a Yes/No/Not Sure answer?",
-    name: "radioGroup1",
+    legend: "Are you a wizard?",
+    name: "hogwartsRadioGroup",
     value: undefined,
     onChange: onChangeFn,
     onBlur: onBlurFn,
     validationStatus: undefined,
-    errorMessage: "This is an error message.",
+    errorMessage: "Don’t let the Muggles get you down.",
     hintText: undefined,
   };
 
   it("renders component with a hint text", () => {
-    render(
-      <YesNoNotSureRadioGroup {...defaultArgs} hintText="This is a hint" />
-    );
-    expect(screen.getByText("This is a hint")).toBeInTheDocument();
+    const hint = "You are a wizard Harry.";
+    render(<YesNoNotSureRadioGroup {...defaultArgs} hintText={hint} />);
+    expect(screen.getByText(hint)).toBeInTheDocument();
   });
 
   it("renders with an error", () => {

--- a/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.tsx
+++ b/frontend/src/app/commonComponents/YesNoNotSureRadioGroup.tsx
@@ -4,9 +4,9 @@ import { useTranslatedConstants } from "../constants";
 
 import RadioGroup from "./RadioGroup";
 
-export const boolToYesNoUnknown = (
+export const boolToYesNoNotSure = (
   value: boolean | null | undefined
-): YesNoUnknown | undefined => {
+): YesNoNotSure | undefined => {
   if (value) {
     return "YES";
   }
@@ -14,13 +14,13 @@ export const boolToYesNoUnknown = (
     return "NO";
   }
   if (value === null) {
-    return "UNKNOWN";
+    return "NOT_SURE";
   }
   return undefined;
 };
 
-export const yesNoUnknownToBool = (
-  value: YesNoUnknown
+export const yesNoNotSureToBool = (
+  value: YesNoNotSure
 ): boolean | null | undefined => {
   if (value === "YES") {
     return true;
@@ -28,7 +28,7 @@ export const yesNoUnknownToBool = (
   if (value === "NO") {
     return false;
   }
-  if (value === "UNKNOWN") {
+  if (value === "NOT_SURE") {
     return null;
   }
   return undefined;
@@ -37,8 +37,8 @@ export const yesNoUnknownToBool = (
 interface Props {
   name: string;
   legend: React.ReactNode;
-  value: YesNoUnknown | undefined;
-  onChange: (value: YesNoUnknown) => void;
+  value: YesNoNotSure | undefined;
+  onChange: (value: YesNoNotSure) => void;
   hintText?: string;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   validationStatus?: "error" | "success";
@@ -46,7 +46,7 @@ interface Props {
   required?: boolean;
 }
 
-const YesNoRadioGroup: React.FC<Props> = ({
+const YesNoNotSureRadioGroup: React.FC<Props> = ({
   name,
   legend,
   value,
@@ -57,7 +57,7 @@ const YesNoRadioGroup: React.FC<Props> = ({
   errorMessage,
   required,
 }) => {
-  const { YES_NO_UNKNOWN_VALUES: values } = useTranslatedConstants();
+  const { YES_NO_NOT_SURE_VALUES: values } = useTranslatedConstants();
 
   return (
     <RadioGroup
@@ -75,4 +75,4 @@ const YesNoRadioGroup: React.FC<Props> = ({
   );
 };
 
-export default YesNoRadioGroup;
+export default YesNoNotSureRadioGroup;

--- a/frontend/src/app/commonComponents/YesNoRadioGroup.test.tsx
+++ b/frontend/src/app/commonComponents/YesNoRadioGroup.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import YesNoNotSureRadioGroup, {
-  boolToYesNoNotSure,
-  yesNoNotSureToBool,
-} from "./YesNoNotSureRadioGroup";
+import YesNoRadioGroup, {
+  boolToYesNoUnknown,
+  yesNoUnknownToBool,
+} from "./YesNoRadioGroup";
 
-describe("Yes/No/Not Sure RadioGroup", () => {
+describe("Yes/No/Unknown RadioGroup", () => {
   const onChangeFn = jest.fn(() => {});
   const onBlurFn = jest.fn(() => {});
 
@@ -23,51 +23,49 @@ describe("Yes/No/Not Sure RadioGroup", () => {
 
   it("renders component with a hint text", () => {
     const hint = "You are a wizard Harry.";
-    render(<YesNoNotSureRadioGroup {...defaultArgs} hintText={hint} />);
+    render(<YesNoRadioGroup {...defaultArgs} hintText={hint} />);
     expect(screen.getByText(hint)).toBeInTheDocument();
   });
 
   it("renders with an error", () => {
-    render(
-      <YesNoNotSureRadioGroup {...defaultArgs} validationStatus="error" />
-    );
+    render(<YesNoRadioGroup {...defaultArgs} validationStatus="error" />);
     expect(screen.getByRole("alert")).toHaveTextContent(
       defaultArgs.errorMessage
     );
   });
 
   it("calls function on change with correct value", () => {
-    render(<YesNoNotSureRadioGroup {...defaultArgs} />);
+    render(<YesNoRadioGroup {...defaultArgs} />);
 
     userEvent.click(screen.getByLabelText("Yes"));
     expect(onChangeFn).toHaveBeenCalledWith("YES");
     userEvent.click(screen.getByLabelText("No"));
     expect(onChangeFn).toHaveBeenCalledWith("NO");
-    userEvent.click(screen.getByLabelText("Not sure"));
-    expect(onChangeFn).toHaveBeenCalledWith("NOT_SURE");
+    userEvent.click(screen.getByLabelText("Unknown"));
+    expect(onChangeFn).toHaveBeenCalledWith("UNKNOWN");
   });
 
   it("calls function on blur", () => {
-    render(<YesNoNotSureRadioGroup {...defaultArgs} />);
+    render(<YesNoRadioGroup {...defaultArgs} />);
 
     userEvent.click(screen.getByLabelText("Yes"));
     userEvent.click(screen.getByLabelText("No"));
     expect(onBlurFn).toHaveBeenCalled();
   });
 
-  describe("Yes/No/Not Sure utility methods", () => {
+  describe("Yes/No/Unknown utility methods", () => {
     it("converts value to bool", () => {
-      expect(yesNoNotSureToBool("YES")).toBeTruthy();
-      expect(yesNoNotSureToBool("NO")).toBeFalsy();
-      expect(yesNoNotSureToBool("NOT_SURE")).toBeNull();
+      expect(yesNoUnknownToBool("YES")).toBeTruthy();
+      expect(yesNoUnknownToBool("NO")).toBeFalsy();
+      expect(yesNoUnknownToBool("UNKNOWN")).toBeNull();
       // @ts-ignore
-      expect(yesNoNotSureToBool(undefined)).toBeUndefined();
+      expect(yesNoUnknownToBool(undefined)).toBeUndefined();
     });
     it("converts bool to value", () => {
-      expect(boolToYesNoNotSure(true)).toBe("YES");
-      expect(boolToYesNoNotSure(false)).toBe("NO");
-      expect(boolToYesNoNotSure(null)).toBe("NOT_SURE");
-      expect(boolToYesNoNotSure(undefined)).toBeUndefined();
+      expect(boolToYesNoUnknown(true)).toBe("YES");
+      expect(boolToYesNoUnknown(false)).toBe("NO");
+      expect(boolToYesNoUnknown(null)).toBe("UNKNOWN");
+      expect(boolToYesNoUnknown(undefined)).toBeUndefined();
     });
   });
 });

--- a/frontend/src/app/constants/constants.d.ts
+++ b/frontend/src/app/constants/constants.d.ts
@@ -12,6 +12,7 @@ type YesNo = "YES" | "NO";
 type Role = "STAFF" | "RESIDENT" | "STUDENT" | "VISITOR" | "";
 type PhoneType = "MOBILE" | "LANDLINE" | "UNKNOWN";
 type YesNoUnknown = YesNo | "UNKNOWN";
+type YesNoNotSure = YesNo | "NOT_SURE";
 type TribalAffiliation =
   | "1"
   | "2"

--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -136,6 +136,18 @@ const yesNoUnkownValues = (
   ];
 };
 
+const yesNoNotSureValues = (
+  t: TFunction
+): {
+  value: YesNoNotSure;
+  label: string;
+}[] => {
+  return [
+    ...yesNoValues(i18n.t),
+    { value: "NOT_SURE", label: i18n.t("constants.yesNoNotSure.NOT_SURE") },
+  ];
+};
+
 const fullTribalAffiliationValueSetMap: { [key: string]: TribalAffiliation } = {
   "Village of Afognak": "338",
   "Agdaagux Tribe of King Cove": "339",
@@ -762,5 +774,6 @@ export const useTranslatedConstants = () => {
     PHONE_TYPE_VALUES: phoneTypeValues(t),
     YES_NO_VALUES: yesNoValues(t),
     YES_NO_UNKNOWN_VALUES: yesNoUnkownValues(t),
+    YES_NO_NOT_SURE_VALUES: yesNoNotSureValues(t),
   };
 };

--- a/frontend/src/app/patients/Components/FacilitySelect.tsx
+++ b/frontend/src/app/patients/Components/FacilitySelect.tsx
@@ -37,7 +37,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
 
   return (
     <Select
-      label="Facility"
+      label="Testing facility"
       name={NAME}
       value={props.facilityId === null ? ALL_FACILITIES : props.facilityId}
       onChange={onChange}

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -24,7 +24,6 @@ import {
   usePersonSchemata,
 } from "../personSchema";
 import { TestResultDeliveryPreference } from "../TestResultDeliveryPreference";
-import YesNoRadioGroup from "../../commonComponents/YesNoRadioGroup";
 import Input from "../../commonComponents/Input";
 import Select from "../../commonComponents/Select";
 import {
@@ -40,6 +39,10 @@ import {
   toggleDeliveryPreferenceEmail,
 } from "../../utils/deliveryPreferences";
 import Prompt from "../../utils/Prompt";
+import YesNoNotSureRadioGroup, {
+  boolToYesNoNotSure,
+  yesNoNotSureToBool,
+} from "../../commonComponents/YesNoNotSureRadioGroup";
 
 import FacilitySelect from "./FacilitySelect";
 import ManagePhoneNumbers from "./ManagePhoneNumbers";
@@ -52,36 +55,6 @@ export enum PersonFormView {
   PXP,
   SELF_REGISTRATION,
 }
-
-const boolToYesNoUnknown = (
-  value: boolean | null | undefined
-): YesNoUnknown | undefined => {
-  if (value) {
-    return "YES";
-  }
-  if (value === false) {
-    return "NO";
-  }
-  if (value === null) {
-    return "UNKNOWN";
-  }
-  return undefined;
-};
-
-const yesNoUnknownToBool = (
-  value: YesNoUnknown
-): boolean | null | undefined => {
-  if (value === "YES") {
-    return true;
-  }
-  if (value === "NO") {
-    return false;
-  }
-  if (value === "UNKNOWN") {
-    return null;
-  }
-  return undefined;
-};
 
 interface Props {
   patient: Nullable<PersonFormData>;
@@ -633,13 +606,13 @@ const PersonForm = (props: Props) => {
         />
       </FormGroup>
       <FormGroup title={t("patient.form.other.heading")}>
-        <YesNoRadioGroup
+        <YesNoNotSureRadioGroup
           legend={t("patient.form.other.congregateLiving.heading")}
           hintText={t("patient.form.other.congregateLiving.helpText")}
           name="residentCongregateSetting"
-          value={boolToYesNoUnknown(patient.residentCongregateSetting)}
+          value={boolToYesNoNotSure(patient.residentCongregateSetting)}
           onChange={(v) =>
-            onPersonChange("residentCongregateSetting")(yesNoUnknownToBool(v))
+            onPersonChange("residentCongregateSetting")(yesNoNotSureToBool(v))
           }
           onBlur={() => {
             onBlurField("residentCongregateSetting");
@@ -647,12 +620,12 @@ const PersonForm = (props: Props) => {
           validationStatus={validationStatus("residentCongregateSetting")}
           errorMessage={errors.residentCongregateSetting}
         />
-        <YesNoRadioGroup
+        <YesNoNotSureRadioGroup
           legend={t("patient.form.other.healthcareWorker")}
           name="employedInHealthcare"
-          value={boolToYesNoUnknown(patient.employedInHealthcare)}
+          value={boolToYesNoNotSure(patient.employedInHealthcare)}
           onChange={(v) =>
-            onPersonChange("employedInHealthcare")(yesNoUnknownToBool(v))
+            onPersonChange("employedInHealthcare")(yesNoNotSureToBool(v))
           }
           onBlur={() => {
             onBlurField("employedInHealthcare");

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -467,7 +467,7 @@ describe("EditPatient", () => {
     },
   ];
 
-  describe("non-answer and unknown options", () => {
+  describe("non-answer and not sure options", () => {
     beforeEach(async () => {
       render(
         <MemoryRouter>
@@ -500,15 +500,15 @@ describe("EditPatient", () => {
         }
       );
     });
-    it("shows unknown answers", () => {
-      ["congregate", "health care"].forEach((legend) => {
+    it("shows not sure answers", () => {
+      ["group or shared housing facility", "health care"].forEach((legend) => {
         const fieldset = screen
           .getByText(legend, { exact: false })
           .closest("fieldset");
         if (fieldset === null) {
           throw Error(`Unable to corresponding fieldset for ${legend}`);
         }
-        const option = within(fieldset).getByLabelText("Unknown");
+        const option = within(fieldset).getByLabelText("Not sure");
         expect(option).toBeChecked();
       });
     });

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -225,7 +225,7 @@ Object {
                         class="usa-label"
                         for="99"
                       >
-                        Facility
+                        Testing facility
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -316,7 +316,7 @@ Object {
                   <p
                     class="usa-hint maxw-prose"
                   >
-                    You're responsible for entering the correct contact information, following applicable federal and state laws.
+                    You're responsible for entering correct contact information, following applicable federal and state laws.
                   </p>
                   <div
                     class="usa-form"
@@ -2417,7 +2417,7 @@ Object {
                   <legend
                     class="prime-formgroup-heading usa-legend"
                   >
-                    Other
+                    Other information
                   </legend>
                   <div
                     class="usa-form-group"
@@ -2428,7 +2428,7 @@ Object {
                       <legend
                         class="usa-legend"
                       >
-                        Are you a resident in a congregate living setting?
+                        Are you a resident in a group or shared housing facility?
                       </legend>
                       <span
                         class="usa-hint"
@@ -2481,16 +2481,16 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="114-val-UNKNOWN"
+                            id="114-val-NOT_SURE"
                             name="residentCongregateSetting"
                             type="radio"
-                            value="UNKNOWN"
+                            value="NOT_SURE"
                           />
                           <label
                             class="usa-radio__label"
-                            for="114-val-UNKNOWN"
+                            for="114-val-NOT_SURE"
                           >
-                            Unknown
+                            Not sure
                           </label>
                         </div>
                       </div>
@@ -2553,16 +2553,16 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="115-val-UNKNOWN"
+                            id="115-val-NOT_SURE"
                             name="employedInHealthcare"
                             type="radio"
-                            value="UNKNOWN"
+                            value="NOT_SURE"
                           />
                           <label
                             class="usa-radio__label"
-                            for="115-val-UNKNOWN"
+                            for="115-val-NOT_SURE"
                           >
-                            Unknown
+                            Not sure
                           </label>
                         </div>
                       </div>
@@ -2812,7 +2812,7 @@ Object {
                       class="usa-label"
                       for="99"
                     >
-                      Facility
+                      Testing facility
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -2903,7 +2903,7 @@ Object {
                 <p
                   class="usa-hint maxw-prose"
                 >
-                  You're responsible for entering the correct contact information, following applicable federal and state laws.
+                  You're responsible for entering correct contact information, following applicable federal and state laws.
                 </p>
                 <div
                   class="usa-form"
@@ -5004,7 +5004,7 @@ Object {
                 <legend
                   class="prime-formgroup-heading usa-legend"
                 >
-                  Other
+                  Other information
                 </legend>
                 <div
                   class="usa-form-group"
@@ -5015,7 +5015,7 @@ Object {
                     <legend
                       class="usa-legend"
                     >
-                      Are you a resident in a congregate living setting?
+                      Are you a resident in a group or shared housing facility?
                     </legend>
                     <span
                       class="usa-hint"
@@ -5068,16 +5068,16 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="114-val-UNKNOWN"
+                          id="114-val-NOT_SURE"
                           name="residentCongregateSetting"
                           type="radio"
-                          value="UNKNOWN"
+                          value="NOT_SURE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="114-val-UNKNOWN"
+                          for="114-val-NOT_SURE"
                         >
-                          Unknown
+                          Not sure
                         </label>
                       </div>
                     </div>
@@ -5140,16 +5140,16 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="115-val-UNKNOWN"
+                          id="115-val-NOT_SURE"
                           name="employedInHealthcare"
                           type="radio"
-                          value="UNKNOWN"
+                          value="NOT_SURE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="115-val-UNKNOWN"
+                          for="115-val-NOT_SURE"
                         >
-                          Unknown
+                          Not sure
                         </label>
                       </div>
                     </div>

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -3,6 +3,7 @@ const NO = "No";
 const OTHER = "Other";
 const REFUSED = "Prefer not to answer";
 const UNKNOWN = "Unknown";
+const NOT_SURE = "Not sure";
 
 export const en = {
   translation: {
@@ -58,6 +59,11 @@ export const en = {
         YES,
         NO,
         UNKNOWN,
+      },
+      yesNoNotSure: {
+        YES,
+        NO,
+        NOT_SURE,
       },
       date: {
         month: "Month",
@@ -122,7 +128,7 @@ export const en = {
         contact: {
           heading: "Contact information",
           helpText:
-            "You're responsible for entering the correct contact information, following applicable federal and state laws.",
+            "You're responsible for entering correct contact information, following applicable federal and state laws.",
           primaryPhoneNumber: "Primary phone number",
           additionalPhoneNumber: "Additional phone number",
           phoneType: "Phone type",
@@ -156,9 +162,10 @@ export const en = {
             "This is usually the gender that is written on your original birth certificate.",
         },
         other: {
-          heading: "Other",
+          heading: "Other information",
           congregateLiving: {
-            heading: "Are you a resident in a congregate living setting?",
+            heading:
+              "Are you a resident in a group or shared housing facility?",
             helpText:
               "For example: nursing home, group home, prison, jail, or military",
           },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -5,6 +5,7 @@ const NO = "No";
 const OTHER = "Otra";
 const REFUSED = "Prefiero no responder";
 const UNKNOWN = "Desconocido";
+const NOT_SURE = "No estoy seguro/a";
 const POSITIVE = "Positivo";
 const NEGATIVE = "Negativo";
 const UNDETERMINED = "No concluyente";
@@ -64,6 +65,11 @@ export const es: LanguageConfig = {
         YES,
         NO,
         UNKNOWN,
+      },
+      yesNoNotSure: {
+        YES,
+        NO,
+        NOT_SURE,
       },
       date: {
         month: "Mes",
@@ -166,7 +172,7 @@ export const es: LanguageConfig = {
             "Por lo general, este es el género que está escrito en su certificado de nacimiento original.",
         },
         other: {
-          heading: "Otro",
+          heading: "Información adicional",
           congregateLiving: {
             heading:
               "¿Reside usted en un entorno compartido por muchas personas?",


### PR DESCRIPTION
## Related Issue

Fixes [#3018](https://github.com/CDCgov/prime-simplereport/issues/3018)

## Changes Proposed
- Creates a new radio group with the Yes/No/Not Sure combo. Added test cases for this new component.
- Replaces the Yes/No/Unknown group with the new Yes/No/Not Sure group.
- Updates different variables in the en and es language configuration to match the story acceptance criteria.
- Moves conversion utility methods to the Yes/No/Unknown component so it is self contained.
- Add testing coverage for the Yes/No/Unknown component.

## Additional Information

- A new radio group got created because 1) The "unknown" wording was really intertwine in the code of the yes/no radio group. 2) the yes/no/unknown radio group is still a useful common component that could be needed in the future so creating a new radio group with the "not sure" combo made more sense.

## Testing

- How should reviewers verify this PR?

**Add a patient flow**
Go to people view and click on add person button and make sure the text changes listed in [#3018](https://github.com/CDCgov/prime-simplereport/issues/3018) are reflected. 

**Patient self-registration flow** (eng/esp)
1)Go to settings-> self-registration tab-> copy the self registration url
2)Launch the patient self-registration form and make sure the text changes listed in [#3018](https://github.com/CDCgov/prime-simplereport/issues/3018) are reflected.

## Screenshots / Demos
![self_registration_esp](https://user-images.githubusercontent.com/103958711/166303086-d56d32d1-c3c1-4b0d-83a9-e8ac6dee71b0.png)
![self_registration_eng](https://user-images.githubusercontent.com/103958711/166303091-09e8bab4-003b-4349-bc6f-25c28ebe21d7.png)
![add_person_content_updates](https://user-images.githubusercontent.com/103958711/166303092-8ec7745b-66d2-4815-9043-2049c2cd511b.png)


- For large changes, please pair with a designer to ensure changes are as intended

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes have been approved by content team

### Support
- [n/a] Any changes that might generate new support requests have been flagged to the support team
- [n/a] Any changes to support infrastructure have been demo'd to support team

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed
