### PR TITLE
Remove aria-label from step indicator and fix list items

### DIFF
--- a/frontend/src/app/commonComponents/StepIndicator.tsx
+++ b/frontend/src/app/commonComponents/StepIndicator.tsx
@@ -24,13 +24,14 @@ const StepIndicator = ({
   };
 
   const SegmentsIndicator = () => (
-    <ol
+    <div
       className={classnames("usa-step-indicator__segments", {
         "margin-top-1": segmentIndicatorOnBottom,
       })}
+      role={"presentation"}
     >
       {steps.map((step) => (
-        <li
+        <div
           key={step.value}
           className={classnames("usa-step-indicator__segment", {
             "usa-step-indicator__segment--current":
@@ -43,9 +44,9 @@ const StepIndicator = ({
           <span className="usa-step-indicator__segment-label">
             {step.label} <span className="usa-sr-only">completed</span>
           </span>
-        </li>
+        </div>
       ))}
-    </ol>
+    </div>
   );
 
   const StepNameAndCount = () => (
@@ -76,7 +77,6 @@ const StepIndicator = ({
           "margin-y-205": !segmentIndicatorOnBottom,
         }
       )}
-      aria-label="progress"
     >
       {segmentIndicatorOnBottom ? (
         <>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #4026 
Fixes #4013 

## Changes Proposed

- Remove the aria-label=progress: it's not well supported on a `div` without a role, and this particular div has no role at all (it's just a container for the other elements.)
- Change the `<li>` elements of the progress bar to `div` elements, as they weren't a true list.

## Additional Information
I re-ran Deque on the step indicator and confirmed that the issues noted are no longer on the scan.

## Screenshots / Demos

Before:
![Screen Shot 2022-08-29 at 4 09 26 PM](https://user-images.githubusercontent.com/80282552/187314979-7e28db33-a23d-46a2-bec0-64842d77e547.png)

After:
![Screen Shot 2022-08-29 at 4 08 35 PM](https://user-images.githubusercontent.com/80282552/187314977-07ae0209-24fb-4bc0-a93a-ffe75da572b5.png)

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README