### PR TITLE
Modify makefile to permit slot promotion for environments with integer identifiers

### DIFF
--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -81,7 +81,7 @@ jobs:
           client-tarball: ./client.tgz
           okta-enabled: true
           okta-url: https://hhs-prime.oktapreview.com
-          okta-client-id: 0oa1khbp5n2wTfe281d7
+          okta-client-id: 0oa3ii5dwmasAsCww1d7
       - name: Save compiled frontend application
         uses: actions/upload-artifact@v2
         if: success()

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -92,7 +92,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: Dev
+      name: Dev2
       url: https://${{env.DEPLOY_ENV}}.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -92,7 +92,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: Dev
+      name: Dev3
       url: https://${{env.DEPLOY_ENV}}.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -81,7 +81,7 @@ jobs:
           client-tarball: ./client.tgz
           okta-enabled: true
           okta-url: https://hhs-prime.oktapreview.com
-          okta-client-id: 0oa1khbp5n2wTfe281d7
+          okta-client-id: 0oa3ivrvd9Jhvt8Sb1d7
       - name: Save compiled frontend application
         uses: actions/upload-artifact@v2
         if: success()

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -81,7 +81,7 @@ jobs:
           client-tarball: ./client.tgz
           okta-enabled: true
           okta-url: https://hhs-prime.oktapreview.com
-          okta-client-id: 0oa1khbp5n2wTfe281d7
+          okta-client-id: 0oa3j1kbqp4ip5Osz1d7
       - name: Save compiled frontend application
         uses: actions/upload-artifact@v2
         if: success()

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -92,7 +92,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: Dev
+      name: Dev4
       url: https://${{env.DEPLOY_ENV}}.simplereport.gov
     needs: [build-frontend, prerelease-backend]
     steps:

--- a/backend/src/main/resources/application-azure-dev2.yaml
+++ b/backend/src/main/resources/application-azure-dev2.yaml
@@ -1,0 +1,18 @@
+spring:
+  profiles.include: okta-dev2, server-debug
+simple-report:
+  azure-reporting-queue:
+    enabled: true
+    exception-webhook-enabled: true
+  patient-link-url: https://dev2.simplereport.gov/app/pxp?plid=
+  twilio-callback-url: https://dev2.simplereport.gov/api/pxp/callback
+  sendgrid:
+    enabled: false
+  cors:
+    allowed-origins:
+      - https://simplereportdev2app.z13.web.core.windows.net
+      - https://simple-report-api-dev2.azurewebsites.net
+      - https://simple-report-dev2.azureedge.net
+      - https://dev2.simplereport.gov
+twilio:
+  enabled: true

--- a/backend/src/main/resources/application-azure-dev3.yaml
+++ b/backend/src/main/resources/application-azure-dev3.yaml
@@ -1,0 +1,18 @@
+spring:
+  profiles.include: okta-dev3, server-debug
+simple-report:
+  azure-reporting-queue:
+    enabled: true
+    exception-webhook-enabled: true
+  patient-link-url: https://dev3.simplereport.gov/app/pxp?plid=
+  twilio-callback-url: https://dev3.simplereport.gov/api/pxp/callback
+  sendgrid:
+    enabled: false
+  cors:
+    allowed-origins:
+      - https://simplereportdev3app.z13.web.core.windows.net
+      - https://simple-report-api-dev3.azurewebsites.net
+      - https://simple-report-dev3.azureedge.net
+      - https://dev3.simplereport.gov
+twilio:
+  enabled: true

--- a/backend/src/main/resources/application-azure-dev4.yaml
+++ b/backend/src/main/resources/application-azure-dev4.yaml
@@ -1,0 +1,18 @@
+spring:
+  profiles.include: okta-dev4, server-debug
+simple-report:
+  azure-reporting-queue:
+    enabled: true
+    exception-webhook-enabled: true
+  patient-link-url: https://dev4.simplereport.gov/app/pxp?plid=
+  twilio-callback-url: https://dev4.simplereport.gov/api/pxp/callback
+  sendgrid:
+    enabled: false
+  cors:
+    allowed-origins:
+      - https://simplereportdev4app.z13.web.core.windows.net
+      - https://simple-report-api-dev4.azurewebsites.net
+      - https://simple-report-dev4.azureedge.net
+      - https://dev4.simplereport.gov
+twilio:
+  enabled: true

--- a/backend/src/main/resources/application-okta-dev2.yaml
+++ b/backend/src/main/resources/application-okta-dev2.yaml
@@ -1,0 +1,12 @@
+# Bean profile to be included in deployment-specific profiles
+# for DEV/TEST deployments.
+okta:
+  oauth2:
+    client-id: 0oa3ii5dwmasAsCww1d7
+    issuer: https://hhs-prime.oktapreview.com/oauth2/default
+  client:
+    org-url: https://hhs-prime.oktapreview.com
+simple-report:
+  authorization:
+    role-claim: dev_roles
+    environment-name: "DEV2"

--- a/backend/src/main/resources/application-okta-dev3.yaml
+++ b/backend/src/main/resources/application-okta-dev3.yaml
@@ -1,0 +1,12 @@
+# Bean profile to be included in deployment-specific profiles
+# for DEV/TEST deployments.
+okta:
+  oauth2:
+    client-id: 0oa3ivrvd9Jhvt8Sb1d7
+    issuer: https://hhs-prime.oktapreview.com/oauth2/default
+  client:
+    org-url: https://hhs-prime.oktapreview.com
+simple-report:
+  authorization:
+    role-claim: dev_roles
+    environment-name: "DEV3"

--- a/backend/src/main/resources/application-okta-dev4.yaml
+++ b/backend/src/main/resources/application-okta-dev4.yaml
@@ -1,0 +1,12 @@
+# Bean profile to be included in deployment-specific profiles
+# for DEV/TEST deployments.
+okta:
+  oauth2:
+    client-id: 0oa3j1kbqp4ip5Osz1d7
+    issuer: https://hhs-prime.oktapreview.com/oauth2/default
+  client:
+    org-url: https://hhs-prime.oktapreview.com
+simple-report:
+  authorization:
+    role-claim: dev_roles
+    environment-name: "DEV4"

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -10,8 +10,8 @@ RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
 CURL_TIMEOUT?=20
 
 # Internal DRYing (also overrideable if you are sufficiently desperate)
-ENVLEVEL=$*
-API_NAME=simple-report-api-${ENVLEVEL}
+API_NAME=simple-report-api-$*
+ENV_LEVEL=$*
 INFO_ENDPOINT=https://$(API_NAME).azurewebsites.net/actuator/info
 SLOT_INFO_ENDPOINT=https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info
 CURL:=curl --silent --fail --max-time $(CURL_TIMEOUT)
@@ -56,7 +56,8 @@ deploy-%: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=30m
 
 promote-%: .be-logged-in .valid-env-%
-	az webapp deployment slot swap -g prime-simple-report-${ENVLVL//[[:digit:]]/} -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
+	ENV_LEVEL=${ENV_LEVEL//[[:digit:]]/}
+	az webapp deployment slot swap -g prime-simple-report-${ENV_LEVEL} -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
 
 wait-for-%-slot-commit: .valid-env-%
 	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $(SOURCE_SLOT) slot of $* at `date`"

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -10,7 +10,8 @@ RELEASE_TAG?=$(subst refs/tags/,,$(GITHUB_REF))
 CURL_TIMEOUT?=20
 
 # Internal DRYing (also overrideable if you are sufficiently desperate)
-API_NAME=simple-report-api-$*
+ENVLEVEL=$*
+API_NAME=simple-report-api-${ENVLEVEL}
 INFO_ENDPOINT=https://$(API_NAME).azurewebsites.net/actuator/info
 SLOT_INFO_ENDPOINT=https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info
 CURL:=curl --silent --fail --max-time $(CURL_TIMEOUT)
@@ -55,7 +56,7 @@ deploy-%: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=30m
 
 promote-%: .be-logged-in .valid-env-%
-	az webapp deployment slot swap -g prime-simple-report-${$*//[[:digit:]]/} -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
+	az webapp deployment slot swap -g prime-simple-report-${ENVLVL//[[:digit:]]/} -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
 
 wait-for-%-slot-commit: .valid-env-%
 	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $(SOURCE_SLOT) slot of $* at `date`"

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -11,7 +11,6 @@ CURL_TIMEOUT?=20
 
 # Internal DRYing (also overrideable if you are sufficiently desperate)
 API_NAME=simple-report-api-$*
-ENV_LEVEL=$*
 INFO_ENDPOINT=https://$(API_NAME).azurewebsites.net/actuator/info
 SLOT_INFO_ENDPOINT=https://$(API_NAME)-$(SOURCE_SLOT).azurewebsites.net/actuator/info
 CURL:=curl --silent --fail --max-time $(CURL_TIMEOUT)

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -55,6 +55,8 @@ deploy-%: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=30m
 
 promote-%: .be-logged-in .valid-env-%
+	ENVLVL=$*
+    ENVLVL=${ENVLVL//[[:digit:]]/}
 	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
 
 wait-for-%-slot-commit: .valid-env-%

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -56,8 +56,7 @@ deploy-%: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=30m
 
 promote-%: .be-logged-in .valid-env-%
-	ENV_LEVEL=${ENV_LEVEL//[[:digit:]]/}
-	az webapp deployment slot swap -g prime-simple-report-${ENV_LEVEL} -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
+	@case $* in dev2|dev3|dev4) az webapp deployment slot swap -g prime-simple-report-dev -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT) ;; *) az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT) ;; esac
 
 wait-for-%-slot-commit: .valid-env-%
 	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $(SOURCE_SLOT) slot of $* at `date`"

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -55,9 +55,7 @@ deploy-%: .valid-env-% api.tfvars
 	terraform -chdir=$* apply -auto-approve -var-file=../api.tfvars -lock-timeout=30m
 
 promote-%: .be-logged-in .valid-env-%
-	ENVLVL=$*
-    ENVLVL=${ENVLVL//[[:digit:]]/}
-	az webapp deployment slot swap -g prime-simple-report-$* -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
+	az webapp deployment slot swap -g prime-simple-report-${$*//[[:digit:]]/} -n $(API_NAME) --slot $(SOURCE_SLOT) --target-slot $(TARGET_SLOT)
 
 wait-for-%-slot-commit: .valid-env-%
 	@echo "Starting wait for commit $(DEPLOYED_COMMIT) in $(SOURCE_SLOT) slot of $* at `date`"

--- a/ops/dev2/api.tf
+++ b/ops/dev2/api.tf
@@ -26,7 +26,7 @@ module "simple_report_api" {
   }
 
   app_settings = {
-    SPRING_PROFILES_ACTIVE                        = "azure-dev"
+    SPRING_PROFILES_ACTIVE                        = "azure-dev2"
     SPRING_DATASOURCE_SIMPLEREPORT_HIKARI_JDBCURL = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_dev2_db_jdbc.id})"
     SPRING_DATASOURCE_METABASE_HIKARI_JDBCURL     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.metabase_db_uri.id})"
     DB_PASSWORD_NO_PHI                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.db_password_no_phi.id})"

--- a/ops/dev3/api.tf
+++ b/ops/dev3/api.tf
@@ -26,7 +26,7 @@ module "simple_report_api" {
   }
 
   app_settings = {
-    SPRING_PROFILES_ACTIVE                        = "azure-dev"
+    SPRING_PROFILES_ACTIVE                        = "azure-dev3"
     SPRING_DATASOURCE_SIMPLEREPORT_HIKARI_JDBCURL = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_dev3_db_jdbc.id})"
     SPRING_DATASOURCE_METABASE_HIKARI_JDBCURL     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.metabase_db_uri.id})"
     DB_PASSWORD_NO_PHI                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.db_password_no_phi.id})"

--- a/ops/dev4/api.tf
+++ b/ops/dev4/api.tf
@@ -26,7 +26,7 @@ module "simple_report_api" {
   }
 
   app_settings = {
-    SPRING_PROFILES_ACTIVE                        = "azure-dev"
+    SPRING_PROFILES_ACTIVE                        = "azure-dev4"
     SPRING_DATASOURCE_SIMPLEREPORT_HIKARI_JDBCURL = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.sr_dev4_db_jdbc.id})"
     SPRING_DATASOURCE_METABASE_HIKARI_JDBCURL     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.metabase_db_uri.id})"
     DB_PASSWORD_NO_PHI                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.db_password_no_phi.id})"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Due to the presence of multiple environments in a single resource group, our makefile needs to be reworked to permit deployments in our newer environments.

## Changes Proposed

- Modify the `promote` target to support `dev`-level environments with integer identifiers.

## Additional Information

- There are arguably cleaner implementations of this. If we get to the point that we add multiple environments in more than just the `dev` resource group, we will need to revisit multiple files. This works for our current use case, however, as we do not anticipate the addition of more environments outside of `dev` at this time.

## Testing

- Testing a deployment of an environment that is not dev2, dev3, or dev4 should be sufficient to verify proper functionality.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification