### PR TITLE
Bump spring-boot-starter-thymeleaf from 2.4.2 to 2.7.2

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.5.8'
 
     // Okta dependencies
     implementation 'com.okta.spring:okta-spring-boot-starter:2.0.0'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'org.json:json:20201115'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.5.8'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.7.2'
 
     // Okta dependencies
     implementation 'com.okta.spring:okta-spring-boot-starter:2.0.0'

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -164,7 +164,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.2
 org.springframework.boot:spring-boot-starter-logging:2.4.2
 org.springframework.boot:spring-boot-starter-mail:2.4.2
 org.springframework.boot:spring-boot-starter-security:2.4.2
-org.springframework.boot:spring-boot-starter-thymeleaf:2.5.8
+org.springframework.boot:spring-boot-starter-thymeleaf:2.7.2
 org.springframework.boot:spring-boot-starter-tomcat:2.4.2
 org.springframework.boot:spring-boot-starter-validation:2.4.2
 org.springframework.boot:spring-boot-starter-web:2.4.2

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -164,7 +164,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.2
 org.springframework.boot:spring-boot-starter-logging:2.4.2
 org.springframework.boot:spring-boot-starter-mail:2.4.2
 org.springframework.boot:spring-boot-starter-security:2.4.2
-org.springframework.boot:spring-boot-starter-thymeleaf:2.4.2
+org.springframework.boot:spring-boot-starter-thymeleaf:2.5.8
 org.springframework.boot:spring-boot-starter-tomcat:2.4.2
 org.springframework.boot:spring-boot-starter-validation:2.4.2
 org.springframework.boot:spring-boot-starter-web:2.4.2

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -178,7 +178,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.2
 org.springframework.boot:spring-boot-starter-logging:2.4.2
 org.springframework.boot:spring-boot-starter-mail:2.4.2
 org.springframework.boot:spring-boot-starter-security:2.4.2
-org.springframework.boot:spring-boot-starter-thymeleaf:2.4.2
+org.springframework.boot:spring-boot-starter-thymeleaf:2.5.8
 org.springframework.boot:spring-boot-starter-tomcat:2.4.2
 org.springframework.boot:spring-boot-starter-validation:2.4.2
 org.springframework.boot:spring-boot-starter-web:2.4.2

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -178,7 +178,7 @@ org.springframework.boot:spring-boot-starter-json:2.4.2
 org.springframework.boot:spring-boot-starter-logging:2.4.2
 org.springframework.boot:spring-boot-starter-mail:2.4.2
 org.springframework.boot:spring-boot-starter-security:2.4.2
-org.springframework.boot:spring-boot-starter-thymeleaf:2.5.8
+org.springframework.boot:spring-boot-starter-thymeleaf:2.7.2
 org.springframework.boot:spring-boot-starter-tomcat:2.4.2
 org.springframework.boot:spring-boot-starter-validation:2.4.2
 org.springframework.boot:spring-boot-starter-web:2.4.2


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Upgrade spring-boot-starter-thymeleaf from 2.4.2 to 2.7.2 (latest version of 2.*) to resolve a vulnerability

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- [Thymeleaf versions](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-thymeleaf)

## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README

----