### PR TITLE
Add patientLink createdAt index

### DIFF
--- a/.github/workflows/testDBChangelog.yml
+++ b/.github/workflows/testDBChangelog.yml
@@ -41,5 +41,5 @@ jobs:
         run: touch ../.env && docker compose -f ../docker-compose.yml up -d db
       - name: Run forward migrations
         run: ./gradlew liquibaseUpdate
-      - name: Test rolling back all migrations
-        run: ./gradlew liquibaseRollbackCount -PliquibaseCommandValue=9999
+      - name: Test rolling back on last 20 migrations
+        run: ./gradlew liquibaseRollbackCount -PliquibaseCommandValue=20

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PatientLinkRepository extends EternalAuditedEntityRepository<PatientLink> {
   @Query(
       value =
-          "select DISTINCT on (ordered.test_order_id) * from (select * from {h-schema}patient_link where test_order_id in :testOrderIds order by created_at desc ) ordered",
+          "select DISTINCT on (ordered.test_order_id) * from (select * from {h-schema}patient_link where test_order_id in :testOrderIds order by created_at desc ) ordered where test_order_id in :testOrderIds",
       nativeQuery = true)
   List<PatientLink> findMostRecentByTestOrderIdIn(Collection<UUID> testOrderIds);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PatientLinkRepository extends EternalAuditedEntityRepository<PatientLink> {
   @Query(
       value =
-          "select DISTINCT on (ordered.test_order_id) * from (select * from {h-schema}patient_link where test_order_id in :testOrderIds order by created_at desc ) ordered where test_order_id in :testOrderIds",
+          "select DISTINCT on (ordered.test_order_id) * from (select * from {h-schema}patient_link where test_order_id in :testOrderIds order by created_at desc ) ordered",
       nativeQuery = true)
   List<PatientLink> findMostRecentByTestOrderIdIn(Collection<UUID> testOrderIds);
 

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4116,3 +4116,19 @@ databaseChangeLog:
       rollback:
         truncateTable:
           tableName: feature_flag
+  - changeSet:
+      id: add-index-patient_link-created_at
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: add-index-patient_link-created_at
+        - createIndex:
+            tableName: patient_link
+            indexName: ix__patient_link__created_at
+            columns:
+              - column:
+                  name: created_at
+                  descending:  true
+      rollback:
+        - dropIndex:
+            indexName: ix__patient_link__created_at

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4128,7 +4128,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: created_at
-                  descending:  true
+                  descending: true
       rollback:
         - dropIndex:
             indexName: ix__patient_link__created_at


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- partially addresses #4266

## Changes Proposed

- add `PatientLink.createdAt` index to speed up DB query


## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested

