### PR TITLE
Fix hiding of Flu columns when no rows contain multiplex results

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -64,6 +64,7 @@ const testResults = [
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
     result: "NEGATIVE",
+    results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
       internalId: "8c1a8efe-8951-4f84-a4c9-dcea561d7fbb",
@@ -102,6 +103,7 @@ const testResults = [
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
     result: "NEGATIVE",
+    results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
       internalId: "8c1a8efe-8951-4f84-a4c9-dcea561d7fbb",
@@ -140,6 +142,7 @@ const testResults = [
     internalId: "7c768a5d-ef90-44cd-8050-b96dd7aaa1d5",
     dateTested: "2021-03-19T19:27:21.052Z",
     result: "POSITIVE",
+    results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
       internalId: "8c1a8efe-8951-4f84-a4c9-dcea561d7fbb",
@@ -1850,6 +1853,7 @@ describe("TestResultsList", () => {
 
     it("should not display Flu result columns if all rows with multiplex results are filtered", async () => {
       // facility 1 has no multiplex results
+      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
       expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
     });
 

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -451,7 +451,8 @@ export const DetachedTestResultsList = ({
 
   const hasMultiplexResults = testResults.some(
     (result: any) =>
-      result.results?.length && result.results.diseaseName !== "COVID-19"
+      result.results?.length &&
+      result.results.some((r: any) => r.disease.name !== "COVID-19")
   );
 
   const rows = testResultRows(


### PR DESCRIPTION
Fix for #3777, currently the Flu columns are always showing, no matter what. Got my types mixed up (DiseaseResult vs MultiplexResult) 🤦 

Improved tests to fail (showing the original bug), then pass with fix.