### PR TITLE
Update preferred-language id field to match label element

### DIFF
--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -378,7 +378,7 @@ const PersonForm = (props: Props) => {
               {t("patient.form.general.preferredLanguage")}
             </label>
             <ComboBox
-              id="preferred-language-wrapper"
+              id="preferred-language"
               defaultValue={patient.preferredLanguage || undefined}
               inputProps={{ id: "preferred-language" }}
               name="preferredLanguage"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Accessibility issue surfaced by end-user during self-registration

## Changes Proposed

- Change the `id` element on the preferred language ComboBox to match the `label` provided for the element above - otherwise, the ComboBox elements are not labelled properly.

## Testing

- How should reviewers verify this PR?
 
## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README