### PR TITLE
Add specimen mutation

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/SpecimenTypeMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/SpecimenTypeMutationResolver.java
@@ -5,19 +5,17 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.service.SpecimenTypeService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class SpecimenTypeMutationResolver implements GraphQLMutationResolver {
 
-  private final SpecimenTypeService _specimenTypeService;
-
-  public SpecimenTypeMutationResolver(SpecimenTypeService specimenTypeService) {
-    _specimenTypeService = specimenTypeService;
-  }
+  private final SpecimenTypeService specimenTypeService;
 
   public SpecimenType createSpecimenType(CreateSpecimenType input)
       throws IllegalGraphqlArgumentException {
-    return _specimenTypeService.createSpecimenType(input);
+    return specimenTypeService.createSpecimenType(input);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/SpecimenTypeMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/SpecimenTypeMutationResolver.java
@@ -1,0 +1,23 @@
+package gov.cdc.usds.simplereport.api.devicetype;
+
+import gov.cdc.usds.simplereport.api.model.CreateSpecimenType;
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
+import gov.cdc.usds.simplereport.service.SpecimenTypeService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpecimenTypeMutationResolver implements GraphQLMutationResolver {
+
+  private final SpecimenTypeService _specimenTypeService;
+
+  public SpecimenTypeMutationResolver(SpecimenTypeService specimenTypeService) {
+    _specimenTypeService = specimenTypeService;
+  }
+
+  public SpecimenType createSpecimenType(CreateSpecimenType input)
+      throws IllegalGraphqlArgumentException {
+    return _specimenTypeService.createSpecimenType(input);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/CreateSpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/CreateSpecimenType.java
@@ -1,10 +1,10 @@
 package gov.cdc.usds.simplereport.api.model;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class CreateSpecimenType {
   public String name;
   public String typeCode;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/CreateSpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/CreateSpecimenType.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateSpecimenType {
+  public String name;
+  public String typeCode;
+  public String collectionLocationName;
+  public String collectionLocationCode;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenTypeService.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import gov.cdc.usds.simplereport.api.model.CreateSpecimenType;
+import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import java.util.List;
@@ -23,6 +24,7 @@ public class SpecimenTypeService {
     return _specimenTypeRepo.findAll();
   }
 
+  @AuthorizationConfiguration.RequireGlobalAdminUser
   public SpecimenType createSpecimenType(CreateSpecimenType input) {
     return _specimenTypeRepo.save(
         new SpecimenType(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenTypeService.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.service;
 
+import gov.cdc.usds.simplereport.api.model.CreateSpecimenType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import java.util.List;
@@ -20,5 +21,14 @@ public class SpecimenTypeService {
 
   public List<SpecimenType> fetchSpecimenTypes() {
     return _specimenTypeRepo.findAll();
+  }
+
+  public SpecimenType createSpecimenType(CreateSpecimenType input) {
+    return _specimenTypeRepo.save(
+        new SpecimenType(
+            input.getName(),
+            input.getTypeCode(),
+            input.getCollectionLocationName(),
+            input.getCollectionLocationCode()));
   }
 }

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -10,6 +10,7 @@ extend type Mutation {
   resendToReportStream(testEventIds: [ID!]!): Boolean
   createDeviceType(input: CreateDeviceType!): DeviceType
   updateDeviceType(input: UpdateDeviceType!): DeviceType
+  createSpecimenType(input: CreateSpecimenType!): SpecimenType
   addUser( # not actually used in the admin console (currently)
     name: NameInput
     firstName: String

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -94,6 +94,13 @@ type SupportedDisease {
   loinc: String!
 }
 
+input CreateSpecimenType {
+  name: String!
+  typeCode: String!
+  collectionLocationName: String
+  collectionLocationCode: String
+}
+
 type SpecimenType {
   internalId: ID!
   name: String!

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/SpecimenTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/SpecimenTypeServiceTest.java
@@ -1,0 +1,72 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.cdc.usds.simplereport.api.model.CreateSpecimenType;
+import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.TransactionSystemException;
+
+@TestPropertySource(
+    properties = {
+      "hibernate.query.interceptor.error-level=ERROR",
+      "spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true"
+    })
+public class SpecimenTypeServiceTest extends BaseServiceTest<SpecimenTypeService> {
+
+  @Autowired private SpecimenTypeRepository specimenTypeRepository;
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void createNewSpecimenType_success() {
+    _service.createSpecimenType(
+        CreateSpecimenType.builder()
+            .name("Nasal swab")
+            .typeCode("012345678")
+            .collectionLocationName("Nasopharangyal Structure")
+            .collectionLocationCode("123456789")
+            .build());
+
+    assertEquals(1, _service.fetchSpecimenTypes().size());
+    assertEquals("Nasal swab", _service.fetchSpecimenTypes().get(0).getName());
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void createNewSpecimenType_failsWithInvalidCredentials() {
+    assertThrows(
+        AccessDeniedException.class,
+        () -> {
+          _service.createSpecimenType(
+              CreateSpecimenType.builder()
+                  .name("Nasal swab")
+                  .typeCode("012345678")
+                  .collectionLocationName("Nasopharangyal Structure")
+                  .collectionLocationCode("123456789")
+                  .build());
+        });
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void createNewSpecimenType_failsWithTooShortLoinc() {
+    Exception exception =
+        assertThrows(
+            TransactionSystemException.class,
+            () -> {
+              _service.createSpecimenType(
+                  CreateSpecimenType.builder()
+                      .name("Nasal swab")
+                      .typeCode("012")
+                      .collectionLocationName("Nasopharangyal Structure")
+                      .collectionLocationCode("123")
+                      .build());
+            });
+    assert (exception.getMessage()).contains("Could not commit JPA transaction");
+  }
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -81,6 +81,13 @@ export type CreateDeviceType = {
   swabTypes: Array<Scalars["ID"]>;
 };
 
+export type CreateSpecimenType = {
+  collectionLocationCode?: InputMaybe<Scalars["String"]>;
+  collectionLocationName?: InputMaybe<Scalars["String"]>;
+  name: Scalars["String"];
+  typeCode: Scalars["String"];
+};
+
 export type DeviceSpecimenType = {
   __typename?: "DeviceSpecimenType";
   deviceType: DeviceType;
@@ -162,6 +169,7 @@ export type Mutation = {
   createFacilityRegistrationLink?: Maybe<Scalars["String"]>;
   createOrganization?: Maybe<Organization>;
   createOrganizationRegistrationLink?: Maybe<Scalars["String"]>;
+  createSpecimenType?: Maybe<SpecimenType>;
   editPendingOrganization?: Maybe<Scalars["String"]>;
   editQueueItem?: Maybe<TestOrder>;
   editQueueItemMultiplex?: Maybe<TestOrder>;
@@ -398,6 +406,10 @@ export type MutationCreateOrganizationArgs = {
 export type MutationCreateOrganizationRegistrationLinkArgs = {
   link: Scalars["String"];
   organizationExternalId: Scalars["String"];
+};
+
+export type MutationCreateSpecimenTypeArgs = {
+  input: CreateSpecimenType;
 };
 
 export type MutationEditPendingOrganizationArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Dev2, 3, and 4 don't have specimen types set up. This makes it impossible to add facilities to these environments, making it difficult for devs to test there.

We're also no longer using the create-device-types Spring profile as far as I can tell, which used to handle the creation of specimen types.

## Changes Proposed

- Add mutation to create specimen types, for superusers only

## Additional Information
Stolen straight from the comparable `AddDeviceType` mutation. 

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Any content updates (user-facing error messages, etc) have been approved by content team
- [x] Any changes that might generate questions in the support inbox have been flagged to the support team
- [x] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [x] Any dependencies introduced have been vetted and discussed
- [x] Any changes to the startup configuration have been documented in the README
