### PR TITLE
Backfill Results table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3952,27 +3952,30 @@ databaseChangeLog:
             sql: |
               ALTER TABLE ${database.defaultSchemaName}.upload ALTER COLUMN errors TYPE text;
               ALTER TABLE ${database.defaultSchemaName}.upload ALTER COLUMN warnings TYPE text;
-#  - changeSet:
-#      id: backfill-results-table
-#      author: emma@skylight.digital
-#      comment: backfill the new results table with existing results from TestOrders
-#      changes:
-#        - tagDatabase:
-#            tag: backfill-results-table
-#        - sql:
-#            sql:
-#              INSERT INTO simple_report.result
-#              SELECT
-#                gen_random_uuid(),
-#                t.created_at,
-#                t.created_by,
-#                t.updated_at,
-#                t.updated_by,
-#                FALSE,
-#                t.test_event_id,
-#                t.internal_id,
-#                d.internal_id,
-#                CASE WHEN t.result='POSITIVE' THEN '260373001' WHEN t.result='NEGATIVE' THEN '260415000' WHEN t.result='UNDETERMINED' THEN '455371000124106' END,
-#                t.result
-#              FROM simple_report.test_order t CROSS JOIN simple_report.supported_disease d
-#              LEFT JOIN simple_report.result ON t.internal_id=simple_report.result.test_order_id WHERE simple_report.result.test_order_id IS NULL AND t.result IS NOT NULL AND d.name='COVID-19';
+  - changeSet:
+      id: backfill-results-table
+      author: emma@skylight.digital
+      comment: backfill the new results table with existing results from TestOrders
+      changes:
+        - tagDatabase:
+            tag: backfill-results-table
+        - sql:
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.result
+              SELECT
+                gen_random_uuid(),
+                t.created_at,
+                t.created_by,
+                t.updated_at,
+                t.updated_by,
+                FALSE,
+                t.test_event_id,
+                t.internal_id,
+                (SELECT d.internal_id from ${database.defaultSchemaName}.supported_disease d WHERE d.name='COVID-19'),
+                CASE WHEN t.result='POSITIVE' THEN '260373001' WHEN t.result='NEGATIVE' THEN '260415000' WHEN t.result='UNDETERMINED' THEN '455371000124106' END,
+                t.result
+              FROM ${database.defaultSchemaName}.test_order t
+              LEFT JOIN ${database.defaultSchemaName}.result ON t.internal_id=${database.defaultSchemaName}.result.test_order_id 
+              WHERE ${database.defaultSchemaName}.result.test_order_id IS NULL AND t.result IS NOT NULL;
+      rollback:
+        sql: SELECT 'foo';

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3952,3 +3952,27 @@ databaseChangeLog:
             sql: |
               ALTER TABLE ${database.defaultSchemaName}.upload ALTER COLUMN errors TYPE text;
               ALTER TABLE ${database.defaultSchemaName}.upload ALTER COLUMN warnings TYPE text;
+#  - changeSet:
+#      id: backfill-results-table
+#      author: emma@skylight.digital
+#      comment: backfill the new results table with existing results from TestOrders
+#      changes:
+#        - tagDatabase:
+#            tag: backfill-results-table
+#        - sql:
+#            sql:
+#              INSERT INTO simple_report.result
+#              SELECT
+#                gen_random_uuid(),
+#                t.created_at,
+#                t.created_by,
+#                t.updated_at,
+#                t.updated_by,
+#                FALSE,
+#                t.test_event_id,
+#                t.internal_id,
+#                d.internal_id,
+#                CASE WHEN t.result='POSITIVE' THEN '260373001' WHEN t.result='NEGATIVE' THEN '260415000' WHEN t.result='UNDETERMINED' THEN '455371000124106' END,
+#                t.result
+#              FROM simple_report.test_order t CROSS JOIN simple_report.supported_disease d
+#              LEFT JOIN simple_report.result ON t.internal_id=simple_report.result.test_order_id WHERE simple_report.result.test_order_id IS NULL AND t.result IS NOT NULL AND d.name='COVID-19';


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

Fixes #3663 

## Changes Proposed

- Backfills the Result table with the existing results stored in TestOrder

## Additional Information

I am not a SQL wizard by any means! If you see room for improvement, please let me know.

This query does roughly the following:
- Gets all TestOrders and joins to the Result table such that only TestOrders _without_ an entry in the Result table are selected.
- Also filters out TestOrders that don't yet have a result (so, orders that are cancelled without saving a result or are pending).
- Inserts a row into the Result table for each TestOrder that fits the above criteria. These rows have the same metadata (created_at, created_by, updated_at, updated_by) as the original TestOrder. 
- All Result rows are marked `is_deleted=false` because TestOrders don't have an `is_deleted` column to pull from. (It has order_status instead, but we don't actually care about the status for Results)
- All rows are backfilled as covid results.
- The result LOINCs are taken from [Translators.java](https://github.com/CDCgov/prime-simplereport/blob/b87b595768ec5e4ab8fcdb593e000b2ed39f44ff/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java#L390-L390)

### Rollbacks
We have three options that I can see for rollbacks:
1. Drop results created before $DATE, where date is the date we rolled out the original changes (this option is gross)
2. Add another column to Result, `is_backfill`, that will be set to TRUE for rows added during the migration. For the rollback, drop all rows where `is_backfill` is set to true
3. Have a no-op rollback, so that Liquibase doesn't freak out but no changes are actually made. This isn't actually a schema change, just a migration, so in my opinion a rollback isn't strictly necessary. But happy to hear other opinions on this. 

### Deployment Plan
We'll manually run the SQL in each database before merging this code to `main`. This should prevent us from running into issues on prod. (The prod rollout will take a while given that we have 4.8M TestOrders that need to be backfilled, so this change will be done after-hours)

We can also use SQL `EXPLAIN` to get a rough idea of the time commitment before actually doing the backfill.

As discussed in the 5/12 engineering sync, ultimately we'd like to split database deployments to their own pipeline. I don't want to wait for that infrastructure change for this particular migration though, because this migration will allow us to start on some of the other multiplex work (see below).

### Next Steps
After this database change is in, it frees us up to read from the Result table in PXP, results filtering, and the dashboard. (#3664, #3755, #3756)

## Testing

- I tested this extensively locally. I'm also planning to run manually in a lower environment before rolling out more broadly.

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment