### PR TITLE
Added conditional to handle null type.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusService.java
@@ -104,7 +104,7 @@ public class TextMessageStatusService {
                 phoneUtil.parse(phoneNumber.getNumber(), "US"),
                 PhoneNumberUtil.PhoneNumberFormat.E164);
         if (convertedNumber.startsWith(numberPrefix)
-            && phoneNumber.getType().equals(PhoneType.MOBILE)) {
+            && (phoneNumber.getType() == null || phoneNumber.getType().equals(PhoneType.MOBILE))) {
           return Optional.of(phoneNumber.getNumber());
         }
       } catch (NumberParseException parseException) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusService.java
@@ -104,7 +104,7 @@ public class TextMessageStatusService {
                 phoneUtil.parse(phoneNumber.getNumber(), "US"),
                 PhoneNumberUtil.PhoneNumberFormat.E164);
         if (convertedNumber.startsWith(numberPrefix)
-            && (phoneNumber.getType() == null || phoneNumber.getType().equals(PhoneType.MOBILE))) {
+            && (phoneNumber.getType() == null || PhoneType.MOBILE.equals(phoneNumber.getType()))) {
           return Optional.of(phoneNumber.getNumber());
         }
       } catch (NumberParseException parseException) {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
Fixes server runtime exceptions reported in [this thread](https://skylight-hq.slack.com/archives/C01LTSNKEPP/p1653585548244349?thread_ts=1653585166.982109&cid=C01LTSNKEPP) . 

## Changes Proposed
Based on the error log. It seems that the code was breaking while trying to assert the phone number type to "MOBILE" while the type being a null object. The fix was addressed with below changes.
- We added a conditional clause stating that in the case that the type is in fact NULL we still want to set it to LANDLINE.
- The assertion is now done by the PhoneType constant agains the phone number type, so even when the type is NULL no method is trying to be executed from it.

## Testing
A twilio event that references a phone number entry with a type equal null should still be changed to LANDLINE and should not trigger a nullPointerException.

## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [X] Changes comply with the SimpleReport Style Guide
