### PR TITLE
dashboard to use results table instead of column

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -74,8 +74,9 @@ public interface TestEventRepository
               + "FROM TestEvent te "
               + "         LEFT JOIN TestEvent corrected_te ON corrected_te.priorCorrectedTestEventId = te.internalId "
               + "         LEFT JOIN Result res ON res.testEvent = te "
+              + "         LEFT JOIN SupportedDisease disease ON res.disease = disease "
               + "WHERE te.facility.internalId IN :facilityIds AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
-              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL "
+              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = '96741-4' "
               + "GROUP BY res.testResult")
   List<TestResultWithCount> countByResultByFacility(
       Collection<UUID> facilityIds, Date startDate, Date endDate);
@@ -86,8 +87,9 @@ public interface TestEventRepository
               + "FROM TestEvent te "
               + "         LEFT JOIN TestEvent corrected_te ON corrected_te.priorCorrectedTestEventId = te.internalId "
               + "         LEFT JOIN Result res ON res.testEvent = te "
+              + "         LEFT JOIN SupportedDisease disease ON res.disease = disease "
               + "WHERE te.facility.internalId = :facilityId AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
-              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL "
+              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = '96741-4' "
               + "GROUP BY res.testResult")
   List<TestResultWithCount> countByResultForFacility(UUID facilityId, Date startDate, Date endDate);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -70,23 +70,25 @@ public interface TestEventRepository
 
   @Query(
       value =
-          "SELECT new gov.cdc.usds.simplereport.db.model.auxiliary.TestResultWithCount(te.result, COUNT(te)) "
+          "SELECT new gov.cdc.usds.simplereport.db.model.auxiliary.TestResultWithCount(res.testResult, COUNT(res)) "
               + "FROM TestEvent te "
               + "         LEFT JOIN TestEvent corrected_te ON corrected_te.priorCorrectedTestEventId = te.internalId "
+              + "         LEFT JOIN Result res ON res.testEvent = te "
               + "WHERE te.facility.internalId IN :facilityIds AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
               + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL "
-              + "GROUP BY te.result")
+              + "GROUP BY res.testResult")
   List<TestResultWithCount> countByResultByFacility(
       Collection<UUID> facilityIds, Date startDate, Date endDate);
 
   @Query(
       value =
-          "SELECT new gov.cdc.usds.simplereport.db.model.auxiliary.TestResultWithCount(te.result, COUNT(te)) "
+          "SELECT new gov.cdc.usds.simplereport.db.model.auxiliary.TestResultWithCount(res.testResult, COUNT(res)) "
               + "FROM TestEvent te "
               + "         LEFT JOIN TestEvent corrected_te ON corrected_te.priorCorrectedTestEventId = te.internalId "
+              + "         LEFT JOIN Result res ON res.testEvent = te "
               + "WHERE te.facility.internalId = :facilityId AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
               + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL "
-              + "GROUP BY te.result")
+              + "GROUP BY res.testResult")
   List<TestResultWithCount> countByResultForFacility(UUID facilityId, Date startDate, Date endDate);
 
   boolean existsByPatient(Person person);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -96,7 +96,6 @@ public class TestOrderService {
       Date startDate,
       Date endDate) {
     return (root, query, cb) -> {
-      // DOES NOT ADD RESULT FROM RESULT TABLE -> STILL USES RESULT COLUMN!!!!!!!!
       Join<TestEvent, Result> resultJoin = root.join(TestEvent_.results);
       Join<TestEvent, TestOrder> order = root.join(TestEvent_.order);
       order.on(cb.equal(root.get(AuditedEntity_.internalId), order.get(TestOrder_.testEvent)));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -96,10 +96,12 @@ public class TestOrderService {
       Date startDate,
       Date endDate) {
     return (root, query, cb) -> {
+      // DOES NOT ADD RESULT FROM RESULT TABLE -> STILL USES RESULT COLUMN!!!!!!!!
       Join<TestEvent, Result> resultJoin = root.join(TestEvent_.results);
       Join<TestEvent, TestOrder> order = root.join(TestEvent_.order);
       order.on(cb.equal(root.get(AuditedEntity_.internalId), order.get(TestOrder_.testEvent)));
       query.orderBy(cb.desc(root.get(AuditedEntity_.createdAt)));
+      query.distinct(true);
 
       Predicate p = cb.conjunction();
       if (facilityId != null) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -18,6 +18,7 @@ import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Person_;
 import gov.cdc.usds.simplereport.db.model.Result;
+import gov.cdc.usds.simplereport.db.model.Result_;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestEvent_;
@@ -95,6 +96,7 @@ public class TestOrderService {
       Date startDate,
       Date endDate) {
     return (root, query, cb) -> {
+      Join<TestEvent, Result> resultJoin = root.join(TestEvent_.results);
       Join<TestEvent, TestOrder> order = root.join(TestEvent_.order);
       order.on(cb.equal(root.get(AuditedEntity_.internalId), order.get(TestOrder_.testEvent)));
       query.orderBy(cb.desc(root.get(AuditedEntity_.createdAt)));
@@ -117,7 +119,7 @@ public class TestOrderService {
                     root.get(BaseTestInfo_.patient).get(AuditedEntity_.internalId), patientId));
       }
       if (result != null) {
-        p = cb.and(p, cb.equal(root.get(BaseTestInfo_.result), result));
+        p = cb.and(p, cb.equal(resultJoin.get(Result_.testResult), result));
       }
       if (role != null) {
         p = cb.and(p, cb.equal(root.get(BaseTestInfo_.patient).get(Person_.role), role));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.db.model.Facility_;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
+import gov.cdc.usds.simplereport.db.model.Result_;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestEvent_;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
@@ -49,6 +50,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
 
   private Specification<TestEvent> filter(UUID facilityId, TestResult result) {
     return (root, query, cb) -> {
+      Join<TestEvent, Result> resultJoin = root.join(TestEvent_.results);
       Join<TestEvent, TestOrder> order = root.join(TestEvent_.order);
       order.on(cb.equal(root.get(TestEvent_.internalId), order.get(TestOrder_.testEvent)));
       query.orderBy(cb.desc(root.get(TestEvent_.createdAt)));
@@ -60,7 +62,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
                 p, cb.equal(root.get(TestEvent_.facility).get(Facility_.internalId), facilityId));
       }
       if (result != null) {
-        p = cb.and(p, cb.equal(root.get(TestEvent_.result), result));
+        p = cb.and(p, cb.equal(resultJoin.get(Result_.testResult), result));
       }
       return p;
     };

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -235,10 +235,13 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     TestOrder firstOrder =
         _dataFactory.createCompletedTestOrder(patient, place, TestResult.POSITIVE);
     TestEvent firstEvent = new TestEvent(firstOrder);
+    _dataFactory.createResult(firstEvent, firstOrder, _diseaseService.covid(), TestResult.POSITIVE);
 
     TestOrder secondOrder =
         _dataFactory.createCompletedTestOrder(patient, place, TestResult.UNDETERMINED);
     TestEvent secondEvent = new TestEvent(secondOrder);
+    _dataFactory.createResult(
+        secondEvent, secondOrder, _diseaseService.covid(), TestResult.UNDETERMINED);
 
     _repo.save(firstEvent);
     _repo.save(secondEvent);
@@ -250,14 +253,17 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     TestOrder firstOrderOtherPlace =
         _dataFactory.createCompletedTestOrder(otherPatient, otherPlace, TestResult.NEGATIVE);
     TestEvent firstEventOtherPlace = new TestEvent(firstOrderOtherPlace);
+    _dataFactory.createResult(
+        firstEventOtherPlace, firstOrderOtherPlace, _diseaseService.covid(), TestResult.NEGATIVE);
 
     TestOrder secondOrderOtherPlace =
         _dataFactory.createCompletedTestOrder(otherPatient, otherPlace, TestResult.POSITIVE);
     TestEvent secondEventOtherPlace = new TestEvent(secondOrderOtherPlace);
+    _dataFactory.createResult(
+        secondEventOtherPlace, secondOrderOtherPlace, _diseaseService.covid(), TestResult.POSITIVE);
 
     _repo.save(firstEventOtherPlace);
     _repo.save(secondEventOtherPlace);
-
     return place;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -203,6 +203,32 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
   }
 
   @Test
+  void countByResultByFacility_singleFacility_onlyCountsCovid() {
+    Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+    final Date DATE_1MIN_FUTURE =
+        new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+    Organization org = _dataFactory.createValidOrg();
+    Facility place = createTestEventsForMetricsTests(org);
+    var p = _dataFactory.createMinimalPerson(org);
+    _dataFactory.createMultiplexTestEvent(
+        p, place, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.UNDETERMINED, false);
+
+    List<TestResultWithCount> results =
+        _repo.countByResultByFacility(Set.of(place.getInternalId()), d1, DATE_1MIN_FUTURE);
+
+    assertEquals(2, results.size());
+
+    Map<TestResult, Long> resultMap =
+        results.stream()
+            .collect(
+                Collectors.toMap(TestResultWithCount::getResult, TestResultWithCount::getCount));
+
+    assertEquals(2L, resultMap.get(TestResult.POSITIVE));
+    assertEquals(1L, resultMap.get(TestResult.UNDETERMINED));
+    assertNull(resultMap.get(TestResult.NEGATIVE));
+  }
+
+  @Test
   void countByResultByFacility_entireOrganization_success() {
     Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
     final Date DATE_1MIN_FUTURE =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -244,6 +244,8 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     TestEvent secondEvent = new TestEvent(secondOrder);
     _dataFactory.createResult(
         secondEvent, secondOrder, _diseaseService.covid(), TestResult.UNDETERMINED);
+    _dataFactory.createResult(
+        secondEvent, secondOrder, _diseaseService.fluA(), TestResult.UNDETERMINED);
 
     _repo.save(firstEvent);
     _repo.save(secondEvent);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -484,10 +484,10 @@ public class TestDataFactory {
   }
 
   public TestEvent doTest(TestOrder order, TestResult result) {
-    Result resultEntity = new Result(order, _diseaseService.covid(), result);
-    _resultRepository.save(resultEntity);
     order.setResultColumn(result);
     TestEvent event = _testEventRepo.save(new TestEvent(order));
+    Result resultEntity = new Result(event, order, _diseaseService.covid(), result);
+    _resultRepository.save(resultEntity);
     order.setTestEventRef(event);
     order.markComplete();
     _testOrderRepo.save(order);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -390,13 +390,14 @@ public class TestDataFactory {
   public TestEvent createTestEvent(Person p, Facility f, AskOnEntrySurvey s, TestResult r, Date d) {
     TestOrder o = createTestOrder(p, f, s);
     o.setDateTestedBackdate(d);
-    Result result = new Result(o, _diseaseService.covid(), r);
-    _resultRepository.save(result);
     o.setResultColumn(r);
 
     TestEvent e = _testEventRepo.save(new TestEvent(o));
     o.setTestEventRef(e);
     o.markComplete();
+
+    Result result = new Result(e, o, _diseaseService.covid(), r);
+    _resultRepository.save(result);
     _testOrderRepo.save(o);
     return e;
   }
@@ -586,5 +587,11 @@ public class TestDataFactory {
 
   public static List<PhoneNumberInput> getListOfOnePhoneNumberInput() {
     return List.of(new PhoneNumberInput("MOBILE", "(503) 867-5309"));
+  }
+
+  public void createResult(
+      TestEvent testEvent, TestOrder testOrder, SupportedDisease disease, TestResult testResult) {
+    var res = new Result(testEvent, testOrder, disease, testResult);
+    _resultRepository.save(res);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Some queries are still using the "Result" column in the test event table instead of the result table

## Changes Proposed

- The query for getting count now joins with the Result table on the TestEvent
- The specification now does the same join \
- **NEW** adds a distinct to remove any duplicate results

## Additional Information

- N/A

## Testing

- **NEW** Additional integration tests were added using multiplex and filtering
- Review tests & the logged queries to see the join of the new table "result"
- Example Query for JPA Query
```sql
select result2_.test_result as col_0_0_, count(result2_.internal_id) as col_1_0_
from simple_report.test_event testevent0_
         left outer join simple_report.test_event testevent1_
                         on (testevent1_.prior_corrected_test_event_id = testevent0_.internal_id)
         left outer join simple_report.result result2_
                         on (result2_.test_event_id = testevent0_.internal_id)
         left outer join simple_report.supported_disease supportedd3_
                         on (result2_.disease_id = supportedd3_.internal_id)
where (testevent0_.facility_id in (?))
  and (coalesce(testevent0_.date_tested_backdate, testevent0_.created_at) between ? and ?)
  and testevent0_.correction_status = 'ORIGINAL'
  and (testevent1_.prior_corrected_test_event_id is null)
  and supportedd3_.loinc = '96741-4'
group by result2_.test_result;
```
- Example Criteria API query
```sql 
select distinct testevent0_.internal_id                   as internal1_24_,
                testevent0_.created_at                    as created_2_24_,
                testevent0_.created_by                    as created13_24_,
                testevent0_.updated_at                    as updated_3_24_,
                testevent0_.updated_by                    as updated14_24_,
                testevent0_.correction_status             as correcti4_24_,
                testevent0_.date_tested_backdate          as date_tes5_24_,
                testevent0_.device_specimen_type_id       as device_15_24_,
                testevent0_.device_type_id                as device_16_24_,
                testevent0_.facility_id                   as facilit17_24_,
                testevent0_.organization_id               as organiz18_24_,
                testevent0_.patient_id                    as patient19_24_,
                testevent0_.reason_for_correction         as reason_f6_24_,
                testevent0_.result                        as result7_24_,
                testevent0_.specimen_type_id              as specime20_24_,
                testevent0_.test_order_id                 as test_or21_24_,
                testevent0_.patient_data                  as patient_8_24_,
                testevent0_.patient_has_prior_tests       as patient_9_24_,
                testevent0_.prior_corrected_test_event_id as prior_c10_24_,
                testevent0_.provider_data                 as provide11_24_,
                testevent0_.survey_data                   as survey_12_24_
from simple_report.test_event testevent0_
         inner join simple_report.result results1_
                    on testevent0_.internal_id = results1_.test_event_id
         inner join simple_report.test_order testorder2_
                    on testevent0_.test_order_id = testorder2_.internal_id and
                       (testevent0_.internal_id = testorder2_.test_event_id)
where 1 = 1
  and testevent0_.facility_id=?
  and results1_.test_result=?
order by testevent0_.created_at desc
limit ?;
```
- No duplicate multiplex results 😅
![image](https://user-images.githubusercontent.com/10108172/180576682-99e256bb-62a9-4842-8365-bddd0eccf9fb.png)
- Filtering "Positive" shows any positive result (covid, flu a, or flu b)
![image](https://user-images.githubusercontent.com/10108172/180576722-c8d6eb31-8f5e-4e53-bce0-40a8800bd536.png)

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README

