### PR TITLE
Fix main logo alt text

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -290,7 +290,7 @@ const Header: React.FC<{}> = () => {
               <img
                 className="width-card desktop:width-full"
                 src={siteLogo}
-                alt="{process.env.REACT_APP_TITLE}"
+                alt={process.env.REACT_APP_TITLE}
               />
             </LinkWithQuery>
             <div className="prime-organization-name">{organization.name}</div>

--- a/frontend/src/patientApp/PatientHeader.test.tsx
+++ b/frontend/src/patientApp/PatientHeader.test.tsx
@@ -90,5 +90,19 @@ describe("PatientHeader", () => {
         await screen.findByText("Test Org, Test Facility", { exact: false })
       ).toBeInTheDocument();
     });
+
+    it("correctly displays the SimpleReport logo", async () => {
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <PatientHeader />
+          </Provider>
+        </MemoryRouter>
+      );
+
+      expect(
+        await screen.findByAltText("SimpleReport", { exact: false })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -35,7 +35,7 @@ const PatientHeader = () => {
               <img
                 className="width-4"
                 src={siteLogo}
-                alt="{process.env.REACT_APP_TITLE}"
+                alt={process.env.REACT_APP_TITLE}
               />
               <div className="logo-text margin-left-1 display-flex flex-column">
                 <span

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -29,8 +29,7 @@ const PatientHeader = () => {
           <div className="margin-bottom-0" id="basic-logo">
             <div
               className="display-flex flex-align-center"
-              title="Home"
-              aria-label="Home"
+              title="SimpleReport"
             >
               <img
                 className="width-4"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

Fixes #3976 and fixes #3982 

## Changes Proposed

- Change logo alt text to parse the variable name, instead the literal string "process.env.REACT_APP_TITLE"
 
## Screenshots / Demos

![Screen Shot 2022-07-29 at 10 32 21 AM](https://user-images.githubusercontent.com/80282552/181813686-baa7a06c-ede3-4fae-bb77-f0fc229fb8c2.png)


## Checklist for Author and Reviewer

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

### Documentation
- [x] Any changes to the startup configuration have been documented in the README