### PR TITLE
Removed sticky property affecting table headers only.

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.scss
+++ b/frontend/src/app/testResults/TestResultsList.scss
@@ -10,12 +10,6 @@
 
     .usa-table {
       margin-bottom: 0;
-
-      thead {
-        position: sticky;
-        background-color: inherit;
-        top: 195px;
-      }
     }
   }
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes [#3736](https://github.com/CDCgov/prime-simplereport/issues/3736)

## Changes Proposed

Removes sticky position in css style that is affecting all table headers in the new "sticky component". This style is not necessary as the stickiness should be applied to the whole sticky component not the table header specifically.

## Testing

- Load a facility with more than 10 test results
- Go to results page and type something on the search filter
- Make sure the list of results look good and the titles do not overlap with the content
 