### PR TITLE
put sign up steps in a list

### DIFF
--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -234,18 +234,26 @@ const OrganizationForm = () => {
             <p className="font-ui-2xs line-height-sans-5 margin-bottom-1">
               <strong>Sign up for SimpleReport in three steps:</strong>
             </p>
-            <div className="margin-y-1">
-              <span className="circled-number margin-right-05">1</span>
-              Fill out your organization information
-            </div>
-            <div className="margin-y-1">
-              <span className="circled-number margin-right-05">2</span>
-              Enter your personal contact details
-            </div>
-            <div className="margin-y-1">
-              <span className="circled-number margin-right-05">3</span>
-              Verify your identity
-            </div>
+            <ol className="prime-ul">
+              <li>
+                <div className="margin-y-1">
+                  <span className="circled-number margin-right-05">1</span>
+                  Fill out your organization information
+                </div>
+              </li>
+              <li>
+                <div className="margin-y-1">
+                  <span className="circled-number margin-right-05">2</span>
+                  Enter your personal contact details
+                </div>
+              </li>
+              <li>
+                <div className="margin-y-1">
+                  <span className="circled-number margin-right-05">3</span>
+                  Verify your identity
+                </div>
+              </li>
+            </ol>
             <p className="font-ui-2xs margin-top-2 line-height-sans-5">
               Each organization only needs one account. After you sign up you
               can add staff and testing locations. Learn more about our{" "}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4025 
- During organization signup, the steps should be in a list element.

## Changes Proposed

- Put the three steps in a list

## Additional Information

## Testing

- Ensure the page looks the same
 
## Screenshots / Demos
Before:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/10108172/186956243-c7e065f9-310f-4b3f-a6e1-4879cca66c3f.png">

Now: 
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/10108172/186953322-68f1def2-97fa-4cea-8a89-a2f3bef92f05.png">

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README