### PR TITLE
George/3951 multiplex cleanup frontend

### DIFF
--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -7,6 +7,7 @@ import {
   getSortedResults,
   hasMultiplexResults,
 } from "../utils/testResults";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../testResults/constants";
 
 interface Props {
   results: MultiplexResults;
@@ -16,11 +17,11 @@ interface Props {
 
 const setDiseaseName = (diseaseName: MultiplexDisease, t: translateFn) => {
   switch (diseaseName) {
-    case "COVID-19":
+    case MULTIPLEX_DISEASES.COVID_19:
       return t("constants.disease.COVID19");
-    case "Flu A":
+    case MULTIPLEX_DISEASES.FLU_A:
       return t("constants.disease.FLUA");
-    case "Flu B":
+    case MULTIPLEX_DISEASES.FLU_B:
       return t("constants.disease.FLUB");
     default:
       return "";
@@ -29,9 +30,9 @@ const setDiseaseName = (diseaseName: MultiplexDisease, t: translateFn) => {
 
 const setResult = (result: string, t: translateFn) => {
   switch (result) {
-    case "POSITIVE":
+    case TEST_RESULTS.POSITIVE:
       return t("constants.testResults.POSITIVE");
-    case "NEGATIVE":
+    case TEST_RESULTS.NEGATIVE:
       return t("constants.testResults.NEGATIVE");
     default:
       return t("constants.testResults.UNDETERMINED");
@@ -40,9 +41,9 @@ const setResult = (result: string, t: translateFn) => {
 
 const setResultSymbol = (result: string, t: translateFn) => {
   switch (result) {
-    case "POSITIVE":
+    case TEST_RESULTS.POSITIVE:
       return t("constants.testResultsSymbols.POSITIVE");
-    case "NEGATIVE":
+    case TEST_RESULTS.NEGATIVE:
       return t("constants.testResultsSymbols.NEGATIVE");
     default:
       return "";

--- a/frontend/src/app/constants/index.tsx
+++ b/frontend/src/app/constants/index.tsx
@@ -6,16 +6,17 @@ import {
   TestResultDeliveryPreference,
   TestResultDeliveryPreferences,
 } from "../patients/TestResultDeliveryPreference";
+import { TEST_RESULTS } from "../testResults/constants";
 import i18n from "../../i18n";
 
 export const DATE_FORMAT_MM_DD_YYYY =
   "^([0-9]{1,2}/[0-9]{1,2}/[0-9]{4})|([0-9]{1,2}-[0-9]{1,2}-[0-9]{4})|([0-9]{8})$";
 
 export const COVID_RESULTS: { [key: string]: TestResult } = {
-  POSITIVE: "POSITIVE",
-  NEGATIVE: "NEGATIVE",
-  INCONCLUSIVE: "UNDETERMINED",
-  UNKNOWN: "UNKNOWN",
+  POSITIVE: TEST_RESULTS.POSITIVE,
+  NEGATIVE: TEST_RESULTS.NEGATIVE,
+  INCONCLUSIVE: TEST_RESULTS.UNDETERMINED,
+  UNKNOWN: TEST_RESULTS.UNKNOWN,
 };
 
 const testResultDescriptions = (t: TFunction): Record<TestResult, string> => {

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -12,8 +12,8 @@ import { getAppInsights } from "../TelemetryService";
 import * as utils from "../utils/index";
 import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 import {
-  SubmitTestResultMultiplexDocument as SUBMIT_TEST_RESULT,
-  EditQueueItemMultiplexDocument as EDIT_QUEUE_ITEM,
+  AddMultiplexResultDocument as SUBMIT_TEST_RESULT,
+  EditQueueItemMultiplexResultDocument as EDIT_QUEUE_ITEM,
 } from "../../generated/graphql";
 import * as generatedGraphql from "../../generated/graphql";
 
@@ -323,7 +323,7 @@ describe("QueueItem", () => {
 
             return {
               data: {
-                editQueueItemMultiplex: {
+                editQueueItemMultiplexResult: {
                   results: [
                     {
                       disease: { name: "COVID-19" },
@@ -360,7 +360,7 @@ describe("QueueItem", () => {
 
             return {
               data: {
-                editQueueItemMultiplex: {
+                editQueueItemMultiplexResult: {
                   results: [
                     {
                       disease: { name: "COVID-19" },
@@ -524,7 +524,7 @@ describe("QueueItem", () => {
             submitTestMockIsDone = true;
             return {
               data: {
-                addTestResultMultiplex: {
+                addMultiplexResult: {
                   testResult: {
                     internalId: internalId,
                   },
@@ -1003,7 +1003,7 @@ describe("QueueItem", () => {
     beforeEach(() => {
       jest.spyOn(flaggedMock, "useFeature").mockReturnValue(true);
 
-      const selectedTestResults: SRMultiplexResult[] = [
+      const selectedTestResults: MultiplexResult[] = [
         {
           disease: { name: "COVID-19" },
           testResult: "POSITIVE",
@@ -1032,7 +1032,7 @@ describe("QueueItem", () => {
           result: () => {
             return {
               data: {
-                editQueueItemMultiplex: {
+                editQueueItemMultiplexResult: {
                   results: [
                     {
                       disease: { name: "COVID-19" },
@@ -1082,7 +1082,7 @@ describe("QueueItem", () => {
           result: () => {
             return {
               data: {
-                editQueueItemMultiplex: {
+                editQueueItemMultiplexResult: {
                   results: [
                     {
                       disease: { name: "COVID-19" },
@@ -1132,7 +1132,7 @@ describe("QueueItem", () => {
           result: () => {
             return {
               data: {
-                editQueueItemMultiplex: {
+                editQueueItemMultiplexResult: {
                   results: [
                     {
                       disease: { name: "COVID-19" },
@@ -1214,7 +1214,7 @@ describe("QueueItem", () => {
 
       const editQueueSpy = jest.spyOn(
         generatedGraphql,
-        "useEditQueueItemMultiplexMutation"
+        "useEditQueueItemMultiplexResultMutation"
       );
       await waitFor(() => expect(editQueueSpy).toHaveBeenCalled());
     });
@@ -1454,7 +1454,7 @@ const mocks = [
     },
     result: {
       data: {
-        addTestResultMultiplex: {
+        addMultiplexResult: {
           testResult: {
             internalId: internalId,
           },

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -147,7 +147,7 @@ export interface QueueItemData extends AoEAnswers {
   deviceSpecimenType: DeviceSpecimenType;
   patient: TestQueuePerson;
   result: TestResult;
-  results: SRMultiplexResult[];
+  results: MultiplexResult[];
   dateTested: string;
   correctionStatus: string;
   reasonForCorrection: TestCorrectionReason;
@@ -268,7 +268,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
               ) || deviceSpecimenTypes[0];
           }
 
-          let selectedTestResults: SRMultiplexResult[];
+          let selectedTestResults: MultiplexResult[];
 
           // backwards compatibility
           if (!results && result) {

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -3,14 +3,14 @@ mutation RemovePatientFromQueue($patientId: ID!) {
     removePatientFromQueue(patientId: $patientId)
   }
 
-mutation EditQueueItemMultiplex(
+mutation EditQueueItemMultiplexResult(
     $id: ID!
     $deviceId: String
     $deviceSpecimenType: ID
-    $results: [DiseaseResult]
+    $results: [MultiplexResultInput]
     $dateTested: DateTime
   ) {
-    editQueueItemMultiplex(
+    editQueueItemMultiplexResult(
       id: $id
       deviceId: $deviceId
       deviceSpecimenType: $deviceSpecimenType
@@ -41,14 +41,14 @@ mutation EditQueueItemMultiplex(
     }
   }
 
-mutation SubmitTestResultMultiplex(
+mutation AddMultiplexResult(
     $patientId: ID!
     $deviceId: String!
     $deviceSpecimenType: ID
-    $results: [DiseaseResult]!
+    $results: [MultiplexResultInput]!
     $dateTested: DateTime
   ) {
-    addTestResultMultiplex(
+    addMultiplexResult(
       patientId: $patientId
       deviceId: $deviceId
       deviceSpecimenType: $deviceSpecimenType

--- a/frontend/src/app/testResults/CovidResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/CovidResultInputForm.test.tsx
@@ -2,15 +2,16 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { DiseaseResult } from "../../generated/graphql";
+import { MultiplexResultInput } from "../../generated/graphql";
 
 import CovidResultInputForm from "./CovidResultInputForm";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "./constants";
 
 describe("TestResultInputForm", () => {
-  const positiveResult: DiseaseResult[] = [
+  const positiveResult: MultiplexResultInput[] = [
     {
-      diseaseName: "COVID-19",
-      testResult: "POSITIVE",
+      diseaseName: MULTIPLEX_DISEASES.COVID_19,
+      testResult: TEST_RESULTS.POSITIVE,
     },
   ];
 
@@ -60,7 +61,10 @@ describe("TestResultInputForm", () => {
 
     userEvent.click(screen.getByLabelText("Negative (-)"));
     expect(onChangeFn).toBeCalledWith([
-      { diseaseName: "COVID-19", testResult: "NEGATIVE" },
+      {
+        diseaseName: MULTIPLEX_DISEASES.COVID_19,
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
     ]);
   });
 

--- a/frontend/src/app/testResults/CovidResultInputForm.tsx
+++ b/frontend/src/app/testResults/CovidResultInputForm.tsx
@@ -4,36 +4,42 @@ import RadioGroup from "../commonComponents/RadioGroup";
 import Button from "../commonComponents/Button/Button";
 import { COVID_RESULTS, TEST_RESULT_DESCRIPTIONS } from "../constants";
 import { findResultByDiseaseName } from "../testQueue/QueueItem";
-import { DiseaseResult } from "../../generated/graphql";
+import { MultiplexResultInput } from "../../generated/graphql";
+
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "./constants";
 
 interface CovidResult {
-  diseaseName: "COVID-19";
+  diseaseName: MULTIPLEX_DISEASES.COVID_19;
   testResult: TestResult;
 }
 
-const convertFromDiseaseResults = (
-  diseaseResults: DiseaseResult[]
+const convertFromMultiplexResultInputs = (
+  multiplexResultInputs: MultiplexResultInput[]
 ): TestResult => {
   const covidResult: TestResult =
-    (findResultByDiseaseName(diseaseResults ?? [], "COVID-19") as TestResult) ??
-    "UNKNOWN";
+    (findResultByDiseaseName(
+      multiplexResultInputs ?? [],
+      MULTIPLEX_DISEASES.COVID_19
+    ) as TestResult) ?? TEST_RESULTS.UNKNOWN;
   return covidResult;
 };
 
 const convertFromCovidResult = (covidResult: TestResult): CovidResult[] => {
-  const diseaseResults: CovidResult[] = [
+  const covidResults: CovidResult[] = [
     {
-      diseaseName: "COVID-19",
+      diseaseName: MULTIPLEX_DISEASES.COVID_19,
       testResult: covidResult,
     },
   ];
 
-  return diseaseResults.filter((result) => result.testResult !== "UNKNOWN");
+  return covidResults.filter(
+    (result) => result.testResult !== TEST_RESULTS.UNKNOWN
+  );
 };
 
 interface Props {
   queueItemId: string;
-  testResults: DiseaseResult[];
+  testResults: MultiplexResultInput[];
   isSubmitDisabled?: boolean;
   onChange: (value: CovidResult[]) => void;
   onSubmit: () => void;
@@ -46,9 +52,11 @@ const CovidResultInputForm: React.FC<Props> = ({
   onSubmit,
   onChange,
 }) => {
-  const resultCovidFormat = convertFromDiseaseResults(testResults);
+  const resultCovidFormat = convertFromMultiplexResultInputs(testResults);
   const allowSubmit =
-    resultCovidFormat && resultCovidFormat !== "UNKNOWN" && !isSubmitDisabled;
+    resultCovidFormat &&
+    resultCovidFormat !== TEST_RESULTS.UNKNOWN &&
+    !isSubmitDisabled;
 
   const onResultSubmit = (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import MultiplexResultInputForm from "./MultiplexResultInputForm";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "./constants";
 
 import spyOn = jest.spyOn;
 
@@ -16,16 +17,16 @@ describe("TestResultInputForm", () => {
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
           {
-            diseaseName: "COVID-19",
-            testResult: "POSITIVE",
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
           },
           {
-            diseaseName: "Flu A",
-            testResult: "NEGATIVE",
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.NEGATIVE,
           },
           {
-            diseaseName: "Flu B",
-            testResult: "NEGATIVE",
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.NEGATIVE,
           },
         ]}
         isSubmitDisabled={undefined}
@@ -105,7 +106,10 @@ describe("TestResultInputForm", () => {
 
     userEvent.click(screen.getAllByLabelText("Negative (-)")[0]);
     expect(onChangeFn).toBeCalledWith([
-      { diseaseName: "COVID-19", testResult: "NEGATIVE" },
+      {
+        diseaseName: MULTIPLEX_DISEASES.COVID_19,
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
     ]);
   });
   it("should pass back a Flu A result value when clicked", async () => {
@@ -120,7 +124,10 @@ describe("TestResultInputForm", () => {
 
     userEvent.click(screen.getAllByLabelText("Negative (-)")[1]);
     expect(onChangeFn).toBeCalledWith([
-      { diseaseName: "Flu A", testResult: "NEGATIVE" },
+      {
+        diseaseName: MULTIPLEX_DISEASES.FLU_A,
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
     ]);
   });
   it("should pass back a Flu B result value when clicked", async () => {
@@ -135,7 +142,10 @@ describe("TestResultInputForm", () => {
 
     userEvent.click(screen.getAllByLabelText("Negative (-)")[2]);
     expect(onChangeFn).toBeCalledWith([
-      { diseaseName: "Flu B", testResult: "NEGATIVE" },
+      {
+        diseaseName: MULTIPLEX_DISEASES.FLU_B,
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
     ]);
   });
 
@@ -145,16 +155,16 @@ describe("TestResultInputForm", () => {
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
           {
-            diseaseName: "COVID-19",
-            testResult: "UNDETERMINED",
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.UNDETERMINED,
           },
           {
-            diseaseName: "Flu A",
-            testResult: "UNDETERMINED",
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.UNDETERMINED,
           },
           {
-            diseaseName: "Flu B",
-            testResult: "UNDETERMINED",
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.UNDETERMINED,
           },
         ]}
         onChange={onChangeFn}
@@ -180,8 +190,8 @@ describe("TestResultInputForm", () => {
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
           {
-            diseaseName: "COVID-19",
-            testResult: "POSITIVE",
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
           },
         ]}
         onChange={onChangeFn}
@@ -198,11 +208,17 @@ describe("TestResultInputForm", () => {
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
           {
-            diseaseName: "COVID-19",
-            testResult: "POSITIVE",
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
           },
-          { diseaseName: "Flu A", testResult: "UNDETERMINED" },
-          { diseaseName: "Flu B", testResult: "UNDETERMINED" },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
         ]}
         onChange={onChangeFn}
         onSubmit={onSubmitFn}
@@ -218,16 +234,16 @@ describe("TestResultInputForm", () => {
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
           {
-            diseaseName: "COVID-19",
-            testResult: "POSITIVE",
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
           },
           {
-            diseaseName: "Flu A",
-            testResult: "NEGATIVE",
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.NEGATIVE,
           },
           {
-            diseaseName: "Flu B",
-            testResult: "NEGATIVE",
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.NEGATIVE,
           },
         ]}
         onChange={onChangeFn}
@@ -239,9 +255,18 @@ describe("TestResultInputForm", () => {
     expect(screen.getAllByLabelText("Negative (-)")[2]).toBeChecked();
     userEvent.click(screen.getByLabelText("inconclusive", { exact: false }));
     expect(onChangeFn).toHaveBeenCalledWith([
-      { diseaseName: "COVID-19", testResult: "UNDETERMINED" },
-      { diseaseName: "Flu A", testResult: "UNDETERMINED" },
-      { diseaseName: "Flu B", testResult: "UNDETERMINED" },
+      {
+        diseaseName: MULTIPLEX_DISEASES.COVID_19,
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
+      {
+        diseaseName: MULTIPLEX_DISEASES.FLU_A,
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
+      {
+        diseaseName: MULTIPLEX_DISEASES.FLU_B,
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
     ]);
   });
   it("should send correct test values when inconclusive checkbox is checked but user switches to positive/negative result", async () => {
@@ -249,9 +274,18 @@ describe("TestResultInputForm", () => {
       <MultiplexResultInputForm
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
-          { diseaseName: "COVID-19", testResult: "UNDETERMINED" },
-          { diseaseName: "Flu A", testResult: "UNDETERMINED" },
-          { diseaseName: "Flu B", testResult: "UNDETERMINED" },
+          {
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
         ]}
         onChange={onChangeFn}
         onSubmit={onSubmitFn}
@@ -272,9 +306,18 @@ describe("TestResultInputForm", () => {
     );
 
     expect(onChangeFn).toHaveBeenCalledWith([
-      { diseaseName: "COVID-19", testResult: "POSITIVE" },
-      { diseaseName: "Flu A", testResult: "UNDETERMINED" },
-      { diseaseName: "Flu B", testResult: "UNDETERMINED" },
+      {
+        diseaseName: MULTIPLEX_DISEASES.COVID_19,
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+      {
+        diseaseName: MULTIPLEX_DISEASES.FLU_A,
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
+      {
+        diseaseName: MULTIPLEX_DISEASES.FLU_B,
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
     ]);
   });
   it("should trigger submit for parent component when submit button is clicked", () => {
@@ -282,9 +325,18 @@ describe("TestResultInputForm", () => {
       <MultiplexResultInputForm
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
         testResults={[
-          { diseaseName: "COVID-19", testResult: "POSITIVE" },
-          { diseaseName: "Flu A", testResult: "POSITIVE" },
-          { diseaseName: "Flu B", testResult: "POSITIVE" },
+          {
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
         ]}
         onChange={onChangeFn}
         onSubmit={onSubmitFn}

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -6,12 +6,14 @@ import { COVID_RESULTS, TEST_RESULT_DESCRIPTIONS } from "../constants";
 import { findResultByDiseaseName } from "../testQueue/QueueItem";
 import { TextWithTooltip } from "../commonComponents/TextWithTooltip";
 import Checkboxes from "../commonComponents/Checkboxes";
-import { DiseaseResult } from "../../generated/graphql";
+import { MultiplexResultInput } from "../../generated/graphql";
+
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "./constants";
 
 const MULTIPLEX_DISEASE_TYPE = {
-  COVID: "COVID-19" as MultiplexDisease,
-  FLU_A: "Flu A" as MultiplexDisease,
-  FLU_B: "Flu B" as MultiplexDisease,
+  COVID: MULTIPLEX_DISEASES.COVID_19 as MultiplexDisease,
+  FLU_A: MULTIPLEX_DISEASES.FLU_A as MultiplexDisease,
+  FLU_B: MULTIPLEX_DISEASES.FLU_B as MultiplexDisease,
   ALL: "All",
 };
 
@@ -26,21 +28,25 @@ interface MultiplexResultState {
   fluB: TestResult;
 }
 
-const convertFromDiseaseResults = (
-  diseaseResults: DiseaseResult[]
+const convertFromMultiplexResultInputs = (
+  diseaseResults: MultiplexResultInput[]
 ): MultiplexResultState => {
   const multiplexResult: MultiplexResultState = {
     covid:
       (findResultByDiseaseName(
         diseaseResults ?? [],
-        "COVID-19"
-      ) as TestResult) ?? "UNKNOWN",
+        MULTIPLEX_DISEASES.COVID_19
+      ) as TestResult) ?? TEST_RESULTS.UNKNOWN,
     fluA:
-      (findResultByDiseaseName(diseaseResults ?? [], "Flu A") as TestResult) ??
-      "UNKNOWN",
+      (findResultByDiseaseName(
+        diseaseResults ?? [],
+        MULTIPLEX_DISEASES.FLU_A
+      ) as TestResult) ?? TEST_RESULTS.UNKNOWN,
     fluB:
-      (findResultByDiseaseName(diseaseResults ?? [], "Flu B") as TestResult) ??
-      "UNKNOWN",
+      (findResultByDiseaseName(
+        diseaseResults ?? [],
+        MULTIPLEX_DISEASES.FLU_B
+      ) as TestResult) ?? TEST_RESULTS.UNKNOWN,
   };
 
   return multiplexResult;
@@ -64,7 +70,9 @@ const convertFromMultiplexResult = (
     },
   ];
 
-  return diseaseResults.filter((result) => result.testResult !== "UNKNOWN");
+  return diseaseResults.filter(
+    (result) => result.testResult !== TEST_RESULTS.UNKNOWN
+  );
 };
 
 /**
@@ -72,7 +80,7 @@ const convertFromMultiplexResult = (
  */
 interface Props {
   queueItemId: string;
-  testResults: DiseaseResult[];
+  testResults: MultiplexResultInput[];
   isSubmitDisabled?: boolean;
   onChange: (value: MultiplexResult[]) => void;
   onSubmit: () => void;
@@ -87,18 +95,18 @@ const MultiplexResultInputForm: React.FC<Props> = ({
 }) => {
   //eslint-disable-next-line no-restricted-globals
   const isMobile = screen.width <= 600;
-  const resultsMultiplexFormat: MultiplexResultState = convertFromDiseaseResults(
+  const resultsMultiplexFormat: MultiplexResultState = convertFromMultiplexResultInputs(
     testResults
   );
   const inconclusiveCheck =
-    resultsMultiplexFormat.covid === "UNDETERMINED" &&
-    resultsMultiplexFormat.fluA === "UNDETERMINED" &&
-    resultsMultiplexFormat.fluB === "UNDETERMINED";
+    resultsMultiplexFormat.covid === TEST_RESULTS.UNDETERMINED &&
+    resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED &&
+    resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED;
 
   /**
    * Handle Setting Results
    */
-  const setDiseaseResult = (
+  const setMultiplexResultInput = (
     diseaseName: "covid" | "fluA" | "fluB",
     value: TestResult
   ) => {
@@ -120,21 +128,21 @@ const MultiplexResultInputForm: React.FC<Props> = ({
     const markedInconclusive = value.target.checked;
     if (markedInconclusive) {
       const inconclusiveState: MultiplexResultState = {
-        covid: "UNDETERMINED",
-        fluA: "UNDETERMINED",
-        fluB: "UNDETERMINED",
+        covid: TEST_RESULTS.UNDETERMINED,
+        fluA: TEST_RESULTS.UNDETERMINED,
+        fluB: TEST_RESULTS.UNDETERMINED,
       };
       convertAndSendResults(inconclusiveState);
     } else {
       const currentState = { ...resultsMultiplexFormat };
-      if (currentState.covid === "UNDETERMINED") {
-        currentState.covid = "UNKNOWN";
+      if (currentState.covid === TEST_RESULTS.UNDETERMINED) {
+        currentState.covid = TEST_RESULTS.UNKNOWN;
       }
-      if (currentState.fluA === "UNDETERMINED") {
-        currentState.fluA = "UNKNOWN";
+      if (currentState.fluA === TEST_RESULTS.UNDETERMINED) {
+        currentState.fluA = TEST_RESULTS.UNKNOWN;
       }
-      if (currentState.fluB === "UNDETERMINED") {
-        currentState.fluB = "UNKNOWN";
+      if (currentState.fluB === TEST_RESULTS.UNDETERMINED) {
+        currentState.fluB = TEST_RESULTS.UNKNOWN;
       }
       convertAndSendResults(currentState);
     }
@@ -146,12 +154,12 @@ const MultiplexResultInputForm: React.FC<Props> = ({
   const validateForm = () => {
     if (
       inconclusiveCheck ||
-      ((resultsMultiplexFormat.covid === "POSITIVE" ||
-        resultsMultiplexFormat.covid === "NEGATIVE") &&
-        (resultsMultiplexFormat.fluA === "POSITIVE" ||
-          resultsMultiplexFormat.fluA === "NEGATIVE") &&
-        (resultsMultiplexFormat.fluB === "POSITIVE" ||
-          resultsMultiplexFormat.fluB === "NEGATIVE"))
+      ((resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||
+        resultsMultiplexFormat.covid === TEST_RESULTS.NEGATIVE) &&
+        (resultsMultiplexFormat.fluA === TEST_RESULTS.POSITIVE ||
+          resultsMultiplexFormat.fluA === TEST_RESULTS.NEGATIVE) &&
+        (resultsMultiplexFormat.fluB === TEST_RESULTS.POSITIVE ||
+          resultsMultiplexFormat.fluB === TEST_RESULTS.NEGATIVE))
     ) {
       return true;
     }
@@ -173,7 +181,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
             legend="COVID-19 result"
             legendSrOnly
             onChange={(value) => {
-              setDiseaseResult("covid", value);
+              setMultiplexResultInput("covid", value);
             }}
             buttons={[
               {
@@ -197,7 +205,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
             legend="Flu A result"
             legendSrOnly
             onChange={(value) => {
-              setDiseaseResult("fluA", value);
+              setMultiplexResultInput("fluA", value);
             }}
             buttons={[
               {
@@ -221,7 +229,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
             legend="Flu B result"
             legendSrOnly
             onChange={(value) => {
-              setDiseaseResult("fluB", value);
+              setMultiplexResultInput("fluB", value);
             }}
             buttons={[
               {

--- a/frontend/src/app/testResults/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.tsx
@@ -17,7 +17,7 @@ import { formatDateWithTimeOption } from "../utils/date";
 type Result = {
   dateTested: string;
   result: TestResult;
-  results: SRMultiplexResult[];
+  results: MultiplexResult[];
   correctionStatus: TestCorrectionStatus;
   noSymptoms: boolean;
   symptoms: string;

--- a/frontend/src/app/testResults/TestResultPrintModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.test.tsx
@@ -6,12 +6,16 @@ import ReactDOM from "react-dom";
 import * as flaggedMock from "flagged";
 
 import { DetachedTestResultPrintModal } from "./TestResultPrintModal";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "./constants";
 
 const testResult = {
   dateTested: new Date("2022-01-28T17:56:48.143Z"),
   result: "NEGATIVE",
   results: [
-    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
+    {
+      disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+      testResult: TEST_RESULTS.NEGATIVE,
+    },
   ] as MultiplexResult[],
   correctionStatus: null,
   deviceType: {
@@ -101,9 +105,18 @@ describe("TestResultPrintModal with multiplex results in SimpleReport App", () =
 
     const multiplexTestResult = cloneDeep(testResult);
     multiplexTestResult.results = [
-      { disease: { name: "Flu B" }, testResult: "POSITIVE" },
-      { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
-      { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
     ];
 
     ReactDOM.createPortal = jest.fn((element, _node) => {
@@ -142,11 +155,17 @@ describe("TestResultPrintModal with multiplex results in Pxp App", () => {
     const multiplexPxpTestResult = cloneDeep(testResult);
     multiplexPxpTestResult.results = [
       {
-        disease: { name: "COVID-19" },
-        result: "NEGATIVE",
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.NEGATIVE,
       } as MultiplexResult,
-      { disease: { name: "Flu A" }, result: "NEGATIVE" } as MultiplexResult,
-      { disease: { name: "Flu B" }, result: "NEGATIVE" } as MultiplexResult,
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.NEGATIVE,
+      } as MultiplexResult,
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.NEGATIVE,
+      } as MultiplexResult,
     ];
     multiplexPxpTestResult.facility.orderingProvider.NPI = undefined;
     multiplexPxpTestResult.facility.orderingProvider.npi = "fake npi for pxp";

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -1,0 +1,12 @@
+export enum MULTIPLEX_DISEASES {
+  COVID_19 = "COVID-19",
+  FLU_A = "Flu A",
+  FLU_B = "Flu B",
+}
+
+export enum TEST_RESULTS {
+  POSITIVE = "POSITIVE",
+  NEGATIVE = "NEGATIVE",
+  UNDETERMINED = "UNDETERMINED",
+  UNKNOWN = "UNKNOWN",
+}

--- a/frontend/src/app/testResults/types.d.ts
+++ b/frontend/src/app/testResults/types.d.ts
@@ -1,5 +1,12 @@
-type MultiplexDisease = "COVID-19" | "Flu A" | "Flu B";
-type TestResult = "POSITIVE" | "NEGATIVE" | "UNDETERMINED" | "UNKNOWN";
+type MultiplexDisease =
+  | MULTIPLEX_DISEASES.COVID_19
+  | MULTIPLEX_DISEASES.FLU_A
+  | MULTIPLEX_DISEASES.FLU_B;
+type TestResult =
+  | TEST_RESULTS.POSITIVE
+  | TEST_RESULTS.NEGATIVE
+  | TEST_RESULTS.UNDETERMINED
+  | TEST_RESULTS.UNKNOWN;
 
 interface DiseaseName {
   disease: {
@@ -7,15 +14,10 @@ interface DiseaseName {
   };
 }
 
-interface SRMultiplexResult extends DiseaseName {
+interface MultiplexResult extends DiseaseName {
   testResult: TestResult;
 }
 
-interface PxpMultiplexResult extends DiseaseName {
-  result: TestResult;
-}
-
-type MultiplexResult = SRMultiplexResult | PxpMultiplexResult;
 type MultiplexResults = MultiplexResult[];
 
 type FilterParams = {

--- a/frontend/src/app/utils/testResults.test.ts
+++ b/frontend/src/app/utils/testResults.test.ts
@@ -1,3 +1,5 @@
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../testResults/constants";
+
 import {
   getResultByDiseaseName,
   getResultObjByDiseaseName,
@@ -7,42 +9,27 @@ import {
 } from "./testResults";
 
 describe("getResultByDiseaseName", () => {
-  describe("SimpleReportResults", () => {
+  describe("MultiplexResults", () => {
     let result: string;
-    const results: SRMultiplexResult[] = [
-      { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
-      { disease: { name: "Flu A" }, testResult: "POSITIVE" },
-      { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+    const results: MultiplexResult[] = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
     ];
-    const covidResults: SRMultiplexResult[] = [
-      { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
-    ];
-    it("returns UNDETERMINED if selecting COVID-19", () => {
-      result = "UNDETERMINED";
-      expect(getResultByDiseaseName(results, "COVID-19")).toEqual(result);
-    });
-    it("returns POSITIVE if selecting Flu A", () => {
-      result = "POSITIVE";
-      expect(getResultByDiseaseName(results, "Flu A")).toEqual(result);
-    });
-    it("returns NEGATIVE if selecting Flu B", () => {
-      result = "NEGATIVE";
-      expect(getResultByDiseaseName(results, "Flu B")).toEqual(result);
-    });
-    it("returns UNKNOWN if selecting a DiseaseName that is not present", () => {
-      result = "UNKNOWN";
-      expect(getResultByDiseaseName(covidResults, "Flu B")).toEqual(result);
-    });
-  });
-  describe("PxpResults", () => {
-    let result: string;
-    const results: PxpMultiplexResult[] = [
-      { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
-      { disease: { name: "Flu A" }, result: "POSITIVE" },
-      { disease: { name: "Flu B" }, result: "NEGATIVE" },
-    ];
-    const covidResults: PxpMultiplexResult[] = [
-      { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
+    const covidResults: MultiplexResult[] = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.UNDETERMINED,
+      },
     ];
     it("returns UNDETERMINED if selecting COVID-19", () => {
       result = "UNDETERMINED";
@@ -64,71 +51,56 @@ describe("getResultByDiseaseName", () => {
 });
 
 describe("getResultObjByDiseaseName", () => {
-  describe("SimpleReportResults", () => {
-    let results: SRMultiplexResult[] = [
-      { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-      { disease: { name: "Flu A" }, testResult: "POSITIVE" },
-      { disease: { name: "Flu B" }, testResult: "UNKNOWN" },
+  describe("MultiplexResults", () => {
+    let results: MultiplexResult[] = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.UNKNOWN,
+      },
     ];
     let expectedResult: MultiplexResult;
     it("returns the COVID-19 result when searching by COVID-19", () => {
       expectedResult = {
-        disease: { name: "COVID-19" },
-        testResult: "NEGATIVE",
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.NEGATIVE,
       };
       expect(
         getResultObjByDiseaseName(results, "COVID-19" as MultiplexDisease)
       ).toEqual(expectedResult);
     });
     it("returns the Flu A result when searching by Flu A", () => {
-      expectedResult = { disease: { name: "Flu A" }, testResult: "POSITIVE" };
-      expect(
-        getResultObjByDiseaseName(results, "Flu A" as MultiplexDisease)
-      ).toEqual(expectedResult);
-    });
-    it("returns the Flu B result when searching by Flu B", () => {
-      expectedResult = { disease: { name: "Flu B" }, testResult: "UNKNOWN" };
-      expect(
-        getResultObjByDiseaseName(results, "Flu B" as MultiplexDisease)
-      ).toEqual(expectedResult);
-    });
-    it("returns null when searching for a MultiplexDisease not in the results", () => {
-      results = [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }];
-      expect(
-        getResultObjByDiseaseName(results, "Flu B" as MultiplexDisease)
-      ).toEqual(null);
-    });
-  });
-  describe("PxpResults", () => {
-    let results: PxpMultiplexResult[] = [
-      { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-      { disease: { name: "Flu A" }, result: "POSITIVE" },
-      { disease: { name: "Flu B" }, result: "UNKNOWN" },
-    ];
-    let expectedResult: MultiplexResult;
-    it("returns the COVID-19 result when searching by COVID-19", () => {
       expectedResult = {
-        disease: { name: "COVID-19" },
-        result: "NEGATIVE",
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.POSITIVE,
       };
       expect(
-        getResultObjByDiseaseName(results, "COVID-19" as MultiplexDisease)
-      ).toEqual(expectedResult);
-    });
-    it("returns the Flu A result when searching by Flu A", () => {
-      expectedResult = { disease: { name: "Flu A" }, result: "POSITIVE" };
-      expect(
         getResultObjByDiseaseName(results, "Flu A" as MultiplexDisease)
       ).toEqual(expectedResult);
     });
     it("returns the Flu B result when searching by Flu B", () => {
-      expectedResult = { disease: { name: "Flu B" }, result: "UNKNOWN" };
+      expectedResult = {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.UNKNOWN,
+      };
       expect(
         getResultObjByDiseaseName(results, "Flu B" as MultiplexDisease)
       ).toEqual(expectedResult);
     });
     it("returns null when searching for a MultiplexDisease not in the results", () => {
-      results = [{ disease: { name: "COVID-19" }, result: "NEGATIVE" }];
+      results = [
+        {
+          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+          testResult: TEST_RESULTS.NEGATIVE,
+        },
+      ];
       expect(
         getResultObjByDiseaseName(results, "Flu B" as MultiplexDisease)
       ).toEqual(null);
@@ -137,46 +109,45 @@ describe("getResultObjByDiseaseName", () => {
 });
 
 describe("getSortedResults", () => {
-  describe("SimpleReportResults", () => {
-    let results: SRMultiplexResult[] = [
-      { disease: { name: "Flu B" }, testResult: "UNKNOWN" },
-      { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-      { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+  describe("MultiplexResults", () => {
+    let results: MultiplexResult[] = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.UNKNOWN,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
     ];
     let expectedResults: MultiplexResults;
     it("returns the result in ABC order by disease name", () => {
       expectedResults = [
-        { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-        { disease: { name: "Flu A" }, testResult: "POSITIVE" },
-        { disease: { name: "Flu B" }, testResult: "UNKNOWN" },
+        {
+          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+          testResult: TEST_RESULTS.NEGATIVE,
+        },
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_A },
+          testResult: TEST_RESULTS.POSITIVE,
+        },
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_B },
+          testResult: TEST_RESULTS.UNKNOWN,
+        },
       ];
       expect(getSortedResults(results)).toEqual(expectedResults);
     });
     it("returns the same array when only one result", () => {
-      let results: SRMultiplexResult[] = [
-        { disease: { name: "Flu B" }, testResult: "UNKNOWN" },
-      ];
-      expect(getSortedResults(results)).toEqual(results);
-    });
-  });
-  describe("PxpResults", () => {
-    let results: PxpMultiplexResult[] = [
-      { disease: { name: "Flu B" }, result: "UNKNOWN" },
-      { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-      { disease: { name: "Flu A" }, result: "POSITIVE" },
-    ];
-    let expectedResults: MultiplexResults;
-    it("returns the result in ABC order by disease name", () => {
-      expectedResults = [
-        { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-        { disease: { name: "Flu A" }, result: "POSITIVE" },
-        { disease: { name: "Flu B" }, result: "UNKNOWN" },
-      ];
-      expect(getSortedResults(results)).toEqual(expectedResults);
-    });
-    it("returns the same array when only one result", () => {
-      let results: PxpMultiplexResult[] = [
-        { disease: { name: "Flu B" }, result: "UNKNOWN" },
+      let results: MultiplexResult[] = [
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_B },
+          testResult: TEST_RESULTS.UNKNOWN,
+        },
       ];
       expect(getSortedResults(results)).toEqual(results);
     });
@@ -184,37 +155,36 @@ describe("getSortedResults", () => {
 });
 
 describe("hasMultiplexResults", () => {
-  describe("SimpleReportResults", () => {
-    let results: SRMultiplexResult[] = [];
+  describe("MultiplexResults", () => {
+    let results: MultiplexResult[] = [];
     it("returns true if it contains a multiplex result", () => {
       results = [
-        { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-        { disease: { name: "Flu A" }, testResult: "POSITIVE" },
-        { disease: { name: "Flu B" }, testResult: "POSITIVE" },
+        {
+          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+          testResult: TEST_RESULTS.NEGATIVE,
+        },
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_A },
+          testResult: TEST_RESULTS.POSITIVE,
+        },
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_B },
+          testResult: TEST_RESULTS.POSITIVE,
+        },
       ];
       expect(hasMultiplexResults(results)).toEqual(true);
     });
     it("returns false if it only contains one result", () => {
-      results = [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }];
+      results = [
+        {
+          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+          testResult: TEST_RESULTS.NEGATIVE,
+        },
+      ];
       expect(hasMultiplexResults(results)).toEqual(false);
     });
     it("returns false if has no results", () => {
       results = [];
-      expect(hasMultiplexResults(results)).toEqual(false);
-    });
-  });
-  describe("PxpResults", () => {
-    let results: PxpMultiplexResult[] = [];
-    it("returns true if it contains a multiplex result", () => {
-      results = [
-        { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-        { disease: { name: "Flu A" }, result: "POSITIVE" },
-        { disease: { name: "Flu B" }, result: "POSITIVE" },
-      ];
-      expect(hasMultiplexResults(results)).toEqual(true);
-    });
-    it("returns false if it only contains one result", () => {
-      results = [{ disease: { name: "COVID-19" }, result: "NEGATIVE" }];
       expect(hasMultiplexResults(results)).toEqual(false);
     });
     it("returns false if it contains no results", () => {
@@ -225,37 +195,32 @@ describe("hasMultiplexResults", () => {
 });
 
 describe("hasPositiveFluResults", () => {
-  describe("SimpleReportResults", () => {
-    let results: SRMultiplexResult[] = [];
+  describe("MultiplexResults", () => {
+    let results: MultiplexResult[] = [];
     it("returns true if it contains a positive flu result", () => {
       results = [
-        { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-        { disease: { name: "Flu A" }, testResult: "POSITIVE" },
-        { disease: { name: "Flu B" }, testResult: "POSITIVE" },
+        {
+          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+          testResult: TEST_RESULTS.UNDETERMINED,
+        },
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_A },
+          testResult: TEST_RESULTS.POSITIVE,
+        },
+        {
+          disease: { name: MULTIPLEX_DISEASES.FLU_B },
+          testResult: TEST_RESULTS.POSITIVE,
+        },
       ];
       expect(hasPositiveFluResults(results)).toEqual(true);
     });
     it("returns false if it does not contain a flu result", () => {
-      results = [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }];
-      expect(hasPositiveFluResults(results)).toEqual(false);
-    });
-    it("returns false if it has no results", () => {
-      results = [];
-      expect(hasMultiplexResults(results)).toEqual(false);
-    });
-  });
-  describe("PxpResults", () => {
-    let results: PxpMultiplexResult[] = [];
-    it("returns true if it contains a positive flu result", () => {
       results = [
-        { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
-        { disease: { name: "Flu A" }, result: "POSITIVE" },
-        { disease: { name: "Flu B" }, result: "POSITIVE" },
+        {
+          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+          testResult: TEST_RESULTS.POSITIVE,
+        },
       ];
-      expect(hasPositiveFluResults(results)).toEqual(true);
-    });
-    it("returns false if it does not contain a flu result", () => {
-      results = [{ disease: { name: "COVID-19" }, result: "NEGATIVE" }];
       expect(hasPositiveFluResults(results)).toEqual(false);
     });
     it("returns false if it contains no results", () => {

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -2,8 +2,6 @@ function getTestResult(result: MultiplexResult): TestResult {
   if (result) {
     if ("testResult" in result) {
       return result.testResult;
-    } else if ("result" in result) {
-      return result.result;
     }
   }
   return "UNKNOWN";
@@ -16,7 +14,7 @@ export function getResultObjByDiseaseName(
   return (
     (results.find((result: MultiplexResult) => {
       return result.disease.name.includes(diseaseName);
-    }) as SRMultiplexResult | PxpMultiplexResult) || null
+    }) as MultiplexResult) || null
   );
 }
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2159,19 +2159,19 @@ export type RemovePatientFromQueueMutation = {
   removePatientFromQueue?: string | null | undefined;
 };
 
-export type EditQueueItemMultiplexMutationVariables = Exact<{
+export type EditQueueItemMultiplexResultMutationVariables = Exact<{
   id: Scalars["ID"];
   deviceId?: InputMaybe<Scalars["String"]>;
   deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
   results?: InputMaybe<
-    Array<InputMaybe<DiseaseResult>> | InputMaybe<DiseaseResult>
+    Array<InputMaybe<MultiplexResultInput>> | InputMaybe<MultiplexResultInput>
   >;
   dateTested?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
-export type EditQueueItemMultiplexMutation = {
+export type EditQueueItemMultiplexResultMutation = {
   __typename?: "Mutation";
-  editQueueItemMultiplex?:
+  editQueueItemMultiplexResult?:
     | {
         __typename?: "TestOrder";
         dateTested?: any | null | undefined;
@@ -2216,17 +2216,19 @@ export type EditQueueItemMultiplexMutation = {
     | undefined;
 };
 
-export type SubmitTestResultMultiplexMutationVariables = Exact<{
+export type AddMultiplexResultMutationVariables = Exact<{
   patientId: Scalars["ID"];
   deviceId: Scalars["String"];
   deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
-  results: Array<InputMaybe<DiseaseResult>> | InputMaybe<DiseaseResult>;
+  results:
+    | Array<InputMaybe<MultiplexResultInput>>
+    | InputMaybe<MultiplexResultInput>;
   dateTested?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
-export type SubmitTestResultMultiplexMutation = {
+export type AddMultiplexResultMutation = {
   __typename?: "Mutation";
-  addTestResultMultiplex?:
+  addMultiplexResult?:
     | {
         __typename?: "AddTestResultResponse";
         deliverySuccess?: boolean | null | undefined;
@@ -6102,15 +6104,15 @@ export type RemovePatientFromQueueMutationOptions = Apollo.BaseMutationOptions<
   RemovePatientFromQueueMutation,
   RemovePatientFromQueueMutationVariables
 >;
-export const EditQueueItemMultiplexDocument = gql`
-  mutation EditQueueItemMultiplex(
+export const EditQueueItemMultiplexResultDocument = gql`
+  mutation EditQueueItemMultiplexResult(
     $id: ID!
     $deviceId: String
     $deviceSpecimenType: ID
-    $results: [DiseaseResult]
+    $results: [MultiplexResultInput]
     $dateTested: DateTime
   ) {
-    editQueueItemMultiplex(
+    editQueueItemMultiplexResult(
       id: $id
       deviceId: $deviceId
       deviceSpecimenType: $deviceSpecimenType
@@ -6141,23 +6143,23 @@ export const EditQueueItemMultiplexDocument = gql`
     }
   }
 `;
-export type EditQueueItemMultiplexMutationFn = Apollo.MutationFunction<
-  EditQueueItemMultiplexMutation,
-  EditQueueItemMultiplexMutationVariables
+export type EditQueueItemMultiplexResultMutationFn = Apollo.MutationFunction<
+  EditQueueItemMultiplexResultMutation,
+  EditQueueItemMultiplexResultMutationVariables
 >;
 
 /**
- * __useEditQueueItemMultiplexMutation__
+ * __useEditQueueItemMultiplexResultMutation__
  *
- * To run a mutation, you first call `useEditQueueItemMultiplexMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useEditQueueItemMultiplexMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useEditQueueItemMultiplexResultMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditQueueItemMultiplexResultMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [editQueueItemMultiplexMutation, { data, loading, error }] = useEditQueueItemMultiplexMutation({
+ * const [editQueueItemMultiplexResultMutation, { data, loading, error }] = useEditQueueItemMultiplexResultMutation({
  *   variables: {
  *      id: // value for 'id'
  *      deviceId: // value for 'deviceId'
@@ -6167,35 +6169,35 @@ export type EditQueueItemMultiplexMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditQueueItemMultiplexMutation(
+export function useEditQueueItemMultiplexResultMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    EditQueueItemMultiplexMutation,
-    EditQueueItemMultiplexMutationVariables
+    EditQueueItemMultiplexResultMutation,
+    EditQueueItemMultiplexResultMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    EditQueueItemMultiplexMutation,
-    EditQueueItemMultiplexMutationVariables
-  >(EditQueueItemMultiplexDocument, options);
+    EditQueueItemMultiplexResultMutation,
+    EditQueueItemMultiplexResultMutationVariables
+  >(EditQueueItemMultiplexResultDocument, options);
 }
-export type EditQueueItemMultiplexMutationHookResult = ReturnType<
-  typeof useEditQueueItemMultiplexMutation
+export type EditQueueItemMultiplexResultMutationHookResult = ReturnType<
+  typeof useEditQueueItemMultiplexResultMutation
 >;
-export type EditQueueItemMultiplexMutationResult = Apollo.MutationResult<EditQueueItemMultiplexMutation>;
-export type EditQueueItemMultiplexMutationOptions = Apollo.BaseMutationOptions<
-  EditQueueItemMultiplexMutation,
-  EditQueueItemMultiplexMutationVariables
+export type EditQueueItemMultiplexResultMutationResult = Apollo.MutationResult<EditQueueItemMultiplexResultMutation>;
+export type EditQueueItemMultiplexResultMutationOptions = Apollo.BaseMutationOptions<
+  EditQueueItemMultiplexResultMutation,
+  EditQueueItemMultiplexResultMutationVariables
 >;
-export const SubmitTestResultMultiplexDocument = gql`
-  mutation SubmitTestResultMultiplex(
+export const AddMultiplexResultDocument = gql`
+  mutation AddMultiplexResult(
     $patientId: ID!
     $deviceId: String!
     $deviceSpecimenType: ID
-    $results: [DiseaseResult]!
+    $results: [MultiplexResultInput]!
     $dateTested: DateTime
   ) {
-    addTestResultMultiplex(
+    addMultiplexResult(
       patientId: $patientId
       deviceId: $deviceId
       deviceSpecimenType: $deviceSpecimenType
@@ -6209,23 +6211,23 @@ export const SubmitTestResultMultiplexDocument = gql`
     }
   }
 `;
-export type SubmitTestResultMultiplexMutationFn = Apollo.MutationFunction<
-  SubmitTestResultMultiplexMutation,
-  SubmitTestResultMultiplexMutationVariables
+export type AddMultiplexResultMutationFn = Apollo.MutationFunction<
+  AddMultiplexResultMutation,
+  AddMultiplexResultMutationVariables
 >;
 
 /**
- * __useSubmitTestResultMultiplexMutation__
+ * __useAddMultiplexResultMutation__
  *
- * To run a mutation, you first call `useSubmitTestResultMultiplexMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useSubmitTestResultMultiplexMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useAddMultiplexResultMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddMultiplexResultMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [submitTestResultMultiplexMutation, { data, loading, error }] = useSubmitTestResultMultiplexMutation({
+ * const [addMultiplexResultMutation, { data, loading, error }] = useAddMultiplexResultMutation({
  *   variables: {
  *      patientId: // value for 'patientId'
  *      deviceId: // value for 'deviceId'
@@ -6235,25 +6237,25 @@ export type SubmitTestResultMultiplexMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSubmitTestResultMultiplexMutation(
+export function useAddMultiplexResultMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    SubmitTestResultMultiplexMutation,
-    SubmitTestResultMultiplexMutationVariables
+    AddMultiplexResultMutation,
+    AddMultiplexResultMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    SubmitTestResultMultiplexMutation,
-    SubmitTestResultMultiplexMutationVariables
-  >(SubmitTestResultMultiplexDocument, options);
+    AddMultiplexResultMutation,
+    AddMultiplexResultMutationVariables
+  >(AddMultiplexResultDocument, options);
 }
-export type SubmitTestResultMultiplexMutationHookResult = ReturnType<
-  typeof useSubmitTestResultMultiplexMutation
+export type AddMultiplexResultMutationHookResult = ReturnType<
+  typeof useAddMultiplexResultMutation
 >;
-export type SubmitTestResultMultiplexMutationResult = Apollo.MutationResult<SubmitTestResultMultiplexMutation>;
-export type SubmitTestResultMultiplexMutationOptions = Apollo.BaseMutationOptions<
-  SubmitTestResultMultiplexMutation,
-  SubmitTestResultMultiplexMutationVariables
+export type AddMultiplexResultMutationResult = Apollo.MutationResult<AddMultiplexResultMutation>;
+export type AddMultiplexResultMutationOptions = Apollo.BaseMutationOptions<
+  AddMultiplexResultMutation,
+  AddMultiplexResultMutationVariables
 >;
 export const GetTestResultForCorrectionDocument = gql`
   query getTestResultForCorrection($id: ID!) {

--- a/frontend/src/patientApp/PxpApiService.ts
+++ b/frontend/src/patientApp/PxpApiService.ts
@@ -45,7 +45,7 @@ export type SelfRegistrationData = Omit<
 export type VerifyV2Response = {
   testEventId: string;
   result: TestResult;
-  results: PxpMultiplexResult[];
+  results: MultiplexResult[];
   dateTested: string;
   correctionStatus: string;
   deviceType: {

--- a/frontend/src/patientApp/timeOfTest/TestResult.stories.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.stories.tsx
@@ -26,8 +26,8 @@ const data = {
     testEventId: "12321312",
     result: "POSITIVE" as TestResult,
     results: [
-      { disease: { name: "COVID-19" }, result: "POSITIVE" },
-    ] as PxpMultiplexResult[],
+      { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
+    ] as MultiplexResult[],
     dateTested: new Date("2021-08-20").toDateString(),
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -77,7 +77,7 @@ export const PositiveCovid = () => {
 export const NegativeCovid = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "COVID-19" }, result: "NEGATIVE" },
+    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
   ];
   let store = mockStore(editedData);
   return (
@@ -93,7 +93,7 @@ export const NegativeCovid = () => {
 export const InconclusiveCovid = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
+    { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
   ];
   let store = mockStore(editedData);
   return (
@@ -109,9 +109,9 @@ export const InconclusiveCovid = () => {
 export const PositiveFluMultiplex = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "Flu B" }, result: "NEGATIVE" },
-    { disease: { name: "Flu A" }, result: "POSITIVE" },
-    { disease: { name: "COVID-19" }, result: "NEGATIVE" },
+    { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+    { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
   ];
   let store = mockStore(editedData);
   return (
@@ -127,9 +127,9 @@ export const PositiveFluMultiplex = () => {
 export const PositiveCovidMultiplex = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "Flu B" }, result: "NEGATIVE" },
-    { disease: { name: "Flu A" }, result: "NEGATIVE" },
-    { disease: { name: "COVID-19" }, result: "POSITIVE" },
+    { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+    { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+    { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
   ];
   let store = mockStore(editedData);
   return (
@@ -145,9 +145,9 @@ export const PositiveCovidMultiplex = () => {
 export const PositiveAllMultiplex = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "Flu A" }, result: "POSITIVE" },
-    { disease: { name: "Flu B" }, result: "POSITIVE" },
-    { disease: { name: "COVID-19" }, result: "POSITIVE" },
+    { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+    { disease: { name: "Flu B" }, testResult: "POSITIVE" },
+    { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
   ];
   let store = mockStore(editedData);
   return (
@@ -163,9 +163,9 @@ export const PositiveAllMultiplex = () => {
 export const NegativeAllMultiplex = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "Flu B" }, result: "NEGATIVE" },
-    { disease: { name: "Flu A" }, result: "NEGATIVE" },
-    { disease: { name: "COVID-19" }, result: "NEGATIVE" },
+    { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+    { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
   ];
   let store = mockStore(editedData);
   return (
@@ -181,9 +181,9 @@ export const NegativeAllMultiplex = () => {
 export const UndeterminedAllMultiplex = () => {
   let editedData = cloneDeep(data);
   editedData.testResult.results = [
-    { disease: { name: "Flu B" }, result: "UNDETERMINED" },
-    { disease: { name: "Flu A" }, result: "UNDETERMINED" },
-    { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
+    { disease: { name: "Flu B" }, testResult: "UNDETERMINED" },
+    { disease: { name: "Flu A" }, testResult: "UNDETERMINED" },
+    { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
   ];
   let store = mockStore(editedData);
   return (

--- a/frontend/src/patientApp/timeOfTest/TestResult.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.test.tsx
@@ -7,9 +7,9 @@ import "../../i18n";
 
 const mockStore = configureStore([]);
 
-let getPatientLinkData = (results: PxpMultiplexResult[]) => ({
+let getPatientLinkData = (results: MultiplexResult[]) => ({
   testEventId: "4606e571-8249-479e-94ab-e2f311713a5f",
-  results: results as PxpMultiplexResult[],
+  results: results as MultiplexResult[],
   dateTested: "2022-02-11T21:16:26.404+00:00",
   correctionStatus: "ORIGINAL",
   patient: {
@@ -46,8 +46,8 @@ let getPatientLinkData = (results: PxpMultiplexResult[]) => ({
 describe("TestResult - COVID-19 only", () => {
   it("should show the patient/device name", () => {
     const results = [
-      { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
-    ] as PxpMultiplexResult[];
+      { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
+    ] as MultiplexResult[];
     const store = mockStore({ testResult: getPatientLinkData(results) });
     render(
       <Provider store={store}>
@@ -69,8 +69,8 @@ describe("TestResult - COVID-19 only", () => {
   });
   it("should show a positive result", () => {
     const results = [
-      { disease: { name: "COVID-19" }, result: "POSITIVE" },
-    ] as PxpMultiplexResult[];
+      { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
+    ] as MultiplexResult[];
     const store = mockStore({ testResult: getPatientLinkData(results) });
     render(
       <Provider store={store}>
@@ -87,8 +87,8 @@ describe("TestResult - COVID-19 only", () => {
   });
   it("should show a negative result", () => {
     const results = [
-      { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-    ] as PxpMultiplexResult[];
+      { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
+    ] as MultiplexResult[];
     const store = mockStore({ testResult: getPatientLinkData(results) });
     render(
       <Provider store={store}>
@@ -105,8 +105,8 @@ describe("TestResult - COVID-19 only", () => {
   });
   it("should show an inconclusive result", () => {
     const results = [
-      { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
-    ] as PxpMultiplexResult[];
+      { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
+    ] as MultiplexResult[];
     const store = mockStore({ testResult: getPatientLinkData(results) });
     render(
       <Provider store={store}>
@@ -127,10 +127,10 @@ if (process.env.REACT_APP_MULTIPLEX_ENABLE) {
   describe("TestResult - Multiplex", () => {
     it("should show the results for positive COVID-19 and negative Flu", () => {
       const results = [
-        { disease: { name: "Flu B" }, result: "NEGATIVE" },
-        { disease: { name: "Flu A" }, result: "NEGATIVE" },
-        { disease: { name: "COVID-19" }, result: "POSITIVE" },
-      ] as PxpMultiplexResult[];
+        { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
+        { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
+        { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
+      ] as MultiplexResult[];
       const store = mockStore({ testResult: getPatientLinkData(results) });
       render(
         <Provider store={store}>
@@ -151,10 +151,10 @@ if (process.env.REACT_APP_MULTIPLEX_ENABLE) {
 
     it("should show the results for negative COVID-19 and positive Flu", () => {
       const results = [
-        { disease: { name: "Flu B" }, result: "POSITIVE" },
-        { disease: { name: "Flu A" }, result: "POSITIVE" },
-        { disease: { name: "COVID-19" }, result: "NEGATIVE" },
-      ] as PxpMultiplexResult[];
+        { disease: { name: "Flu B" }, testResult: "POSITIVE" },
+        { disease: { name: "Flu A" }, testResult: "POSITIVE" },
+        { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
+      ] as MultiplexResult[];
       const store = mockStore({ testResult: getPatientLinkData(results) });
       render(
         <Provider store={store}>
@@ -179,10 +179,10 @@ if (process.env.REACT_APP_MULTIPLEX_ENABLE) {
 
     it("should show the results for undetermined COVID-19 and Flu", () => {
       const results = [
-        { disease: { name: "Flu B" }, result: "UNDETERMINED" },
-        { disease: { name: "Flu A" }, result: "UNDETERMINED" },
-        { disease: { name: "COVID-19" }, result: "UNDETERMINED" },
-      ] as PxpMultiplexResult[];
+        { disease: { name: "Flu B" }, testResult: "UNDETERMINED" },
+        { disease: { name: "Flu A" }, testResult: "UNDETERMINED" },
+        { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
+      ] as MultiplexResult[];
       const store = mockStore({ testResult: getPatientLinkData(results) });
       render(
         <Provider store={store}>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #3951 

- This PR is the frontend portion for Issue #3951. For more context, see the [original PR](https://github.com/CDCgov/prime-simplereport/pull/4160) #4160, which I split into multiple PRs due to backwards compatibility issues.

## Changes Proposed

- Modifies the graphql model and calls to use `MultiplexResultInput` instead of `DiseaseResult`
- Following the changes from https://github.com/CDCgov/prime-simplereport/issues/3958, frontend types have now been cleaned up to use a single `MultiplexResult` type instead of the obsolete `PxpMultiplexResult` and `SrMultiplexResult`
  - This includes test cleanup and removing duplicated tests for `PxpMultiplexResult` and `SrMultiplexResult`
- Added an enum type for multiplex disease and test result strings so that we don't have to repeat string literals in test results code. This seemed like the cleanest implementation to me, but feel free to suggest a better alternative.

## Additional Information

- Further backend changes will follow in a third PR to remove obsolete code and tests in the backend. It's necessary to leave this for now as removing it simultaneously with frontend changes will result in graphql backwards compatibility errors. (Tested this is dev.)

## Testing

- Visit `[dev1](https://dev.simplereport.gov/)` and observe that test results can be successfully added and corrected. Frontend should send `MultiplexResultInput` for multiplex result mutation, and the backend will handle it properly.
 
## Screenshots / Demos

- Editing a test result
<img width="1527" alt="Screen Shot 2022-08-24 at 4 49 55 PM" src="https://user-images.githubusercontent.com/89797785/186520889-dbcf8085-4c1f-432b-bfd8-5f0a8245d6b6.png">

- Adding a test result
<img width="1122" alt="Screen Shot 2022-08-24 at 4 50 15 PM" src="https://user-images.githubusercontent.com/89797785/186520909-53771d08-5678-4799-9bad-0a333c645116.png">

## Checklist for Author and Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
