### PR TITLE
Add pull_request_target event to PR workflows.

### DIFF
--- a/.github/workflows/checkGraphql.yml
+++ b/.github/workflows/checkGraphql.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - "**"
+  pull_request_target:
+    branches:
+      - "**"
   push:
     branches:
       - main

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - "**"
+  pull_request_target:
+    branches:
+      - "**"
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - "**"
+  pull_request_target:
+    branches:
+      - "**"
   push:
     branches:
       - main

--- a/.github/workflows/testDBChangelog.yml
+++ b/.github/workflows/testDBChangelog.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - "**"
+  pull_request_target:
+    branches:
+      - "**"
     paths:
       - backend/src/main/resources/db/changelog/db.changelog-master.yaml
   push:


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Our repository is paradoxically configured. As things stand, a series of completed checks are required for a PR to be merged. However, PRs that originate from an outside fork do not trigger the PR checks, as the source branches are not part of our existing code. Because of this, PRs from forks can never be merged, as the checks will never run.

## Changes Proposed

- Leverage the `pull_request_target` event as a valid trigger for PR check workflows.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)