### PR TITLE
Fix markup for test card submit button when disabled

### DIFF
--- a/frontend/src/app/commonComponents/Button/Button.tsx
+++ b/frontend/src/app/commonComponents/Button/Button.tsx
@@ -39,6 +39,7 @@ const Button = ({
   <button
     type={type}
     disabled={disabled}
+    aria-disabled={disabled}
     className={classnames(
       "usa-button",
       variant && `usa-button--${variant}`,

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -58,6 +58,7 @@ Object {
                     class="display-flex flex-align-center"
                   >
                     <button
+                      aria-disabled="true"
                       class="usa-button usa-button--outline usa-button-disabled prime-save-patient-changes-start-test"
                       disabled=""
                       id="edit-patient-save-lower"
@@ -2574,6 +2575,7 @@ Object {
                 class="prime-edit-patient-heading"
               >
                 <button
+                  aria-disabled="true"
                   class="usa-button usa-button-disabled prime-save-patient-changes"
                   disabled=""
                   id="edit-patient-save-lower"
@@ -2645,6 +2647,7 @@ Object {
                   class="display-flex flex-align-center"
                 >
                   <button
+                    aria-disabled="true"
                     class="usa-button usa-button--outline usa-button-disabled prime-save-patient-changes-start-test"
                     disabled=""
                     id="edit-patient-save-lower"
@@ -5161,6 +5164,7 @@ Object {
               class="prime-edit-patient-heading"
             >
               <button
+                aria-disabled="true"
                 class="usa-button usa-button-disabled prime-save-patient-changes"
                 disabled=""
                 id="edit-patient-save-lower"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -29,6 +29,7 @@ Object {
                   style="display: flex; justify-content: center; align-items: center;"
                 >
                   <button
+                    aria-disabled="true"
                     class="usa-button usa-button-disabled"
                     disabled=""
                     type="button"
@@ -554,6 +555,7 @@ Object {
                 style="display: flex; justify-content: center; align-items: center;"
               >
                 <button
+                  aria-disabled="true"
                   class="usa-button usa-button-disabled"
                   disabled=""
                   type="button"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDevicesForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDevicesForm.test.tsx.snap
@@ -29,6 +29,7 @@ Object {
                   style="display: flex; justify-content: center; align-items: center;"
                 >
                   <button
+                    aria-disabled="true"
                     class="usa-button usa-button-disabled"
                     disabled=""
                     type="button"
@@ -551,6 +552,7 @@ Object {
                 style="display: flex; justify-content: center; align-items: center;"
               >
                 <button
+                  aria-disabled="true"
                   class="usa-button usa-button-disabled"
                   disabled=""
                   type="button"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -445,6 +445,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   class="prime-test-result-submit"
                 >
                   <button
+                    aria-disabled="true"
                     class="usa-button usa-button--outline usa-button-disabled"
                     disabled=""
                     type="submit"
@@ -852,6 +853,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   class="prime-test-result-submit"
                 >
                   <button
+                    aria-disabled="true"
                     class="usa-button usa-button--outline usa-button-disabled"
                     disabled=""
                     type="submit"

--- a/frontend/src/app/testResults/__snapshots__/DownloadResultsCsvModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/DownloadResultsCsvModal.test.tsx.snap
@@ -108,6 +108,7 @@ Object {
                   No, go back
                 </button>
                 <button
+                  aria-disabled="false"
                   class="usa-button"
                   type="button"
                 >
@@ -246,6 +247,7 @@ Object {
                 No, go back
               </button>
               <button
+                aria-disabled="false"
                 class="usa-button"
                 type="button"
               >
@@ -440,6 +442,7 @@ Object {
                   No, go back
                 </button>
                 <button
+                  aria-disabled="false"
                   class="usa-button"
                   type="button"
                 >
@@ -578,6 +581,7 @@ Object {
                 No, go back
               </button>
               <button
+                aria-disabled="false"
                 class="usa-button"
                 type="button"
               >
@@ -761,6 +765,7 @@ Object {
                   Go back
                 </button>
                 <button
+                  aria-disabled="true"
                   class="usa-button usa-button-disabled"
                   disabled=""
                   type="button"
@@ -889,6 +894,7 @@ Object {
                 Go back
               </button>
               <button
+                aria-disabled="true"
                 class="usa-button usa-button-disabled"
                 disabled=""
                 type="button"

--- a/frontend/src/app/testResults/__snapshots__/TestResultCorrectionModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultCorrectionModal.test.tsx.snap
@@ -78,6 +78,7 @@ Object {
               No, go back
             </button>
             <button
+              aria-disabled="false"
               class="usa-button"
               type="button"
             >
@@ -162,6 +163,7 @@ Object {
             No, go back
           </button>
           <button
+            aria-disabled="false"
             class="usa-button"
             type="button"
           >


### PR DESCRIPTION
## Related Issue
* Closes #4048 

## Changes Proposed
- The `disabled` prop passed to a `Button` component is also applied to the `aria-disabled` attribute on the rendered button element

## Testing
### Before
<img width="777" alt="Screen Shot 2022-08-02 at 4 48 49 PM" src="https://user-images.githubusercontent.com/27730981/182649326-364b081e-8427-4f8c-9e1b-e11cbe4577a9.png">

### After
<img width="678" alt="Screen Shot 2022-08-02 at 4 48 58 PM" src="https://user-images.githubusercontent.com/27730981/182649328-a4a47998-7e0d-4f80-8cf3-0bb4205b66c4.png">

## Checklist for Author and Reviewer

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

### Documentation
- [x] Any changes to the startup configuration have been documented in the README