### PR TITLE
Added noindex meta tag to index page

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -20,6 +20,7 @@
       name="description"
       content="%REACT_APP_DESCRIPTION%"
     />
+    <meta name="robots" content="noindex" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/%REACT_APP_ICON%" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes [#3667](https://github.com/CDCgov/prime-simplereport/issues/3667)

## Changes Proposed

To prevent most search engine web crawlers from indexing a page on your site, place the following meta tag into the <meta name="robots" content="noindex">

## Testing

Check that the index.html contains the new meta tag.
 
## Screenshots / Demos

<img width="632" alt="Screen Shot 2022-05-06 at 10 48 35 AM" src="https://user-images.githubusercontent.com/103958711/167157244-abfc50fd-3e46-4424-ab9b-f49ef27a564d.png">

