### PR TITLE
Deconflict `<header>` across the app

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -147,199 +147,201 @@ const App = () => {
         <TrainingNotification />
       )}
       <WithFacility>
-        <Page>
-          <Header />
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <Navigate
-                  to={{ pathname: homepagePath, search: location.search }}
-                />
-              }
-            />
-            <Route path="queue" element={<TestQueueContainer />} />
-            <Route
-              path="results/:pageNumber"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canViewResults}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <TestResultsList />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
-            <Route
-              path="results"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canViewResults}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <CleanTestResultsList />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
-            <Route
-              path="results/upload/submit"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canUseCsvUploaderPilot}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <Uploads />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
-            <Route
-              path="results/upload/submit/guide"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canUseCsvUploaderPilot}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <Schema />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
+        <Page
+          header={<Header />}
+          children={
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <Navigate
+                    to={{ pathname: homepagePath, search: location.search }}
+                  />
+                }
+              />
+              <Route path="queue" element={<TestQueueContainer />} />
+              <Route
+                path="results/:pageNumber"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canViewResults}
+                    userPermissions={data.whoami.permissions}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <TestResultsList />
+                      </ResultsNavWrapper>
+                    }
+                  />
+                }
+              />
+              <Route
+                path="results"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canViewResults}
+                    userPermissions={data.whoami.permissions}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <CleanTestResultsList />
+                      </ResultsNavWrapper>
+                    }
+                  />
+                }
+              />
+              <Route
+                path="results/upload/submit"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canUseCsvUploaderPilot}
+                    userPermissions={data.whoami.permissions}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <Uploads />
+                      </ResultsNavWrapper>
+                    }
+                  />
+                }
+              />
+              <Route
+                path="results/upload/submit/guide"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canUseCsvUploaderPilot}
+                    userPermissions={data.whoami.permissions}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <Schema />
+                      </ResultsNavWrapper>
+                    }
+                  />
+                }
+              />
 
-            <Route
-              path="results/upload/submissions/submission/:id"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canUseCsvUploaderPilot}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <Submission />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
-            <Route
-              path={"results/upload/submissions"}
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canUseCsvUploaderPilot}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <Submissions />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
-            <Route
-              path={"results/upload/submissions/:pageNumber"}
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canUseCsvUploaderPilot}
-                  userPermissions={data.whoami.permissions}
-                  element={
-                    <ResultsNavWrapper
-                      userPermissions={data.whoami.permissions}
-                    >
-                      <Submissions />
-                    </ResultsNavWrapper>
-                  }
-                />
-              }
-            />
-            <Route path="patients">
               <Route
-                path=":pageNumber"
+                path="results/upload/submissions/submission/:id"
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canViewPeople}
+                    requiredPermissions={canUseCsvUploaderPilot}
                     userPermissions={data.whoami.permissions}
-                    element={<ManagePatientsContainer />}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <Submission />
+                      </ResultsNavWrapper>
+                    }
                   />
                 }
               />
               <Route
-                path=""
+                path={"results/upload/submissions"}
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canViewPeople}
+                    requiredPermissions={canUseCsvUploaderPilot}
                     userPermissions={data.whoami.permissions}
-                    element={<ManagePatientsContainer />}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <Submissions />
+                      </ResultsNavWrapper>
+                    }
                   />
                 }
               />
-            </Route>
-            <Route
-              path="patient/:patientId"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canEditPeople}
-                  userPermissions={data.whoami.permissions}
-                  element={<EditPatientContainer />}
+              <Route
+                path={"results/upload/submissions/:pageNumber"}
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canUseCsvUploaderPilot}
+                    userPermissions={data.whoami.permissions}
+                    element={
+                      <ResultsNavWrapper
+                        userPermissions={data.whoami.permissions}
+                      >
+                        <Submissions />
+                      </ResultsNavWrapper>
+                    }
+                  />
+                }
+              />
+              <Route path="patients">
+                <Route
+                  path=":pageNumber"
+                  element={
+                    <ProtectedRoute
+                      requiredPermissions={canViewPeople}
+                      userPermissions={data.whoami.permissions}
+                      element={<ManagePatientsContainer />}
+                    />
+                  }
                 />
-              }
-            />
-            <Route
-              path="add-patient"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canEditPeople}
-                  userPermissions={data.whoami.permissions}
-                  element={<AddPatient />}
+                <Route
+                  path=""
+                  element={
+                    <ProtectedRoute
+                      requiredPermissions={canViewPeople}
+                      userPermissions={data.whoami.permissions}
+                      element={<ManagePatientsContainer />}
+                    />
+                  }
                 />
-              }
-            />
-            <Route
-              path="settings/*"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canViewSettings}
-                  userPermissions={data.whoami.permissions}
-                  element={<Settings />}
-                />
-              }
-            />
-            <Route
-              path="dashboard"
-              element={
-                <ProtectedRoute
-                  requiredPermissions={canViewSettings}
-                  userPermissions={data.whoami.permissions}
-                  element={<Analytics />}
-                />
-              }
-            />
-            <Route
-              path="admin/*"
-              element={<SupportAdminRoutes isAdmin={isSupportAdmin} />}
-            />
-          </Routes>
-        </Page>
+              </Route>
+              <Route
+                path="patient/:patientId"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canEditPeople}
+                    userPermissions={data.whoami.permissions}
+                    element={<EditPatientContainer />}
+                  />
+                }
+              />
+              <Route
+                path="add-patient"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canEditPeople}
+                    userPermissions={data.whoami.permissions}
+                    element={<AddPatient />}
+                  />
+                }
+              />
+              <Route
+                path="settings/*"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canViewSettings}
+                    userPermissions={data.whoami.permissions}
+                    element={<Settings />}
+                  />
+                }
+              />
+              <Route
+                path="dashboard"
+                element={
+                  <ProtectedRoute
+                    requiredPermissions={canViewSettings}
+                    userPermissions={data.whoami.permissions}
+                    element={<Analytics />}
+                  />
+                }
+              />
+              <Route
+                path="admin/*"
+                element={<SupportAdminRoutes isAdmin={isSupportAdmin} />}
+              />
+            </Routes>
+          }
+        />
       </WithFacility>
     </>
   );

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -290,7 +290,7 @@ const Header: React.FC<{}> = () => {
               <img
                 className="width-card desktop:width-full"
                 src={siteLogo}
-                alt="{process.env.REACT_APP_TITLE}"
+                alt={process.env.REACT_APP_TITLE}
               />
             </LinkWithQuery>
             <div className="prime-organization-name">{organization.name}</div>

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -282,101 +282,99 @@ const Header: React.FC<{}> = () => {
   };
 
   return (
-    <header className="usa-header usa-header--basic">
-      <div className="usa-nav-container prime-header">
-        <div className="usa-navbar">
-          <div className="usa-logo" id="basic-logo">
-            <LinkWithQuery to={siteLogoLinkPath} title="Home" aria-label="Home">
-              <img
-                className="width-card desktop:width-full"
-                src={siteLogo}
-                alt={process.env.REACT_APP_TITLE}
-              />
-            </LinkWithQuery>
-            <div className="prime-organization-name">{organization.name}</div>
-          </div>
-
-          <button
-            onClick={() => setMenuVisible(!menuVisible)}
-            className="usa-menu-btn"
-          >
-            Menu
-          </button>
-
-          <nav
-            aria-label="Primary navigation"
-            className={classNames(
-              "usa-nav",
-              "prime-nav",
-              "desktop:display-none",
-              {
-                "is-visible": menuVisible,
-              },
-              "mobile-nav"
-            )}
-          >
-            <button
-              className="fa-layers fa-fw fa-2x usa-nav__close prime-nav-close-button"
-              onClick={() => setMenuVisible(false)}
-              title={"close menu"}
-            >
-              <FontAwesomeIcon icon={"window-close"} />
-            </button>
-            <ul className="usa-nav__primary usa-accordion mobile-main-nav-container">
-              {mainNavList("mobile")}
-            </ul>
-            <ul className="usa-nav__primary usa-accordion mobile-secondary-nav-container">
-              {secondaryNav("mobile")}
-            </ul>
-            <div className="usa-nav__primary mobile-sublist-container">
-              {secondaryNavSublist("mobile")}
-              <hr />
-
-              <label id="mobile-facility-label" className="usa-label ">
-                Facility
-              </label>
-              <div className="prime-facility-select facility-select-mobile-container">
-                <Dropdown
-                  selectedValue={facility.id}
-                  onChange={onFacilitySelect}
-                  className={"mobile-facility-select"}
-                  options={facilities.map(({ name, id }) => ({
-                    label: name,
-                    value: id,
-                  }))}
-                />
-              </div>
-
-              <TouchpointsButton />
-            </div>
-          </nav>
+    <div className="usa-nav-container prime-header">
+      <div className="usa-navbar">
+        <div className="usa-logo" id="basic-logo">
+          <LinkWithQuery to={siteLogoLinkPath} title="Home" aria-label="Home">
+            <img
+              className="width-card desktop:width-full"
+              src={siteLogo}
+              alt={process.env.REACT_APP_TITLE}
+            />
+          </LinkWithQuery>
+          <div className="prime-organization-name">{organization.name}</div>
         </div>
+
+        <button
+          onClick={() => setMenuVisible(!menuVisible)}
+          className="usa-menu-btn"
+        >
+          Menu
+        </button>
 
         <nav
           aria-label="Primary navigation"
-          className="usa-nav prime-nav desktop-nav"
+          className={classNames(
+            "usa-nav",
+            "prime-nav",
+            "desktop:display-none",
+            {
+              "is-visible": menuVisible,
+            },
+            "mobile-nav"
+          )}
         >
-          <ul className="usa-nav__primary usa-accordion">
-            {mainNavList("desktop")}
+          <button
+            className="fa-layers fa-fw fa-2x usa-nav__close prime-nav-close-button"
+            onClick={() => setMenuVisible(false)}
+            title={"close menu"}
+          >
+            <FontAwesomeIcon icon={"window-close"} />
+          </button>
+          <ul className="usa-nav__primary usa-accordion mobile-main-nav-container">
+            {mainNavList("mobile")}
           </ul>
-          {facilities && facilities.length > 0 ? (
-            <div className="prime-facility-select">
+          <ul className="usa-nav__primary usa-accordion mobile-secondary-nav-container">
+            {secondaryNav("mobile")}
+          </ul>
+          <div className="usa-nav__primary mobile-sublist-container">
+            {secondaryNavSublist("mobile")}
+            <hr />
+
+            <label id="mobile-facility-label" className="usa-label ">
+              Facility
+            </label>
+            <div className="prime-facility-select facility-select-mobile-container">
               <Dropdown
                 selectedValue={facility.id}
                 onChange={onFacilitySelect}
+                className={"mobile-facility-select"}
                 options={facilities.map(({ name, id }) => ({
                   label: name,
                   value: id,
                 }))}
               />
             </div>
-          ) : null}
-          <ul className="usa-nav__primary usa-accordion">
-            {secondaryNav("desktop")}
-          </ul>
+
+            <TouchpointsButton />
+          </div>
         </nav>
       </div>
-    </header>
+
+      <nav
+        aria-label="Primary navigation"
+        className="usa-nav prime-nav desktop-nav"
+      >
+        <ul className="usa-nav__primary usa-accordion">
+          {mainNavList("desktop")}
+        </ul>
+        {facilities && facilities.length > 0 ? (
+          <div className="prime-facility-select">
+            <Dropdown
+              selectedValue={facility.id}
+              onChange={onFacilitySelect}
+              options={facilities.map(({ name, id }) => ({
+                label: name,
+                value: id,
+              }))}
+            />
+          </div>
+        ) : null}
+        <ul className="usa-nav__primary usa-accordion">
+          {secondaryNav("desktop")}
+        </ul>
+      </nav>
+    </div>
   );
 };
 

--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -13,7 +13,13 @@ declare global {
   }
 }
 
-const Page: React.FC<{}> = ({ children }) => {
+interface Props {
+  header?: React.ReactNode;
+  children?: React.ReactNode;
+  isPatientApp?: boolean;
+}
+
+const Page: React.FC<Props> = ({ header, children, isPatientApp }) => {
   // load touchpoints script
   useEffect(() => {
     // don't load script when running in cypress
@@ -32,8 +38,17 @@ const Page: React.FC<{}> = ({ children }) => {
   }, []);
   return (
     <div className="App">
-      <div id="main-wrapper">
+      <header
+        className={
+          isPatientApp
+            ? "header border-bottom border-base-lighter"
+            : "usa-header usa-header--basic"
+        }
+      >
         <USAGovBanner />
+        {header}
+      </header>
+      <div id="main-wrapper">
         {children}
         <ToastContainer
           autoClose={5000}

--- a/frontend/src/app/commonComponents/USAGovBanner.tsx
+++ b/frontend/src/app/commonComponents/USAGovBanner.tsx
@@ -75,37 +75,37 @@ class USAGovBanner extends React.Component<Props, State> {
 
   render() {
     return (
-      <div className="usa-banner">
+      <div className="usa-banner usa-banner__header">
         <div className="usa-accordion">
-          <header className="usa-banner__header">
-            <div className="usa-banner__inner">
-              <div className="grid-col-auto">
-                <img
-                  className="usa-banner__header-flag"
-                  src={usFlagSmall}
-                  alt="U.S. flag"
-                />
-              </div>
-              <div className="grid-col-fill tablet:grid-col-auto">
-                <p className="usa-banner__header-text">
-                  {i18n.t("banner.officialWebsite")}
-                </p>
-                <p className="usa-banner__header-action" aria-hidden="true">
-                  {i18n.t("banner.howYouKnow")}
-                </p>
-              </div>
-              <button
-                className="usa-accordion__button usa-banner__button"
-                aria-expanded={this.state.contentVisible}
-                aria-controls="gov-banner"
-                onClick={this.toggleDetails.bind(this)}
-              >
-                <span className="usa-banner__button-text">
-                  {i18n.t("banner.howYouKnow")}
-                </span>
-              </button>
+          <div className="usa-banner__inner">
+            <div className="grid-col-auto">
+              <img
+                className="usa-banner__header-flag"
+                src={usFlagSmall}
+                alt="U.S. flag"
+              />
             </div>
-          </header>
+            <div className="grid-col-fill tablet:grid-col-auto">
+              <p className="usa-banner__header-text">
+                {i18n.t("banner.officialWebsite")}
+              </p>
+              <p className="usa-banner__header-action" aria-hidden="true">
+                {i18n.t("banner.howYouKnow")}
+              </p>
+            </div>
+            <button
+              className="usa-accordion__button usa-banner__button"
+              aria-expanded={this.state.contentVisible}
+              aria-controls="gov-banner"
+              aria-label={"Here's how you know this is an official website"}
+              type="button"
+              onClick={this.toggleDetails.bind(this)}
+            >
+              <span className="usa-banner__button-text" aria-hidden={true}>
+                {i18n.t("banner.howYouKnow")}
+              </span>
+            </button>
+          </div>
           {this.renderAccordionContent()}
         </div>
       </div>

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -49,37 +49,42 @@ const PatientApp = () => {
 
   if (!isValidUUID(plid)) {
     return (
-      <Page>
-        <PatientHeader />
-        <main>
-          <div className="grid-container maxw-tablet">
-            <p></p>
-            <Alert
-              type="error"
-              title="Page not found"
-              body={t("testResult.dob.linkNotFound")}
-            />
-          </div>
-        </main>
-      </Page>
+      <Page
+        header={<PatientHeader />}
+        children={
+          <main>
+            <div className="grid-container maxw-tablet">
+              <p></p>
+              <Alert
+                type="error"
+                title="Page not found"
+                body={t("testResult.dob.linkNotFound")}
+              />
+            </div>
+          </main>
+        }
+        isPatientApp={true}
+      />
     );
   }
 
   return (
-    <Page>
-      <PatientHeader />
-      <PatientLinkURL404Wrapper plid={plid}>
-        <Routes>
-          <Route path="/" element={<TermsOfService />} />
-          <Route path="terms-of-service" element={<TermsOfService />} />
-          <Route path="birth-date-confirmation" element={<DOB />} />
-          <Route
-            path="test-result"
-            element={<GuardedRoute auth={auth} element={<TestResult />} />}
-          />
-        </Routes>
-      </PatientLinkURL404Wrapper>
-    </Page>
+    <Page
+      header={<PatientHeader />}
+      children={
+        <PatientLinkURL404Wrapper plid={plid}>
+          <Routes>
+            <Route path="/" element={<TermsOfService />} />
+            <Route path="terms-of-service" element={<TermsOfService />} />
+            <Route path="birth-date-confirmation" element={<DOB />} />
+            <Route
+              path="test-result"
+              element={<GuardedRoute auth={auth} element={<TestResult />} />}
+            />
+          </Routes>
+        </PatientLinkURL404Wrapper>
+      }
+    />
   );
 };
 

--- a/frontend/src/patientApp/PatientHeader.test.tsx
+++ b/frontend/src/patientApp/PatientHeader.test.tsx
@@ -90,5 +90,19 @@ describe("PatientHeader", () => {
         await screen.findByText("Test Org, Test Facility", { exact: false })
       ).toBeInTheDocument();
     });
+
+    it("correctly displays the SimpleReport logo", async () => {
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <PatientHeader />
+          </Provider>
+        </MemoryRouter>
+      );
+
+      expect(
+        await screen.findByAltText("SimpleReport", { exact: false })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -35,7 +35,7 @@ const PatientHeader = () => {
               <img
                 className="width-4"
                 src={siteLogo}
-                alt="{process.env.REACT_APP_TITLE}"
+                alt={process.env.REACT_APP_TITLE}
               />
               <div className="logo-text margin-left-1 display-flex flex-column">
                 <span

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -23,40 +23,35 @@ const PatientHeader = () => {
   const { t } = useTranslation("translation");
 
   return (
-    <header className="header border-bottom border-base-lighter">
-      <div className="display-flex flex-align-center maxw-tablet grid-container patient-header">
-        <div className="padding-y-1">
-          <div className="margin-bottom-0" id="basic-logo">
-            <div
-              className="display-flex flex-align-center"
-              title="SimpleReport"
-            >
-              <img
-                className="width-4"
-                src={siteLogo}
-                alt={process.env.REACT_APP_TITLE}
-              />
-              <div className="logo-text margin-left-1 display-flex flex-column">
-                <span
-                  className="prime-organization-name margin-left-0 font-body-md text-primary-darker text-bold"
-                  data-testid="banner-text"
-                >
-                  {organizationName &&
-                    facilityName &&
-                    `${organizationName}, ${facilityName}`}
-                </span>
-                <span className="prime-organization-name margin-left-0 margin-top-05 text-primary-darker">
-                  {t("header")}
-                </span>
-              </div>
+    <div className="display-flex flex-align-center maxw-tablet grid-container patient-header">
+      <div className="padding-y-1">
+        <div className="margin-bottom-0" id="basic-logo">
+          <div className="display-flex flex-align-center" title="SimpleReport">
+            <img
+              className="width-4"
+              src={siteLogo}
+              alt={process.env.REACT_APP_TITLE}
+            />
+            <div className="logo-text margin-left-1 display-flex flex-column">
+              <span
+                className="prime-organization-name margin-left-0 font-body-md text-primary-darker text-bold"
+                data-testid="banner-text"
+              >
+                {organizationName &&
+                  facilityName &&
+                  `${organizationName}, ${facilityName}`}
+              </span>
+              <span className="prime-organization-name margin-left-0 margin-top-05 text-primary-darker">
+                {t("header")}
+              </span>
             </div>
           </div>
         </div>
-        <div className="display-flex flex-align-end">
-          <LanguageToggler />
-        </div>
       </div>
-    </header>
+      <div className="display-flex flex-align-end">
+        <LanguageToggler />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -29,8 +29,7 @@ const PatientHeader = () => {
           <div className="margin-bottom-0" id="basic-logo">
             <div
               className="display-flex flex-align-center"
-              title="Home"
-              aria-label="Home"
+              title="SimpleReport"
             >
               <img
                 className="width-4"

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -5,12 +5,12 @@ import moment from "moment";
 import "react-toastify/dist/ReactToastify.css";
 import { useTranslation } from "react-i18next";
 
-import USAGovBanner from "../../app/commonComponents/USAGovBanner";
 import { showError } from "../../app/utils";
 import { formatFullName } from "../../app/utils/user";
 import PatientHeader from "../PatientHeader";
 import { PxpApi, SelfRegistrationData } from "../PxpApiService";
 import TermsOfService from "../timeOfTest/TermsOfService";
+import Page from "../../app/commonComponents/Page/Page";
 
 import { Confirmation } from "./Confirmation";
 import { RegistrationContainer } from "./RegistrationContainer";
@@ -88,52 +88,63 @@ export const SelfRegistration = () => {
 
   return (
     <div className="bg-base-lightest minh-viewport">
-      <div className="bg-white">
-        <USAGovBanner />
-        <PatientHeader />
-      </div>
-      <RegistrationContainer
-        registrationLink={registrationLink}
-        setEntityName={setEntityName}
-      >
-        <div className="bg-white padding-y-105">
-          <div className="grid-container maxw-tablet">
-            <h1 className="margin-top-0 margin-bottom-1">
-              {step === RegistrationStep.FINISHED
-                ? t("selfRegistration.form.complete")
-                : t("selfRegistration.form.inProgress")}
-            </h1>
-            <h2 className="margin-y-0 text-normal">{entityName}</h2>
+      <Page
+        header={
+          <div className="bg-white">
+            <PatientHeader />
           </div>
-        </div>
-        <div className="bg-base-lightest">
-          {step === RegistrationStep.TERMS && (
-            <TermsOfService
-              className="padding-top-05"
-              onAgree={() => {
-                setStep(RegistrationStep.FORM);
-              }}
-            />
-          )}
-          {step === RegistrationStep.FORM && (
-            <SelfRegistrationForm
-              savePerson={savePerson}
-              onDuplicate={onDuplicate}
-              entityName={entityName}
+        }
+        children={
+          <div>
+            <RegistrationContainer
               registrationLink={registrationLink}
+              setEntityName={setEntityName}
+            >
+              <div className="bg-white padding-y-105">
+                <div className="grid-container maxw-tablet">
+                  <h1 className="margin-top-0 margin-bottom-1">
+                    {step === RegistrationStep.FINISHED
+                      ? t("selfRegistration.form.complete")
+                      : t("selfRegistration.form.inProgress")}
+                  </h1>
+                  <h2 className="margin-y-0 text-normal">{entityName}</h2>
+                </div>
+              </div>
+              <div className="bg-base-lightest">
+                {step === RegistrationStep.TERMS && (
+                  <TermsOfService
+                    className="padding-top-05"
+                    onAgree={() => {
+                      setStep(RegistrationStep.FORM);
+                    }}
+                  />
+                )}
+                {step === RegistrationStep.FORM && (
+                  <SelfRegistrationForm
+                    savePerson={savePerson}
+                    onDuplicate={onDuplicate}
+                    entityName={entityName}
+                    registrationLink={registrationLink}
+                  />
+                )}
+                {step === RegistrationStep.FINISHED && (
+                  <Confirmation
+                    personName={personName}
+                    entityName={entityName}
+                  />
+                )}
+              </div>
+            </RegistrationContainer>
+            <ToastContainer
+              autoClose={5000}
+              closeButton={false}
+              limit={2}
+              position="bottom-center"
+              hideProgressBar={true}
             />
-          )}
-          {step === RegistrationStep.FINISHED && (
-            <Confirmation personName={personName} entityName={entityName} />
-          )}
-        </div>
-      </RegistrationContainer>
-      <ToastContainer
-        autoClose={5000}
-        closeButton={false}
-        limit={2}
-        position="bottom-center"
-        hideProgressBar={true}
+          </div>
+        }
+        isPatientApp={true}
       />
     </div>
   );


### PR DESCRIPTION
# FRONTEND PULL REQUEST

- Fixes #3974 

## Changes Proposed

There should only be a single `<header>` landmark on any page. SimpleReport had `<header>` elements both for the USAGov banner, and for the navigation bar. 

This change deconflicts these `<header>` elements by putting both of them inside the `Page` component.

## Additional Information

- The usual caveats of "I am a backend engineer attempting to write frontend code, please check this throughly"
- Chromatic definitely should be checked here

## The Diff
Github has not done a great job with diff-checking this one...the actual changes to the `App`, `PatientExperience`, and `PatientRegistration` files are from

```
<Page>
{ child components, including header }
< /Page>
```

to
```
< Page 
 header = {header}
children = {children}
/>
```
none of the actual `children` content changed at all.

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README