### PR TITLE
add aria described by to the button

### DIFF
--- a/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
+++ b/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
@@ -54,10 +54,11 @@ const TermsOfService: React.FunctionComponent<Props> = ({
         <div className="tos-content prime-formgroup usa-prose height-card-lg overflow-x-hidden font-body-3xs">
           <ToS />
         </div>
-        <p>{t("testResult.tos.consent")}</p>
+        <p id="tos-consent-message">{t("testResult.tos.consent")}</p>
         <Button
           id="tos-consent-button"
           label={t("testResult.tos.submit")}
+          ariaDescribedBy={"tos-consent-message"}
           onClick={() => {
             if (onAgree) {
               onAgree();


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #3977 

## Changes Proposed

- Adds an aria-describedby element to the ToS agreement button

## Additional Information

The original ticket mentions we should used an aria-labeledby, but I opted to use aria-describedby since the helper text is more a description than a label. If we feel strongly the other way, happy to change it, but though this way of doing it fits better semantically. MSN documentation below for reference

<img width="826" alt="Screen Shot 2022-08-09 at 9 15 52 AM" src="https://user-images.githubusercontent.com/29645040/183672655-7c9d5f0f-15be-46e9-9a7f-c24cb5f0b98f.png">

cc @lauraykerr for your awareness / input
## Testing

- Navigate to patient self-reg page (or any page with the ToS button)
- Verify that the aria-describedby element is applied to the agree button and that it references the agreement message.

## Screenshots / Demos

<img width="1276" alt="Screen Shot 2022-08-09 at 9 13 44 AM" src="https://user-images.githubusercontent.com/29645040/183672931-ad82a7ad-c72c-4e56-89a8-f2ea630a27df.png">

### Content
- [ ] Any content changes have been approved by content team
