### PR TITLE
Attempt to fix e2e runner

### DIFF
--- a/.github/workflows/e2eLocal.yml
+++ b/.github/workflows/e2eLocal.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         echo "::group::Generate ssl certs"
         sudo apt install libnss3-tools
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         brew install mkcert
         mkcert -install
         mkdir -p certs


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Fix `brew not found` error on e2e action (see https://github.com/actions/runner-images/issues/6283)

## Changes Proposed

- Add the suggested solution from ubuntu image team: `eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`

## Additional Information

- all e2e runs on PRs are currently failing; this should fix that issue

## Testing

- e2e action passes on this PR