### PR TITLE
Adding test results sub tabs

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -25,6 +25,7 @@ import { MaintenanceBanner } from "./commonComponents/MaintenanceBanner";
 import { Analytics } from "./analytics/Analytics";
 import Uploads from "./testResults/uploads/Uploads";
 import Submissions from "./testResults/submissions/Submissions";
+import ResultsNavWrapper from "./testResults/ResultsNavWrapper";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -162,7 +163,13 @@ const App = () => {
                 <ProtectedRoute
                   requiredPermissions={canViewResults}
                   userPermissions={data.whoami.permissions}
-                  element={<TestResultsList />}
+                  element={
+                    <ResultsNavWrapper
+                      userPermissions={data.whoami.permissions}
+                    >
+                      <TestResultsList />
+                    </ResultsNavWrapper>
+                  }
                 />
               }
             />
@@ -172,7 +179,13 @@ const App = () => {
                 <ProtectedRoute
                   requiredPermissions={canViewResults}
                   userPermissions={data.whoami.permissions}
-                  element={<CleanTestResultsList />}
+                  element={
+                    <ResultsNavWrapper
+                      userPermissions={data.whoami.permissions}
+                    >
+                      <CleanTestResultsList />
+                    </ResultsNavWrapper>
+                  }
                 />
               }
             />
@@ -182,7 +195,13 @@ const App = () => {
                 <ProtectedRoute
                   requiredPermissions={canUseCsvUploaderPilot}
                   userPermissions={data.whoami.permissions}
-                  element={<Uploads />}
+                  element={
+                    <ResultsNavWrapper
+                      userPermissions={data.whoami.permissions}
+                    >
+                      <Uploads />
+                    </ResultsNavWrapper>
+                  }
                 />
               }
             />
@@ -192,7 +211,13 @@ const App = () => {
                 <ProtectedRoute
                   requiredPermissions={canUseCsvUploaderPilot}
                   userPermissions={data.whoami.permissions}
-                  element={<Submissions />}
+                  element={
+                    <ResultsNavWrapper
+                      userPermissions={data.whoami.permissions}
+                    >
+                      <Submissions />
+                    </ResultsNavWrapper>
+                  }
                 />
               }
             />
@@ -202,7 +227,13 @@ const App = () => {
                 <ProtectedRoute
                   requiredPermissions={canUseCsvUploaderPilot}
                   userPermissions={data.whoami.permissions}
-                  element={<Submissions />}
+                  element={
+                    <ResultsNavWrapper
+                      userPermissions={data.whoami.permissions}
+                    >
+                      <Submissions />
+                    </ResultsNavWrapper>
+                  }
                 />
               }
             />

--- a/frontend/src/app/testResults/ResultsNav.test.tsx
+++ b/frontend/src/app/testResults/ResultsNav.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import ResultsNav from "./ResultsNav";
+
+describe("ResultsNav", () => {
+  it("displays the nav order correctly and defaults to 'Test Results'", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ResultsNav />
+      </MemoryRouter>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/testResults/ResultsNav.tsx
+++ b/frontend/src/app/testResults/ResultsNav.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
+
+const ResultsNav = () => {
+  const classNameByActive = ({ isActive }: { isActive: boolean }) =>
+    isActive ? "active" : "";
+
+  return (
+    <div className="prime-home">
+      <div className="grid-container">
+        <nav className="prime-secondary-nav" aria-label="Secondary navigation">
+          <ul className="usa-nav__secondary-links prime-nav">
+            <li className="usa-nav__secondary-item">
+              <LinkWithQuery
+                to={`/results/1`}
+                end
+                className={classNameByActive}
+              >
+                Test results
+              </LinkWithQuery>
+            </li>
+            <li className="usa-nav__secondary-item">
+              <LinkWithQuery
+                to={`/results/upload`}
+                end
+                className={classNameByActive}
+              >
+                CSV upload
+              </LinkWithQuery>
+            </li>
+            <li className="usa-nav__secondary-item">
+              <LinkWithQuery
+                to={`/results/upload/submissions`}
+                className={classNameByActive}
+              >
+                CSV upload history
+              </LinkWithQuery>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+export default ResultsNav;

--- a/frontend/src/app/testResults/ResultsNavWrapper.test.tsx
+++ b/frontend/src/app/testResults/ResultsNavWrapper.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { appPermissions } from "../permissions";
+
+import ResultsNavWrapper from "./ResultsNavWrapper";
+
+describe("ResultsNav", () => {
+  it("displays the results sub nav when user has the permission", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ResultsNavWrapper
+          userPermissions={appPermissions.featureFlags.SrCsvUploaderPilot}
+        >
+          <>Testing 123</>
+        </ResultsNavWrapper>
+      </MemoryRouter>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("doesnt display the results sub nav when user doesnt have the permission", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ResultsNavWrapper>
+          <>Testing 123</>
+        </ResultsNavWrapper>
+      </MemoryRouter>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/testResults/ResultsNavWrapper.tsx
+++ b/frontend/src/app/testResults/ResultsNavWrapper.tsx
@@ -1,0 +1,31 @@
+import React, { ReactElement } from "react";
+
+import { appPermissions } from "../permissions";
+import { UserPermission } from "../../generated/graphql";
+
+import ResultsNav from "./ResultsNav";
+
+type Props = {
+  children: ReactElement;
+  userPermissions?: UserPermission[];
+};
+
+const ResultsNavWrapper = ({ children, userPermissions }: Props) => {
+  const canUseCsvUploaderPilot = appPermissions.featureFlags.SrCsvUploaderPilot;
+
+  let showSubTabs = false;
+  if (userPermissions !== undefined) {
+    showSubTabs = canUseCsvUploaderPilot.every((requiredPermission) =>
+      userPermissions.includes(requiredPermission)
+    );
+  }
+
+  return (
+    <>
+      {showSubTabs && <ResultsNav />}
+      {children}
+    </>
+  );
+};
+
+export default ResultsNavWrapper;

--- a/frontend/src/app/testResults/__snapshots__/ResultsNav.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/ResultsNav.test.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsNav displays the nav order correctly and defaults to 'Test Results' 1`] = `
+<div>
+  <div
+    class="prime-home"
+  >
+    <div
+      class="grid-container"
+    >
+      <nav
+        aria-label="Secondary navigation"
+        class="prime-secondary-nav"
+      >
+        <ul
+          class="usa-nav__secondary-links prime-nav"
+        >
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/1"
+            >
+              Test results
+            </a>
+          </li>
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/upload"
+            >
+              CSV upload
+            </a>
+          </li>
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/upload/submissions"
+            >
+              CSV upload history
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/app/testResults/__snapshots__/ResultsNavWrapper.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/ResultsNavWrapper.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsNav displays the results sub nav when user has the permission 1`] = `
+<div>
+  <div
+    class="prime-home"
+  >
+    <div
+      class="grid-container"
+    >
+      <nav
+        aria-label="Secondary navigation"
+        class="prime-secondary-nav"
+      >
+        <ul
+          class="usa-nav__secondary-links prime-nav"
+        >
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/1"
+            >
+              Test results
+            </a>
+          </li>
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/upload"
+            >
+              CSV upload
+            </a>
+          </li>
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/upload/submissions"
+            >
+              CSV upload history
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  Testing 123
+</div>
+`;
+
+exports[`ResultsNav doesnt display the results sub nav when user doesnt have the permission 1`] = `
+<div>
+  Testing 123
+</div>
+`;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolves #3864 

## Changes Proposed

- Add subtab to results page only when user has the `SrCsvUploaderPilot` permission


## Screenshots / Demos

### Test results:
![image](https://user-images.githubusercontent.com/4952042/172942509-adfb238f-2780-4b46-96d3-f85be4e22d4f.png)

### CSV upload:
![image](https://user-images.githubusercontent.com/4952042/172942662-4938e886-b6f3-47b2-956c-b6d6383328d5.png)

### CSV upload history:
![image](https://user-images.githubusercontent.com/4952042/172942596-dd169db0-ae80-46ed-966b-20154353fac2.png)


## Checklist for Author and Reviewer

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed
