### PR TITLE
Update http_2xx_failed_requests

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -67,9 +67,9 @@ variable "http_response_time_aggregation" {
   default = "Average"
 }
 
-variable "failed_http_2xx_threshold" {
-  // The resource that uses this value doesn't have a >= check, so we need n - 1 here
-  default = 24
+variable "http_2xx_failure_rate_threshold" {
+  # percentage of total requests allowed to fail
+  default = 1
 }
 
 variable "skip_on_weekends" {

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -72,7 +72,7 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_2xx_failed_requests" {
   name                = "${var.env}-api-2xx-failed-requests"
-  description         = "${local.env_title} HTTP Server 2xx Errors (where successful request == false) >= 25"
+  description         = "${local.env_title} HTTP Server 2xx (requests where (failed requests * 100.00 / total requests) >= ${var.http_2xx_failure_rate_threshold}). This query finds all requests in our timeframe and transforms the failed requests into a percentage of total requests."
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
   severity            = var.severity
@@ -85,12 +85,15 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "http_2xx_failed_requests
   query = <<-QUERY
 requests
 ${local.skip_on_weekends}
-| where toint(resultCode) between (200 .. 299) and success == false and timestamp >= ago(5m)
+| where toint(resultCode) between (200 .. 299) and timestamp >= ago(5m)
+| sort by timestamp asc
+| summarize alert = iff((todouble(sumif(1, success == false)) * 100 / todouble(count()) >= ${var.http_2xx_failure_rate_threshold}), 1, 0)
+| where alert == 1
   QUERY
 
   trigger {
     operator  = "GreaterThan"
-    threshold = var.failed_http_2xx_threshold
+    threshold = 0
   }
 
   action {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

- resolves #3705 

## Changes Proposed

- In the last [PR](https://github.com/CDCgov/prime-simplereport/pull/3739), I was trying to alert based on the value in the column we return, but this works by triggering an alert on whether we return any table, this is filtered by the last `where` clause. If we are greater than or equal to our `http_2xx_failure_rate_threshold`, we return a table which triggers an alert.
- Updates http_2xx_failed_requests to alert based on a percentage of failed requests out of all requests within a 5-minute window.

## Additional Information

- Failure rate chart for the last week!
![image](https://user-images.githubusercontent.com/94012653/167693011-4dd86f3c-4528-45c0-826b-8d12cee571b8.png)

- Failure rate chart since early Feb! This is as far back as I seem to be able to go.
![image](https://user-images.githubusercontent.com/94012653/167699827-5f8f207d-f656-47f5-a476-abc1d880422a.png)

## Testing

- I tested this by deploying it to the test environment using different values for our threshold. I consistently received alerts when the threshold was 0% and didn't see any alerts when the threshold was set to 1%.

## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

## Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification