### PR TITLE
Johanna/result table nullpointer fix

### DIFF
--- a/frontend/src/app/testResults/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.tsx
@@ -113,12 +113,12 @@ export const DetachedTestResultDetailsModal = ({ data, closeModal }: Props) => {
     results &&
     results.some((d) => d.disease.name !== "COVID-19");
   if (hasMultiplexResults) {
-    displayResult["fluAResult"] = results.filter(
+    displayResult["fluAResult"] = results?.filter(
       (d) => d.disease.name === "Flu A"
-    )[0].testResult;
-    displayResult["fluBResult"] = results.filter(
+    )?.[0]?.testResult;
+    displayResult["fluBResult"] = results?.filter(
       (d) => d.disease.name === "Flu B"
-    )[0].testResult;
+    )?.[0]?.testResult;
   }
   return (
     <Modal

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
@@ -103,9 +103,9 @@ const generateResultRows = (
     const getResultCell = (disease: string) => {
       let result;
       if (r.results && r.results.length > 1) {
-        result = r.results.find(
+        result = r.results?.find(
           (result: any) => result.disease.name === disease
-        ).testResult;
+        )?.testResult;
       }
       if (result) {
         return TEST_RESULT_DESCRIPTIONS[result as Results];

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -12,7 +12,7 @@ function getResultByDiseaseName(
   results: MultiplexResult[],
   diseaseName: string
 ) {
-  const resultObj = results.find((result: MultiplexResult) => {
+  const resultObj = results?.find((result: MultiplexResult) => {
     return result.disease.name.includes(diseaseName);
   });
   if (resultObj) {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Informal fix to handle null pointer exceptions that are breaking the application at runtime when multiplex results are incomplete. These exceptions are happening in the results view across various functionalities like: results table, print modal and details modal.

## Changes Proposed

Add optional chaining so code does not attempt to execute array operations on null objects.

## Additional Information
No new testing has been added to this PR but I made sure regression testing passes.

## Testing
Open a multiplex test only mark results for covid and flub then switch to a regular covid test and submit. Go to the results table and verify application does not break. Open print and details modal and verify application does not break in those instances either.
 