### PR TITLE
Integration test gradle task

### DIFF
--- a/.run/test db down.run.xml
+++ b/.run/test db down.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="test db down" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="docker compose --env-file .env.test -p simple-report-tests down -v db " />
+    <option name="SCRIPT_TEXT" value="docker compose --env-file .env.test -p simple-report-tests down -v " />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,6 +22,13 @@ repositories {
     mavenCentral()
 }
 
+sourceSets {
+    integrationTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
 dependencies {
     // core infrastructure
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -150,6 +157,10 @@ springBoot {
 
 configurations {
     liquibaseRuntime.extendsFrom runtimeClasspath // inefficient but extremely effective
+
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+
     compileClasspath {
         resolutionStrategy.activateDependencyLocking()
     }
@@ -229,7 +240,17 @@ task testDbReset(type: Exec) {
     commandLine "db-setup/nuke-db.sh"
 }
 
-test {
+task integrationTest(type: Test) {
+    description= 'Run Integration Tests'
+    group = 'Verification'
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    shouldRunAfter test
+
+    if(parallelization.toBoolean()) {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
     // people sometimes export this to run local dev more easily: don't let it break the tests
     environment "SPRING_PROFILES_ACTIVE", ""
     // For some reason, setting this in application-default doesn't work, but it's needed
@@ -250,3 +271,30 @@ test {
     }
 }
 
+check.dependsOn integrationTest
+
+test {
+
+    if(parallelization.toBoolean()) {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
+
+    // people sometimes export this to run local dev more easily: don't let it break the tests
+    environment "SPRING_PROFILES_ACTIVE", ""
+    // For some reason, setting this in application-default doesn't work, but it's needed
+    // to prevent the Okta client from throwing an exception when we point it at WireMock,
+    // which doesn't use HTTPS
+    environment "OKTA_TESTING_DISABLEHTTPSCHECK", "true"
+    useJUnitPlatform()
+    // uncomment this to log to stdout when each test starts, so you can tell what's going on
+    // testLogging {
+    //   events "started", "failed"
+    // }
+    systemProperty "test-db-host", testDbHost
+    systemProperty "test-db-port", testDbPort
+    systemProperty "skip-db-setup", skipDbSetup
+    if (skipDbSetup == "false" && System.getenv("CI") == null) {
+        dependsOn testDbStart
+        finalizedBy testDbStop
+    }
+}

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,4 +1,5 @@
 testDbHost=localhost
 testDbPort=5444
 skipDbSetup=false
+parallelization=true
 liquibaseTaskPrefix=liquibase

--- a/backend/src/integrationTest/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/integrationTest/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -1,0 +1,16 @@
+package gov.cdc.usds.simplereport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
+public class SimpleReportApplicationTests {
+
+  @Test
+  void contextLoads() {
+    // no-op
+  }
+}

--- a/backend/src/integrationTest/resources/application-default.yaml
+++ b/backend/src/integrationTest/resources/application-default.yaml
@@ -1,0 +1,233 @@
+spring:
+  profiles.include: no-security,no-okta-mgmt, no-okta-auth, no-experian
+  datasource:
+    simplereport:
+      hikari:
+        jdbc-url: jdbc:postgresql://${test-db-host:localhost}:${test-db-port:5444}/simple_report
+        minimum-idle: 2
+        idle-timeout: 10000
+    metabase:
+      hikari:
+        jdbc-url: jdbc:postgresql://${test-db-host:localhost}:${test-db-port:5444}/metabase
+        idle-timeout: 10000
+        maximum-pool-size: 2
+  liquibase:
+    simplereport:
+      user: simple_report_migrations
+      password: migrations456
+    metabase:
+      user: simple_report_migrations
+      password: migrations456
+      default-schema: public
+  jpa:
+    properties:
+      hibernate:
+        default_schema: simple_report
+okta:
+  client:
+    org-url: http://localhost:8088
+    token: foo
+management:
+  endpoints:
+    web:
+      exposure:
+        exclude: liquibase # this causes the liquibase connection pool to keep 10 connections active forever
+        # Excluding it here will probably not work, so let's be clear (and grep-friendly): if you get
+        # "org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for non-replication superuser connections"
+        # there is a decent chance that this actuator has been activated and is making liquibase eat your database connections.
+logging:
+  level:
+    # Always have our own debug logging turned on in tests:
+    gov.cdc.usds: DEBUG
+    # Hibernate SQL query logging: basically the same as hibernate.show_sql but through slf4j
+    org.hibernate.SQL: DEBUG
+    # NOTE: un-comment any of the below to turn on something potentially interesting
+    # Hibernate input and output value logging: SUPER VERBOSE
+    # org.hibernate.type: TRACE
+    # Other possibilities:
+    # com.okta: DEBUG
+    # org.springframework.security: DEBUG
+    org.springframework.web.client.RestTemplate: DEBUG
+simple-report:
+  authorization:
+    environment-name: "UNITTEST"
+  sendgrid:
+    enabled: false
+    from-email: support@simplereport.gov
+    account-request-recipient:
+      - support@simplereport.gov
+    waitlist-recipient:
+      - support@simplereport.gov
+  azure-reporting-queue:
+    exception-webhook-enabled: true
+    exception-webhook-token: WATERMELON
+  demo-users:
+    site-admin-emails:
+      - ruby@example.com
+      - notruby@example.com
+    # These users are mapped to constants in TestUserIdentities. Do not modify casually!
+    alternate-users:
+      - identity: # STANDARD_USER
+          username: bobbity@example.com
+          first-name: Bobbity
+          middle-name: Bob
+          last-name: Bobberoo
+        authorization: # USER_ORG_ROLES
+          organization-external-id: DIS_ORG
+          granted-roles: NO_ACCESS, USER
+          facilities:
+            - Injection Site
+      - identity: # org admin
+          username: admin@example.com
+          first-name: Alice
+          last-name: Andrews
+        authorization: # ADMIN_ORG_ROLES
+          organization-external-id: DIS_ORG
+          granted-roles: NO_ACCESS, ADMIN
+      - identity: # entry-only
+          username: nobody@example.com
+          first-name: Nemo
+          last-name: Nixon
+        authorization: # ENTRY_ONLY_ORG_ROLES
+          organization-external-id: DIS_ORG
+          granted-roles: NO_ACCESS, ENTRY_ONLY
+          facilities:
+            - Testing Site
+      - identity: # standard user with all-facility access
+          username: allfacilities@example.com
+          first-name: Wendy
+          middle-name: Wanda
+          last-name: Williams
+        authorization: # USER_ALL_FACILITIES_ORG_ROLES
+          organization-external-id: DIS_ORG
+          granted-roles: NO_ACCESS, USER, ALL_FACILITIES
+      - identity: #SITE_ADMIN_USER
+          username: ruby@example.com
+          first-name: Ruby
+          middle-name: Raven
+          last-name: Reynolds
+      - identity: #SITE_ADMIN_USER_WITH_ORG
+          username: notruby@example.com
+          first-name: Ruby
+          middle-name: Raven
+          last-name: Reynolds
+        authorization: # USER_ALL_FACILITIES_ORG_ROLES
+          organization-external-id: DIS_ORG
+          granted-roles: NO_ACCESS, ADMIN
+      - identity: # OUTSIDE_ORG_USER
+          username: intruder@pirate.com
+          first-name: Bootstrap
+          middle-name: Bill
+          last-name: Turner
+        authorization:
+          organization-external-id: DAT_ORG
+          granted-roles: NO_ACCESS, USER
+      - identity: # OUTSIDE_ORG_ADMIN
+          username: captain@pirate.com
+          first-name: Jack
+          last-name: Sparrow
+        authorization:
+          organization-external-id: DAT_ORG
+          granted-roles: NO_ACCESS, ADMIN
+      - identity: # BROKEN
+          username: castaway@pirate.com
+          first-name: Candida
+          last-name: Cannotlogin
+simple-report-initialization:
+  organizations:
+    - org-name: Dis Organization
+      org-type: university
+      external-id: DIS_ORG
+      identity-verified: true
+    - org-name: Dat Organization
+      org-type: urgent_care
+      external-id: DAT_ORG
+      identity-verified: true
+  facilities:
+    - facility-name: Injection Site
+      clia-number: "000111222-3"
+      address:
+        street-1: 2797 N Cerrada de Beto
+      organization-external-id: DIS_ORG
+    - facility-name: Testing Site
+      clia-number: "999888777-6"
+      address:
+        street-1: 1001 Rodeo Dr
+        city: Los Angeles
+        state: CA
+        postal-code: 90000
+      email: testingsite@disorg.com
+      organization-external-id: DIS_ORG
+    - facility-name: Uptown Clinic
+      clia-number: "123456789-0"
+      address:
+        street-1: 1400 Lexington Ave
+        city: New York
+        state: NY
+        postal-code: 10128
+      organization-external-id: DAT_ORG
+    - facility-name: Downtown Clinic
+      clia-number: "987654321-0"
+      address:
+        street-1: 5 Bleecker St
+        city: New York
+        state: NY
+        postal-code: 10010
+      email: downtownclinic@dat.org
+      organization-external-id: DAT_ORG
+  provider:
+    first-name: Fred
+    last-name: Flintstone
+    provider-id: PEBBLES
+    telephone: (202) 555-1212
+    address:
+      street-1: 123 Main Street
+      city: Oz
+      state: KS
+      postal-code: "12345"
+  configured-device-types:
+    - LumiraDX
+    - Quidel Sofia 2
+  specimen-types:
+    - name: Swab of the Nose
+      type-code: "445297001"
+      collection-location-name: "NOSE"
+      collection-location-code: "71836000"
+    - name: Swab of the Ear
+      type-code: "445297999"
+      collection-location-name: "EAR"
+      collection-location-code: "71836099"
+  device-types:
+    - name: Abbott IDNow
+      manufacturer: Abbott
+      model: ID Now
+      loinc-code: "94534-5"
+      swab-type: "445297001"
+    - name: Abbott BinaxNow
+      manufacturer: Abbott
+      model: BinaxNOW COVID-19 Ag Card
+      loinc-code: "94558-4"
+      swab-type: "445297001"
+    - name: Quidel Sofia 2
+      manufacturer: Quidel
+      model: Sofia 2 SARS Antigen FIA
+      loinc-code: "95209-3"
+      swab-type: "445297001"
+    - name: BD Veritor
+      manufacturer: Becton, Dickinson and Company (BD)
+      model: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
+      loinc-code: "94558-4"
+      swab-type: "445297001"
+    - name: LumiraDX
+      manufacturer: LumiraDx UK Ltd.
+      model: LumiraDx SARS-CoV-2 Ag Test*
+      loinc-code: "95209-3"
+      swab-type: "445297001"
+  patient-registration-links:
+    - patient-registration-link: dis-org
+      organization-external-id: DIS_ORG
+    - patient-registration-link: inj3ct
+      facility-name: Injection Site
+datahub:
+url: http://localhost:9561
+api-key: "super-secret-api-key"


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

resolves #4024 

- We're moving the integration tests into a separate directory for the sake of clarity
- Also experimenting with running the tests in parallel in CI

## Changes Proposed

- Update the build.gradle with an additional task to run integration tests, with a no-op test to verify things work.
- Will hold off migrating all the integration tests over (there are a lot of them) until after the spring upgrade #2634 is finished because of the likelihood of merge conflicts 

## Additional Information

- Running the unit tests in parallel on my older macbook cut the run time in half (from almost 20m to about 10)
- Running on a new M1 macbook I've run into issues where database calls from the unit tests cause a deadlock, but just running the unit tests without parallelization takes about 12m.  Working through M1 issues will likely be a continuing journey

## Testing

- Pull it down locally, run unit tests, run integration tests.  There should not be any runtime changes but it wouldn't hurt to run the app as a smoke test.

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
