### PR TITLE
remove aria label on div

### DIFF
--- a/frontend/src/app/commonComponents/StepIndicator.tsx
+++ b/frontend/src/app/commonComponents/StepIndicator.tsx
@@ -60,7 +60,6 @@ const StepIndicator = ({
             {currentStep.order + 1}
           </span>
           <span className="usa-step-indicator__total-steps">
-            {" "}
             of {steps.length}
           </span>
         </span>

--- a/frontend/src/app/commonComponents/StepIndicator.tsx
+++ b/frontend/src/app/commonComponents/StepIndicator.tsx
@@ -60,6 +60,7 @@ const StepIndicator = ({
             {currentStep.order + 1}
           </span>
           <span className="usa-step-indicator__total-steps">
+            {" "}
             of {steps.length}
           </span>
         </span>
@@ -79,7 +80,6 @@ const StepIndicator = ({
           "margin-y-205": !segmentIndicatorOnBottom,
         }
       )}
-      aria-label="progress"
       aria-hidden={ariaHidden}
     >
       {segmentIndicatorOnBottom ? (


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #4014
- removes aria-label on div and makes sure it's still accessible

## Changes Proposed

- Removed the  offending aria-label on the div enclosing the step indicator

## Additional Information

- The step indicator is interpreted by screen readers, and I don't believe it needs anything additional to ensure accessibility. See screenshots below. The spacing doesn't look good on this plugin, but I don't think that will affect its readability by screen readers.
- I ran the page through the the Axe DevTools scanner plugin, and it no longer the aria-label after I removed it

## Testing

- Run the branch locally and observe no aria-label and ensure your screen reader can interpret the step indicator
 
## Screenshots / Demos
![Screen Shot 2022-09-15 at 10 17 20 AM](https://user-images.githubusercontent.com/89797785/190427857-53073798-b4ee-47a5-98b5-7dd2b7e2a1c3.png)
![Screen Shot 2022-09-15 at 10 17 38 AM](https://user-images.githubusercontent.com/89797785/190427863-ee169fc3-7a21-420a-9b87-5d3fbad0c681.png)

## Checklist for Author and Reviewer

- [x] Component is still accessible