### PR TITLE
Update http_2xx_failed_requests

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -67,9 +67,9 @@ variable "http_response_time_aggregation" {
   default = "Average"
 }
 
-variable "failed_http_2xx_threshold" {
-  // The resource that uses this value doesn't have a >= check, so we need n - 1 here
-  default = 24
+variable "http_2xx_failure_rate_threshold" {
+  # percentage of total requests allowed to fail
+  default = 1
 }
 
 variable "skip_on_weekends" {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

- resolves #3705 

## Changes Proposed

- Updates http_2xx_failed_requests to alert based on a percentage of failed requests out of all requests within a 5-minute window.

## Additional Information

- The threshold needs to be between 0 and 10000 inclusive. 
- Failure rates vary quite a lot, and it was a tad challenging to find a good starting number. 0.0034 is higher than daily failure rates so I'm hoping it won't trigger often but it should definitely pick up on spikes. I'd rather start too sensitive than not sensitive enough.

- Failure rate chart for the last week!
![image](https://user-images.githubusercontent.com/94012653/167693011-4dd86f3c-4528-45c0-826b-8d12cee571b8.png)

- Failure rate chart since early Feb! This is as far back as I seem to be able to go.
![image](https://user-images.githubusercontent.com/94012653/167699827-5f8f207d-f656-47f5-a476-abc1d880422a.png)

## Testing

- Please take the query and fiddle with it in the Azure monitor portal.

## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification