### PR TITLE
Change device selection to MultiSelect

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
@@ -34,6 +34,7 @@ function ManageDevicesContainer(props: { selectedDevices: DeviceType[] }) {
       selectedDevices={selectedDevices}
       updateSelectedDevices={updateSelectedDevices}
       errors={{}}
+      clearError={jest.fn}
     />
   );
 }

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
@@ -90,7 +90,9 @@ describe("ManageDevices", () => {
 
       within(pillContainer).getByText("Device A");
       within(pillContainer).getByText("Device B");
-      expect(within(pillContainer).queryByText("Device C")).not.toBeInTheDocument();
+      expect(
+        within(pillContainer).queryByText("Device C")
+      ).not.toBeInTheDocument();
     });
 
     it("allows user to add a device type to the existing list of devices", async () => {
@@ -113,7 +115,9 @@ describe("ManageDevices", () => {
       within(pillContainer).getByText("Device A");
       fireEvent.click(deleteIcon);
 
-      expect(within(pillContainer).queryByText("Device A")).not.toBeInTheDocument();
+      expect(
+        within(pillContainer).queryByText("Device A")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
@@ -108,9 +108,7 @@ describe("ManageDevices", () => {
 
     it("removes a device from the list", async () => {
       const pillContainer = screen.getByTestId("pill-container");
-      const deleteIcon = within(pillContainer).getAllByTestId("-pill-delete", {
-        exact: false,
-      })[0];
+      const deleteIcon = within(pillContainer).getAllByRole("button")[0];
 
       within(pillContainer).getByText("Device A");
       fireEvent.click(deleteIcon);

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
@@ -58,80 +58,62 @@ describe("ManageDevices", () => {
     });
 
     it("renders a list of devices", () => {
-      const dropdowns = screen.getAllByRole("combobox");
+      const multiselect = screen.getByTestId("multi-select");
 
-      expect(dropdowns.length).toBe(2);
-
-      const [deviceOne, deviceTwo] = dropdowns;
-
-      expect(deviceOne).toHaveValue(devices[0].internalId);
-      expect(deviceTwo).toHaveValue(devices[1].internalId);
+      expect(multiselect).toBeInTheDocument();
     });
 
     it("renders the device dropdown in alphabetical order", async () => {
-      const dropdowns = screen.getAllByRole("combobox");
-
-      expect(dropdowns.length).toBe(2);
-
-      const [deviceOne] = dropdowns;
-
-      const deviceOptions = await within(deviceOne).findAllByRole("option");
-
-      expect(
-        deviceOptions.map(
-          (deviceOption) => (deviceOption as HTMLOptionElement).value
-        )
-      ).toStrictEqual([
+      const multiselect = screen.getByTestId("multi-select");
+      const deviceList = within(multiselect).getByTestId(
+        "multi-select-option-list"
+      );
+      const deviceOptionIds = within(deviceList)
+        .getAllByTestId("multi-select-option-device", { exact: false })
+        .map((deviceOption) => deviceOption.id);
+      const expectedDeviceOptionIds = [
         deviceA.internalId,
         deviceB.internalId,
         deviceC.internalId,
-      ]);
-    });
+      ];
 
-    it("allows user to change the device type on an existing device", async () => {
-      const [deviceDropdown] = await screen.findAllByRole("combobox");
-
-      userEvent.selectOptions(deviceDropdown, "device-a");
-
+      expect(deviceOptionIds.length === expectedDeviceOptionIds.length);
       expect(
-        ((
-          await screen.findAllByRole("option", {
-            name: "Device A",
-          })
-        )[0] as HTMLOptionElement).selected
-      ).toBeTruthy();
+        deviceOptionIds.every(
+          (id, index) => id === expectedDeviceOptionIds[index]
+        )
+      );
     });
 
-    it("prevents selecting a device type more than once", () => {
-      const [devices] = screen.getAllByRole("combobox");
+    it("renders the selected devices", async () => {
+      const pillContainer = screen.getByTestId("pill-container");
 
-      const option = within(devices).getByText("Device A") as HTMLOptionElement;
-      expect(option.disabled).toBeTruthy();
+      within(pillContainer).getByText("Device A");
+      within(pillContainer).getByText("Device B");
+      expect(within(pillContainer).queryByText("Device C")).not.toBeInTheDocument();
     });
 
-    it("adds a device to the list", async () => {
-      const dropdowns = await screen.findAllByRole("combobox");
+    it("allows user to add a device type to the existing list of devices", async () => {
+      const deviceInput = screen.getByTestId("multi-select-toggle");
+      const deviceList = screen.getByTestId("multi-select-option-list");
 
-      expect(dropdowns.length).toBe(2);
+      userEvent.click(deviceInput);
+      userEvent.click(within(deviceList).getByText("Device C"));
 
-      fireEvent.click(screen.getByText("Add device", { exact: false }));
-
-      const updatedDropdowns = await screen.findAllByRole("combobox");
-      expect(updatedDropdowns.length).toBe(3);
+      const pillContainer = screen.getByTestId("pill-container");
+      within(pillContainer).getByText("Device C");
     });
 
     it("removes a device from the list", async () => {
-      const dropdowns = await screen.findAllByRole("combobox");
+      const pillContainer = screen.getByTestId("pill-container");
+      const deleteIcon = within(pillContainer).getAllByTestId("-pill-delete", {
+        exact: false,
+      })[0];
 
-      expect(dropdowns.length).toBe(2);
+      within(pillContainer).getByText("Device A");
+      fireEvent.click(deleteIcon);
 
-      fireEvent.click(
-        screen.getAllByLabelText("Delete device", { exact: false })[0]
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const updatedDropdowns = await screen.findAllByRole("combobox");
-      expect(updatedDropdowns.length).toBe(1);
+      expect(within(pillContainer).queryByText("Device A")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -66,7 +66,11 @@ const ManageDevices: React.FC<Props> = ({
           errorMessage={errors.deviceTypes}
           validationStatus={errors.deviceTypes ? "error" : "success"}
           required
+          placeholder="Add device"
         />
+        {!selectedDevices.length ? (
+          <p> There are currently no devices </p>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -8,6 +8,7 @@ interface Props {
   selectedDevices: DeviceType[];
   updateSelectedDevices: (deviceTypes: DeviceType[]) => void;
   errors: FacilityErrors;
+  clearError: (field: keyof FacilityErrors) => void;
 }
 
 const ManageDevices: React.FC<Props> = ({
@@ -15,13 +16,8 @@ const ManageDevices: React.FC<Props> = ({
   selectedDevices,
   updateSelectedDevices,
   errors,
+  clearError,
 }) => {
-  const deviceErrors: React.ReactNode[] = [];
-
-  if (errors.deviceTypes) {
-    deviceErrors.push(errors.deviceTypes);
-  }
-
   const getDeviceTypeOptions = Array.from(
     deviceTypes.map((device) => ({
       label: device.name,
@@ -40,12 +36,8 @@ const ManageDevices: React.FC<Props> = ({
   };
 
   const updateDevices = (newDeviceIds: String[]) => {
-    // validation does not work as expected here,
-    // only works on the second selection, not the first;
-    // add to props if we decide to use
-    // validateField("deviceTypes");
-    const newDevices = getDeviceTypesFromIds(newDeviceIds);
-    updateSelectedDevices(newDevices);
+    clearError("deviceTypes");
+    updateSelectedDevices(getDeviceTypesFromIds(newDeviceIds));
   };
 
   const getInitialValues = selectedDevices.length
@@ -71,18 +63,11 @@ const ManageDevices: React.FC<Props> = ({
           }}
           options={getDeviceTypeOptions}
           initialSelectedValues={getInitialValues}
-          // Other option for validation
-          // errorMessage={deviceErrors.map((err, index) => { return err})}
-          // validationStatus={deviceErrors.length > 0 ? "error" : "success"}
+          errorMessage={errors.deviceTypes}
+          validationStatus={errors.deviceTypes ? "error" : "success"}
+          required
         />
       </div>
-      {deviceErrors.length > 0 && (
-        <ul className="text-bold text-secondary-vivid margin-top-0">
-          {deviceErrors.map((err, index) => (
-            <li key={index}>{err}</li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 };

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -759,10 +759,7 @@ describe("FacilityForm", () => {
 
       const pillContainer = screen.getByTestId("pill-container");
 
-      const deleteButtons = within(pillContainer).getAllByTestId(
-        "-pill-delete",
-        { exact: false }
-      );
+      const deleteButtons = within(pillContainer).getAllByRole("button");
       deleteButtons.forEach((button) => fireEvent.click(button));
 
       expect(
@@ -796,10 +793,7 @@ describe("FacilityForm", () => {
 
       // Delete devices
       const pillContainer = screen.getByTestId("pill-container");
-      const deleteButtons = within(pillContainer).getAllByTestId(
-        "-pill-delete",
-        { exact: false }
-      );
+      const deleteButtons = within(pillContainer).getAllByRole("button");
       deleteButtons.forEach((button) => fireEvent.click(button));
 
       expect(

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -746,7 +746,7 @@ describe("FacilityForm", () => {
   });
 
   describe("Device validation", () => {
-    it("warns about missing device selection", async () => {
+    beforeEach(() => {
       render(
         <MemoryRouter>
           <FacilityForm
@@ -756,56 +756,30 @@ describe("FacilityForm", () => {
           />
         </MemoryRouter>
       );
+    });
 
-      const pillContainer = screen.getByTestId("pill-container");
+    it("warns about missing device selection", async () => {
+      await deleteAllDevices();
 
-      const deleteButtons = within(pillContainer).getAllByRole("button");
-      deleteButtons.forEach((button) => fireEvent.click(button));
+      await screen.findByText("There are currently no devices", {
+        exact: false,
+      });
 
-      expect(
-        await screen.findByText("There are currently no devices", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
+      await attemptSaveDevices();
 
-      // Attempt save
-      const saveButtons = await screen.findAllByText("Save changes");
-      await waitFor(async () => expect(saveButtons[0]).toBeEnabled());
-      userEvent.click(saveButtons[0]);
-
-      const warning = await screen.findByText(
-        "There must be at least one device",
-        { exact: false }
-      );
-      expect(warning).toBeInTheDocument();
+      await screen.findByText("There must be at least one device", {
+        exact: false,
+      });
     });
 
     it("resolves the error when a device is selected", async () => {
-      render(
-        <MemoryRouter>
-          <FacilityForm
-            facility={validFacility}
-            deviceTypes={devices}
-            saveFacility={saveFacility}
-          />
-        </MemoryRouter>
-      );
+      await deleteAllDevices();
 
-      // Delete devices
-      const pillContainer = screen.getByTestId("pill-container");
-      const deleteButtons = within(pillContainer).getAllByRole("button");
-      deleteButtons.forEach((button) => fireEvent.click(button));
+      await screen.findByText("There are currently no devices", {
+        exact: false,
+      });
 
-      expect(
-        await screen.findByText("There are currently no devices", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-
-      // Attempt save
-      const saveButtons = await screen.findAllByText("Save changes");
-      await waitFor(async () => expect(saveButtons[0]).toBeEnabled());
-      userEvent.click(saveButtons[0]);
+      await attemptSaveDevices();
 
       await screen.findByText("There must be at least one device", {
         exact: false,
@@ -817,7 +791,7 @@ describe("FacilityForm", () => {
       userEvent.click(deviceInput);
       userEvent.click(within(deviceList).getByText("Device 1"));
 
-      // Post condition
+      // Expect no errors
       expect(
         screen.queryByText("There are currently no devices", {
           exact: false,
@@ -831,6 +805,18 @@ describe("FacilityForm", () => {
     });
   });
 });
+
+async function attemptSaveDevices() {
+  const saveButtons = await screen.findAllByText("Save changes");
+  await waitFor(async () => expect(saveButtons[0]).toBeEnabled());
+  userEvent.click(saveButtons[0]);
+}
+
+async function deleteAllDevices() {
+  const pillContainer = screen.getByTestId("pill-container");
+  const deleteButtons = within(pillContainer).getAllByRole("button");
+  deleteButtons.forEach((button) => fireEvent.click(button));
+}
 
 async function validateAddress(
   saveFacility: (facility: Facility) => void,

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -814,8 +814,8 @@ describe("FacilityForm", () => {
       userEvent.click(saveButtons[0]);
 
       await screen.findByText("There must be at least one device", {
-            exact: false,
-          });
+        exact: false,
+      });
 
       // Select Device
       const deviceInput = screen.getByTestId("multi-select-toggle");

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -59,33 +59,6 @@ const validFacility: Facility = {
   deviceTypes: devices,
 };
 
-const facilityWithoutDevices: Facility = {
-  name: "Foo Facility",
-  cliaNumber: "12D4567890",
-  phone: "(202) 395-3080",
-  street: "736 Jackson Pl NW",
-  zipCode: "20503",
-  state: "AZ",
-  id: "some-id",
-  email: null,
-  streetTwo: null,
-  city: null,
-  orderingProvider: {
-    firstName: "Frank",
-    lastName: "Grimes",
-    NPI: "000",
-    street: null,
-    zipCode: null,
-    state: null,
-    middleName: null,
-    suffix: null,
-    phone: "phone",
-    streetTwo: null,
-    city: null,
-  },
-  deviceTypes: [],
-};
-
 // Hardcoded suggestion scenarios
 const addresses = [
   {
@@ -814,14 +787,21 @@ describe("FacilityForm", () => {
       render(
         <MemoryRouter>
           <FacilityForm
-            facility={facilityWithoutDevices}
+            facility={validFacility}
             deviceTypes={devices}
             saveFacility={saveFacility}
           />
         </MemoryRouter>
       );
 
-      // Pre condition
+      // Delete devices
+      const pillContainer = screen.getByTestId("pill-container");
+      const deleteButtons = within(pillContainer).getAllByTestId(
+        "-pill-delete",
+        { exact: false }
+      );
+      deleteButtons.forEach((button) => fireEvent.click(button));
+
       expect(
         await screen.findByText("There are currently no devices", {
           exact: false,
@@ -833,11 +813,9 @@ describe("FacilityForm", () => {
       await waitFor(async () => expect(saveButtons[0]).toBeEnabled());
       userEvent.click(saveButtons[0]);
 
-      expect(
-        await screen.findByText("There must be at least one device", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
+      await screen.findByText("There must be at least one device", {
+            exact: false,
+          });
 
       // Select Device
       const deviceInput = screen.getByTestId("multi-select-toggle");

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -98,7 +98,7 @@ export const useFacilityValidation = (facility: Facility) => {
     }
   };
 
-  return { errors, validateField, validateFacility };
+  return { errors, clearError, validateField, validateFacility };
 };
 
 const createStateError = (stateCode: string | number) => {
@@ -163,9 +163,12 @@ const FacilityForm: React.FC<Props> = (props) => {
     }));
   };
 
-  const { errors, validateField, validateFacility } = useFacilityValidation(
-    facility
-  );
+  const {
+    errors,
+    clearError,
+    validateField,
+    validateFacility,
+  } = useFacilityValidation(facility);
 
   const getFacilityAddress = (f: Nullable<Facility>): AddressWithMetaData => {
     return {
@@ -376,6 +379,7 @@ const FacilityForm: React.FC<Props> = (props) => {
           selectedDevices={facility.deviceTypes}
           updateSelectedDevices={updateSelectedDevices}
           errors={errors}
+          clearError={clearError}
         />
         <div className="float-right margin-bottom-4 margin-top-4">
           <Button

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -93,8 +93,6 @@ export const useFacilityValidation = (facility: Facility) => {
       );
       showNotification(alert);
       let firstError = document.querySelector("[aria-invalid=true]");
-      console.log("focusing");
-      console.log(firstError);
       (firstError as HTMLElement)?.focus();
       return "error";
     }

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -93,6 +93,8 @@ export const useFacilityValidation = (facility: Facility) => {
       );
       showNotification(alert);
       let firstError = document.querySelector("[aria-invalid=true]");
+      console.log("focusing");
+      console.log(firstError);
       (firstError as HTMLElement)?.focus();
       return "error";
     }

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.scss
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.scss
@@ -22,6 +22,7 @@
   }
 
   .close-button {
+    color: #005ea2;
     cursor: pointer;
     width: 24px;
     height: 24px;
@@ -31,6 +32,11 @@
   }
 }
 
-.pill-container.sr-pill-container--hidden {
+.pill-container.pill-container--hidden {
   display: none;
+}
+
+.fieldset--unstyled {
+  border: none;
+  padding: inherit;
 }

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.scss
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.scss
@@ -1,4 +1,3 @@
-
 .multi-select-dropdown {
   max-width: unset !important;
 }
@@ -30,4 +29,8 @@
     align-items: center;
     justify-content: center;
   }
+}
+
+.pill-container.sr-pill-container--hidden {
+  display: none;
 }

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.test.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.test.tsx
@@ -17,84 +17,129 @@ const fruitOptions: MultiSelectDropdownOption[] = [
   { label: "Strawberries", value: "Strawberries" },
 ];
 
+const onChange = jest.fn();
+
+const renderWithoutInitialOptions = () => {
+  render(
+    <MultiSelect
+      name="fruits"
+      label="Favorite Fruit"
+      onChange={onChange}
+      options={fruitOptions}
+    />
+  );
+};
+
+const renderWithInitialOptions = () => {
+  render(
+    <MultiSelect
+      name="fruits"
+      label="Favorite Fruit"
+      onChange={onChange}
+      options={fruitOptions}
+      initialSelectedValues={["Apples", "Bananas"]}
+    />
+  );
+};
+
 describe("Multi Select", () => {
-  const onChange = jest.fn();
-
-  beforeEach(() => {
-    render(
-      <MultiSelect
-        name="fruits"
-        label="Favorite Fruit"
-        onChange={onChange}
-        options={fruitOptions}
-      />
-    );
-  });
-
-  it("should display the label", () => {
-    expect(screen.getByText("Favorite Fruit")).toBeInTheDocument();
-  });
-
-  it("should display the option list when clicking on the input", () => {
-    const optionList = screen.getByTestId("multi-select-option-list");
-    expect(optionList).toBeInTheDocument();
-    expect(optionList.children.length).toEqual(6);
-    expect(within(optionList).getByText("Apples")).toBeInTheDocument();
-    expect(within(optionList).getByText("Bananas")).toBeInTheDocument();
-    expect(within(optionList).getByText("Blueberries")).toBeInTheDocument();
-    expect(within(optionList).getByText("Grapes")).toBeInTheDocument();
-    expect(within(optionList).getByText("Oranges")).toBeInTheDocument();
-    expect(within(optionList).getByText("Strawberries")).toBeInTheDocument();
-  });
-
-  describe("when selecting an item", () => {
+  describe("With no initial options", () => {
     beforeEach(() => {
-      userEvent.click(screen.getByTestId("multi-select-input"));
+      renderWithoutInitialOptions();
+    });
+
+    it("should display the label", () => {
+      expect(screen.getByText("Favorite Fruit")).toBeInTheDocument();
+    });
+
+    it("should display the option list when clicking on the input", () => {
       const optionList = screen.getByTestId("multi-select-option-list");
-      userEvent.click(within(optionList).getByText("Apples"));
-      userEvent.click(within(optionList).getByText("Oranges"));
+      expect(optionList).toBeInTheDocument();
+      expect(optionList.children.length).toEqual(6);
+      expect(within(optionList).getByText("Apples")).toBeInTheDocument();
+      expect(within(optionList).getByText("Bananas")).toBeInTheDocument();
+      expect(within(optionList).getByText("Blueberries")).toBeInTheDocument();
+      expect(within(optionList).getByText("Grapes")).toBeInTheDocument();
+      expect(within(optionList).getByText("Oranges")).toBeInTheDocument();
+      expect(within(optionList).getByText("Strawberries")).toBeInTheDocument();
+    });
+  });
+
+  describe("With initial options", () => {
+    beforeEach(() => {
+      renderWithInitialOptions();
     });
 
-    it("should show the pill with the selected item's label", () => {
-      const pillContainer = screen.getByTestId("pill-container");
-      expect(pillContainer).toBeInTheDocument();
-
-      // children includes a legend, so length is 1 more than selected items
-      expect(pillContainer.children.length).toEqual(3);
-      within(pillContainer).getByText("Apples");
-      within(pillContainer).getByText("Oranges");
-    });
-    it("should show the remove the selected options from the options list", () => {
+    it("should display only the options that have not been selected", () => {
       const optionList = screen.getByTestId("multi-select-option-list");
       expect(optionList).toBeInTheDocument();
       expect(optionList.children.length).toEqual(4);
       expect(within(optionList).queryByText("Apples")).not.toBeInTheDocument();
-      expect(within(optionList).queryByText("Oranges")).not.toBeInTheDocument();
+      expect(within(optionList).queryByText("Bananas")).not.toBeInTheDocument();
+      expect(within(optionList).getByText("Blueberries")).toBeInTheDocument();
+      expect(within(optionList).getByText("Grapes")).toBeInTheDocument();
+      expect(within(optionList).getByText("Oranges")).toBeInTheDocument();
+      expect(within(optionList).getByText("Strawberries")).toBeInTheDocument();
     });
+  });
 
-    describe("when deleting a selected item", () => {
+  describe("selecting and unselecting", () => {
+    beforeEach(() => {
+      renderWithoutInitialOptions();
+    });
+    describe("when selecting an item", () => {
       beforeEach(() => {
-        const pillContainer = screen.getByTestId("pill-container");
-        expect(pillContainer).toBeInTheDocument();
-        userEvent.click(within(pillContainer).getAllByRole("button")[0]);
         userEvent.click(screen.getByTestId("multi-select-input"));
+        const optionList = screen.getByTestId("multi-select-option-list");
+        userEvent.click(within(optionList).getByText("Apples"));
+        userEvent.click(within(optionList).getByText("Oranges"));
       });
 
-      it("should remove the pill ", () => {
+      it("should show the pill with the selected item's label", () => {
         const pillContainer = screen.getByTestId("pill-container");
         expect(pillContainer).toBeInTheDocument();
 
         // children includes a legend, so length is 1 more than selected items
-        expect(pillContainer.children.length).toEqual(2);
+        expect(pillContainer.children.length).toEqual(3);
+        within(pillContainer).getByText("Apples");
         within(pillContainer).getByText("Oranges");
       });
-      it("should make the option available to select", () => {
+      it("should show the remove the selected options from the options list", () => {
         const optionList = screen.getByTestId("multi-select-option-list");
         expect(optionList).toBeInTheDocument();
-        expect(optionList.children.length).toEqual(5);
+        expect(optionList.children.length).toEqual(4);
+        expect(
+          within(optionList).queryByText("Apples")
+        ).not.toBeInTheDocument();
         expect(
           within(optionList).queryByText("Oranges")
         ).not.toBeInTheDocument();
+      });
+
+      describe("when deleting a selected item", () => {
+        beforeEach(() => {
+          const pillContainer = screen.getByTestId("pill-container");
+          expect(pillContainer).toBeInTheDocument();
+          userEvent.click(within(pillContainer).getAllByRole("button")[0]);
+          userEvent.click(screen.getByTestId("multi-select-input"));
+        });
+
+        it("should remove the pill ", () => {
+          const pillContainer = screen.getByTestId("pill-container");
+          expect(pillContainer).toBeInTheDocument();
+
+          // children includes a legend, so length is 1 more than selected items
+          expect(pillContainer.children.length).toEqual(2);
+          within(pillContainer).getByText("Oranges");
+        });
+        it("should make the option available to select", () => {
+          const optionList = screen.getByTestId("multi-select-option-list");
+          expect(optionList).toBeInTheDocument();
+          expect(optionList.children.length).toEqual(5);
+          expect(
+            within(optionList).queryByText("Oranges")
+          ).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.test.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.test.tsx
@@ -59,7 +59,8 @@ describe("Multi Select", () => {
       const pillContainer = screen.getByTestId("pill-container");
       expect(pillContainer).toBeInTheDocument();
 
-      expect(pillContainer.children.length).toEqual(2);
+      // children includes a legend, so length is 1 more than selected items
+      expect(pillContainer.children.length).toEqual(3);
       within(pillContainer).getByText("Apples");
       within(pillContainer).getByText("Oranges");
     });
@@ -75,9 +76,7 @@ describe("Multi Select", () => {
       beforeEach(() => {
         const pillContainer = screen.getByTestId("pill-container");
         expect(pillContainer).toBeInTheDocument();
-        userEvent.click(
-          within(pillContainer).getByTestId("Apples-pill-delete")
-        );
+        userEvent.click(within(pillContainer).getAllByRole("button")[0]);
         userEvent.click(screen.getByTestId("multi-select-input"));
       });
 
@@ -85,7 +84,8 @@ describe("Multi Select", () => {
         const pillContainer = screen.getByTestId("pill-container");
         expect(pillContainer).toBeInTheDocument();
 
-        expect(pillContainer.children.length).toEqual(1);
+        // children includes a legend, so length is 1 more than selected items
+        expect(pillContainer.children.length).toEqual(2);
         within(pillContainer).getByText("Oranges");
       });
       it("should make the option available to select", () => {

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -161,7 +161,14 @@ export const MultiSelect = ({
             className="multi-select-dropdown"
             disabled={isDisabled}
           />
-          <div className="pill-container" data-testid="pill-container">
+          <div
+            className={`pill-container ${
+              selectedItems &&
+              selectedItems.length < 1 &&
+              "sr-pill-container--hidden"
+            }`}
+            data-testid="pill-container"
+          >
             {selectedItems &&
               selectedItems.map((value) => {
                 const option = options.find((item) => item.value === value);

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -43,7 +43,6 @@ const Pill = (props: PillProps) => (
     {props.option.label}
     <Button
       className="close-button usa-button--unstyled"
-      data-testid={`${props.option.label}-pill-delete`}
       onClick={() => props.onDelete(props.option)}
     >
       <FontAwesomeIcon

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -55,8 +55,10 @@ const Pill = (props: PillProps) => (
   </div>
 );
 
-const getSortedOptions = (options: MultiSelectDropdownOption[]) =>
-  _.orderBy(options, ["label"], ["asc"]);
+const getSortedOptions = (options: MultiSelectDropdownOption[]) => {
+  const sortedOptions = _.orderBy(options, ["label"], ["asc"]);
+  return _.uniqBy(sortedOptions, "value");
+};
 
 export const MultiSelect = ({
   name,
@@ -99,14 +101,10 @@ export const MultiSelect = ({
     const selectedItemsSet = new Set(selectedItems);
     selectedItemsSet.delete(option.value);
     setSelectedItems(Array.from(selectedItemsSet));
+
     const sortedOptions = getSortedOptions([...availableOptions, option]);
     setAvailableOptions(sortedOptions);
   };
-
-  useEffect(() => {
-    const sortedOptions = getSortedOptions([...options]);
-    setAvailableOptions(sortedOptions);
-  }, [options, setAvailableOptions]);
 
   useEffect(() => {
     if (selectedItems) {

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -55,11 +55,6 @@ const Pill = (props: PillProps) => (
   </div>
 );
 
-const getSortedOptions = (options: MultiSelectDropdownOption[]) => {
-  const sortedOptions = _.orderBy(options, ["label"], ["asc"]);
-  return _.uniqBy(sortedOptions, "value");
-};
-
 export const MultiSelect = ({
   name,
   label,
@@ -79,9 +74,22 @@ export const MultiSelect = ({
 }: MultiSelectProps): React.ReactElement => {
   const isDisabled = !!disabled;
 
+  const getInitialOptions = (options: MultiSelectDropdownOption[]) => {
+    const alreadySelected = initialSelectedValues || [];
+
+    return options.filter((option) => {
+      return !alreadySelected.includes(option.value);
+    });
+  };
+
+  const getSortedOptions = (options: MultiSelectDropdownOption[]) => {
+    const sortedOptions = _.orderBy(options, ["label"], ["asc"]);
+    return _.uniqBy(sortedOptions, "value");
+  };
+
   const [availableOptions, setAvailableOptions] = useState<
     MultiSelectDropdownOption[]
-  >(getSortedOptions(options));
+  >(getSortedOptions(getInitialOptions(options)));
 
   const [selectedItems, setSelectedItems] = useState<string[] | undefined>(
     initialSelectedValues

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -49,7 +49,7 @@ const Pill = (props: PillProps) => (
         aria-hidden={false}
         fontSize={24}
         icon={"times"}
-        aria-label={"Delete device"}
+        aria-label={`Delete ${props.option.label}`}
       />
     </Button>
   </div>

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -12,6 +12,7 @@ import MultiSelectDropdown, {
 } from "./MultiSelectDropdown/MultiSelectDropdown";
 
 import "./MultiSelect.scss";
+import Button from "../Button/Button";
 
 export type MultiSelectProps = {
   name: string;
@@ -40,13 +41,18 @@ type PillProps = {
 const Pill = (props: PillProps) => (
   <div className="pill">
     {props.option.label}
-    <div
-      className="close-button"
+    <Button
+      className="close-button usa-button--unstyled"
       data-testid={`${props.option.label}-pill-delete`}
       onClick={() => props.onDelete(props.option)}
     >
-      <FontAwesomeIcon fontSize={24} icon={"times"} />
-    </div>
+      <FontAwesomeIcon
+        aria-hidden={false}
+        fontSize={24}
+        icon={"times"}
+        aria-label={"Delete device"}
+      />
+    </Button>
   </div>
 );
 
@@ -165,14 +171,15 @@ export const MultiSelect = ({
             placeholder={placeholder}
             ariaInvalid={validationStatus === "error"}
           />
-          <div
-            className={`pill-container${
+          <fieldset
+            className={`fieldset--unstyled pill-container${
               selectedItems && selectedItems.length < 1
-                ? " sr-pill-container--hidden"
+                ? " pill-container--hidden"
                 : ""
             }`}
             data-testid="pill-container"
           >
+            <legend className="usa-sr-only">{`Selected ${name}`}</legend>
             {selectedItems &&
               selectedItems.map((value) => {
                 const option = options.find((item) => item.value === value);
@@ -186,7 +193,7 @@ export const MultiSelect = ({
                   )
                 );
               })}
-          </div>
+          </fieldset>
         </div>
       )}
     </UIDConsumer>

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -29,6 +29,7 @@ export type MultiSelectProps = {
   initialSelectedValues?: string[];
   disabled?: boolean;
   inputProps?: JSX.IntrinsicElements["input"];
+  placeholder?: string;
 };
 
 type PillProps = {
@@ -67,6 +68,7 @@ export const MultiSelect = ({
   options,
   disabled,
   initialSelectedValues,
+  placeholder,
 }: MultiSelectProps): React.ReactElement => {
   const isDisabled = !!disabled;
 
@@ -160,12 +162,13 @@ export const MultiSelect = ({
             onChange={onItemSelected}
             className="multi-select-dropdown"
             disabled={isDisabled}
+            placeholder={placeholder}
           />
           <div
-            className={`pill-container ${
-              selectedItems &&
-              selectedItems.length < 1 &&
-              "sr-pill-container--hidden"
+            className={`pill-container${
+              selectedItems && selectedItems.length < 1
+                ? " sr-pill-container--hidden"
+                : ""
             }`}
             data-testid="pill-container"
           >

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -179,7 +179,7 @@ export const MultiSelect = ({
             }`}
             data-testid="pill-container"
           >
-            <legend className="usa-sr-only">{`Selected ${name}`}</legend>
+            <legend className="usa-sr-only">{`Selected ${label}`}</legend>
             {selectedItems &&
               selectedItems.map((value) => {
                 const option = options.find((item) => item.value === value);

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -163,6 +163,7 @@ export const MultiSelect = ({
             className="multi-select-dropdown"
             disabled={isDisabled}
             placeholder={placeholder}
+            ariaInvalid={validationStatus === "error"}
           />
           <div
             className={`pill-container${

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelect.tsx
@@ -6,13 +6,13 @@ import _ from "lodash";
 
 import Required from "../Required";
 import Optional from "../Optional";
+import Button from "../Button/Button";
 
 import MultiSelectDropdown, {
   MultiSelectDropdownOption,
 } from "./MultiSelectDropdown/MultiSelectDropdown";
 
 import "./MultiSelect.scss";
-import Button from "../Button/Button";
 
 export type MultiSelectProps = {
   name: string;

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
@@ -43,10 +43,8 @@ describe("MultiSelectDropdown component", () => {
         onChange={jest.fn()}
       />
     );
-    expect(screen.getByRole("multi-select-input")).toBeInTheDocument();
-    expect(screen.getByRole("multi-select-input")).toBeInstanceOf(
-      HTMLInputElement
-    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInstanceOf(HTMLInputElement);
   });
 
   it("renders hidden options list on load", () => {

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -40,6 +40,7 @@ interface MultiSelectDropDownProps {
   onChange: (option: MultiSelectDropdownOption) => void;
   noResults?: string;
   inputProps?: JSX.IntrinsicElements["input"];
+  placeholder?: string;
 }
 
 interface InputProps {
@@ -175,6 +176,7 @@ export const MultiSelectDropdown = ({
   onChange,
   noResults,
   inputProps,
+  placeholder,
 }: MultiSelectDropDownProps): React.ReactElement => {
   const isDisabled = !!disabled;
 
@@ -269,6 +271,7 @@ export const MultiSelectDropdown = ({
         aria-owns={listID}
         aria-expanded={state.isOpen}
         disabled={isDisabled}
+        placeholder={placeholder}
         {...inputProps}
       />
       <span className="usa-combo-box__input-button-separator">&nbsp;</span>

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -269,7 +269,8 @@ export const MultiSelectDropdown = ({
         onKeyDown={handleInputKeyDown(dispatch, state, selectOption)}
         value={state.inputValue}
         focused={state.focusMode === FocusMode.Input}
-        role="multi-select-input"
+        role="combobox"
+        aria-label={placeholder}
         aria-owns={listID}
         aria-expanded={state.isOpen}
         aria-invalid={ariaInvalid}
@@ -284,7 +285,7 @@ export const MultiSelectDropdown = ({
           type="button"
           className="usa-combo-box__toggle-list"
           tabIndex={-1}
-          aria-label="Toggle the dropdown list"
+          aria-hidden={"true"}
           onClick={(): void =>
             dispatch({
               type: state.isOpen

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -41,6 +41,7 @@ interface MultiSelectDropDownProps {
   noResults?: string;
   inputProps?: JSX.IntrinsicElements["input"];
   placeholder?: string;
+  ariaInvalid?: boolean;
 }
 
 interface InputProps {
@@ -177,6 +178,7 @@ export const MultiSelectDropdown = ({
   noResults,
   inputProps,
   placeholder,
+  ariaInvalid,
 }: MultiSelectDropDownProps): React.ReactElement => {
   const isDisabled = !!disabled;
 
@@ -270,6 +272,7 @@ export const MultiSelectDropdown = ({
         role="multi-select-input"
         aria-owns={listID}
         aria-expanded={state.isOpen}
+        aria-invalid={ariaInvalid}
         disabled={isDisabled}
         placeholder={placeholder}
         {...inputProps}

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -448,7 +448,7 @@ Object {
                           class="usa-combo-box__input"
                           data-testid="multi-select-input"
                           disabled=""
-                          role="multi-select-input"
+                          role="combobox"
                           type="text"
                           value=""
                         />
@@ -462,7 +462,7 @@ Object {
                           tabindex="-1"
                         >
                           <button
-                            aria-label="Toggle the dropdown list"
+                            aria-hidden="true"
                             class="usa-combo-box__toggle-list"
                             data-testid="multi-select-toggle"
                             disabled=""
@@ -525,10 +525,16 @@ Object {
                           role="status"
                         />
                       </div>
-                      <div
-                        class="pill-container"
+                      <fieldset
+                        class="fieldset--unstyled pill-container"
                         data-testid="pill-container"
-                      />
+                      >
+                        <legend
+                          class="usa-sr-only"
+                        >
+                          Selected SNOMED code for swab type(s)
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -569,7 +575,7 @@ Object {
                           class="usa-combo-box__input"
                           data-testid="multi-select-input"
                           disabled=""
-                          role="multi-select-input"
+                          role="combobox"
                           type="text"
                           value=""
                         />
@@ -583,7 +589,7 @@ Object {
                           tabindex="-1"
                         >
                           <button
-                            aria-label="Toggle the dropdown list"
+                            aria-hidden="true"
                             class="usa-combo-box__toggle-list"
                             data-testid="multi-select-toggle"
                             disabled=""
@@ -620,10 +626,16 @@ Object {
                           role="status"
                         />
                       </div>
-                      <div
-                        class="pill-container"
+                      <fieldset
+                        class="fieldset--unstyled pill-container"
                         data-testid="pill-container"
-                      />
+                      >
+                        <legend
+                          class="usa-sr-only"
+                        >
+                          Selected Supported diseases
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -1078,7 +1090,7 @@ Object {
                         class="usa-combo-box__input"
                         data-testid="multi-select-input"
                         disabled=""
-                        role="multi-select-input"
+                        role="combobox"
                         type="text"
                         value=""
                       />
@@ -1092,7 +1104,7 @@ Object {
                         tabindex="-1"
                       >
                         <button
-                          aria-label="Toggle the dropdown list"
+                          aria-hidden="true"
                           class="usa-combo-box__toggle-list"
                           data-testid="multi-select-toggle"
                           disabled=""
@@ -1155,10 +1167,16 @@ Object {
                         role="status"
                       />
                     </div>
-                    <div
-                      class="pill-container"
+                    <fieldset
+                      class="fieldset--unstyled pill-container"
                       data-testid="pill-container"
-                    />
+                    >
+                      <legend
+                        class="usa-sr-only"
+                      >
+                        Selected SNOMED code for swab type(s)
+                      </legend>
+                    </fieldset>
                   </div>
                 </div>
               </div>
@@ -1199,7 +1217,7 @@ Object {
                         class="usa-combo-box__input"
                         data-testid="multi-select-input"
                         disabled=""
-                        role="multi-select-input"
+                        role="combobox"
                         type="text"
                         value=""
                       />
@@ -1213,7 +1231,7 @@ Object {
                         tabindex="-1"
                       >
                         <button
-                          aria-label="Toggle the dropdown list"
+                          aria-hidden="true"
                           class="usa-combo-box__toggle-list"
                           data-testid="multi-select-toggle"
                           disabled=""
@@ -1250,10 +1268,16 @@ Object {
                         role="status"
                       />
                     </div>
-                    <div
-                      class="pill-container"
+                    <fieldset
+                      class="fieldset--unstyled pill-container"
                       data-testid="pill-container"
-                    />
+                    >
+                      <legend
+                        class="usa-sr-only"
+                      >
+                        Selected Supported diseases
+                      </legend>
+                    </fieldset>
                   </div>
                 </div>
               </div>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -441,6 +441,7 @@ Object {
                       >
                         <input
                           aria-expanded="false"
+                          aria-invalid="false"
                           aria-owns="multi-select-swabTypes-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -561,6 +562,7 @@ Object {
                       >
                         <input
                           aria-expanded="false"
+                          aria-invalid="false"
                           aria-owns="multi-select-supportedDiseases-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -1069,6 +1071,7 @@ Object {
                     >
                       <input
                         aria-expanded="false"
+                        aria-invalid="false"
                         aria-owns="multi-select-swabTypes-list"
                         autocapitalize="off"
                         autocomplete="off"
@@ -1189,6 +1192,7 @@ Object {
                     >
                       <input
                         aria-expanded="false"
+                        aria-invalid="false"
                         aria-owns="multi-select-supportedDiseases-list"
                         autocapitalize="off"
                         autocomplete="off"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -279,6 +279,7 @@ Object {
                       >
                         <input
                           aria-expanded="false"
+                          aria-invalid="false"
                           aria-owns="multi-select-swabTypes-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -371,6 +372,7 @@ Object {
                       >
                         <input
                           aria-expanded="false"
+                          aria-invalid="false"
                           aria-owns="multi-select-supportedDiseases-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -718,6 +720,7 @@ Object {
                     >
                       <input
                         aria-expanded="false"
+                        aria-invalid="false"
                         aria-owns="multi-select-swabTypes-list"
                         autocapitalize="off"
                         autocomplete="off"
@@ -810,6 +813,7 @@ Object {
                     >
                       <input
                         aria-expanded="false"
+                        aria-invalid="false"
                         aria-owns="multi-select-supportedDiseases-list"
                         autocapitalize="off"
                         autocomplete="off"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -285,7 +285,7 @@ Object {
                           autocomplete="off"
                           class="usa-combo-box__input"
                           data-testid="multi-select-input"
-                          role="multi-select-input"
+                          role="combobox"
                           type="text"
                           value=""
                         />
@@ -299,7 +299,7 @@ Object {
                           tabindex="-1"
                         >
                           <button
-                            aria-label="Toggle the dropdown list"
+                            aria-hidden="true"
                             class="usa-combo-box__toggle-list"
                             data-testid="multi-select-toggle"
                             tabindex="-1"
@@ -335,10 +335,16 @@ Object {
                           role="status"
                         />
                       </div>
-                      <div
-                        class="pill-container"
+                      <fieldset
+                        class="fieldset--unstyled pill-container"
                         data-testid="pill-container"
-                      />
+                      >
+                        <legend
+                          class="usa-sr-only"
+                        >
+                          Selected SNOMED code for swab type(s)
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -378,7 +384,7 @@ Object {
                           autocomplete="off"
                           class="usa-combo-box__input"
                           data-testid="multi-select-input"
-                          role="multi-select-input"
+                          role="combobox"
                           type="text"
                           value=""
                         />
@@ -392,7 +398,7 @@ Object {
                           tabindex="-1"
                         >
                           <button
-                            aria-label="Toggle the dropdown list"
+                            aria-hidden="true"
                             class="usa-combo-box__toggle-list"
                             data-testid="multi-select-toggle"
                             tabindex="-1"
@@ -428,10 +434,16 @@ Object {
                           role="status"
                         />
                       </div>
-                      <div
-                        class="pill-container"
+                      <fieldset
+                        class="fieldset--unstyled pill-container"
                         data-testid="pill-container"
-                      />
+                      >
+                        <legend
+                          class="usa-sr-only"
+                        >
+                          Selected Supported diseases
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -726,7 +738,7 @@ Object {
                         autocomplete="off"
                         class="usa-combo-box__input"
                         data-testid="multi-select-input"
-                        role="multi-select-input"
+                        role="combobox"
                         type="text"
                         value=""
                       />
@@ -740,7 +752,7 @@ Object {
                         tabindex="-1"
                       >
                         <button
-                          aria-label="Toggle the dropdown list"
+                          aria-hidden="true"
                           class="usa-combo-box__toggle-list"
                           data-testid="multi-select-toggle"
                           tabindex="-1"
@@ -776,10 +788,16 @@ Object {
                         role="status"
                       />
                     </div>
-                    <div
-                      class="pill-container"
+                    <fieldset
+                      class="fieldset--unstyled pill-container"
                       data-testid="pill-container"
-                    />
+                    >
+                      <legend
+                        class="usa-sr-only"
+                      >
+                        Selected SNOMED code for swab type(s)
+                      </legend>
+                    </fieldset>
                   </div>
                 </div>
               </div>
@@ -819,7 +837,7 @@ Object {
                         autocomplete="off"
                         class="usa-combo-box__input"
                         data-testid="multi-select-input"
-                        role="multi-select-input"
+                        role="combobox"
                         type="text"
                         value=""
                       />
@@ -833,7 +851,7 @@ Object {
                         tabindex="-1"
                       >
                         <button
-                          aria-label="Toggle the dropdown list"
+                          aria-hidden="true"
                           class="usa-combo-box__toggle-list"
                           data-testid="multi-select-toggle"
                           tabindex="-1"
@@ -869,10 +887,16 @@ Object {
                         role="status"
                       />
                     </div>
-                    <div
-                      class="pill-container"
+                    <fieldset
+                      class="fieldset--unstyled pill-container"
                       data-testid="pill-container"
-                    />
+                    >
+                      <legend
+                        class="usa-sr-only"
+                      >
+                        Selected Supported diseases
+                      </legend>
+                    </fieldset>
                   </div>
                 </div>
               </div>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -448,7 +448,7 @@ Object {
                           class="usa-combo-box__input"
                           data-testid="multi-select-input"
                           disabled=""
-                          role="multi-select-input"
+                          role="combobox"
                           type="text"
                           value=""
                         />
@@ -462,7 +462,7 @@ Object {
                           tabindex="-1"
                         >
                           <button
-                            aria-label="Toggle the dropdown list"
+                            aria-hidden="true"
                             class="usa-combo-box__toggle-list"
                             data-testid="multi-select-toggle"
                             disabled=""
@@ -525,10 +525,16 @@ Object {
                           role="status"
                         />
                       </div>
-                      <div
-                        class="pill-container"
+                      <fieldset
+                        class="fieldset--unstyled pill-container"
                         data-testid="pill-container"
-                      />
+                      >
+                        <legend
+                          class="usa-sr-only"
+                        >
+                          Selected SNOMED code for swab type(s)
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -569,7 +575,7 @@ Object {
                           class="usa-combo-box__input"
                           data-testid="multi-select-input"
                           disabled=""
-                          role="multi-select-input"
+                          role="combobox"
                           type="text"
                           value=""
                         />
@@ -583,7 +589,7 @@ Object {
                           tabindex="-1"
                         >
                           <button
-                            aria-label="Toggle the dropdown list"
+                            aria-hidden="true"
                             class="usa-combo-box__toggle-list"
                             data-testid="multi-select-toggle"
                             disabled=""
@@ -620,10 +626,16 @@ Object {
                           role="status"
                         />
                       </div>
-                      <div
-                        class="pill-container"
+                      <fieldset
+                        class="fieldset--unstyled pill-container"
                         data-testid="pill-container"
-                      />
+                      >
+                        <legend
+                          class="usa-sr-only"
+                        >
+                          Selected Supported diseases
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -1081,7 +1093,7 @@ Object {
                         class="usa-combo-box__input"
                         data-testid="multi-select-input"
                         disabled=""
-                        role="multi-select-input"
+                        role="combobox"
                         type="text"
                         value=""
                       />
@@ -1095,7 +1107,7 @@ Object {
                         tabindex="-1"
                       >
                         <button
-                          aria-label="Toggle the dropdown list"
+                          aria-hidden="true"
                           class="usa-combo-box__toggle-list"
                           data-testid="multi-select-toggle"
                           disabled=""
@@ -1158,10 +1170,16 @@ Object {
                         role="status"
                       />
                     </div>
-                    <div
-                      class="pill-container"
+                    <fieldset
+                      class="fieldset--unstyled pill-container"
                       data-testid="pill-container"
-                    />
+                    >
+                      <legend
+                        class="usa-sr-only"
+                      >
+                        Selected SNOMED code for swab type(s)
+                      </legend>
+                    </fieldset>
                   </div>
                 </div>
               </div>
@@ -1202,7 +1220,7 @@ Object {
                         class="usa-combo-box__input"
                         data-testid="multi-select-input"
                         disabled=""
-                        role="multi-select-input"
+                        role="combobox"
                         type="text"
                         value=""
                       />
@@ -1216,7 +1234,7 @@ Object {
                         tabindex="-1"
                       >
                         <button
-                          aria-label="Toggle the dropdown list"
+                          aria-hidden="true"
                           class="usa-combo-box__toggle-list"
                           data-testid="multi-select-toggle"
                           disabled=""
@@ -1253,10 +1271,16 @@ Object {
                         role="status"
                       />
                     </div>
-                    <div
-                      class="pill-container"
+                    <fieldset
+                      class="fieldset--unstyled pill-container"
                       data-testid="pill-container"
-                    />
+                    >
+                      <legend
+                        class="usa-sr-only"
+                      >
+                        Selected Supported diseases
+                      </legend>
+                    </fieldset>
                   </div>
                 </div>
               </div>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -441,6 +441,7 @@ Object {
                       >
                         <input
                           aria-expanded="false"
+                          aria-invalid="false"
                           aria-owns="multi-select-swabTypes-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -561,6 +562,7 @@ Object {
                       >
                         <input
                           aria-expanded="false"
+                          aria-invalid="false"
                           aria-owns="multi-select-supportedDiseases-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -1072,6 +1074,7 @@ Object {
                     >
                       <input
                         aria-expanded="false"
+                        aria-invalid="false"
                         aria-owns="multi-select-swabTypes-list"
                         autocapitalize="off"
                         autocomplete="off"
@@ -1192,6 +1195,7 @@ Object {
                     >
                       <input
                         aria-expanded="false"
+                        aria-invalid="false"
                         aria-owns="multi-select-supportedDiseases-list"
                         autocapitalize="off"
                         autocomplete="off"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #4269 #4098 #4095

- Use a MultiSelect for device selection on the Manage Facilities page

## Changes Proposed

- [x] Replaces the device selection table (multiple dropdowns + trashcans) with a single multiselect
- [x] Fixes up error handling for device selection
  - Removed the existing error handling on `ManageDevices` component - this implementation was not tied to the rest of the form errors on the page, and was not properly accessible. Error handling now works like the rest of the form and focuses properly.
  - functionally, nothing changed on the multiselect component wrt error handling, just added a css class to render the error more prettily
  - device validation happens _only_ on `Save changes` for the facility page, see notes below
  - changing device selection clears existing errors
 - [x] Fixes up accessibility issues
   - #4098 MultiSelect replaces the former trash can icons with `X` on pills. Modified the pills to use buttons and proper aria elements for accessibility.
   - #4095 Refactored the MultiSelect to use a valid aria role (combobox) - selection now works via keyboard - and aria label
   - Refactored the pill container to use a fieldset and an sr-only legend so the grouping now makes sense to screenreaders
 - [x] Frontend tests
   - snapshot tests - updates snaps for both facility/device management and for admin pages, since the multiselect component changed and is also featured on admin pages 
   - tests for multiselect, manage devices, and manage facility

## Additional Information

- Error validation - it was not working correctly before, this seemed like the right time to fix it. Form error caused by selecting no devices did not clear after device selection, it now does. Note that validation is only on `Save changes` for the facility page. This is because the fancy facility form validation does not support multiselect dropdown item arrays, and adding this custom capability would have made the code even more obtuse.  I tried adding it to the custom `onBlur` for MultiSelect like on other fields on the page, however this got very messy. I additionally did not want to break the boundary between `ManageDevices` and `MultiSelect`, and there was not a clean way to push the validation down.
- Accessibility should now be better for any pages that use `MultiSelect`! 🎉 

## Testing

- Check out the `Manage Devices` page in `dev.simplereport.gov` and ensure that the MultiSelect component is fully accessible
- I ran this implementation through AXE DevTools and there are no longer any flagged issues, but it would be great to have this confirmed

## Screenshots / Demos

- Mouse navigation of device addition/deletion (+ error handling)

https://user-images.githubusercontent.com/89797785/193041370-0330f9f8-f00e-4775-8d37-078ce85e835c.mov

- Accessible navigation of device addition/deletion (+ error handling)

https://user-images.githubusercontent.com/89797785/193041278-cf912d74-d42a-45ca-b84e-7c86846b660e.mov

- Accessibility concerns
  - has error id, see #4329 
![Screen Shot 2022-09-29 at 9 30 15 AM](https://user-images.githubusercontent.com/89797785/193045199-133e326f-1169-4539-ac98-09a97ef886aa.png)

- delete icon is visible to screenreaders, see #4098
![Screen Shot 2022-09-29 at 9 34 47 AM](https://user-images.githubusercontent.com/89797785/193046012-18a7cdd7-16de-4a12-bab7-66010cacd2dc.png)
![Screen Shot 2022-09-29 at 10 47 45 AM](https://user-images.githubusercontent.com/89797785/193063969-cd013b00-8f3a-4a0e-8b73-8926a9ddaf07.png)

- MultiSelect has a valid aria-role and aria-label, see #4095, and selections are in an accessible fieldset
![Screen Shot 2022-09-29 at 10 29 47 AM](https://user-images.githubusercontent.com/89797785/193059498-31466d15-d963-4282-a328-212ce507095a.png)

![Screen Shot 2022-09-29 at 10 47 45 AM](https://user-images.githubusercontent.com/89797785/193063969-cd013b00-8f3a-4a0e-8b73-8926a9ddaf07.png)


## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved - @kenieh 
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams
- [ ] engineers - please review the Chromatic changes!

### Accessibility
- [ ] Any changes do not cause accessibility regressions


<!---


### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
