### PR TITLE
Patient Experience supports removed tests

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/MissingDataPatientLinkException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/MissingDataPatientLinkException.java
@@ -1,0 +1,11 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(
+    code = HttpStatus.INTERNAL_SERVER_ERROR,
+    reason = "Error fetching data at this patient link.")
+public class MissingDataPatientLinkException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
@@ -1,10 +1,12 @@
 package gov.cdc.usds.simplereport.api.model.pxp;
 
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +16,8 @@ public class PxpVerifyResponseV2 {
 
   private final UUID testEventId;
   private final TestResult result;
+  private TestResult fluAResult = null;
+  private TestResult fluBResult = null;
   private final Date dateTested;
   private final String correctionStatus;
   private final Patient patient;
@@ -21,10 +25,18 @@ public class PxpVerifyResponseV2 {
   private final Facility facility;
   private final DeviceTypeWrapper deviceType;
 
-  public PxpVerifyResponseV2(Person person, TestEvent testEvent) {
+  public PxpVerifyResponseV2(
+      Person person,
+      TestEvent testEvent,
+      Result covidResult,
+      Optional<Result> fluAResult,
+      Optional<Result> fluBResult) {
+
+    this.result = covidResult.getTestResult();
+    fluAResult.ifPresent(value -> this.fluAResult = value.getTestResult());
+    fluBResult.ifPresent(value -> this.fluBResult = value.getTestResult());
 
     this.testEventId = testEvent.getInternalId();
-    this.result = testEvent.getResult();
     this.dateTested = testEvent.getDateTested();
     this.correctionStatus = testEvent.getCorrectionStatus().toString();
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -168,6 +168,14 @@ public class TestEvent extends BaseTestInfo {
     return super.getResult();
   }
 
+  public Optional<Result> getResultForDisease(SupportedDisease disease) {
+    Hibernate.initialize(this.results);
+    if (results != null) {
+      return results.stream().filter(r -> r.getDisease().equals(disease)).findFirst();
+    }
+    return Optional.empty();
+  }
+
   @Override
   public TestResult getResult() {
     return getTestResult();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -50,6 +50,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   private Person person;
   private PatientLink patientLink;
   private TestEvent testEvent;
+  private TestEvent removedTestEvent;
 
   @BeforeEach
   void init() {
@@ -140,7 +141,144 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("NEGATIVE")))
+            .andExpect(jsonPath("$.fluAResult").doesNotExist())
+            .andExpect(jsonPath("$.fluBResult").doesNotExist())
             .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
+            .andExpect(jsonPath("$.patient.firstName", is("Fred")))
+            .andExpect(jsonPath("$.patient.middleName", is("M")))
+            .andExpect(jsonPath("$.patient.lastName", is("Astaire")))
+            .andExpect(jsonPath("$.patient.birthDate", is("1899-05-10")))
+            .andExpect(jsonPath("$.organization.name", is("The Mall")))
+            .andExpect(jsonPath("$.facility.name", is("Imaginary Site")))
+            .andExpect(jsonPath("$.facility.cliaNumber", is("123456")))
+            .andExpect(jsonPath("$.facility.street", is("736 Jackson PI NW")))
+            .andExpect(jsonPath("$.facility.streetTwo", is("")))
+            .andExpect(jsonPath("$.facility.city", is("Washington")))
+            .andExpect(jsonPath("$.facility.state", is("DC")))
+            .andExpect(jsonPath("$.facility.zipCode", is("20503")))
+            .andExpect(jsonPath("$.facility.phone", is("555-867-5309")))
+            .andExpect(jsonPath("$.facility.orderingProvider.firstName", is("Doctor")))
+            .andExpect(jsonPath("$.facility.orderingProvider.middleName", is("")))
+            .andExpect(jsonPath("$.facility.orderingProvider.lastName", is("Doom")))
+            .andExpect(jsonPath("$.facility.orderingProvider.npi", is("DOOOOOOM")))
+            .andExpect(jsonPath("$.deviceType.name", is("Acme SuperFine")))
+            .andExpect(jsonPath("$.deviceType.model", is("SFN")))
+            .andReturn()
+            .getResponse()
+            .getHeader(LoggingConstants.REQUEST_ID_HEADER);
+
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, requestId);
+  }
+
+  @Test
+  void verifyLinkV2ReturnsTestResultInfo_multiplex() throws Exception {
+
+    TestUserIdentities.withStandardUser(
+        () -> {
+          testEvent =
+              _dataFactory.createMultiplexTestEvent(
+                  person,
+                  facility,
+                  TestResult.POSITIVE,
+                  TestResult.NEGATIVE,
+                  TestResult.NEGATIVE,
+                  false);
+          patientLink = _dataFactory.createPatientLink(testEvent.getTestOrder());
+        });
+
+    // GIVEN
+    String dob = person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String requestBody =
+        "{\"patientLinkId\":\""
+            + patientLink.getInternalId()
+            + "\",\"dateOfBirth\":\""
+            + dob
+            + "\"}";
+
+    // WHEN
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.VERIFY_LINK_V2)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    // THEN
+    String requestId =
+        mockMvc
+            .perform(builder)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
+            .andExpect(jsonPath("$.result", is("POSITIVE")))
+            .andExpect(jsonPath("$.fluAResult", is("NEGATIVE")))
+            .andExpect(jsonPath("$.fluBResult", is("NEGATIVE")))
+            .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
+            .andExpect(jsonPath("$.patient.firstName", is("Fred")))
+            .andExpect(jsonPath("$.patient.middleName", is("M")))
+            .andExpect(jsonPath("$.patient.lastName", is("Astaire")))
+            .andExpect(jsonPath("$.patient.birthDate", is("1899-05-10")))
+            .andExpect(jsonPath("$.organization.name", is("The Mall")))
+            .andExpect(jsonPath("$.facility.name", is("Imaginary Site")))
+            .andExpect(jsonPath("$.facility.cliaNumber", is("123456")))
+            .andExpect(jsonPath("$.facility.street", is("736 Jackson PI NW")))
+            .andExpect(jsonPath("$.facility.streetTwo", is("")))
+            .andExpect(jsonPath("$.facility.city", is("Washington")))
+            .andExpect(jsonPath("$.facility.state", is("DC")))
+            .andExpect(jsonPath("$.facility.zipCode", is("20503")))
+            .andExpect(jsonPath("$.facility.phone", is("555-867-5309")))
+            .andExpect(jsonPath("$.facility.orderingProvider.firstName", is("Doctor")))
+            .andExpect(jsonPath("$.facility.orderingProvider.middleName", is("")))
+            .andExpect(jsonPath("$.facility.orderingProvider.lastName", is("Doom")))
+            .andExpect(jsonPath("$.facility.orderingProvider.npi", is("DOOOOOOM")))
+            .andExpect(jsonPath("$.deviceType.name", is("Acme SuperFine")))
+            .andExpect(jsonPath("$.deviceType.model", is("SFN")))
+            .andReturn()
+            .getResponse()
+            .getHeader(LoggingConstants.REQUEST_ID_HEADER);
+
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, requestId);
+  }
+
+  @Test
+  void verifyResultsDisplayForRemovedTests() throws Exception {
+    TestUserIdentities.withStandardUser(
+        () -> {
+          testEvent = _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE);
+          patientLink = _dataFactory.createPatientLink(testEvent.getTestOrder());
+        });
+
+    TestUserIdentities.withStandardUser(
+        () -> {
+          removedTestEvent = _dataFactory.createTestEventRemoval(testEvent);
+        });
+
+    // GIVEN
+    String dob = person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String requestBody =
+        "{\"patientLinkId\":\""
+            + patientLink.getInternalId()
+            + "\",\"dateOfBirth\":\""
+            + dob
+            + "\"}";
+
+    // WHEN
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.VERIFY_LINK_V2)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    // THEN
+    String requestId =
+        mockMvc
+            .perform(builder)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.testEventId", is(removedTestEvent.getInternalId().toString())))
+            .andExpect(jsonPath("$.result", is("POSITIVE")))
+            .andExpect(jsonPath("$.fluAResult").doesNotExist())
+            .andExpect(jsonPath("$.fluBResult").doesNotExist())
+            .andExpect(jsonPath("$.correctionStatus", is("REMOVED")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))
             .andExpect(jsonPath("$.patient.middleName", is("M")))
             .andExpect(jsonPath("$.patient.lastName", is("Astaire")))

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -443,8 +443,19 @@ public class TestDataFactory {
   }
 
   public TestEvent createTestEventRemoval(TestEvent originalTestEvent) {
-    return _testEventRepo.save(
-        new TestEvent(originalTestEvent, TestCorrectionStatus.REMOVED, "Cold feet"));
+    TestEvent newRemoveEvent =
+        new TestEvent(originalTestEvent, TestCorrectionStatus.REMOVED, "Cold feet");
+    _testEventRepo.save(newRemoveEvent);
+
+    TestOrder order = originalTestEvent.getTestOrder();
+
+    order.setReasonForCorrection("Cold feet");
+    order.setTestEventRef(newRemoveEvent);
+    order.setCorrectionStatus(TestCorrectionStatus.REMOVED);
+
+    _testOrderRepo.save(order);
+
+    return newRemoveEvent;
   }
 
   public TestEvent doTest(TestOrder order, TestResult result) {

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -594,6 +594,8 @@ export const en = {
           "This link has expired. Please contact your test provider to generate a new link.",
         linkNotFound:
           "This test result link is invalid. Please double check the URL or contact your test provider for the correct link.",
+        missingData:
+          "This test result link is missing data. Please contact your test provider for your results.",
         exampleText: "For example: 4 28 1986",
         submit: "Continue",
       },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -512,6 +512,8 @@ export const es: LanguageConfig = {
           "Este enlace ha caducado. Comuníquese con su proveedor de prueba para generar un nuevo enlace.",
         linkNotFound:
           "Este enlace de resultado de la prueba no es válido. Vuelva a verificar el enlace o comuníquese con su proveedor de prueba para obtener el enlace correcto.",
+        missingData:
+          "This test result link is missing data. Please contact your test provider for your results.",
         exampleText: "Por ejemplo: 4 28 1986",
         submit: "Continuar",
       },

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -46,6 +46,8 @@ export type SelfRegistrationData = Omit<
 export type VerifyV2Response = {
   testEventId: string;
   result: TestResult;
+  fluAResult: TestResult | undefined;
+  fluBResult: TestResult | undefined;
   dateTested: string;
   correctionStatus: string;
   deviceType: {

--- a/frontend/src/patientApp/timeOfTest/DOB.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.test.tsx
@@ -233,6 +233,29 @@ describe("DOB (valid UUID)", () => {
     ).toBeInTheDocument();
     expect(validateDateOfBirthSpy).toHaveBeenCalled();
   });
+
+  it("Shows an error when invalid data is returned", async () => {
+    // GIVEN
+    validateDateOfBirthSpy.mockRejectedValue({ status: 500 });
+    userEvent.type(await screen.findByLabelText("Month"), "08");
+    userEvent.type(await screen.findByLabelText("Day"), "21");
+    userEvent.type(await screen.findByLabelText("Year"), "1987");
+
+    // WHEN
+    userEvent.click(await screen.findByText("Continue"));
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText("Validating birth date...")
+    );
+
+    // THEN
+    expect(
+      await screen.findByText(
+        "This test result link is missing data. Please contact your test provider for your results.",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+    expect(validateDateOfBirthSpy).toHaveBeenCalled();
+  });
 });
 
 describe("DOB (invalid UUID)", () => {

--- a/frontend/src/patientApp/timeOfTest/DOB.tsx
+++ b/frontend/src/patientApp/timeOfTest/DOB.tsx
@@ -53,6 +53,7 @@ const DOB = () => {
   const [linkNotFoundError, setLinkNotFoundError] = useState(
     !isValidUUID(plid)
   );
+  const [missingDataError, setMissingDataError] = useState(false);
   const dobRef = useRef<HTMLInputElement>(null);
   const testResult = useSelector((state: any) => state.testResult);
   const [loading, setLoading] = useState(false);
@@ -108,6 +109,8 @@ const DOB = () => {
         strError.includes("401")
       ) {
         setBirthDateError(t("testResult.dob.error"));
+      } else if (error?.status === 500 || strError.includes("500")) {
+        setMissingDataError(true);
       }
     } finally {
       setLoading(false);
@@ -159,6 +162,21 @@ const DOB = () => {
             type="error"
             title="Page not found"
             body={t("testResult.dob.linkNotFound")}
+          />
+        </div>
+      </main>
+    );
+  }
+
+  if (missingDataError) {
+    return (
+      <main>
+        <div className="grid-container maxw-tablet">
+          <p></p>
+          <Alert
+            type="error"
+            title="Missing data"
+            body={t("testResult.dob.missingData")}
           />
         </div>
       </main>


### PR DESCRIPTION
## Related Issue

- In the previous deploy for these pxp changes (see #3822), we saw null pointer exceptions when getting results for Covid in a small subset of cases. It turns out that only happened for tests that had been removed, because the Result object didn't point at the new (removed) testEvent in those cases.
 
## Changes Proposed

- This change adds back the patient experience changes to support multiplex
- It also adds logic for removed events to grab the Result off the `priorCorrectedTestEvent` if applicable.
- Finally, it gracefully handles a 500 on the frontend by telling patients to contact their testing provider.

## Additional Information

@zdeveloper I know this is not quite the PR I promised - the underlying fix will be addressed in #3831, to create a second Result for removed TestEvents. But this short-term fix to make sure we have the patient experience squared away before we release multiplex.

Error on a 500 response (triggered manually, I haven't gotten this to trigger with the current code)
![Screen Shot 2022-06-01 at 9 47 04 AM](https://user-images.githubusercontent.com/80282552/171464178-300ed4af-2cc2-4ce3-9478-c4594e9a1087.png)

Accessing a removed result:
![Screen Shot 2022-06-01 at 10 18 46 AM](https://user-images.githubusercontent.com/80282552/171464559-da83ba89-7a19-4531-9376-e844e5b11d78.png)

## Testing

- PXP works as intended

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
