### PR TITLE
Force json-smart to invulnerable version.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-web:5.5.7'
     implementation 'com.nimbusds:oauth2-oidc-sdk:8.36.2'
     implementation 'org.yaml:snakeyaml:1.31'
+    implementation 'net.minidev:json-smart:2.3.1'
 
     // data layer dependencies
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -111,8 +111,8 @@ javax.transaction:javax.transaction-api:1.3
 javax.websocket:javax.websocket-api:1.1
 javax.xml.bind:jaxb-api:2.3.1
 net.bytebuddy:byte-buddy:1.10.19
-net.minidev:accessors-smart:1.2
-net.minidev:json-smart:2.3
+net.minidev:accessors-smart:2.3.1
+net.minidev:json-smart:2.3.1
 org.apache.commons:commons-lang3:3.11
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.14

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -120,8 +120,8 @@ javax.transaction:javax.transaction-api:1.3
 javax.websocket:javax.websocket-api:1.1
 javax.xml.bind:jaxb-api:2.3.1
 net.bytebuddy:byte-buddy:1.10.19
-net.minidev:accessors-smart:1.2
-net.minidev:json-smart:2.3
+net.minidev:accessors-smart:2.3.1
+net.minidev:json-smart:2.3.1
 org.antlr:antlr4-runtime:4.8
 org.apache.commons:commons-lang3:3.11
 org.apache.httpcomponents:httpclient:4.5.13


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- This fix addresses a potential Denial of Service (DoS) ability introduced by an outdated version of the `com.nimbusds:oauth2-oidc-sdk` package.

## Changes Proposed

- Pins the `json-smart` bundled dependency to an invulnerable version.

## Additional Information

- Additional information about this vulnerability can be found at the following link: https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-1078499

## Testing

- A simple smoke test of the application should be all that is required. I have verified that the Okta flow is unbroken by this change, which covers the parent package that triggered the vulnerability.
 
## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification