### PR TITLE
Multiplex refactor - backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ backend/locust/__pycache__/
 wiremock*.jar
 cypress/cypress.env.json
 frontend/src/.env.local
+.run/Backend.run.xml
+.run/Frontend.run.xml

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -7,6 +7,7 @@ import gov.cdc.usds.simplereport.api.model.AddTestResultResponse;
 import gov.cdc.usds.simplereport.api.model.ApiTestOrder;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.DiseaseResult;
+import gov.cdc.usds.simplereport.db.model.auxiliary.MultiplexResultInput;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
@@ -62,6 +63,18 @@ public class QueueMutationResolver implements GraphQLMutationResolver {
     return _tos.addTestResultMultiplex(deviceSpecimenTypeId, results, patientID, dateTested);
   }
 
+  public AddTestResultResponse addMultiplexResult(
+      String deviceID,
+      UUID deviceSpecimenType,
+      List<MultiplexResultInput> results,
+      UUID patientID,
+      Date dateTested)
+      throws NumberParseException {
+    UUID deviceSpecimenTypeId = getDeviceSpecimenTypeId(deviceID, deviceSpecimenType);
+
+    return _tos.addMultiplexResult(deviceSpecimenTypeId, results, patientID, dateTested);
+  }
+
   public ApiTestOrder editQueueItem(
       UUID id, String deviceId, UUID deviceSpecimenType, String result, Date dateTested) {
     UUID dst = getDeviceSpecimenTypeId(deviceId, deviceSpecimenType);
@@ -78,6 +91,17 @@ public class QueueMutationResolver implements GraphQLMutationResolver {
     UUID dst = getDeviceSpecimenTypeId(deviceId, deviceSpecimenType);
 
     return new ApiTestOrder(_tos.editQueueItemMultiplex(id, dst, results, dateTested));
+  }
+
+  public ApiTestOrder editQueueItemMultiplexResult(
+      UUID id,
+      String deviceId,
+      UUID deviceSpecimenType,
+      List<MultiplexResultInput> results,
+      Date dateTested) {
+    UUID dst = getDeviceSpecimenTypeId(deviceId, deviceSpecimenType);
+
+    return new ApiTestOrder(_tos.editQueueItemMultiplexResult(id, dst, results, dateTested));
   }
 
   public String addPatientToQueue(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/MultiplexResultInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/MultiplexResultInput.java
@@ -1,0 +1,11 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MultiplexResultInput {
+  private String diseaseName;
+  private TestResult testResult;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -26,6 +26,7 @@ import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.TestOrder_;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.DiseaseResult;
+import gov.cdc.usds.simplereport.db.model.auxiliary.MultiplexResultInput;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
@@ -292,6 +293,36 @@ public class TestOrderService {
     }
   }
 
+  @AuthorizationConfiguration.RequirePermissionUpdateTestForTestOrder
+  public TestOrder editQueueItemMultiplexResult(
+      UUID testOrderId,
+      UUID deviceSpecimenTypeId,
+      List<MultiplexResultInput> results,
+      Date dateTested) {
+    lockOrder(testOrderId);
+    try {
+      TestOrder order = this.getTestOrder(testOrderId);
+
+      if (deviceSpecimenTypeId != null) {
+        DeviceSpecimenType deviceSpecimenType = _dts.getDeviceSpecimenType(deviceSpecimenTypeId);
+
+        if (deviceSpecimenType != null) {
+          order.setDeviceSpecimen(deviceSpecimenType);
+          // Set the most-recently configured device specimen for a facility's
+          // test as facility default
+          order.getFacility().addDefaultDeviceSpecimen(deviceSpecimenType);
+        }
+      }
+      if (!results.isEmpty()) {
+        editMultiplexResult(order, results);
+      }
+      order.setDateTestedBackdate(dateTested);
+      return _repo.save(order);
+    } finally {
+      unlockOrder(testOrderId);
+    }
+  }
+
   // Deprecated - remove this method after we've switched to the multiplex
   // endpoints on frontend
   @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
@@ -410,10 +441,98 @@ public class TestOrderService {
     return new AddTestResultResponse(savedOrder, deliveryStatus);
   }
 
+  @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
+  public AddTestResultResponse addMultiplexResult(
+      UUID deviceSpecimenTypeId,
+      List<MultiplexResultInput> results,
+      UUID patientId,
+      Date dateTested) {
+    Organization org = _os.getCurrentOrganization();
+    Person person = _ps.getPatientNoPermissionsCheck(patientId, org);
+    TestOrder order =
+        _repo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
+
+    DeviceSpecimenType deviceSpecimenType = _dts.getDeviceSpecimenType(deviceSpecimenTypeId);
+
+    lockOrder(order.getInternalId());
+
+    TestOrder savedOrder = null;
+
+    try {
+      order.setDeviceSpecimen(deviceSpecimenType);
+      editMultiplexResult(order, results);
+      order.setDateTestedBackdate(dateTested);
+      order.markComplete();
+
+      boolean hasPriorTests = _terepo.existsByPatient(person);
+      TestEvent testEvent =
+          order.getCorrectionStatus() == TestCorrectionStatus.ORIGINAL
+              ? new TestEvent(order, hasPriorTests)
+              : new TestEvent(order, order.getCorrectionStatus(), order.getReasonForCorrection());
+
+      TestEvent savedEvent = _terepo.save(testEvent);
+      saveFinalResults(order, testEvent);
+
+      order.setTestEventRef(savedEvent);
+      savedOrder = _repo.save(order);
+      _testEventReportingService.report(savedEvent);
+    } finally {
+      unlockOrder(order.getInternalId());
+    }
+
+    ArrayList<Boolean> deliveryStatuses = new ArrayList<>();
+
+    PatientLink patientLink = _pls.createPatientLink(savedOrder.getInternalId());
+    if (patientHasDeliveryPreference(savedOrder)) {
+
+      if (smsDeliveryPreference(savedOrder) || smsAndEmailDeliveryPreference(savedOrder)) {
+        boolean smsDeliveryStatus = testResultsDeliveryService.smsTestResults(patientLink);
+        deliveryStatuses.add(smsDeliveryStatus);
+      }
+
+      if (emailDeliveryPreference(savedOrder) || smsAndEmailDeliveryPreference(savedOrder)) {
+        boolean emailDeliveryStatus = testResultsDeliveryService.emailTestResults(patientLink);
+        deliveryStatuses.add(emailDeliveryStatus);
+      }
+    }
+
+    boolean deliveryStatus =
+        deliveryStatuses.isEmpty() || deliveryStatuses.stream().anyMatch(status -> status);
+    return new AddTestResultResponse(savedOrder, deliveryStatus);
+  }
+
   private void editResults(TestOrder order, List<DiseaseResult> newResults) {
     // For now - we still need to save the covid results to the result column
     // To be removed in #3664
     Optional<DiseaseResult> covidResult =
+        newResults.stream().filter(r -> r.getDiseaseName().equals("COVID-19")).findFirst();
+    covidResult.ifPresent(diseaseResult -> order.setResultColumn(diseaseResult.getTestResult()));
+
+    // For new results, check if there's already a pending result for the same test.
+    // If so, update it, if not, create a new one.
+    newResults.forEach(
+        newResult -> {
+          Optional<Result> pendingResult =
+              _resultRepo.getPendingResult(
+                  order, _diseaseService.getDiseaseByName(newResult.getDiseaseName()));
+          if (pendingResult.isPresent()) {
+            pendingResult.get().setResult(newResult.getTestResult());
+            _resultRepo.save(pendingResult.get());
+          } else {
+            Result result =
+                new Result(
+                    order,
+                    _diseaseService.getDiseaseByName(newResult.getDiseaseName()),
+                    newResult.getTestResult());
+            _resultRepo.save(result);
+          }
+        });
+  }
+
+  private void editMultiplexResult(TestOrder order, List<MultiplexResultInput> newResults) {
+    // For now - we still need to save the covid results to the result column
+    // To be removed in #3664
+    Optional<MultiplexResultInput> covidResult =
         newResults.stream().filter(r -> r.getDiseaseName().equals("COVID-19")).findFirst();
     covidResult.ifPresent(diseaseResult -> order.setResultColumn(diseaseResult.getTestResult()));
 

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -262,6 +262,16 @@ type MultiplexResult {
   testResult: String
 }
 
+input DiseaseResult {
+  diseaseName: String
+  testResult: String
+}
+
+input MultiplexResultInput {
+  diseaseName: String
+  testResult: String
+}
+
 type OrganizationLevelDashboardMetrics {
   organizationPositiveTestCount: Int
   organizationNegativeTestCount: Int
@@ -331,11 +341,6 @@ type FeedbackMessage {
 type UploadSubmissionPage {
   totalElements: Int!
   content: [UploadResult!]!
-}
-
-input DiseaseResult {
-  diseaseName: String
-  testResult: String
 }
 
 # Queries and mutations for everyday use
@@ -654,6 +659,13 @@ type Mutation {
     patientId: ID!
     dateTested: DateTime
   ): AddTestResultResponse @requiredPermissions(allOf: ["SUBMIT_TEST"])
+  addMultiplexResult (
+    deviceId: String!
+    deviceSpecimenType: ID
+    results: [MultiplexResultInput]!
+    patientId: ID!
+    dateTested: DateTime
+  ): AddTestResultResponse @requiredPermissions(allOf: ["SUBMIT_TEST"])
   editQueueItem(
     id: ID!
     deviceId: String
@@ -666,6 +678,13 @@ type Mutation {
     deviceId: String
     deviceSpecimenType: ID
     results: [DiseaseResult]
+    dateTested: DateTime
+  ): TestOrder @requiredPermissions(allOf: ["UPDATE_TEST"])
+  editQueueItemMultiplexResult(
+    id: ID!
+    deviceId: String
+    deviceSpecimenType: ID
+    results: [MultiplexResultInput]
     dateTested: DateTime
   ): TestOrder @requiredPermissions(allOf: ["UPDATE_TEST"])
   correctTestMarkAsError(id: ID!, reason: String): TestResult

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolverTest.java
@@ -11,6 +11,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.DiseaseResult;
+import gov.cdc.usds.simplereport.db.model.auxiliary.MultiplexResultInput;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
@@ -70,7 +71,7 @@ class QueueMutationResolverTest extends BaseServiceTest<TestOrderService> {
   }
 
   @Test
-  void getDeviceSpecimenTypeId_returnsDeviceSpecimenTypeId() {
+  void getDeviceSpecimenTypeId_returnsDeviceSpecimenTypeIdGivenDiseaseResult() {
     var deviceTypeService = mock(DeviceTypeService.class);
     var personService = mock(PersonService.class);
     var testOrderService = mock(TestOrderService.class);
@@ -90,6 +91,30 @@ class QueueMutationResolverTest extends BaseServiceTest<TestOrderService> {
     verify(deviceTypeService, never()).getFirstDeviceSpecimenTypeForDeviceTypeId(deviceUUID);
     verify(testOrderService)
         .editQueueItemMultiplex(
+            eq(testOrderId), eq(deviceSpecimenTypeUUID), eq(results), eq(_dateTested));
+  }
+
+  @Test
+  void getDeviceSpecimenTypeId_returnsDeviceSpecimenTypeId() {
+    var deviceTypeService = mock(DeviceTypeService.class);
+    var personService = mock(PersonService.class);
+    var testOrderService = mock(TestOrderService.class);
+    var queueMutationResolver =
+        new QueueMutationResolver(testOrderService, personService, deviceTypeService);
+    List<MultiplexResultInput> results = new ArrayList<>();
+    results.add(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
+    UUID deviceUUID = _deviceType.getInternalId();
+    String deviceId = deviceUUID.toString();
+    UUID deviceSpecimenTypeUUID = _deviceSpecimenType.getInternalId();
+    UUID testOrderId = UUID.randomUUID();
+
+    // WHEN
+    queueMutationResolver.editQueueItemMultiplexResult(
+        testOrderId, deviceId, deviceSpecimenTypeUUID, results, _dateTested);
+    // THEN
+    verify(deviceTypeService, never()).getFirstDeviceSpecimenTypeForDeviceTypeId(deviceUUID);
+    verify(testOrderService)
+        .editQueueItemMultiplexResult(
             eq(testOrderId), eq(deviceSpecimenTypeUUID), eq(results), eq(_dateTested));
   }
 }

--- a/backend/src/test/resources/queries/add-multiplex-result-mutation
+++ b/backend/src/test/resources/queries/add-multiplex-result-mutation
@@ -1,0 +1,17 @@
+mutation addMultiplexResult($deviceId: String!, $results: [MultiplexResultInput]!, $patientId: ID!, $dateTested: DateTime) {
+    addMultiplexResult(
+      patientId: $patientId,
+      deviceId: $deviceId,
+      results: $results,
+      dateTested: $dateTested
+    ) {
+      testResult {
+        internalId,
+        result,
+        deviceType {
+          internalId
+        }
+      }
+      deliverySuccess
+    }
+  }

--- a/backend/src/test/resources/queries/edit-queue-item-multiplex-result-mutation
+++ b/backend/src/test/resources/queries/edit-queue-item-multiplex-result-mutation
@@ -1,0 +1,14 @@
+mutation EditQueueItemMultiplexResult($id: ID!, $deviceId: String, $results: [MultiplexResultInput], $dateTested: DateTime) {
+    editQueueItemMultiplexResult(
+      id: $id,
+      deviceId: $deviceId,
+      results: $results,
+      dateTested: $dateTested
+    ) {
+      internalId,
+      result,
+      deviceType {
+        internalId
+      }
+    }
+  }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -144,10 +144,16 @@ export type MultiplexResult = {
   testResult?: Maybe<Scalars["String"]>;
 };
 
+export type MultiplexResultInput = {
+  diseaseName?: InputMaybe<Scalars["String"]>;
+  testResult?: InputMaybe<Scalars["String"]>;
+};
+
 export type Mutation = {
   __typename?: "Mutation";
   addFacility?: Maybe<Facility>;
   addFacilityNew?: Maybe<Scalars["String"]>;
+  addMultiplexResult?: Maybe<AddTestResultResponse>;
   addPatient?: Maybe<Patient>;
   addPatientToQueue?: Maybe<Scalars["String"]>;
   addTestResultMultiplex?: Maybe<AddTestResultResponse>;
@@ -165,6 +171,7 @@ export type Mutation = {
   editPendingOrganization?: Maybe<Scalars["String"]>;
   editQueueItem?: Maybe<TestOrder>;
   editQueueItemMultiplex?: Maybe<TestOrder>;
+  editQueueItemMultiplexResult?: Maybe<TestOrder>;
   markFacilityAsDeleted?: Maybe<Scalars["String"]>;
   markOrganizationAsDeleted?: Maybe<Scalars["String"]>;
   markPendingOrganizationAsDeleted?: Maybe<Scalars["String"]>;
@@ -245,6 +252,14 @@ export type MutationAddFacilityNewArgs = {
   streetTwo?: InputMaybe<Scalars["String"]>;
   testingFacilityName: Scalars["String"];
   zipCode: Scalars["String"];
+};
+
+export type MutationAddMultiplexResultArgs = {
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
+  deviceId: Scalars["String"];
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
+  patientId: Scalars["ID"];
+  results: Array<InputMaybe<MultiplexResultInput>>;
 };
 
 export type MutationAddPatientArgs = {
@@ -423,6 +438,14 @@ export type MutationEditQueueItemMultiplexArgs = {
   deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
   id: Scalars["ID"];
   results?: InputMaybe<Array<InputMaybe<DiseaseResult>>>;
+};
+
+export type MutationEditQueueItemMultiplexResultArgs = {
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
+  deviceId?: InputMaybe<Scalars["String"]>;
+  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
+  id: Scalars["ID"];
+  results?: InputMaybe<Array<InputMaybe<MultiplexResultInput>>>;
 };
 
 export type MutationMarkFacilityAsDeletedArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue #3951 

See Closed PR #4160  for reference. This PR is for the backend portion from PR #4160. The original PR had frontend backwards compatibility issues, caused by our frontend deploy architecture. This PR will be followed by a second frontend PR to complete the refactor and remove duplicated code.

## Changes Proposed

- Refactor backend to include `MultiplexResultInput` graphql input and java model in addition to the existing `DiseaseResult`. This is because the frontend cannot be updated simultaneously, and we need to retain the existing functionality so the old frontend will function with the new backend. The next PR will include the frontend refactor and the deprecated `DiseaseResult` input can be deleted at that time.
- Add backend tests for `MultiplexResultInput`. There are a lot of duplicated tests, these can be removed in the next PR. They'll fail nicely when the duplicated code for `Disease Result` is successfully removed, and then they can be removed.

## Additional Information
There are currently some issues with duplicated code - b/c I've duplicated implementation to add the new `MultiplexResultInput` but keep `DiseaseResult` for backwards compatibility, sonar is unhappy.  This does not block merge, and will be resolved with the subsequent frontend PR.

## Testing

- Pull the branch down locally or test remotely on [dev2](https://dev2.simplereport.gov/). Try to conduct a test or edit an existing test result and observe no issues.

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide

----

## Checklist for Author and Reviewer