### PR TITLE
Pin firefox version for Cypress.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: ${{ env.FIREFOX_VERSION }}
+          firefox-version: 101.0.1
       - name: Run e2e tests
         working-directory: ./frontend
         env:


### PR DESCRIPTION
Pins headless Cypress Firefox version to 101.0.1. It was discovered that the version of Firefox the e2e tests were using was not pinned, and an update from 101.0.1 to 102 caused e2e tests to fail.

The error was not reproducible on a desktop version of Firefox.