### PR TITLE
George/3958 pxp api response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ certs/
 yarn-error.log
 backend/locust/__pycache__/
 frontend/cypress.env.json
+frontend/src/.env.local

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/SupportedDiseaseTestResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/SupportedDiseaseTestResult.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 @Getter
 public class SupportedDiseaseTestResult {
   private SupportedDisease disease;
-  private TestResult result;
+  private TestResult testResult;
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -143,7 +143,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("NEGATIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.results[0].testResult", is("NEGATIVE"))) // TODO
+            .andExpect(jsonPath("$.results[0].testResult", is("NEGATIVE")))
             .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
             .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))
@@ -212,7 +212,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("POSITIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(3)))
-            .andExpect( // TODO
+            .andExpect(
                 jsonPath(
                         "$.results[?(@.disease.name == \"COVID-19\" && @.testResult == \"POSITIVE\")]")
                     .exists())
@@ -287,7 +287,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(jsonPath("$.testEventId", is(removedTestEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("POSITIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.results[0].testResult", is("POSITIVE"))) // TODO
+            .andExpect(jsonPath("$.results[0].testResult", is("POSITIVE")))
             .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
             .andExpect(jsonPath("$.correctionStatus", is("REMOVED")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -217,10 +217,12 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
                         "$.results[?(@.disease.name == \"COVID-19\" && @.testResult == \"POSITIVE\")]")
                     .exists())
             .andExpect(
-                jsonPath("$.results[?(@.disease.name == \"Flu A\" && @.result == \"NEGATIVE\")]")
+                jsonPath(
+                        "$.results[?(@.disease.name == \"Flu A\" && @.testResult == \"NEGATIVE\")]")
                     .exists())
             .andExpect(
-                jsonPath("$.results[?(@.disease.name == \"Flu B\" && @.result == \"NEGATIVE\")]")
+                jsonPath(
+                        "$.results[?(@.disease.name == \"Flu B\" && @.testResult == \"NEGATIVE\")]")
                     .exists())
             .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -143,7 +143,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("NEGATIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.results[0].result", is("NEGATIVE")))
+            .andExpect(jsonPath("$.results[0].testResult", is("NEGATIVE"))) // TODO
             .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
             .andExpect(jsonPath("$.correctionStatus", is("ORIGINAL")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))
@@ -212,8 +212,9 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("POSITIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(3)))
-            .andExpect(
-                jsonPath("$.results[?(@.disease.name == \"COVID-19\" && @.result == \"POSITIVE\")]")
+            .andExpect( // TODO
+                jsonPath(
+                        "$.results[?(@.disease.name == \"COVID-19\" && @.testResult == \"POSITIVE\")]")
                     .exists())
             .andExpect(
                 jsonPath("$.results[?(@.disease.name == \"Flu A\" && @.result == \"NEGATIVE\")]")
@@ -286,7 +287,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .andExpect(jsonPath("$.testEventId", is(removedTestEvent.getInternalId().toString())))
             .andExpect(jsonPath("$.result", is("POSITIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.results[0].result", is("POSITIVE")))
+            .andExpect(jsonPath("$.results[0].testResult", is("POSITIVE"))) // TODO
             .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
             .andExpect(jsonPath("$.correctionStatus", is("REMOVED")))
             .andExpect(jsonPath("$.patient.firstName", is("Fred")))


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #3958 
- Backend cleanup to return consistent test result response

## Changes Proposed

- Refactors `SupportedDiseaseTestResult` object to return a `testResult` instead of `result`, so the `PxpApiResponseV2` is consistent with the shape of the object returned in other places that return a list of `results`.

## Additional Information

## Testing

❗ ~~successfully deployed to `dev2` but currently there are okta issues with `dev2` so may not be able to test there~~ now successfully deployed in `test` ❗ 

To verify, view the response from:
1. Navigate to the results in ~~`https://dev2.simplereport.gov`~~ `https://test.simplereport.gov` and click to print a result
2. Navigate to ~~`https://dev2.simplereport.gov/pxp?plid={patientLinkUUID}`~~  `https://test.simplereport.gov/pxp?plid={patientLinkUUID}`

Observe the response for both includes `results: [ { disease : { } }, testResult : " " } ]`

graphql response screenshot for reference:
![Screen Shot 2022-08-04 at 2 45 20 PM](https://user-images.githubusercontent.com/89797785/183107065-b0c1f265-2b9c-4c82-ae54-b4ae8c36c615.png)

screenshot from local development before refactor of the pxp api response:
![Screen Shot 2022-08-04 at 2 44 22 PM](https://user-images.githubusercontent.com/89797785/183107132-aa154c6b-c6e7-4e00-9e59-128e51860342.png)

And after:
![Screen Shot 2022-08-04 at 2 49 52 PM](https://user-images.githubusercontent.com/89797785/183107220-c2295203-bb5b-4747-ae82-4961deb5b013.png)


## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Changes comply with the SimpleReport Style Guide