### PR TITLE
set focus on first field with aria invalid on facility form

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -242,6 +242,27 @@ describe("FacilityForm", () => {
       const state = await screen.findByText("Palau", { exact: false });
       expect(state).toBeInTheDocument();
     });
+
+    it("focuses on error with facility name", async () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      const saveButton = await screen.getAllByText("Save changes")[0];
+      userEvent.type(
+        screen.getByLabelText("Testing facility name", { exact: false }),
+        ""
+      );
+      userEvent.click(saveButton);
+      expect(
+        screen.getByLabelText("Testing facility name", { exact: false })
+      ).toHaveFocus();
+    });
   });
 
   describe("CLIA number validation", () => {

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -92,6 +92,8 @@ export const useFacilityValidation = (facility: Facility) => {
         />
       );
       showNotification(alert);
+      let firstError = document.querySelector("[aria-invalid=true]");
+      (firstError as HTMLElement)?.focus();
       return "error";
     }
   };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4094 

## Changes Proposed

- Set error on the very first error form

## Additional Information

## Testing

- fill out the form one by one and make sure that the focus changes to the invalid field. 

## Screenshots / Demos


https://user-images.githubusercontent.com/10108172/192058668-d5325d00-08e1-4eca-ba11-bab5c9b726e3.mp4


<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
