### PR TITLE
Change self reg "Other information" to "Housing and work"

### DIFF
--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -649,10 +649,10 @@ const PersonForm = (props: Props) => {
           onChange={onPersonChange("gender")}
         />
       </FormGroup>
-      <FormGroup title={t("patient.form.other.heading")}>
+      <FormGroup title={t("patient.form.housingAndWork.heading")}>
         <YesNoNotSureRadioGroup
-          legend={t("patient.form.other.congregateLiving.heading")}
-          hintText={t("patient.form.other.congregateLiving.helpText")}
+          legend={t("patient.form.housingAndWork.congregateLiving.heading")}
+          hintText={t("patient.form.housingAndWork.congregateLiving.helpText")}
           name="residentCongregateSetting"
           value={boolToYesNoNotSure(patient.residentCongregateSetting)}
           onChange={(v) =>
@@ -665,7 +665,7 @@ const PersonForm = (props: Props) => {
           errorMessage={errors.residentCongregateSetting}
         />
         <YesNoNotSureRadioGroup
-          legend={t("patient.form.other.healthcareWorker")}
+          legend={t("patient.form.housingAndWork.healthcareWorker")}
           name="employedInHealthcare"
           value={boolToYesNoNotSure(patient.employedInHealthcare)}
           onChange={(v) =>

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -2428,7 +2428,7 @@ Object {
                   <legend
                     class="prime-formgroup-heading usa-legend"
                   >
-                    Other information
+                    Housing and work
                   </legend>
                   <div
                     class="usa-form-group"
@@ -5029,7 +5029,7 @@ Object {
                 <legend
                   class="prime-formgroup-heading usa-legend"
                 >
-                  Other information
+                  Housing and work
                 </legend>
                 <div
                   class="usa-form-group"

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -170,8 +170,8 @@ export const en = {
           genderHelpText:
             "This is usually the gender that is written on your original birth certificate.",
         },
-        other: {
-          heading: "Other information",
+        housingAndWork: {
+          heading: "Housing and work",
           congregateLiving: {
             heading:
               "Are you a resident in a group or shared housing facility?",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -181,7 +181,7 @@ export const es: LanguageConfig = {
             "Por lo general, este es el género que está escrito en su certificado de nacimiento original.",
         },
         housingAndWork: {
-          heading: "Trabajo y vivienda",
+          heading: "Vivienda y trabajo",
           congregateLiving: {
             heading:
               "¿Reside usted en un entorno compartido por muchas personas?",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -180,8 +180,8 @@ export const es: LanguageConfig = {
           genderHelpText:
             "Por lo general, este es el género que está escrito en su certificado de nacimiento original.",
         },
-        other: {
-          heading: "Información adicional",
+        housingAndWork: {
+          heading: "Trabajo y vivienda",
           congregateLiving: {
             heading:
               "¿Reside usted en un entorno compartido por muchas personas?",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

- resolves #3985 

## Changes Proposed

- Change "Other Information" section name to "Housing and work" inside the self registration form

## Additional Information

~- Awaiting confirmation on Spanish translations from CDC~

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/4952042/184433601-4dca9dd1-d06c-4b33-a142-8d4f8a21bdba.png)

## Checklist for Author and Reviewer

### Design
- [X] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [X] Any content changes have been approved by content team

### Support
- [X] Any changes that might generate new support requests have been flagged to the support team
- [X] Any changes to support infrastructure have been demo'd to support team

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [X] Any dependencies introduced have been vetted and discussed

### Documentation
- [X] Any changes to the startup configuration have been documented in the README