### PR TITLE
Rename "All facilities" link text

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -128,6 +128,23 @@ describe("FacilityForm", () => {
   });
 
   describe("form submission", () => {
+    it("has a link to return to all facilities page", () => {
+      render(
+        <MemoryRouter>
+          <FacilityForm
+            facility={validFacility}
+            deviceTypes={devices}
+            saveFacility={saveFacility}
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByText("Back to all facilities")).toBeInTheDocument();
+      expect(screen.getByText("Back to all facilities")).toHaveAttribute(
+        "href",
+        "/settings/facilities"
+      );
+    });
+
     it("submits a valid form", async () => {
       render(
         <MemoryRouter>

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -329,7 +329,7 @@ const FacilityForm: React.FC<Props> = (props) => {
                       to={`/settings/facilities`}
                       className="margin-left-05"
                     >
-                      All facilities
+                      Back to all facilities
                     </LinkWithQuery>
                   </>
                 )}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #4097 

## Changes Proposed
Renames the "All facilities" link that takes a user back to `/facilities` to "Back to all facilities" so that it is more descriptive to users accessing the page from a screen reader


## Additional Information
In a separate story, we might want to check-in with design about spacing between the link and the facility name if a user is exploring an existing facility.

How it looks now:
<img width="995" alt="Screen Shot 2022-09-24 at 3 58 13 PM" src="https://user-images.githubusercontent.com/20211771/192118596-f7fcd16c-5edd-4031-8715-c60e25f2f23b.png">

## Testing
- Ensure the back link works as intended
- Ensure no new accessibility issues were introduced

## Screenshots / Demos
<img width="1010" alt="Screen Shot 2022-09-24 at 3 55 03 PM" src="https://user-images.githubusercontent.com/20211771/192118623-ef349807-7d23-47ce-97eb-d83f2641f2de.png">
<img width="1010" alt="Screen Shot 2022-09-24 at 3 54 52 PM" src="https://user-images.githubusercontent.com/20211771/192118625-079f3950-de84-402b-a93a-0761049f55b9.png">
