### PR TITLE
Remove alt text for flag image

### DIFF
--- a/frontend/src/app/commonComponents/USAGovBanner.tsx
+++ b/frontend/src/app/commonComponents/USAGovBanner.tsx
@@ -82,7 +82,7 @@ class USAGovBanner extends React.Component<Props, State> {
               <img
                 className="usa-banner__header-flag"
                 src={usFlagSmall}
-                alt="U.S. flag"
+                alt=""
               />
             </div>
             <div className="grid-col-fill tablet:grid-col-auto">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #3981 

## Changes Proposed

- Give US flag an empty alt tag

## Additional Information

- Image is decorative, so alt text is unnecessary and not recommended

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README