### PR TITLE
Bump dockerfile nginx:1.21.1-alpine to nginx:1.23-alpine

### DIFF
--- a/frontend/cypress/support/nginx/Dockerfile.nginx.compose
+++ b/frontend/cypress/support/nginx/Dockerfile.nginx.compose
@@ -1,2 +1,2 @@
-FROM nginx:1.21.1-alpine
+FROM nginx:1.23-alpine
 COPY ./cypress/support/nginx/compose.conf /etc/nginx/conf.d/default.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.1-alpine
+FROM nginx:1.23-alpine
 LABEL org.opencontainers.image.source https://github.com/CDCgov/prime-simplereport
 
 COPY ./default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- [Unsupported nginx](https://endoflife.date/nginx) docker image

## Changes Proposed

- Move from nginx:1.21.1-alpine to nginx:1.23-alpine (which will use the latest in the 1.23 line)
- This includes a dockerfile for Cypress testing

## Additional Information

- Current image: nginx:1.21.1-alpine vulnerabilities 40  (4 Critical, 24 High, 9 Medium, 3 Low)

## Testing

- How should reviewers verify this PR?
 
## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README