### PR TITLE
Only org admins can search for archived patients

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -151,7 +151,7 @@ export const DetachedTestResultsList = ({
   ] = useLazyQuery(QUERY_PATIENT, {
     fetchPolicy: "no-cache",
     variables: {
-      includeArchived: true,
+      includeArchived: isOrgAdmin,
       facilityId:
         filterParams.filterFacilityId === ALL_FACILITIES_ID
           ? null


### PR DESCRIPTION
## Related Issue

- Follow-up to #3567 
- Received the following support request:
    - > There is an error in Simple Report, when searching a name under results it gives an error. The error reads “Current user does not have permission to supply a non-default value for [includeArchived]. Please check errors and try again”.
    - Non-admin users did not have permissions to set the `includeArchived` parameter

## Changes Proposed
- Only org admins can search for test results for archived patients

## Screenshots / Demos

https://user-images.githubusercontent.com/27730981/192010599-fc0599ad-065b-4d16-9459-587e41a6f323.mov

<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
