### PR TITLE
"Save and start test" correctly populates patient email in AOE form

### DIFF
--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -43,6 +43,7 @@ export const QUERY_SINGLE_PATIENT = gql`
         type
         number
       }
+      emails
       testResultDelivery
     }
   }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2013,6 +2013,7 @@ export type GetPatientQuery = {
         birthDate?: any | null | undefined;
         gender?: string | null | undefined;
         telephone?: string | null | undefined;
+        emails?: Array<string | null | undefined> | null | undefined;
         testResultDelivery?: TestResultDeliveryPreference | null | undefined;
         phoneNumbers?:
           | Array<
@@ -5634,6 +5635,7 @@ export const GetPatientDocument = gql`
         type
         number
       }
+      emails
       testResultDelivery
     }
   }


### PR DESCRIPTION
## Related Issue
  - Closes #3536 

## Changes Proposed
- The "get single patient" GraphQL query used to populate the AOE form now returns the `emails` property of a patient
  - This did not and does not affect tests initiated via the patient search input field, as that retrieves patient data via a different query

## Testing
- Try it and see! 🧙 

## Screenshots / Demos
### Edit Patient
https://user-images.githubusercontent.com/27730981/169906609-05d64981-9e4c-47f8-8097-d1654c6f6b8d.mov

### Add New Patient
https://user-images.githubusercontent.com/27730981/169906641-21c8c48b-9f8d-4cd7-a853-1ab3c93beb02.mov

## Checklist for Author and Reviewer
- [ ] Think we can meaningfully test this change? The redirect logic bridges **several** different components which makes a unit test tricky. Best would be an end-to-end test for this case, which we can add after @mehansen's work to lay the groundwork (#2994).

### Design
- [x] ~Any UI/UX changes have a designer as a reviewer, and changes have been approved~
- [x] ~Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams~

### Content
- [x] ~Any content changes have been approved by content team~

### Support
- [x] ~Any changes that might generate new support requests have been flagged to the support team~
- [x] ~Any changes to support infrastructure have been demo'd to support team~

### Security
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~
