### PR TITLE
Clean up `result` references in frontend GraphQL and mocks

### DIFF
--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -92,7 +92,6 @@ export const queueQuery = gql`
           number
         }
       }
-      result
       results {
         disease {
           name

--- a/frontend/src/app/testResults/TestResultCorrectionModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.test.tsx
@@ -22,7 +22,7 @@ const internalId = "a665c5d9-ac47-4fd4-8be9-ab7cb5d9f2dd";
 const testResult = {
   testResult: {
     dateTested: "2022-01-28T17:56:48.143Z",
-    result: "NEGATIVE" as TestResult,
+    results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: null,
     noSymptoms: false,
     symptoms: '{"00000":"false"}',

--- a/frontend/src/app/testResults/TestResultCorrectionModal.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.tsx
@@ -72,7 +72,12 @@ export const testQuery = gql`
   query getTestResultForCorrection($id: ID!) {
     testResult(id: $id) {
       dateTested
-      result
+      results {
+        disease {
+          name
+        }
+        testResult
+      }
       correctionStatus
       deviceType {
         name

--- a/frontend/src/app/testResults/TestResultDetailsModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.test.tsx
@@ -6,7 +6,6 @@ import { DetachedTestResultDetailsModal } from "./TestResultDetailsModal";
 
 const nonMultiplexTestResult = {
   dateTested: "2022-01-28T17:56:48.143Z",
-  result: "NEGATIVE" as TestResult,
   results: [
     {
       disease: { name: "COVID-19" as MultiplexDisease },

--- a/frontend/src/app/testResults/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.tsx
@@ -22,7 +22,6 @@ import { MULTIPLEX_DISEASES } from "./constants";
 
 type Result = {
   dateTested: string;
-  result: TestResult;
   results: MultiplexResult[];
   correctionStatus: TestCorrectionStatus;
   noSymptoms: boolean;
@@ -51,7 +50,6 @@ export const testResultDetailsQuery = gql`
   query getTestResultDetails($id: ID!) {
     testResult(id: $id) {
       dateTested
-      result
       results {
         disease {
           name

--- a/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.stories.tsx
@@ -18,7 +18,6 @@ export default {
 
 const testResult = {
   dateTested: new Date("2021-08-20"),
-  result: "NEGATIVE",
   results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
   correctionStatus: null,
   deviceType: {

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -473,18 +473,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 Positive
               </td>
               <td
-                class="test-result-cell"
-                data-testid="flu-a-result"
-              >
-                N/A
-              </td>
-              <td
-                class="test-result-cell"
-                data-testid="flu-b-result"
-              >
-                N/A
-              </td>
-              <td
                 class="test-device-cell"
               >
                 Abbott IDNow
@@ -563,18 +551,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 Negative
               </td>
               <td
-                class="test-result-cell"
-                data-testid="flu-a-result"
-              >
-                N/A
-              </td>
-              <td
-                class="test-result-cell"
-                data-testid="flu-b-result"
-              >
-                N/A
-              </td>
-              <td
                 class="test-device-cell"
               >
                 Abbott IDNow
@@ -651,18 +627,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 data-testid="covid-19-result"
               >
                 Negative
-              </td>
-              <td
-                class="test-result-cell"
-                data-testid="flu-a-result"
-              >
-                N/A
-              </td>
-              <td
-                class="test-result-cell"
-                data-testid="flu-b-result"
-              >
-                N/A
               </td>
               <td
                 class="test-device-cell"

--- a/frontend/src/app/testResults/mocks/queries.mock.tsx
+++ b/frontend/src/app/testResults/mocks/queries.mock.tsx
@@ -75,7 +75,7 @@ export const mocks = [
       data: {
         testResult: {
           dateTested: "2021-03-17T19:27:23.806Z",
-          result: "NEGATIVE",
+          results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
           correctionStatus: "ORIGINAL",
           deviceType: {
             name: "Abbott IDNow",

--- a/frontend/src/app/testResults/mocks/resultsByAllFacilities.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByAllFacilities.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_BY_ALL_FACILITIES = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0123a",
     dateTested: "2021-04-12T12:40:33.381Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -39,7 +38,6 @@ const TEST_RESULTS_BY_ALL_FACILITIES = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsByFacility.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByFacility.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_BY_FACILITY = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0123a",
     dateTested: "2021-04-12T12:40:33.381Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsByPatient.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByPatient.mock.tsx
@@ -2,7 +2,6 @@ const RESULTS_BY_PATIENT = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsByResultValue.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByResultValue.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_BY_RESULT_VALUE = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -41,7 +40,6 @@ const TEST_RESULTS_BY_RESULT_VALUE = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsByRole.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByRole.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_BY_ROLE = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -41,7 +40,6 @@ const TEST_RESULTS_BY_ROLE = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd7aaa1d5",
     dateTested: "2021-03-19T19:27:21.052Z",
-    result: "POSITIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsByStartAndEndDate.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByStartAndEndDate.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_BY_START_END_DATE = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsByStartDate.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByStartDate.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_BY_START_DATE = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -41,7 +40,6 @@ const TEST_RESULTS_BY_START_DATE = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd7aaa1d5",
     dateTested: "2021-03-19T19:27:21.052Z",
-    result: "POSITIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsCSV.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsCSV.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_CSV = [
   {
     facility: { name: "Central Middle School", __typename: "Facility" },
     dateTested: "2022-01-19T16:45:11.446Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     reasonForCorrection: null,
@@ -57,7 +56,6 @@ const TEST_RESULTS_CSV = [
   {
     facility: { name: "Central Middle School", __typename: "Facility" },
     dateTested: "2022-01-19T16:42:46.744Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     reasonForCorrection: null,
@@ -111,7 +109,6 @@ const TEST_RESULTS_CSV = [
   {
     facility: { name: "Central Middle School", __typename: "Facility" },
     dateTested: "2022-01-13T22:44:52.193Z",
-    result: "POSITIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
     correctionStatus: "ORIGINAL",
     reasonForCorrection: null,

--- a/frontend/src/app/testResults/mocks/resultsCovid.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsCovid.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_COVID = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -41,7 +40,6 @@ const TEST_RESULTS_COVID = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
-    result: "NEGATIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {
@@ -80,7 +78,6 @@ const TEST_RESULTS_COVID = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd7aaa1d5",
     dateTested: "2021-03-19T19:27:21.052Z",
-    result: "POSITIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
@@ -2,7 +2,6 @@ const TEST_RESULTS_MULTIPLEX = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
-    result: "NEGATIVE",
     results: [
       { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
       { disease: { name: "Flu A" }, testResult: "POSITIVE" },
@@ -46,7 +45,6 @@ const TEST_RESULTS_MULTIPLEX = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
-    result: "NEGATIVE",
     results: [
       { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
       { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
@@ -95,7 +93,6 @@ const TEST_RESULTS_MULTIPLEX = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd7aaa1d5",
     dateTested: "2021-03-19T19:27:21.052Z",
-    result: "POSITIVE",
     results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
     correctionStatus: "ORIGINAL",
     deviceType: {

--- a/frontend/src/app/testResults/operations.graphql
+++ b/frontend/src/app/testResults/operations.graphql
@@ -41,7 +41,6 @@ query GetFacilityResultsForCsv(
     }
     dateTested
     dateUpdated
-    result
     results {
       disease {
         name
@@ -115,7 +114,6 @@ query GetFacilityResultsMultiplex(
   ) {
     internalId
     dateTested
-    result
     results {
       disease {
         name
@@ -185,7 +183,6 @@ query GetResultsCountByFacility(
 query GetTestResultForPrint($id: ID!) {
   testResult(id: $id) {
     dateTested
-    result
     results {
       disease {
         name

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
@@ -111,8 +111,8 @@ describe("Component ResultsTable", () => {
     );
 
     expect(screen.getByTestId("covid-19-result")).toHaveTextContent("Negative");
-    expect(screen.getByTestId("flu-a-result")).toHaveTextContent("N/A");
-    expect(screen.getByTestId("flu-b-result")).toHaveTextContent("N/A");
+    expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
+    expect(screen.queryByText("Flu B")).not.toBeInTheDocument();
   });
 
   it("checks table with multiplex results", () => {
@@ -124,7 +124,7 @@ describe("Component ResultsTable", () => {
         setDetailsModalId={setDetailsModalIdFn}
         setTextModalId={setTextModalIdFn}
         setEmailModalTestResultId={setEmailModalTestResultIdFn}
-        hasMultiplexResults={false}
+        hasMultiplexResults={true}
         hasFacility={false}
       />
     );
@@ -134,6 +134,9 @@ describe("Component ResultsTable", () => {
         screen.getByTestId(`test-result-${result.internalId}`)
       ).toBeInTheDocument();
     });
+    expect(screen.getByText("COVID-19")).toBeInTheDocument();
+    expect(screen.getByText("Flu A")).toBeInTheDocument();
+    expect(screen.getByText("Flu B")).toBeInTheDocument();
   });
 
   describe("actions menu", () => {

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
@@ -76,11 +76,10 @@ const generateResultRows = (
 
   // `sort` mutates the array, so make a copy
   return [...testResults].sort(byDateTested).map((r) => {
-    const testResultOrder = [
-      MULTIPLEX_DISEASES.COVID_19,
-      MULTIPLEX_DISEASES.FLU_A,
-      MULTIPLEX_DISEASES.FLU_B,
-    ];
+    const testResultOrder = [MULTIPLEX_DISEASES.COVID_19];
+    if (hasMultiplexResults) {
+      testResultOrder.push(MULTIPLEX_DISEASES.FLU_A, MULTIPLEX_DISEASES.FLU_B);
+    }
     const actionItems = [];
     actionItems.push({
       name: "Print result",

--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -10,7 +10,6 @@ const data = [
     },
     dateTested: "2022-06-13T19:24:31.187Z",
     dateUpdated: "2022-03-13T19:24:31.187Z",
-    result: "NEGATIVE",
     results: [
       {
         disease: {

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -23,24 +23,20 @@ export function parseDataForCSV(data: any, multiplexEnabled: boolean) {
       ),
       "Patient date of birth": moment(r.patient.birthDate).format("MM/DD/YYYY"),
       "Test date": moment(r.dateTested).format("MM/DD/YYYY h:mma"),
-      ...(multiplexEnabled
-        ? {
-            "COVID-19 result":
-              TEST_RESULT_DESCRIPTIONS[
-                getResultByDiseaseName(r.results, "COVID-19") as Results
-              ],
-            "Flu A result":
-              TEST_RESULT_DESCRIPTIONS[
-                getResultByDiseaseName(r.results, "Flu A") as Results
-              ],
-            "Flu B result":
-              TEST_RESULT_DESCRIPTIONS[
-                getResultByDiseaseName(r.results, "Flu B") as Results
-              ],
-          }
-        : {
-            "COVID-19 result": TEST_RESULT_DESCRIPTIONS[r.result as Results],
-          }),
+      "COVID-19 result":
+        TEST_RESULT_DESCRIPTIONS[
+          getResultByDiseaseName(r.results, "COVID-19") as Results
+        ],
+      ...(multiplexEnabled && {
+        "Flu A result":
+          TEST_RESULT_DESCRIPTIONS[
+            getResultByDiseaseName(r.results, "Flu A") as Results
+          ],
+        "Flu B result":
+          TEST_RESULT_DESCRIPTIONS[
+            getResultByDiseaseName(r.results, "Flu B") as Results
+          ],
+      }),
       "Result reported date": moment(r.dateUpdated).format("MM/DD/YYYY h:mma"),
       "Test correction status": r.correctionStatus,
       "Test correction reason": r.reasonForCorrection,

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1908,7 +1908,6 @@ export type GetFacilityQueueMultiplexQuery = {
             symptoms?: string | null | undefined;
             symptomOnset?: any | null | undefined;
             noSymptoms?: boolean | null | undefined;
-            result?: string | null | undefined;
             dateTested?: any | null | undefined;
             correctionStatus?: string | null | undefined;
             reasonForCorrection?: string | null | undefined;
@@ -2243,8 +2242,22 @@ export type GetTestResultForCorrectionQuery = {
     | {
         __typename?: "TestResult";
         dateTested?: any | null | undefined;
-        result?: string | null | undefined;
         correctionStatus?: string | null | undefined;
+        results?:
+          | Array<
+              | {
+                  __typename?: "MultiplexResult";
+                  testResult?: string | null | undefined;
+                  disease?:
+                    | { __typename?: "SupportedDisease"; name: string }
+                    | null
+                    | undefined;
+                }
+              | null
+              | undefined
+            >
+          | null
+          | undefined;
         deviceType?:
           | { __typename?: "DeviceType"; name: string }
           | null
@@ -2300,7 +2313,6 @@ export type GetTestResultDetailsQuery = {
     | {
         __typename?: "TestResult";
         dateTested?: any | null | undefined;
-        result?: string | null | undefined;
         correctionStatus?: string | null | undefined;
         symptoms?: string | null | undefined;
         symptomOnset?: any | null | undefined;
@@ -2451,7 +2463,6 @@ export type GetFacilityResultsForCsvQuery = {
             __typename?: "TestResult";
             dateTested?: any | null | undefined;
             dateUpdated?: any | null | undefined;
-            result?: string | null | undefined;
             correctionStatus?: string | null | undefined;
             reasonForCorrection?: string | null | undefined;
             symptoms?: string | null | undefined;
@@ -2563,7 +2574,6 @@ export type GetFacilityResultsMultiplexQuery = {
             __typename?: "TestResult";
             internalId?: string | null | undefined;
             dateTested?: any | null | undefined;
-            result?: string | null | undefined;
             correctionStatus?: string | null | undefined;
             results?:
               | Array<
@@ -2688,7 +2698,6 @@ export type GetTestResultForPrintQuery = {
     | {
         __typename?: "TestResult";
         dateTested?: any | null | undefined;
-        result?: string | null | undefined;
         correctionStatus?: string | null | undefined;
         results?:
           | Array<
@@ -5675,7 +5684,6 @@ export const GetFacilityQueueMultiplexDocument = gql`
           number
         }
       }
-      result
       results {
         disease {
           name
@@ -6259,7 +6267,12 @@ export const GetTestResultForCorrectionDocument = gql`
   query getTestResultForCorrection($id: ID!) {
     testResult(id: $id) {
       dateTested
-      result
+      results {
+        disease {
+          name
+        }
+        testResult
+      }
       correctionStatus
       deviceType {
         name
@@ -6428,7 +6441,6 @@ export const GetTestResultDetailsDocument = gql`
   query getTestResultDetails($id: ID!) {
     testResult(id: $id) {
       dateTested
-      result
       results {
         disease {
           name
@@ -6761,7 +6773,6 @@ export const GetFacilityResultsForCsvDocument = gql`
       }
       dateTested
       dateUpdated
-      result
       results {
         disease {
           name
@@ -6894,7 +6905,6 @@ export const GetFacilityResultsMultiplexDocument = gql`
     ) {
       internalId
       dateTested
-      result
       results {
         disease {
           name
@@ -7132,7 +7142,6 @@ export const GetTestResultForPrintDocument = gql`
   query GetTestResultForPrint($id: ID!) {
     testResult(id: $id) {
       dateTested
-      result
       results {
         disease {
           name

--- a/frontend/src/patientApp/timeOfTest/TestResult.stories.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.stories.tsx
@@ -24,7 +24,6 @@ export default {
 const data = {
   testResult: {
     testEventId: "12321312",
-    result: "POSITIVE" as TestResult,
     results: [
       { disease: { name: "COVID-19" }, testResult: "POSITIVE" },
     ] as MultiplexResult[],


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- frontend work for #3757
- continuation of #4222
- unblocks #4259 for future merge

## Changes Proposed
This PR accomplishes the following:
  - stops referencing `result` field on frontend GraphQL calls
  - cleans up mock data to remove `result` field
  - cleans up storybook data to remove `result` field (will need to remove feature flag check for storybook to display these properly -- which should be accomplished in #4301)
  - cleans up another instance of frontend referencing `result` ([see this comment](https://github.com/CDCgov/prime-simplereport/pull/4306#discussion_r976958972))
  - **NEW** Fixes the results table issue for results without flu results

## Additional Information
N/A

## Testing
Smoke test parts of the app that uses test results:
  - test queue
  - results tab
     - correct a result
     - view details
     - print modal
     - download results

## Screenshots / Demos
Fixed! 
<img width="1432" alt="Screen Shot 2022-09-22 at 4 34 54 PM" src="https://user-images.githubusercontent.com/20211771/191855497-0b55dbb7-b6c0-42cd-9a65-60b2fedb2945.png">

<img width="1464" alt="Screen Shot 2022-09-22 at 4 35 06 PM" src="https://user-images.githubusercontent.com/20211771/191855460-5cdef705-86c6-4142-9755-ee049a6a5c7d.png">
