### PR TITLE
Add skipnav link to Page element

### DIFF
--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -38,6 +38,9 @@ const Page: React.FC<Props> = ({ header, children, isPatientApp }) => {
   }, []);
   return (
     <div className="App">
+      <a className="usa-skipnav" href="#main-wrapper">
+        Skip to main content
+      </a>
       <header
         className={
           isPatientApp


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #4105 

## Changes Proposed

- Add skipnav link to our Page element. This is the same skipnav link that already exists the static site: https://github.com/CDCgov/prime-simplereport-site/blob/3aab6f2d0f2bf1e5cf2810ae8bf95822e014f1c8/_includes/skipnav.html

## Testing

- Tabbing through the site, the first link you hit is "skip to main content"
 
## Screenshots / Demos
Skipnav on internal site:
<img width="1498" alt="Screen Shot 2022-08-19 at 3 40 31 PM" src="https://user-images.githubusercontent.com/80282552/185716045-37e43673-e2ba-4ed8-aa17-d2e83abe3863.png">

Skipnav on patient-facing site:
<img width="1452" alt="Screen Shot 2022-08-19 at 3 40 20 PM" src="https://user-images.githubusercontent.com/80282552/185716085-dd7d5a70-8ca9-4439-a0d5-1f5b707df207.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README