### PR TITLE
batch the request to get phone number

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/dataloader/PatientPrimaryPhoneDataLoaderTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/dataloader/PatientPrimaryPhoneDataLoaderTest.java
@@ -1,0 +1,71 @@
+package gov.cdc.usds.simplereport.service.dataloader;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.PhoneNumber;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
+import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PatientPrimaryPhoneDataLoaderTest {
+  int limit = 5000;
+  @Mock PhoneNumberRepository mockPhoneNumberRepository;
+
+  @Test
+  void dataloaderMakesOneCallToRepository_whenLessThanLimitItemsAreRequested() {
+    AtomicBoolean success = new AtomicBoolean();
+    var dataloader = (new PatientPrimaryPhoneDataLoader(mockPhoneNumberRepository)).get();
+    var res = dataloader.loadMany(generatePersonList(limit - 1));
+
+    res.thenAccept(
+        val -> {
+          Mockito.verify(mockPhoneNumberRepository).findAllByInternalIdIn(Mockito.anyCollection());
+          success.set(true);
+        });
+
+    dataloader.dispatch();
+    await().untilAtomic(success, is(true));
+  }
+
+  @Test
+  void dataloaderMakesMultipleCallsToRepository_whenGreaterThanLimitItemsAreRequested() {
+    AtomicBoolean success = new AtomicBoolean();
+    var dataloader = (new PatientPrimaryPhoneDataLoader(mockPhoneNumberRepository)).get();
+    var times = 2;
+    var res = dataloader.loadMany(generatePersonList(limit * times));
+
+    res.thenAccept(
+        val -> {
+          Mockito.verify(mockPhoneNumberRepository, Mockito.times(times))
+              .findAllByInternalIdIn(Mockito.anyCollection());
+          success.set(true);
+        });
+
+    dataloader.dispatch();
+    await().untilAtomic(success, is(true));
+  }
+
+  List<Person> generatePersonList(int count) {
+    List<Person> personList = new ArrayList<>();
+    var org = new Organization("SomeOrg", "SomeType", "SomeId", true);
+
+    for (var i = 0; i < count; i++) {
+      var p = new Person("FirstName", "Middle", "Last", "", org);
+      p.setPrimaryPhone(new PhoneNumber(PhoneType.MOBILE, "+12485551234"));
+
+      personList.add(p);
+    }
+    return personList;
+  }
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Service is crashing when large amounts of data is being retrieved. 
- Based on issue: #3953, and through local testing giant queries are being generated by the dataloader to fetch a patient's primary phone number
- Example with most params `?` removed for clarity:
  - `Hibernate: select phonenumbe0_.internal_id as internal1_17_, phonenumbe0_.created_at as created_2_17_, phonenumbe0_.created_by as created_6_17_, phonenumbe0_.updated_at as updated_3_17_, phonenumbe0_.updated_by as updated_7_17_, phonenumbe0_.number as number4_17_, phonenumbe0_.person_internal_id as person_i8_17_, phonenumbe0_.type as type5_17_ from simple_report.phone_number phonenumbe0_ where phonenumbe0_.internal_id in (? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ?)`

## Changes Proposed

- The limit discovered is the max 2 byte integer (32,767), so as along as requests being made are smaller than that there will be no exception being thrown by JDBC. This change introduces batching of the request in 5000 increments to avoid any issues. 

## Additional Information

- While investigating, we noticed that in dev large requests (~20k+ rows) would fail with a different error but would not take the server down. This will be resolved in a future change.

## Testing

- **This has not been verified in dev** 
- Download and view large results and verify the server is still accessible afterwards
![image](https://user-images.githubusercontent.com/10108172/180575226-316fb759-2d65-4ef7-916a-2906ff05c348.png)
![image](https://user-images.githubusercontent.com/10108172/180575576-fc83a438-43a9-4649-b0d4-61580032927d.png)
![image](https://user-images.githubusercontent.com/10108172/180575625-826f538c-0baa-45c0-b590-6cc6c7184776.png)


## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README