### PR TITLE
log TestEvent ID when processing messages in RS upload queue

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -153,8 +153,16 @@ export async function deleteSuccessfullyParsedMessages(
         message.messageId,
         message.popReceipt
       );
+
+      if(message.dequeueCount > 1){
+        context.log(
+          `Message has been dequeued ${message.dequeueCount} times, possibly sent more than once to RS`
+        );
+      }
+
+      const testEventId = JSON.parse(message.messageText)['Result_ID'];
       context.log(
-        `Message ${message.messageId} deleted with request id ${deleteResponse.requestId}`
+        `Message ${message.messageId} deleted with request id ${deleteResponse.requestId} and has TestEvent id ${testEventId}`
       );
     } catch (e: any) {
       context.log(


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- currently its hard to trace when a test event was processed and sent over to RS

## Changes Proposed

- Adding TestEvent Id to the azure function logs for better traceability
