### PR TITLE
implement device combobox for superadmin view

### DIFF
--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -151,20 +151,19 @@ describe("update existing devices", () => {
 
   it("shows a list of devices to select from", () => {
     userEvent.click(screen.getByLabelText("Select device", { exact: false }));
-    expect(screen.getByText("Tesla Emitter")).toBeInTheDocument();
-    expect(screen.getByText("Fission Energizer")).toBeInTheDocument();
-    expect(screen.getByText("Covalent Observer")).toBeInTheDocument();
+
+    expect(screen.getAllByRole("option").length).toBe(3);
+
+    expect(screen.getAllByText("Tesla Emitter")[1]).toBeInTheDocument();
+    expect(screen.getAllByText("Fission Energizer")[1]).toBeInTheDocument();
+    expect(screen.getAllByText("Covalent Observer")[1]).toBeInTheDocument();
   });
 
   describe("When selecting a device", () => {
-    beforeEach(() => {
-      userEvent.selectOptions(
-        screen.getByLabelText("Select device", { exact: false }),
-        "Tesla Emitter"
-      );
-    });
-
     it("enables input fields and prefills them with current values", () => {
+      userEvent.click(screen.getByTestId("combo-box-select"));
+      userEvent.click(screen.getAllByText("Tesla Emitter")[1]);
+
       const manufacturerInput = screen.getByLabelText("Manufacturer", {
         exact: false,
       });
@@ -195,14 +194,10 @@ describe("update existing devices", () => {
     });
 
     describe("selecting another device", () => {
-      beforeEach(() => {
-        userEvent.selectOptions(
-          screen.getByLabelText("Select device", { exact: false }),
-          "Fission Energizer"
-        );
-      });
-
       it("prefills input fields with new values", () => {
+        userEvent.click(screen.getByTestId("combo-box-select"));
+        userEvent.click(screen.getAllByText("Fission Energizer")[1]);
+
         const manufacturerInput = screen.getByLabelText("Manufacturer", {
           exact: false,
         });
@@ -223,6 +218,9 @@ describe("update existing devices", () => {
 
     describe("updating a device", () => {
       it("calls update device with the current values", () => {
+        userEvent.click(screen.getByTestId("combo-box-select"));
+        userEvent.click(screen.getAllByText("Tesla Emitter")[1]);
+
         const snomedInput = screen.getAllByTestId("multi-select-toggle")[0];
         const snomedList = screen.getAllByTestId("multi-select-option-list")[0];
 

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -150,10 +150,7 @@ describe("update existing devices", () => {
   });
 
   it("shows a list of devices to select from", () => {
-    userEvent.click(screen.getByLabelText("Select device", { exact: false }));
-
-    expect(screen.getAllByRole("option").length).toBe(3);
-
+    userEvent.click(screen.getByTestId("combo-box-select"));
     expect(screen.getAllByText("Tesla Emitter")[1]).toBeInTheDocument();
     expect(screen.getAllByText("Fission Energizer")[1]).toBeInTheDocument();
     expect(screen.getAllByText("Covalent Observer")[1]).toBeInTheDocument();

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
+import { ComboBox } from "@trussworks/react-uswds";
 
 import Button from "../../commonComponents/Button/Button";
 import TextInput from "../../commonComponents/TextInput";
 import MultiSelect from "../../commonComponents/MultiSelect/MultiSelect";
 import { MultiSelectDropdownOption } from "../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
-import Select from "../../commonComponents/Select";
 import { DeviceType } from "../../../generated/graphql";
 
 import DeviceTypeReminderMessage from "./DeviceTypeReminderMessage";
@@ -50,10 +50,12 @@ const DeviceForm = (props: Props) => {
 
   const getDeviceOptions = () =>
     props.deviceOptions
-      ? props.deviceOptions.map((deviceType) => ({
-          label: deviceType.name,
-          value: deviceType.internalId,
-        }))
+      ? props.deviceOptions
+          .map((deviceType) => ({
+            label: deviceType.name,
+            value: deviceType.internalId,
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label))
       : [];
 
   const getDeviceFromDeviceType = (device?: DeviceType): Device | undefined => {
@@ -102,12 +104,15 @@ const DeviceForm = (props: Props) => {
               {props.deviceOptions ? (
                 <div className="grid-row grid-gap">
                   <div className="tablet:grid-col">
-                    <Select
-                      label="Select device"
+                    <label className="usa-legend" htmlFor="selectDevice">
+                      Select Device{" "}
+                      {true && <span className="text-secondary-vivid">*</span>}
+                    </label>
+                    <ComboBox
+                      className="usa-combo-box__full-width"
+                      id="selectDevice"
                       name="selectDevice"
-                      value={device?.internalId || ""}
                       options={getDeviceOptions()}
-                      defaultSelect
                       onChange={(id) => {
                         updateFormChanged(false);
                         updateDevice(
@@ -118,7 +123,7 @@ const DeviceForm = (props: Props) => {
                           )
                         );
                       }}
-                      required
+                      defaultValue={device?.internalId || ""}
                     />
                   </div>
                 </div>

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -6,6 +6,7 @@ import TextInput from "../../commonComponents/TextInput";
 import MultiSelect from "../../commonComponents/MultiSelect/MultiSelect";
 import { MultiSelectDropdownOption } from "../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
 import { DeviceType } from "../../../generated/graphql";
+import Required from "../../commonComponents/Required";
 
 import DeviceTypeReminderMessage from "./DeviceTypeReminderMessage";
 
@@ -104,10 +105,7 @@ const DeviceForm = (props: Props) => {
               {props.deviceOptions ? (
                 <div className="grid-row grid-gap">
                   <div className="tablet:grid-col">
-                    <label className="usa-legend" htmlFor="selectDevice">
-                      Select Device{" "}
-                      <span className="text-secondary-vivid">*</span>
-                    </label>
+                    <Required label={"Select device"} />
                     <ComboBox
                       className="usa-combo-box__full-width"
                       id="selectDevice"

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -106,7 +106,7 @@ const DeviceForm = (props: Props) => {
                   <div className="tablet:grid-col">
                     <label className="usa-legend" htmlFor="selectDevice">
                       Select Device{" "}
-                      {true && <span className="text-secondary-vivid">*</span>}
+                      <span className="text-secondary-vivid">*</span>
                     </label>
                     <ComboBox
                       className="usa-combo-box__full-width"

--- a/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.test.tsx
@@ -153,10 +153,8 @@ describe("ManageDeviceTypeFormContainer", () => {
   it("should update the selected device", async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    userEvent.selectOptions(
-      screen.getByLabelText("Select device", { exact: false }),
-      "Covalent Observer"
-    );
+    userEvent.click(screen.getByTestId("combo-box-select"));
+    userEvent.click(screen.getAllByText("Covalent Observer")[1]);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -189,10 +187,8 @@ describe("ManageDeviceTypeFormContainer", () => {
   it("should display error when update fails", async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    userEvent.selectOptions(
-      screen.getByLabelText("Select device", { exact: false }),
-      "Covalent Observer"
-    );
+    userEvent.click(screen.getByTestId("combo-box-select"));
+    userEvent.click(screen.getAllByText("Covalent Observer")[1]);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -88,18 +88,14 @@ Object {
                   <div
                     class="tablet:grid-col"
                   >
-                    <label
-                      class="usa-legend"
-                      for="selectDevice"
+                    Select device
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
                     >
-                      Select Device
                        
-                      <span
-                        class="text-secondary-vivid"
-                      >
-                        *
-                      </span>
-                    </label>
+                      *
+                    </abbr>
                     <div
                       class="usa-combo-box usa-combo-box__full-width"
                       data-enhanced="true"
@@ -720,18 +716,14 @@ Object {
                 <div
                   class="tablet:grid-col"
                 >
-                  <label
-                    class="usa-legend"
-                    for="selectDevice"
+                  Select device
+                  <abbr
+                    class="usa-hint usa-hint--required"
+                    title="required"
                   >
-                    Select Device
                      
-                    <span
-                      class="text-secondary-vivid"
-                    >
-                      *
-                    </span>
-                  </label>
+                    *
+                  </abbr>
                   <div
                     class="usa-combo-box usa-combo-box__full-width"
                     data-enhanced="true"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -88,14 +88,175 @@ Object {
                   <div
                     class="tablet:grid-col"
                   >
+                    <label
+                      class="usa-legend"
+                      for="selectDevice"
+                    >
+                      Select Device
+                       
+                      <span
+                        class="text-secondary-vivid"
+                      >
+                        *
+                      </span>
+                    </label>
                     <div
-                      class="usa-form-group prime-dropdown "
+                      class="usa-combo-box usa-combo-box__full-width"
+                      data-enhanced="true"
+                      data-testid="combo-box"
+                    >
+                      <select
+                        aria-hidden="true"
+                        class="usa-select usa-sr-only usa-combo-box__select"
+                        data-testid="combo-box-select"
+                        name="selectDevice"
+                        tabindex="-1"
+                      >
+                        <option
+                          value="abc3"
+                        >
+                          Covalent Observer
+                        </option>
+                        <option
+                          value="abc2"
+                        >
+                          Fission Energizer
+                        </option>
+                        <option
+                          value="abc1"
+                        >
+                          Tesla Emitter
+                        </option>
+                      </select>
+                      <input
+                        aria-activedescendant=""
+                        aria-autocomplete="list"
+                        aria-describedby="selectDevice--assistiveHint"
+                        aria-expanded="false"
+                        aria-owns="selectDevice--list"
+                        autocapitalize="off"
+                        autocomplete="off"
+                        class="usa-combo-box__input"
+                        data-testid="combo-box-input"
+                        id="selectDevice"
+                        role="combobox"
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        class="usa-combo-box__clear-input__wrapper"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-label="Clear the select contents"
+                          class="usa-combo-box__clear-input"
+                          data-testid="combo-box-clear-button"
+                          hidden=""
+                          type="button"
+                        >
+                           
+                        </button>
+                      </span>
+                      <span
+                        class="usa-combo-box__input-button-separator"
+                      >
+                         
+                      </span>
+                      <span
+                        class="usa-combo-box__toggle-list__wrapper"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-label="Toggle the dropdown list"
+                          class="usa-combo-box__toggle-list"
+                          data-testid="combo-box-toggle"
+                          tabindex="-1"
+                          type="button"
+                        >
+                           
+                        </button>
+                      </span>
+                      <ul
+                        class="usa-combo-box__list"
+                        data-testid="combo-box-option-list"
+                        hidden=""
+                        id="selectDevice--list"
+                        role="listbox"
+                        tabindex="-1"
+                      >
+                        <li
+                          aria-posinset="1"
+                          aria-selected="false"
+                          aria-setsize="3"
+                          class="usa-combo-box__list-option"
+                          data-testid="combo-box-option-abc3"
+                          data-value="abc3"
+                          id="selectDevice--list--option-0"
+                          role="option"
+                          tabindex="-1"
+                          value="abc3"
+                        >
+                          Covalent Observer
+                        </li>
+                        <li
+                          aria-posinset="2"
+                          aria-selected="false"
+                          aria-setsize="3"
+                          class="usa-combo-box__list-option"
+                          data-testid="combo-box-option-abc2"
+                          data-value="abc2"
+                          id="selectDevice--list--option-1"
+                          role="option"
+                          tabindex="-1"
+                          value="abc2"
+                        >
+                          Fission Energizer
+                        </li>
+                        <li
+                          aria-posinset="3"
+                          aria-selected="false"
+                          aria-setsize="3"
+                          class="usa-combo-box__list-option"
+                          data-testid="combo-box-option-abc1"
+                          data-value="abc1"
+                          id="selectDevice--list--option-2"
+                          role="option"
+                          tabindex="-1"
+                          value="abc1"
+                        >
+                          Tesla Emitter
+                        </li>
+                      </ul>
+                      <div
+                        class="usa-combo-box__status usa-sr-only"
+                        role="status"
+                      />
+                      <span
+                        class="usa-sr-only"
+                        data-testid="combo-box-assistive-hint"
+                        id="selectDevice--assistiveHint"
+                      >
+                        When autocomplete results are available use up and down arrows to review
+           and enter to select. Touch device users, explore by touch or with swipe
+           gestures.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="grid-row grid-gap"
+                >
+                  <div
+                    class="tablet:grid-col"
+                  >
+                    <div
+                      class="usa-form-group"
                     >
                       <label
                         class="usa-label"
                         for="22"
                       >
-                        Select device
+                        Device name
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -104,33 +265,16 @@ Object {
                           *
                         </abbr>
                       </label>
-                      <select
+                      <input
+                        aria-disabled="true"
                         aria-required="true"
-                        class="usa-select"
+                        class="usa-input"
+                        disabled=""
                         id="22"
-                        name="selectDevice"
-                      >
-                        <option
-                          value=""
-                        >
-                          - Select -
-                        </option>
-                        <option
-                          value="abc1"
-                        >
-                          Tesla Emitter
-                        </option>
-                        <option
-                          value="abc2"
-                        >
-                          Fission Energizer
-                        </option>
-                        <option
-                          value="abc3"
-                        >
-                          Covalent Observer
-                        </option>
-                      </select>
+                        name="name"
+                        type="text"
+                        value=""
+                      />
                     </div>
                   </div>
                 </div>
@@ -147,7 +291,7 @@ Object {
                         class="usa-label"
                         for="23"
                       >
-                        Device name
+                        Model
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -162,7 +306,7 @@ Object {
                         class="usa-input"
                         disabled=""
                         id="23"
-                        name="name"
+                        name="model"
                         type="text"
                         value=""
                       />
@@ -182,7 +326,7 @@ Object {
                         class="usa-label"
                         for="24"
                       >
-                        Model
+                        Manufacturer
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -197,7 +341,7 @@ Object {
                         class="usa-input"
                         disabled=""
                         id="24"
-                        name="model"
+                        name="manufacturer"
                         type="text"
                         value=""
                       />
@@ -217,41 +361,6 @@ Object {
                         class="usa-label"
                         for="25"
                       >
-                        Manufacturer
-                        <abbr
-                          class="usa-hint usa-hint--required"
-                          title="required"
-                        >
-                           
-                          *
-                        </abbr>
-                      </label>
-                      <input
-                        aria-disabled="true"
-                        aria-required="true"
-                        class="usa-input"
-                        disabled=""
-                        id="25"
-                        name="manufacturer"
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="grid-row grid-gap"
-                >
-                  <div
-                    class="tablet:grid-col"
-                  >
-                    <div
-                      class="usa-form-group"
-                    >
-                      <label
-                        class="usa-label"
-                        for="26"
-                      >
                         LOINC code
                         <abbr
                           class="usa-hint usa-hint--required"
@@ -266,7 +375,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="26"
+                        id="25"
                         name="loincCode"
                         type="text"
                         value=""
@@ -281,7 +390,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="27"
+                        for="26"
                       >
                         Test length (minutes)
                         <abbr
@@ -297,7 +406,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="27"
+                        id="26"
                         max="999"
                         min="0"
                         name="testLength"
@@ -318,7 +427,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="28"
+                        for="27"
                       >
                         SNOMED code for swab type(s)
                         <abbr
@@ -332,7 +441,7 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="28"
+                        id="27"
                       >
                         <input
                           aria-expanded="false"
@@ -438,7 +547,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="29"
+                        for="28"
                       >
                         Supported diseases
                         <abbr
@@ -452,7 +561,7 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="29"
+                        id="28"
                       >
                         <input
                           aria-expanded="false"
@@ -611,14 +720,175 @@ Object {
                 <div
                   class="tablet:grid-col"
                 >
+                  <label
+                    class="usa-legend"
+                    for="selectDevice"
+                  >
+                    Select Device
+                     
+                    <span
+                      class="text-secondary-vivid"
+                    >
+                      *
+                    </span>
+                  </label>
                   <div
-                    class="usa-form-group prime-dropdown "
+                    class="usa-combo-box usa-combo-box__full-width"
+                    data-enhanced="true"
+                    data-testid="combo-box"
+                  >
+                    <select
+                      aria-hidden="true"
+                      class="usa-select usa-sr-only usa-combo-box__select"
+                      data-testid="combo-box-select"
+                      name="selectDevice"
+                      tabindex="-1"
+                    >
+                      <option
+                        value="abc3"
+                      >
+                        Covalent Observer
+                      </option>
+                      <option
+                        value="abc2"
+                      >
+                        Fission Energizer
+                      </option>
+                      <option
+                        value="abc1"
+                      >
+                        Tesla Emitter
+                      </option>
+                    </select>
+                    <input
+                      aria-activedescendant=""
+                      aria-autocomplete="list"
+                      aria-describedby="selectDevice--assistiveHint"
+                      aria-expanded="false"
+                      aria-owns="selectDevice--list"
+                      autocapitalize="off"
+                      autocomplete="off"
+                      class="usa-combo-box__input"
+                      data-testid="combo-box-input"
+                      id="selectDevice"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
+                    <span
+                      class="usa-combo-box__clear-input__wrapper"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-label="Clear the select contents"
+                        class="usa-combo-box__clear-input"
+                        data-testid="combo-box-clear-button"
+                        hidden=""
+                        type="button"
+                      >
+                         
+                      </button>
+                    </span>
+                    <span
+                      class="usa-combo-box__input-button-separator"
+                    >
+                       
+                    </span>
+                    <span
+                      class="usa-combo-box__toggle-list__wrapper"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-label="Toggle the dropdown list"
+                        class="usa-combo-box__toggle-list"
+                        data-testid="combo-box-toggle"
+                        tabindex="-1"
+                        type="button"
+                      >
+                         
+                      </button>
+                    </span>
+                    <ul
+                      class="usa-combo-box__list"
+                      data-testid="combo-box-option-list"
+                      hidden=""
+                      id="selectDevice--list"
+                      role="listbox"
+                      tabindex="-1"
+                    >
+                      <li
+                        aria-posinset="1"
+                        aria-selected="false"
+                        aria-setsize="3"
+                        class="usa-combo-box__list-option"
+                        data-testid="combo-box-option-abc3"
+                        data-value="abc3"
+                        id="selectDevice--list--option-0"
+                        role="option"
+                        tabindex="-1"
+                        value="abc3"
+                      >
+                        Covalent Observer
+                      </li>
+                      <li
+                        aria-posinset="2"
+                        aria-selected="false"
+                        aria-setsize="3"
+                        class="usa-combo-box__list-option"
+                        data-testid="combo-box-option-abc2"
+                        data-value="abc2"
+                        id="selectDevice--list--option-1"
+                        role="option"
+                        tabindex="-1"
+                        value="abc2"
+                      >
+                        Fission Energizer
+                      </li>
+                      <li
+                        aria-posinset="3"
+                        aria-selected="false"
+                        aria-setsize="3"
+                        class="usa-combo-box__list-option"
+                        data-testid="combo-box-option-abc1"
+                        data-value="abc1"
+                        id="selectDevice--list--option-2"
+                        role="option"
+                        tabindex="-1"
+                        value="abc1"
+                      >
+                        Tesla Emitter
+                      </li>
+                    </ul>
+                    <div
+                      class="usa-combo-box__status usa-sr-only"
+                      role="status"
+                    />
+                    <span
+                      class="usa-sr-only"
+                      data-testid="combo-box-assistive-hint"
+                      id="selectDevice--assistiveHint"
+                    >
+                      When autocomplete results are available use up and down arrows to review
+           and enter to select. Touch device users, explore by touch or with swipe
+           gestures.
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="grid-row grid-gap"
+              >
+                <div
+                  class="tablet:grid-col"
+                >
+                  <div
+                    class="usa-form-group"
                   >
                     <label
                       class="usa-label"
                       for="22"
                     >
-                      Select device
+                      Device name
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -627,33 +897,16 @@ Object {
                         *
                       </abbr>
                     </label>
-                    <select
+                    <input
+                      aria-disabled="true"
                       aria-required="true"
-                      class="usa-select"
+                      class="usa-input"
+                      disabled=""
                       id="22"
-                      name="selectDevice"
-                    >
-                      <option
-                        value=""
-                      >
-                        - Select -
-                      </option>
-                      <option
-                        value="abc1"
-                      >
-                        Tesla Emitter
-                      </option>
-                      <option
-                        value="abc2"
-                      >
-                        Fission Energizer
-                      </option>
-                      <option
-                        value="abc3"
-                      >
-                        Covalent Observer
-                      </option>
-                    </select>
+                      name="name"
+                      type="text"
+                      value=""
+                    />
                   </div>
                 </div>
               </div>
@@ -670,7 +923,7 @@ Object {
                       class="usa-label"
                       for="23"
                     >
-                      Device name
+                      Model
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -685,7 +938,7 @@ Object {
                       class="usa-input"
                       disabled=""
                       id="23"
-                      name="name"
+                      name="model"
                       type="text"
                       value=""
                     />
@@ -705,7 +958,7 @@ Object {
                       class="usa-label"
                       for="24"
                     >
-                      Model
+                      Manufacturer
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -720,7 +973,7 @@ Object {
                       class="usa-input"
                       disabled=""
                       id="24"
-                      name="model"
+                      name="manufacturer"
                       type="text"
                       value=""
                     />
@@ -740,41 +993,6 @@ Object {
                       class="usa-label"
                       for="25"
                     >
-                      Manufacturer
-                      <abbr
-                        class="usa-hint usa-hint--required"
-                        title="required"
-                      >
-                         
-                        *
-                      </abbr>
-                    </label>
-                    <input
-                      aria-disabled="true"
-                      aria-required="true"
-                      class="usa-input"
-                      disabled=""
-                      id="25"
-                      name="manufacturer"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-              </div>
-              <div
-                class="grid-row grid-gap"
-              >
-                <div
-                  class="tablet:grid-col"
-                >
-                  <div
-                    class="usa-form-group"
-                  >
-                    <label
-                      class="usa-label"
-                      for="26"
-                    >
                       LOINC code
                       <abbr
                         class="usa-hint usa-hint--required"
@@ -789,7 +1007,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="26"
+                      id="25"
                       name="loincCode"
                       type="text"
                       value=""
@@ -804,7 +1022,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="27"
+                      for="26"
                     >
                       Test length (minutes)
                       <abbr
@@ -820,7 +1038,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="27"
+                      id="26"
                       max="999"
                       min="0"
                       name="testLength"
@@ -841,7 +1059,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="28"
+                      for="27"
                     >
                       SNOMED code for swab type(s)
                       <abbr
@@ -855,7 +1073,7 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="28"
+                      id="27"
                     >
                       <input
                         aria-expanded="false"
@@ -961,7 +1179,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="29"
+                      for="28"
                     >
                       Supported diseases
                       <abbr
@@ -975,7 +1193,7 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="29"
+                      id="28"
                     >
                       <input
                         aria-expanded="false"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -88,14 +88,175 @@ Object {
                   <div
                     class="tablet:grid-col"
                   >
+                    <label
+                      class="usa-legend"
+                      for="selectDevice"
+                    >
+                      Select Device
+                       
+                      <span
+                        class="text-secondary-vivid"
+                      >
+                        *
+                      </span>
+                    </label>
                     <div
-                      class="usa-form-group prime-dropdown "
+                      class="usa-combo-box usa-combo-box__full-width"
+                      data-enhanced="true"
+                      data-testid="combo-box"
+                    >
+                      <select
+                        aria-hidden="true"
+                        class="usa-select usa-sr-only usa-combo-box__select"
+                        data-testid="combo-box-select"
+                        name="selectDevice"
+                        tabindex="-1"
+                      >
+                        <option
+                          value="abc3"
+                        >
+                          Covalent Observer
+                        </option>
+                        <option
+                          value="abc2"
+                        >
+                          Fission Energizer
+                        </option>
+                        <option
+                          value="abc1"
+                        >
+                          Tesla Emitter
+                        </option>
+                      </select>
+                      <input
+                        aria-activedescendant=""
+                        aria-autocomplete="list"
+                        aria-describedby="selectDevice--assistiveHint"
+                        aria-expanded="false"
+                        aria-owns="selectDevice--list"
+                        autocapitalize="off"
+                        autocomplete="off"
+                        class="usa-combo-box__input"
+                        data-testid="combo-box-input"
+                        id="selectDevice"
+                        role="combobox"
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        class="usa-combo-box__clear-input__wrapper"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-label="Clear the select contents"
+                          class="usa-combo-box__clear-input"
+                          data-testid="combo-box-clear-button"
+                          hidden=""
+                          type="button"
+                        >
+                           
+                        </button>
+                      </span>
+                      <span
+                        class="usa-combo-box__input-button-separator"
+                      >
+                         
+                      </span>
+                      <span
+                        class="usa-combo-box__toggle-list__wrapper"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-label="Toggle the dropdown list"
+                          class="usa-combo-box__toggle-list"
+                          data-testid="combo-box-toggle"
+                          tabindex="-1"
+                          type="button"
+                        >
+                           
+                        </button>
+                      </span>
+                      <ul
+                        class="usa-combo-box__list"
+                        data-testid="combo-box-option-list"
+                        hidden=""
+                        id="selectDevice--list"
+                        role="listbox"
+                        tabindex="-1"
+                      >
+                        <li
+                          aria-posinset="1"
+                          aria-selected="false"
+                          aria-setsize="3"
+                          class="usa-combo-box__list-option"
+                          data-testid="combo-box-option-abc3"
+                          data-value="abc3"
+                          id="selectDevice--list--option-0"
+                          role="option"
+                          tabindex="-1"
+                          value="abc3"
+                        >
+                          Covalent Observer
+                        </li>
+                        <li
+                          aria-posinset="2"
+                          aria-selected="false"
+                          aria-setsize="3"
+                          class="usa-combo-box__list-option"
+                          data-testid="combo-box-option-abc2"
+                          data-value="abc2"
+                          id="selectDevice--list--option-1"
+                          role="option"
+                          tabindex="-1"
+                          value="abc2"
+                        >
+                          Fission Energizer
+                        </li>
+                        <li
+                          aria-posinset="3"
+                          aria-selected="false"
+                          aria-setsize="3"
+                          class="usa-combo-box__list-option"
+                          data-testid="combo-box-option-abc1"
+                          data-value="abc1"
+                          id="selectDevice--list--option-2"
+                          role="option"
+                          tabindex="-1"
+                          value="abc1"
+                        >
+                          Tesla Emitter
+                        </li>
+                      </ul>
+                      <div
+                        class="usa-combo-box__status usa-sr-only"
+                        role="status"
+                      />
+                      <span
+                        class="usa-sr-only"
+                        data-testid="combo-box-assistive-hint"
+                        id="selectDevice--assistiveHint"
+                      >
+                        When autocomplete results are available use up and down arrows to review
+           and enter to select. Touch device users, explore by touch or with swipe
+           gestures.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="grid-row grid-gap"
+                >
+                  <div
+                    class="tablet:grid-col"
+                  >
+                    <div
+                      class="usa-form-group"
                     >
                       <label
                         class="usa-label"
                         for="1"
                       >
-                        Select device
+                        Device name
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -104,33 +265,16 @@ Object {
                           *
                         </abbr>
                       </label>
-                      <select
+                      <input
+                        aria-disabled="true"
                         aria-required="true"
-                        class="usa-select"
+                        class="usa-input"
+                        disabled=""
                         id="1"
-                        name="selectDevice"
-                      >
-                        <option
-                          value=""
-                        >
-                          - Select -
-                        </option>
-                        <option
-                          value="abc1"
-                        >
-                          Tesla Emitter
-                        </option>
-                        <option
-                          value="abc2"
-                        >
-                          Fission Energizer
-                        </option>
-                        <option
-                          value="abc3"
-                        >
-                          Covalent Observer
-                        </option>
-                      </select>
+                        name="name"
+                        type="text"
+                        value=""
+                      />
                     </div>
                   </div>
                 </div>
@@ -147,7 +291,7 @@ Object {
                         class="usa-label"
                         for="2"
                       >
-                        Device name
+                        Model
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -162,7 +306,7 @@ Object {
                         class="usa-input"
                         disabled=""
                         id="2"
-                        name="name"
+                        name="model"
                         type="text"
                         value=""
                       />
@@ -182,7 +326,7 @@ Object {
                         class="usa-label"
                         for="3"
                       >
-                        Model
+                        Manufacturer
                         <abbr
                           class="usa-hint usa-hint--required"
                           title="required"
@@ -197,7 +341,7 @@ Object {
                         class="usa-input"
                         disabled=""
                         id="3"
-                        name="model"
+                        name="manufacturer"
                         type="text"
                         value=""
                       />
@@ -217,41 +361,6 @@ Object {
                         class="usa-label"
                         for="4"
                       >
-                        Manufacturer
-                        <abbr
-                          class="usa-hint usa-hint--required"
-                          title="required"
-                        >
-                           
-                          *
-                        </abbr>
-                      </label>
-                      <input
-                        aria-disabled="true"
-                        aria-required="true"
-                        class="usa-input"
-                        disabled=""
-                        id="4"
-                        name="manufacturer"
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="grid-row grid-gap"
-                >
-                  <div
-                    class="tablet:grid-col"
-                  >
-                    <div
-                      class="usa-form-group"
-                    >
-                      <label
-                        class="usa-label"
-                        for="5"
-                      >
                         LOINC code
                         <abbr
                           class="usa-hint usa-hint--required"
@@ -266,7 +375,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="5"
+                        id="4"
                         name="loincCode"
                         type="text"
                         value=""
@@ -281,7 +390,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="6"
+                        for="5"
                       >
                         Test length (minutes)
                         <abbr
@@ -297,7 +406,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="6"
+                        id="5"
                         max="999"
                         min="0"
                         name="testLength"
@@ -318,7 +427,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="7"
+                        for="6"
                       >
                         SNOMED code for swab type(s)
                         <abbr
@@ -332,7 +441,7 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="7"
+                        id="6"
                       >
                         <input
                           aria-expanded="false"
@@ -438,7 +547,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="8"
+                        for="7"
                       >
                         Supported diseases
                         <abbr
@@ -452,7 +561,7 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="8"
+                        id="7"
                       >
                         <input
                           aria-expanded="false"
@@ -614,14 +723,175 @@ Object {
                 <div
                   class="tablet:grid-col"
                 >
+                  <label
+                    class="usa-legend"
+                    for="selectDevice"
+                  >
+                    Select Device
+                     
+                    <span
+                      class="text-secondary-vivid"
+                    >
+                      *
+                    </span>
+                  </label>
                   <div
-                    class="usa-form-group prime-dropdown "
+                    class="usa-combo-box usa-combo-box__full-width"
+                    data-enhanced="true"
+                    data-testid="combo-box"
+                  >
+                    <select
+                      aria-hidden="true"
+                      class="usa-select usa-sr-only usa-combo-box__select"
+                      data-testid="combo-box-select"
+                      name="selectDevice"
+                      tabindex="-1"
+                    >
+                      <option
+                        value="abc3"
+                      >
+                        Covalent Observer
+                      </option>
+                      <option
+                        value="abc2"
+                      >
+                        Fission Energizer
+                      </option>
+                      <option
+                        value="abc1"
+                      >
+                        Tesla Emitter
+                      </option>
+                    </select>
+                    <input
+                      aria-activedescendant=""
+                      aria-autocomplete="list"
+                      aria-describedby="selectDevice--assistiveHint"
+                      aria-expanded="false"
+                      aria-owns="selectDevice--list"
+                      autocapitalize="off"
+                      autocomplete="off"
+                      class="usa-combo-box__input"
+                      data-testid="combo-box-input"
+                      id="selectDevice"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
+                    <span
+                      class="usa-combo-box__clear-input__wrapper"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-label="Clear the select contents"
+                        class="usa-combo-box__clear-input"
+                        data-testid="combo-box-clear-button"
+                        hidden=""
+                        type="button"
+                      >
+                         
+                      </button>
+                    </span>
+                    <span
+                      class="usa-combo-box__input-button-separator"
+                    >
+                       
+                    </span>
+                    <span
+                      class="usa-combo-box__toggle-list__wrapper"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-label="Toggle the dropdown list"
+                        class="usa-combo-box__toggle-list"
+                        data-testid="combo-box-toggle"
+                        tabindex="-1"
+                        type="button"
+                      >
+                         
+                      </button>
+                    </span>
+                    <ul
+                      class="usa-combo-box__list"
+                      data-testid="combo-box-option-list"
+                      hidden=""
+                      id="selectDevice--list"
+                      role="listbox"
+                      tabindex="-1"
+                    >
+                      <li
+                        aria-posinset="1"
+                        aria-selected="false"
+                        aria-setsize="3"
+                        class="usa-combo-box__list-option"
+                        data-testid="combo-box-option-abc3"
+                        data-value="abc3"
+                        id="selectDevice--list--option-0"
+                        role="option"
+                        tabindex="-1"
+                        value="abc3"
+                      >
+                        Covalent Observer
+                      </li>
+                      <li
+                        aria-posinset="2"
+                        aria-selected="false"
+                        aria-setsize="3"
+                        class="usa-combo-box__list-option"
+                        data-testid="combo-box-option-abc2"
+                        data-value="abc2"
+                        id="selectDevice--list--option-1"
+                        role="option"
+                        tabindex="-1"
+                        value="abc2"
+                      >
+                        Fission Energizer
+                      </li>
+                      <li
+                        aria-posinset="3"
+                        aria-selected="false"
+                        aria-setsize="3"
+                        class="usa-combo-box__list-option"
+                        data-testid="combo-box-option-abc1"
+                        data-value="abc1"
+                        id="selectDevice--list--option-2"
+                        role="option"
+                        tabindex="-1"
+                        value="abc1"
+                      >
+                        Tesla Emitter
+                      </li>
+                    </ul>
+                    <div
+                      class="usa-combo-box__status usa-sr-only"
+                      role="status"
+                    />
+                    <span
+                      class="usa-sr-only"
+                      data-testid="combo-box-assistive-hint"
+                      id="selectDevice--assistiveHint"
+                    >
+                      When autocomplete results are available use up and down arrows to review
+           and enter to select. Touch device users, explore by touch or with swipe
+           gestures.
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="grid-row grid-gap"
+              >
+                <div
+                  class="tablet:grid-col"
+                >
+                  <div
+                    class="usa-form-group"
                   >
                     <label
                       class="usa-label"
                       for="1"
                     >
-                      Select device
+                      Device name
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -630,33 +900,16 @@ Object {
                         *
                       </abbr>
                     </label>
-                    <select
+                    <input
+                      aria-disabled="true"
                       aria-required="true"
-                      class="usa-select"
+                      class="usa-input"
+                      disabled=""
                       id="1"
-                      name="selectDevice"
-                    >
-                      <option
-                        value=""
-                      >
-                        - Select -
-                      </option>
-                      <option
-                        value="abc1"
-                      >
-                        Tesla Emitter
-                      </option>
-                      <option
-                        value="abc2"
-                      >
-                        Fission Energizer
-                      </option>
-                      <option
-                        value="abc3"
-                      >
-                        Covalent Observer
-                      </option>
-                    </select>
+                      name="name"
+                      type="text"
+                      value=""
+                    />
                   </div>
                 </div>
               </div>
@@ -673,7 +926,7 @@ Object {
                       class="usa-label"
                       for="2"
                     >
-                      Device name
+                      Model
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -688,7 +941,7 @@ Object {
                       class="usa-input"
                       disabled=""
                       id="2"
-                      name="name"
+                      name="model"
                       type="text"
                       value=""
                     />
@@ -708,7 +961,7 @@ Object {
                       class="usa-label"
                       for="3"
                     >
-                      Model
+                      Manufacturer
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -723,7 +976,7 @@ Object {
                       class="usa-input"
                       disabled=""
                       id="3"
-                      name="model"
+                      name="manufacturer"
                       type="text"
                       value=""
                     />
@@ -743,41 +996,6 @@ Object {
                       class="usa-label"
                       for="4"
                     >
-                      Manufacturer
-                      <abbr
-                        class="usa-hint usa-hint--required"
-                        title="required"
-                      >
-                         
-                        *
-                      </abbr>
-                    </label>
-                    <input
-                      aria-disabled="true"
-                      aria-required="true"
-                      class="usa-input"
-                      disabled=""
-                      id="4"
-                      name="manufacturer"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-              </div>
-              <div
-                class="grid-row grid-gap"
-              >
-                <div
-                  class="tablet:grid-col"
-                >
-                  <div
-                    class="usa-form-group"
-                  >
-                    <label
-                      class="usa-label"
-                      for="5"
-                    >
                       LOINC code
                       <abbr
                         class="usa-hint usa-hint--required"
@@ -792,7 +1010,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="5"
+                      id="4"
                       name="loincCode"
                       type="text"
                       value=""
@@ -807,7 +1025,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="6"
+                      for="5"
                     >
                       Test length (minutes)
                       <abbr
@@ -823,7 +1041,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="6"
+                      id="5"
                       max="999"
                       min="0"
                       name="testLength"
@@ -844,7 +1062,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="7"
+                      for="6"
                     >
                       SNOMED code for swab type(s)
                       <abbr
@@ -858,7 +1076,7 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="7"
+                      id="6"
                     >
                       <input
                         aria-expanded="false"
@@ -964,7 +1182,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="8"
+                      for="7"
                     >
                       Supported diseases
                       <abbr
@@ -978,7 +1196,7 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="8"
+                      id="7"
                     >
                       <input
                         aria-expanded="false"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -88,18 +88,14 @@ Object {
                   <div
                     class="tablet:grid-col"
                   >
-                    <label
-                      class="usa-legend"
-                      for="selectDevice"
+                    Select device
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
                     >
-                      Select Device
                        
-                      <span
-                        class="text-secondary-vivid"
-                      >
-                        *
-                      </span>
-                    </label>
+                      *
+                    </abbr>
                     <div
                       class="usa-combo-box usa-combo-box__full-width"
                       data-enhanced="true"
@@ -723,18 +719,14 @@ Object {
                 <div
                   class="tablet:grid-col"
                 >
-                  <label
-                    class="usa-legend"
-                    for="selectDevice"
+                  Select device
+                  <abbr
+                    class="usa-hint usa-hint--required"
+                    title="required"
                   >
-                    Select Device
                      
-                    <span
-                      class="text-secondary-vivid"
-                    >
-                      *
-                    </span>
-                  </label>
+                    *
+                  </abbr>
                   <div
                     class="usa-combo-box usa-combo-box__full-width"
                     data-enhanced="true"

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -862,6 +862,10 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
   max-width: none;
 }
 
+.usa-combo-box__full-width {
+  max-width: none !important;
+}
+
 // Patient form
 .patient-app--form {
   background-color: color("base-lightest");


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #4124 

- Make device selection easier by using comboboxes instead of dropdowns

## Changes Proposed

- On the super admin Edit device page, switch out dropdown for combobox
- Add some styling to keep the combobox width styled the same as the dropdown was
- Alphabetize the device options list (this was missing before)
- Update frontend tests to reflect combobox usage

## Additional Information

- Initially, the intent was to also switch out dropdowns and use comboboxes on the Manage Device section on the Manage Facilities for org admins. The combobox we use is quite lean out of the box, and would have required adding a significant amount of code to handle local state updates for the table of comboboxes on that page. See the alternative suggestions recommended in [this ticket comment](https://github.com/CDCgov/prime-simplereport/issues/4124#issuecomment-1244240764). Upon agreement with design, we will likely adopt a new design leveraging existing SimpleReport components (MultiSelect), and this work will move to a new ticket for validation and implementation.

## Testing

- Check out the branch locally or in dev1, go to the admin page, and then to "Edit existing testing device". Verify that you can select a device to edit and that the changes propagate as expected.
 
## Screenshots / Demos

https://user-images.githubusercontent.com/89797785/189928511-e5cbe34c-982a-414b-96a3-edf5335b7b4d.mov


## Checklist for Author and Reviewer

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams
- [x] New UI component meets accessibility reqs