### PR TITLE
Bob/3829 fix symptom selection UI

### DIFF
--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -921,6 +921,17 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
             margin-top: 0;
           }
         }
+        // The way USWDS was interacting with the two column layout
+        // in Chrome was causing checkboxes not to populate for some folks.
+        // Using this as a workaround
+        .usa-checkbox__label {
+          padding-left: 0;
+        }
+
+        .usa-checkbox__label::before {
+          position: relative;
+          float: left;
+        }
       }
 
       > .usa-checkbox {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes https://github.com/cdcgov/prime-simplereport/issues/3829 which was discussed in more detail [here](https://skylight-hq.slack.com/archives/C01T5NC1WMN/p1654019220272919)

## Changes Proposed

USWDS's custom checkbox implementation interacts strangely with the `column-count` property we're using in the symptom selection screen to display the symptoms. This PR implements the workaround discussed [here](https://stackoverflow.com/questions/35244485/using-column-count-together-with-before) specifically for the two-column layout on that piece of the UI.

## Testing

- To recreate the bug, navigate to the AOE screen on demo by starting a test and scrolling down to symptom selection. Open the inspector on any of the checkboxes by finding the `::before` psuedo element on any of the checkbox label HTML tags. Uncheck any property on the `::before` element and verify that the checkboxes disappear (and don't re-populate once that item is re-checked)
- Perform the same set of checks on the deployed test instance (you may need to ghost into an org first by clicking "Organization data" and selecting an org) and notice the bug isn't reproduced.
