### PR TITLE
Update copy for printable multiplex results (#3493)

### DIFF
--- a/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/frontend/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -40,7 +40,7 @@ describe("Getting a test result from a patient link", () => {
     cy.get("#dob-submit-button").click();
   });
   it("shows the test result", () => {
-    cy.contains("SARS-CoV-2 result");
+    cy.contains("Test result: COVID-19");
     cy.contains("Test result");
     cy.contains("Test date");
     cy.contains("Test device");

--- a/frontend/src/app/commonComponents/CovidResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/CovidResultGuidance.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+
+import { COVID_RESULTS } from "../constants";
+
+interface Props {
+  result: string;
+  isPatientApp: boolean;
+}
+
+const CovidResultGuidance = (props: Props) => {
+  const result = props.result;
+  const isPatientApp = props.isPatientApp;
+  const { t } = useTranslation();
+
+  switch (result) {
+    case COVID_RESULTS.POSITIVE:
+      return (
+        <>
+          <p>{t("testResult.notes.positive.p1")}</p>
+          <ul>
+            <li>{t("testResult.notes.positive.guidelines.li0")}</li>
+            <li>{t("testResult.notes.positive.guidelines.li1")}</li>
+            <li>{t("testResult.notes.positive.guidelines.li2")}</li>
+            <li>{t("testResult.notes.positive.guidelines.li3")}</li>
+            <li>{t("testResult.notes.positive.guidelines.li4")}</li>
+            <li>{t("testResult.notes.positive.guidelines.li5")}</li>
+          </ul>
+          {isPatientApp ? (
+            <Trans
+              t={t}
+              parent="p"
+              i18nKey="testResult.notes.positive.p2"
+              components={[
+                <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">
+                  Watch for symptoms and learn when to seek emergency medical
+                  attention
+                </a>,
+              ]}
+            />
+          ) : (
+            <Trans
+              t={t}
+              parent="p"
+              i18nKey="testResult.notes.positive.p2"
+              components={[
+                <a
+                  href={t("testResult.notes.positive.symptomsLink")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  symptoms link
+                </a>,
+              ]}
+            />
+          )}
+          <ul>
+            <li>{t("testResult.notes.positive.emergency.li0")}</li>
+            <li>{t("testResult.notes.positive.emergency.li1")}</li>
+            <li>{t("testResult.notes.positive.emergency.li2")}</li>
+            <li>{t("testResult.notes.positive.emergency.li3")}</li>
+            <li>{t("testResult.notes.positive.emergency.li4")}</li>
+          </ul>
+          <p>{t("testResult.notes.positive.p3")}</p>
+        </>
+      );
+    case COVID_RESULTS.NEGATIVE:
+      return (
+        <>
+          <p>{t("testResult.notes.negative.p0")}</p>
+          <ul className={isPatientApp ? "" : "sr-multi-column"}>
+            <li>{t("testResult.notes.negative.symptoms.li0")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li1")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li2")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li3")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li4")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li5")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li6")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li7")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li8")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li9")}</li>
+            <li>{t("testResult.notes.negative.symptoms.li10")}</li>
+          </ul>
+        </>
+      );
+    default:
+      return (
+        <>
+          <p>{t("testResult.notes.inconclusive.p0")}</p>
+          {isPatientApp && <p>{t("testResult.notes.inconclusive.p1")}</p>}
+        </>
+      );
+  }
+};
+
+export default CovidResultGuidance;

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -55,7 +55,8 @@ export interface MultiplexResult {
   disease: {
     name: string;
   };
-  testResult: TestResult;
+  testResult?: TestResult;
+  result?: TestResult;
 }
 
 const EARLIEST_TEST_DATE = new Date("01/01/2020 12:00:00 AM");

--- a/frontend/src/app/testResults/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.tsx
@@ -114,9 +114,9 @@ export const DetachedTestResultDetailsModal = ({ data, closeModal }: Props) => {
     results.some((d) => d.disease.name !== "COVID-19");
   if (hasMultiplexResults) {
     displayResult["fluAResult"] =
-      results.filter((d) => d.disease.name === "Flu A")[0].testResult || null;
+      results.filter((d) => d.disease.name === "Flu A")[0]?.testResult || null;
     displayResult["fluBResult"] =
-      results.filter((d) => d.disease.name === "Flu B")[0].testResult || null;
+      results.filter((d) => d.disease.name === "Flu B")[0]?.testResult || null;
   }
   return (
     <Modal

--- a/frontend/src/app/testResults/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.tsx
@@ -113,12 +113,10 @@ export const DetachedTestResultDetailsModal = ({ data, closeModal }: Props) => {
     results &&
     results.some((d) => d.disease.name !== "COVID-19");
   if (hasMultiplexResults) {
-    displayResult["fluAResult"] = results.filter(
-      (d) => d.disease.name === "Flu A"
-    )[0].testResult;
-    displayResult["fluBResult"] = results.filter(
-      (d) => d.disease.name === "Flu B"
-    )[0].testResult;
+    displayResult["fluAResult"] =
+      results.filter((d) => d.disease.name === "Flu A")[0].testResult || null;
+    displayResult["fluBResult"] =
+      results.filter((d) => d.disease.name === "Flu B")[0].testResult || null;
   }
   return (
     <Modal

--- a/frontend/src/app/testResults/TestResultPrintModal.scss
+++ b/frontend/src/app/testResults/TestResultPrintModal.scss
@@ -1,23 +1,42 @@
+@media print {
+  body {
+    // ensures extra content is not printed in results page
+    &.ReactModal__Body--open {
+      #root {
+        display: none !important;
+      }
+    }
+
+    // ensures overflow content prints on next page
+    .sr-test-results-modal-overlay {
+      display: block;
+      overflow: visible;
+      position: static;
+    }
+
+    // ensures extra content is not printed
+    .dont-print,
+    .usa-header,
+    .usa-banner {
+      display: none !important;
+    }
+
+    .sr-test-results-modal-content {
+      margin: 0 auto;
+      max-height: none;
+      padding: 0;
+      transform: none;
+      width: 8.5in;
+    }
+  }
+}
+
 .sr-result-print-buttons {
   display: flex;
   justify-content: flex-end;
 
   & button {
     margin: 0 0 0 1.5rem;
-  }
-}
-
-@media print {
-  body {
-    .dont-print {
-      display: none !important;
-    }
-
-    .sr-test-results-modal-content {
-      transform: none;
-      max-height: none;
-      padding: 0;
-    }
   }
 }
 
@@ -111,6 +130,14 @@
 
   p {
     margin: 0.75rem 1rem;
+  }
+
+  .sr-guidance-heading {
+    margin-bottom: 0.625rem;
+  }
+
+  .sr-margin-bottom-28px {
+    margin-bottom: 1.75rem;
   }
 }
 

--- a/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
@@ -65,7 +65,7 @@ positiveCovidProps.data.testResult.results = [
 ];
 
 const undeterminedCovidProps = cloneDeep(defaultProps);
-positiveCovidProps.data.testResult.results = [
+undeterminedCovidProps.data.testResult.results = [
   { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
 ];
 
@@ -100,8 +100,15 @@ negativeAllMultiplexProps.data.testResult.results = [
 const undeterminedCovidMultiplexProps = cloneDeep(defaultProps);
 undeterminedCovidMultiplexProps.data.testResult.results = [
   { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
-  { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+  { disease: { name: "Flu A" }, testResult: "POSITIVE" },
   { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+];
+
+const undeterminedAllMultiplexProps = cloneDeep(defaultProps);
+undeterminedAllMultiplexProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
+  { disease: { name: "Flu A" }, testResult: "UNDETERMINED" },
+  { disease: { name: "Flu B" }, testResult: "UNDETERMINED" },
 ];
 
 const Template: Story<TestResultPrintModalProps> = (args) => {
@@ -131,3 +138,6 @@ WithNegativeAllMultiplex.args = negativeAllMultiplexProps;
 
 export const WithUndeterminedCovidMultiplex = Template.bind({});
 WithUndeterminedCovidMultiplex.args = undeterminedCovidMultiplexProps;
+
+export const WithUndeterminedAllMultiplex = Template.bind({});
+WithUndeterminedAllMultiplex.args = undeterminedAllMultiplexProps;

--- a/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
@@ -1,5 +1,5 @@
 import { Story, Meta } from "@storybook/react";
-import { uniqueId } from "lodash";
+import { uniqueId, cloneDeep } from "lodash";
 
 import {
   DetachedTestResultPrintModal,
@@ -19,6 +19,7 @@ export default {
 const testResult = {
   dateTested: new Date("2021-08-20"),
   result: "NEGATIVE",
+  results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
   correctionStatus: null,
   deviceType: {
     name: "Fake device",
@@ -58,9 +59,75 @@ const defaultProps: TestResultPrintModalProps = {
   hardcodedPrintDate: "8/24/2021, 9:44:25 AM",
 };
 
+const positiveCovidProps = cloneDeep(defaultProps);
+positiveCovidProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
+];
+
+const undeterminedCovidProps = cloneDeep(defaultProps);
+positiveCovidProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
+];
+
+const positiveFluMultiplexProps = cloneDeep(defaultProps);
+positiveFluMultiplexProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
+  { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+  { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+];
+
+const positiveCovidMultiplexProps = cloneDeep(defaultProps);
+positiveCovidMultiplexProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
+  { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+  { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+];
+
+const positiveAllMultiplexProps = cloneDeep(defaultProps);
+positiveAllMultiplexProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
+  { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+  { disease: { name: "Flu B" }, testResult: "POSITIVE" },
+];
+
+const negativeAllMultiplexProps = cloneDeep(defaultProps);
+negativeAllMultiplexProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
+  { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+  { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+];
+
+const undeterminedCovidMultiplexProps = cloneDeep(defaultProps);
+undeterminedCovidMultiplexProps.data.testResult.results = [
+  { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
+  { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+  { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+];
+
 const Template: Story<TestResultPrintModalProps> = (args) => {
   return <DetachedTestResultPrintModal {...args} />;
 };
 
 export const Default = Template.bind({});
 Default.args = defaultProps;
+
+export const WithPositiveCovid = Template.bind({});
+WithPositiveCovid.args = positiveCovidProps;
+
+export const WithUndeterminedCovid = Template.bind({});
+WithUndeterminedCovid.args = undeterminedCovidProps;
+
+export const WithPositiveFluMultiplex = Template.bind({});
+WithPositiveFluMultiplex.args = positiveFluMultiplexProps;
+
+export const WithPositiveCovidMultiplex = Template.bind({});
+WithPositiveCovidMultiplex.args = positiveCovidMultiplexProps;
+
+export const WithPositiveAllMultiplex = Template.bind({});
+WithPositiveAllMultiplex.args = positiveAllMultiplexProps;
+
+export const WithNegativeAllMultiplex = Template.bind({});
+WithNegativeAllMultiplex.args = negativeAllMultiplexProps;
+
+export const WithUndeterminedCovidMultiplex = Template.bind({});
+WithUndeterminedCovidMultiplex.args = undeterminedCovidMultiplexProps;

--- a/frontend/src/app/testResults/TestResultPrintModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.test.tsx
@@ -4,12 +4,16 @@ import { cloneDeep } from "lodash";
 import MockDate from "mockdate";
 import ReactDOM from "react-dom";
 
+import { MultiplexResult } from "../testQueue/QueueItem";
+
 import { DetachedTestResultPrintModal } from "./TestResultPrintModal";
 
 const testResult = {
   dateTested: new Date("2022-01-28T17:56:48.143Z"),
   result: "NEGATIVE",
-  results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
+  results: [
+    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
+  ] as MultiplexResult[],
   correctionStatus: null,
   deviceType: {
     name: "Fake device",
@@ -33,7 +37,8 @@ const testResult = {
       firstName: "Ordering",
       middleName: null,
       lastName: "Provider",
-      NPI: "fake-npi",
+      NPI: "fake-npi" as string | undefined,
+      npi: undefined as string | undefined,
     },
   },
   testPerformed: {
@@ -132,16 +137,14 @@ if (process.env.MULTIPLEX_ENABLED === "true") {
     beforeEach(() => {
       const multiplexPxpTestResult = cloneDeep(testResult);
       multiplexPxpTestResult.results = [
-        // @ts-ignore
-        { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-        // @ts-ignore
-        { disease: { name: "Flu A" }, result: "NEGATIVE" },
-        // @ts-ignore
-        { disease: { name: "Flu B" }, result: "NEGATIVE" },
+        {
+          disease: { name: "COVID-19" },
+          result: "NEGATIVE",
+        } as MultiplexResult,
+        { disease: { name: "Flu A" }, result: "NEGATIVE" } as MultiplexResult,
+        { disease: { name: "Flu B" }, result: "NEGATIVE" } as MultiplexResult,
       ];
-      // @ts-ignore
       multiplexPxpTestResult.facility.orderingProvider.NPI = undefined;
-      // @ts-ignore
       multiplexPxpTestResult.facility.orderingProvider.npi = "fake npi for pxp";
 
       ReactDOM.createPortal = jest.fn((element, _node) => {

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -1,58 +1,59 @@
 import React from "react";
-import { gql } from "@apollo/client";
 import Modal from "react-modal";
 import classnames from "classnames";
 import { Trans, useTranslation } from "react-i18next";
 
 import Button from "../commonComponents/Button/Button";
+import CovidResultGuidance from "../commonComponents/CovidResultGuidance";
 import { displayFullName } from "../utils";
 import "./TestResultPrintModal.scss";
 import logo from "../../img/simplereport-logo-black.svg";
 import { QueryWrapper } from "../commonComponents/QueryWrapper";
 import LanguageToggler from "../../patientApp/LanguageToggler";
 import { formatDateWithTimeOption } from "../utils/date";
+import { GetTestResultForPrintDocument } from "../../generated/graphql";
+import { MultiplexResult } from "../testQueue/QueueItem";
 
-export const testQuery = gql`
-  query getTestResultForPrint($id: ID!) {
-    testResult(id: $id) {
-      dateTested
-      result
-      correctionStatus
-      deviceType {
-        name
-        model
-      }
-      patient {
-        firstName
-        middleName
-        lastName
-        birthDate
-      }
-      facility {
-        name
-        cliaNumber
-        phone
-        street
-        streetTwo
-        city
-        state
-        zipCode
-        orderingProvider {
-          firstName
-          middleName
-          lastName
-          NPI
-        }
-      }
-    }
-  }
-`;
+interface OrderingProvider {
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  npi?: string | null;
+  NPI?: string | null;
+}
+
+interface Patient {
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  birthDate: string;
+}
+
+interface Facility extends Address {
+  name: string;
+  phone: string;
+  cliaNumber: string;
+  orderingProvider: OrderingProvider;
+}
+
+export interface TestResult {
+  correctionStatus: string;
+  dateTested: string;
+  deviceType: {
+    model: string;
+    name: string;
+  };
+  facility: Facility;
+  patient: Patient;
+  results: MultiplexResult[];
+}
 
 interface StaticTestResultModalProps {
   testResultId: string | undefined;
-  testResult: any;
+  testResult: TestResult;
   hardcodedPrintDate?: string;
 }
+
 export const StaticTestResultModal = ({
   testResultId,
   testResult,
@@ -64,9 +65,198 @@ export const StaticTestResultModal = ({
     facility,
     deviceType,
     correctionStatus,
-    result,
+    results,
     dateTested,
   } = testResult;
+
+  const multiplexEnabled = process.env.REACT_APP_MULTIPLEX_ENABLED === "true";
+  const getSortedResults = () => {
+    return Object.values(results).sort(
+      (a: MultiplexResult, b: MultiplexResult) => {
+        return a.disease.name.localeCompare(b.disease.name);
+      }
+    );
+  };
+
+  const hasMultiplexResults = Object.values(results).some(
+    (multiplexResult: MultiplexResult) =>
+      multiplexResult.disease.name !== "COVID-19"
+  );
+
+  const getCovidResult = Object.values(
+    results
+  ).filter((multiplexResult: MultiplexResult) =>
+    multiplexResult.disease.name.includes("COVID-19")
+  );
+
+  const hasPositiveFluResults =
+    Object.values(results).filter(
+      (multiplexResult: MultiplexResult) =>
+        (multiplexResult.disease.name.includes("Flu") &&
+          multiplexResult.testResult === "POSITIVE") ||
+        multiplexResult.result === "POSITIVE"
+    ).length > 0;
+
+  const setCovidGuidance = (result?: string) => {
+    return (
+      <div
+        className={
+          multiplexEnabled && hasMultiplexResults && hasPositiveFluResults
+            ? "sr-margin-bottom-28px"
+            : ""
+        }
+      >
+        {multiplexEnabled && hasPositiveFluResults && (
+          <p className="text-bold sr-guidance-heading">
+            {t("testResult.notes.h1")}
+          </p>
+        )}
+        {result === "UNDETERMINED" && (
+          <CovidResultGuidance result={"UNDETERMINED"} isPatientApp={false} />
+        )}
+        {result !== "POSITIVE" && (
+          <>
+            <CovidResultGuidance result={"NEGATIVE"} isPatientApp={false} />
+            <Trans
+              t={t}
+              parent="p"
+              i18nKey="testResult.notes.negative.moreInformation"
+              components={[
+                <a
+                  href={t("testResult.cdcLink")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  cdc.gov
+                </a>,
+              ]}
+            />
+          </>
+        )}
+        {result === "POSITIVE" && (
+          <>
+            <CovidResultGuidance result={"POSITIVE"} isPatientApp={false} />
+            <Trans
+              t={t}
+              parent="p"
+              i18nKey="testResult.information"
+              components={[
+                <a
+                  href={t("testResult.cdcLink")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  cdc.gov
+                </a>,
+                <a
+                  href={t("testResult.countyCheckToolLink")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  county check tool
+                </a>,
+              ]}
+            />
+          </>
+        )}
+      </div>
+    );
+  };
+
+  const setPositiveFluGuidance = () => {
+    return (
+      <>
+        {multiplexEnabled && hasPositiveFluResults && (
+          <p className="text-bold sr-guidance-heading">
+            {t("testResult.fluNotes.h1")}
+          </p>
+        )}
+        <p>{t("testResult.fluNotes.positive.p0")}</p>
+        <Trans
+          t={t}
+          parent="p"
+          i18nKey="testResult.fluNotes.positive.p1"
+          components={[
+            <a
+              href={t("testResult.fluNotes.positive.highRiskLink")}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              flu high risk link
+            </a>,
+          ]}
+        />
+        <Trans
+          t={t}
+          parent="p"
+          i18nKey="testResult.fluNotes.positive.p2"
+          components={[
+            <a
+              href={t("testResult.fluNotes.positive.treatmentLink")}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              flu treatment link
+            </a>,
+          ]}
+        />
+      </>
+    );
+  };
+
+  const testResultsList = () => {
+    const sortedTestResults = multiplexEnabled
+      ? getSortedResults()
+      : getCovidResult;
+    const testResultsArray: any = [];
+    sortedTestResults.forEach((sortedTestResult: MultiplexResult) => {
+      let sortedResult = sortedTestResult.testResult || sortedTestResult.result;
+      testResultsArray.push(
+        <li>
+          <b>
+            {sortedTestResult.disease.name === "COVID-19" &&
+              t("constants.disease.COVID19")}
+            {sortedTestResult.disease.name === "Flu A" &&
+              t("constants.disease.FLUA")}
+            {sortedTestResult.disease.name === "Flu B" &&
+              t("constants.disease.FLUB")}
+          </b>
+          <div>
+            <strong>
+              <span>
+                {sortedResult === "POSITIVE" &&
+                  t("constants.testResults.POSITIVE")}
+                {sortedResult === "NEGATIVE" &&
+                  t("constants.testResults.NEGATIVE")}
+                {sortedResult === "UNDETERMINED" &&
+                  t("constants.testResults.UNDETERMINED")}
+              </span>
+              <span>
+                &nbsp;
+                {sortedResult === "POSITIVE" &&
+                  t("constants.testResultsSymbols.POSITIVE")}
+                {sortedResult === "NEGATIVE" &&
+                  t("constants.testResultsSymbols.NEGATIVE")}
+              </span>
+            </strong>
+          </div>
+        </li>
+      );
+    });
+    return testResultsArray;
+  };
+
+  const testResultsGuidance = () => {
+    const testGuidanceArray: any = [];
+    const covidGuidanceElement = setCovidGuidance(
+      getCovidResult[0].testResult || getCovidResult[0].result
+    );
+    testGuidanceArray.push(covidGuidanceElement);
+    if (multiplexEnabled && hasPositiveFluResults) {
+      testGuidanceArray.push(setPositiveFluGuidance());
+    }
+    return testGuidanceArray;
+  };
 
   return (
     <div
@@ -76,7 +266,11 @@ export const StaticTestResultModal = ({
       )}
     >
       <header className="display-flex flex-align-end flex-justify margin-bottom-1">
-        <h1>{t("testResult.result")}</h1>
+        <h1>
+          {multiplexEnabled && hasMultiplexResults
+            ? t("testResult.multiplexResultHeader")
+            : t("testResult.covidResultHeader")}
+        </h1>
         <img alt="SimpleReport logo" src={logo} className="sr-print-logo" />
       </header>
       <main>
@@ -138,7 +332,9 @@ export const StaticTestResultModal = ({
             </li>
             <li>
               <b>{t("testResult.testingFacility.npi")}</b>
-              <div>{facility.orderingProvider.NPI}</div>
+              <div>
+                {facility.orderingProvider.NPI || facility.orderingProvider.npi}
+              </div>
             </li>
           </ul>
         </section>
@@ -157,100 +353,16 @@ export const StaticTestResultModal = ({
               <b>{t("testResult.testDevice")}</b>
               <div>{deviceType.model}</div>
             </li>
-            <li>
+            <li className="sr-margin-bottom-28px">
               <b>{t("testResult.testDate")}</b>
               <div>{formatDateWithTimeOption(dateTested, true)}</div>
             </li>
-            <li>
-              <b>{t("testResult.testResult")}</b>
-              <div>
-                <strong>
-                  {result === "POSITIVE" && t("constants.testResults.POSITIVE")}
-                  {result === "NEGATIVE" && t("constants.testResults.NEGATIVE")}
-                  {result === "UNDETERMINED" &&
-                    t("constants.testResults.UNDETERMINED")}
-                </strong>
-              </div>
-            </li>
+            {testResultsList()}
           </ul>
         </section>
         <section className="sr-result-section sr-result-next-steps">
           <h2>{t("testResult.moreInformation")}</h2>
-          {result === "UNDETERMINED" && (
-            <p>{t("testResult.notes.inconclusive.p0")}</p>
-          )}
-          {result !== "POSITIVE" && (
-            <>
-              <p>{t("testResult.notes.negative.p0")}</p>
-              <ul className="sr-multi-column">
-                <li>{t("testResult.notes.negative.symptoms.li2")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li3")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li4")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li5")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li6")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li7")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li8")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li9")}</li>
-                <li>{t("testResult.notes.negative.symptoms.li10")}</li>
-              </ul>
-            </>
-          )}
-          {result === "POSITIVE" && (
-            <>
-              <p>{t("testResult.notes.positive.p1")}</p>
-              <ul>
-                <li>{t("testResult.notes.positive.guidelines.li0")}</li>
-                <li>{t("testResult.notes.positive.guidelines.li1")}</li>
-                <li>{t("testResult.notes.positive.guidelines.li2")}</li>
-                <li>{t("testResult.notes.positive.guidelines.li3")}</li>
-                <li>{t("testResult.notes.positive.guidelines.li4")}</li>
-                <li>{t("testResult.notes.positive.guidelines.li5")}</li>
-              </ul>
-              <Trans
-                t={t}
-                parent="p"
-                i18nKey="testResult.notes.positive.p2"
-                components={[
-                  <a
-                    href={t("testResult.notes.positive.symptomsLink")}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    symptoms link
-                  </a>,
-                ]}
-              />
-              <ul>
-                <li>{t("testResult.notes.positive.emergency.li0")}</li>
-                <li>{t("testResult.notes.positive.emergency.li1")}</li>
-                <li>{t("testResult.notes.positive.emergency.li2")}</li>
-                <li>{t("testResult.notes.positive.emergency.li3")}</li>
-                <li>{t("testResult.notes.positive.emergency.li4")}</li>
-              </ul>
-              <p>{t("testResult.notes.positive.p3")}</p>
-            </>
-          )}
-          <Trans
-            t={t}
-            parent="p"
-            i18nKey="testResult.information"
-            components={[
-              <a
-                href={t("testResult.cdcLink")}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                cdc.gov
-              </a>,
-              <a
-                href={t("testResult.countyCheckToolLink")}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                county check tool
-              </a>,
-            ]}
-          />
+          {testResultsGuidance()}
         </section>
       </main>
       <footer>
@@ -314,7 +426,7 @@ const TestResultPrintModal = (
   props: Omit<TestResultPrintModalProps, "data">
 ) => (
   <QueryWrapper<TestResultPrintModalProps>
-    query={testQuery}
+    query={GetTestResultForPrintDocument}
     queryOptions={{ variables: { id: props.testResultId } }}
     Component={DetachedTestResultPrintModal}
     componentProps={{ ...props }}

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -210,7 +210,8 @@ export const StaticTestResultModal = ({
       : getCovidResult;
     const testResultsArray: any = [];
     sortedTestResults.forEach((sortedTestResult: MultiplexResult) => {
-      let sortedResult = sortedTestResult.testResult || sortedTestResult.result;
+      const sortedResult =
+        sortedTestResult.testResult || sortedTestResult.result;
       testResultsArray.push(
         <li>
           <b>

--- a/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TestResultPrintModal matches screenshot 1`] = `
+exports[`TestResultPrintModal with only COVID results matches screenshot 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body
@@ -71,7 +71,7 @@ Object {
               class="display-flex flex-align-end flex-justify margin-bottom-1"
             >
               <h1>
-                SARS-CoV-2 result
+                Test result: COVID-19
               </h1>
               <img
                 alt="SimpleReport logo"
@@ -208,7 +208,9 @@ Object {
                     </b>
                     <div />
                   </li>
-                  <li>
+                  <li
+                    class="sr-margin-bottom-28px"
+                  >
                     <b>
                       Test date
                     </b>
@@ -218,11 +220,17 @@ Object {
                   </li>
                   <li>
                     <b>
-                      Test result
+                      COVID-19
                     </b>
                     <div>
                       <strong>
-                        Negative
+                        <span>
+                          Negative
+                        </span>
+                        <span>
+                           
+                          (-)
+                        </span>
                       </strong>
                     </div>
                   </li>
@@ -234,59 +242,62 @@ Object {
                 <h2>
                   More information
                 </h2>
-                <p>
-                  Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
-                </p>
-                <ul
-                  class="sr-multi-column"
+                <div
+                  class=""
                 >
-                  <li>
-                    Shortness of breath or difficulty breathing
-                  </li>
-                  <li>
-                    Fatigue
-                  </li>
-                  <li>
-                    Muscle or body aches
-                  </li>
-                  <li>
-                    Headache
-                  </li>
-                  <li>
-                    Loss of taste or smell
-                  </li>
-                  <li>
-                    Sore throat
-                  </li>
-                  <li>
-                    Congestion or runny nose
-                  </li>
-                  <li>
-                    Nausea or vomiting
-                  </li>
-                  <li>
-                    Diarrhea
-                  </li>
-                </ul>
-                <p>
-                  For more information go to 
-                  <a
-                    href="https://www.cdc.gov/"
-                    rel="noopener noreferrer"
-                    target="_blank"
+                  <p>
+                    Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
+                  </p>
+                  <ul
+                    class="sr-multi-column"
                   >
-                    CDC.gov
-                  </a>
-                   or call 1-800-CDC-INFO (1-800-232-4636). Use the 
-                  <a
-                    href="https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    County Check Tool
-                  </a>
-                   (cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html) to understand your Community Level (COVID-19 risk and hospital capacity in your area), tips for prevention, and how to find vaccine, testing, and treatment resources.
-                </p>
+                    <li>
+                      Fever or chills
+                    </li>
+                    <li>
+                      Cough
+                    </li>
+                    <li>
+                      Shortness of breath or difficulty breathing
+                    </li>
+                    <li>
+                      Fatigue
+                    </li>
+                    <li>
+                      Muscle or body aches
+                    </li>
+                    <li>
+                      Headache
+                    </li>
+                    <li>
+                      Loss of taste or smell
+                    </li>
+                    <li>
+                      Sore throat
+                    </li>
+                    <li>
+                      Congestion or runny nose
+                    </li>
+                    <li>
+                      Nausea or vomiting
+                    </li>
+                    <li>
+                      Diarrhea
+                    </li>
+                  </ul>
+                  <p>
+                    For more information, please visit the 
+                    <a
+                      href="https://www.cdc.gov/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Centers for Disease Control and Prevention (CDC)
+                    </a>
+                     website or contact
+your local health department.
+                  </p>
+                </div>
               </section>
             </main>
             <footer>
@@ -384,7 +395,7 @@ Object {
             class="display-flex flex-align-end flex-justify margin-bottom-1"
           >
             <h1>
-              SARS-CoV-2 result
+              Test result: COVID-19
             </h1>
             <img
               alt="SimpleReport logo"
@@ -521,7 +532,9 @@ Object {
                   </b>
                   <div />
                 </li>
-                <li>
+                <li
+                  class="sr-margin-bottom-28px"
+                >
                   <b>
                     Test date
                   </b>
@@ -531,11 +544,17 @@ Object {
                 </li>
                 <li>
                   <b>
-                    Test result
+                    COVID-19
                   </b>
                   <div>
                     <strong>
-                      Negative
+                      <span>
+                        Negative
+                      </span>
+                      <span>
+                         
+                        (-)
+                      </span>
                     </strong>
                   </div>
                 </li>
@@ -547,59 +566,62 @@ Object {
               <h2>
                 More information
               </h2>
-              <p>
-                Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
-              </p>
-              <ul
-                class="sr-multi-column"
+              <div
+                class=""
               >
-                <li>
-                  Shortness of breath or difficulty breathing
-                </li>
-                <li>
-                  Fatigue
-                </li>
-                <li>
-                  Muscle or body aches
-                </li>
-                <li>
-                  Headache
-                </li>
-                <li>
-                  Loss of taste or smell
-                </li>
-                <li>
-                  Sore throat
-                </li>
-                <li>
-                  Congestion or runny nose
-                </li>
-                <li>
-                  Nausea or vomiting
-                </li>
-                <li>
-                  Diarrhea
-                </li>
-              </ul>
-              <p>
-                For more information go to 
-                <a
-                  href="https://www.cdc.gov/"
-                  rel="noopener noreferrer"
-                  target="_blank"
+                <p>
+                  Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
+                </p>
+                <ul
+                  class="sr-multi-column"
                 >
-                  CDC.gov
-                </a>
-                 or call 1-800-CDC-INFO (1-800-232-4636). Use the 
-                <a
-                  href="https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  County Check Tool
-                </a>
-                 (cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html) to understand your Community Level (COVID-19 risk and hospital capacity in your area), tips for prevention, and how to find vaccine, testing, and treatment resources.
-              </p>
+                  <li>
+                    Fever or chills
+                  </li>
+                  <li>
+                    Cough
+                  </li>
+                  <li>
+                    Shortness of breath or difficulty breathing
+                  </li>
+                  <li>
+                    Fatigue
+                  </li>
+                  <li>
+                    Muscle or body aches
+                  </li>
+                  <li>
+                    Headache
+                  </li>
+                  <li>
+                    Loss of taste or smell
+                  </li>
+                  <li>
+                    Sore throat
+                  </li>
+                  <li>
+                    Congestion or runny nose
+                  </li>
+                  <li>
+                    Nausea or vomiting
+                  </li>
+                  <li>
+                    Diarrhea
+                  </li>
+                </ul>
+                <p>
+                  For more information, please visit the 
+                  <a
+                    href="https://www.cdc.gov/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Centers for Disease Control and Prevention (CDC)
+                  </a>
+                   website or contact
+your local health department.
+                </p>
+              </div>
             </section>
           </main>
           <footer>

--- a/frontend/src/app/testResults/operations.graphql
+++ b/frontend/src/app/testResults/operations.graphql
@@ -176,3 +176,43 @@ query GetResultsCountByFacility(
       endDate: $endDate
     )
   }
+
+query GetTestResultForPrint($id: ID!) {
+  testResult(id: $id) {
+    dateTested
+    result
+    results {
+      disease {
+        name
+      }
+      testResult
+    }
+    correctionStatus
+    deviceType {
+      name
+      model
+    }
+    patient {
+      firstName
+      middleName
+      lastName
+      birthDate
+    }
+    facility {
+      name
+      cliaNumber
+      phone
+      street
+      streetTwo
+      city
+      state
+      zipCode
+      orderingProvider {
+        firstName
+        middleName
+        lastName
+        NPI
+      }
+    }
+  }
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2330,61 +2330,6 @@ export type GetTestResultDetailsQuery = {
     | undefined;
 };
 
-export type GetTestResultForPrintQueryVariables = Exact<{
-  id: Scalars["ID"];
-}>;
-
-export type GetTestResultForPrintQuery = {
-  __typename?: "Query";
-  testResult?:
-    | {
-        __typename?: "TestResult";
-        dateTested?: any | null | undefined;
-        result?: string | null | undefined;
-        correctionStatus?: string | null | undefined;
-        deviceType?:
-          | { __typename?: "DeviceType"; name: string; model: string }
-          | null
-          | undefined;
-        patient?:
-          | {
-              __typename?: "Patient";
-              firstName?: string | null | undefined;
-              middleName?: string | null | undefined;
-              lastName?: string | null | undefined;
-              birthDate?: any | null | undefined;
-            }
-          | null
-          | undefined;
-        facility?:
-          | {
-              __typename?: "Facility";
-              name: string;
-              cliaNumber?: string | null | undefined;
-              phone?: string | null | undefined;
-              street?: string | null | undefined;
-              streetTwo?: string | null | undefined;
-              city?: string | null | undefined;
-              state?: string | null | undefined;
-              zipCode?: string | null | undefined;
-              orderingProvider?:
-                | {
-                    __typename?: "Provider";
-                    firstName?: string | null | undefined;
-                    middleName?: string | null | undefined;
-                    lastName?: string | null | undefined;
-                    NPI?: string | null | undefined;
-                  }
-                | null
-                | undefined;
-            }
-          | null
-          | undefined;
-      }
-    | null
-    | undefined;
-};
-
 export type GetTestResultForTextQueryVariables = Exact<{
   id: Scalars["ID"];
 }>;
@@ -2697,6 +2642,76 @@ export type GetResultsCountByFacilityQueryVariables = Exact<{
 export type GetResultsCountByFacilityQuery = {
   __typename?: "Query";
   testResultsCount?: number | null | undefined;
+};
+
+export type GetTestResultForPrintQueryVariables = Exact<{
+  id: Scalars["ID"];
+}>;
+
+export type GetTestResultForPrintQuery = {
+  __typename?: "Query";
+  testResult?:
+    | {
+        __typename?: "TestResult";
+        dateTested?: any | null | undefined;
+        result?: string | null | undefined;
+        correctionStatus?: string | null | undefined;
+        results?:
+          | Array<
+              | {
+                  __typename?: "MultiplexResult";
+                  testResult?: string | null | undefined;
+                  disease?:
+                    | { __typename?: "SupportedDisease"; name: string }
+                    | null
+                    | undefined;
+                }
+              | null
+              | undefined
+            >
+          | null
+          | undefined;
+        deviceType?:
+          | { __typename?: "DeviceType"; name: string; model: string }
+          | null
+          | undefined;
+        patient?:
+          | {
+              __typename?: "Patient";
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              birthDate?: any | null | undefined;
+            }
+          | null
+          | undefined;
+        facility?:
+          | {
+              __typename?: "Facility";
+              name: string;
+              cliaNumber?: string | null | undefined;
+              phone?: string | null | undefined;
+              street?: string | null | undefined;
+              streetTwo?: string | null | undefined;
+              city?: string | null | undefined;
+              state?: string | null | undefined;
+              zipCode?: string | null | undefined;
+              orderingProvider?:
+                | {
+                    __typename?: "Provider";
+                    firstName?: string | null | undefined;
+                    middleName?: string | null | undefined;
+                    lastName?: string | null | undefined;
+                    NPI?: string | null | undefined;
+                  }
+                | null
+                | undefined;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
 };
 
 export type GetUploadSubmissionQueryVariables = Exact<{
@@ -6450,92 +6465,6 @@ export type GetTestResultDetailsQueryResult = Apollo.QueryResult<
   GetTestResultDetailsQuery,
   GetTestResultDetailsQueryVariables
 >;
-export const GetTestResultForPrintDocument = gql`
-  query getTestResultForPrint($id: ID!) {
-    testResult(id: $id) {
-      dateTested
-      result
-      correctionStatus
-      deviceType {
-        name
-        model
-      }
-      patient {
-        firstName
-        middleName
-        lastName
-        birthDate
-      }
-      facility {
-        name
-        cliaNumber
-        phone
-        street
-        streetTwo
-        city
-        state
-        zipCode
-        orderingProvider {
-          firstName
-          middleName
-          lastName
-          NPI
-        }
-      }
-    }
-  }
-`;
-
-/**
- * __useGetTestResultForPrintQuery__
- *
- * To run a query within a React component, call `useGetTestResultForPrintQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTestResultForPrintQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTestResultForPrintQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetTestResultForPrintQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >(GetTestResultForPrintDocument, options);
-}
-export function useGetTestResultForPrintLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetTestResultForPrintQuery,
-    GetTestResultForPrintQueryVariables
-  >(GetTestResultForPrintDocument, options);
-}
-export type GetTestResultForPrintQueryHookResult = ReturnType<
-  typeof useGetTestResultForPrintQuery
->;
-export type GetTestResultForPrintLazyQueryHookResult = ReturnType<
-  typeof useGetTestResultForPrintLazyQuery
->;
-export type GetTestResultForPrintQueryResult = Apollo.QueryResult<
-  GetTestResultForPrintQuery,
-  GetTestResultForPrintQueryVariables
->;
 export const GetTestResultForTextDocument = gql`
   query getTestResultForText($id: ID!) {
     testResult(id: $id) {
@@ -7149,6 +7078,98 @@ export type GetResultsCountByFacilityLazyQueryHookResult = ReturnType<
 export type GetResultsCountByFacilityQueryResult = Apollo.QueryResult<
   GetResultsCountByFacilityQuery,
   GetResultsCountByFacilityQueryVariables
+>;
+export const GetTestResultForPrintDocument = gql`
+  query GetTestResultForPrint($id: ID!) {
+    testResult(id: $id) {
+      dateTested
+      result
+      results {
+        disease {
+          name
+        }
+        testResult
+      }
+      correctionStatus
+      deviceType {
+        name
+        model
+      }
+      patient {
+        firstName
+        middleName
+        lastName
+        birthDate
+      }
+      facility {
+        name
+        cliaNumber
+        phone
+        street
+        streetTwo
+        city
+        state
+        zipCode
+        orderingProvider {
+          firstName
+          middleName
+          lastName
+          NPI
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetTestResultForPrintQuery__
+ *
+ * To run a query within a React component, call `useGetTestResultForPrintQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTestResultForPrintQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTestResultForPrintQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetTestResultForPrintQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetTestResultForPrintQuery,
+    GetTestResultForPrintQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetTestResultForPrintQuery,
+    GetTestResultForPrintQueryVariables
+  >(GetTestResultForPrintDocument, options);
+}
+export function useGetTestResultForPrintLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetTestResultForPrintQuery,
+    GetTestResultForPrintQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetTestResultForPrintQuery,
+    GetTestResultForPrintQueryVariables
+  >(GetTestResultForPrintDocument, options);
+}
+export type GetTestResultForPrintQueryHookResult = ReturnType<
+  typeof useGetTestResultForPrintQuery
+>;
+export type GetTestResultForPrintLazyQueryHookResult = ReturnType<
+  typeof useGetTestResultForPrintLazyQuery
+>;
+export type GetTestResultForPrintQueryResult = Apollo.QueryResult<
+  GetTestResultForPrintQuery,
+  GetTestResultForPrintQueryVariables
 >;
 export const GetUploadSubmissionDocument = gql`
   query GetUploadSubmission($id: ID!) {

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -25,6 +25,15 @@ export const en = {
         UNDETERMINED: "Inconclusive",
         UNKNOWN: UNKNOWN,
       },
+      testResultsSymbols: {
+        POSITIVE: "(+)",
+        NEGATIVE: "(-)",
+      },
+      disease: {
+        COVID19: "COVID-19",
+        FLUA: "Flu A",
+        FLUB: "Flu B",
+      },
       role: {
         STAFF: "Staff",
         RESIDENT: "Resident",
@@ -239,6 +248,8 @@ export const en = {
     },
     testResult: {
       result: "SARS-CoV-2 result",
+      covidResultHeader: "Test result: COVID-19",
+      multiplexResultHeader: "Test results: COVID-19 and flu",
       downloadResult: "Download result",
       patient: "Patient",
       patientDetails: "Patient details",
@@ -273,8 +284,9 @@ export const en = {
         npi: "NPI",
       },
       notes: {
+        h1: "For COVID-19:",
         meaning:
-          "COVID-19 antigen tests can sometimes provid inaccurate or false results and follow up testing may be needed. Continue " +
+          "COVID-19 antigen tests can sometimes provide inaccurate or false results and follow up testing may be needed. Continue " +
           "social distancing and wearing a mask. Contact your health care provider to determine if additional " +
           "testing is needed especially if you experience any of these  symptoms.",
         positive: {
@@ -327,6 +339,9 @@ export const en = {
             li9: "Nausea or vomiting",
             li10: "Diarrhea",
           },
+          moreInformation:
+            "For more information, please visit the <0>Centers for Disease Control and Prevention (CDC)</0> website or contact\n" +
+            "your local health department.",
         },
         inconclusive: {
           p0:
@@ -336,6 +351,19 @@ export const en = {
           p1:
             "Please make an appointment for another test as soon as possible. If you’ve gotten tested due to COVID-19 symptoms, it is " +
             "recommended that you self-isolate until you get your new test results.",
+        },
+      },
+      fluNotes: {
+        h1: "For flu A and B:",
+        positive: {
+          p0:
+            "Most people with flu have mild illness and can recover at home. Stay at home and avoid contact with others until at least 24 hours after your fever is gone, except to get medical care or other necessities. Wear a face mask if you leave home, or cover coughs and sneezes with a tissue. Wash your hands often.",
+          p1:
+            "<0>People at Higher Risk of Developing Flu–Related Complications</0> (cdc.gov/flu/highrisk) should contact a doctor as soon as possible to see if antiviral treatment is recommended.",
+          p2:
+            "For more information, visit <0> Flu: What To Do If You Get Sick</0> (cdc.gov/flu/treatment/takingcare.htm).",
+          highRiskLink: "https://www.cdc.gov/flu/highrisk",
+          treatmentLink: "https://www.cdc.gov/flu/treatment/takingcare.htm",
         },
       },
       tos: {

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -31,6 +31,15 @@ export const es: LanguageConfig = {
         UNDETERMINED,
         UNKNOWN,
       },
+      testResultsSymbols: {
+        POSITIVE: "(+)",
+        NEGATIVE: "(-)",
+      },
+      disease: {
+        COVID19: "COVID-19",
+        FLUA: "Flu A",
+        FLUB: "Flu B",
+      },
       role: {
         STAFF: "Personal",
         RESIDENT: "Residente",
@@ -249,6 +258,9 @@ export const es: LanguageConfig = {
     },
     testResult: {
       result: "Resultado de SARS-CoV-2",
+      covidResultHeader: "Resultado de la prueba: COVID-19",
+      multiplexResultHeader:
+        "Resultados de las pruebas: COVID-19 y la influenza",
       downloadResult: "Descargar resultado",
       patient: "Paciente",
       patientDetails: "Detalles del paciente",
@@ -283,6 +295,7 @@ export const es: LanguageConfig = {
         npi: "Número de NPI",
       },
       notes: {
+        h1: "Para el COVID-19:",
         meaning:
           "Las pruebas de antígenos de COVID-19 a veces pueden arrojar resultados inexactos o falsos, y es posible que se " +
           "necesiten pruebas de seguimiento. Continúe practicando el distanciamiento social y usando mascarilla. Comuníquese " +
@@ -342,6 +355,9 @@ export const es: LanguageConfig = {
             li9: "Náuseas o vómitos",
             li10: "Diarrea",
           },
+          moreInformation:
+            "Para obtener más información, por favor visite el sitio web de los <0>Centros para el Control y la Prevención de\n" +
+            "Enfermedades (CDC)</0> o comuníquese con su departamento de salud local.",
         },
         inconclusive: {
           p0:
@@ -351,6 +367,25 @@ export const es: LanguageConfig = {
           p1:
             "Programe una cita para que le realicen otra prueba lo antes posible. Si se ha realizado la prueba porque tiene síntomas de COVID-19, se recomienda que se " +
             "autoaísle hasta que obtenga los resultados de la nueva prueba.",
+        },
+      },
+      fluNotes: {
+        h1: "Para influenza A y B:",
+        positive: {
+          p0:
+            "La mayoría de las personas con influenza (gripe) tienen un caso leve de la enfermedad y se pueden " +
+            "recuperar en casa. Quédate en casa y evita el contacto con los demás hasta por lo menos 24 horas " +
+            "después de que haya desaparecido la fiebre, excepto para obtener atención médica o para otras " +
+            "necesidades. Ponte una mascarilla si sales de casa, o cúbrete con un pañuelo desechable la nariz y la " +
+            "boca al toser y estornudar. Lávate las manos con frecuencia.",
+          p1:
+            "<0>Las personas con un riesgo mayor de presentar complicaciones relacionadas con la influenza</0> " +
+            "(https://espanol.cdc.gov/flu/highrisk/index.htm) deben contactar a un médico lo más pronto posible " +
+            "para ver si se recomienda el tratamiento antiviral.",
+          p2:
+            "Para obtener más información, visita <0>Influenza: qué hacer en caso de enfermarse</0> (https://espanol.cdc.gov/flu/treatment/takingcare.htm).",
+          highRiskLink: "https://espanol.cdc.gov/flu/highrisk/index.htm",
+          treatmentLink: "https://espanol.cdc.gov/flu/treatment/takingcare.htm",
         },
       },
       tos: {

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -51,7 +51,7 @@ export type VerifyV2Response = {
       name: string;
     };
     testResult: TestResult;
-  };
+  }[];
   dateTested: string;
   correctionStatus: string;
   deviceType: {

--- a/frontend/src/patientApp/timeOfTest/TestResult.scss
+++ b/frontend/src/patientApp/timeOfTest/TestResult.scss
@@ -26,7 +26,6 @@
       font-size: 80% !important;
       background: #fff;
       overflow: auto;
-      padding: 0.2in 0.4in 0 0.4in;
       transform: none;
       max-height: none;
     }

--- a/frontend/src/patientApp/timeOfTest/TestResult.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.test.tsx
@@ -10,6 +10,7 @@ const mockStore = configureStore([]);
 const getPatientLinkData = (result: string) => ({
   testEventId: "4606e571-8249-479e-94ab-e2f311713a5f",
   result: result,
+  results: [{ disease: { name: "COVID-19" }, result: result }],
   dateTested: "2022-02-11T21:16:26.404+00:00",
   correctionStatus: "ORIGINAL",
   patient: {

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -4,11 +4,10 @@ import React from "react";
 
 import { formatFullName } from "../../app/utils/user";
 import { RootState } from "../../app/store";
-import { TestResult as TestResultType } from "../../app/testQueue/QueueItem";
-import { COVID_RESULTS } from "../../app/constants";
 import { VerifyV2Response } from "../PxpApiService";
 import { StaticTestResultModal } from "../../app/testResults/TestResultPrintModal";
 import Button from "../../app/commonComponents/Button/Button";
+import CovidResultGuidance from "../../app/commonComponents/CovidResultGuidance";
 import { formatDateWithTimeOption } from "../../app/utils/date";
 
 import "./TestResult.scss";
@@ -77,7 +76,10 @@ const TestResult = () => {
             <h2 className="font-heading-sm">{t("testResult.testDevice")}</h2>
             <p className="margin-top-05">{deviceType}</p>
             <h2 className="font-heading-sm">{t("testResult.meaning")}</h2>
-            <TestResultNotes result={testResult.result} />
+            <CovidResultGuidance
+              result={testResult.result}
+              isPatientApp={true}
+            />
             <Trans
               t={t}
               parent="p"
@@ -104,76 +106,6 @@ const TestResult = () => {
       </main>
     </div>
   );
-};
-
-interface TestResultNotesProps {
-  result: TestResultType;
-}
-
-const TestResultNotes: React.FC<TestResultNotesProps> = (props) => {
-  const { t } = useTranslation();
-
-  switch (props.result) {
-    case COVID_RESULTS.POSITIVE:
-      return (
-        <>
-          <p>{t("testResult.notes.positive.p1")}</p>
-          <ul>
-            <li>{t("testResult.notes.positive.guidelines.li0")}</li>
-            <li>{t("testResult.notes.positive.guidelines.li1")}</li>
-            <li>{t("testResult.notes.positive.guidelines.li2")}</li>
-            <li>{t("testResult.notes.positive.guidelines.li3")}</li>
-            <li>{t("testResult.notes.positive.guidelines.li4")}</li>
-            <li>{t("testResult.notes.positive.guidelines.li5")}</li>
-          </ul>
-          <Trans
-            t={t}
-            parent="p"
-            i18nKey="testResult.notes.positive.p2"
-            components={[
-              <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">
-                Watch for symptoms and learn when to seek emergency medical
-                attention
-              </a>,
-            ]}
-          />
-          <ul>
-            <li>{t("testResult.notes.positive.emergency.li0")}</li>
-            <li>{t("testResult.notes.positive.emergency.li1")}</li>
-            <li>{t("testResult.notes.positive.emergency.li2")}</li>
-            <li>{t("testResult.notes.positive.emergency.li3")}</li>
-            <li>{t("testResult.notes.positive.emergency.li4")}</li>
-          </ul>
-          <p>{t("testResult.notes.positive.p3")}</p>
-        </>
-      );
-    case COVID_RESULTS.NEGATIVE:
-      return (
-        <>
-          <p>{t("testResult.notes.negative.p0")}</p>
-          <ul>
-            <li>{t("testResult.notes.negative.symptoms.li0")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li1")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li2")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li3")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li4")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li5")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li6")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li7")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li8")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li9")}</li>
-            <li>{t("testResult.notes.negative.symptoms.li10")}</li>
-          </ul>
-        </>
-      );
-    default:
-      return (
-        <>
-          <p>{t("testResult.notes.inconclusive.p0")}</p>
-          <p>{t("testResult.notes.inconclusive.p1")}</p>
-        </>
-      );
-  }
 };
 
 export default TestResult;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #3493 

Previous PR for this effort here: https://github.com/CDCgov/prime-simplereport/pull/3835
- Design had been previously approved by @kenieh
- Closed due to merge conflicts

## Changes Proposed
This PR should accomplish the following:
- update the printable test result view both in the SimpleReport app and the Patient Experience App to
  - include multiplex results in English and Spanish
  - include guidance based on multiplex results in English and Spanish
- update the header copy and styles of the printable test results page
- update Storybook components to include multiplex results

## Additional Information
N/A

## Testing
**Multiplex Enabled**
_SimpleReport experience_
1. Go to the "Test Results" page
2. See the print view for a variety of combination of test results (multiplex and non multiplex, corrected, duplicated, etc..)
  - check the Spanish and English translations
  - check the guidance shows up correctly
  - check the symbols next to the test results show up correctly (e.g. Positive (+), etc...)
  - ensure when you click "Print" no content is cut off
  - ensure the print view appears as defined in [Figma](https://www.figma.com/file/NPSPM5SBzQ7Ra3mmr9M9cB/SimpleReport-Public-Site?node-id=6991%3A25519)
(difference from Figma) (Based on feedback from Jayna and Emma, we will ALWAYS display the negative COVID guidance when there is a negative COVID result)
 
_Patient experience_
1. Go to the patient results section of the patient experience
2. Ensure the result still shows up (PXP copy will be changed in [this PR ](https://github.com/CDCgov/prime-simplereport/pull/3924))
3. Click "Download result"
4. Ensure step 2 of the SimpleReport experience works
5. Ensure NPI shows up and the results should appear correctly

**Multiplex Disabled**
Ensure the PXP and Test Results page print downloads continue to work

## Screenshots / Demos
Non multiplex
<img width="506" alt="Screen Shot 2022-06-30 at 5 40 01 PM" src="https://user-images.githubusercontent.com/20211771/176790685-a5b1e916-bb01-4102-bdab-6df088506103.png">

<img width="499" alt="Screen Shot 2022-06-30 at 5 44 40 PM" src="https://user-images.githubusercontent.com/20211771/176791361-61406b47-32f3-4a46-ab84-7496c037dd0e.png">

Multiplex
<img width="658" alt="Screen Shot 2022-06-30 at 5 45 43 PM" src="https://user-images.githubusercontent.com/20211771/176791403-b06dec15-7670-4de0-9439-b4cc3a4308a4.png">
<img width="657" alt="Screen Shot 2022-06-30 at 5 45 51 PM" src="https://user-images.githubusercontent.com/20211771/176791409-dc2a3675-4d8a-4828-ab7c-dd40c91fd2cd.png">

<img width="662" alt="Screen Shot 2022-06-30 at 5 50 02 PM" src="https://user-images.githubusercontent.com/20211771/176791415-93d0551f-51a7-4f08-88aa-ee3809793934.png">
<img width="659" alt="Screen Shot 2022-06-30 at 5 50 07 PM" src="https://user-images.githubusercontent.com/20211771/176791419-a4ce762f-6e08-47c3-be9b-f4fa9f36fc25.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
