### PR TITLE
add warning stylings when a test card is dated > 6 months ago

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.scss
+++ b/frontend/src/app/testQueue/QueueItem.scss
@@ -30,6 +30,14 @@
     padding: 0.5rem 0 0.5rem 15px;
   }
 
+  .card-correction-label {
+    color: #ffbe2e;
+  }
+
+  .card-correction-input {
+    border: 1px solid #ffbe2e;
+  }
+
   .card-test-input {
     height: 34px;
     margin-right: 12px;

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -33,6 +33,7 @@ jest.mock("react-router-dom", () => {
 
 const initialDateString = "2021-02-14";
 const updatedDateString = "2021-03-10";
+const dateStringBeforeWarningThreshold = "2001-01-01";
 const updatedTimeString = "10:05";
 const fakeDate = Date.parse(initialDateString);
 const updatedDate = Date.parse(updatedDateString);
@@ -733,6 +734,46 @@ describe("QueueItem", () => {
     await waitFor(async () => {
       expect(await screen.findByText("Invalid test date")).toBeInTheDocument();
     });
+  });
+
+  it("formats card with warning state if selected date input is more than six months ago", async () => {
+    render(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Provider store={store}>
+            <QueueItem
+              internalId={testProps.internalId}
+              patient={testProps.patient}
+              askOnEntry={testProps.askOnEntry}
+              selectedDeviceId={testProps.selectedDeviceId}
+              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
+              selectedDeviceSpecimenTypeId={
+                testProps.selectedDeviceSpecimenTypeId
+              }
+              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
+              selectedTestResults={testProps.selectedTestResults}
+              devices={testProps.devices}
+              refetchQueue={testProps.refetchQueue}
+              facilityId={testProps.facilityId}
+              dateTestedProp={testProps.dateTestedProp}
+              facilityName="Foo facility"
+              setStartTestPatientId={setStartTestPatientIdMock}
+              startTestPatientId=""
+            />
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    const dateInput = screen.getByTestId("test-date");
+    const timeInput = screen.getByTestId("test-time");
+
+    userEvent.type(dateInput, `${dateStringBeforeWarningThreshold}T00:00`);
+    const testCard = await screen.findByTestId(`test-card-${internalId}`);
+
+    expect(testCard).toHaveClass("prime-queue-item__ready");
+    expect(dateInput).toHaveClass("card-correction-input");
+    expect(timeInput).toHaveClass("card-correction-input");
+    expect(screen.getByTestId("test-correction-header")).toBeInTheDocument();
   });
 
   it("highlights the test card where the validation failure occurs", async () => {

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -609,6 +609,12 @@ const QueueItem = ({
     // if we want to use a custom date
     if (shouldUseCurrentDateTime()) {
       updateUseCurrentDateTime("false");
+
+      // reset the date fields to their default values
+      const defaultDateString = formatDate(moment().toDate());
+      (document.getElementById(
+        "test-date"
+      ) as HTMLInputElement).value = defaultDateString;
     }
     // if we want to use the current date time
     else {
@@ -689,8 +695,6 @@ const QueueItem = ({
     onDateTestedChange(newDate);
   };
 
-  const selectedDate = dateTested ? moment(dateTested) : moment();
-
   const timer = useTestTimer(internalId, deviceTestLength);
 
   function cardColorDisplay() {
@@ -730,6 +734,7 @@ const QueueItem = ({
     patientId: patient.internalId,
     testOrderId: internalId,
   };
+  const selectedDate = dateTested ? moment(dateTested) : moment();
 
   return (
     <React.Fragment>

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -166,7 +166,7 @@ const QueueItem = ({
   facilityName,
   facilityId,
   dateTestedProp,
-  isCorrection,
+  isCorrection = false,
   reasonForCorrection,
 }: QueueItemProps) => {
   const appInsights = getAppInsights();

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -489,6 +489,7 @@ const QueueItem = ({
     // Save any date given as input to React state, valid or otherwise. Validation
     // is performed on submit
     updateDateTested(newDateTested);
+    setSelectedDate(date);
   };
 
   const isMounted = useRef(false);
@@ -608,13 +609,8 @@ const QueueItem = ({
   const onUseCurrentDateChange = () => {
     // if we want to use a custom date
     if (shouldUseCurrentDateTime()) {
+      setSelectedDate(moment());
       updateUseCurrentDateTime("false");
-
-      // reset the date fields to their default values
-      const defaultDateString = formatDate(moment().toDate());
-      (document.getElementById(
-        "test-date"
-      ) as HTMLInputElement).value = defaultDateString;
     }
     // if we want to use the current date time
     else {
@@ -666,6 +662,11 @@ const QueueItem = ({
   const [dateBeforeWarnThreshold, setBeforeDateWarning] = useState(
     isBeforeDateWarningThreshold(moment(dateTested))
   );
+
+  const [selectedDate, setSelectedDate] = useState(
+    dateTested ? moment(dateTested) : moment()
+  );
+
   const handleDateChange = (date: string) => {
     if (date) {
       const newDate = moment(date)
@@ -682,7 +683,6 @@ const QueueItem = ({
       ) {
         setBeforeDateWarning(false);
       }
-
       onDateTestedChange(newDate);
     }
   };
@@ -734,7 +734,6 @@ const QueueItem = ({
     patientId: patient.internalId,
     testOrderId: internalId,
   };
-  const selectedDate = dateTested ? moment(dateTested) : moment();
 
   return (
     <React.Fragment>
@@ -847,7 +846,7 @@ const QueueItem = ({
                         type="date"
                         min={formatDate(new Date("Jan 1, 2020"))}
                         max={formatDate(moment().toDate())}
-                        defaultValue={formatDate(selectedDate.toDate())}
+                        value={formatDate(selectedDate.toDate())}
                         onChange={(event) =>
                           handleDateChange(event.target.value)
                         }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #3792 

## Changes Proposed

- Applies the existing warning styling if a queue item is backdated more than 6 months from the current date 

## Additional Information

## Testing

- Ensure the UX of the deployed instance works as expected.
- Verify new tests are ok 

## Screenshots / Demos

https://user-images.githubusercontent.com/29645040/179770789-bcc5f0b1-c824-42b2-8c9a-0402bcf6c32f.mov

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team
