### PR TITLE
Terraform populates Datahub Key Vault secrets into environment variables

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -47,8 +47,8 @@ spring:
     store-type: jdbc
     timeout: 15m
     jdbc:
-        initialize-schema: never
-        table-name: ${spring.jpa.properties.hibernate.default_schema}.spring_session
+      initialize-schema: never
+      table-name: ${spring.jpa.properties.hibernate.default_schema}.spring_session
 management:
   health.probes.enabled: true
 graphql:
@@ -141,3 +141,6 @@ logging:
     console: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": \"%replace(%m%wEx){'[\r\n]+', '\\n'}%nopex\"}%n"
     json-log: "{\"time\": \"%d{yyyy-MM-dd HH:mm:ss.SSS}\", \"level\": \"%p\", \"source\": \"%logger{39}:%L\", \"message\": %replace(%m%wEx){'[\r\n]+', '\\n'}%nopex}%n"
 hibernate.query.interceptor.error-level: ERROR
+datahub:
+  url: ${DATAHUB_URL}
+  api-key: ${DATAHUB_API_KEY}

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -228,3 +228,6 @@ simple-report-initialization:
       organization-external-id: DIS_ORG
     - patient-registration-link: inj3ct
       facility-name: Injection Site
+datahub:
+  url: "https://test.example"
+  api-key: "super-secret-api-key"

--- a/ops/demo/_data.tf
+++ b/ops/demo/_data.tf
@@ -162,3 +162,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/demo/api.tf
+++ b/ops/demo/api.tf
@@ -46,6 +46,8 @@ module "simple_report_api" {
     EXPERIAN_PID_CLIENT_REFERENCE_ID              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_client_reference_id.id})"
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev/_data.tf
+++ b/ops/dev/_data.tf
@@ -215,3 +215,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev/api.tf
+++ b/ops/dev/api.tf
@@ -52,6 +52,8 @@ module "simple_report_api" {
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev2/_data.tf
+++ b/ops/dev2/_data.tf
@@ -215,3 +215,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/dev2/_data.tf
+++ b/ops/dev2/_data.tf
@@ -218,10 +218,10 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
   name         = "datahub-api-key-test"
-  key_vault_id = data.azurerm_key_vault.global.id
+  key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
   name         = "datahub-url-test"
-  key_vault_id = data.azurerm_key_vault.global.id
+  key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev2/api.tf
+++ b/ops/dev2/api.tf
@@ -53,6 +53,8 @@ module "simple_report_api" {
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev3/_data.tf
+++ b/ops/dev3/_data.tf
@@ -215,3 +215,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev3/api.tf
+++ b/ops/dev3/api.tf
@@ -53,6 +53,8 @@ module "simple_report_api" {
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev4/_data.tf
+++ b/ops/dev4/_data.tf
@@ -215,3 +215,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/dev4/_data.tf
+++ b/ops/dev4/_data.tf
@@ -218,10 +218,10 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
   name         = "datahub-api-key-test"
-  key_vault_id = data.azurerm_key_vault.global.id
+  key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
   name         = "datahub-url-test"
-  key_vault_id = data.azurerm_key_vault.global.id
+  key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev4/api.tf
+++ b/ops/dev4/api.tf
@@ -53,6 +53,8 @@ module "simple_report_api" {
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/pentest/_data.tf
+++ b/ops/pentest/_data.tf
@@ -196,3 +196,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/pentest/api.tf
+++ b/ops/pentest/api.tf
@@ -53,6 +53,8 @@ module "simple_report_api" {
     EXPERIAN_PID_CLIENT_REFERENCE_ID              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_client_reference_id.id})"
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/prod/_data.tf
+++ b/ops/prod/_data.tf
@@ -223,3 +223,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-prod"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-prod"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -56,6 +56,9 @@ module "simple_report_api" {
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
+
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/stg/_data.tf
+++ b/ops/stg/_data.tf
@@ -190,3 +190,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -55,6 +55,8 @@ module "simple_report_api" {
     EXPERIAN_PID_CLIENT_REFERENCE_ID              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_client_reference_id.id})"
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/test/_data.tf
+++ b/ops/test/_data.tf
@@ -215,3 +215,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/test/api.tf
+++ b/ops/test/api.tf
@@ -50,6 +50,8 @@ module "simple_report_api" {
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default, can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows/overrides an identical declaration in application.yaml

--- a/ops/training/_data.tf
+++ b/ops/training/_data.tf
@@ -190,3 +190,13 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
   name         = "simple-report-${local.env}-db-password-no-phi"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "datahub_api_key" {
+  name         = "datahub-api-key-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "datahub_url" {
+  name         = "datahub-url-test"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/training/api.tf
+++ b/ops/training/api.tf
@@ -48,6 +48,8 @@ module "simple_report_api" {
     EXPERIAN_PID_CLIENT_REFERENCE_ID              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_client_reference_id.id})"
     EXPERIAN_PID_USERNAME                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_username.id})"
     EXPERIAN_PID_PASSWORD                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.experian_preciseid_password.id})"
+    DATAHUB_URL                                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_url.id})"
+    DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Prepares for #3644 

## Changes Proposed
- Datahub API keys are stored as secrets in SimpleReport's global Azure Key Vault
- These changes will populate environment variables with these secrets, allowing us to access those values in code

## Additional Information
- N/A

## Testing
- I will deploy and make sure we do not experience any Terraform errors
- For testing, one could apply these changes to the #3714 PR and deploy, making sure the expected secrets are accessible

## Checklist for Reviewers
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] ~Any content updates (user-facing error messages, etc) have been approved by content team~
- [x] ~Any changes that might generate questions in the support inbox have been flagged to the support team~
- [x] ~GraphQL schema changes are backward compatible with older version of the front-end~
- [x] ~Changes comply with the SimpleReport Style Guide~
- [x] ~Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)~
- [x] ~Any dependencies introduced have been vetted and discussed~
