### PR TITLE
Add aria-label to tooltip custom buttons (#4019)

### DIFF
--- a/frontend/src/app/commonComponents/TextWithTooltip.tsx
+++ b/frontend/src/app/commonComponents/TextWithTooltip.tsx
@@ -13,6 +13,7 @@ type CustomButtonProps = React.PropsWithChildren<{
 interface Props {
   tooltip: string;
   position?: "top" | "bottom" | "left" | "right";
+  buttonLabel?: string;
   text?: string;
   className?: string;
 }
@@ -21,6 +22,7 @@ export const TextWithTooltip = ({
   tooltip,
   position,
   text,
+  buttonLabel,
   className,
 }: Props) => {
   const CustomButton: React.ForwardRefExoticComponent<CustomButtonProps> = React.forwardRef(
@@ -28,6 +30,7 @@ export const TextWithTooltip = ({
       <button
         className={`usa-button usa-button--unstyled ${className}`}
         ref={ref}
+        aria-label={buttonLabel}
         {...tooltipProps}
       >
         {children}

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -907,6 +907,7 @@ const QueueItem = ({
                           <span>Device</span>
 
                           <TextWithTooltip
+                            buttonLabel="Device"
                             tooltip="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
                             position="right"
                           />

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -271,6 +271,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         >
                           <button
                             aria-describedby="tooltip-211111"
+                            aria-label="Device"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -680,6 +681,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         >
                           <button
                             aria-describedby="tooltip-211111"
+                            aria-label="Device"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #4019 

## Changes Proposed
- Add a new optional prop to the `TextWithTooltip` component so that the `<Button>` wrapping around the tooltip can have an `aria-label` associated with it
- Adds an `aria-label` for the device tooltip

## Additional Information
N/A

## Testing

- Use VoiceOver or similar screen reader
- Navigate to the "Conduct tests" tab

<img width="637" alt="Screen Shot 2022-08-05 at 1 52 37 PM" src="https://user-images.githubusercontent.com/20211771/183142687-859e6add-478c-4819-892f-60045d17adab.png">

- Keyboard tab over to the Device tooltip with VoiceOver/screen reader
- Ensure you hear "Device button" when tabbing to the Device tooltip
 
## Screenshots / Demos

N/A

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README