### PR TITLE
Include correction test events

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -76,7 +76,7 @@ public interface TestEventRepository
               + "         LEFT JOIN Result res ON res.testEvent = te "
               + "         LEFT JOIN SupportedDisease disease ON res.disease = disease "
               + "WHERE te.facility.internalId IN :facilityIds AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
-              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = '96741-4' "
+              + "    te.correctionStatus <> 'REMOVED' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = '96741-4' "
               + "GROUP BY res.testResult")
   List<TestResultWithCount> countByResultByFacility(
       Collection<UUID> facilityIds, Date startDate, Date endDate);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Resolves #3860 
Also fixes a customer support request that came in on 8/22 about "Positive test result is not showing up on facility's dashboard"

## Changes Proposed

Alter the query for test results used for TopLevelDashboardMetrics (populates the admin analytics dashboard) to count test events that are corrections

## Additional Information

`te.correctionStatus <> 'REMOVED' AND corrected_te.priorCorrectedTestEventId IS NULL`
when a test event is corrected, the original row isn't touched but an additional row is added with correctionStatus = 'CORRECTED' (or 'REMOVED' if it's a removal instead of replacement) and priorCorrectedTestEventId pointing to the original.

so the original query written before we supported corrections was getting all events with status = ORIGINAL that hadn't been removed (no `corrected_te` after the left join)
now that we support corrections in addition to removals, we want all events that aren't a removal that haven't themselves been removed or corrected (still no `corrected_te` after the left join)

## Testing

deploying to Dev2
- check that the result of a corrected test will appear in the dashboard according to its result value and test date
- check that the "old" result is no longer counted
- check that removed test results do not get counted for the dashboard

## Checklist for Primary Reviewer

- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [n/a] Any content updates (user-facing error messages, etc) have been approved by content team
- [n/a] Any changes that might generate questions in the support inbox have been flagged to the support team
- [n/a] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [n/a] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [n/a] Any dependencies introduced have been vetted and discussed
- [n/a] Any changes to the startup configuration have been documented in the README