### PR TITLE
add bulk upload submissions graphql changes

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -4,19 +4,24 @@ import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.TestResultUpload;
 import gov.cdc.usds.simplereport.service.TestOrderService;
+import gov.cdc.usds.simplereport.service.TestResultUploadService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class TestResultResolver implements GraphQLQueryResolver, GraphQLMutationResolver {
 
-  @Autowired private TestOrderService tos;
+  private final TestOrderService tos;
+  private final TestResultUploadService testResultUploadService;
 
   public List<TestEvent> getTestResults(
       UUID facilityId,
@@ -86,5 +91,10 @@ public class TestResultResolver implements GraphQLQueryResolver, GraphQLMutation
   public TopLevelDashboardMetrics getTopLevelDashboardMetrics(
       UUID facilityId, Date startDate, Date endDate) {
     return tos.getTopLevelDashboardMetrics(facilityId, startDate, endDate);
+  }
+
+  public Page<TestResultUpload> getUploadSubmissions(
+      Date startDate, Date endDate, int pageNumber, int pageSize) {
+    return testResultUploadService.getUploadSubmissions(startDate, endDate, pageNumber, pageSize);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestResultUploadRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestResultUploadRepository.java
@@ -1,5 +1,19 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.TestResultUpload;
+import java.util.Date;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface TestResultUploadRepository extends AuditedEntityRepository<TestResultUpload> {}
+public interface TestResultUploadRepository extends AuditedEntityRepository<TestResultUpload> {
+  @Query(
+      "SELECT record FROM TestResultUpload record WHERE (record.organization = :org) and (cast(:startDate as date) is null or record.createdAt >= :startDate) and (cast(:endDate as date) is null or record.createdAt <= :endDate)")
+  Page<TestResultUpload> findAll(
+      @Param("org") Organization org,
+      @Param("startDate") Date startDate,
+      @Param("endDate") Date endDate,
+      Pageable p);
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -13,8 +13,12 @@ import gov.cdc.usds.simplereport.service.model.reportstream.ReportStreamStatus;
 import gov.cdc.usds.simplereport.service.model.reportstream.UploadResponse;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -70,6 +74,15 @@ public class TestResultUploadService {
     }
 
     return result;
+  }
+
+  public Page<TestResultUpload> getUploadSubmissions(
+      Date startDate, Date endDate, int pageNumber, int pageSize) {
+    Organization org = _orgService.getCurrentOrganization();
+    PageRequest pageRequest =
+        PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+
+    return _repo.findAll(org, startDate, endDate, pageRequest);
   }
 
   private UploadStatus parseStatus(ReportStreamStatus status) {

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -301,9 +301,11 @@ type PendingOrganization {
 }
 
 type UploadResult {
+  internalId: ID!
   reportId: ID
-  status: String
-  recordsCount: Int
+  createdAt: DateTime!
+  status: UploadStatus!
+  recordsCount: Int!
   warnings: [FeedbackMessage]
   errors: [FeedbackMessage]
 }
@@ -313,6 +315,12 @@ type FeedbackMessage {
   message: String
   indices: [Int]
 }
+
+type UploadSubmissionPage {
+  totalElements: Int!
+  content: [UploadResult!]!
+}
+
 input DiseaseResult {
   diseaseName: String
   testResult: String
@@ -404,6 +412,13 @@ type Query {
     @requiredPermissions(allOf: ["MANAGE_USERS"])
   user(id: ID!): User @requiredPermissions(allOf: ["MANAGE_USERS"])
   whoami: User!
+  uploadSubmissions(
+    startDate: DateTime
+    endDate: DateTime
+    pageNumber: Int
+    pageSize: Int
+  ): UploadSubmissionPage!
+  @requiredPermissions(allOf: ["SR_CSV_UPLOADER_PILOT"])
 }
 
 type Mutation {

--- a/backend/src/main/resources/graphql/wiring.graphqls
+++ b/backend/src/main/resources/graphql/wiring.graphqls
@@ -40,6 +40,12 @@ scalar DateTime
 scalar LocalDate
 scalar Upload
 
+enum UploadStatus {
+  PENDING
+  SUCCESS
+  FAILURE
+}
+
 enum ResultValue {
   POSITIVE
   NEGATIVE

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceIntegrationTest.java
@@ -1,0 +1,137 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.TestResultUpload;
+import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
+import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.Page;
+
+class TestResultUploadServiceIntegrationTest extends BaseServiceTest<TestResultUploadService> {
+
+  public static final UUID REPORT_ID_1 = UUID.randomUUID();
+  public static final UUID REPORT_ID_2 = UUID.randomUUID();
+  public static final UUID REPORT_ID_3 = UUID.randomUUID();
+  @MockBean DateTimeProvider dateTimeProvider;
+
+  @SpyBean private AuditingHandler handler;
+
+  @Autowired private TestResultUploadRepository uploadRepository;
+
+  @Autowired private OrganizationService organizationService;
+
+  @Autowired private TestResultUploadService testResultUploadService;
+
+  @BeforeEach
+  void setup() {
+    mockCreationTime("2020-01-01 00:00");
+    initSampleData();
+    Organization currentOrganization = organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createValidFacility(currentOrganization);
+
+    mockCreationTime("2020-02-17 00:00");
+    uploadRepository.save(
+        new TestResultUpload(
+            REPORT_ID_1, UploadStatus.SUCCESS, 30, currentOrganization, null, null));
+
+    mockCreationTime("2021-02-17 00:00");
+    uploadRepository.save(
+        new TestResultUpload(
+            REPORT_ID_2, UploadStatus.PENDING, 20, currentOrganization, null, null));
+
+    mockCreationTime("2022-02-17 00:00");
+    uploadRepository.save(
+        new TestResultUpload(
+            REPORT_ID_3, UploadStatus.FAILURE, 10, currentOrganization, null, null));
+  }
+
+  @Test
+  void getUploadSubmissions_happy_path() {
+    // WHEN
+    Page<TestResultUpload> uploadSubmissions =
+        testResultUploadService.getUploadSubmissions(null, null, 0, 5);
+
+    // THEN
+    assertThat(uploadSubmissions.getTotalElements()).isEqualTo(3);
+  }
+
+  @Test
+  void getUploadSubmissions_start_date_end_date() {
+    // GIVEN
+    Date startDate = getDate("2020-02-10 00:00");
+    Date endDate = getDate("2021-02-20 00:00");
+
+    // WHEN
+    Page<TestResultUpload> uploadSubmissions =
+        testResultUploadService.getUploadSubmissions(startDate, endDate, 0, 5);
+
+    // THEN
+    assertThat(uploadSubmissions.getTotalElements()).isEqualTo(2);
+    assertThat(uploadSubmissions.getContent().get(0).getReportId())
+        .isIn(List.of(REPORT_ID_1, REPORT_ID_2));
+    assertThat(uploadSubmissions.getContent().get(1).getReportId())
+        .isIn(List.of(REPORT_ID_1, REPORT_ID_2));
+  }
+
+  @Test
+  void getUploadSubmissions_start_date_null() {
+    // GIVEN
+    Date endDate = getDate("2021-02-16 00:00");
+
+    // WHEN
+    Page<TestResultUpload> uploadSubmissions =
+        testResultUploadService.getUploadSubmissions(null, endDate, 0, 5);
+
+    // THEN
+    assertThat(uploadSubmissions.getTotalElements()).isEqualTo(1);
+    assertThat(uploadSubmissions.getContent().get(0).getReportId()).isEqualTo(REPORT_ID_1);
+  }
+
+  @Test
+  void getUploadSubmissions_end_date_null() {
+    // GIVEN
+    Date startDate = getDate("2021-02-16 00:00");
+
+    // WHEN
+    Page<TestResultUpload> uploadSubmissions =
+        testResultUploadService.getUploadSubmissions(startDate, null, 0, 5);
+
+    // THEN
+    assertThat(uploadSubmissions.getTotalElements()).isEqualTo(2);
+    assertThat(uploadSubmissions.getContent().get(0).getReportId())
+        .isIn(List.of(REPORT_ID_2, REPORT_ID_3));
+    assertThat(uploadSubmissions.getContent().get(1).getReportId())
+        .isIn(List.of(REPORT_ID_2, REPORT_ID_3));
+  }
+
+  private void mockCreationTime(String date) {
+    LocalDateTime localDateTime = getLocalDateTime(date);
+    when(dateTimeProvider.getNow()).thenReturn(Optional.of(localDateTime));
+    handler.setDateTimeProvider(dateTimeProvider);
+  }
+
+  private LocalDateTime getLocalDateTime(String date) {
+    return LocalDateTime.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+  }
+
+  private Date getDate(String date) {
+    return Date.from(getLocalDateTime(date).atZone(ZoneId.systemDefault()).toInstant());
+  }
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -783,6 +783,7 @@ export type Query = {
   testResults?: Maybe<Array<Maybe<TestResult>>>;
   testResultsCount?: Maybe<Scalars["Int"]>;
   topLevelDashboardMetrics?: Maybe<TopLevelDashboardMetrics>;
+  uploadSubmissions: UploadSubmissionPage;
   user?: Maybe<User>;
   users?: Maybe<Array<Maybe<ApiUser>>>;
   usersWithStatus?: Maybe<Array<ApiUserWithStatus>>;
@@ -867,6 +868,13 @@ export type QueryTestResultsCountArgs = {
 export type QueryTopLevelDashboardMetricsArgs = {
   endDate?: InputMaybe<Scalars["DateTime"]>;
   facilityId?: InputMaybe<Scalars["ID"]>;
+  startDate?: InputMaybe<Scalars["DateTime"]>;
+};
+
+export type QueryUploadSubmissionsArgs = {
+  endDate?: InputMaybe<Scalars["DateTime"]>;
+  pageNumber?: InputMaybe<Scalars["Int"]>;
+  pageSize?: InputMaybe<Scalars["Int"]>;
   startDate?: InputMaybe<Scalars["DateTime"]>;
 };
 
@@ -983,11 +991,25 @@ export type UpdateDeviceType = {
 
 export type UploadResult = {
   __typename?: "UploadResult";
+  createdAt: Scalars["DateTime"];
   errors?: Maybe<Array<Maybe<FeedbackMessage>>>;
-  recordsCount?: Maybe<Scalars["Int"]>;
+  internalId: Scalars["ID"];
+  recordsCount: Scalars["Int"];
   reportId?: Maybe<Scalars["ID"]>;
-  status?: Maybe<Scalars["String"]>;
+  status: UploadStatus;
   warnings?: Maybe<Array<Maybe<FeedbackMessage>>>;
+};
+
+export enum UploadStatus {
+  Failure = "FAILURE",
+  Pending = "PENDING",
+  Success = "SUCCESS",
+}
+
+export type UploadSubmissionPage = {
+  __typename?: "UploadSubmissionPage";
+  content: Array<UploadResult>;
+  totalElements: Scalars["Int"];
 };
 
 export type User = {
@@ -2594,8 +2616,8 @@ export type UploadTestResultCsvMutation = {
     | {
         __typename?: "UploadResult";
         reportId?: string | null | undefined;
-        status?: string | null | undefined;
-        recordsCount?: number | null | undefined;
+        status: UploadStatus;
+        recordsCount: number;
         warnings?:
           | Array<
               | {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- backend changes for #3645

## Changes Proposed

- adds a graphql endpoint to retrieve bulk upload submission history

## Additional Information

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Any content updates (user-facing error messages, etc) have been approved by content team
- [x] Any changes that might generate questions in the support inbox have been flagged to the support team
- [x] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

