### PR TITLE
db migration - updating upload table columns and types

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3918,3 +3918,35 @@ databaseChangeLog:
             selectQuery: SELECT id, event_timestamp, request_id, api_user_id, is_admin_user, user_permissions, organization_id, patient_link_id, response_code FROM ${database.defaultSchemaName}.api_audit_event
         - sql: |
             GRANT SELECT ON TABLE ${database.defaultSchemaName}.api_audit_event_no_phi TO ${noPhiUsername};
+  - changeSet:
+      id: modify-upload-table
+      author: dsass@skylight.digital
+      comment: remove facility id column and change data type of error and warning columns to json
+      changes:
+        - dropColumn:
+            tableName: upload
+            columnName: facility_id
+        - modifyDataType:
+            tableName: upload
+            columnName: errors
+            newDataType: jsonb
+        - modifyDataType:
+            tableName: upload
+            columnName: warnings
+            newDataType: jsonb
+      rollback:
+        - addColumn:
+            tableName: upload
+            columns:
+              - column:
+                  name: facility_id
+                  remarks: The facility id that uploaded the data.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__upload__facility
+                    references: facility(internal_id)
+        - sql:
+            sql: |
+              ALTER TABLE ${database.defaultSchemaName}.upload ALTER COLUMN errors TYPE text;
+              ALTER TABLE ${database.defaultSchemaName}.upload ALTER COLUMN warnings TYPE text;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3923,6 +3923,8 @@ databaseChangeLog:
       author: dsass@skylight.digital
       comment: remove facility id column and change data type of error and warning columns to json
       changes:
+        - tagDatabase:
+            tag: alter-upload-table
         - dropColumn:
             tableName: upload
             columnName: facility_id


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

#3644 

- Mistakes were made, correcting them now.  Don't believe facility id is useful / beneficial - might actually be misleading so we're removing it.  Moving the type of `warnings` and `errors` to jsonb

## Changes Proposed
For the `upload` table
- removed column `facility_id`
- alter types of `errors` and `warnings` columns to jsonb

## Additional Information

Changes are prompted by ongoing work with the upload ui

## Testing

- Tested migration + rollback locally.

## Checklist for Primary Reviewer

- [x] Only database changes are included in this PR
- [x] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [x] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verified locally and in a deployed environment
