### PR TITLE
add additional accessibility properties to icon in the header

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -180,6 +180,9 @@ const Header: React.FC<{}> = () => {
       icon: (
         <FontAwesomeIcon
           icon={"user-circle"}
+          aria-hidden={false}
+          aria-label={"Profile"}
+          role={"img"}
           style={{
             color: staffDetailsVisible && !menuVisible ? "white" : "",
           }}
@@ -193,7 +196,14 @@ const Header: React.FC<{}> = () => {
       onClick: () => setMenuVisible(false),
       className: getNavItemClassName,
       dataTestId: "settings-button",
-      icon: <FontAwesomeIcon icon={"cog"} />,
+      icon: (
+        <FontAwesomeIcon
+          icon={"cog"}
+          aria-hidden={false}
+          role={"img"}
+          aria-label={"Settings"}
+        />
+      ),
       mobileDisplay: true,
       mobileDisplayText: "Settings",
       hasSubmenu: false,

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -181,7 +181,7 @@ const Header: React.FC<{}> = () => {
         <FontAwesomeIcon
           icon={"user-circle"}
           aria-hidden={false}
-          aria-label={"my account"}
+          aria-label={"My account"}
           role={"img"}
           style={{
             color: staffDetailsVisible && !menuVisible ? "white" : "",

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -181,7 +181,7 @@ const Header: React.FC<{}> = () => {
         <FontAwesomeIcon
           icon={"user-circle"}
           aria-hidden={false}
-          aria-label={"Profile"}
+          aria-label={"my account"}
           role={"img"}
           style={{
             color: staffDetailsVisible && !menuVisible ? "white" : "",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- #4052 
- #4067
- Improve accessibility on icons in the header

## Changes Proposed

- unhide and add description to the icons

## Additional Information

## Testing
 
## Screenshots / Demos

- I'm not entirely sure how this would be demoed, but I got this kinda cool extension that I think shows it off! Please let me know how I should actually show this. 
![image](https://user-images.githubusercontent.com/10108172/185704208-90420f54-b1c4-4ec6-98c1-35ba0fae706f.png)


## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README