### PR TITLE
Manage devices update

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/UpdateDeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/UpdateDeviceType.java
@@ -15,4 +15,5 @@ public class UpdateDeviceType {
   private String loincCode;
   private List<UUID> swabTypes;
   private List<UUID> supportedDiseases;
+  private int testLength;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -104,6 +104,9 @@ public class DeviceTypeService {
       device.setName(updateDevice.getName());
       device.setTestLength((determineTestLength(updateDevice.getName())));
     }
+    if (updateDevice.getTestLength() > 0) {
+      device.setTestLength(updateDevice.getTestLength());
+    }
     if (updateDevice.getManufacturer() != null) {
       device.setManufacturer(updateDevice.getManufacturer());
     }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -73,6 +73,7 @@ input UpdateDeviceType {
   loincCode: String!
   swabTypes: [ID!]!
   supportedDiseases: [ID!]!
+  testLength: Int!
 }
 
 type DeviceType {

--- a/frontend/src/app/supportAdmin/DeviceType/ManageDevicesForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/ManageDevicesForm.tsx
@@ -62,6 +62,7 @@ const ManageDevicesForm: React.FC<Props> = ({
             device.supportedDiseases?.map((disease) => disease.internalId) ||
             [],
           loincCode: device.loincCode,
+          testLength: device.testLength ? device.testLength : 0,
         }
       : undefined;
   };
@@ -97,7 +98,7 @@ const ManageDevicesForm: React.FC<Props> = ({
               <div className="grid-row grid-gap">
                 <div className="tablet:grid-col">
                   <Select
-                    label="Device name"
+                    label="Select device"
                     name="name"
                     value={selectedDevice?.internalId || ""}
                     options={getDeviceNames()}
@@ -113,21 +114,13 @@ const ManageDevicesForm: React.FC<Props> = ({
                     required
                   />
                 </div>
+              </div>
+              <div className="grid-row grid-gap">
                 <div className="tablet:grid-col">
                   <TextInput
-                    label="Manufacturer"
-                    name="manufacturer"
-                    value={selectedDevice?.manufacturer}
-                    onChange={onChange}
-                    disabled={!selectedDevice}
-                    required
-                  />
-                </div>
-                <div className="tablet:grid-col">
-                  <TextInput
-                    label="LOINC code"
-                    name="loincCode"
-                    value={selectedDevice?.loincCode}
+                    label="Device name"
+                    name="deviceName"
+                    value={selectedDevice?.name}
                     onChange={onChange}
                     disabled={!selectedDevice}
                     required
@@ -140,6 +133,43 @@ const ManageDevicesForm: React.FC<Props> = ({
                     label="Model"
                     name="model"
                     value={selectedDevice?.model}
+                    onChange={onChange}
+                    disabled={!selectedDevice}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="grid-row grid-gap">
+                <div className="tablet:grid-col">
+                  <TextInput
+                    label="Manufacturer"
+                    name="manufacturer"
+                    value={selectedDevice?.manufacturer}
+                    onChange={onChange}
+                    disabled={!selectedDevice}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="grid-row grid-gap">
+                <div className="tablet:grid-col">
+                  <TextInput
+                    label="LOINC code"
+                    name="loincCode"
+                    value={selectedDevice?.loincCode}
+                    onChange={onChange}
+                    disabled={!selectedDevice}
+                    required
+                  />
+                </div>
+                <div className="tablet:grid-col">
+                  <TextInput
+                    type={"number"}
+                    label="Test Length"
+                    name="testLength"
+                    min={0}
+                    max={60}
+                    value={selectedDevice?.testLength.toString()}
                     onChange={onChange}
                     disabled={!selectedDevice}
                     required

--- a/frontend/src/app/supportAdmin/DeviceType/operations.graphql
+++ b/frontend/src/app/supportAdmin/DeviceType/operations.graphql
@@ -28,6 +28,7 @@ mutation updateDeviceType(
   $loincCode: String!
   $swabTypes: [ID!]!
   $supportedDiseases: [ID!]!
+  $testLength: Int!
 ) {
   updateDeviceType(
     input: {
@@ -38,6 +39,7 @@ mutation updateDeviceType(
       loincCode: $loincCode
       swabTypes: $swabTypes
       supportedDiseases: $supportedDiseases
+      testLength: $testLength
     }
   ) {
     internalId
@@ -59,6 +61,7 @@ query getDeviceTypeList{
     loincCode,
     manufacturer,
     model,
+    testLength,
     swabTypes {
       internalId,
       name

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1004,6 +1004,7 @@ export type UpdateDeviceType = {
   name: Scalars["String"];
   supportedDiseases: Array<Scalars["ID"]>;
   swabTypes: Array<Scalars["ID"]>;
+  testLength: Scalars["Int"];
 };
 
 export type UploadResponse = {
@@ -1727,6 +1728,7 @@ export type UpdateDeviceTypeMutationVariables = Exact<{
   loincCode: Scalars["String"];
   swabTypes: Array<Scalars["ID"]> | Scalars["ID"];
   supportedDiseases: Array<Scalars["ID"]> | Scalars["ID"];
+  testLength: Scalars["Int"];
 }>;
 
 export type UpdateDeviceTypeMutation = {
@@ -1760,6 +1762,7 @@ export type GetDeviceTypeListQuery = {
     loincCode: string;
     manufacturer: string;
     model: string;
+    testLength?: number | null | undefined;
     swabTypes: Array<{
       __typename?: "SpecimenType";
       internalId: string;
@@ -4992,6 +4995,7 @@ export const UpdateDeviceTypeDocument = gql`
     $loincCode: String!
     $swabTypes: [ID!]!
     $supportedDiseases: [ID!]!
+    $testLength: Int!
   ) {
     updateDeviceType(
       input: {
@@ -5002,6 +5006,7 @@ export const UpdateDeviceTypeDocument = gql`
         loincCode: $loincCode
         swabTypes: $swabTypes
         supportedDiseases: $supportedDiseases
+        testLength: $testLength
       }
     ) {
       internalId
@@ -5033,6 +5038,7 @@ export type UpdateDeviceTypeMutationFn = Apollo.MutationFunction<
  *      loincCode: // value for 'loincCode'
  *      swabTypes: // value for 'swabTypes'
  *      supportedDiseases: // value for 'supportedDiseases'
+ *      testLength: // value for 'testLength'
  *   },
  * });
  */
@@ -5123,6 +5129,7 @@ export const GetDeviceTypeListDocument = gql`
       loincCode
       manufacturer
       model
+      testLength
       swabTypes {
         internalId
         name


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #3415 - Making Device name and Test length editable.

## Changes Proposed

- Add two new fields to the Update UI - update Graphql mutations & queries as necessary.

## Testing

- How should reviewers verify this PR?
    Run the app, attempt to update a Test device - go to start a test using that device and verify that the timer reflects the updated test length.
 
## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README