### PR TITLE
PendingOrganization query to only return unverified organizations in queue

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
 /** Resolver for {@link Organization} related queries */
@@ -66,17 +65,8 @@ public class OrganizationResolver implements GraphQLQueryResolver {
    * @return a list of pending organizations
    */
   public List<ApiPendingOrganization> getPendingOrganizations() {
-    List<ApiPendingOrganization> pendingOrgsAlreadyCreated =
-        _organizationService.getOrganizations(false).stream()
-            .map(ApiPendingOrganization::new)
-            .collect(Collectors.toList());
-
-    List<ApiPendingOrganization> pendingOrgsInQueue =
-        _organizationQueueService.getUnverifiedQueuedOrganizations().stream()
-            .map(ApiPendingOrganization::new)
-            .collect(Collectors.toList());
-
-    return Stream.concat(pendingOrgsAlreadyCreated.stream(), pendingOrgsInQueue.stream())
+    return _organizationQueueService.getUnverifiedQueuedOrganizations().stream()
+        .map(ApiPendingOrganization::new)
         .collect(Collectors.toList());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -168,18 +168,16 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
     TestUserIdentities.withUser(
         TestUserIdentities.SITE_ADMIN_USER,
         () -> {
-          Organization org = _dataFactory.createUnverifiedOrg();
+          _dataFactory.createUnverifiedOrg();
           OrganizationQueueItem orgQueueItem = _dataFactory.createOrganizationQueueItem();
           useSuperUser();
 
-          // Get all pending orgs and queue items
+          // Get all queue items
           ObjectNode result = runQuery("get-pending-organizations");
           ArrayNode pendingOrgs = (ArrayNode) result.path("pendingOrganizations");
-          assertEquals(2, pendingOrgs.size());
+          assertEquals(1, pendingOrgs.size());
           JsonNode firstEntry = pendingOrgs.get(0);
-          JsonNode secondEntry = pendingOrgs.get(1);
-          assertEquals(org.getExternalId(), firstEntry.path("externalId").asText());
-          assertEquals(orgQueueItem.getExternalId(), secondEntry.path("externalId").asText());
+          assertEquals(orgQueueItem.getExternalId(), firstEntry.path("externalId").asText());
         });
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -1,0 +1,43 @@
+package gov.cdc.usds.simplereport.api.organization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.api.model.ApiPendingOrganization;
+import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
+import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
+import gov.cdc.usds.simplereport.service.OrganizationQueueService;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class OrganizationResolverTest {
+  @Mock OrganizationQueueService mockedOrganizationQueueService;
+
+  @InjectMocks OrganizationResolver organizationMutationResolver;
+
+  @Test
+  void getPendingOrganizations_success() {
+    // GIVEN
+    var orgQueueItem = new OrganizationQueueItem();
+    orgQueueItem.editOrganizationQueueItem("OrgName", "0123", new OrganizationAccountRequest());
+    List<OrganizationQueueItem> orgQueueItems = List.of(orgQueueItem);
+
+    when(mockedOrganizationQueueService.getUnverifiedQueuedOrganizations())
+        .thenReturn(orgQueueItems);
+    var expected =
+        orgQueueItems.stream().map(ApiPendingOrganization::new).collect(Collectors.toList());
+
+    // WHEN
+    var result = organizationMutationResolver.getPendingOrganizations();
+
+    // THEN
+    assertThat(expected).hasSameSizeAs(result);
+    assertThat(expected.get(0).getExternalId()).isEqualTo(result.get(0).getExternalId());
+  }
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

[- Why is this being done? Link to issue, or a few sentences describing why this PR exists]: #
- Organizations are not created until after they are verified since November 2021, this PR is to remove those unverified organizations from the PendingOrganizations query and only return unverified organizations that are in the queue.
- [View Open Issue here](https://github.com/CDCgov/prime-simplereport/issues/2927)

## Changes Proposed

- PendingOrganizations query should only return unverified organizations in the queue. 

## Additional Information

## Testing

- Review the tests added/modified

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
