### PR TITLE
Add NY to live jurisdictions

### DIFF
--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -30,6 +30,7 @@ export const liveJurisdictions = [
   "NJ",
   "NM",
   "NV",
+  "NY",
   "OH",
   "OR",
   "PA",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- New York is live!
https://skylight-hq.slack.com/archives/C01KGBU542K/p1662736289257789

## Changes Proposed

- Add NY to list of live jurisdictions, enabling facilities to sign up there

