### PR TITLE
Remove Touchpoints temporarily

### DIFF
--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { ToastContainer } from "react-toastify";
 
 import "react-toastify/dist/ReactToastify.css";
-import TouchpointsButton from "../../analytics/TouchpointsButton";
+// import TouchpointsButton from "../../analytics/TouchpointsButton";
 import { getUrl } from "../../utils/url";
 import USAGovBanner from "../USAGovBanner";
 
@@ -61,7 +61,8 @@ const Page: React.FC<Props> = ({ header, children, isPatientApp }) => {
         />
       </div>
       <footer>
-        <TouchpointsButton />
+        {/*  Disabling Touchpoints until we have designs that specify how to contact Support */}
+        {/*<TouchpointsButton />*/}
       </footer>
     </div>
   );

--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import { ToastContainer } from "react-toastify";
 
 import "react-toastify/dist/ReactToastify.css";
-// import TouchpointsButton from "../../analytics/TouchpointsButton";
 import { getUrl } from "../../utils/url";
 import USAGovBanner from "../USAGovBanner";
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Related to #4309 
 
## Changes Proposed

- Disable Touchpoints on the app as users keep trying to use it as an alternative to the support inbox.
- Once we have new designs that emphasize this is separate from support, we can re-enable.
