### PR TITLE
Comment out checklists

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,8 @@
 
 - How should reviewers verify this PR?
 
+<!---
 ## Checklist for Primary Reviewer
-
 - [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
 - [ ] Any content updates (user-facing error messages, etc) have been approved by content team
 - [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
@@ -27,8 +27,9 @@
 - [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
 - [ ] Any dependencies introduced have been vetted and discussed
 - [ ] Any changes to the startup configuration have been documented in the README
+-->
 
-----
+---
 
 # DATABASE PULL REQUEST
 
@@ -48,6 +49,7 @@
 ## Testing
 
 - How should reviewers verify this PR?
+<!---
 
 ## Checklist for Primary Reviewer
 
@@ -57,8 +59,9 @@
 - [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
 - [ ] Rollback has been verifed locally and in a deployed environment
 - [ ] Any changes to the startup configuration have been documented in the README
+      -->
 
-----
+---
 
 # DEVOPS PULL REQUEST
 
@@ -78,9 +81,9 @@
 ## Testing
 
 - How should reviewers verify this PR?
- 
-## Checklist for Primary Reviewer
 
+<!---
+## Checklist for Primary Reviewer
 ### Infrastructure
 - [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!
 
@@ -94,7 +97,9 @@
 
 ### Documentation
 - [ ] Any changes to the startup configuration have been documented in the README
-----
+-->
+
+---
 
 # FRONTEND PULL REQUEST
 
@@ -114,13 +119,13 @@
 ## Testing
 
 - How should reviewers verify this PR?
- 
+
 ## Screenshots / Demos
 
 - For large changes, please pair with a designer to ensure changes are as intended
 
+<!---
 ## Checklist for Author and Reviewer
-
 ### Design
 - [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
 - [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams
@@ -138,3 +143,4 @@
 
 ### Documentation
 - [ ] Any changes to the startup configuration have been documented in the README
+-->


### PR DESCRIPTION
Commenting out the checklists in the PR template to follow up on a convo during the 8/8 eng sync

Tested out the formating in a issue comment and this is how the backend template renders. The checklist items are still available in commented-out form.
<img width="642" alt="Screen Shot 2022-09-15 at 12 20 46 PM" src="https://user-images.githubusercontent.com/29645040/190469979-ea7217a9-163c-4be6-9998-bd3cffa9a955.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cdcgov/prime-simplereport/4281)
<!-- Reviewable:end -->
