### PR TITLE
getTestResult method specifically returns covid result

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -151,9 +151,8 @@ public class TestEvent extends BaseTestInfo {
     return order.getDeviceSpecimen();
   }
 
-  // This logic (specifically, the findAny) will need to be updated later on in the multiplex
-  // process - this method is temporary
-  // Eventually, this method will be deprecated in favor of getResultSet()
+  // This method is temporary and eventually, this method will be deprecated in favor of
+  // getResultSet()
   public TestResult getTestResult() {
     final String COVID_LOINC = "96741-4";
     if (this.results != null) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -155,8 +155,12 @@ public class TestEvent extends BaseTestInfo {
   // process - this method is temporary
   // Eventually, this method will be deprecated in favor of getResultSet()
   public TestResult getTestResult() {
+    final String COVID_LOINC = "96741-4";
     if (this.results != null) {
-      Optional<Result> resultObject = this.results.stream().findAny();
+      Optional<Result> resultObject =
+          this.results.stream()
+              .filter(result -> COVID_LOINC.equals(result.getDisease().getLoinc()))
+              .findFirst();
       if (resultObject.isPresent()) {
         return resultObject.get().getTestResult();
       }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
Fixes [#3435](https://github.com/cdcgov/prime-simplereport/issues/3435)

## Changes Proposed
This PR is making sure that as part of the backwards compatibility implementation we are always returning only the covid result when the getTestResult method gets invoke. This method was partially handling this by always returning one result object, so with this PR we just make sure that object is in fact the covid result.


## Testing
Verify that results are loaded correctly in the results table or any other flow that allows you to read a reported result.

## Checklist for Primary Reviewer

- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [n/a] Any content updates (user-facing error messages, etc) have been approved by content team
- [n/a] Any changes that might generate questions in the support inbox have been flagged to the support team
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end
- [X] Changes comply with the SimpleReport Style Guide
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a ] Any dependencies introduced have been vetted and discussed

