### PR TITLE
Testing time improvements: Alis/3049

### DIFF
--- a/.github/workflows/buildBackendImage.yml
+++ b/.github/workflows/buildBackendImage.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1

--- a/.github/workflows/buildFrontendImage.yml
+++ b/.github/workflows/buildFrontendImage.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1

--- a/.github/workflows/buildNginxImage.yml
+++ b/.github/workflows/buildNginxImage.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1

--- a/.github/workflows/checkGraphql.yml
+++ b/.github/workflows/checkGraphql.yml
@@ -20,7 +20,7 @@ jobs:
   check-graphql-types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{env.NODE_VERSION}}
         uses: actions/setup-node@v2.1.5
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,7 +10,7 @@ jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Chromatic wants the history
       - uses: actions/setup-node@v2

--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: "14"

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -41,7 +41,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -62,7 +62,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -97,7 +97,7 @@ jobs:
       url: https://demo.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -36,7 +36,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -60,7 +60,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -96,7 +96,7 @@ jobs:
       url: https://dev.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -116,7 +116,7 @@ jobs:
       run:
         working-directory: ./ops
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run health checks
         uses: ./.github/actions/health-checks
         with:

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -36,7 +36,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -60,7 +60,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -96,7 +96,7 @@ jobs:
       url: https://${{env.DEPLOY_ENV}}.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -116,7 +116,7 @@ jobs:
       run:
         working-directory: ./ops
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run health checks
         uses: ./.github/actions/health-checks
         with:

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -36,7 +36,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -60,7 +60,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -96,7 +96,7 @@ jobs:
       url: https://${{env.DEPLOY_ENV}}.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -116,7 +116,7 @@ jobs:
       run:
         working-directory: ./ops
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run health checks
         uses: ./.github/actions/health-checks
         with:

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -36,7 +36,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -60,7 +60,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -96,7 +96,7 @@ jobs:
       url: https://${{env.DEPLOY_ENV}}.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -116,7 +116,7 @@ jobs:
       run:
         working-directory: ./ops
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run health checks
         uses: ./.github/actions/health-checks
         with:

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -36,7 +36,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -56,7 +56,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -92,7 +92,7 @@ jobs:
       url: https://pentest.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -41,7 +41,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -68,7 +68,7 @@ jobs:
     outputs:
       download-url: ${{steps.upload.outputs.url}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -106,7 +106,7 @@ jobs:
       url: https://simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -38,7 +38,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -58,7 +58,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -94,7 +94,7 @@ jobs:
       url: https://stg.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -114,7 +114,7 @@ jobs:
       run:
         working-directory: ./ops
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run health checks
         uses: ./.github/actions/health-checks
         with:

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -37,7 +37,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -61,7 +61,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -97,7 +97,7 @@ jobs:
       url: https://test.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ACR
@@ -41,7 +41,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -62,7 +62,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{env.NODE_VERSION}}
@@ -98,7 +98,7 @@ jobs:
       url: https://training.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
       - name: Set up JDK ${{env.JAVA_VERSION}}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,7 +6,7 @@ jobs:
   validate-508:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Lighthouse CI Action
       uses: treosh/lighthouse-ci-action@v7

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -27,7 +27,7 @@ jobs:
       run:
         working-directory: ./frontend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "14.0"

--- a/.github/workflows/resetTrainingDB.yml
+++ b/.github/workflows/resetTrainingDB.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: ./frontend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "14.0"

--- a/.github/workflows/rollbackDB.yml
+++ b/.github/workflows/rollbackDB.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -50,7 +50,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackDemoAPI.yml
+++ b/.github/workflows/rollbackDemoAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackDevAPI.yml
+++ b/.github/workflows/rollbackDevAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackPentestAPI.yml
+++ b/.github/workflows/rollbackPentestAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackProdAPI.yml
+++ b/.github/workflows/rollbackProdAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackStgAPI.yml
+++ b/.github/workflows/rollbackStgAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackTestAPI.yml
+++ b/.github/workflows/rollbackTestAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/rollbackTrainingAPI.yml
+++ b/.github/workflows/rollbackTrainingAPI.yml
@@ -20,7 +20,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -21,7 +21,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -14,7 +14,7 @@ jobs:
   check-terraform-formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.4
@@ -30,7 +30,7 @@ jobs:
           stg stg/persistent pentest pentest/persistent prod prod/persistent
           global
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.4
@@ -59,7 +59,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ defaults:
     working-directory: backend
 
 jobs:
-  test:
+  backend-tests:
     runs-on: ubuntu-latest
     services:
       test-db:
@@ -36,9 +36,8 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:
@@ -66,13 +65,23 @@ jobs:
           TWILIO_ACCOUNT_SID: ${{secrets.TWILIO_TEST_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{secrets.TWILIO_TEST_AUTH_TOKEN }}
         run: ./gradlew jacocoTestReport -PtestDbPort=5432
-      - name: Archive Test Results
+      - name: Archive Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: backend-build
+          path: backend/build/
+      - name: Archive Failed Test Results
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-report
+          name: backtest-report
           path: backend/build/reports/tests/test
           retention-days: 7
+  frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Use Node.js ${{env.NODE_VERSION}}
         uses: actions/setup-node@v2.1.5
         with:
@@ -90,17 +99,61 @@ jobs:
       - name: Test
         working-directory: ./frontend
         run: yarn test:ci
+      - name: Archive Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+  function-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        with:
+          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: "Function Apps: npm install"
         working-directory: ./ops/services/app_functions/report_stream_batched_publisher/functions
         run: npm ci
       - name: "Function Apps: Test"
         working-directory: ./ops/services/app_functions/report_stream_batched_publisher/functions
         run: npm run coverage
-      - name: Sonar analysis
+      - name: Archive Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: function-coverage
+          path: ops/services/app_functions/report_stream_batched_publisher/functions/coverage
+  sonar:
+    needs: [backend-tests, frontend-tests, function-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
         if: ${{ github.actor != 'dependabot[bot]' }}
+        with:
+          fetch-depth: 0 # Disable shallow clones so Sonar can have all the data
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Download backend artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: backend-build
+          path: backend/build
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
+      - name: Download function artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: function-coverage
+          path: ops/services/app_functions/report_stream_batched_publisher/functions/coverage
+      - name: Sonar analysis
         run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.PROJECT_ROOT }} --info
   build-jar:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: backtest-report
+          name: backend-test-report
           path: backend/build/reports/tests/test
           retention-days: 7
   frontend-tests:

--- a/.github/workflows/testDBChangelog.yml
+++ b/.github/workflows/testDBChangelog.yml
@@ -25,7 +25,7 @@ jobs:
   test-db-rollback:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/updateGradleLocks.yml
+++ b/.github/workflows/updateGradleLocks.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Disable shallow clones: we need to be able to push
       - name: Set up JDK ${{env.JAVA_VERSION}}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #3049

- This is work to reduce the time it takes to run tests. 
- I took a quick look at testing times, and before this change, I saw time ranges between 17m 4s and 23m 4s. The test runs on this PR are as low as 11m 57s.
- Additionally, now you can rerun just the failed test suite, which cuts down on wasted time from test flake, and sonar will still be able to build a full report due to the cache we make.

## Changes Proposed

- This breaks out backend, frontend, and function tests into different jobs and caches the output required for Sonar to report on the results.

## Additional Information

- I initially tried using artifacts (because that's what I'm more comfortable with), but the gains were minimal. It took too much time to upload and download the artifacts between jobs.

## Testing

- Double-check that the testing and coverage output from the jobs is sufficient for sonar to do proper sonar reporting.
 
## Checklist for Primary Reviewer

### Cache
- [ ] Is the caching sufficient
- [ ] Does the cache names make sense

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
