### PR TITLE
Stop hanging end-to-end tests when navigating between different pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 certs/
 yarn-error.log
 backend/locust/__pycache__/
+frontend/cypress.env.json

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To run the integration tests locally, you'll need the following files set up:
 ```
 
 ```
-# frontend/cypresss.env.json
+# frontend/cypress.env.json
 {
   "OKTA_USERNAME": "",
   "OKTA_PASSWORD": "",
@@ -169,9 +169,9 @@ To run the integration tests locally, you'll need the following files set up:
 }
 ```
 
-You'll also need address validation through Smarty to be working:
-- `REACT_APP_SMARTY_STREETS_KEY` must be set in `frontend/.env.local`
-- your backend configuration needs to have the environment variables `SMARTY_AUTH_ID` and `SMARTY_AUTH_TOKEN` set
+You'll also need the following environment variables set for the backend configuration:
+- `SMARTY_AUTH_ID`
+- `SMARTY_AUTH_TOKEN`
 
 Ask another developer for the Okta and Smarty secrets to populate the environment variables.
 

--- a/README.md
+++ b/README.md
@@ -148,11 +148,18 @@ E2E/Integration tests are available using [Cypress](https://www.cypress.io/).
 
 #### Requirements:
 
-These files required to run integration tests.
+To run the integration tests locally, you'll need:
 - `frontend/.env.local`
 - `frontend/cypress/.env.e2e`
-  - only used when running the end-to-end tests with Docker
+  - only required when running the end-to-end tests with Docker
 - `/etc/hosts`
+- `frontend/cypress.env.json`
+  - only required if running with Okta
+
+```
+# frontend/.env.local
+
+```
 
 ```
 # frontend/cypress/.env.e2e
@@ -162,13 +169,21 @@ REACT_APP_OKTA_ENABLED=true
 REACT_APP_OKTA_URL=http://localhost:8088
 ```
 
-The `frontend/.env.local` file has a template at `frontend/cypress/.env.e2e.sample`. Reach out to another developer to get proper values for these secrets.
-
 ```
 # /etc/hosts
 # add the following line
 127.0.0.1 localhost.simplereport.gov
 ```
+
+```
+# frontend/cypresss.env.json
+{
+  "OKTA_USERNAME": "",
+  "OKTA_PASSWORD": "",
+  "OKTA_SECRET": ""
+}
+```
+Ask another developer for the Okta secrets to populate this file.
 
 #### Running Cypress
 Now that you have those files set up, you are ready for a test run! There are a few ways to run the tests from the `frontend` directory, including:
@@ -179,7 +194,7 @@ Now that you have those files set up, you are ready for a test run! There are a 
     - the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _dev_ profile set for the backend
     - `REACT_APP_OKTA_ENABLED=false` in `frontend/.env.local`
 - `yarn e2e:local:okta`
-  - Same as `yarn e2e:local`, except that specs with a login step will log in to Okta using the credentials from `.env.local`.
+  - Same as `yarn e2e:local`, except that specs with a login step will log in to Okta
   - Prerequisite(s):
     - the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _okta_local_ and _local_ profiles set for the backend
     - `REACT_APP_OKTA_ENABLED=true` in `frontend/.env.local`
@@ -197,7 +212,14 @@ Now that you have those files set up, you are ready for a test run! There are a 
   - This will run cypress with default values and display Cypress, API, DB, Frontend, and Nginx logs.
 -->
 
-Note that our Cypress tests expect there to only be 1 facility and will fail if there are multiple. Additionally, tests are expected to be run in order, so some spec files rely on data generated in previous specs.
+#### Caveats and known gotchas
+Our e2e are currently very state-dependent, so here are some things to keep in mind when running:
+- tests are expected to be run in order and some specs are dependent on the state produced by previous specs, for example:
+  - `03-conduct_test_spec.js` uses the patient created in `02-add_patient_spec.js`
+  - `04-get_result_from_patient_link_spec.js` uses the patient link generated in `03-conduct_test_spec.js`
+- our tests expect there to only be 1 facility and will fail if there are multiple facilities for whatever org the test user is authenticated into
+- `00-health_check.js` is used in our CI to check that the app is up but fails when running locally with either of the commands listed here
+- `01-organization_sign_up_spec.js` is not re-runnable
 
 See the [Cypress documentation](https://docs.cypress.io/api/table-of-contents) for writing new tests. If you need to generate new Wiremock mappings for external services, see [this wiki page](https://github.com/CDCgov/prime-simplereport/wiki/WireMock).
 

--- a/README.md
+++ b/README.md
@@ -148,30 +148,15 @@ E2E/Integration tests are available using [Cypress](https://www.cypress.io/).
 
 #### Requirements:
 
-To run the integration tests locally, you'll need:
+To run the integration tests locally, you'll need the following files set up:
 - `frontend/.env.local`
-- `frontend/cypress/.env.e2e`
-  - only required when running the end-to-end tests with Docker
 - `/etc/hosts`
 - `frontend/cypress.env.json`
   - only required if running with Okta
-
-```
-# frontend/.env.local
-
-```
-
-```
-# frontend/cypress/.env.e2e
-REACT_APP_BASE_URL=http://localhost.simplereport.gov
-REACT_APP_BACKEND_URL=http://localhost.simplereport.gov/api
-REACT_APP_OKTA_ENABLED=true
-REACT_APP_OKTA_URL=http://localhost:8088
-```
-
+  
 ```
 # /etc/hosts
-# add the following line
+# add the following line if running with Okta
 127.0.0.1 localhost.simplereport.gov
 ```
 
@@ -183,22 +168,38 @@ REACT_APP_OKTA_URL=http://localhost:8088
   "OKTA_SECRET": ""
 }
 ```
-Ask another developer for the Okta secrets to populate this file.
+
+You'll also need address validation through Smarty to be working:
+- `REACT_APP_SMARTY_STREETS_KEY` must be set in `frontend/.env.local`
+- your backend configuration needs to have the environment variables `SMARTY_AUTH_ID` and `SMARTY_AUTH_TOKEN` set
+
+Ask another developer for the Okta and Smarty secrets to populate the environment variables.
 
 #### Running Cypress
-Now that you have those files set up, you are ready for a test run! There are a few ways to run the tests from the `frontend` directory, including:
+Now that you have your environment set up, you are ready for a test run! There are a few ways to run the tests from the `frontend` directory, including:
 
 - `yarn e2e:local`
   - This will open an interactive test runner that lets you select browsers and run your desired specs.
   - Prerequisite(s):
-    - the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _dev_ profile set for the backend
+    - the app must be running locally with the frontend base URL set to `http://localhost:3000` and backend running with the _dev_ profile
     - `REACT_APP_OKTA_ENABLED=false` in `frontend/.env.local`
 - `yarn e2e:local:okta`
-  - Same as `yarn e2e:local`, except that specs with a login step will log in to Okta
+  - Same as `yarn e2e:local`, except that specs with a login step will log in to Okta. This is more similar to how the tests run in our GitHub PR workflow.
   - Prerequisite(s):
-    - the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _okta_local_ and _local_ profiles set for the backend
+    - the app must be running [locally with Okta](https://github.com/CDCgov/prime-simplereport/wiki/Running-outside-of-docker#running-locally-with-okta) with the frontend base URL set to `http://localhost:3000` and the backend running with the _okta-local_ and _local_ profiles
     - `REACT_APP_OKTA_ENABLED=true` in `frontend/.env.local`
+
 <!-- Dockerized end-to-end tests are currently broken
+Dockerized end-to-end tests require the following file:
+```
+# frontend/cypress/.env.e2e
+REACT_APP_BASE_URL=http://localhost.simplereport.gov
+REACT_APP_BACKEND_URL=http://localhost.simplereport.gov/api
+REACT_APP_OKTA_ENABLED=true
+REACT_APP_OKTA_URL=http://localhost:8088
+```
+
+To run the end-to-end tests in Docker:
 - `yarn e2e`
   - This will run cypress with default values and display Cypress logs.
 - `yarn e2e:open`
@@ -212,14 +213,17 @@ Now that you have those files set up, you are ready for a test run! There are a 
   - This will run cypress with default values and display Cypress, API, DB, Frontend, and Nginx logs.
 -->
 
-#### Caveats and known gotchas
-Our e2e are currently very state-dependent, so here are some things to keep in mind when running:
+#### Troubleshooting
+Our e2e tests are currently very state-dependent, so here are some things to keep in mind when running:
 - tests are expected to be run in order and some specs are dependent on the state produced by previous specs, for example:
   - `03-conduct_test_spec.js` uses the patient created in `02-add_patient_spec.js`
   - `04-get_result_from_patient_link_spec.js` uses the patient link generated in `03-conduct_test_spec.js`
+  - `08-save_and_start_test_spec.js` uses the patient created in `02-add_patient_spec.js` and expects them to not have any tests in progress
 - our tests expect there to only be 1 facility and will fail if there are multiple facilities for whatever org the test user is authenticated into
+  - when running the tests with Okta, the test user Cypress McTestUser has admin access to an org with external ID `DAT_ORG`, which with our default sample data will have 2 facilities
 - `00-health_check.js` is used in our CI to check that the app is up but fails when running locally with either of the commands listed here
 - `01-organization_sign_up_spec.js` is not re-runnable
+- `05-self_registration_spec.js` expects the org your test user is in to have a patient registration link generated
 
 See the [Cypress documentation](https://docs.cypress.io/api/table-of-contents) for writing new tests. If you need to generate new Wiremock mappings for external services, see [this wiki page](https://github.com/CDCgov/prime-simplereport/wiki/WireMock).
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ E2E/Integration tests are available using [Cypress](https://www.cypress.io/).
 These files required to run integration tests.
 - `frontend/.env.local`
 - `frontend/cypress/.env.e2e`
+  - only used when running the end-to-end tests with Docker
 - `/etc/hosts`
 
 ```
@@ -174,10 +175,14 @@ Now that you have those files set up, you are ready for a test run! There are a 
 
 - `yarn e2e:local`
   - This will open an interactive test runner that lets you select browsers and run your desired specs.
-  - Prerequisite(s): the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _dev_ profile set for the backend
+  - Prerequisite(s):
+    - the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _dev_ profile set for the backend
+    - `REACT_APP_OKTA_ENABLED=false` in `frontend/.env.local`
 - `yarn e2e:local:okta`
-  - Same as `yarn e2e:local`, except that specs with a login step will log in to Okta.
-  - Prerequisite(s): in addition to the prereqs for `yarn e2e:local`, the app must be running with Okta enabled
+  - Same as `yarn e2e:local`, except that specs with a login step will log in to Okta using the credentials from `.env.local`.
+  - Prerequisite(s):
+    - the app must be running locally with the frontend base URL set to `http://localhost:3000` and the _okta_local_ and _local_ profiles set for the backend
+    - `REACT_APP_OKTA_ENABLED=true` in `frontend/.env.local`
 <!-- Dockerized end-to-end tests are currently broken
 - `yarn e2e`
   - This will run cypress with default values and display Cypress logs.

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -106,6 +106,8 @@ simple-report-initialization:
       organization-external-id: DIS_ORG
     - patient-registration-link: t37ft
       facility-name: Testing Site
+    - patient-registration-link: dat-org
+      organization-external-id: DAT_ORG
 simple-report:
   demo-users:
     site-admin-emails:

--- a/frontend/cypress/integration/08-save_and_start_test_spec.js
+++ b/frontend/cypress/integration/08-save_and_start_test_spec.js
@@ -77,6 +77,7 @@ describe("add patient and save and start test", () => {
       '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
     ).click();
     cy.get(".modal__container #save-confirmed-address").click();
+    cy.url().should("include", "queue");
   });
   it("verifies patient contact info is correctly populated in the AoE form", () => {
     cy.get('input[name="testResultDeliverySms"][value="SMS"]').should(
@@ -116,9 +117,9 @@ describe("edit patient from test queue", () => {
     cy.get('input[value="female"]+label').click();
     cy.get(".prime-save-patient-changes").first().click();
     cy.get(".ReactModal__Content").should("not.exist");
+    cy.url().should("include", "queue");
   });
   it("verifies test queue page with test card highlighted", () => {
-    cy.url().should("include", "queue");
     cy.get(".prime-queue-item__info").contains(patientName);
   });
 });

--- a/frontend/cypress/integration/08-save_and_start_test_spec.js
+++ b/frontend/cypress/integration/08-save_and_start_test_spec.js
@@ -107,25 +107,25 @@ describe("add patient and save and start test", () => {
 });
 
 describe("edit patient from test queue", () => {
-  it("navigates to test queue and clicks on patient name", () => {
+  it("navigates to test queue and edits patient", () => {
     cy.visit("/");
     cy.get(".usa-nav-container");
     cy.get("#desktop-conduct-test-nav-link").click();
     cy.get(".card-name").contains(patientName).click();
-  });
-  it("edits the patient and clicks save changes", () => {
     cy.get('input[value="female"]+label').click();
+  });
+  it("clicks save changes and verifies test queue redirect", () => {
     cy.get(".prime-save-patient-changes").first().click();
     cy.get(".ReactModal__Content").should("not.exist");
     cy.url().should("include", "queue");
   });
-  it("verifies test queue page with test card highlighted", () => {
+  it("verifies test card highlighted", () => {
     cy.get(".prime-queue-item__info").contains(patientName);
   });
 });
 
 describe("start test from people page for patient already in queue", () => {
-  it("navigates to people page and selects Start test", () => {
+  it("navigates to people page, selects Start test, and verifies link to test queue", () => {
     cy.visit("/");
     cy.get(".usa-nav-container");
     cy.get("#desktop-patient-nav-link").click();
@@ -133,9 +133,9 @@ describe("start test from people page for patient already in queue", () => {
     cy.contains("tr", patientName).find(".sr-actions-menu").click();
     cy.contains("Start test").click();
     cy.get(".ReactModal__Content").should("not.exist");
-  });
-  it("verifies test queue page with test card highlighted", () => {
     cy.url().should("include", "queue");
+  });
+  it("verifies test card highlighted", () => {
     cy.get(".prime-queue-item__info").contains(patientName);
   });
 });


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

End-to-end tests have been hanging, mostly during `08-save_and_start_test_spec.js` but sometimes during `02-add_patient_spec.js`. Cypress clears local storage between test blocks, so when running with Okta, we save local storage (which includes the Okta access token) after each test block and then restore it again before each test block. I think what happens is if you are loading a new page of the app while switching to a new test block, sometimes Cypress will try to load the page while you do not have the access token restored yet. Then you get redirected to the Okta login page, which breaks the expected user flow and the test sits and waits for the expected page to load.

## Changes Proposed

* move test steps around so we're not loading a new page while local storage is being cleared and reloaded
* updated README to hopefully clarify how to run e2e locally

## Additional Information

- `02-add_patient_spec.js` used to hang sometimes, but it was before I updated our workflow to save the Cypress screenshots on timeout, so I can't tell where I need to fix things in that file. Will keep an eye out for additional timeout failures in that spec.

## Testing

Run, rerun, rerun again the end-to-end tests and verify they pass.
 
## Screenshots / Demos

n/a

## Checklist for Author and Reviewer

### Design
- [n/a] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [n/a] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [n/a] Any content changes have been approved by content team

### Support
- [n/a] Any changes that might generate new support requests have been flagged to the support team
- [n/a] Any changes to support infrastructure have been demo'd to support team

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

### Documentation
- [n/a] Any changes to the startup configuration have been documented in the README