### PR TITLE
Set manage facilities active when viewing facility

### DIFF
--- a/frontend/src/app/Settings/SettingsNav.test.tsx
+++ b/frontend/src/app/Settings/SettingsNav.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import SettingsNav from "./SettingsNav";
@@ -11,5 +11,35 @@ describe("SettingsNav", () => {
       </MemoryRouter>
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it("displays manage facilities as active when viewing all facilities", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/facilities"]}>
+        <SettingsNav />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Manage facilities")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByText("Manage facilities")).toHaveClass("active", {
+      exact: true,
+    });
+  });
+
+  it("displays manage facilities as active when viewing specific facility", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/facility/some-uuid"]}>
+        <SettingsNav />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Manage facilities").parentElement).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByText("Manage facilities")).toHaveClass("active", {
+      exact: true,
+    });
   });
 });

--- a/frontend/src/app/Settings/SettingsNav.test.tsx
+++ b/frontend/src/app/Settings/SettingsNav.test.tsx
@@ -23,6 +23,9 @@ describe("SettingsNav", () => {
         "aria-current",
         "page"
       );
+      expect(
+        screen.getByText("Manage facilities").parentElement
+      ).not.toHaveAttribute("aria-current");
       expect(screen.getByText("Manage facilities")).toHaveClass("active", {
         exact: true,
       });

--- a/frontend/src/app/Settings/SettingsNav.test.tsx
+++ b/frontend/src/app/Settings/SettingsNav.test.tsx
@@ -12,34 +12,46 @@ describe("SettingsNav", () => {
     );
     expect(container).toMatchSnapshot();
   });
-
-  it("displays manage facilities as active when viewing all facilities", () => {
-    render(
-      <MemoryRouter initialEntries={["/settings/facilities"]}>
-        <SettingsNav />
-      </MemoryRouter>
-    );
-    expect(screen.getByText("Manage facilities")).toHaveAttribute(
-      "aria-current",
-      "page"
-    );
-    expect(screen.getByText("Manage facilities")).toHaveClass("active", {
-      exact: true,
+  describe("ManageFacility", () => {
+    it("displays as active when viewing all facilities", () => {
+      render(
+        <MemoryRouter initialEntries={["/settings/facilities"]}>
+          <SettingsNav />
+        </MemoryRouter>
+      );
+      expect(screen.getByText("Manage facilities")).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
+      expect(screen.getByText("Manage facilities")).toHaveClass("active", {
+        exact: true,
+      });
     });
-  });
-
-  it("displays manage facilities as active when viewing specific facility", () => {
-    render(
-      <MemoryRouter initialEntries={["/settings/facility/some-uuid"]}>
-        <SettingsNav />
-      </MemoryRouter>
-    );
-    expect(screen.getByText("Manage facilities").parentElement).toHaveAttribute(
-      "aria-current",
-      "page"
-    );
-    expect(screen.getByText("Manage facilities")).toHaveClass("active", {
-      exact: true,
+    it("displays as active when viewing specific facility", () => {
+      render(
+        <MemoryRouter initialEntries={["/settings/facility/some-uuid"]}>
+          <SettingsNav />
+        </MemoryRouter>
+      );
+      expect(
+        screen.getByText("Manage facilities").parentElement
+      ).toHaveAttribute("aria-current", "page");
+      expect(screen.getByText("Manage facilities")).toHaveClass("active", {
+        exact: true,
+      });
+    });
+    it("displays as active when adding new facility", () => {
+      render(
+        <MemoryRouter initialEntries={["/settings/add-facility/some-uuid"]}>
+          <SettingsNav />
+        </MemoryRouter>
+      );
+      expect(
+        screen.getByText("Manage facilities").parentElement
+      ).toHaveAttribute("aria-current", "page");
+      expect(screen.getByText("Manage facilities")).toHaveClass("active", {
+        exact: true,
+      });
     });
   });
 });

--- a/frontend/src/app/Settings/SettingsNav.tsx
+++ b/frontend/src/app/Settings/SettingsNav.tsx
@@ -11,7 +11,6 @@ const SettingsNav = () => {
   const location = useLocation();
   const onFacilitiesPage =
     location.pathname.startsWith("/settings/facility") ||
-    location.pathname.startsWith("/settings/facilities") ||
     location.pathname.startsWith("/settings/add-facility");
   const classNameByActiveFacility = ({ isActive }: { isActive: boolean }) => {
     return isActive || onFacilitiesPage ? "active" : "";

--- a/frontend/src/app/Settings/SettingsNav.tsx
+++ b/frontend/src/app/Settings/SettingsNav.tsx
@@ -1,10 +1,19 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 
 const SettingsNav = () => {
-  const classNameByActive = ({ isActive }: { isActive: boolean }) =>
-    isActive ? "active" : "";
+  const classNameByActive = ({ isActive }: { isActive: boolean }) => {
+    return isActive ? "active" : "";
+  };
+
+  const location = useLocation();
+  const onFacilitiesPage = location.pathname.startsWith("/settings/facilit");
+  const classNameByActiveFacility = ({ isActive }: { isActive: boolean }) => {
+    return isActive || onFacilitiesPage ? "active" : "";
+  };
+  const facilityActive = onFacilitiesPage ? "page" : undefined;
 
   return (
     <nav className="prime-secondary-nav" aria-label="Secondary navigation">
@@ -14,10 +23,10 @@ const SettingsNav = () => {
             Manage users
           </LinkWithQuery>
         </li>
-        <li className="usa-nav__secondary-item">
+        <li className="usa-nav__secondary-item" aria-current={facilityActive}>
           <LinkWithQuery
             to={`/settings/facilities`}
-            className={classNameByActive}
+            className={classNameByActiveFacility}
           >
             Manage facilities
           </LinkWithQuery>

--- a/frontend/src/app/Settings/SettingsNav.tsx
+++ b/frontend/src/app/Settings/SettingsNav.tsx
@@ -9,7 +9,10 @@ const SettingsNav = () => {
   };
 
   const location = useLocation();
-  const onFacilitiesPage = location.pathname.startsWith("/settings/facilit");
+  const onFacilitiesPage =
+    location.pathname.startsWith("/settings/facility") ||
+    location.pathname.startsWith("/settings/facilities") ||
+    location.pathname.startsWith("/settings/add-facility");
   const classNameByActiveFacility = ({ isActive }: { isActive: boolean }) => {
     return isActive || onFacilitiesPage ? "active" : "";
   };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4096 
- Manage facility tab is not "active", when viewing specific facility details or adding a new facility.

## Changes Proposed

- Update the `isActive` function to also check the other facility pages. If on one of the facilities page, set the tab to active and set `aria-current="page"`

## Additional Information

- On the manage facilities page, the`aria-current` is set on the link where as for the other facility pages is set on the list item. There is no way to remove the `aria-current` property on the [`navLink`](https://github.com/remix-run/react-router/blob/f3009f5536b6bb3354bfe91d5ff02dd2fae91285/packages/react-router-dom/index.tsx#L426).

## Testing

- Check that the Manage Facilities tab stays active as going through the facility related pages. 
- Ensure that there are no accessibility issues. 

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/10108172/192041076-c061a95f-7197-4be9-9e63-95c4a98e6bf5.png)
![image](https://user-images.githubusercontent.com/10108172/192041149-13db98c3-0e38-4e58-abf9-2e7c9a3fd9a9.png)
![image](https://user-images.githubusercontent.com/10108172/192041200-ebcddbd1-6bab-4738-95b9-b59114985815.png)

<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
