### PR TITLE
Allow test result list filtering on archived patient

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
@@ -42,24 +42,6 @@ public class PatientResolver implements GraphQLQueryResolver {
         includeArchivedFacilities);
   }
 
-  public List<Person> getPatients(
-      UUID facilityId,
-      int pageNumber,
-      int pageSize,
-      boolean showActive,
-      boolean showDeleted,
-      String namePrefixMatch,
-      boolean includeArchivedFacilities) {
-    return _ps.getPatients(
-        facilityId,
-        pageNumber,
-        pageSize,
-        showActive,
-        showDeleted,
-        namePrefixMatch,
-        includeArchivedFacilities);
-  }
-
   // authorization happens in calls to PersonService
   public long patientsCount(UUID facilityId, boolean showDeleted, String namePrefixMatch) {
     return _ps.getPatientsCount(facilityId, showDeleted, namePrefixMatch, false);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
@@ -33,7 +33,31 @@ public class PatientResolver implements GraphQLQueryResolver {
       String namePrefixMatch,
       boolean includeArchivedFacilities) {
     return _ps.getPatients(
-        facilityId, pageNumber, pageSize, showDeleted, namePrefixMatch, includeArchivedFacilities);
+        facilityId,
+        pageNumber,
+        pageSize,
+        true,
+        showDeleted,
+        namePrefixMatch,
+        includeArchivedFacilities);
+  }
+
+  public List<Person> getPatients(
+      UUID facilityId,
+      int pageNumber,
+      int pageSize,
+      boolean showActive,
+      boolean showDeleted,
+      String namePrefixMatch,
+      boolean includeArchivedFacilities) {
+    return _ps.getPatients(
+        facilityId,
+        pageNumber,
+        pageSize,
+        showActive,
+        showDeleted,
+        namePrefixMatch,
+        includeArchivedFacilities);
   }
 
   // authorization happens in calls to PersonService

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -224,7 +224,6 @@ public class PersonService {
             includeArchivedFacilities);
   }
 
-  @AuthorizationConfiguration.RequireSpecificPatientSearchPermission
   public List<Person> getPatients(
       UUID facilityId,
       int pageOffset,
@@ -281,7 +280,7 @@ public class PersonService {
     var filter =
         isArchived
             ? buildPersonSearchFilter(
-                facilityId, false, true, namePrefixMatch, includeArchivedFacilities)
+                facilityId, true, true, namePrefixMatch, includeArchivedFacilities)
             : buildPersonSearchFilter(
                 facilityId, true, false, namePrefixMatch, includeArchivedFacilities);
     return _repo.count(filter);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -139,8 +139,8 @@ public class PersonService {
   // called by List function and Count function
   protected Specification<Person> buildPersonSearchFilter(
       UUID facilityId,
-      boolean isActive,
-      boolean isArchived,
+      boolean includeActivePatients,
+      boolean includeArchivedPatients,
       String namePrefixMatch,
       boolean includeArchivedFacilities) {
 
@@ -152,11 +152,11 @@ public class PersonService {
     // build up filter based on params
     Specification<Person> filter = inCurrentOrganizationFilter();
 
-    if (isActive && isArchived) {
+    if (includeActivePatients && includeArchivedPatients) {
       filter = filter.and(isActiveFilter().or(isDeletedFilter()));
-    } else if (isActive) {
+    } else if (includeActivePatients) {
       filter = filter.and(isActiveFilter());
-    } else if (isArchived) {
+    } else if (includeArchivedPatients) {
       filter = filter.and(isDeletedFilter());
     }
 
@@ -190,7 +190,7 @@ public class PersonService {
    * @param facilityId If null, then it means across accessible facilities in the whole organization
    * @param pageOffset Pagination offset is zero based
    * @param pageSize How many results to return, zero will result in the default page size (large)
-   * @param isArchived Default is false. true will ONLY show deleted users
+   * @param includeArchivedPatients Default is false, true will ONLY show deleted users
    * @param namePrefixMatch Null returns all users, any string will filter by first,middle,last
    *     names that start with these characters. Case insenstive. If fewer than
    * @param includeArchivedFacilities setting to true will include patients in archived facilities,
@@ -202,10 +202,10 @@ public class PersonService {
       UUID facilityId,
       int pageOffset,
       int pageSize,
-      boolean isArchived,
+      boolean includeArchivedPatients,
       String namePrefixMatch,
       boolean includeArchivedFacilities) {
-    return isArchived
+    return includeArchivedPatients
         ? getPatients(
             facilityId,
             pageOffset,
@@ -229,8 +229,8 @@ public class PersonService {
       UUID facilityId,
       int pageOffset,
       int pageSize,
-      boolean isActive,
-      boolean isArchived,
+      boolean includeActivePatients,
+      boolean includeArchivedPatients,
       String namePrefixMatch,
       boolean includeArchivedFacilities) {
     if (pageOffset < 0) {
@@ -246,7 +246,11 @@ public class PersonService {
 
     return _repo.findAll(
         buildPersonSearchFilter(
-            facilityId, isActive, isArchived, namePrefixMatch, includeArchivedFacilities),
+            facilityId,
+            includeActivePatients,
+            includeArchivedPatients,
+            namePrefixMatch,
+            includeArchivedFacilities),
         PageRequest.of(pageOffset, pageSize, NAME_SORT));
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -197,7 +197,6 @@ public class PersonService {
    *     ignored if facilityId is not null
    * @return A list of matching patients.
    */
-  @AuthorizationConfiguration.RequireSpecificPatientSearchPermission
   public List<Person> getPatients(
       UUID facilityId,
       int pageOffset,
@@ -224,6 +223,7 @@ public class PersonService {
             includeArchivedFacilities);
   }
 
+  @AuthorizationConfiguration.RequireSpecificPatientSearchPermission
   public List<Person> getPatients(
       UUID facilityId,
       int pageOffset,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -643,8 +643,9 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
 
     assertEquals(10, _service.getPatientsCount(null, false, null, false));
     assertEquals(6, _service.getPatientsCount(site2Id, false, null, false));
-    assertEquals(2, _service.getPatientsCount(null, true, null, false));
-    assertEquals(1, _service.getPatientsCount(site2Id, true, null, false));
+    // Charles and Frank archived in this test, plus one by `makedata`
+    assertEquals(3, _service.getPatientsCount(null, true, null, false));
+    assertEquals(2, _service.getPatientsCount(site2Id, true, null, false));
 
     // counts for name filtering
     assertEquals(5, _service.getPatientsCount(null, false, "ma", false));
@@ -754,6 +755,39 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
         AccessDeniedException.class,
         () ->
             _service.getPatients(site1Id, PATIENT_PAGEOFFSET, PATIENT_PAGESIZE, true, null, false));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getPatients_includeArchived_returnsDeletedOnly() {
+    makedata(true);
+
+    UUID site1Id = _site1.getInternalId();
+    var results =
+        _service.getPatients(null, PATIENT_PAGEOFFSET, PATIENT_PAGESIZE, true, null, false);
+    assertEquals(1, results.size());
+    assertEquals("Margaret", results.get(0).getFirstName());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getPatients_includeActive_returnsActiveOnly() {
+    makedata(true);
+
+    var results =
+        _service.getPatients(null, PATIENT_PAGEOFFSET, PATIENT_PAGESIZE, true, false, null, false);
+    // 13 patients created; one (archived) not returned
+    assertEquals(12, results.size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getPatients_includeAll_returnsActiveAndDeleted() {
+    makedata(true);
+
+    var results =
+        _service.getPatients(null, PATIENT_PAGEOFFSET, PATIENT_PAGESIZE, true, true, null, false);
+    assertEquals(13, results.size());
   }
 
   @Test
@@ -1018,6 +1052,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
       _dataFactory.createMinimalPerson(_org, _site2, JANNELLE);
       _dataFactory.createMinimalPerson(_org, _site2, KACEY);
       _dataFactory.createMinimalPerson(_org, _site2, LEELOO);
+      _dataFactory.createMinimalPerson(_org, _site2, MARGARET, null, true);
     }
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -762,7 +762,6 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
   void getPatients_includeArchived_returnsDeletedOnly() {
     makedata(true);
 
-    UUID site1Id = _site1.getInternalId();
     var results =
         _service.getPatients(null, PATIENT_PAGEOFFSET, PATIENT_PAGESIZE, true, null, false);
     assertEquals(1, results.size());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -200,17 +200,26 @@ public class TestDataFactory {
 
   @Transactional
   public Person createMinimalPerson(Organization org, Facility fac, PersonName names) {
-    return createMinimalPerson(org, fac, names, PersonRole.STAFF);
+    return createMinimalPerson(org, fac, names, PersonRole.STAFF, false);
   }
 
   @Transactional
   public Person createMinimalPerson(
       Organization org, Facility fac, PersonName names, PersonRole role) {
+    return createMinimalPerson(org, fac, names, role, false);
+  }
+
+  @Transactional
+  public Person createMinimalPerson(
+      Organization org, Facility fac, PersonName names, PersonRole role, boolean isDeleted) {
     Person p = new Person(names, org, fac, role);
     _personRepo.save(p);
     PhoneNumber pn = new PhoneNumber(p, PhoneType.MOBILE, "503-867-5309");
     _phoneNumberRepo.save(pn);
     p.setPrimaryPhone(pn);
+    if (isDeleted) {
+      p.setIsDeleted(true);
+    }
     return _personRepo.save(p);
   }
 

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -44,7 +44,6 @@ const mocks = [
       variables: {
         facilityId,
         namePrefixMatch: "bar",
-        includeArchivedPatients: false,
       },
     },
     result: {
@@ -59,7 +58,6 @@ const mocks = [
       variables: {
         facilityId,
         namePrefixMatch: "joh",
-        includeArchivedPatients: false,
       },
     },
     result: {

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -44,6 +44,7 @@ const mocks = [
       variables: {
         facilityId,
         namePrefixMatch: "bar",
+        includeArchivedPatients: false,
       },
     },
     result: {
@@ -58,6 +59,7 @@ const mocks = [
       variables: {
         facilityId,
         namePrefixMatch: "joh",
+        includeArchivedPatients: false,
       },
     },
     result: {

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -175,7 +175,6 @@ const AddToQueueSearchBox = ({
 
   useQuery<{ patient: Patient }>(QUERY_SINGLE_PATIENT, {
     fetchPolicy: "no-cache",
-    //variables: { internalId: patientIdParam },
     variables: { internalId: startTestPatientId },
     onCompleted: (response) => {
       setSelectedPatient(response.patient);

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -54,12 +54,13 @@ export const QUERY_PATIENT = gql`
     $facilityId: ID
     $namePrefixMatch: String
     $includeArchivedFacilities: Boolean
+    $includeArchivedPatients: Boolean = false
   ) {
     patients(
       facilityId: $facilityId
       pageNumber: 0
       pageSize: 100
-      showDeleted: false
+      showDeleted: $includeArchivedPatients
       namePrefixMatch: $namePrefixMatch
       includeArchivedFacilities: $includeArchivedFacilities
     ) {

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -157,6 +157,7 @@ export const DetachedTestResultsList = ({
           : filterParams.filterFacilityId || activeFacilityId,
       namePrefixMatch: queryString,
       includeArchivedFacilities: isOrgAdmin,
+      includeArchivedPatients: true,
     },
   });
 

--- a/frontend/src/app/testResults/mocks/queries.mock.tsx
+++ b/frontend/src/app/testResults/mocks/queries.mock.tsx
@@ -317,6 +317,7 @@ export const mocks = [
         facilityId: "1",
         namePrefixMatch: "Cragell",
         includeArchivedFacilities: true,
+        includeArchivedPatients: true,
       },
     },
     result: {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2057,6 +2057,7 @@ export type GetPatientsByFacilityForQueueQueryVariables = Exact<{
   facilityId?: InputMaybe<Scalars["ID"]>;
   namePrefixMatch?: InputMaybe<Scalars["String"]>;
   includeArchivedFacilities?: InputMaybe<Scalars["Boolean"]>;
+  includeArchivedPatients?: InputMaybe<Scalars["Boolean"]>;
 }>;
 
 export type GetPatientsByFacilityForQueueQuery = {
@@ -5818,12 +5819,13 @@ export const GetPatientsByFacilityForQueueDocument = gql`
     $facilityId: ID
     $namePrefixMatch: String
     $includeArchivedFacilities: Boolean
+    $includeArchivedPatients: Boolean = false
   ) {
     patients(
       facilityId: $facilityId
       pageNumber: 0
       pageSize: 100
-      showDeleted: false
+      showDeleted: $includeArchivedPatients
       namePrefixMatch: $namePrefixMatch
       includeArchivedFacilities: $includeArchivedFacilities
     ) {
@@ -5860,6 +5862,7 @@ export const GetPatientsByFacilityForQueueDocument = gql`
  *      facilityId: // value for 'facilityId'
  *      namePrefixMatch: // value for 'namePrefixMatch'
  *      includeArchivedFacilities: // value for 'includeArchivedFacilities'
+ *      includeArchivedPatients: // value for 'includeArchivedPatients'
  *   },
  * });
  */


### PR DESCRIPTION
## Related Issue
- Closes #3567 
- Test results for archived patients are included in the test results list, but such patients do not appear as suggestions in the `Filter by name` input field

## Changes Proposed
- The behavior of the `showDeleted` parameter on the patient search GraphQL query is **changed in-place**
    - More specifically, this parameter would formerly return _only_ archived users when true
    - This now returns archived users _in addition_ to active ones
    - Normally we would never do this as it's a backwards-compatibility no-no!
        - However, I am _almost positive_ that no query ever performed by frontend sets that parameter to `true`
        - Therefore we should be able to change the behavior of the existing query rather than creating a side-by-side backwards compatibility shim
    - This is `true` **only** for the test result list filter
    - This is `false` for the "add to queue" search, since we presumably do not want to accept new test results for archived patients

## Screenshots / Demos
https://user-images.githubusercontent.com/27730981/186012450-df06aa9c-4917-4f4e-939e-a5eb84a50a93.mov

## Checklist for Author and Reviewer
- [ ] **Please confirm** that I am not changing the behavior of any existing `getPatients` calls by the frontend
    - Specifically, we're looking for calls where `showDeleted: true` where the desired behavior is receiving a list of _only_ archived patients
- [ ] Does this introduce any sneaky side effects?
- [ ] This casts a light on some less-than-ideal design around how archived patients are displayed throughout the app. Anything that reviewers identify will be worked under another ticket

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [x] Any changes that might generate new support requests have been flagged to the support team
- [x] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed

### Documentation
- [x] Any changes to the startup configuration have been documented in the README