### PR TITLE
Make "Facility access" tab accessible

### DIFF
--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -155,11 +155,11 @@
         line-height: 26px;
         color: #1b1b1b;
 
-        span {
+        button {
           padding-bottom: 2px;
         }
 
-        &.usa-current span {
+        &.usa-current button {
           font-weight: 600;
           border-bottom: 0.25rem solid #005ea2;
         }

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -11,6 +11,8 @@
       font-size: 16px;
       line-height: 19px;
       color: #1b1b1b;
+      margin-block-start: 1em;
+      margin-block-end: 1em;
     }
   }
 
@@ -19,8 +21,6 @@
   }
 
   .user-header {
-    // border-bottom: 1px solid #dfe1e2;
-    // padding: 0 0.5em;
     margin-bottom: 1em;
   }
 
@@ -107,6 +107,14 @@
 
   .usa-card__header {
     padding-bottom: 2rem;
+
+    h1 {
+      font-size: 1.5em;
+      margin-top: 8px !important;
+      margin-bottom: 0 !important;
+      margin-block-start: 0.83em;
+      margin-block-end: 0.83em;
+    }
 
     h2 {
       margin-top: 8px;
@@ -211,6 +219,7 @@
       line-height: 19px;
       color: #1b1b1b;
       margin-bottom: 2rem;
+      margin-block-start: 1.33em;
     }
 
     .usercontrols-text {
@@ -250,6 +259,7 @@
       font-size: 16px;
       line-height: 19px;
       color: #1b1b1b;
+      margin-block-start: 1em;
     }
 
     .testing-facility-access-subtext {

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -5,7 +5,7 @@
 
   .users-sidenav {
     border-right: 1px solid #dfe1e2; // color("text-base-lighter");
-    .users-header {
+    .users-sidenav-header {
       font-style: normal;
       font-weight: bold;
       font-size: 16px;

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -457,7 +457,7 @@ const ManageUsers: React.FC<Props> = ({
   return (
     <div className="prime-container card-container manage-users-card">
       <div className="usa-card__header">
-        <h2>Manage users</h2>
+        <h1>Manage users</h1>
         <Button
           onClick={() => updateShowAddUserModal(true)}
           label="+ Add user"

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -183,7 +183,7 @@ const UserDetail: React.FC<Props> = ({
         ) : null}
       </div>
       <nav
-        className="prime-secondary-nav margin-top-4"
+        className="prime-secondary-nav margin-top-4 padding-bottom-0"
         aria-label="Tertiary navigation"
       >
         <ul className="usa-nav__secondary-links prime-nav">
@@ -191,17 +191,27 @@ const UserDetail: React.FC<Props> = ({
             className={`usa-nav__secondary-item ${
               navItemSelected === "userInfo" ? "usa-current" : ""
             }`}
-            onClick={() => setNavItemSelected("userInfo")}
           >
-            <span>User information</span>
+            <button
+              role="tab"
+              className="usa-button--unstyled text-ink text-no-underline"
+              onClick={() => setNavItemSelected("userInfo")}
+            >
+              User information
+            </button>
           </li>
           <li
             className={`usa-nav__secondary-item ${
               navItemSelected === "facilityAccess" ? "usa-current" : ""
             }`}
-            onClick={() => setNavItemSelected("facilityAccess")}
           >
-            <span>Facility access</span>
+            <button
+              role="tab"
+              className="usa-button--unstyled text-ink text-no-underline"
+              onClick={() => setNavItemSelected("facilityAccess")}
+            >
+              Facility access
+            </button>
           </li>
         </ul>
       </nav>

--- a/frontend/src/app/Settings/Users/UserDetail.tsx
+++ b/frontend/src/app/Settings/Users/UserDetail.tsx
@@ -140,7 +140,11 @@ const UserDetail: React.FC<Props> = ({
   }
 
   return (
-    <div className="tablet:grid-col padding-left-3 user-detail-column">
+    <div
+      role="tabpanel"
+      aria-labelledby={"user-tab-" + user?.id}
+      className="tablet:grid-col padding-left-3 user-detail-column"
+    >
       <div>
         <h2 className="display-inline-block margin-top-1 margin-bottom-0 user-name-header">
           {displayFullName(user.firstName, user.middleName, user.lastName)}
@@ -184,40 +188,52 @@ const UserDetail: React.FC<Props> = ({
       </div>
       <nav
         className="prime-secondary-nav margin-top-4 padding-bottom-0"
-        aria-label="Tertiary navigation"
+        aria-label="User action navigation"
       >
-        <ul className="usa-nav__secondary-links prime-nav">
-          <li
+        <div
+          role="tablist"
+          aria-owns={"user-info-tab-id facility-access-tab-id"}
+          className="usa-nav__secondary-links prime-nav usa-list"
+        >
+          <div
             className={`usa-nav__secondary-item ${
               navItemSelected === "userInfo" ? "usa-current" : ""
             }`}
           >
             <button
+              id="user-info-tab-id"
               role="tab"
               className="usa-button--unstyled text-ink text-no-underline"
               onClick={() => setNavItemSelected("userInfo")}
+              aria-selected={navItemSelected === "userInfo"}
             >
               User information
             </button>
-          </li>
-          <li
+          </div>
+          <div
             className={`usa-nav__secondary-item ${
               navItemSelected === "facilityAccess" ? "usa-current" : ""
             }`}
           >
             <button
+              id="facility-access-tab-id"
               role="tab"
               className="usa-button--unstyled text-ink text-no-underline"
               onClick={() => setNavItemSelected("facilityAccess")}
+              aria-selected={navItemSelected === "facilityAccess"}
             >
               Facility access
             </button>
-          </li>
-        </ul>
+          </div>
+        </div>
       </nav>
       {navItemSelected === "userInfo" ? (
-        <div className="padding-left-1">
-          <h4 className="basic-info-header">Basic information</h4>
+        <div
+          role="tabpanel"
+          aria-labelledby="user-info-tab-id"
+          className="padding-left-1"
+        >
+          <h3 className="basic-info-header">Basic information</h3>
           <div
             className={classnames(
               "user-header grid-row flex-row flex-align-center",
@@ -259,7 +275,7 @@ const UserDetail: React.FC<Props> = ({
             />
           </div>
           <div className="userinfo-divider"></div>
-          <h4 className="user-controls-header">User controls</h4>
+          <h3 className="user-controls-header">User controls</h3>
           <div
             className={classnames(
               "user-header grid-row flex-row flex-align-center",
@@ -325,8 +341,12 @@ const UserDetail: React.FC<Props> = ({
           </div>
         </div>
       ) : (
-        <div className="padding-left-1">
-          <h4 className="basic-info-header margin-bottom-1">User role</h4>
+        <div
+          role="tabpanel"
+          aria-labelledby="facility-access-tab-id"
+          className="padding-left-1"
+        >
+          <h3 className="basic-info-header margin-bottom-1">User role</h3>
           <div className="userrole-subtext">
             Admins have full access to use and change settings on SimpleReport.
             Standard and testing-only users have limited access for specific

--- a/frontend/src/app/Settings/Users/UserFacilitiesSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserFacilitiesSettingsForm.tsx
@@ -142,10 +142,10 @@ const UserFacilitiesSettingsForm: React.FC<Props> = ({
 
   return (
     <>
-      <h3 className="testing-facility-access-subheader margin-bottom-0">
+      <h4 className="testing-facility-access-subheader margin-bottom-0">
         Testing facility access{" "}
         {showRequired && <span className="text-secondary-vivid">*</span>}
-      </h3>
+      </h4>
       <p className="testing-facility-access-subtext">
         {facilityAccessDescription}
       </p>

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -27,7 +27,7 @@ const UsersSideNav: React.FC<Props> = ({
 
   return (
     <div className="display-block users-sidenav">
-      <h2 className="users-header">Users</h2>
+      <h2 className="users-sidenav-header">Users</h2>
       <nav className="prime-secondary-nav" aria-label="Tertiary navigation">
         <div
           role="tablist"

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -21,77 +21,86 @@ const UsersSideNav: React.FC<Props> = ({
   users,
   onChangeActiveUser,
 }) => {
+  const getIdsAsString = (users: LimitedUser[]) => {
+    return users.map((user) => "user-tab-" + user.id.toString()).join(" ");
+  };
+
   return (
     <div className="display-block users-sidenav">
-      <h3 className="users-header">Users</h3>
-      <ul className="usa-sidenav">
-        {users.map((user: LimitedUser) => {
-          let statusText;
-          switch (user.status) {
-            case "ACTIVE":
-              statusText = (
-                <span className="sidenav-user-status padding-left-0"></span>
-              );
-              break;
-            case "PROVISIONED":
-              statusText = (
-                <>
-                  <PendingIcon />
-                  <span className="sidenav-user-status">
-                    {formatUserStatus(user.status)}
-                  </span>
-                </>
-              );
-              break;
-            case "SUSPENDED":
-              statusText = (
-                <>
-                  <DeactivatedIcon />
-                  <span className="sidenav-user-status">
-                    {formatUserStatus(user.status)}
-                  </span>
-                </>
-              );
-              break;
-            default:
-              statusText = "";
-          }
-          return (
-            <li
-              className="usa-sidenav__item users-sidenav-item"
-              onClick={() => onChangeActiveUser(user.id)}
-              key={user.id}
-            >
-              <button
-                role="tab"
-                style={{ cursor: "pointer" }}
-                className={classnames(
-                  "usa-button--unstyled",
-                  "text-ink",
-                  "text-no-underline",
-                  "padding-105 padding-right-2 padding-left-3",
-                  activeUserId === user.id && "usa-current"
-                )}
-                aria-selected={activeUserId === user.id}
-                aria-label={displayFullName(
-                  user.firstName,
-                  user.middleName,
-                  user.lastName
-                )}
-              >
-                <div className="sidenav-user-name">
-                  {displayFullName(
+      <h2 className="users-header">Users</h2>
+      <nav className="prime-secondary-nav" aria-label="Tertiary navigation">
+        <div
+          role="tablist"
+          aria-owns={getIdsAsString(users)}
+          className="usa-sidenav"
+        >
+          {users.map((user: LimitedUser) => {
+            let statusText;
+            switch (user.status) {
+              case "ACTIVE":
+                statusText = (
+                  <span className="sidenav-user-status padding-left-0"></span>
+                );
+                break;
+              case "PROVISIONED":
+                statusText = (
+                  <>
+                    <PendingIcon />
+                    <span className="sidenav-user-status">
+                      {formatUserStatus(user.status)}
+                    </span>
+                  </>
+                );
+                break;
+              case "SUSPENDED":
+                statusText = (
+                  <>
+                    <DeactivatedIcon />
+                    <span className="sidenav-user-status">
+                      {formatUserStatus(user.status)}
+                    </span>
+                  </>
+                );
+                break;
+              default:
+                statusText = "";
+            }
+            return (
+              <div className="usa-sidenav__item users-sidenav-item">
+                <button
+                  id={"user-tab-" + user.id}
+                  role="tab"
+                  style={{ cursor: "pointer" }}
+                  className={classnames(
+                    "usa-button--unstyled",
+                    "text-ink",
+                    "text-no-underline",
+                    "padding-105 padding-right-2 padding-left-3",
+                    activeUserId === user.id && "usa-current"
+                  )}
+                  aria-label={displayFullName(
                     user.firstName,
                     user.middleName,
                     user.lastName
                   )}
-                </div>
-                {statusText}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+                  aria-selected={activeUserId === user.id}
+                  onClick={() => onChangeActiveUser(user.id)}
+                  key={user.id}
+                >
+                  <div className="sidenav-user-name">
+                    {displayFullName(
+                      user.firstName,
+                      user.middleName,
+                      user.lastName
+                    )}
+                  </div>
+                  {statusText}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </nav>
     </div>
   );
 };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #4099 #4100 #4104

- The "Facility access" tab on the "Manage Users" page is not accessible via keyboard
- User list on left side nav of "Manage Users" tab is also not accessible via keyboard
- headers are wildly out of order on the "Manage Users" tab

## Changes Proposed

- Refactored the left nav and user info nav to be accessible for #4099 and #4100
  - Replace `<span>` with `<button>` to take advantage of built-in accessibility
  - Replace `<ul>` and `<li>` with a `<div>` that has a `tablist` role and specifically indicates which (grand)children are the `tab`s. This is the preferred accessible solution, more info [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#description).
  - Adds a `tabpanel` role to indicate which page sections belong to a `tab`
  - Update styling to reflect usage of `<div>` + `<button>`
- Reorg headers on the "Manage Users" page for #4104 
  - There were multiple violations, I've added a top-level header (deque wanted one of those too) and ordered the headers to make functional sense as much as possible.

## Additional Information

- I re-ran the page through deque and the header and tab violations now look to be resolved
- I compared local extensively to demo to make sure the styling remained the same.

## Testing

- Pull down the branch locally and observe you can tab through the "Users" menu and to "Facility access"
- Inspect to confirm correct order of headers
- currently **deploying to dev4** if anyone wants to look at it there

## Screenshots / Demos

**Headers**
Before and After on User Information
![Screen Shot 2022-09-20 at 2 07 55 PM](https://user-images.githubusercontent.com/89797785/191332249-82b951c6-7957-4f26-9d68-ded6902f19c1.png)
![Screen Shot 2022-09-20 at 2 06 56 PM](https://user-images.githubusercontent.com/89797785/191332259-fce63ed2-0d2e-4ddc-9dc5-2b0f6909ef45.png)

Before and After on Facility Access
![Screen Shot 2022-09-20 at 2 09 25 PM](https://user-images.githubusercontent.com/89797785/191332558-2b81441a-b18f-4c8f-8fac-9f3ca202ddd1.png)
![Screen Shot 2022-09-20 at 2 08 54 PM](https://user-images.githubusercontent.com/89797785/191332539-19481a9f-3211-4048-a6ba-dd7ddc943a51.png)

**Accessing the Menus Before and After**

https://user-images.githubusercontent.com/89797785/191333207-74b3725f-795c-4afb-8f4a-106b84ae8bdd.mov

https://user-images.githubusercontent.com/89797785/191333175-a15ebdee-c852-483d-9d10-a6418bba74c4.mov

**Tabs are contained in Tablist**
User left nav
![Screen Shot 2022-09-20 at 2 15 35 PM](https://user-images.githubusercontent.com/89797785/191333897-e71d7451-bc59-440d-95eb-51c4a4eb1a8c.png)

User info nav
![Screen Shot 2022-09-20 at 2 15 58 PM](https://user-images.githubusercontent.com/89797785/191333928-bdde3cc7-d79f-4cbe-a27e-6e881bc329c3.png)

## Checklist for Author and Reviewer
- [x] Component is accessible
- [x] Component retains same styling as prior to change

<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
