### PR TITLE
Store additional results for removed and corrected events

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Result.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Result.java
@@ -56,6 +56,15 @@ public class Result extends EternalAuditedEntity {
     this.testResult = testResult;
   }
 
+  /* Copy constructor, used for corrections and removals */
+  public Result(Result originalResult, TestEvent testEvent) {
+    this.testEvent = testEvent;
+    this.testOrder = originalResult.testOrder;
+    this.disease = originalResult.disease;
+    this.resultLOINC = originalResult.resultLOINC;
+    this.testResult = originalResult.testResult;
+  }
+
   public void setTestEvent(TestEvent event) {
     this.testEvent = event;
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -584,6 +584,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         LocalDate.of(1865, 12, 25),
         LocalDate.ofInstant(
             correctionTestEvent.getDateTested().toInstant(), ZoneId.systemDefault()));
+    assertEquals(2, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(correctionTestEvent).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(originalTestEvent).size());
   }
 
   @Test
@@ -1264,6 +1267,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertEquals(
         deleteMarkerEvent.getInternalId().toString(),
         events_after.get(0).getInternalId().toString());
+
+    // verify that a Result object is created for both the original and new TestEvent
+    assertEquals(2, _resultRepository.findAllByTestOrder(onlySavedOrder).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(mostRecentEvent).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(deleteMarkerEvent).size());
 
     // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
     // to report stream


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixes #3831 

## Changes Proposed

- For test removals, create a new Result object that links the testOrder to the new removed testEvent. This is required for correctly printing and displaying results to patients.
- For test corrections, instead of overwriting the Result with the corrected test event, create a new one.

## Additional Information

- This PR blocks #3493 

## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
