### PR TITLE
Additional WAF refinements to reduce false positives

### DIFF
--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -85,20 +85,40 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector                = "iss"
       selector_match_operator = "Equals"
     }
+    exclusion {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "ssm_au"
+    }
+    exclusion {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "ssm_au_c"
+    }
 
     exclusion {
       match_variable          = "RequestArgNames"
-      selector                = "street"  //Will need to turn on 942440 and 942110 if not effective.
-      selector_match_operator = "Equals"
+      selector                = "street"
+      selector_match_operator = "Contains"
     }
     exclusion {
       match_variable          = "RequestArgNames"
-      selector                = "iss"  //Will need to turn on 942440 and 942110 if not effective.
-      selector_match_operator = "Equals"
+      selector                = "phoneNumbers"
+      selector_match_operator = "Contains"
+    }
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "phoneNumbers"
+      selector_match_operator = "number"
     }
     exclusion {
       match_variable          = "RequestArgNames"
       selector                = "iss"
+      selector_match_operator = "Equals"
+    }
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "namePrefixMatch"
       selector_match_operator = "Equals"
     }
 
@@ -133,15 +153,12 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       rule_group_override {
         rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
         disabled_rules = [
-          "942110",
           "942150",
           "942190",
           "942200",
           "942260",
-          "942330",
           "942410",
-          "942430",
-          "942440"
+          "942430"
         ]
       }
     }

--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -101,6 +101,11 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector                = "iss"
       selector_match_operator = "Equals"
     }
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "variables.testResultList"
+      selector_match_operator = "Equals"
+    }
 
     managed_rule_set {
       type    = "OWASP"
@@ -139,6 +144,7 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
           "942200",
           "942260",
           "942330",
+          "942361",
           "942410",
           "942430",
           "942440"

--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -98,27 +98,7 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
 
     exclusion {
       match_variable          = "RequestArgNames"
-      selector                = "street"
-      selector_match_operator = "Contains"
-    }
-    exclusion {
-      match_variable          = "RequestArgNames"
-      selector                = "phoneNumbers"
-      selector_match_operator = "Contains"
-    }
-    exclusion {
-      match_variable          = "RequestArgNames"
-      selector                = "phoneNumbers"
-      selector_match_operator = "number"
-    }
-    exclusion {
-      match_variable          = "RequestArgNames"
       selector                = "iss"
-      selector_match_operator = "Equals"
-    }
-    exclusion {
-      match_variable          = "RequestArgNames"
-      selector                = "namePrefixMatch"
       selector_match_operator = "Equals"
     }
 
@@ -153,12 +133,15 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       rule_group_override {
         rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
         disabled_rules = [
+          "942110",
           "942150",
           "942190",
           "942200",
           "942260",
+          "942330",
           "942410",
-          "942430"
+          "942430",
+          "942440"
         ]
       }
     }

--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -86,14 +86,14 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector_match_operator = "Equals"
     }
     exclusion {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "ssm_au"
+      match_variable = "RequestCookieNames"
+      operator       = "Equals"
+      selector       = "ssm_au"
     }
     exclusion {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "ssm_au_c"
+      match_variable = "RequestCookieNames"
+      operator       = "Equals"
+      selector       = "ssm_au_c"
     }
 
     exclusion {

--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -86,14 +86,14 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector_match_operator = "Equals"
     }
     exclusion {
-      match_variable = "RequestCookieNames"
-      operator       = "Equals"
-      selector       = "ssm_au"
+      match_variable          = "RequestCookieNames"
+      selector                = "ssm_au"
+      selector_match_operator = "Equals"
     }
     exclusion {
-      match_variable = "RequestCookieNames"
-      operator       = "Equals"
-      selector       = "ssm_au_c"
+      match_variable          = "RequestCookieNames"
+      selector                = "ssm_au_c"
+      selector_match_operator = "Equals"
     }
 
     exclusion {

--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -78,6 +78,17 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector_match_operator = "Equals"
     }
 
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "street"  //Will need to turn on 942440 and 942110 if not effective.
+      selector_match_operator = "Equals"
+    }
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "namePrefixMatch" //Will need to turn on 942330 if not effective
+      selector_match_operator = "Equals"
+    }
+
     managed_rule_set {
       type    = "OWASP"
       version = "3.2"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- This should hopefully be the last stage of false positive identification and removal. We've gone from several thousand false positives per day to only a few hundred catches, about 95-99% of which are valid.

## Changes Proposed

- Add exceptions for analytics cookies
- Add exceptions for CSV Uploader variable arguments
- Add additional SQL injection rule exception

## Additional Information

- This will be allowed to settle for 24-48 hours. If no other problematic requests are found, one more PR will be issued to activate "Prevention" mode.
