### PR TITLE
Add ARIA labels to test card timer

### DIFF
--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -237,8 +237,10 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
         className="timer-button timer-reset"
         onClick={() => start(trackTimerStart)}
         data-testid="timer"
+        aria-label="Start timer"
       >
-        <span>{mmss(countdown)}</span> <FontAwesomeIcon icon={faStopwatch} />
+        <span role="timer">{mmss(countdown)}</span>{" "}
+        <FontAwesomeIcon icon={faStopwatch} />
       </button>
     );
   }
@@ -248,8 +250,10 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
         className="timer-button timer-running"
         onClick={() => reset(trackTimerReset)}
         data-testid="timer"
+        aria-label="Reset timer"
       >
-        <span>{mmss(countdown)}</span> <FontAwesomeIcon icon={faRedo} />
+        <span role="timer">{mmss(countdown)}</span>{" "}
+        <FontAwesomeIcon icon={faRedo} />
       </button>
     );
   }
@@ -266,9 +270,12 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
         className="timer-button timer-ready"
         onClick={() => reset(trackTimerReset)}
         data-testid="timer"
+        aria-label="Reset timer"
       >
         <span className="result-ready">RESULT READY</span>{" "}
-        <span className="timer-overtime">{mmss(elapsed)} elapsed </span>{" "}
+        <span className="timer-overtime" role="timer">
+          {mmss(elapsed)} elapsed{" "}
+        </span>{" "}
         <FontAwesomeIcon icon={faRedo} />
       </button>
     </div>

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -145,10 +145,13 @@ exports[`TestQueue should render the test queue 1`] = `
                   </div>
                 </div>
                 <button
+                  aria-label="Start timer"
                   class="timer-button timer-reset"
                   data-testid="timer"
                 >
-                  <span>
+                  <span
+                    role="timer"
+                  >
                     10:00
                   </span>
                    
@@ -555,10 +558,13 @@ exports[`TestQueue should render the test queue 1`] = `
                   </div>
                 </div>
                 <button
+                  aria-label="Start timer"
                   class="timer-button timer-reset"
                   data-testid="timer"
                 >
-                  <span>
+                  <span
+                    role="timer"
+                  >
                     10:00
                   </span>
                    


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #4046 

## Changes Proposed

- Labels the timer button with the given action
- Sets the role of the timer text within the button to 'timer' - I think this should also prevent a screenreader from repeatedly announcing every time the text updates

## Additional Information

- went with more specific label than just "timer" because I think it's not clear from that whether you're starting or stopping the timer since screen readers can't read the start and reset icons

## Testing

Deploy locally or to a lower and inspect the elements to see that they have the correct label - should be different when the timer is stopped than when it's running
 
## Screenshots / Demos
<img width="1552" alt="Screen Shot 2022-08-16 at 8 54 10 AM" src="https://user-images.githubusercontent.com/6401323/184897432-853bdd28-cb16-4d95-aba4-48f5824bb3a0.png">

<img width="1552" alt="Screen Shot 2022-08-16 at 8 54 17 AM" src="https://user-images.githubusercontent.com/6401323/184897416-c58260a6-558f-4cbb-a4c8-45fff4ca6bf3.png">

<img width="1552" alt="Screen Shot 2022-08-16 at 8 54 29 AM" src="https://user-images.githubusercontent.com/6401323/184897394-d5e32625-dace-4f70-985e-609f9aea586b.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [n/a] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [x] Any content changes have been approved by content team

### Support
- [n/a] Any changes that might generate new support requests have been flagged to the support team
- [n/a] Any changes to support infrastructure have been demo'd to support team

### Security
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed

### Documentation
- [n/a] Any changes to the startup configuration have been documented in the README