### PR TITLE
updating the scope per a conversation with report stream

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -52,8 +52,8 @@ public class TestResultUploadService {
   private static final int FIVE_MINUTES_MS = 300 * 1000;
   private static final String REPORTING_SCOPE = "report";
 
-  private String createReportingScope(String scope) {
-    return String.join(".", scope, REPORTING_SCOPE);
+  private String createReportingScope(String reportStreamClientName) {
+    return String.join(".", reportStreamClientName, "*", REPORTING_SCOPE);
   }
 
   public String createDataHubSenderToken(String privateKey) throws InvalidRSAPrivateKeyException {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -49,12 +49,10 @@ public class TestResultUploadService {
   @Value("${data-hub.signing-key}")
   private String signingKey;
 
-  private static final int FIVE_MINUTES_MS = 300 * 1000;
-  private static final String REPORTING_SCOPE = "report";
+  @Value("${data-hub.jwt-scope}")
+  private String scope;
 
-  private String createReportingScope(String reportStreamClientName) {
-    return String.join(".", reportStreamClientName, "*", REPORTING_SCOPE);
-  }
+  private static final int FIVE_MINUTES_MS = 300 * 1000;
 
   public String createDataHubSenderToken(String privateKey) throws InvalidRSAPrivateKeyException {
     Date inFiveMinutes = new Date(System.currentTimeMillis() + FIVE_MINUTES_MS);
@@ -139,10 +137,8 @@ public class TestResultUploadService {
             .findByInternalIdAndOrganization(id, org)
             .orElseThrow(InvalidBulkTestResultUploadException::new);
 
-    String reportingScope = createReportingScope(simpleReportCsvUploadClientName);
-
     Map<String, String> queryParams = new LinkedHashMap<>();
-    queryParams.put("scope", reportingScope);
+    queryParams.put("scope", scope);
     queryParams.put("grant_type", "client_credentials");
     queryParams.put(
         "client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/TokenAuthentication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/TokenAuthentication.java
@@ -36,12 +36,12 @@ public class TokenAuthentication {
     }
   }
 
-  private String createJWT(String scope, String audience, Date exp, Key signingKey) {
+  private String createJWT(String clientName, String audience, Date exp, Key signingKey) {
     return Jwts.builder()
-        .setHeaderParam("kid", scope)
+        .setHeaderParam("kid", clientName)
         .setHeaderParam("typ", "JWT")
-        .setIssuer(scope)
-        .setSubject(scope)
+        .setIssuer(clientName)
+        .setSubject(clientName)
         .setAudience(audience)
         .setId(UUID.randomUUID().toString())
         .setExpiration(exp)
@@ -50,8 +50,8 @@ public class TokenAuthentication {
         .compact();
   }
 
-  public String createRSAJWT(String scope, String audience, Date exp, String signingKey)
+  public String createRSAJWT(String clientName, String audience, Date exp, String signingKey)
       throws InvalidRSAPrivateKeyException {
-    return createJWT(scope, audience, exp, getRSAPrivateKey(signingKey));
+    return createJWT(clientName, audience, exp, getRSAPrivateKey(signingKey));
   }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -145,5 +145,6 @@ datahub:
   url: ${DATAHUB_URL:http://localhost:9561}
   api-key: ${DATAHUB_API_KEY:super-secret-api-key}
   api-version: "2021-09-21"
+  jwt-scope: "simple_report.*.report"
   signing-key: ${DATAHUB_SIGNING_KEY:super-secret-signing-key}
   csv-upload-api-client: "simple_report.csvuploader"

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -229,5 +229,6 @@ simple-report-initialization:
     - patient-registration-link: inj3ct
       facility-name: Injection Site
 datahub:
-url: http://localhost:9561
-api-key: "super-secret-api-key"
+  url: http://localhost:9561
+  api-key: "super-secret-api-key"
+  jwt-scope: "simple_report.*.report"


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
resolves #4199 
Updates to the token api broke our integration.

## Changes Proposed

- Update the `scope` URL Param that is sent when generating a bearer token for the waters api 

## Testing

- Browse to {appurl}/results/upload/submissions/submission/{submissionid} and verify that the data loads

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README