### PR TITLE
always specify the schema when referencing a table name in the migration

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1598,6 +1598,7 @@ databaseChangeLog:
         - sql:
             remarks: Create migrations user to indicate records created by migration rather than by a human.
             sql: |
+              SET search_path TO ${database.defaultSchemaName};
               INSERT INTO ${database.defaultSchemaName}.api_user
               (internal_id, created_at, updated_at, is_deleted, last_seen, login_email, last_name)
               VALUES (
@@ -2174,7 +2175,7 @@ databaseChangeLog:
                     nullable: false
         - sql:
             remarks: Add constraint to allow for a facility or an organization.
-            sql: ALTER TABLE patient_registration_link ADD CONSTRAINT facility_or_organization CHECK (num_nonnulls(facility_id, organization_id) = 1)
+            sql: ALTER TABLE  ${database.defaultSchemaName}.patient_registration_link ADD CONSTRAINT facility_or_organization CHECK (num_nonnulls(facility_id, organization_id) = 1)
       rollback:
         - dropTable:
             tableName: patient_registration_link
@@ -2560,7 +2561,7 @@ databaseChangeLog:
                 pp.preferred_language,
                 pp.test_result_delivery
               FROM ${database.defaultSchemaName}.person p
-              JOIN patient_preferences pp on pp.internal_id=p.internal_id
+              JOIN ${database.defaultSchemaName}.patient_preferences pp on pp.internal_id=p.internal_id
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
       rollback:
@@ -2747,7 +2748,7 @@ databaseChangeLog:
                   SELECT
                     o.internal_id AS organization_id, f.internal_id AS facility_id, m.migrations_user_id AS migrations_user_id
                   FROM
-                    facility AS f 
+                    ${database.defaultSchemaName}.facility AS f 
                     FULL OUTER JOIN ${database.defaultSchemaName}.patient_registration_link AS p ON f.internal_id = p.facility_id 
                     FULL OUTER JOIN ${database.defaultSchemaName}.organization AS o ON o.internal_id = p.organization_id
                     CROSS JOIN migration_user AS m
@@ -2881,7 +2882,7 @@ databaseChangeLog:
                 pp.preferred_language,
                 pp.test_result_delivery
               FROM ${database.defaultSchemaName}.person p
-              JOIN patient_preferences pp on pp.internal_id=p.internal_id
+              JOIN ${database.defaultSchemaName}.patient_preferences pp on pp.internal_id=p.internal_id
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.person_no_phi_view TO ${noPhiUsername};
       rollback:
@@ -3454,7 +3455,7 @@ databaseChangeLog:
         - sql:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
-              UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+              UPDATE ${database.defaultSchemaName}.person SET emails = ARRAY[email] WHERE email IS NOT NULL;
       rollback:
         - dropColumn:
             tableName: person
@@ -3469,7 +3470,7 @@ databaseChangeLog:
         - sql:
             remarks: Populate new `emails` column with value from patient `email`
             sql: |
-              UPDATE person SET emails = ARRAY[email] WHERE email IS NOT NULL;
+              UPDATE ${database.defaultSchemaName}.person SET emails = ARRAY[email] WHERE email IS NOT NULL;
       rollback:
         - sql:
             sql: |


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Newer versions of spring uses a newer versions of the Liquibase library that is more strict than the current version.

## Changes Proposed

liquibase `org.liquibase:liquibase-core` version (managed by spring) has been updated from 3.10 to 4.5, the new version is stricter when running the old migrations, and it require you to specify the schema every time you reference a table, 

Note:
**this will require manual db checksum fix, for every azure env and local db**