### PR TITLE
Restore save-and-start-test behavior on "close enough" patient addresses 

### DIFF
--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -209,7 +209,7 @@ const PersonForm = (props: Props) => {
     };
   };
 
-  const validatePatientAddress = async () => {
+  const validatePatientAddress = async (shouldStartTest = false) => {
     const originalAddress = getAddress(patient);
 
     const zipCodeData = await getZipCodeData(originalAddress.zipCode);
@@ -228,7 +228,7 @@ const PersonForm = (props: Props) => {
 
     const suggestedAddress = await getBestSuggestion(originalAddress);
     if (suggestionIsCloseEnough(originalAddress, suggestedAddress)) {
-      onSave(suggestedAddress, startTest);
+      onSave(suggestedAddress, shouldStartTest);
     } else {
       setAddressSuggestion(suggestedAddress);
       setAddressModalOpen(true);
@@ -273,6 +273,7 @@ const PersonForm = (props: Props) => {
 
       return;
     }
+
     if (
       JSON.stringify(getAddress(patient)) ===
         JSON.stringify(getAddress(props.patient)) ||
@@ -280,7 +281,7 @@ const PersonForm = (props: Props) => {
     ) {
       onSave(undefined, shouldStartTest);
     } else {
-      validatePatientAddress();
+      validatePatientAddress(shouldStartTest);
     }
   };
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Closes #3758 

## Changes Proposed
- The "Save and start test" button now properly redirects to the test queue in all cases

## Additional Information
- The root cause was a React timing issue. 
    * Previously, the "should start test" flag was managed in local state
    * The state-setting operation is asynchronous and could not guarantee to be completed at the time the test was actually submitted
- Instead, the flag variable is manually passed through to the various methods that handle form submission

## Testing
- Give it a whirl, should be pretty straightforward to test
 
## Screenshots / Demos

https://user-images.githubusercontent.com/27730981/170101552-05bfa3b4-66ff-4ee0-a704-1a9cfb3a778a.mov

## Checklist for Author and Reviewer
- General review please

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed
