### PR TITLE
add model name to WAF variable exclusion

### DIFF
--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -136,6 +136,11 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector                = "phoneNumbers.number"
       selector_match_operator = "Contains"
     }
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "variables.model"
+      selector_match_operator = "Equals"
+    }
 
     managed_rule_set {
       type    = "OWASP"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Adds a WAF exception needed to respond to a support request 
<img width="705" alt="Screen Shot 2022-08-17 at 3 33 56 PM" src="https://user-images.githubusercontent.com/29645040/185237771-ab59b869-e4dc-4504-8359-3f0313fba250.png">

## Changes Proposed

- Adds `variable.model` from the update devices GraphQL mutation to the exception ruleset

## Additional Information
Below are screenshots of the part of the app I was working in and the relevant Azure log. It looks like the WAF was complaining about part of the model input so I went ahead and allowlisted that field.

<img width="1094" alt="Screen Shot 2022-08-17 at 2 55 18 PM" src="https://user-images.githubusercontent.com/29645040/185237355-52305f1c-6825-4a62-9d82-96ca1c06715c.png">

<img width="1060" alt="Screen Shot 2022-08-17 at 2 51 58 PM" src="https://user-images.githubusercontent.com/29645040/185231645-4f32ff9f-c5b2-499c-888d-952ab113ddff.png">

## Testing

- Verify exception was added correctly
- Flag any security concerns of excepting that input field (this is an internal part of the app available to superadmins only, so hopefully there isn't anything we need to worry about.)
 
## Checklist for Primary Reviewer

### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
