### PR TITLE
bob/3986 fix trashcan icon

### DIFF
--- a/frontend/src/app/patients/Components/ManageEmails.test.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.test.tsx
@@ -120,13 +120,13 @@ describe("ManageEmails", () => {
       exact: false,
     });
     userEvent.click(addButton);
-    const second = (await screen.findAllByText("Email address"))[1];
+
+    const second = (await screen.findAllByText("Additional email address"))[1];
     userEvent.type(second, "foo@bar.com");
-    userEvent.click(
-      (await screen.findAllByLabelText("Delete email", { exact: false }))[1]
-    );
-    await waitFor(() => {
-      expect(second).not.toBeInTheDocument();
-    });
+    userEvent.click(screen.getByTestId(`delete-email-1`));
+    expect(
+      screen.queryByText("Additional email address")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("foo@bar.com")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/patients/Components/ManageEmails.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.tsx
@@ -147,10 +147,10 @@ const ManageEmails: React.FC<Props> = ({
             {idx > 0 ? (
               <div className="flex-align-self-end">
                 <button
-                  className="usa-button--unstyled padding-105 height-5"
+                  className="usa-button--unstyled padding-105 height-5 cursor-pointer"
                   data-testid={`delete-email-${idx}`}
                   onClick={() => onEmailRemove(idx)}
-                  aria-label={`Delete email ${email}`.trim()}
+                  aria-label={`Delete email ${email.trim()}`}
                 >
                   <FontAwesomeIcon icon={"trash"} className={"text-error"} />
                 </button>

--- a/frontend/src/app/patients/Components/ManageEmails.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.tsx
@@ -127,7 +127,11 @@ const ManageEmails: React.FC<Props> = ({
               className="flex-fill emailFormElement"
               value={emailsOrDefault[idx] || ""}
               errorMessage={errors[idx]}
-              label={t("patient.form.contact.email")}
+              label={
+                idx > 0
+                  ? t("patient.form.contact.additionalEmail")
+                  : t("patient.form.contact.email")
+              }
               onBlur={() => {
                 validateField(idx);
               }}
@@ -136,15 +140,19 @@ const ManageEmails: React.FC<Props> = ({
                 onEmailChange(idx, e.target.value)
               }
             />
-            <div className="flex-align-self-end">
-              <button
-                className="usa-button--unstyled padding-105 height-5"
-                onClick={() => onEmailRemove(idx)}
-                aria-label={`Delete email ${email}`.trim()}
-              >
-                <FontAwesomeIcon icon={"trash"} className={"text-error"} />
-              </button>
-            </div>
+            {idx > 0 ? (
+              <div className="flex-align-self-end">
+                <button
+                  className="usa-button--unstyled padding-105 height-5"
+                  onClick={() => onEmailRemove(idx)}
+                  aria-label={`Delete email ${email}`.trim()}
+                >
+                  <FontAwesomeIcon icon={"trash"} className={"text-error"} />
+                </button>
+              </div>
+            ) : (
+              <></>
+            )}
           </div>
         </div>
       ))}

--- a/frontend/src/app/patients/Components/ManageEmails.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.tsx
@@ -148,6 +148,7 @@ const ManageEmails: React.FC<Props> = ({
               <div className="flex-align-self-end">
                 <button
                   className="usa-button--unstyled padding-105 height-5"
+                  data-testid={`delete-email-${idx}`}
                   onClick={() => onEmailRemove(idx)}
                   aria-label={`Delete email ${email}`.trim()}
                 >

--- a/frontend/src/app/patients/Components/ManageEmails.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.tsx
@@ -120,7 +120,11 @@ const ManageEmails: React.FC<Props> = ({
     <div className="usa-form">
       {emailsOrDefault.map((email, idx) => (
         <div key={idx}>
-          <div className="display-flex">
+          <div
+            className={`display-flex ${
+              idx === 0 ? "" : "patient-form-deletion-field "
+            }`}
+          >
             <TextInput
               name={`email-${idx}`}
               idString={`email-${idx}`}

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -227,9 +227,9 @@ const ManagePhoneNumbers: React.FC<Props> = ({
             {!isPrimary && (
               <div className="flex-align-self-end">
                 <button
-                  className="usa-button--unstyled padding-105 height-5"
+                  className="usa-button--unstyled padding-105 height-5 cursor-pointer"
                   onClick={() => onPhoneNumberRemove(idx)}
-                  aria-label={`Delete phone number ${phoneNumber.number}`.trim()}
+                  aria-label={`Delete phone number ${phoneNumber.number.trim()}`}
                 >
                   <FontAwesomeIcon icon={"trash"} className={"text-error"} />
                 </button>

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -200,7 +200,11 @@ const ManagePhoneNumbers: React.FC<Props> = ({
 
       return (
         <div key={idx}>
-          <div className="display-flex">
+          <div
+            className={`display-flex ${
+              isPrimary ? "" : "patient-form-deletion-field "
+            }`}
+          >
             <Input
               idString={`phoneInput-${idx}`}
               className={`flex-fill phoneNumberFormElement`}

--- a/frontend/src/app/patients/ManagePatients.scss
+++ b/frontend/src/app/patients/ManagePatients.scss
@@ -23,3 +23,7 @@
     border: 0;
   }
 }
+
+.patient-form-deletion-field {
+  width: calc(100% + 2.5rem);
+}

--- a/frontend/src/app/patients/ManagePatients.scss
+++ b/frontend/src/app/patients/ManagePatients.scss
@@ -27,3 +27,7 @@
 .patient-form-deletion-field {
   width: calc(100% + 2.5rem);
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/frontend/src/app/patients/ManagePatients.scss
+++ b/frontend/src/app/patients/ManagePatients.scss
@@ -27,7 +27,3 @@
 .patient-form-deletion-field {
   width: calc(100% + 2.5rem);
 }
-
-.cursor-pointer {
-  cursor: pointer;
-}

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -324,7 +324,7 @@ Object {
                   >
                     <div>
                       <div
-                        class="display-flex"
+                        class="display-flex "
                       >
                         <div
                           class="usa-form-group flex-fill phoneNumberFormElement"
@@ -502,7 +502,7 @@ Object {
                     >
                       <div>
                         <div
-                          class="display-flex"
+                          class="display-flex "
                         >
                           <div
                             class="usa-form-group flex-fill emailFormElement"
@@ -523,30 +523,6 @@ Object {
                               type="text"
                               value="foo@bar.com"
                             />
-                          </div>
-                          <div
-                            class="flex-align-self-end"
-                          >
-                            <button
-                              aria-label="Delete email foo@bar.com"
-                              class="usa-button--unstyled padding-105 height-5"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="svg-inline--fa fa-trash fa-w-14 text-error"
-                                data-icon="trash"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            </button>
                           </div>
                         </div>
                       </div>
@@ -2925,7 +2901,7 @@ Object {
                 >
                   <div>
                     <div
-                      class="display-flex"
+                      class="display-flex "
                     >
                       <div
                         class="usa-form-group flex-fill phoneNumberFormElement"
@@ -3103,7 +3079,7 @@ Object {
                   >
                     <div>
                       <div
-                        class="display-flex"
+                        class="display-flex "
                       >
                         <div
                           class="usa-form-group flex-fill emailFormElement"
@@ -3124,30 +3100,6 @@ Object {
                             type="text"
                             value="foo@bar.com"
                           />
-                        </div>
-                        <div
-                          class="flex-align-self-end"
-                        >
-                          <button
-                            aria-label="Delete email foo@bar.com"
-                            class="usa-button--unstyled padding-105 height-5"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="svg-inline--fa fa-trash fa-w-14 text-error"
-                              data-icon="trash"
-                              data-prefix="fas"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 448 512"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
-                                fill="currentColor"
-                              />
-                            </svg>
-                          </button>
                         </div>
                       </div>
                     </div>

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -143,6 +143,7 @@ export const en = {
           phoneType: "Phone type",
           addNumber: "Add another number",
           email: "Email address",
+          additionalEmail: "Additional email address",
           addEmail: "Add another email address",
           country: "Country",
           street1: "Street address 1",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -151,7 +151,7 @@ export const es: LanguageConfig = {
           addNumber: "Agregar otro número",
           addEmail: "Agregue otra dirección de correo electrónico",
           email: "Dirección de correo electrónico",
-          additionalEmail: "Dirección de correo electrónico",
+          additionalEmail: "Dirección de correo electrónico adicional",
           country: "País",
           street1: "Dirección 1",
           street2: "Dirección 2",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -151,6 +151,7 @@ export const es: LanguageConfig = {
           addNumber: "Agregar otro número",
           addEmail: "Agregue otra dirección de correo electrónico",
           email: "Dirección de correo electrónico",
+          additionalEmail: "Dirección de correo electrónico",
           country: "País",
           street1: "Dirección 1",
           street2: "Dirección 2",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #3986 

## Changes Proposed

- Conditionally shows the trashcan icon the email form only when additional emails are present

## Additional Information

- Adds some additional labeling to the email form when relevant (ok'ed by @lauraykerr)
- Minor styling tweak to the get the input forms to align (ok'ed by @kenieh)

## Testing

- Navigate to the patient self reg/editing form
- Add optional email
- Notice trashcan icon only populates for additional fields unlike before

## Screenshots / Demos

https://user-images.githubusercontent.com/29645040/183710398-a77bcdb7-ec51-4549-a862-5269c63cdd8a.mov

## Checklist for Author and Reviewer

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved

### Content
- [x] Any content changes have been approved by content team
