### PR TITLE
remove redundant where clause in findMostRecentByTestOrderIdIn

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PatientLinkRepository extends EternalAuditedEntityRepository<PatientLink> {
   @Query(
       value =
-          "select DISTINCT on (ordered.test_order_id) * from (select * from {h-schema}patient_link where test_order_id in :testOrderIds order by created_at desc ) ordered where test_order_id in :testOrderIds",
+          "select DISTINCT on (ordered.test_order_id) * from (select * from {h-schema}patient_link where test_order_id in :testOrderIds order by created_at desc ) ordered",
       nativeQuery = true)
   List<PatientLink> findMostRecentByTestOrderIdIn(Collection<UUID> testOrderIds);
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- partially addresses #4266

## Changes Proposed

- removes extra where clause in query!


## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested

