### PR TITLE
Add new mutation to add apiUser directly

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -4,6 +4,7 @@ import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.User;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.model.UserInfo;
@@ -51,6 +52,17 @@ public class UserMutationResolver implements GraphQLMutationResolver {
     name = Translators.consolidateNameArguments(name, firstName, middleName, lastName, suffix);
     UserInfo user = _us.createUserInCurrentOrg(email, name, role, true);
     return new User(user);
+  }
+
+  public ApiUser createApiUserNoOkta(
+      PersonName name,
+      String firstName,
+      String middleName,
+      String lastName,
+      String suffix,
+      String email) {
+    name = Translators.consolidateNameArguments(name, firstName, middleName, lastName, suffix);
+    return _us.createApiUserNoOkta(email, name);
   }
 
   public User updateUser(

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -20,7 +20,15 @@ extend type Mutation {
     organizationExternalId: String!
     role: Role!
   ): User
-  createOrganization(
+  createApiUserNoOkta(
+    name: NameInput
+    firstName: String
+    middleName: String
+    lastName: String
+    suffix: String
+    email: String
+  ): ApiUser
+    createOrganization(
     name: String!
     type: String!
     externalId: String!

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -157,6 +157,7 @@ export type Mutation = {
   adminUpdateOrganization?: Maybe<Scalars["String"]>;
   correctTestMarkAsCorrection?: Maybe<TestResult>;
   correctTestMarkAsError?: Maybe<TestResult>;
+  createApiUserNoOkta?: Maybe<ApiUser>;
   createDeviceType?: Maybe<DeviceType>;
   createFacilityRegistrationLink?: Maybe<Scalars["String"]>;
   createOrganization?: Maybe<Organization>;
@@ -336,6 +337,15 @@ export type MutationCorrectTestMarkAsCorrectionArgs = {
 export type MutationCorrectTestMarkAsErrorArgs = {
   id: Scalars["ID"];
   reason?: InputMaybe<Scalars["String"]>;
+};
+
+export type MutationCreateApiUserNoOktaArgs = {
+  email?: InputMaybe<Scalars["String"]>;
+  firstName?: InputMaybe<Scalars["String"]>;
+  lastName?: InputMaybe<Scalars["String"]>;
+  middleName?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<NameInput>;
+  suffix?: InputMaybe<Scalars["String"]>;
 };
 
 export type MutationCreateDeviceTypeArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- For the bulk upload changes, we need to manually add api users to our database as they already exist in Okta, so the typical add user flows don't work.

## Changes Proposed

- Add new super-user only mutation to add an api user directly, without interfacing with Okta.

## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
