### PR TITLE
fix header order on personal details page

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -238,7 +238,7 @@ const PersonalDetailsForm = ({
               Identity verification helps protect organizations working with
               personal health information.
             </p>
-            <h2 className="h3-override">{getPersonFullName()}</h2>
+            <h2 className="questions-form-name">{getPersonFullName()}</h2>
           </div>
           {Object.entries(personalDetailsFields).map(
             ([key, { label, required, hintText }]) => {

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -238,7 +238,7 @@ const PersonalDetailsForm = ({
               Identity verification helps protect organizations working with
               personal health information.
             </p>
-            <h3>{getPersonFullName()}</h3>
+            <h2 className="h3-override">{getPersonFullName()}</h2>
           </div>
           {Object.entries(personalDetailsFields).map(
             ([key, { label, required, hintText }]) => {

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.scss
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.scss
@@ -15,3 +15,9 @@
   line-height: 1.4;
   font-size: 1rem;
 }
+
+.h3-override {
+  font-size: 1.17em;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+}

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.scss
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.scss
@@ -16,7 +16,7 @@
   font-size: 1rem;
 }
 
-.h3-override {
+.questions-form-name {
   font-size: 1.17em;
   margin-block-start: 1em;
   margin-block-end: 1em;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #4077 

- there's an h3 on the page right after an h1, this is not good practice

## Changes Proposed

- Make the h3 and h2
- Use custom styling so it still looks like an h3

## Additional Information

- I was not sure the best place to but the new css to make it look the same. Open to suggestions on better organization!

## Testing

- Check it out locally
 
## Screenshots / Demos

Before and After:
![Screen Shot 2022-09-15 at 10 38 39 AM](https://user-images.githubusercontent.com/89797785/190434383-ea854369-b996-4b63-a15d-3adb1785eb20.png)
![Screen Shot 2022-09-15 at 10 37 56 AM](https://user-images.githubusercontent.com/89797785/190434424-bb12057d-cc70-4058-b952-470d6a2e768e.png)

## Checklist for Author and Reviewer

- [ ] css is in a reasonable place