### PR TITLE
Send multiplex results to patient experience frontend

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
@@ -1,10 +1,12 @@
 package gov.cdc.usds.simplereport.api.model.pxp;
 
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +16,8 @@ public class PxpVerifyResponseV2 {
 
   private final UUID testEventId;
   private final TestResult result;
+  private TestResult fluAResult = null;
+  private TestResult fluBResult = null;
   private final Date dateTested;
   private final String correctionStatus;
   private final Patient patient;
@@ -21,10 +25,18 @@ public class PxpVerifyResponseV2 {
   private final Facility facility;
   private final DeviceTypeWrapper deviceType;
 
-  public PxpVerifyResponseV2(Person person, TestEvent testEvent) {
+  public PxpVerifyResponseV2(
+      Person person,
+      TestEvent testEvent,
+      Result covidResult,
+      Optional<Result> fluAResult,
+      Optional<Result> fluBResult) {
+
+    this.result = covidResult.getTestResult();
+    fluAResult.ifPresent(value -> this.fluAResult = value.getTestResult());
+    fluBResult.ifPresent(value -> this.fluBResult = value.getTestResult());
 
     this.testEventId = testEvent.getInternalId();
-    this.result = testEvent.getResult();
     this.dateTested = testEvent.getDateTested();
     this.correctionStatus = testEvent.getCorrectionStatus().toString();
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -45,6 +45,7 @@ public class TestEvent extends BaseTestInfo {
   @JoinColumn(name = "test_order_id")
   private TestOrder order;
 
+  @JsonIgnore
   @OneToMany(mappedBy = "testEvent", cascade = CascadeType.MERGE, fetch = FetchType.LAZY)
   private Set<Result> results;
 
@@ -162,6 +163,14 @@ public class TestEvent extends BaseTestInfo {
       }
     }
     return super.getResult();
+  }
+
+  public Optional<Result> getResultForDisease(SupportedDisease disease) {
+    Hibernate.initialize(this.results);
+    if (results != null) {
+      return results.stream().filter(r -> r.getDisease().equals(disease)).findFirst();
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import gov.cdc.usds.simplereport.db.model.auxiliary.OrderStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
@@ -48,6 +49,7 @@ public class TestOrder extends BaseTestInfo {
   @JoinColumn(name = "test_event_id")
   private TestEvent testEvent;
 
+  @JsonIgnore
   @OneToMany(mappedBy = "testOrder", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private Set<Result> results;
 
@@ -96,6 +98,7 @@ public class TestOrder extends BaseTestInfo {
     return super.getResult();
   }
 
+  @JsonIgnore
   public Set<Result> getResultSet() {
     Hibernate.initialize(this.results);
     return results;

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -46,6 +46,8 @@ export type SelfRegistrationData = Omit<
 export type VerifyV2Response = {
   testEventId: string;
   result: TestResult;
+  fluAResult: TestResult | undefined;
+  fluBResult: TestResult | undefined;
   dateTested: string;
   correctionStatus: string;
   deviceType: {

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -22,8 +22,6 @@ const TestResult = () => {
   const dateTested = formatDateWithTimeOption(testResult?.dateTested, true);
   const deviceType = testResult?.deviceType.name;
 
-  console.log(testResult);
-
   return (
     <div className="pxp-test-results">
       <div id="section-to-print">

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -22,6 +22,8 @@ const TestResult = () => {
   const dateTested = formatDateWithTimeOption(testResult?.dateTested, true);
   const deviceType = testResult?.deviceType.name;
 
+  console.log(testResult);
+
   return (
     <div className="pxp-test-results">
       <div id="section-to-print">


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Fixes #3756 

## Changes Proposed

- Send multiplex (flu A and flu B) results to the frontend when they exist.

## Additional Information

- The results aren't actually being shown to patients yet - that work will be done in #3494.
- I also had to add a number of `@JsonIgnore` annotations across `Results` - otherwise, the audit logging in the patient experience caused the same recursion we saw before during the audit log rollout.
![Screen Shot 2022-05-19 at 9 19 53 AM](https://user-images.githubusercontent.com/80282552/169349809-253872b0-a4b4-4b6b-adb3-68e359ba9995.png)


## Testing

- Verify that patient experience works normally for covid results

## Screenshots
Frontend on regular request:
![Screen Shot 2022-05-18 at 3 26 55 PM](https://user-images.githubusercontent.com/80282552/169350862-75d76d56-97e9-4232-8e68-02e20277c0e1.png)

Frontend requesting multiplex results:
![Screen Shot 2022-05-19 at 9 09 58 AM](https://user-images.githubusercontent.com/80282552/169350900-2530637c-4779-494c-bde3-001d99659438.png)

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
