### PR TITLE
Enable `build-frontend` to handle new environment syntax.

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -37,10 +37,11 @@ runs:
       working-directory: ./frontend
       run: |
           echo "::group::Set build variables"
+          ENVLVL=${${{ inputs.deploy-env }}//[[:digit:]]/} 
           az config set extension.use_dynamic_install=yes_without_prompt
           INSIGHTS_CONNECTION_STRING=$(
             az monitor app-insights component show \
-              -g prime-simple-report-${{inputs.deploy-env}} \
+              -g prime-simple-report-$ENVLVL \
               -a prime-simple-report-${{inputs.deploy-env}}-insights \
             | jq -r '.connectionString')
           echo "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING=${INSIGHTS_CONNECTION_STRING}" > .env.production.local

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -37,9 +37,7 @@ runs:
       working-directory: ./frontend
       run: |
           echo "::group::Set build variables"
-          ENVLVL=${{inputs.deploy-env}}
-          echo "Environment level before replacement: $ENVLVL"
-          ENVLVL=${ENVLVL//[[:digit:]]/}
+          ENVLVL=${{{inputs.deploy-env}}//[[:digit:]]/}
           echo "Environment level: $ENVLVL"
           az config set extension.use_dynamic_install=yes_without_prompt
           INSIGHTS_CONNECTION_STRING=$(

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -37,7 +37,9 @@ runs:
       working-directory: ./frontend
       run: |
           echo "::group::Set build variables"
-          ENVLVL=${${{ inputs.deploy-env }}//[[:digit:]]/}
+          ENVLVL=${{inputs.deploy-env}}
+          echo "Environment level before replacement: $ENVLVL"
+          ENVLVL=${ENVLVL//[[:digit:]]/}
           echo "Environment level: $ENVLVL"
           az config set extension.use_dynamic_install=yes_without_prompt
           INSIGHTS_CONNECTION_STRING=$(

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -37,7 +37,8 @@ runs:
       working-directory: ./frontend
       run: |
           echo "::group::Set build variables"
-          ENVLVL=${${{ inputs.deploy-env }}//[[:digit:]]/} 
+          ENVLVL=${${{ inputs.deploy-env }}//[[:digit:]]/}
+          echo "Environment level: $ENVLVL"
           az config set extension.use_dynamic_install=yes_without_prompt
           INSIGHTS_CONNECTION_STRING=$(
             az monitor app-insights component show \

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -37,7 +37,8 @@ runs:
       working-directory: ./frontend
       run: |
           echo "::group::Set build variables"
-          ENVLVL=${{{inputs.deploy-env}}//[[:digit:]]/}
+          ENVLVL=${{inputs.deploy-env}}
+          ENVLVL=${ENVLVL//[[:digit:]]/}
           echo "Environment level: $ENVLVL"
           az config set extension.use_dynamic_install=yes_without_prompt
           INSIGHTS_CONNECTION_STRING=$(

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -30,7 +30,7 @@ default:
 
 # Internal target: check if the passed-in wildcard is a known environment name. Hard-coding them because let's be real here.
 .valid-env-%:
-	@case $* in test|dev|demo|training|pentest|stg|prod) ;; *) echo "$* is not a valid environment"; exit 1;; esac
+	@case $* in test|dev|dev2|dev3|dev4|demo|training|pentest|stg|prod) ;; *) echo "$* is not a valid environment"; exit 1;; esac
 
 api.tfvars: /dev/null
 	echo "acr_image_tag=\"$(DEPLOYED_COMMIT)\"" > $@; \


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Environments that have differing names from their resource groups fail to proceed past the `build-frontend` step due to a resource group mismatch. This must be corrected at a workflow level to enable environment rollout.

## Changes Proposed

- Correct the `build-frontend` action to dynamically trim numerical digits out of an environment declaration. This allows an environment level to be used for the resource group without having to manually specify, which also saves changes to a ton of individual files.
- Adds the new environments to the `Makefile` in the `ops` folder.

## Additional Information

- I still need to liaise with the CDC to get the new hostname values in place. This was the last step of the process prior to that work; until that step is completed, deploys to the new environments will continue to fail.

## Testing

- This PR can be verified by checking the output of any of the deployment workflows for `dev2`, `dev3`, or `dev4`. If the `build-frontend` phase passes, the changes were successful.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!
