### PR TITLE
Added change set to create feature-flags table and insert multiplex flag

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4027,7 +4027,7 @@ databaseChangeLog:
   - changeSet:
       id: create-feature-flag-table
       author: johanna@skylight.digital
-      comment: creates the feature flag table which will host feature flags feature flags to control visibility of features at the application level
+      comment: creates the feature flag table which will host flags that control visibility of features at the application level
       changes:
         - tagDatabase:
             tag: create-feature-flag-table-with-multiplex-flag

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4030,7 +4030,7 @@ databaseChangeLog:
       comment: creates the feature flag table which will host feature flags feature flags to control visibility of features at the application level
       changes:
         - tagDatabase:
-            tag: create-feature-flag-table and insert multiplex flag
+            tag: create-feature-flag-table-with-multiplex-flag
         - createTable:
             tableName: feature_flag
             remarks: feature flags to control visibility of features at the application level.
@@ -4105,4 +4105,4 @@ databaseChangeLog:
               FROM migration_user
       rollback:
         dropTable:
-          tableName: ${database.defaultSchemaName}.feature_flag
+          tableName: feature_flag

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4030,7 +4030,7 @@ databaseChangeLog:
       comment: creates the feature flag table which will host flags that control visibility of features at the application level
       changes:
         - tagDatabase:
-            tag: create-feature-flag-table-with-multiplex-flag
+            tag: create-feature-flag-table
         - createTable:
             tableName: feature_flag
             remarks: feature flags to control visibility of features at the application level.
@@ -4084,6 +4084,16 @@ databaseChangeLog:
                     foreignKeyName: fk__anyentity__updated_by
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.feature_flag TO ${noPhiUsername};
+      rollback:
+        dropTable:
+          tableName: feature_flag
+  - changeSet:
+      id: insert-multiplex-flag
+      author: johanna@skylight.digital
+      comment: inserts multiplex flag in table
+      changes:
+        - tagDatabase:
+            tag: insert-multiplex-flag
         - sql:
             remarks: Insert multiplexEnabled flag with value equal true.
             sql: |
@@ -4104,5 +4114,5 @@ databaseChangeLog:
                 migration_user_id
               FROM migration_user
       rollback:
-        dropTable:
+        truncateTable:
           tableName: feature_flag

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4024,3 +4024,85 @@ databaseChangeLog:
               WHERE ${database.defaultSchemaName}.result.test_event_id IS NULL AND t.result IS NOT NULL;
       rollback:
         sql: SELECT 'foo';
+  - changeSet:
+      id: create-feature-flag-table
+      author: johanna@skylight.digital
+      comment: creates the feature flag table which will host feature flags feature flags to control visibility of features at the application level
+      changes:
+        - tagDatabase:
+            tag: create-feature-flag-table and insert multiplex flag
+        - createTable:
+            tableName: feature_flag
+            remarks: feature flags to control visibility of features at the application level.
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: text
+                  remarks: The name of the flag. It should describe the feature it represents.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: value
+                  type: boolean
+                  remarks: The value of the flag. It indicates if the feature is enable or disable for the app.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  remarks: The creation timestamp for this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: uuid
+                  remarks: The user who created this entity.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__anyentity__created_by
+                    references: api_user
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  remarks: The timestamp for the most recent update of this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_by
+                  type: uuid
+                  remarks: The user who most recently updated this entity.
+                  constraints:
+                    nullable: false
+                    references: api_user
+                    foreignKeyName: fk__anyentity__updated_by
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.feature_flag TO ${noPhiUsername};
+        - sql:
+            remarks: Insert multiplexEnabled flag with value equal true.
+            sql: |
+              WITH migration_user as (
+                 SELECT internal_id as migration_user_id
+                 FROM ${database.defaultSchemaName}.api_user
+                 WHERE login_email = '${migrations_user_email}'
+               )
+              INSERT INTO ${database.defaultSchemaName}.feature_flag (internal_id, name, value,
+              created_at, created_by, updated_at, updated_by)
+              SELECT
+                gen_random_uuid(),
+                'multiplexEnabled',
+                true,
+                now(),
+                migration_user_id,
+                now(),
+                migration_user_id
+              FROM migration_user
+      rollback:
+        dropTable:
+          tableName: ${database.defaultSchemaName}.feature_flag


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

DB implementation for #3905 

## Changes Proposed

- Creates a new table feature_flag and inserts the multiplexEnabled feature flag 

## Testing

Verify feature_flag table gets created and a row for multiplexEnabled flag displays

## Checklist for Primary Reviewer

- [X] Only database changes are included in this PR
- [X] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [X] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [X] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [X] Rollback has been verifed locally and in a deployed environment
- [X] Any changes to the startup configuration have been documented in the README
