### PR TITLE
Encode language change for "Espanol" button

### DIFF
--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -14,7 +14,7 @@ import { GetTestResultForPrintDocument } from "../../generated/graphql";
 import { displayFullName } from "../utils";
 import { formatDateWithTimeOption } from "../utils/date";
 import { hasMultiplexResults } from "../utils/testResults";
-import { setDocumentLanguage } from "../utils/languages";
+import { setLanguage } from "../utils/languages";
 
 interface OrderingProvider {
   firstName: string;
@@ -220,7 +220,7 @@ export const DetachedTestResultPrintModal = ({
         label={t("testResult.close")}
         onClick={() => {
           closeModal();
-          setDocumentLanguage("en");
+          setLanguage("en");
         }}
       />
       <Button label={t("testResult.print")} onClick={() => window.print()} />

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -14,6 +14,7 @@ import { GetTestResultForPrintDocument } from "../../generated/graphql";
 import { displayFullName } from "../utils";
 import { formatDateWithTimeOption } from "../utils/date";
 import { hasMultiplexResults } from "../utils/testResults";
+import { setDocumentLanguage } from "../utils/languages";
 
 interface OrderingProvider {
   firstName: string;
@@ -217,7 +218,10 @@ export const DetachedTestResultPrintModal = ({
       <Button
         variant="unstyled"
         label={t("testResult.close")}
-        onClick={closeModal}
+        onClick={() => {
+          closeModal();
+          setDocumentLanguage("en");
+        }}
       />
       <Button label={t("testResult.print")} onClick={() => window.print()} />
     </div>

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -44,6 +44,7 @@ import {
   useGetFacilityResultsMultiplexQuery,
   useGetResultsCountByFacilityQuery,
 } from "../../generated/graphql";
+import { setDocumentLanguage } from "../utils/languages";
 
 import TestResultPrintModal from "./TestResultPrintModal";
 import TestResultTextModal from "./TestResultTextModal";
@@ -220,7 +221,10 @@ export const DetachedTestResultsList = ({
     return (
       <TestResultPrintModal
         testResultId={printModalId}
-        closeModal={() => setPrintModalId(undefined)}
+        closeModal={() => {
+          setDocumentLanguage("en");
+          setPrintModalId(undefined);
+        }}
       />
     );
   }

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -44,7 +44,6 @@ import {
   useGetFacilityResultsMultiplexQuery,
   useGetResultsCountByFacilityQuery,
 } from "../../generated/graphql";
-import { setDocumentLanguage } from "../utils/languages";
 
 import TestResultPrintModal from "./TestResultPrintModal";
 import TestResultTextModal from "./TestResultTextModal";
@@ -221,10 +220,7 @@ export const DetachedTestResultsList = ({
     return (
       <TestResultPrintModal
         testResultId={printModalId}
-        closeModal={() => {
-          setDocumentLanguage("en");
-          setPrintModalId(undefined);
-        }}
+        closeModal={() => setPrintModalId(undefined)}
       />
     );
   }

--- a/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
@@ -26,27 +26,31 @@ Object {
           <div
             class="display-flex flex-align-center maxw-tablet grid-container patient-header padding-x-0 dont-print"
           >
-            <button
-              class="usa-button usa-button--unstyled"
-              type="button"
+            <div
+              lang="es"
             >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-globe fa-w-16 margin-right-1"
-                data-icon="globe"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                viewBox="0 0 496 512"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                class="usa-button usa-button--unstyled"
+                type="button"
               >
-                <path
-                  d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
-                  fill="currentColor"
-                />
-              </svg>
-              Español
-            </button>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-globe fa-w-16 margin-right-1"
+                  data-icon="globe"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 496 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
+                    fill="currentColor"
+                  />
+                </svg>
+                Español
+              </button>
+            </div>
             <div
               class="sr-result-print-buttons dont-print"
             >
@@ -352,27 +356,31 @@ your local health department.
         <div
           class="display-flex flex-align-center maxw-tablet grid-container patient-header padding-x-0 dont-print"
         >
-          <button
-            class="usa-button usa-button--unstyled"
-            type="button"
+          <div
+            lang="es"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-globe fa-w-16 margin-right-1"
-              data-icon="globe"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 496 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              class="usa-button usa-button--unstyled"
+              type="button"
             >
-              <path
-                d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
-                fill="currentColor"
-              />
-            </svg>
-            Español
-          </button>
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-globe fa-w-16 margin-right-1"
+                data-icon="globe"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 496 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
+                  fill="currentColor"
+                />
+              </svg>
+              Español
+            </button>
+          </div>
           <div
             class="sr-result-print-buttons dont-print"
           >

--- a/frontend/src/app/utils/languages.tsx
+++ b/frontend/src/app/utils/languages.tsx
@@ -1,7 +1,8 @@
 import { languages } from "../../config/constants";
 import i18n from "../../i18n";
 
-export function setDocumentLanguage(displayLanguage: string) {
+export function setLanguage(displayLanguage: string) {
+  i18n.changeLanguage(displayLanguage);
   document.documentElement.setAttribute("lang", displayLanguage);
 }
 

--- a/frontend/src/app/utils/languages.tsx
+++ b/frontend/src/app/utils/languages.tsx
@@ -1,6 +1,10 @@
 import { languages } from "../../config/constants";
 import i18n from "../../i18n";
 
+export function setDocumentLanguage(displayLanguage: string) {
+  document.documentElement.setAttribute("lang", displayLanguage);
+}
+
 export default function getI18nLanguages(): string[] {
   return languages.map((language) => {
     const translationKey = `languages.${language}`;

--- a/frontend/src/patientApp/LanguageToggler.tsx
+++ b/frontend/src/patientApp/LanguageToggler.tsx
@@ -3,15 +3,18 @@ import i18n from "../i18n";
 
 export default function LanguageToggler() {
   return (
-    <Button
-      icon={"globe"}
-      className="usa-button--unstyled"
-      onClick={() => {
-        const displayLanguage = i18n.language === "en" ? "es" : "en";
-        i18n.changeLanguage(displayLanguage);
-      }}
-    >
-      {i18n.language === "en" ? "Español" : "English"}
-    </Button>
+    <div lang={i18n.language === "en" ? "es" : "en"}>
+      <Button
+        icon={"globe"}
+        className="usa-button--unstyled"
+        onClick={() => {
+          const displayLanguage = i18n.language === "en" ? "es" : "en";
+          i18n.changeLanguage(displayLanguage);
+          document.documentElement.setAttribute("lang", displayLanguage);
+        }}
+      >
+        {i18n.language === "en" ? "Español" : "English"}
+      </Button>
+    </div>
   );
 }

--- a/frontend/src/patientApp/LanguageToggler.tsx
+++ b/frontend/src/patientApp/LanguageToggler.tsx
@@ -1,5 +1,6 @@
 import Button from "../app/commonComponents/Button/Button";
 import i18n from "../i18n";
+import { setDocumentLanguage } from "../app/utils/languages";
 
 export default function LanguageToggler() {
   return (
@@ -10,7 +11,7 @@ export default function LanguageToggler() {
         onClick={() => {
           const displayLanguage = i18n.language === "en" ? "es" : "en";
           i18n.changeLanguage(displayLanguage);
-          document.documentElement.setAttribute("lang", displayLanguage);
+          setDocumentLanguage(displayLanguage);
         }}
       >
         {i18n.language === "en" ? "Español" : "English"}

--- a/frontend/src/patientApp/LanguageToggler.tsx
+++ b/frontend/src/patientApp/LanguageToggler.tsx
@@ -1,6 +1,6 @@
 import Button from "../app/commonComponents/Button/Button";
 import i18n from "../i18n";
-import { setDocumentLanguage } from "../app/utils/languages";
+import { setLanguage } from "../app/utils/languages";
 
 export default function LanguageToggler() {
   return (
@@ -10,8 +10,7 @@ export default function LanguageToggler() {
         className="usa-button--unstyled"
         onClick={() => {
           const displayLanguage = i18n.language === "en" ? "es" : "en";
-          i18n.changeLanguage(displayLanguage);
-          setDocumentLanguage(displayLanguage);
+          setLanguage(displayLanguage);
         }}
       >
         {i18n.language === "en" ? "Español" : "English"}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #3975 
Fixes #4087 
Fixes untracked issue where the overall document language didn't change when a user elected to view the result in Spanish.

## Changes Proposed

- Add a language change to the button specifically (so that the button text "Espanol" is marked Spanish-language)
- Changes the document `lang` attribute to reflect the language chosen in the toggler

## Additional Information

- `document.setAttribute` hack grabbed from the [i18next docs](https://github.com/i18next/react-i18next/issues/925#issuecomment-522299751) but if there's a better way to do this I'm all ears

## Screenshots

https://user-images.githubusercontent.com/80282552/182261908-60ba857d-8f4e-4a9b-8400-7d06b39b42ca.mp4

## Testing

- Validate that document `lang` attribute is correct in all locations

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README