### PR TITLE
Improve ARIA labeling of test card "close" buttons

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -947,7 +947,9 @@ describe("QueueItem", () => {
     });
 
     it("tracks removal of patient from queue as custom event", () => {
-      const button = screen.getByLabelText("Close");
+      const button = screen.getByLabelText(
+        `Close test for Potter, Harry James`
+      );
       userEvent.click(button);
       const iAmSure = screen.getByText("Yes, I'm sure");
       userEvent.click(iAmSure);

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -646,7 +646,7 @@ const QueueItem = ({
         setConfirmationType("removeFromQueue");
       }}
       className="prime-close-button"
-      aria-label="Close"
+      aria-label={`Close test for ${patientFullName}`}
     >
       <span className="fa-layers">
         <FontAwesomeIcon icon={"circle"} size="2x" inverse />

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -83,7 +83,9 @@ describe("TestQueue", () => {
       </MemoryRouter>
     );
     expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
-    const removeButton = (await screen.findAllByLabelText("Close"))[0];
+    const removeButton = await screen.findByLabelText(
+      "Close test for Doe, John A"
+    );
     userEvent.click(removeButton);
     const confirmButton = await screen.findByText("Yes", { exact: false });
     userEvent.click(confirmButton);

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`TestQueue should render the test queue 1`] = `
           class="prime-card-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Close test for Doe, John A"
             class="prime-close-button"
           >
             <span
@@ -482,7 +482,7 @@ exports[`TestQueue should render the test queue 1`] = `
           class="prime-card-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Close test for Smith, Jane"
             class="prime-close-button"
           >
             <span


### PR DESCRIPTION
## Related Issue

- Closes #4018 

## Changes Proposed

- Adds more detail to the ARIA label for the test card close button
    - Be explicit that the thing you can close is a _test_
    - Adds the patient's full name to the label
        - ARIA labels should not be shared between elements, so adding the patient name disambiguates the labels in almost all cases

## Screenshots / Demos
### Before
<img width="1071" alt="Screen Shot 2022-08-04 at 1 47 39 PM" src="https://user-images.githubusercontent.com/27730981/182953884-cf4ae256-7268-4d59-9a6f-8c7e56cb6df2.png">

### After
<img width="1092" alt="Screen Shot 2022-08-04 at 3 47 24 PM" src="https://user-images.githubusercontent.com/27730981/182953887-d17b0c63-31a5-4e20-8995-2c40ca334129.png">

## Checklist for Author and Reviewer

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

### Documentation
- [x] Any changes to the startup configuration have been documented in the README