### PR TITLE
Add accessible name for facility select dropdown in app header

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -361,6 +361,7 @@ const Header: React.FC<{}> = () => {
         {facilities && facilities.length > 0 ? (
           <div className="prime-facility-select">
             <Dropdown
+              aria-label={"Select facility"}
               selectedValue={facility.id}
               onChange={onFacilitySelect}
               options={facilities.map(({ name, id }) => ({


### PR DESCRIPTION
## Related Issue
* Closes #4020 

## Changes Proposed
* Adds an accessible name for the facility select dropdown in the app header

## Testing
### Before
<img width="779" alt="Screen Shot 2022-08-02 at 3 35 25 PM" src="https://user-images.githubusercontent.com/27730981/182461919-429cf990-5547-4b3e-b12c-3d9a0a91c51f.png">

### After
<img width="768" alt="Screen Shot 2022-08-02 at 3 35 49 PM" src="https://user-images.githubusercontent.com/27730981/182461921-f6bd8c7f-63f7-4dc2-8c3e-7571469ccd17.png">

<img width="715" alt="Screen Shot 2022-08-02 at 3 59 43 PM" src="https://user-images.githubusercontent.com/27730981/182462589-9d4c15d1-a21a-4199-b19d-c3b830caf4d6.png">

## Checklist for Author and Reviewer
- [ ] Does the label I chose cohere with the overall AT experience of the app?
    - "Select facility" won out over "Facility select" or just "Facility" but open to input!

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

### Documentation
- [x] Any changes to the startup configuration have been documented in the README