### PR TITLE
Send Results set to pxp frontend

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
@@ -1,10 +1,14 @@
 package gov.cdc.usds.simplereport.api.model.pxp;
 
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.auxiliary.SupportedDiseaseTestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +18,7 @@ public class PxpVerifyResponseV2 {
 
   private final UUID testEventId;
   private final TestResult result;
+  private final Set<SupportedDiseaseTestResult> results;
   private final Date dateTested;
   private final String correctionStatus;
   private final Patient patient;
@@ -25,6 +30,12 @@ public class PxpVerifyResponseV2 {
 
     this.testEventId = testEvent.getInternalId();
     this.result = testEvent.getResult();
+    Set<Result> allResults = testEvent.getResults();
+    results = new HashSet<>();
+    allResults.forEach(
+        r -> {
+          results.add(r.getDiseaseResult());
+        });
     this.dateTested = testEvent.getDateTested();
     this.correctionStatus = testEvent.getCorrectionStatus().toString();
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Result.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Result.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import gov.cdc.usds.simplereport.api.Translators;
+import gov.cdc.usds.simplereport.db.model.auxiliary.SupportedDiseaseTestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -72,6 +73,10 @@ public class Result extends EternalAuditedEntity {
   public void setResult(TestResult testResult) {
     this.resultLOINC = Translators.convertTestResultToLoinc(testResult);
     this.testResult = testResult;
+  }
+
+  public SupportedDiseaseTestResult getDiseaseResult() {
+    return new SupportedDiseaseTestResult(this.disease, this.testResult);
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/SupportedDiseaseTestResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/SupportedDiseaseTestResult.java
@@ -1,0 +1,12 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+import gov.cdc.usds.simplereport.db.model.SupportedDisease;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SupportedDiseaseTestResult {
+  private SupportedDisease disease;
+  private TestResult result;
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.UUID;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
   private Person person;
   private PatientLink patientLink;
   private TestEvent testEvent;
+  private TestEvent removedTestEvent;
 
   @BeforeEach
   void init() {
@@ -140,7 +142,152 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("NEGATIVE")))
+            .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
+            .andExpect(jsonPath("$.results[0].result", is("NEGATIVE")))
+            .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
             .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
+            .andExpect(jsonPath("$.patient.firstName", is("Fred")))
+            .andExpect(jsonPath("$.patient.middleName", is("M")))
+            .andExpect(jsonPath("$.patient.lastName", is("Astaire")))
+            .andExpect(jsonPath("$.patient.birthDate", is("1899-05-10")))
+            .andExpect(jsonPath("$.organization.name", is("The Mall")))
+            .andExpect(jsonPath("$.facility.name", is("Imaginary Site")))
+            .andExpect(jsonPath("$.facility.cliaNumber", is("123456")))
+            .andExpect(jsonPath("$.facility.street", is("736 Jackson PI NW")))
+            .andExpect(jsonPath("$.facility.streetTwo", is("")))
+            .andExpect(jsonPath("$.facility.city", is("Washington")))
+            .andExpect(jsonPath("$.facility.state", is("DC")))
+            .andExpect(jsonPath("$.facility.zipCode", is("20503")))
+            .andExpect(jsonPath("$.facility.phone", is("555-867-5309")))
+            .andExpect(jsonPath("$.facility.orderingProvider.firstName", is("Doctor")))
+            .andExpect(jsonPath("$.facility.orderingProvider.middleName", is("")))
+            .andExpect(jsonPath("$.facility.orderingProvider.lastName", is("Doom")))
+            .andExpect(jsonPath("$.facility.orderingProvider.npi", is("DOOOOOOM")))
+            .andExpect(jsonPath("$.deviceType.name", is("Acme SuperFine")))
+            .andExpect(jsonPath("$.deviceType.model", is("SFN")))
+            .andReturn()
+            .getResponse()
+            .getHeader(LoggingConstants.REQUEST_ID_HEADER);
+
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, requestId);
+  }
+
+  @Test
+  void verifyLinkV2ReturnsTestResultInfo_multiplex() throws Exception {
+    TestUserIdentities.withStandardUser(
+        () -> {
+          testEvent =
+              _dataFactory.createMultiplexTestEvent(
+                  person,
+                  facility,
+                  TestResult.POSITIVE,
+                  TestResult.NEGATIVE,
+                  TestResult.NEGATIVE,
+                  false);
+          patientLink = _dataFactory.createPatientLink(testEvent.getTestOrder());
+        });
+
+    // GIVEN
+    String dob = person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String requestBody =
+        "{\"patientLinkId\":\""
+            + patientLink.getInternalId()
+            + "\",\"dateOfBirth\":\""
+            + dob
+            + "\"}";
+
+    // WHEN
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.VERIFY_LINK_V2)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    // THEN
+    String requestId =
+        mockMvc
+            .perform(builder)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
+            .andExpect(jsonPath("$.results", Matchers.hasSize(3)))
+            .andExpect(
+                jsonPath("$.results[?(@.disease.name == \"COVID-19\" && @.result == \"POSITIVE\")]")
+                    .exists())
+            .andExpect(
+                jsonPath("$.results[?(@.disease.name == \"Flu A\" && @.result == \"NEGATIVE\")]")
+                    .exists())
+            .andExpect(
+                jsonPath("$.results[?(@.disease.name == \"Flu B\" && @.result == \"NEGATIVE\")]")
+                    .exists())
+            .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
+            .andExpect(jsonPath("$.patient.firstName", is("Fred")))
+            .andExpect(jsonPath("$.patient.middleName", is("M")))
+            .andExpect(jsonPath("$.patient.lastName", is("Astaire")))
+            .andExpect(jsonPath("$.patient.birthDate", is("1899-05-10")))
+            .andExpect(jsonPath("$.organization.name", is("The Mall")))
+            .andExpect(jsonPath("$.facility.name", is("Imaginary Site")))
+            .andExpect(jsonPath("$.facility.cliaNumber", is("123456")))
+            .andExpect(jsonPath("$.facility.street", is("736 Jackson PI NW")))
+            .andExpect(jsonPath("$.facility.streetTwo", is("")))
+            .andExpect(jsonPath("$.facility.city", is("Washington")))
+            .andExpect(jsonPath("$.facility.state", is("DC")))
+            .andExpect(jsonPath("$.facility.zipCode", is("20503")))
+            .andExpect(jsonPath("$.facility.phone", is("555-867-5309")))
+            .andExpect(jsonPath("$.facility.orderingProvider.firstName", is("Doctor")))
+            .andExpect(jsonPath("$.facility.orderingProvider.middleName", is("")))
+            .andExpect(jsonPath("$.facility.orderingProvider.lastName", is("Doom")))
+            .andExpect(jsonPath("$.facility.orderingProvider.npi", is("DOOOOOOM")))
+            .andExpect(jsonPath("$.deviceType.name", is("Acme SuperFine")))
+            .andExpect(jsonPath("$.deviceType.model", is("SFN")))
+            .andReturn()
+            .getResponse()
+            .getHeader(LoggingConstants.REQUEST_ID_HEADER);
+
+    assertLastAuditEntry(HttpStatus.OK, ResourceLinks.VERIFY_LINK_V2, requestId);
+  }
+
+  @Test
+  void verifyResultsDisplayForRemovedTests() throws Exception {
+    TestUserIdentities.withStandardUser(
+        () -> {
+          testEvent = _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE);
+          patientLink = _dataFactory.createPatientLink(testEvent.getTestOrder());
+        });
+
+    TestUserIdentities.withStandardUser(
+        () -> {
+          removedTestEvent = _dataFactory.createTestEventRemoval(testEvent);
+        });
+
+    // GIVEN
+    String dob = person.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String requestBody =
+        "{\"patientLinkId\":\""
+            + patientLink.getInternalId()
+            + "\",\"dateOfBirth\":\""
+            + dob
+            + "\"}";
+
+    // WHEN
+    MockHttpServletRequestBuilder builder =
+        post(ResourceLinks.VERIFY_LINK_V2)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .content(requestBody);
+
+    // THEN
+    String requestId =
+        mockMvc
+            .perform(builder)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.testEventId", is(removedTestEvent.getInternalId().toString())))
+            .andExpect(jsonPath("$.result", is("POSITIVE")))
+            .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
+            .andExpect(jsonPath("$.results[0].result", is("POSITIVE")))
+            .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
+            .andExpect(jsonPath("$.correctionStatus", is("REMOVED")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))
             .andExpect(jsonPath("$.patient.middleName", is("M")))
             .andExpect(jsonPath("$.patient.lastName", is("Astaire")))

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -50,7 +50,9 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -443,8 +445,26 @@ public class TestDataFactory {
   }
 
   public TestEvent createTestEventRemoval(TestEvent originalTestEvent) {
-    return _testEventRepo.save(
-        new TestEvent(originalTestEvent, TestCorrectionStatus.REMOVED, "Cold feet"));
+    TestEvent newRemoveEvent =
+        new TestEvent(originalTestEvent, TestCorrectionStatus.REMOVED, "Cold feet");
+    _testEventRepo.save(newRemoveEvent);
+
+    TestOrder order = originalTestEvent.getTestOrder();
+
+    order.setReasonForCorrection("Cold feet");
+    order.setTestEventRef(newRemoveEvent);
+    order.setCorrectionStatus(TestCorrectionStatus.REMOVED);
+    _testOrderRepo.save(order);
+
+    List<Result> originalResults = _resultRepository.findAllByTestOrder(order);
+    Set<Result> copiedResults = new HashSet<>();
+    originalResults.forEach(
+        result -> {
+          copiedResults.add(new Result(result, newRemoveEvent));
+        });
+    _resultRepository.saveAll(copiedResults);
+
+    return newRemoveEvent;
   }
 
   public TestEvent doTest(TestOrder order, TestResult result) {

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -46,6 +46,12 @@ export type SelfRegistrationData = Omit<
 export type VerifyV2Response = {
   testEventId: string;
   result: TestResult;
+  results: {
+    disease: {
+      name: string;
+    };
+    testResult: TestResult;
+  };
   dateTested: string;
   correctionStatus: string;
   deviceType: {

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -22,6 +22,8 @@ const TestResult = () => {
   const dateTested = formatDateWithTimeOption(testResult?.dateTested, true);
   const deviceType = testResult?.deviceType.name;
 
+  console.log(testResult);
+
   return (
     <div className="pxp-test-results">
       <div id="section-to-print">


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part one of #3756 - the UI still needs to be updated to show multiplex results

## Changes Proposed

- Update the PxpResponse object to send the set of results as well as the existing results column.

## Additional Information

- I verified that this change works with removed and corrected results created before #3853, which was our problem before
- This is slightly different from other attempts to send Results to the pxp frontend in two ways:
      1. The type we're sending is a little different. Rather than sending a TestResult for covid, fluA, and fluB specifically, we're just sending the entire set of results. This brings the pxp response in line with the graphQL response (which is important for the print modal - this is why pxp failed to load during our bug bash.)
      2. We're not sending the entire Result object, as when it's serialized by the pxp response it includes too much information (testOrder ID, testEvent id, etc). Instead, a new `SupportedDiseaseTestResult` is created to hold the key information - the disease and the test result.

## Testing

- Patient experience shows no changes
- Patient experience loads for all kinds of tests (corrected, removed, etc)

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
