### PR TITLE
fix submissions paging

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -207,7 +207,7 @@ const App = () => {
               }
             />
             <Route
-              path="results/upload/submissions/:id"
+              path="results/upload/submission/:id"
               element={
                 <ProtectedRoute
                   requiredPermissions={canUseCsvUploaderPilot}

--- a/frontend/src/app/testResults/submissions/Submission.test.tsx
+++ b/frontend/src/app/testResults/submissions/Submission.test.tsx
@@ -58,12 +58,12 @@ describe("Submission", () => {
         <Provider store={store}>
           <MemoryRouter
             initialEntries={[
-              "/results/upload/submissions/12b86a9d-a9d6-4391-a555-6618e8ac66d9",
+              "/results/upload/submission/12b86a9d-a9d6-4391-a555-6618e8ac66d9",
             ]}
           >
             <Routes>
               <Route
-                path={"/results/upload/submissions/:id"}
+                path={"/results/upload/submission/:id"}
                 element={<Submission />}
               ></Route>
             </Routes>

--- a/frontend/src/app/testResults/submissions/Submissions.test.tsx
+++ b/frontend/src/app/testResults/submissions/Submissions.test.tsx
@@ -230,7 +230,7 @@ describe("Submissions", () => {
     [result_1, result_2, result_3].forEach((result) => {
       expect(screen.getByText(result.reportId).closest("a")).toHaveAttribute(
         "href",
-        `/results/upload/submissions/${result.internalId}`
+        `/results/upload/submission/${result.internalId}`
       );
     });
   });

--- a/frontend/src/app/testResults/submissions/Submissions.tsx
+++ b/frontend/src/app/testResults/submissions/Submissions.tsx
@@ -60,7 +60,7 @@ const Submissions = () => {
         <tr key={submission.internalId}>
           <td>
             <LinkWithQuery
-              to={`/results/upload/submissions/${submission.internalId}`}
+              to={`/results/upload/submission/${submission.internalId}`}
               className="sr-link__primary"
             >
               {submission.reportId}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #3908 Paging was broken.  Now it is now.

## Changes Proposed

- Change the path for individual submissions to `../submission/:id` from `../submissions/:id` (the latter conflicted with `../submissions/:pageNumber`)

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?
 
## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

## Checklist for Author and Reviewer
