### PR TITLE
bump jackson-databind:2.12.6.1

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
+
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // Okta dependencies
@@ -108,7 +110,6 @@ dependencies {
     runtimeOnly 'com.azure:azure-core-http-netty:1.11.9'
     runtimeOnly 'com.azure:azure-core:1.27.0'
     runtimeOnly 'com.azure:azure-storage-common:12.15.1'
-    runtimeOnly "com.azure:azure-storage-queue:12.12.1"
 
     runtimeOnly "io.zipkin.brave:brave-instrumentation-http:5.13.2"
     runtimeOnly "io.zipkin.brave:brave:5.13.2"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.4'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,13 +4,13 @@
 antlr:antlr:2.7.7
 ch.qos.logback:logback-classic:1.2.3
 ch.qos.logback:logback-core:1.2.3
-com.azure:azure-core-http-netty:1.11.9
-com.azure:azure-core:1.27.0
-com.azure:azure-storage-common:12.15.1
-com.azure:azure-storage-queue:12.12.1
+com.azure:azure-core-http-netty:1.12.0
+com.azure:azure-core:1.28.0
+com.azure:azure-storage-common:12.15.2
+com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.11.3
+com.fasterxml.jackson.core:jackson-databind:2.12.6.1
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,6 +19,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
+com.fasterxml.jackson:jackson-bom:2.12.6
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -10,7 +10,7 @@ com.azure:azure-storage-common:12.15.2
 com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.12.1
+com.fasterxml.jackson.core:jackson-databind:2.13.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,7 +19,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
-com.fasterxml.jackson:jackson-bom:2.12.1
+com.fasterxml.jackson:jackson-bom:2.13.3
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -10,7 +10,7 @@ com.azure:azure-storage-common:12.15.2
 com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.11.4
+com.fasterxml.jackson.core:jackson-databind:2.12.1
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,6 +19,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
+com.fasterxml.jackson:jackson-bom:2.12.1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -10,7 +10,7 @@ com.azure:azure-storage-common:12.15.2
 com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.12.6.1
+com.fasterxml.jackson.core:jackson-databind:2.11.4
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,7 +19,6 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
-com.fasterxml.jackson:jackson-bom:2.12.6
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -10,7 +10,7 @@ com.azure:azure-storage-common:12.15.1
 com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.12.1
+com.fasterxml.jackson.core:jackson-databind:2.13.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,7 +19,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
-com.fasterxml.jackson:jackson-bom:2.12.1
+com.fasterxml.jackson:jackson-bom:2.13.3
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -10,7 +10,7 @@ com.azure:azure-storage-common:12.15.1
 com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.12.6.1
+com.fasterxml.jackson.core:jackson-databind:2.11.4
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,7 +19,6 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
-com.fasterxml.jackson:jackson-bom:2.12.6
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -10,7 +10,7 @@ com.azure:azure-storage-common:12.15.1
 com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.11.4
+com.fasterxml.jackson.core:jackson-databind:2.12.1
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,6 +19,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
+com.fasterxml.jackson:jackson-bom:2.12.1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -7,10 +7,10 @@ ch.qos.logback:logback-core:1.2.3
 com.azure:azure-core-http-netty:1.11.9
 com.azure:azure-core:1.27.0
 com.azure:azure-storage-common:12.15.1
-com.azure:azure-storage-queue:12.12.1
+com.azure:azure-storage-queue:12.12.2
 com.fasterxml.jackson.core:jackson-annotations:2.11.3
 com.fasterxml.jackson.core:jackson-core:2.11.3
-com.fasterxml.jackson.core:jackson-databind:2.11.3
+com.fasterxml.jackson.core:jackson-databind:2.12.6.1
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.3
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3
 com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.11.3
@@ -19,6 +19,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.3
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3
+com.fasterxml.jackson:jackson-bom:2.12.6
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.fasterxml:classmate:1.5.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1


### PR DESCRIPTION
# BACKEND PULL REQUEST
updated jackson-databind from 2.11.3 to 2.12.6.1

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists
Snyk vulnerability findings

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

