### PR TITLE
Change alt text for logo on signup flow

### DIFF
--- a/frontend/src/app/commonComponents/Card/Card.tsx
+++ b/frontend/src/app/commonComponents/Card/Card.tsx
@@ -34,7 +34,7 @@ export const Card: React.FC<CardProps> = ({
           <img
             className="flex-align-self-center maxw-card-lg width-full"
             src={siteLogo}
-            alt="SimpleReport"
+            alt="SimpleReport logo"
           />
           <div className="border-bottom border-base-lighter margin-x-neg-3 margin-top-3"></div>
         </header>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #4001 

## Changes Proposed

- Changes alt text on signup cards to read "SimpleReport logo" instead of "SimpleReport"

## Screenshots and demos
Before:
<img width="1430" alt="Screen Shot 2022-09-13 at 3 49 08 PM" src="https://user-images.githubusercontent.com/80282552/190022753-971f7243-7865-4b4b-99af-c253983b6c28.png">

After:
<img width="1461" alt="Screen Shot 2022-09-13 at 3 48 53 PM" src="https://user-images.githubusercontent.com/80282552/190022765-40701319-83b2-4f8c-aedb-77c2b8a84499.png">