### PR TITLE
update runQuery to use Map instead of NodeObject

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
+import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,7 +13,6 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.model.Role;
@@ -255,7 +255,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void addUser_newArgStructure_success() {
     useSuperUser();
-    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, true);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.ADMIN, true);
     JsonNode user = runQuery("add-user", "addUserNovel", variables, null).get("addUser");
     assertEquals("Rhonda", user.get("name").get("firstName").asText());
 
@@ -273,7 +273,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
           useSuperUser();
 
-          ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, true);
+          Map<String, Object> variables = makeBoilerplateArgs(Role.ADMIN, true);
           variables.put("organizationExternalId", org.getExternalId());
           JsonNode user = runQuery("add-user", "addUserNovel", variables, null).get("addUser");
           assertEquals("Rhonda", user.get("name").get("firstName").asText());
@@ -288,23 +288,25 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void addUser_invalidNames_failure() {
     useSuperUser();
-    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, false);
+    HashMap<String, Object> variables = new HashMap<>(makeBoilerplateArgs(Role.ADMIN, false));
     variables.remove("lastName");
+
     runQuery("add-user", "addUserNovel", variables, "cannot be empty");
-    variables = makeBoilerplateArgs(Role.ADMIN, true).put("lastName", "Oopsies");
+    variables = new HashMap<>(makeBoilerplateArgs(Role.ADMIN, true));
+    variables.put("lastName", "Oopsies");
     runQuery("add-user", "addUserNovel", variables, "both unrolled and structured name arguments");
   }
 
   @Test
   void addUser_adminUser_failure() {
     useOrgAdmin();
-    ObjectNode variables = makeBoilerplateArgs(Role.USER);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.USER);
     runQuery("add-user", "addUserOp", variables, ACCESS_ERROR);
   }
 
   @Test
   void addUser_orgUser_failure() {
-    ObjectNode variables = makeBoilerplateArgs(Role.USER);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.USER);
     runQuery("add-user", "addUserOp", variables, ACCESS_ERROR);
     assertLastAuditEntry(
         TestUserIdentities.STANDARD_USER,
@@ -352,7 +354,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void addUserToCurrentOrg_newArgStructure_success() {
     useOrgAdmin();
-    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, true);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.ADMIN, true);
     JsonNode user =
         runQuery("add-user-to-current-org", "addUserToCurrentOrgNovel", variables, null)
             .get("addUserToCurrentOrg");
@@ -366,10 +368,11 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void addUserToCurrentOrg_invalidNames_failure() {
     useOrgAdmin();
-    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, false);
+    HashMap<String, Object> variables = new HashMap<>(makeBoilerplateArgs(Role.ADMIN, false));
     variables.remove("lastName");
     runQuery("add-user-to-current-org", "addUserToCurrentOrgNovel", variables, "cannot be empty");
-    variables = makeBoilerplateArgs(Role.ADMIN, true).put("lastName", "Oopsies");
+    variables = new HashMap<>(makeBoilerplateArgs(Role.ADMIN, true));
+    variables.put("lastName", "Oopsies");
     runQuery(
         "add-user-to-current-org",
         "addUserToCurrentOrgNovel",
@@ -380,7 +383,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void addUserToCurrentOrg_superUser_failure() {
     useSuperUser();
-    ObjectNode variables = makeBoilerplateArgs(Role.USER);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.USER);
     runQuery("add-user-to-current-org", "addUserToCurrentOrgOp", variables, ACCESS_ERROR);
     assertLastAuditEntry(
         TestUserIdentities.SITE_ADMIN_USER,
@@ -391,7 +394,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
   @Test
   void addUserToCurrentOrg_orgUser_failure() {
-    ObjectNode variables = makeBoilerplateArgs(Role.USER);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.USER);
     runQuery(
         "add-user-to-current-org",
         "addUserToCurrentOrgOp",
@@ -407,8 +410,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String addedUserId = runBoilerplateAddUserToCurrentOrg(Role.ENTRY_ONLY).get("id").asText();
 
     // disable new user
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", addedUserId).put("deleted", true);
+    Map<String, Object> deleteVariables = Map.of("id", addedUserId, "deleted", true);
     String email =
         runQuery("set-user-is-deleted", deleteVariables)
             .get("setUserIsDeleted")
@@ -416,7 +418,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
             .asText();
 
     // add user again (expect the user to be re-enabled with their original role)
-    ObjectNode addVariables = makeBoilerplateArgs(Role.USER, false);
+    Map<String, Object> addVariables = makeBoilerplateArgs(Role.USER, false);
     addVariables.put("email", email);
     addVariables.put("firstName", "A-Different-FirstName");
     addVariables.put("lastName", "A-Different-LastName");
@@ -454,7 +456,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     useOrgAdmin();
     runBoilerplateAddUserToCurrentOrg(Role.ADMIN);
 
-    ObjectNode variables = makeBoilerplateArgs(Role.ADMIN, false);
+    Map<String, Object> variables = makeBoilerplateArgs(Role.ADMIN, false);
     runQuery(
         "add-user-to-current-org",
         "addUserToCurrentOrgNovel",
@@ -469,7 +471,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode addUser = runBoilerplateAddUserToCurrentOrg(Role.USER);
     String id = addUser.get("id").asText();
 
-    ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
+    Map<String, Object> updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
     ObjectNode updateResp = runQuery("update-user", "updateUser", updateVariables, null);
     ObjectNode updateUser = (ObjectNode) updateResp.get("updateUser");
     assertEquals("Ronda", updateUser.get("firstName").asText());
@@ -497,7 +499,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode addUser = runBoilerplateAddUser(Role.ADMIN);
     String id = addUser.get("id").asText();
 
-    ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
+    Map<String, Object> updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
     ObjectNode resp = runQuery("update-user", "updateUser", updateVariables, null);
     ObjectNode updateUser = (ObjectNode) resp.get("updateUser");
     assertEquals("Ronda", updateUser.get("firstName").asText());
@@ -518,7 +520,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
+    Map<String, Object> updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
     runQuery(
         "update-user",
         "updateUser",
@@ -529,7 +531,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void updateUser_nonexistentUser_failure() {
     useSuperUser();
-    ObjectNode updateVariables =
+    Map<String, Object> updateVariables =
         getUpdateUserVariables(
             "fa2efa2e-fa2e-fa2e-fa2e-fa2efa2efa2e", "Ronda", "J", "Jones", "III");
     runQuery("update-user", "updateUser", updateVariables, NO_USER_ERROR);
@@ -541,7 +543,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode who = (ObjectNode) runQuery("current-user-query").get("whoami");
     String id = who.get("id").asText();
 
-    ObjectNode updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
+    Map<String, Object> updateVariables = getUpdateUserVariables(id, "Ronda", "J", "Jones", "III");
     ObjectNode resp = runQuery("update-user", "updateUser", updateVariables, null);
     ObjectNode updateUser = (ObjectNode) resp.get("updateUser");
     assertEquals("Ronda", updateUser.get("firstName").asText());
@@ -559,8 +561,11 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String newEmail = addUser.get("id").asText();
     String id = addUser.get("id").asText();
 
-    ObjectNode newEmailNode =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("email", newEmail);
+    Map<String, Object> newEmailNode =
+        Map.of(
+            "id", id,
+            "email", newEmail);
+
     ObjectNode updateResp = runQuery("update-user-email", "updateUserEmail", newEmailNode, null);
     ObjectNode updateUser = (ObjectNode) updateResp.get("updateUserEmail");
 
@@ -576,8 +581,10 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String newEmail = addUser.get("id").asText();
     String id = addUser.get("id").asText();
 
-    ObjectNode updateVars =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("email", newEmail);
+    Map<String, Object> updateVars =
+        Map.of(
+            "id", id,
+            "email", newEmail);
     ObjectNode updateResp = runQuery("update-user-email", "updateUserEmail", updateVars, null);
     ObjectNode updateUser = (ObjectNode) updateResp.get("updateUserEmail");
 
@@ -595,8 +602,11 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode updateVars =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("email", newEmail);
+    Map<String, Object> updateVars =
+        Map.of(
+            "id", id,
+            "email", newEmail);
+
     runQuery(
         "update-user-email",
         "updateUserEmail",
@@ -611,8 +621,10 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String newEmail = who.get("id").asText();
     String id = who.get("id").asText();
 
-    ObjectNode updateVars =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("email", newEmail);
+    Map<String, Object> updateVars =
+        Map.of(
+            "id", id,
+            "email", newEmail);
     ObjectNode resp = runQuery("update-user-email", "updateUserEmail", updateVars, null);
     ObjectNode updateUser = (ObjectNode) resp.get("updateUserEmail");
 
@@ -629,7 +641,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgAdmin();
 
-    ObjectNode resetUserPasswordVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    Map<String, Object> resetUserPasswordVariables = Map.of("id", id);
     ObjectNode resp =
         runQuery("reset-user-password", "resetUserPassword", resetUserPasswordVariables, null);
     ObjectNode resetUserPassword = (ObjectNode) resp.get("resetUserPassword");
@@ -645,7 +657,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode resetUserPasswordVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    Map<String, Object> resetUserPasswordVariables = Map.of("id", id);
     runQuery(
         "reset-user-password",
         "resetUserPassword",
@@ -662,7 +674,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgAdmin();
 
-    ObjectNode resetUserMfaVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    Map<String, Object> resetUserMfaVariables = Map.of("id", id);
     ObjectNode resp = runQuery("reset-user-mfa", "resetUserMfa", resetUserMfaVariables, null);
     ObjectNode resetUserMfa = (ObjectNode) resp.get("resetUserMfa");
     assertEquals(USERNAMES.get(0), resetUserMfa.get("email").asText());
@@ -677,7 +689,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode resetUserMfaVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    Map<String, Object> resetUserMfaVariables = Map.of("id", id);
     runQuery(
         "reset-user-mfa",
         "resetUserMfa",
@@ -694,7 +706,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgAdmin();
 
-    ObjectNode resendActivationEmailVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    Map<String, Object> resendActivationEmailVariables = Map.of("id", id);
     ObjectNode resp =
         runQuery(
             "resend-activation-email",
@@ -714,7 +726,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode resendActivationEmailVariables = JsonNodeFactory.instance.objectNode().put("id", id);
+    Map<String, Object> resendActivationEmailVariables = Map.of("id", id);
     runQuery(
         "resend-activation-email",
         "resendActivationEmail",
@@ -730,7 +742,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String id = addUser.get("id").asText();
 
     // Update 1: ENTRY_ONLY, All facilities
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(id, Role.ENTRY_ONLY, true, Set.of());
 
     ObjectNode updateResp = runQuery("update-user-privileges", updatePrivilegesVariables);
@@ -823,7 +835,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
   private ObjectNode runBoilerplateAddUserToCurrentOrg(Role newUserRole, String operation) {
 
-    ObjectNode addVariables = makeBoilerplateArgs(newUserRole);
+    Map<String, Object> addVariables = makeBoilerplateArgs(newUserRole);
     ObjectNode addResp = runQuery("add-user-to-current-org", operation, addVariables, null);
     ObjectNode addUser = (ObjectNode) addResp.get("addUserToCurrentOrg");
     return addUser;
@@ -834,17 +846,17 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   }
 
   private ObjectNode runBoilerplateAddUser(Role newUserRole, String operation) {
-    ObjectNode addVariables = makeBoilerplateArgs(Role.ADMIN);
+    Map<String, Object> addVariables = makeBoilerplateArgs(Role.ADMIN);
     ObjectNode addResp = runQuery("add-user", operation, addVariables, null);
     ObjectNode addUser = (ObjectNode) addResp.get("addUser");
     return addUser;
   }
 
-  private ObjectNode makeBoilerplateArgs(Role role) {
+  private Map<String, Object> makeBoilerplateArgs(Role role) {
     return makeBoilerplateArgs(role, false);
   }
 
-  private ObjectNode makeBoilerplateArgs(Role role, boolean useNestedName) {
+  private Map<String, Object> makeBoilerplateArgs(Role role, boolean useNestedName) {
     return getAddUserVariables(
         "Rhonda",
         "Janet",
@@ -863,7 +875,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode addUser = runBoilerplateAddUser(Role.ADMIN);
     String id = addUser.get("id").asText();
 
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(id, Role.ENTRY_ONLY, true, Set.of());
 
     ObjectNode updateResp = runQuery("update-user-privileges", updatePrivilegesVariables);
@@ -891,7 +903,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOutsideOrgAdmin();
 
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(id, Role.ENTRY_ONLY, false, Set.of());
 
     runQuery("update-user-privileges", updatePrivilegesVariables, ACCESS_ERROR);
@@ -904,7 +916,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOutsideOrgUser();
 
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(id, Role.ENTRY_ONLY, false, Set.of());
 
     runQuery(
@@ -920,7 +932,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(id, Role.ENTRY_ONLY, false, Set.of());
 
     runQuery(
@@ -932,7 +944,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void updateUserPrivileges_nonexistentUser_failure() {
     useSuperUser();
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(
             "fa2efa2e-fa2e-fa2e-fa2e-fa2efa2efa2e", Role.ENTRY_ONLY, true, Set.of());
     runQuery("update-user-privileges", updatePrivilegesVariables, NO_USER_ERROR);
@@ -944,7 +956,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode who = (ObjectNode) runQuery("current-user-query").get("whoami");
     String id = who.get("id").asText();
 
-    ObjectNode updatePrivilegesVariables =
+    Map<String, Object> updatePrivilegesVariables =
         getUpdateUserPrivilegesVariables(id, Role.ENTRY_ONLY, true, Set.of());
     runQuery("update-user-privileges", updatePrivilegesVariables, ACCESS_ERROR);
   }
@@ -955,16 +967,13 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     String id = runBoilerplateAddUserToCurrentOrg(Role.ENTRY_ONLY).get("id").asText();
     assertTrue(fetchUserList().stream().anyMatch(o -> id.equals(o.get("id").asText())));
 
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", true);
-
+    Map<String, Object> deleteVariables = Map.of("id", id, "deleted", true);
     ObjectNode resp = runQuery("set-user-is-deleted", deleteVariables);
     assertEquals(USERNAMES.get(0), resp.get("setUserIsDeleted").get("email").asText());
 
     assertTrue(fetchUserList().stream().noneMatch(o -> id.equals(o.get("id").asText())));
 
-    ObjectNode restoreVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", false);
+    Map<String, Object> restoreVariables = Map.of("id", id, "deleted", false);
     ObjectNode restoreResp = runQuery("set-user-is-deleted", restoreVariables);
     assertEquals(USERNAMES.get(0), restoreResp.get("setUserIsDeleted").get("email").asText());
 
@@ -976,8 +985,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     useSuperUser();
     String id = runBoilerplateAddUser(Role.USER).get("id").asText();
 
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", true);
+    Map<String, Object> deleteVariables = Map.of("id", id, "deleted", true);
 
     ObjectNode resp = runQuery("set-user-is-deleted", deleteVariables);
     assertEquals(USERNAMES.get(0), resp.get("setUserIsDeleted").get("email").asText());
@@ -995,8 +1003,8 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOutsideOrgAdmin();
 
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", true);
+    Map<String, Object> deleteVariables = Map.of("id", id, "deleted", true);
+
     runQuery("set-user-is-deleted", deleteVariables, ACCESS_ERROR);
   }
 
@@ -1007,8 +1015,8 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOutsideOrgUser();
 
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", true);
+    Map<String, Object> deleteVariables = Map.of("id", id, "deleted", true);
+
     runQuery(
         "set-user-is-deleted",
         deleteVariables,
@@ -1031,8 +1039,8 @@ class ApiUserManagementTest extends BaseGraphqlTest {
 
     useOrgUser();
 
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", true);
+    Map<String, Object> deleteVariables = Map.of("id", id, "deleted", true);
+
     runQuery(
         "set-user-is-deleted",
         deleteVariables,
@@ -1045,8 +1053,8 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     ObjectNode who = (ObjectNode) runQuery("current-user-query").get("whoami");
     String id = who.get("id").asText();
 
-    ObjectNode deleteVariables =
-        JsonNodeFactory.instance.objectNode().put("id", id).put("deleted", true);
+    Map<String, Object> deleteVariables = Map.of("id", id, "deleted", true);
+
     runQuery("set-user-is-deleted", deleteVariables, ACCESS_ERROR);
   }
 
@@ -1055,7 +1063,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   void getUsers_adminUser_success() {
     useOrgAdmin();
 
-    List<ObjectNode> usersAdded =
+    List<Map<String, Object>> usersAdded =
         Arrays.asList(
             makeBoilerplateArgs(Role.ADMIN),
             getAddUserVariables(
@@ -1074,7 +1082,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
                 USERNAMES.get(3),
                 TestUserIdentities.DEFAULT_ORGANIZATION,
                 Role.ADMIN.name()));
-    for (ObjectNode userVariables : usersAdded) {
+    for (Map<String, Object> userVariables : usersAdded) {
       runQuery("add-user-to-current-org", "addUserToCurrentOrgOp", userVariables, null);
     }
 
@@ -1083,16 +1091,16 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     assertTrue(usersRetrieved.size() > usersAdded.size());
 
     for (int i = 0; i < usersAdded.size(); i++) {
-      ObjectNode userAdded = usersAdded.get(i);
+      Map<String, Object> userAdded = usersAdded.get(i);
       Optional<ObjectNode> found =
           usersRetrieved.stream()
-              .filter(u -> u.get("email").asText().equals(userAdded.get("email").asText()))
+              .filter(u -> u.get("email").asText().equals(userAdded.get("email")))
               .findFirst();
       assertTrue(found.isPresent());
       ObjectNode userRetrieved = found.get();
 
-      assertEquals(userRetrieved.get("firstName").asText(), userAdded.get("firstName").asText());
-      assertEquals(userRetrieved.get("email").asText(), userAdded.get("email").asText());
+      assertEquals(userRetrieved.get("firstName").asText(), userAdded.get("firstName"));
+      assertEquals(userRetrieved.get("email").asText(), userAdded.get("email"));
     }
   }
 
@@ -1108,11 +1116,12 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void setCurrentUserTenantDataAccess_adminUser_success() {
     useSuperUser();
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("organizationExternalId", TestUserIdentities.DEFAULT_ORGANIZATION)
-            .put("justification", "This is my justification");
+    Map<String, Object> variables =
+        Map.of(
+            "organizationExternalId",
+            TestUserIdentities.DEFAULT_ORGANIZATION,
+            "justification",
+            "This is my justification");
     ObjectNode user =
         (ObjectNode)
             runQuery(
@@ -1138,13 +1147,12 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void setCurrentUserTenantDataAccess_adminUserRemoveAccess_success() {
     useSuperUser();
-    ObjectNode variables = JsonNodeFactory.instance.objectNode();
     ObjectNode user =
         (ObjectNode)
             runQuery(
                     "set-current-user-tenant-data-access",
                     "SetCurrentUserTenantDataAccessOp",
-                    variables,
+                    emptyMap(),
                     null)
                 .get("setCurrentUserTenantDataAccess");
     assertEquals("ruby@example.com", user.get("email").asText());
@@ -1156,11 +1164,12 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   @Test
   void setCurrentUserTenantDataAccess_orgAdminUser_failure() {
     useOrgAdmin();
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("organizationExternalId", TestUserIdentities.DEFAULT_ORGANIZATION)
-            .put("justification", "This is my justification");
+    Map<String, Object> variables =
+        Map.of(
+            "organizationExternalId",
+            TestUserIdentities.DEFAULT_ORGANIZATION,
+            "justification",
+            "This is my justification");
     runQuery(
         "set-current-user-tenant-data-access",
         "SetCurrentUserTenantDataAccessOp",
@@ -1176,11 +1185,10 @@ class ApiUserManagementTest extends BaseGraphqlTest {
           useSuperUser();
           _dataFactory.createValidOrg("The Mall", "k12", "dc-with-trailing-space ", true);
 
-          ObjectNode variables =
-              JsonNodeFactory.instance
-                  .objectNode()
-                  .put("organizationExternalId", "dc-with-trailing-space ")
-                  .put("justification", "This is my justification");
+          Map<String, Object> variables =
+              Map.of(
+                  "organizationExternalId", "dc-with-trailing-space ",
+                  "justification", "This is my justification");
           ObjectNode user =
               (ObjectNode)
                   runQuery(
@@ -1209,7 +1217,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     return list;
   }
 
-  private ObjectNode getAddUserVariables(
+  private Map<String, Object> getAddUserVariables(
       String firstName,
       String middleName,
       String lastName,
@@ -1218,26 +1226,26 @@ class ApiUserManagementTest extends BaseGraphqlTest {
       String orgExternalId,
       String role,
       boolean nestedName) {
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("email", email)
-            .put("organizationExternalId", orgExternalId)
-            .put("role", role);
-    ObjectNode forNameFields = variables;
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("email", email);
+    variables.put("organizationExternalId", orgExternalId);
+    variables.put("role", role);
+
+    HashMap<String, Object> nameInfo = new HashMap<>();
+    nameInfo.put("firstName", firstName);
+    nameInfo.put("middleName", middleName);
+    nameInfo.put("lastName", lastName);
+    nameInfo.put("suffix", suffix);
+
     if (nestedName) {
-      forNameFields = JsonNodeFactory.instance.objectNode();
-      variables.set("name", forNameFields);
+      variables.put("name", nameInfo);
+    } else {
+      variables.putAll(nameInfo);
     }
-    forNameFields
-        .put("firstName", firstName)
-        .put("middleName", middleName)
-        .put("lastName", lastName)
-        .put("suffix", suffix);
     return variables;
   }
 
-  private ObjectNode getAddUserVariables(
+  private Map<String, Object> getAddUserVariables(
       String firstName,
       String middleName,
       String lastName,
@@ -1249,16 +1257,15 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         firstName, middleName, lastName, suffix, email, orgExternalId, role, false);
   }
 
-  private ObjectNode getUpdateUserVariables(
+  private Map<String, Object> getUpdateUserVariables(
       String id, String firstName, String middleName, String lastName, String suffix) {
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("id", id)
-            .put("firstName", firstName)
-            .put("middleName", middleName)
-            .put("lastName", lastName)
-            .put("suffix", suffix);
+    Map<String, Object> variables =
+        Map.of(
+            "id", id,
+            "firstName", firstName,
+            "middleName", middleName,
+            "lastName", lastName,
+            "suffix", suffix);
     return variables;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
@@ -5,13 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.model.CreateDeviceType;
 import gov.cdc.usds.simplereport.api.model.UpdateDeviceType;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -32,15 +33,15 @@ class DeviceManagementTest extends BaseGraphqlTest {
 
   @Test
   void createDeviceTypeNew_orgUser_failure() {
-    ObjectNode variables = getCreateDeviceTypeInput();
+    Map<String, Object> variables = getCreateDeviceTypeInput();
     runQuery("device-type-add", variables, ACCESS_ERROR);
   }
 
   @Test
   void updateDeviceTypeNew_orgUser_failure() {
     ObjectNode someDeviceType = (ObjectNode) fetchSorted().get(0);
-    ObjectNode variables =
-        getCreateDeviceTypeInput().put("id", someDeviceType.get("internalId").asText());
+    HashMap<String, Object> variables = new HashMap<>(getCreateDeviceTypeInput());
+    variables.put("id", someDeviceType.get("internalId").asText());
     runQuery("device-type-add", variables, ACCESS_ERROR);
   }
 
@@ -91,7 +92,7 @@ class DeviceManagementTest extends BaseGraphqlTest {
     return List.of(disease1, disease2, disease3);
   }
 
-  private ObjectNode getCreateDeviceTypeInput() {
+  private Map<String, Object> getCreateDeviceTypeInput() {
 
     List<UUID> specimenTypeIds =
         fetchSpecimenTypeIds().stream().map(UUID::fromString).collect(Collectors.toList());
@@ -109,10 +110,10 @@ class DeviceManagementTest extends BaseGraphqlTest {
             .supportedDiseases(supportedDiseaseIds)
             .build();
 
-    return JsonNodeFactory.instance.objectNode().putPOJO("input", input);
+    return Map.of("input", input);
   }
 
-  private ObjectNode getUpdateDeviceTypeInput(UUID internalId) {
+  private Map<String, Object> getUpdateDeviceTypeInput(UUID internalId) {
 
     List<UUID> specimenTypeIds =
         fetchSpecimenTypeIds().stream().map(UUID::fromString).collect(Collectors.toList());
@@ -131,6 +132,6 @@ class DeviceManagementTest extends BaseGraphqlTest {
             .supportedDiseases(supportedDiseaseIds)
             .build();
 
-    return JsonNodeFactory.instance.objectNode().putPOJO("input", input);
+    return Map.of("input", input);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
 import gov.cdc.usds.simplereport.api.model.Role;
@@ -16,7 +15,9 @@ import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -438,7 +439,7 @@ class PatientManagementTest extends BaseGraphqlTest {
         Optional.empty());
 
     useOrgEntryOnly();
-    ObjectNode variables = JsonNodeFactory.instance.objectNode().put("namePrefixMatch", "San");
+    Map<String, Object> variables = Map.of("namePrefixMatch", "San");
     runQuery(
         "person-with-last-test-result-query", "getPatientsWithLastTestResult", variables, null);
     assertLastAuditEntry(
@@ -468,14 +469,12 @@ class PatientManagementTest extends BaseGraphqlTest {
                     Optional.empty())
                 .get("addPatient");
 
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("patientId", patient.get("internalId").asText())
-            .put("firstName", patient.get("firstName").asText())
-            .put("lastName", patient.get("lastName").asText())
-            .put("birthDate", "1100-12-25")
-            .put(argName, argValue);
+    HashMap<String, Object> variables = new HashMap<>();
+    variables.put("patientId", patient.get("internalId").asText());
+    variables.put("firstName", patient.get("firstName").asText());
+    variables.put("lastName", patient.get("lastName").asText());
+    variables.put("birthDate", "1100-12-25");
+    variables.put(argName, argValue);
     runQuery("update-person", variables, expectedError);
   }
 
@@ -505,10 +504,10 @@ class PatientManagementTest extends BaseGraphqlTest {
   }
 
   private JsonNode fetchPatients(Optional<UUID> facilityId) {
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("facilityId", facilityId.map(UUID::toString).orElse(null));
+    Map<String, Object> variables = null;
+    if (facilityId.isPresent()) {
+      variables = Map.of("facilityId", facilityId.get().toString());
+    }
     return (JsonNode) runQuery("person-query", variables).get("patients");
   }
 
@@ -526,23 +525,22 @@ class PatientManagementTest extends BaseGraphqlTest {
       Optional<UUID> facilityId,
       Optional<String> expectedError)
       throws IOException {
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("patientId", patientId.toString())
-            .put("firstName", firstName)
-            .put("lastName", lastName)
-            .put("birthDate", birthDate)
-            .put("telephone", phone)
-            .put("lookupId", lookupId)
-            .put("facilityId", facilityId.map(UUID::toString).orElse(null));
+    Map<String, Object> variables =
+        new HashMap<>(
+            Map.of(
+                "patientId", patientId.toString(),
+                "firstName", firstName,
+                "lastName", lastName,
+                "birthDate", birthDate,
+                "telephone", phone,
+                "lookupId", lookupId));
+    facilityId.ifPresent(uuid -> variables.put("facilityId", uuid.toString()));
     return runQuery("update-person", variables, expectedError.orElse(null)).get("updatePatient");
   }
 
   private JsonNode executeDeletePersonMutation(UUID patientId, Optional<String> expectedError)
       throws IOException {
-    ObjectNode variables =
-        JsonNodeFactory.instance.objectNode().put("id", patientId.toString()).put("deleted", true);
+    Map<String, Object> variables = Map.of("id", patientId.toString(), "deleted", true);
     return runQuery("delete-person", variables, expectedError.orElse(null))
         .get("setPatientIsDeleted");
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -2,8 +2,6 @@ package gov.cdc.usds.simplereport.api.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
 import gov.cdc.usds.simplereport.api.graphql.BaseGraphqlTest;
 import gov.cdc.usds.simplereport.db.model.Facility;
@@ -15,6 +13,7 @@ import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.TestEventService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,13 +46,14 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
     Person patient = _dataFactory.createFullPerson(organization);
     _dataFactory.createTestOrder(patient, facility);
     // create testEvent via the API to test the view layer hibernate session
-    ObjectNode variables =
-        JsonNodeFactory.instance
-            .objectNode()
-            .put("deviceId", facility.getDefaultDeviceType().getInternalId().toString())
-            .put("patientId", patient.getInternalId().toString())
-            .put("result", TestResult.NEGATIVE.toString())
-            .put("dateTested", "2021-09-01T10:31:30.001Z");
+
+    Map<String, Object> variables =
+        Map.of(
+            "deviceId", facility.getDefaultDeviceType().getInternalId().toString(),
+            "patientId", patient.getInternalId().toString(),
+            "result", TestResult.NEGATIVE.toString(),
+            "dateTested", "2021-09-01T10:31:30.001Z");
+
     submitTestResult(variables, Optional.empty());
     // getting the testEvent can be improve to use the same context as used by the uploader
     testEvent = _testEventService.getLastTestResultsForPatient(patient);
@@ -356,7 +356,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
         false);
   }
 
-  private JsonNode submitTestResult(ObjectNode variables, Optional<String> expectedError) {
+  private JsonNode submitTestResult(Map<String, Object> variables, Optional<String> expectedError) {
     return runQuery("add-test-result-mutation", variables, expectedError.orElse(null));
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- partially addresses https://github.com/CDCgov/prime-simplereport/issues/4266

## Changes Proposed

- update `runQuery` to use `Map<>` instead of `NodeObject`

## Additional Information

- This only affects `test` files
- `Map.of()` produces an **immutable** Map
- to make it **mutable**, you have to wrap it with a `new HashMap()`

