### PR TITLE
set focus on fields with errors for org signup

### DIFF
--- a/frontend/src/app/commonComponents/DatePicker.tsx
+++ b/frontend/src/app/commonComponents/DatePicker.tsx
@@ -68,6 +68,9 @@ export const DatePicker = ({
         defaultValue={defaultValue}
         minDate={minDate}
         maxDate={maxDate}
+        {...(validationStatus === "error"
+          ? { "aria-describedby": `error_${name}`, "aria-invalid": true }
+          : null)}
       />
     </div>
   );

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -93,6 +93,9 @@ const Dropdown: React.FC<Props & SelectProps> = ({
             value={selectedValue || defaultOption || ""}
             disabled={disabled}
             {...inputProps}
+            {...(validationStatus === "error"
+              ? { "aria-describedby": `error_${id}`, "aria-invalid": true }
+              : null)}
           >
             {defaultSelect && <option value="">{defaultOption}</option>}
             {options.map(({ value, label, disabled }) => (

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.test.tsx
@@ -61,6 +61,9 @@ describe("PersonalDetailsForm", () => {
         expect(
           await screen.findByText("A valid phone number is required")
         ).toBeInTheDocument();
+        expect(
+          screen.getByRole("textbox", { name: "Date of birth" })
+        ).toHaveFocus();
       });
     });
     describe("On submitting an invalid street address 1", () => {

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -95,6 +95,12 @@ const PersonalDetailsForm = ({
     );
     showNotification(alert);
     setSaving(false);
+    let elementsWithErrors = Array.from(
+      document.querySelectorAll("[aria-invalid=true]")
+    );
+    (elementsWithErrors.find(
+      (element) => element.getAttribute("aria-hidden") !== "true"
+    ) as HTMLElement | null)?.focus();
   };
 
   if (orgExternalId === null) {

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -93,6 +93,10 @@ describe("OrganizationForm", () => {
         exact: false,
       })
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("textbox", { name: "Organization name required" })
+    ).toHaveFocus();
   });
 
   it("redirects to identity verification when submitting valid input", async () => {

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -108,7 +108,7 @@ const OrganizationForm = () => {
     setLoading(false);
     let firstError = document.querySelector(
       "[aria-invalid=true]"
-    ) as HTMLInputElement | null;
+    ) as HTMLElement | null;
     firstError?.focus();
   };
 

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -106,10 +106,8 @@ const OrganizationForm = () => {
     );
     showNotification(alert);
     setLoading(false);
-    let firstError = document.querySelector(
-      "[aria-invalid=true]"
-    ) as HTMLElement | null;
-    firstError?.focus();
+    let firstError = document.querySelector("[aria-invalid=true]");
+    (firstError as HTMLElement)?.focus();
   };
 
   if (orgExternalId) {

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -104,9 +104,12 @@ const OrganizationForm = () => {
         body="Please check the form to make sure you complete all of the required fields."
       />
     );
-    window.scrollTo(0, 0);
     showNotification(alert);
     setLoading(false);
+    let firstError = document.querySelector(
+      "[aria-invalid=true]"
+    ) as HTMLInputElement | null;
+    firstError?.focus();
   };
 
   if (orgExternalId) {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4015
- On the org signup and the identity verification page focus does not return to the first errored object

## Changes Proposed

- If any errors occur, find the first field with the `aria-invalid` attribute is true and then focus on it.

## Additional Information

- The library we use for our date picker component has an `aria-hidden` on one of the elements that they also copy the properties over to. In this case, we just filtered where `aria-hidden` !== true. 

## Testing

- Walk through the signup page and ensure the focus returns to the correct field
 
## Screenshots / Demos

https://user-images.githubusercontent.com/10108172/186732352-24fc4903-5d6a-4294-9a9f-bf8d76656bb6.mov



## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README