### PR TITLE
Upgrade runtime of Azure function app

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_function_app" "functions" {
   storage_account_name       = data.azurerm_storage_account.app.name
   storage_account_access_key = data.azurerm_storage_account.app.primary_access_key
   https_only                 = true
-  version                    = "~3"
+  version                    = "~4"
   os_type                    = "linux"
   site_config {
     linux_fx_version          = "node|14"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #4175.

## Changes Proposed

- Upgrade the runtime version of the ReportStreamBatchedPublisher to `~4` in Terraform. This is a prerequisite for leveraging more advanced elements of the function SDK, and can help with triaging efficiency problems moving forward.

## Testing

Reviewers should deploy this code to an environment that integrates with an instance of ReportStream. Function app run logs should be checked for any errors or unexpected messages.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification