### PR TITLE
Add "Result reported date" to the download CSV (#3793)

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
@@ -27,6 +27,10 @@ public class ApiTestOrder extends WrappedEntity<TestOrder> {
     return wrapped.getDateTestedBackdate();
   }
 
+  public Date getDateUpdated() {
+    return wrapped.getUpdatedAt();
+  }
+
   public TestCorrectionStatus getCorrectionStatus() {
     return wrapped.getCorrectionStatus();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
@@ -38,6 +38,10 @@ public class TestResultDataResolver
     return testEvent.getDateTested();
   }
 
+  public Date getDateUpdated(TestEvent testEvent) {
+    return testEvent.getUpdatedAt();
+  }
+
   public String getPregnancy(TestEvent testEvent) {
     return getSurvey(testEvent).getPregnancy();
   }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -240,6 +240,7 @@ type TestResult {
   facility: Facility
   patient: Patient
   dateAdded: String
+  dateUpdated: DateTime
   pregnancy: String
   noSymptoms: Boolean
   symptoms: String

--- a/frontend/src/app/testResults/operations.graphql
+++ b/frontend/src/app/testResults/operations.graphql
@@ -40,6 +40,7 @@ query GetFacilityResultsForCsv(
       isDeleted
     }
     dateTested
+    dateUpdated
     result
     results {
       disease {

--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -9,6 +9,7 @@ const data = [
       isDeleted: false,
     },
     dateTested: "2022-06-13T19:24:31.187Z",
+    dateUpdated: "2022-03-13T19:24:31.187Z",
     result: "NEGATIVE",
     results: [
       {
@@ -96,6 +97,7 @@ const result = [
     "Patient street address 2": "",
     "Patient tribal affiliation": "",
     "Patient zip code": "90210",
+    "Result reported date": "03/13/2022 7:24pm",
     Submitter: "Doe, Jane",
     "Symptom onset": "Invalid date",
     "Symptoms present": "No symptoms",

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -41,6 +41,7 @@ export function parseDataForCSV(data: any, multiplexEnabled: boolean) {
         : {
             "COVID-19 result": TEST_RESULT_DESCRIPTIONS[r.result as Results],
           }),
+      "Result reported date": moment(r.dateUpdated).format("MM/DD/YYYY h:mma"),
       "Test correction status": r.correctionStatus,
       "Test correction reason": r.reasonForCorrection,
       "Device name": r.deviceType.name,

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -968,6 +968,7 @@ export type TestResult = {
   createdBy?: Maybe<ApiUser>;
   dateAdded?: Maybe<Scalars["String"]>;
   dateTested?: Maybe<Scalars["DateTime"]>;
+  dateUpdated?: Maybe<Scalars["DateTime"]>;
   deviceType?: Maybe<DeviceType>;
   facility?: Maybe<Facility>;
   internalId?: Maybe<Scalars["ID"]>;
@@ -2429,6 +2430,7 @@ export type GetFacilityResultsForCsvQuery = {
         | {
             __typename?: "TestResult";
             dateTested?: any | null | undefined;
+            dateUpdated?: any | null | undefined;
             result?: string | null | undefined;
             correctionStatus?: string | null | undefined;
             reasonForCorrection?: string | null | undefined;
@@ -6716,6 +6718,7 @@ export const GetFacilityResultsForCsvDocument = gql`
         isDeleted
       }
       dateTested
+      dateUpdated
       result
       results {
         disease {


### PR DESCRIPTION
# BACKEND & FRONTEND PULL REQUEST

## Related Issue
Resolves #3793 

## Changes Proposed
- sends the `TestEvent`'s `updated_at` field to the frontend when getting test results
- adds a `dateUpdated` field to the `GetFacilityResultsForCsv` graphQL query
- adds a new column called "Result reported date" to the test results CSV download

## Additional Information
N/A

## Testing
- Log in as a org admin
- Go to the "Results" tab
- Click "Download results"
- Open the csv and ensure you see a "Result reported date" column and the value should correspond to the date the test was submitted

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README