### PR TITLE
removing CSV Upload Pilot permission from Admin role

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Role.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Role.java
@@ -27,15 +27,15 @@ public enum Role {
    */
   USER(OrganizationRole.USER),
   /**
-   * This is a specific role for users who are in the test result bulk upload feature pilot and have
-   * the ability to submit test results as a CSV
-   */
-  TEST_RESULT_UPLOAD_USER(OrganizationRole.TEST_RESULT_UPLOAD_USER),
-  /**
    * This is the organization admin role: if you have this role, then you have the ability to change
    * your role, so other roles you may have are moot.
    */
-  ADMIN(OrganizationRole.ADMIN);
+  ADMIN(OrganizationRole.ADMIN),
+  /**
+   * This is a specific role for users who are in the test result bulk upload feature pilot and have
+   * the ability to submit test results as a CSV
+   */
+  TEST_RESULT_UPLOAD_USER(OrganizationRole.TEST_RESULT_UPLOAD_USER);
 
   private OrganizationRole translation;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
@@ -62,9 +62,25 @@ public enum OrganizationRole implements Principal {
   /**
    * This is the organization admin role: if you have this role, then you have the ability to change
    * your role, so other roles you may have are moot. This role's permission (which is to say all of
-   * them) take precedence over any other roles.
+   * them except SR_CSV_UPLOADER_PILOT) take precedence over any other roles.
    */
-  ADMIN("Admin user", EnumSet.allOf(UserPermission.class));
+  ADMIN(
+      "Admin user",
+      EnumSet.of(
+          UserPermission.READ_PATIENT_LIST,
+          UserPermission.READ_ARCHIVED_PATIENT_LIST,
+          UserPermission.SEARCH_PATIENTS,
+          UserPermission.READ_RESULT_LIST,
+          UserPermission.EDIT_PATIENT,
+          UserPermission.ARCHIVE_PATIENT,
+          UserPermission.EDIT_FACILITY,
+          UserPermission.EDIT_ORGANIZATION,
+          UserPermission.MANAGE_USERS,
+          UserPermission.START_TEST,
+          UserPermission.UPDATE_TEST,
+          UserPermission.SUBMIT_TEST,
+          UserPermission.ACCESS_ALL_FACILITIES,
+          UserPermission.VIEW_ARCHIVED_FACILITIES));
 
   private String description;
   private Set<UserPermission> grantedPermissions;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -94,7 +94,21 @@ class AuditLoggingTest extends BaseGraphqlTest {
             getGraphqlRequestIdHeader(),
             TestUserIdentities.OTHER_ORG_ADMIN,
             "whoDat",
-            EnumSet.allOf(UserPermission.class),
+            EnumSet.of(
+                UserPermission.READ_PATIENT_LIST,
+                UserPermission.READ_ARCHIVED_PATIENT_LIST,
+                UserPermission.SEARCH_PATIENTS,
+                UserPermission.READ_RESULT_LIST,
+                UserPermission.EDIT_PATIENT,
+                UserPermission.ARCHIVE_PATIENT,
+                UserPermission.EDIT_FACILITY,
+                UserPermission.EDIT_ORGANIZATION,
+                UserPermission.MANAGE_USERS,
+                UserPermission.START_TEST,
+                UserPermission.UPDATE_TEST,
+                UserPermission.SUBMIT_TEST,
+                UserPermission.ACCESS_ALL_FACILITIES,
+                UserPermission.VIEW_ARCHIVED_FACILITIES),
             null);
     assertEquals(
         "DAT_ORG", // this should be a constant

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -405,7 +405,21 @@ class PatientManagementTest extends BaseGraphqlTest {
     assertLastAuditEntry(
         TestUserIdentities.ORG_ADMIN_USER,
         "getDeletedPatients",
-        EnumSet.allOf(UserPermission.class),
+        EnumSet.of(
+            UserPermission.READ_PATIENT_LIST,
+            UserPermission.READ_ARCHIVED_PATIENT_LIST,
+            UserPermission.SEARCH_PATIENTS,
+            UserPermission.READ_RESULT_LIST,
+            UserPermission.EDIT_PATIENT,
+            UserPermission.ARCHIVE_PATIENT,
+            UserPermission.EDIT_FACILITY,
+            UserPermission.EDIT_ORGANIZATION,
+            UserPermission.MANAGE_USERS,
+            UserPermission.START_TEST,
+            UserPermission.UPDATE_TEST,
+            UserPermission.SUBMIT_TEST,
+            UserPermission.ACCESS_ALL_FACILITIES,
+            UserPermission.VIEW_ARCHIVED_FACILITIES),
         List.of());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientUploadTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientUploadTest.java
@@ -28,7 +28,21 @@ class PatientUploadTest extends BaseGraphqlTest {
     assertLastAuditEntry(
         TestUserIdentities.SITE_ADMIN_USER_WITH_ORG,
         "UploadPatients",
-        EnumSet.allOf(UserPermission.class),
+        EnumSet.of(
+            UserPermission.READ_PATIENT_LIST,
+            UserPermission.READ_ARCHIVED_PATIENT_LIST,
+            UserPermission.SEARCH_PATIENTS,
+            UserPermission.READ_RESULT_LIST,
+            UserPermission.EDIT_PATIENT,
+            UserPermission.ARCHIVE_PATIENT,
+            UserPermission.EDIT_FACILITY,
+            UserPermission.EDIT_ORGANIZATION,
+            UserPermission.MANAGE_USERS,
+            UserPermission.START_TEST,
+            UserPermission.UPDATE_TEST,
+            UserPermission.SUBMIT_TEST,
+            UserPermission.ACCESS_ALL_FACILITIES,
+            UserPermission.VIEW_ARCHIVED_FACILITIES),
         null);
   }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #3644 : correction to Okta permissions.  Previously all org admins had the CSV Upload pilot permission.  That's bad.

## Changes Proposed

- Remove the CSV Upload pilot permission from the admin role

## Additional Information


## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
