### PR TITLE
refactor findSupportedDiseaseByNameContains to findByName

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SupportedDiseaseRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SupportedDiseaseRepository.java
@@ -2,11 +2,12 @@ package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface SupportedDiseaseRepository extends CrudRepository<SupportedDisease, UUID> {
   List<SupportedDisease> findAllByName(String name);
 
-  SupportedDisease findSupportedDiseaseByNameContains(String name);
+  Optional<SupportedDisease> findByName(String name);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -23,9 +23,9 @@ public class DiseaseService {
   private SupportedDisease fluB;
 
   public void initDiseases() {
-    covid = _supportedDiseaseRepo.findSupportedDiseaseByNameContains("COVID");
-    fluA = _supportedDiseaseRepo.findSupportedDiseaseByNameContains("Flu A");
-    fluB = _supportedDiseaseRepo.findSupportedDiseaseByNameContains("Flu B");
+    covid = _supportedDiseaseRepo.findByName("COVID-19").orElse(null);
+    fluA = _supportedDiseaseRepo.findByName("Flu A").orElse(null);
+    fluB = _supportedDiseaseRepo.findByName("Flu B").orElse(null);
   }
 
   public List<SupportedDisease> fetchSupportedDiseases() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/SupportedDiseaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/SupportedDiseaseRepositoryTest.java
@@ -1,32 +1,28 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 class SupportedDiseaseRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private SupportedDiseaseRepository _repo;
 
   @Test
-  void findSupportedDiseaseByNameContains_successful() {
-    SupportedDisease covid = _repo.findSupportedDiseaseByNameContains("COVID");
+  void findSupportedDiseaseByName_successful() {
+    SupportedDisease covid = _repo.findByName("COVID-19").orElse(null);
+    assertNotNull(covid);
     assertEquals("96741-4", covid.getLoinc());
   }
 
   @Test
-  void findSupportedDiseaseByNameContains_needsConclusiveSearchTerm() {
-    Throwable caught =
-        assertThrows(
-            IncorrectResultSizeDataAccessException.class,
-            () -> {
-              _repo.findSupportedDiseaseByNameContains("Flu");
-            });
-    assertTrue(caught.getMessage().contains("query did not return a unique result: 2"));
+  void findSupportedDiseaseByName_needsConclusiveSearchTerm() {
+    Optional<SupportedDisease> flu = _repo.findByName("Flu");
+    assertTrue(flu.isEmpty());
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- `findSupportedDiseaseByNameContains` causes the following error in future spring versions


```java
Caused by: org.springframework.dao.InvalidDataAccessApiUsageException: Parameter value [\] did not match expected type [java.lang.String (n/a)]; nested exception is java.lang.IllegalArgumentException: Parameter value [\] did not match expected type [java.lang.String (n/a)]
	at app//org.springframework.orm.jpa.EntityManagerFactoryUtils.convertJpaAccessExceptionIfPossible(EntityManagerFactoryUtils.java:374)
	at app//org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:235)
	at app//org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.translateExceptionIfPossible(AbstractEntityManagerFactoryBean.java:551)
	at app//org.springframework.dao.support.ChainedPersistenceExceptionTranslator.translateExceptionIfPossible(ChainedPersistenceExceptionTranslator.java:61)
	at app//org.springframework.dao.support.DataAccessUtils.translateIfNecessary(DataAccessUtils.java:242)
	at app//org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:152)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at app//org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:145)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at app//org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at app//org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at app//com.sun.proxy.$Proxy211.findSupportedDiseaseByNameContains(Unknown Source)
	at app//gov.cdc.usds.simplereport.service.DiseaseService.initDiseases(DiseaseService.java:27)
	at app//gov.cdc.usds.simplereport.service.DiseaseService$$FastClassBySpringCGLIB$$e4305785.invoke(<generated>)
	at app//org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at app//org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
	at app//org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388)
	at app//org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at app//org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at app//gov.cdc.usds.simplereport.service.DiseaseService$$EnhancerBySpringCGLIB$$d844157.initDiseases(<generated>)
	at app//gov.cdc.usds.simplereport.SimpleReportApplication.lambda$initDiseasesOnStartup$0(SimpleReportApplication.java:50)
	at app//org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:777)
	... 84 more

```


## Changes Proposed

- refactor `findSupportedDiseaseByNameContains` to `findByName` in `SupportedDiseaseRepository` and utilize `Optionals`
