### PR TITLE
Improve app insights exception tracking

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -109,7 +109,10 @@ const App = () => {
 
   if (error) {
     if (appInsights instanceof ApplicationInsights) {
-      appInsights.trackException({ error });
+      appInsights.trackException({
+        exception: error,
+        properties: { "user message": "Server connection error" },
+      });
     }
     return <p>Server connection error...</p>;
   }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -94,7 +94,12 @@ const logoutLink = onError(({ networkError, graphQLErrors }: ErrorResponse) => {
     } else {
       const appInsights = getAppInsights();
       if (appInsights instanceof ApplicationInsights) {
-        appInsights.trackException({ error: networkError });
+        appInsights.trackException({
+          exception: networkError,
+          properties: {
+            "user message": `${networkError.message} Please check for errors and try again`,
+          },
+        });
       }
       showError("Please check for errors and try again", networkError.message);
     }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

There have been multiple support requests related to intermittently getting the "Server connection error" message, and it's impossible for me to find anything helpful in the logs. I believe the `error` field for reporting exceptions may be deprecated and I'm seeing a lot of exceptions in Azure Portal that just say "not_specified", which I think is because the `exception` field is not specified.

## Changes Proposed

- set the exception field of the exception we send to app insights
- add a user message custom property so we can hopefully search by what the user is reporting seeing

## Additional Information



## Testing

- How should reviewers verify this PR?

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README