### PR TITLE
Fixing aria label issues for test card

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -825,7 +825,6 @@ const QueueItem = ({
 
                   <div className="desktop:grid-col-fill flex-col-container">
                     <div
-                      id="test-date-time-label"
                       className={classnames(
                         saveState === "error" && "queue-item-error-message",
                         dateBeforeWarnThreshold && "card-correction-label"
@@ -841,8 +840,7 @@ const QueueItem = ({
                           saveState === "error" && "card-test-input__error",
                           dateBeforeWarnThreshold && "card-correction-input"
                         )}
-                        aria-labelledby="test-date-time-label"
-                        aria-label="test date"
+                        aria-label="Test date"
                         id="test-date"
                         data-testid="test-date"
                         name="test-date"
@@ -862,8 +860,7 @@ const QueueItem = ({
                           dateBeforeWarnThreshold && "card-correction-input"
                         )}
                         name={"test-time"}
-                        aria-labelledby="test-date-time-label"
-                        aria-label="test time"
+                        aria-label="Test time"
                         data-testid="test-time"
                         type="time"
                         step="60"
@@ -880,6 +877,7 @@ const QueueItem = ({
                             checked={useCurrentDateTime === "true"}
                             type="checkbox"
                             onChange={onUseCurrentDateChange}
+                            aria-label="Use current date and time"
                           />
                           <label
                             className="usa-checkbox__label margin-0 margin-right-05em"

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -825,6 +825,7 @@ const QueueItem = ({
 
                   <div className="desktop:grid-col-fill flex-col-container">
                     <div
+                      id="test-date-time-label"
                       className={classnames(
                         saveState === "error" && "queue-item-error-message",
                         dateBeforeWarnThreshold && "card-correction-label"
@@ -840,6 +841,8 @@ const QueueItem = ({
                           saveState === "error" && "card-test-input__error",
                           dateBeforeWarnThreshold && "card-correction-input"
                         )}
+                        aria-labelledby="test-date-time-label"
+                        aria-label="test date"
                         id="test-date"
                         data-testid="test-date"
                         name="test-date"
@@ -859,6 +862,8 @@ const QueueItem = ({
                           dateBeforeWarnThreshold && "card-correction-input"
                         )}
                         name={"test-time"}
+                        aria-labelledby="test-date-time-label"
+                        aria-label="test time"
                         data-testid="test-time"
                         type="time"
                         step="60"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -206,6 +206,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       class="test-date-time-container"
                     >
                       <input
+                        aria-label="test date"
                         class="card-test-input"
                         data-testid="test-date"
                         hidden=""
@@ -217,6 +218,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         value="2021-08-01"
                       />
                       <input
+                        aria-label="test time"
                         class="card-test-input"
                         data-testid="test-time"
                         hidden=""
@@ -232,6 +234,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           class="usa-checkbox"
                         >
                           <input
+                            aria-label="use current date and time"
                             checked=""
                             class="usa-checkbox__input margin"
                             id="current-date-check-abc"
@@ -616,6 +619,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       class="test-date-time-container"
                     >
                       <input
+                        aria-label="test date"
                         class="card-test-input"
                         data-testid="test-date"
                         hidden=""
@@ -627,6 +631,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         value="2021-08-01"
                       />
                       <input
+                        aria-label="test time"
                         class="card-test-input"
                         data-testid="test-time"
                         hidden=""
@@ -642,6 +647,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           class="usa-checkbox"
                         >
                           <input
+                            aria-label="use current date and time"
                             checked=""
                             class="usa-checkbox__input margin"
                             id="current-date-check-def"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       class="test-date-time-container"
                     >
                       <input
-                        aria-label="test date"
+                        aria-label="Test date"
                         class="card-test-input"
                         data-testid="test-date"
                         hidden=""
@@ -218,7 +218,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         value="2021-08-01"
                       />
                       <input
-                        aria-label="test time"
+                        aria-label="Test time"
                         class="card-test-input"
                         data-testid="test-time"
                         hidden=""
@@ -234,7 +234,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           class="usa-checkbox"
                         >
                           <input
-                            aria-label="use current date and time"
+                            aria-label="Use current date and time"
                             checked=""
                             class="usa-checkbox__input margin"
                             id="current-date-check-abc"
@@ -619,7 +619,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       class="test-date-time-container"
                     >
                       <input
-                        aria-label="test date"
+                        aria-label="Test date"
                         class="card-test-input"
                         data-testid="test-date"
                         hidden=""
@@ -631,7 +631,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         value="2021-08-01"
                       />
                       <input
-                        aria-label="test time"
+                        aria-label="Test time"
                         class="card-test-input"
                         data-testid="test-time"
                         hidden=""
@@ -647,7 +647,7 @@ exports[`TestQueue should render the test queue 1`] = `
                           class="usa-checkbox"
                         >
                           <input
-                            aria-label="use current date and time"
+                            aria-label="Use current date and time"
                             checked=""
                             class="usa-checkbox__input margin"
                             id="current-date-check-def"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- related to #4021 

## Changes Proposed

- minor fixes to aria label issues

## Additional Information

- note the original issue was a false positive, turns out that all input elements have a default focus state that is applied by the `app.css` file.


<img width="568" alt="Screen Shot 2022-08-12 at 10 29 12 AM" src="https://user-images.githubusercontent.com/4952042/184388541-38b01238-7654-46d8-b4c6-e94d2ec2e999.png">

## Checklist for Author and Reviewer

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Security
- [X] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

### Documentation
- [X] Any changes to the startup configuration have been documented in the README