### PR TITLE
Edit Patient from Conduct tests page redirects back to Conduct tests on save

### DIFF
--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -1,3 +1,5 @@
+import qs from "querystring";
+
 import {
   render,
   screen,
@@ -579,15 +581,74 @@ describe("EditPatient", () => {
   describe("EditPatientContainer", () => {
     it("doesn't render if no facility is provided", async () => {
       render(
-        <MemoryRouter initialEntries={[{ search: "?patientId=5" }]}>
-          <Provider store={configureStore()({ facilities: [] })}>
-            <EditPatientContainer />
+        <MemoryRouter initialEntries={[{ pathname: "/patient/5" }]}>
+          <Provider store={store}>
+            <Routes>
+              <Route
+                path="/patient/:patientId"
+                element={<EditPatientContainer />}
+              />
+            </Routes>
           </Provider>
         </MemoryRouter>
       );
       expect(
         await screen.findByText("No facility selected", { exact: false })
       ).toBeInTheDocument();
+    });
+    it("renders EditPatient with valid params", async () => {
+      const search = {
+        facility: mockFacilityID,
+        fromQueue: "true",
+      };
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: `/patient/${mockPatientID}`,
+              search: qs.stringify(search),
+            },
+          ]}
+        >
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <Routes>
+                <Route
+                  path="/patient/:patientId"
+                  element={<EditPatientContainer />}
+                />
+              </Routes>
+            </MockedProvider>
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(
+        await screen.findByText("Franecki, Eugenia", { exact: false })
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Conduct tests")).toBeInTheDocument();
+    });
+  });
+
+  describe("edit patient from conduct tests page", () => {
+    beforeEach(async () => {
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <EditPatient
+                facilityId={mockFacilityID}
+                patientId={mockPatientID}
+                fromQueue={true}
+              />
+            </MockedProvider>
+          </Provider>
+        </MemoryRouter>
+      );
+    });
+    it("shows Conduct tests link and hides Save and start test button", async () => {
+      expect(await screen.findByText("Conduct tests")).toBeInTheDocument();
+      expect(screen.queryByText("People")).not.toBeInTheDocument();
+      expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -337,7 +337,7 @@ const EditPatient = (props: Props) => {
                     </div>
                   </div>
                   <div className="display-flex flex-align-center">
-                    {props.fromQueue ? null : (
+                    {props.fromQueue != true && (
                       <Button
                         id="edit-patient-save-lower"
                         className="prime-save-patient-changes-start-test"

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -337,7 +337,7 @@ const EditPatient = (props: Props) => {
                     </div>
                   </div>
                   <div className="display-flex flex-align-center">
-                    {props.fromQueue !== true && (
+                    {!props.fromQueue && (
                       <Button
                         id="edit-patient-save-lower"
                         className="prime-save-patient-changes-start-test"

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -337,7 +337,7 @@ const EditPatient = (props: Props) => {
                     </div>
                   </div>
                   <div className="display-flex flex-align-center">
-                    {props.fromQueue != true && (
+                    {props.fromQueue !== true && (
                       <Button
                         id="edit-patient-save-lower"
                         className="prime-save-patient-changes-start-test"

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { NavigateOptions, useNavigate } from "react-router-dom";
+import { NavigateOptions, NavLink, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
@@ -159,6 +159,7 @@ export const UPDATE_PATIENT = gql`
 interface Props {
   facilityId: string;
   patientId: string;
+  fromQueue?: boolean;
 }
 
 interface EditPatientParams extends Nullable<Omit<PersonFormData, "lookupId">> {
@@ -313,12 +314,21 @@ const EditPatient = (props: Props) => {
                       >
                         <use xlinkHref={iconSprite + "#arrow_back"}></use>
                       </svg>
-                      <LinkWithQuery
-                        to={`/patients`}
-                        className="margin-left-05"
-                      >
-                        People
-                      </LinkWithQuery>
+                      {props.fromQueue ? (
+                        <NavLink
+                          to={`/queue?facility=${props.facilityId}`}
+                          className="margin-left-05"
+                        >
+                          Conduct tests
+                        </NavLink>
+                      ) : (
+                        <LinkWithQuery
+                          to={`/patients`}
+                          className="margin-left-05"
+                        >
+                          People
+                        </LinkWithQuery>
+                      )}
                     </div>
                     <div className="prime-edit-patient-heading margin-y-0">
                       <h1 className="font-heading-lg margin-top-1 margin-bottom-0">
@@ -327,24 +337,26 @@ const EditPatient = (props: Props) => {
                     </div>
                   </div>
                   <div className="display-flex flex-align-center">
-                    <Button
-                      id="edit-patient-save-lower"
-                      className="prime-save-patient-changes-start-test"
-                      disabled={loading || !formChanged}
-                      onClick={() => {
-                        onSave(true);
-                      }}
-                      variant="outline"
-                      label={
-                        loading
-                          ? `${t("common.button.saving")}...`
-                          : "Save and start test"
-                      }
-                    />
+                    {props.fromQueue ? null : (
+                      <Button
+                        id="edit-patient-save-lower"
+                        className="prime-save-patient-changes-start-test"
+                        disabled={loading || !formChanged}
+                        onClick={() => {
+                          onSave(true);
+                        }}
+                        variant="outline"
+                        label={
+                          loading
+                            ? `${t("common.button.saving")}...`
+                            : "Save and start test"
+                        }
+                      />
+                    )}
                     <button
                       className="prime-save-patient-changes usa-button margin-right-0"
                       disabled={editPersonLoading || !formChanged}
-                      onClick={() => onSave(false)}
+                      onClick={() => onSave(props.fromQueue)}
                     >
                       {editPersonLoading
                         ? `${t("common.button.saving")}...`

--- a/frontend/src/app/patients/EditPatientContainer.tsx
+++ b/frontend/src/app/patients/EditPatientContainer.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
+import { getParameterFromUrl } from "../utils/url";
 
 import EditPatient from "./EditPatient";
 
@@ -9,6 +10,7 @@ const EditPatientContainer = () => {
   const activeFacilityId = facility?.id;
   const params = useParams();
   const patientId = params.patientId || "";
+  const fromQueue = getParameterFromUrl("fromQueue") === "true";
 
   if (!activeFacilityId) {
     return <div>"No facility selected"</div>;
@@ -18,7 +20,13 @@ const EditPatientContainer = () => {
     return <div>No patient selected</div>;
   }
 
-  return <EditPatient facilityId={activeFacilityId} patientId={patientId} />;
+  return (
+    <EditPatient
+      facilityId={activeFacilityId}
+      patientId={patientId}
+      fromQueue={fromQueue}
+    />
+  );
 };
 
 export default EditPatientContainer;

--- a/frontend/src/app/patients/EditPatientContainer.tsx
+++ b/frontend/src/app/patients/EditPatientContainer.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { getParameterFromUrl } from "../utils/url";
@@ -10,7 +10,7 @@ const EditPatientContainer = () => {
   const activeFacilityId = facility?.id;
   const params = useParams();
   const patientId = params.patientId || "";
-  const fromQueue = getParameterFromUrl("fromQueue") === "true";
+  const fromQueue = getParameterFromUrl("fromQueue", useLocation()) === "true";
 
   if (!activeFacilityId) {
     return <div>"No facility selected"</div>;

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -106,7 +106,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="95"
+                        for="120"
                       >
                         First name
                         <abbr
@@ -121,7 +121,7 @@ Object {
                         aria-disabled="false"
                         aria-required="true"
                         class="usa-input"
-                        id="95"
+                        id="120"
                         name="firstName"
                         type="text"
                         value="Eugenia"
@@ -132,7 +132,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="96"
+                        for="121"
                       >
                         Middle name
                       </label>
@@ -140,7 +140,7 @@ Object {
                         aria-disabled="false"
                         aria-required="false"
                         class="usa-input"
-                        id="96"
+                        id="121"
                         name="middleName"
                         type="text"
                         value=""
@@ -151,7 +151,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="97"
+                        for="122"
                       >
                         Last name
                         <abbr
@@ -166,7 +166,7 @@ Object {
                         aria-disabled="false"
                         aria-required="true"
                         class="usa-input"
-                        id="97"
+                        id="122"
                         name="lastName"
                         type="text"
                         value="Franecki"
@@ -181,14 +181,14 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="98"
+                        for="123"
                       >
                         Role
                       </label>
                       <select
                         aria-required="false"
                         class="usa-select"
-                        id="98"
+                        id="123"
                         name="role"
                       >
                         <option
@@ -223,7 +223,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="99"
+                        for="124"
                       >
                         Testing facility
                         <abbr
@@ -237,7 +237,7 @@ Object {
                       <select
                         aria-required="true"
                         class="usa-select"
-                        id="99"
+                        id="124"
                         name="facilityId"
                       >
                         <option
@@ -276,7 +276,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="100"
+                        for="125"
                       >
                         Date of birth (mm/dd/yyyy)
                         <abbr
@@ -291,7 +291,7 @@ Object {
                         aria-disabled="false"
                         aria-required="true"
                         class="usa-input"
-                        id="100"
+                        id="125"
                         max="2021-08-01"
                         min="1900-01-01"
                         name="birthDate"
@@ -330,7 +330,7 @@ Object {
                         >
                           <label
                             class="usa-label"
-                            for="101"
+                            for="126"
                           >
                             Primary phone number
                             <abbr
@@ -344,7 +344,7 @@ Object {
                           <input
                             aria-required="true"
                             class="usa-input"
-                            id="101"
+                            id="126"
                             name="number"
                             type="text"
                             value="(270) 867-5309"
@@ -379,14 +379,14 @@ Object {
                                 checked=""
                                 class="usa-radio__input"
                                 data-required="true"
-                                id="102-val-MOBILE"
+                                id="127-val-MOBILE"
                                 name="phoneType-0"
                                 type="radio"
                                 value="MOBILE"
                               />
                               <label
                                 class="usa-radio__label"
-                                for="102-val-MOBILE"
+                                for="127-val-MOBILE"
                               >
                                 Mobile
                               </label>
@@ -397,14 +397,14 @@ Object {
                               <input
                                 class="usa-radio__input"
                                 data-required="true"
-                                id="102-val-LANDLINE"
+                                id="127-val-LANDLINE"
                                 name="phoneType-0"
                                 type="radio"
                                 value="LANDLINE"
                               />
                               <label
                                 class="usa-radio__label"
-                                for="102-val-LANDLINE"
+                                for="127-val-LANDLINE"
                               >
                                 Landline
                               </label>
@@ -454,14 +454,14 @@ Object {
                             <input
                               class="usa-radio__input"
                               data-required="false"
-                              id="103-val-SMS"
+                              id="128-val-SMS"
                               name="testResultDeliveryText"
                               type="radio"
                               value="SMS"
                             />
                             <label
                               class="usa-radio__label"
-                              for="103-val-SMS"
+                              for="128-val-SMS"
                             >
                               Yes, text all mobile numbers on file.
                             </label>
@@ -473,14 +473,14 @@ Object {
                               checked=""
                               class="usa-radio__input"
                               data-required="false"
-                              id="103-val-NONE"
+                              id="128-val-NONE"
                               name="testResultDeliveryText"
                               type="radio"
                               value="NONE"
                             />
                             <label
                               class="usa-radio__label"
-                              for="103-val-NONE"
+                              for="128-val-NONE"
                             >
                               No
                             </label>
@@ -504,14 +504,14 @@ Object {
                           >
                             <label
                               class="usa-label"
-                              for="104"
+                              for="129"
                             >
                               Email address
                             </label>
                             <input
                               aria-required="false"
                               class="usa-input"
-                              id="104"
+                              id="129"
                               name="email-0"
                               type="text"
                               value="foo@bar.com"
@@ -585,14 +585,14 @@ Object {
                             <input
                               class="usa-radio__input"
                               data-required="false"
-                              id="105-val-EMAIL"
+                              id="130-val-EMAIL"
                               name="testResultDeliveryEmail"
                               type="radio"
                               value="EMAIL"
                             />
                             <label
                               class="usa-radio__label"
-                              for="105-val-EMAIL"
+                              for="130-val-EMAIL"
                             >
                               Yes
                             </label>
@@ -604,14 +604,14 @@ Object {
                               checked=""
                               class="usa-radio__input"
                               data-required="false"
-                              id="105-val-NONE"
+                              id="130-val-NONE"
                               name="testResultDeliveryEmail"
                               type="radio"
                               value="NONE"
                             />
                             <label
                               class="usa-radio__label"
-                              for="105-val-NONE"
+                              for="130-val-NONE"
                             >
                               No
                             </label>
@@ -628,7 +628,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="106"
+                        for="131"
                       >
                         Country
                         <abbr
@@ -642,7 +642,7 @@ Object {
                       <select
                         aria-required="true"
                         class="usa-select"
-                        id="106"
+                        id="131"
                         name="country"
                       >
                         <option
@@ -1966,7 +1966,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="107"
+                        for="132"
                       >
                         Street address 1
                         <abbr
@@ -1980,7 +1980,7 @@ Object {
                       <input
                         aria-required="true"
                         class="usa-input"
-                        id="107"
+                        id="132"
                         name="street"
                         type="text"
                         value="736 Jackson PI NW"
@@ -1995,14 +1995,14 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="108"
+                        for="133"
                       >
                         Street address 2
                       </label>
                       <input
                         aria-required="false"
                         class="usa-input"
-                        id="108"
+                        id="133"
                         name="streetTwo"
                         type="text"
                         value="DC"
@@ -2017,14 +2017,14 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="109"
+                        for="134"
                       >
                         City
                       </label>
                       <input
                         aria-required="false"
                         class="usa-input"
-                        id="109"
+                        id="134"
                         name="city"
                         type="text"
                         value=""
@@ -2035,14 +2035,14 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="110"
+                        for="135"
                       >
                         County
                       </label>
                       <input
                         aria-required="false"
                         class="usa-input"
-                        id="110"
+                        id="135"
                         name="county"
                         type="text"
                         value=""
@@ -2094,14 +2094,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-native"
+                            id="136-val-native"
                             name="race"
                             type="radio"
                             value="native"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-native"
+                            for="136-val-native"
                           >
                             American Indian/Alaskan Native
                           </label>
@@ -2112,14 +2112,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-asian"
+                            id="136-val-asian"
                             name="race"
                             type="radio"
                             value="asian"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-asian"
+                            for="136-val-asian"
                           >
                             Asian
                           </label>
@@ -2130,14 +2130,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-black"
+                            id="136-val-black"
                             name="race"
                             type="radio"
                             value="black"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-black"
+                            for="136-val-black"
                           >
                             Black/African American
                           </label>
@@ -2148,14 +2148,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-pacific"
+                            id="136-val-pacific"
                             name="race"
                             type="radio"
                             value="pacific"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-pacific"
+                            for="136-val-pacific"
                           >
                             Native Hawaiian/other Pacific Islander
                           </label>
@@ -2166,14 +2166,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-white"
+                            id="136-val-white"
                             name="race"
                             type="radio"
                             value="white"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-white"
+                            for="136-val-white"
                           >
                             White
                           </label>
@@ -2184,14 +2184,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-other"
+                            id="136-val-other"
                             name="race"
                             type="radio"
                             value="other"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-other"
+                            for="136-val-other"
                           >
                             Other
                           </label>
@@ -2202,14 +2202,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="111-val-refused"
+                            id="136-val-refused"
                             name="race"
                             type="radio"
                             value="refused"
                           />
                           <label
                             class="usa-radio__label"
-                            for="111-val-refused"
+                            for="136-val-refused"
                           >
                             Prefer not to answer
                           </label>
@@ -2254,14 +2254,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="112-val-hispanic"
+                            id="137-val-hispanic"
                             name="ethnicity"
                             type="radio"
                             value="hispanic"
                           />
                           <label
                             class="usa-radio__label"
-                            for="112-val-hispanic"
+                            for="137-val-hispanic"
                           >
                             Yes
                           </label>
@@ -2272,14 +2272,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="112-val-not_hispanic"
+                            id="137-val-not_hispanic"
                             name="ethnicity"
                             type="radio"
                             value="not_hispanic"
                           />
                           <label
                             class="usa-radio__label"
-                            for="112-val-not_hispanic"
+                            for="137-val-not_hispanic"
                           >
                             No
                           </label>
@@ -2290,14 +2290,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="112-val-refused"
+                            id="137-val-refused"
                             name="ethnicity"
                             type="radio"
                             value="refused"
                           />
                           <label
                             class="usa-radio__label"
-                            for="112-val-refused"
+                            for="137-val-refused"
                           >
                             Prefer not to answer
                           </label>
@@ -2337,14 +2337,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="113-val-female"
+                            id="138-val-female"
                             name="gender"
                             type="radio"
                             value="female"
                           />
                           <label
                             class="usa-radio__label"
-                            for="113-val-female"
+                            for="138-val-female"
                           >
                             Female
                           </label>
@@ -2355,14 +2355,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="113-val-male"
+                            id="138-val-male"
                             name="gender"
                             type="radio"
                             value="male"
                           />
                           <label
                             class="usa-radio__label"
-                            for="113-val-male"
+                            for="138-val-male"
                           >
                             Male
                           </label>
@@ -2373,14 +2373,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="113-val-other"
+                            id="138-val-other"
                             name="gender"
                             type="radio"
                             value="other"
                           />
                           <label
                             class="usa-radio__label"
-                            for="113-val-other"
+                            for="138-val-other"
                           >
                             Other
                           </label>
@@ -2391,14 +2391,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="true"
-                            id="113-val-refused"
+                            id="138-val-refused"
                             name="gender"
                             type="radio"
                             value="refused"
                           />
                           <label
                             class="usa-radio__label"
-                            for="113-val-refused"
+                            for="138-val-refused"
                           >
                             Prefer not to answer
                           </label>
@@ -2445,14 +2445,14 @@ Object {
                             checked=""
                             class="usa-radio__input"
                             data-required="false"
-                            id="114-val-YES"
+                            id="139-val-YES"
                             name="residentCongregateSetting"
                             type="radio"
                             value="YES"
                           />
                           <label
                             class="usa-radio__label"
-                            for="114-val-YES"
+                            for="139-val-YES"
                           >
                             Yes
                           </label>
@@ -2463,14 +2463,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="114-val-NO"
+                            id="139-val-NO"
                             name="residentCongregateSetting"
                             type="radio"
                             value="NO"
                           />
                           <label
                             class="usa-radio__label"
-                            for="114-val-NO"
+                            for="139-val-NO"
                           >
                             No
                           </label>
@@ -2481,14 +2481,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="114-val-NOT_SURE"
+                            id="139-val-NOT_SURE"
                             name="residentCongregateSetting"
                             type="radio"
                             value="NOT_SURE"
                           />
                           <label
                             class="usa-radio__label"
-                            for="114-val-NOT_SURE"
+                            for="139-val-NOT_SURE"
                           >
                             Not sure
                           </label>
@@ -2517,14 +2517,14 @@ Object {
                             checked=""
                             class="usa-radio__input"
                             data-required="false"
-                            id="115-val-YES"
+                            id="140-val-YES"
                             name="employedInHealthcare"
                             type="radio"
                             value="YES"
                           />
                           <label
                             class="usa-radio__label"
-                            for="115-val-YES"
+                            for="140-val-YES"
                           >
                             Yes
                           </label>
@@ -2535,14 +2535,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="115-val-NO"
+                            id="140-val-NO"
                             name="employedInHealthcare"
                             type="radio"
                             value="NO"
                           />
                           <label
                             class="usa-radio__label"
-                            for="115-val-NO"
+                            for="140-val-NO"
                           >
                             No
                           </label>
@@ -2553,14 +2553,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="115-val-NOT_SURE"
+                            id="140-val-NOT_SURE"
                             name="employedInHealthcare"
                             type="radio"
                             value="NOT_SURE"
                           />
                           <label
                             class="usa-radio__label"
-                            for="115-val-NOT_SURE"
+                            for="140-val-NOT_SURE"
                           >
                             Not sure
                           </label>
@@ -2693,7 +2693,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="95"
+                      for="120"
                     >
                       First name
                       <abbr
@@ -2708,7 +2708,7 @@ Object {
                       aria-disabled="false"
                       aria-required="true"
                       class="usa-input"
-                      id="95"
+                      id="120"
                       name="firstName"
                       type="text"
                       value="Eugenia"
@@ -2719,7 +2719,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="96"
+                      for="121"
                     >
                       Middle name
                     </label>
@@ -2727,7 +2727,7 @@ Object {
                       aria-disabled="false"
                       aria-required="false"
                       class="usa-input"
-                      id="96"
+                      id="121"
                       name="middleName"
                       type="text"
                       value=""
@@ -2738,7 +2738,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="97"
+                      for="122"
                     >
                       Last name
                       <abbr
@@ -2753,7 +2753,7 @@ Object {
                       aria-disabled="false"
                       aria-required="true"
                       class="usa-input"
-                      id="97"
+                      id="122"
                       name="lastName"
                       type="text"
                       value="Franecki"
@@ -2768,14 +2768,14 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="98"
+                      for="123"
                     >
                       Role
                     </label>
                     <select
                       aria-required="false"
                       class="usa-select"
-                      id="98"
+                      id="123"
                       name="role"
                     >
                       <option
@@ -2810,7 +2810,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="99"
+                      for="124"
                     >
                       Testing facility
                       <abbr
@@ -2824,7 +2824,7 @@ Object {
                     <select
                       aria-required="true"
                       class="usa-select"
-                      id="99"
+                      id="124"
                       name="facilityId"
                     >
                       <option
@@ -2863,7 +2863,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="100"
+                      for="125"
                     >
                       Date of birth (mm/dd/yyyy)
                       <abbr
@@ -2878,7 +2878,7 @@ Object {
                       aria-disabled="false"
                       aria-required="true"
                       class="usa-input"
-                      id="100"
+                      id="125"
                       max="2021-08-01"
                       min="1900-01-01"
                       name="birthDate"
@@ -2917,7 +2917,7 @@ Object {
                       >
                         <label
                           class="usa-label"
-                          for="101"
+                          for="126"
                         >
                           Primary phone number
                           <abbr
@@ -2931,7 +2931,7 @@ Object {
                         <input
                           aria-required="true"
                           class="usa-input"
-                          id="101"
+                          id="126"
                           name="number"
                           type="text"
                           value="(270) 867-5309"
@@ -2966,14 +2966,14 @@ Object {
                               checked=""
                               class="usa-radio__input"
                               data-required="true"
-                              id="102-val-MOBILE"
+                              id="127-val-MOBILE"
                               name="phoneType-0"
                               type="radio"
                               value="MOBILE"
                             />
                             <label
                               class="usa-radio__label"
-                              for="102-val-MOBILE"
+                              for="127-val-MOBILE"
                             >
                               Mobile
                             </label>
@@ -2984,14 +2984,14 @@ Object {
                             <input
                               class="usa-radio__input"
                               data-required="true"
-                              id="102-val-LANDLINE"
+                              id="127-val-LANDLINE"
                               name="phoneType-0"
                               type="radio"
                               value="LANDLINE"
                             />
                             <label
                               class="usa-radio__label"
-                              for="102-val-LANDLINE"
+                              for="127-val-LANDLINE"
                             >
                               Landline
                             </label>
@@ -3041,14 +3041,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="103-val-SMS"
+                            id="128-val-SMS"
                             name="testResultDeliveryText"
                             type="radio"
                             value="SMS"
                           />
                           <label
                             class="usa-radio__label"
-                            for="103-val-SMS"
+                            for="128-val-SMS"
                           >
                             Yes, text all mobile numbers on file.
                           </label>
@@ -3060,14 +3060,14 @@ Object {
                             checked=""
                             class="usa-radio__input"
                             data-required="false"
-                            id="103-val-NONE"
+                            id="128-val-NONE"
                             name="testResultDeliveryText"
                             type="radio"
                             value="NONE"
                           />
                           <label
                             class="usa-radio__label"
-                            for="103-val-NONE"
+                            for="128-val-NONE"
                           >
                             No
                           </label>
@@ -3091,14 +3091,14 @@ Object {
                         >
                           <label
                             class="usa-label"
-                            for="104"
+                            for="129"
                           >
                             Email address
                           </label>
                           <input
                             aria-required="false"
                             class="usa-input"
-                            id="104"
+                            id="129"
                             name="email-0"
                             type="text"
                             value="foo@bar.com"
@@ -3172,14 +3172,14 @@ Object {
                           <input
                             class="usa-radio__input"
                             data-required="false"
-                            id="105-val-EMAIL"
+                            id="130-val-EMAIL"
                             name="testResultDeliveryEmail"
                             type="radio"
                             value="EMAIL"
                           />
                           <label
                             class="usa-radio__label"
-                            for="105-val-EMAIL"
+                            for="130-val-EMAIL"
                           >
                             Yes
                           </label>
@@ -3191,14 +3191,14 @@ Object {
                             checked=""
                             class="usa-radio__input"
                             data-required="false"
-                            id="105-val-NONE"
+                            id="130-val-NONE"
                             name="testResultDeliveryEmail"
                             type="radio"
                             value="NONE"
                           />
                           <label
                             class="usa-radio__label"
-                            for="105-val-NONE"
+                            for="130-val-NONE"
                           >
                             No
                           </label>
@@ -3215,7 +3215,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="106"
+                      for="131"
                     >
                       Country
                       <abbr
@@ -3229,7 +3229,7 @@ Object {
                     <select
                       aria-required="true"
                       class="usa-select"
-                      id="106"
+                      id="131"
                       name="country"
                     >
                       <option
@@ -4553,7 +4553,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="107"
+                      for="132"
                     >
                       Street address 1
                       <abbr
@@ -4567,7 +4567,7 @@ Object {
                     <input
                       aria-required="true"
                       class="usa-input"
-                      id="107"
+                      id="132"
                       name="street"
                       type="text"
                       value="736 Jackson PI NW"
@@ -4582,14 +4582,14 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="108"
+                      for="133"
                     >
                       Street address 2
                     </label>
                     <input
                       aria-required="false"
                       class="usa-input"
-                      id="108"
+                      id="133"
                       name="streetTwo"
                       type="text"
                       value="DC"
@@ -4604,14 +4604,14 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="109"
+                      for="134"
                     >
                       City
                     </label>
                     <input
                       aria-required="false"
                       class="usa-input"
-                      id="109"
+                      id="134"
                       name="city"
                       type="text"
                       value=""
@@ -4622,14 +4622,14 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="110"
+                      for="135"
                     >
                       County
                     </label>
                     <input
                       aria-required="false"
                       class="usa-input"
-                      id="110"
+                      id="135"
                       name="county"
                       type="text"
                       value=""
@@ -4681,14 +4681,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-native"
+                          id="136-val-native"
                           name="race"
                           type="radio"
                           value="native"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-native"
+                          for="136-val-native"
                         >
                           American Indian/Alaskan Native
                         </label>
@@ -4699,14 +4699,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-asian"
+                          id="136-val-asian"
                           name="race"
                           type="radio"
                           value="asian"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-asian"
+                          for="136-val-asian"
                         >
                           Asian
                         </label>
@@ -4717,14 +4717,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-black"
+                          id="136-val-black"
                           name="race"
                           type="radio"
                           value="black"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-black"
+                          for="136-val-black"
                         >
                           Black/African American
                         </label>
@@ -4735,14 +4735,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-pacific"
+                          id="136-val-pacific"
                           name="race"
                           type="radio"
                           value="pacific"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-pacific"
+                          for="136-val-pacific"
                         >
                           Native Hawaiian/other Pacific Islander
                         </label>
@@ -4753,14 +4753,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-white"
+                          id="136-val-white"
                           name="race"
                           type="radio"
                           value="white"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-white"
+                          for="136-val-white"
                         >
                           White
                         </label>
@@ -4771,14 +4771,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-other"
+                          id="136-val-other"
                           name="race"
                           type="radio"
                           value="other"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-other"
+                          for="136-val-other"
                         >
                           Other
                         </label>
@@ -4789,14 +4789,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="111-val-refused"
+                          id="136-val-refused"
                           name="race"
                           type="radio"
                           value="refused"
                         />
                         <label
                           class="usa-radio__label"
-                          for="111-val-refused"
+                          for="136-val-refused"
                         >
                           Prefer not to answer
                         </label>
@@ -4841,14 +4841,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="112-val-hispanic"
+                          id="137-val-hispanic"
                           name="ethnicity"
                           type="radio"
                           value="hispanic"
                         />
                         <label
                           class="usa-radio__label"
-                          for="112-val-hispanic"
+                          for="137-val-hispanic"
                         >
                           Yes
                         </label>
@@ -4859,14 +4859,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="112-val-not_hispanic"
+                          id="137-val-not_hispanic"
                           name="ethnicity"
                           type="radio"
                           value="not_hispanic"
                         />
                         <label
                           class="usa-radio__label"
-                          for="112-val-not_hispanic"
+                          for="137-val-not_hispanic"
                         >
                           No
                         </label>
@@ -4877,14 +4877,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="112-val-refused"
+                          id="137-val-refused"
                           name="ethnicity"
                           type="radio"
                           value="refused"
                         />
                         <label
                           class="usa-radio__label"
-                          for="112-val-refused"
+                          for="137-val-refused"
                         >
                           Prefer not to answer
                         </label>
@@ -4924,14 +4924,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="113-val-female"
+                          id="138-val-female"
                           name="gender"
                           type="radio"
                           value="female"
                         />
                         <label
                           class="usa-radio__label"
-                          for="113-val-female"
+                          for="138-val-female"
                         >
                           Female
                         </label>
@@ -4942,14 +4942,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="113-val-male"
+                          id="138-val-male"
                           name="gender"
                           type="radio"
                           value="male"
                         />
                         <label
                           class="usa-radio__label"
-                          for="113-val-male"
+                          for="138-val-male"
                         >
                           Male
                         </label>
@@ -4960,14 +4960,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="113-val-other"
+                          id="138-val-other"
                           name="gender"
                           type="radio"
                           value="other"
                         />
                         <label
                           class="usa-radio__label"
-                          for="113-val-other"
+                          for="138-val-other"
                         >
                           Other
                         </label>
@@ -4978,14 +4978,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="true"
-                          id="113-val-refused"
+                          id="138-val-refused"
                           name="gender"
                           type="radio"
                           value="refused"
                         />
                         <label
                           class="usa-radio__label"
-                          for="113-val-refused"
+                          for="138-val-refused"
                         >
                           Prefer not to answer
                         </label>
@@ -5032,14 +5032,14 @@ Object {
                           checked=""
                           class="usa-radio__input"
                           data-required="false"
-                          id="114-val-YES"
+                          id="139-val-YES"
                           name="residentCongregateSetting"
                           type="radio"
                           value="YES"
                         />
                         <label
                           class="usa-radio__label"
-                          for="114-val-YES"
+                          for="139-val-YES"
                         >
                           Yes
                         </label>
@@ -5050,14 +5050,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="114-val-NO"
+                          id="139-val-NO"
                           name="residentCongregateSetting"
                           type="radio"
                           value="NO"
                         />
                         <label
                           class="usa-radio__label"
-                          for="114-val-NO"
+                          for="139-val-NO"
                         >
                           No
                         </label>
@@ -5068,14 +5068,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="114-val-NOT_SURE"
+                          id="139-val-NOT_SURE"
                           name="residentCongregateSetting"
                           type="radio"
                           value="NOT_SURE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="114-val-NOT_SURE"
+                          for="139-val-NOT_SURE"
                         >
                           Not sure
                         </label>
@@ -5104,14 +5104,14 @@ Object {
                           checked=""
                           class="usa-radio__input"
                           data-required="false"
-                          id="115-val-YES"
+                          id="140-val-YES"
                           name="employedInHealthcare"
                           type="radio"
                           value="YES"
                         />
                         <label
                           class="usa-radio__label"
-                          for="115-val-YES"
+                          for="140-val-YES"
                         >
                           Yes
                         </label>
@@ -5122,14 +5122,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="115-val-NO"
+                          id="140-val-NO"
                           name="employedInHealthcare"
                           type="radio"
                           value="NO"
                         />
                         <label
                           class="usa-radio__label"
-                          for="115-val-NO"
+                          for="140-val-NO"
                         >
                           No
                         </label>
@@ -5140,14 +5140,14 @@ Object {
                         <input
                           class="usa-radio__input"
                           data-required="false"
-                          id="115-val-NOT_SURE"
+                          id="140-val-NOT_SURE"
                           name="employedInHealthcare"
                           type="radio"
                           value="NOT_SURE"
                         />
                         <label
                           class="usa-radio__label"
-                          for="115-val-NOT_SURE"
+                          for="140-val-NOT_SURE"
                         >
                           Not sure
                         </label>

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -162,7 +162,7 @@ describe("QueueItem", () => {
     userEvent.click(patientName);
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: "/patient/f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554",
-      search: "?facility=Hogwarts+123",
+      search: "?facility=Hogwarts+123&fromQueue=true",
     });
   });
 

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -730,7 +730,7 @@ const QueueItem = ({
                     onClick={() => {
                       navigate({
                         pathname: `/patient/${patient.internalId}`,
-                        search: `?facility=${facilityId}`,
+                        search: `?facility=${facilityId}&fromQueue=true`,
                       });
                     }}
                   >


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #3086  

## Changes Proposed

- When editing a patient from the Conduct tests page, 1) the back arrow above the form should navigate back to the testing queue instead of the people page, and 2) there should only be a "Save changes" button, which behaves like "Save and start test" in that it redirects back to queue page with patient test card highlighted on save.

## Additional Information

- I chose to add a fromQueue param to EditPatient component that gets passed in as true when clicking the person's name on the test card. Open to suggestions if there's a design pattern for this that makes more sense.
- This does not fix known issue #3758, so users will get incorrectly routed to the Person page if a new address is "close enough" to the Smarty streets validated address.

## Testing

- Try it out in dev: from test queue, click on patient name to open edit patient view. Verify save routes back to test queue.
 
## Screenshots / Demos

https://user-images.githubusercontent.com/6401323/169132129-480c304c-a99c-416c-975b-9acbdda65b3e.mov



## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [n/a] Any content changes have been approved by content team

### Support
- [n/a] Any changes that might generate new support requests have been flagged to the support team
- [n/a] Any changes to support infrastructure have been demo'd to support team

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed
