### PR TITLE
Add test result upload user permission to GraphQL Role enum

### DIFF
--- a/backend/src/main/resources/graphql/wiring.graphqls
+++ b/backend/src/main/resources/graphql/wiring.graphqls
@@ -74,6 +74,7 @@ enum Role {
   ENTRY_ONLY
   USER
   ADMIN
+  TEST_RESULT_UPLOAD_USER
 }
 
 enum TestCorrectionStatus {

--- a/frontend/src/app/permissions.tsx
+++ b/frontend/src/app/permissions.tsx
@@ -4,10 +4,11 @@ import { UserPermission } from "../generated/graphql";
 export type RoleDescription =
   | "Admin user"
   | "Standard user"
-  | "Test-entry user";
+  | "Test-entry user"
+  | "test-result-upload-pilot user";
 
 // when changing a user's role, the server expects one of these values as the roleDescription. It's annoying how its not consistent with RoleDescription
-export type Role = "ADMIN" | "USER" | "ENTRY_ONLY";
+export type Role = "ADMIN" | "USER" | "ENTRY_ONLY" | "TEST_RESULT_UPLOAD_USER";
 
 /* 
     TODO: this is a quick v0

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -906,6 +906,7 @@ export enum ResultValue {
 export enum Role {
   Admin = "ADMIN",
   EntryOnly = "ENTRY_ONLY",
+  TestResultUploadUser = "TEST_RESULT_UPLOAD_USER",
   User = "USER",
 }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
The `TEST_RESULT_UPLOAD_USER` exists as a role that may be held by a SimpleReport user. This role is defined in code but not in the GraphQL `wiring.graphqls` definition for the Role enum.

This was discovered when attempting to delete a user in the SimpleReport admin panel. If the user held the `TEST_RESULT_UPLOAD_USER` role, a GraphQL error would be thrown on the unexpected enum member and prevent the removal from taking place.

## Changes Proposed
- Add `TEST_RESULT_UPLOAD_USER` to `Role` GraphQL enum in `wiring.graphqls`

## Testing
- I'll push this out to dev and attempt to replicate the error that resulted in this ticket

## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Any content updates (user-facing error messages, etc) have been approved by content team
- [x] Any changes that might generate questions in the support inbox have been flagged to the support team
- [x] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed