### PR TITLE
Add flu test results to downloads (#3849)

### DIFF
--- a/frontend/src/app/testResults/operations.graphql
+++ b/frontend/src/app/testResults/operations.graphql
@@ -41,6 +41,12 @@ query GetFacilityResultsForCsv(
     }
     dateTested
     result
+    results {
+      disease {
+        name
+      }
+      testResult
+    }
     correctionStatus
     reasonForCorrection
     deviceType {

--- a/frontend/src/app/utils/symptoms.test.ts
+++ b/frontend/src/app/utils/symptoms.test.ts
@@ -1,6 +1,6 @@
-import { symptomsStringToArray } from "./symptoms";
+import { symptomsStringToArray, hasSymptomsForView } from "./symptoms";
 
-describe("symtomsStringToArray", () => {
+describe("symptomsStringToArray", () => {
   it("translates a string with zero symptoms to an array", () => {
     const symptomString =
       '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}';
@@ -20,5 +20,27 @@ describe("symtomsStringToArray", () => {
       "Fatigue",
       "Fever over 100.4F",
     ]);
+  });
+});
+
+describe("hasSymptomsForView", () => {
+  it("returns 'Yes' if there are symptoms present", () => {
+    const noSymptomsBoolean = false;
+    const symptomString =
+      '{"64531003":"true","103001002":"false","84229001":"true","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}';
+    expect(hasSymptomsForView(noSymptomsBoolean, symptomString)).toEqual("Yes");
+  });
+  it("returns 'No' if there are no symptoms present", () => {
+    const noSymptomsBoolean = true;
+    const symptomString =
+      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}';
+    expect(hasSymptomsForView(noSymptomsBoolean, symptomString)).toEqual("No");
+  });
+  it("returns 'Unknown' for all other scenarios", () => {
+    const noSymptomsBoolean = false;
+    const symptomString = '{"64531003":"badData"}';
+    expect(hasSymptomsForView(noSymptomsBoolean, symptomString)).toEqual(
+      "Unknown"
+    );
   });
 });

--- a/frontend/src/app/utils/symptoms.ts
+++ b/frontend/src/app/utils/symptoms.ts
@@ -15,3 +15,17 @@ export const symptomsStringToArray = (symptomString: string): SymptomName[] => {
     return acc;
   }, [] as SymptomName[]);
 };
+
+// symptoms should be a JSON string
+export function hasSymptomsForView(noSymptoms: boolean, symptoms: string) {
+  if (noSymptoms) {
+    return "No";
+  }
+  const symptomsList: Record<string, string> = JSON.parse(symptoms);
+  for (let key in symptomsList) {
+    if (symptomsList[key] === "true") {
+      return "Yes";
+    }
+  }
+  return "Unknown";
+}

--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -1,0 +1,140 @@
+import { cloneDeep } from "lodash";
+
+import { parseDataForCSV } from "./testResultCSV";
+
+const data = [
+  {
+    facility: {
+      name: "test facility",
+      isDeleted: false,
+    },
+    dateTested: "2022-06-13T19:24:31.187Z",
+    result: "NEGATIVE",
+    results: [
+      {
+        disease: {
+          name: "COVID-19",
+        },
+        testResult: "NEGATIVE",
+      },
+    ],
+    correctionStatus: "REMOVED",
+    reasonForCorrection: "DUPLICATE_TEST",
+    deviceType: {
+      name: "Access Bio CareStart",
+      manufacturer: "Access Bio, Inc.",
+      model: "CareStart COVID-19 Antigen test*",
+      swabType: "258500001",
+    },
+    patient: {
+      firstName: "John",
+      middleName: "E",
+      lastName: "Doe",
+      birthDate: "1980-01-01",
+      gender: "female",
+      race: "white",
+      ethnicity: "hispanic",
+      tribalAffiliation: [null],
+      lookupId: null,
+      telephone: "(123) 456-7890",
+      email: "foo@bar.com",
+      street: "1234 Green Street",
+      streetTwo: "",
+      city: "Minneapolis",
+      county: null,
+      state: "MN",
+      zipCode: "90210",
+      country: "USA",
+      role: "STAFF",
+      residentCongregateSetting: null,
+      employedInHealthcare: null,
+      preferredLanguage: "English",
+    },
+    createdBy: {
+      nameInfo: {
+        firstName: "Jane",
+        middleName: null,
+        lastName: "Doe",
+      },
+    },
+    symptoms:
+      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
+    noSymptoms: false,
+    symptomOnset: null,
+  },
+];
+
+const result = [
+  {
+    "COVID-19 result": "Negative",
+    "Device manufacturer": "Access Bio, Inc.",
+    "Device model": "CareStart COVID-19 Antigen test*",
+    "Device name": "Access Bio CareStart",
+    "Device swab type": "258500001",
+    "Facility name": "test facility",
+    "Has symptoms": "Unknown",
+    "Patient ID (Student ID, Employee ID, etc.)": null,
+    "Patient city": "Minneapolis",
+    "Patient country": "USA",
+    "Patient county": null,
+    "Patient date of birth": "01/01/1980",
+    "Patient email": "foo@bar.com",
+    "Patient ethnicity": "hispanic",
+    "Patient first name": "John",
+    "Patient full name": "Doe, John E",
+    "Patient gender": "female",
+    "Patient is a resident in a congregate setting": null,
+    "Patient is employed in healthcare": null,
+    "Patient last name": "Doe",
+    "Patient middle name": "E",
+    "Patient phone number": "(123) 456-7890",
+    "Patient preferred language": "English",
+    "Patient race": "white",
+    "Patient role": "STAFF",
+    "Patient state": "MN",
+    "Patient street address": "1234 Green Street",
+    "Patient street address 2": "",
+    "Patient tribal affiliation": "",
+    "Patient zip code": "90210",
+    Submitter: "Doe, Jane",
+    "Symptom onset": "Invalid date",
+    "Symptoms present": "No symptoms",
+    "Test correction reason": "DUPLICATE_TEST",
+    "Test correction status": "REMOVED",
+    "Test date": "06/13/2022 7:24pm",
+  },
+];
+
+describe("parseDataForCSV", () => {
+  it("parses non-multiplex data", () => {
+    const multiplexEnabled = false;
+    expect(parseDataForCSV(data, multiplexEnabled)).toEqual(result);
+  });
+
+  it("parses multiplex data", () => {
+    const multiplexData = cloneDeep(data);
+    multiplexData[0]["results"].push(
+      {
+        disease: {
+          name: "Flu A",
+        },
+        testResult: "NEGATIVE",
+      },
+      {
+        disease: {
+          name: "Flu B",
+        },
+        testResult: "NEGATIVE",
+      }
+    );
+    const multiplexEnabled = true;
+    const multiplexResult = cloneDeep(result);
+    // @ts-ignore
+    multiplexResult[0]["Flu A result"] = "Negative";
+    // @ts-ignore
+    multiplexResult[0]["Flu B result"] = "Negative";
+    expect(parseDataForCSV(multiplexData, multiplexEnabled)).toEqual(
+      multiplexResult
+    );
+  });
+});

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -1,0 +1,98 @@
+import moment from "moment";
+
+import { byDateTested, Results } from "../testResults/TestResultsList";
+import { TEST_RESULT_DESCRIPTIONS } from "../constants";
+import { MultiplexResult } from "../testQueue/QueueItem";
+
+import { symptomsStringToArray, hasSymptomsForView } from "./symptoms";
+
+import { displayFullName, facilityDisplayName } from "./index";
+
+function getResultByDiseaseName(
+  results: MultiplexResult[],
+  diseaseName: string
+) {
+  const resultObj = results.find((result: MultiplexResult) => {
+    return result.disease.name.includes(diseaseName);
+  });
+  if (resultObj) {
+    return resultObj.testResult;
+  } else {
+    return "N/A";
+  }
+}
+
+export function parseDataForCSV(data: any, multiplexEnabled: boolean) {
+  return data.sort(byDateTested).map((r: any) => {
+    const symptomList = r.symptoms ? symptomsStringToArray(r.symptoms) : [];
+
+    return {
+      "Patient first name": r.patient.firstName,
+      "Patient middle name": r.patient.middleName,
+      "Patient last name": r.patient.lastName,
+      "Patient full name": displayFullName(
+        r.patient.firstName,
+        r.patient.middleName,
+        r.patient.lastName
+      ),
+      "Patient date of birth": moment(r.patient.birthDate).format("MM/DD/YYYY"),
+      "Test date": moment(r.dateTested).format("MM/DD/YYYY h:mma"),
+      ...(multiplexEnabled
+        ? {
+            "COVID-19 result":
+              TEST_RESULT_DESCRIPTIONS[
+                getResultByDiseaseName(r.results, "COVID-19") as Results
+              ],
+            "Flu A result":
+              TEST_RESULT_DESCRIPTIONS[
+                getResultByDiseaseName(r.results, "Flu A") as Results
+              ],
+            "Flu B result":
+              TEST_RESULT_DESCRIPTIONS[
+                getResultByDiseaseName(r.results, "Flu B") as Results
+              ],
+          }
+        : {
+            "COVID-19 result": TEST_RESULT_DESCRIPTIONS[r.result as Results],
+          }),
+      "Test correction status": r.correctionStatus,
+      "Test correction reason": r.reasonForCorrection,
+      "Device name": r.deviceType.name,
+      "Device manufacturer": r.deviceType.manufacturer,
+      "Device model": r.deviceType.model,
+      "Device swab type": r.deviceType.swabType,
+      "Has symptoms": hasSymptomsForView(r.noSymptoms, r.symptoms),
+      "Symptoms present":
+        symptomList.length > 0 ? symptomList.join(", ") : "No symptoms",
+      "Symptom onset": moment(r.symptomOnset).format("MM/DD/YYYY"),
+      "Facility name": facilityDisplayName(
+        r.facility.name,
+        r.facility.isDeleted
+      ),
+      Submitter: displayFullName(
+        r.createdBy.nameInfo.firstName,
+        r.createdBy.nameInfo.middleName,
+        r.createdBy.nameInfo.lastName
+      ),
+      "Patient role": r.patient.role,
+      "Patient ID (Student ID, Employee ID, etc.)": r.patient.lookupId,
+      "Patient preferred language": r.patient.preferredLanguage,
+      "Patient phone number": r.patient.telephone,
+      "Patient email": r.patient.email,
+      "Patient street address": r.patient.street,
+      "Patient street address 2": r.patient.streetTwo,
+      "Patient city": r.patient.city,
+      "Patient state": r.patient.state,
+      "Patient zip code": r.patient.zipCode,
+      "Patient county": r.patient.county,
+      "Patient country": r.patient.country,
+      "Patient gender": r.patient.gender,
+      "Patient race": r.patient.race,
+      "Patient ethnicity": r.patient.ethnicity,
+      "Patient tribal affiliation": r.patient.tribalAffiliation.join(", "),
+      "Patient is a resident in a congregate setting":
+        r.patient.residentCongregateSetting,
+      "Patient is employed in healthcare": r.patient.employedInHealthcare,
+    };
+  });
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2483,6 +2483,21 @@ export type GetFacilityResultsForCsvQuery = {
                 }
               | null
               | undefined;
+            results?:
+              | Array<
+                  | {
+                      __typename?: "MultiplexResult";
+                      testResult?: string | null | undefined;
+                      disease?:
+                        | { __typename?: "SupportedDisease"; name: string }
+                        | null
+                        | undefined;
+                    }
+                  | null
+                  | undefined
+                >
+              | null
+              | undefined;
             deviceType?:
               | {
                   __typename?: "DeviceType";
@@ -6752,6 +6767,12 @@ export const GetFacilityResultsForCsvDocument = gql`
       }
       dateTested
       result
+      results {
+        disease {
+          name
+        }
+        testResult
+      }
       correctionStatus
       reasonForCorrection
       deviceType {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #3849 

## Changes Proposed
This PR accomplishes the following:
- creates a utility method for parsing the CSV for test results
- displays flu results in CSV download when multiplex env variable enabled
- specifies "Test result" header in CSV to "COVID-19 result"

## Additional Information
- N/A

## Testing
**Multiplex Enabled** 
- in your appropriate `.env` file set `REACT_APP_MULTIPLEX_ENABLED="true"`
- ensure you have multiplex results
- on the "Results" page, click "Download results"
- ensure the csv has the "COVID-19 result" column and "Flu A result" and "Flu B result" columns with the correct results

**Multiplex Disabled** 
- in your appropriate `.env` file set `REACT_APP_MULTIPLEX_ENABLED="false"`
- on the "Results" page, click "Download results"
- ensure the csv has the "COVID-19 result" column but **DOES NOT** contain "Flu A result" and "Flu B result" columns 


## Screenshots / Demos
**Multiplex Enabled** 
<img width="1433" alt="Screen Shot 2022-06-27 at 5 44 59 PM" src="https://user-images.githubusercontent.com/20211771/176049208-93a586ee-5a39-45aa-97b2-9e71153403ae.png">

**Multiplex Disabled** 
<img width="1436" alt="Screen Shot 2022-06-27 at 5 45 19 PM" src="https://user-images.githubusercontent.com/20211771/176049232-892e1bca-8be3-4e14-ae79-e9e58e7c2c28.png">


## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
