### PR TITLE
Add legend to radio group fieldset for Sign Up

### DIFF
--- a/frontend/src/app/signUp/Organization/SignUpGoals.tsx
+++ b/frontend/src/app/signUp/Organization/SignUpGoals.tsx
@@ -51,6 +51,8 @@ const SignUpGoals = () => {
           <RadioGroup
             wrapperClassName="margin-top-1"
             name="signUpGoal"
+            legend="Select Sign Up Goal"
+            legendSrOnly
             buttons={[
               {
                 value: "existingOrg",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #4016 

## Changes Proposed

- Passes a `legend` field with descriptive text to the `RadioGroup` component, so that the existing `fieldset` created in `RadioGroup` for the Sign Up radio button group has an accessibility-appropriate label.

## Additional Information

- Adding the recommended legend to fieldset should resolve the accessibility violations, and is the solution recommended by Deque
- It appears that we use the `legendSrOnly` field with some other radio groups (see `UserRoleSettingsForm.tsx`) when we want to show more flavor text with custom styles before the radio group (such as with a `<p>` element). In this case, the legend element is sent backwards so it doesn't appear visually, but is still available as a label to screen readers.
- I've used `legendSrOnly` here since we want to render the flavor text before the radio group with custom style instead of the default legend style used in other places. Doing it this way means no changes in visual appearance to the page.
- Future work: I'm not totally sure this construct with `legendSrOnly` is the best solution in general, it might be better to have an alternate construct that uses `<p>` and `aria-labelledby`, which is the second recommended solution for this violation. However, because `RadioGroup` is a generic component we use throughout the app, it's not a trivial refactor.

## Testing

- Ideally someone with Deque/Axe DevTools Pro can run against this page and ensure the violations are resolved
- Visit [dev2.simplerport.gov/app/sign-up](https://dev2.simplereport.gov/app/sign-up) and ensure the radio group is properly labeled with the `Select Sign Up Goal` legend
 
## Screenshots / Demos

### Before

![Screen Shot 2022-09-08 at 9 06 11 AM](https://user-images.githubusercontent.com/89797785/189144767-74ea7493-c440-4437-abc1-5c020f5be269.png)

### After

Sign Up radio group
![Screen Shot 2022-09-08 at 9 28 13 AM](https://user-images.githubusercontent.com/89797785/189144871-e4fa0bf7-dc87-48f1-83cd-e85b8af113bc.png)

Compare to the User Role radio group
![Screen Shot 2022-09-08 at 9 10 42 AM](https://user-images.githubusercontent.com/89797785/189144965-3ec134bc-7ffc-4f8f-abc5-ed8fda38b183.png)



## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content 
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README