### PR TITLE
replace date picker with native input

### DIFF
--- a/frontend/src/app/testQueue/addToQueue/useDebounce.ts
+++ b/frontend/src/app/testQueue/addToQueue/useDebounce.ts
@@ -25,3 +25,16 @@ export function useDebounce<T>(
 
   return [debouncedValue, value, setValue];
 }
+
+export const useDebouncedEffect = (
+  effect: () => void,
+  deps: any[],
+  delay: number
+) => {
+  useEffect(() => {
+    const handler = setTimeout(() => effect(), delay);
+
+    return () => clearTimeout(handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...(deps || []), delay]);
+};

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -299,7 +299,7 @@ describe("TestResultsList", () => {
 
   describe("with mocks", () => {
     beforeEach(async () => {
-      render(
+      await render(
         <WithRouter>
           <Provider store={store}>
             <MockedProvider mocks={mocks}>
@@ -308,7 +308,6 @@ describe("TestResultsList", () => {
           </Provider>
         </WithRouter>
       );
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
     });
 
     it("should call appropriate gql endpoints for pagination", async () => {
@@ -321,6 +320,7 @@ describe("TestResultsList", () => {
     });
 
     it("should be able to filter by patient", async () => {
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(
         await screen.findByText("Test Results", { exact: false })
       ).toBeInTheDocument();

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -739,4 +739,23 @@ describe("TestResultsList", () => {
       screen.queryByRole("option", { name: "All facilities" })
     ).not.toBeInTheDocument();
   });
+
+  it("should display error if end date is before the start date", async () => {
+    render(
+      <WithRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <TestResultsList />
+          </MockedProvider>
+        </Provider>
+      </WithRouter>
+    );
+    userEvent.type(await screen.findByText("Date range (start)"), "2021-03-18");
+    await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+    userEvent.type(await screen.findByText("Date range (end)"), "2021-03-17");
+    new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+    expect(
+      screen.getByText("End date cannot be before start date", { exact: false })
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -4,6 +4,7 @@ import { MockedProvider } from "@apollo/client/testing";
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
@@ -320,10 +321,7 @@ describe("TestResultsList", () => {
     });
 
     it("should be able to filter by patient", async () => {
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
+      await screen.findByText("Test Results", { exact: false });
       expect(
         await screen.findByText("Cragell, Barb Whitaker")
       ).toBeInTheDocument();
@@ -428,26 +426,27 @@ describe("TestResultsList", () => {
       expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
       userEvent.type(screen.getByText("Date range (start)"), "2021-03-18");
       userEvent.tab();
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      expect(screen.getByText("Colleer, Barde X")).toBeInTheDocument();
       expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Cragell, Barb Whitaker")
-      ).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Cragell, Barb Whitaker")
+        ).not.toBeInTheDocument()
+      );
       userEvent.type(screen.getByText("Date range (end)"), "2021-03-18");
       userEvent.tab();
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText("Cragell, Barb Whitaker")
-      ).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Cragell, Barb Whitaker")
+        ).not.toBeInTheDocument()
+      );
     });
     it("should be able to clear patient filter", async () => {
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
+      await screen.findByText("Test Results", { exact: false });
 
       // Apply filter
       expect(await screen.findByText("Search by name")).toBeInTheDocument();
@@ -469,11 +468,9 @@ describe("TestResultsList", () => {
     it("should be able to clear date filters", async () => {
       // Apply filter
       userEvent.type(screen.getByLabelText("Date range (start)"), "2021-03-18");
-
-      userEvent.tab();
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
 
       // Filter applied
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
       expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
       expect(

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -447,6 +447,7 @@ describe("TestResultsList", () => {
       ).not.toBeInTheDocument();
     });
     it("should be able to clear patient filter", async () => {
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(
         await screen.findByText("Test Results", { exact: false })
       ).toBeInTheDocument();
@@ -740,22 +741,31 @@ describe("TestResultsList", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should display error if end date is before the start date", async () => {
-    render(
-      <WithRouter>
-        <Provider store={store}>
-          <MockedProvider mocks={mocks}>
-            <TestResultsList />
-          </MockedProvider>
-        </Provider>
-      </WithRouter>
-    );
-    userEvent.type(await screen.findByText("Date range (start)"), "2021-03-18");
-    await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-    userEvent.type(await screen.findByText("Date range (end)"), "2021-03-17");
-    new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-    expect(
-      screen.getByText("End date cannot be before start date", { exact: false })
-    ).toBeInTheDocument();
+  describe("end date error", () => {
+    beforeEach(() => {
+      render(
+        <WithRouter>
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <TestResultsList />
+            </MockedProvider>
+          </Provider>
+        </WithRouter>
+      );
+    });
+    it("should display error if end date is before the start date", async () => {
+      userEvent.type(
+        await screen.findByText("Date range (start)"),
+        "2021-03-18"
+      );
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+      userEvent.type(await screen.findByText("Date range (end)"), "2021-03-17");
+      new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+      expect(
+        screen.getByText("End date cannot be before start date", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -753,19 +753,36 @@ describe("TestResultsList", () => {
         </WithRouter>
       );
     });
-    it("should display error if end date is before the start date", async () => {
-      userEvent.type(
-        await screen.findByText("Date range (start)"),
-        "2021-03-18"
-      );
+    const setDateRange = async (
+      startDate = "2021-03-17",
+      endDate = "2021-03-18"
+    ) => {
+      userEvent.type(await screen.findByText("Date range (start)"), startDate);
       await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-      userEvent.type(await screen.findByText("Date range (end)"), "2021-03-17");
+      userEvent.type(await screen.findByText("Date range (end)"), endDate);
       new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+    };
+    it("should display error if end date is before the start date", async () => {
+      await setDateRange("2021-03-18", "2021-03-17");
       expect(
         screen.getByText("End date cannot be before start date", {
           exact: false,
         })
       ).toBeInTheDocument();
+    });
+    it("should display clear error message when clear filters button is pressed", async () => {
+      await setDateRange("2021-03-18", "2021-03-17");
+      expect(
+        screen.getByText("End date cannot be before start date", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      userEvent.click(screen.getByText("Clear filters"));
+      expect(
+        screen.queryByText("End date cannot be before start date", {
+          exact: false,
+        })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -14,6 +14,7 @@ import userEvent from "@testing-library/user-event";
 
 import { GetAllFacilitiesDocument } from "../../generated/graphql";
 import { appPermissions } from "../permissions";
+import { SEARCH_DEBOUNCE_TIME } from "../testQueue/constants";
 
 import TestResultsList, {
   ALL_FACILITIES_ID,
@@ -72,6 +73,7 @@ describe("TestResultsList", () => {
               loading={false}
               loadingTotalResults={false}
               refetch={() => {}}
+              maxDate="2022-09-26"
             />
           </MockedProvider>
         </Provider>
@@ -296,7 +298,7 @@ describe("TestResultsList", () => {
   });
 
   describe("with mocks", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(
         <WithRouter>
           <Provider store={store}>
@@ -306,6 +308,7 @@ describe("TestResultsList", () => {
           </Provider>
         </WithRouter>
       );
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
     });
 
     it("should call appropriate gql endpoints for pagination", async () => {
@@ -428,6 +431,7 @@ describe("TestResultsList", () => {
         "2021-03-18"
       );
       userEvent.tab();
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
       expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
       expect(
@@ -435,6 +439,7 @@ describe("TestResultsList", () => {
       ).not.toBeInTheDocument();
       userEvent.type(await screen.findByText("Date range (end)"), "2021-03-18");
       userEvent.tab();
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
       expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
       expect(
@@ -470,6 +475,7 @@ describe("TestResultsList", () => {
       userEvent.tab();
 
       // Filter applied
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
       expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
       expect(

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -298,8 +298,8 @@ describe("TestResultsList", () => {
   });
 
   describe("with mocks", () => {
-    beforeEach(async () => {
-      await render(
+    beforeEach(() => {
+      render(
         <WithRouter>
           <Provider store={store}>
             <MockedProvider mocks={mocks}>
@@ -426,10 +426,7 @@ describe("TestResultsList", () => {
       expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
       expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
       expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
-      userEvent.type(
-        await screen.findByText("Date range (start)"),
-        "2021-03-18"
-      );
+      userEvent.type(screen.getByText("Date range (start)"), "2021-03-18");
       userEvent.tab();
       await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
@@ -437,7 +434,7 @@ describe("TestResultsList", () => {
       expect(
         screen.queryByText("Cragell, Barb Whitaker")
       ).not.toBeInTheDocument();
-      userEvent.type(await screen.findByText("Date range (end)"), "2021-03-18");
+      userEvent.type(screen.getByText("Date range (end)"), "2021-03-18");
       userEvent.tab();
       await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -116,12 +116,12 @@ describe("TestResultsList", () => {
     expect(
       await screen.findByLabelText("Date range (start)")
     ).toBeInTheDocument();
-    expect(await screen.findByDisplayValue("03/18/2021")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("2021-03-18")).toBeInTheDocument();
 
     expect(
       await screen.findByLabelText("Date range (end)")
     ).toBeInTheDocument();
-    expect(await screen.findByDisplayValue("03/19/2021")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("2021-03-19")).toBeInTheDocument();
 
     const roleSelect = (await screen.findByLabelText(
       "Role"
@@ -424,8 +424,8 @@ describe("TestResultsList", () => {
       expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
       expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
       userEvent.type(
-        screen.getAllByTestId("date-picker-external-input")[0],
-        "03/18/2021"
+        await screen.findByText("Date range (start)"),
+        "2021-03-18"
       );
       userEvent.tab();
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
@@ -433,10 +433,7 @@ describe("TestResultsList", () => {
       expect(
         screen.queryByText("Cragell, Barb Whitaker")
       ).not.toBeInTheDocument();
-      userEvent.type(
-        screen.getAllByTestId("date-picker-external-input")[1],
-        "03/18/2021"
-      );
+      userEvent.type(await screen.findByText("Date range (end)"), "2021-03-18");
       userEvent.tab();
       expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
       expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
@@ -468,10 +465,7 @@ describe("TestResultsList", () => {
 
     it("should be able to clear date filters", async () => {
       // Apply filter
-      userEvent.type(
-        screen.getAllByTestId("date-picker-external-input")[0],
-        "03/18/2021"
-      );
+      userEvent.type(screen.getByLabelText("Date range (start)"), "2021-03-18");
 
       userEvent.tab();
 
@@ -482,9 +476,9 @@ describe("TestResultsList", () => {
         screen.queryByText("Cragell, Barb Whitaker")
       ).not.toBeInTheDocument();
 
-      expect(
-        screen.getAllByTestId("date-picker-external-input")[0]
-      ).toHaveValue("03/18/2021");
+      expect(screen.getByLabelText("Date range (start)")).toHaveValue(
+        "2021-03-18"
+      );
       // Clear filter
       expect(await screen.findByText("Clear filters")).toBeInTheDocument();
       userEvent.click(screen.getByText("Clear filters"));
@@ -495,9 +489,7 @@ describe("TestResultsList", () => {
       ).toBeInTheDocument();
 
       // Date picker no longer displays the selected date
-      expect(
-        screen.getAllByTestId("date-picker-external-input")[0]
-      ).toHaveValue("");
+      expect(screen.getByLabelText("Date range (start)")).toHaveValue("");
     });
 
     it("opens the test detail modal from the patient's name", async () => {

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -297,14 +297,6 @@ export const DetachedTestResultsList = ({
         const startDate = moment(value, "YYYY-MM-DD").startOf("day");
         setStartDateError(undefined);
         setStartDate(startDate.toISOString());
-        // if(endDateError){
-        //   // try to clear it
-        //   console.log("clear");
-        //   const endDate = (document.querySelector(
-        //       "input[id=end-date]"
-        //   ) as HTMLInputElement).value;
-        //   processEndDate(endDate);
-        // }
       }
     } else {
       setStartDate("");
@@ -312,7 +304,6 @@ export const DetachedTestResultsList = ({
   };
 
   const processEndDate = (value: string | undefined) => {
-    // console.log("processing ", value);
     if (value) {
       if (!isValidDate(value)) {
         setEndDateError("Date must be in format MM/DD/YYYY");
@@ -323,7 +314,7 @@ export const DetachedTestResultsList = ({
           endDate.isBefore(moment(filterParams.startDate))
         ) {
           setEndDateError("End date cannot be before start date");
-          // setEndDate("0");
+          setEndDate("");
         } else {
           setEndDateError(undefined);
           setEndDate(endDate.toISOString());

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -12,7 +12,7 @@ import React, {
 } from "react";
 import moment from "moment";
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
-import { DatePicker, Label } from "@trussworks/react-uswds";
+import { Label } from "@trussworks/react-uswds";
 import { useSelector } from "react-redux";
 
 import { displayFullName, facilityDisplayName } from "../utils";
@@ -131,7 +131,6 @@ export const DetachedTestResultsList = ({
   const [showSuggestion, setShowSuggestion] = useState(true);
   const [startDateError, setStartDateError] = useState<string | undefined>();
   const [endDateError, setEndDateError] = useState<string | undefined>();
-  const [resetCount, setResetCount] = useState<number>(0);
 
   const [queryString, debounced, setDebounced] = useDebounce("", {
     debounceTime: SEARCH_DEBOUNCE_TIME,
@@ -269,7 +268,7 @@ export const DetachedTestResultsList = ({
       if (!isValidDate(value, true)) {
         setStartDateError("Date must be in format MM/DD/YYYY");
       } else {
-        const startDate = moment(value, "MM/DD/YYYY").startOf("day");
+        const startDate = moment(value, "YYYY-MM-DD").startOf("day");
         setStartDateError(undefined);
         setFilterParams("startDate")(startDate.toISOString());
       }
@@ -283,7 +282,7 @@ export const DetachedTestResultsList = ({
       if (!isValidDate(value)) {
         setEndDateError("Date must be in format MM/DD/YYYY");
       } else {
-        const endDate = moment(value, "MM/DD/YYYY").endOf("day");
+        const endDate = moment(value, "YYYY-MM-DD").endOf("day");
         if (
           isValidDate(filterParams.startDate || "") &&
           endDate.isBefore(moment(filterParams.startDate))
@@ -363,12 +362,12 @@ export const DetachedTestResultsList = ({
                   onClick={() => {
                     setDebounced("");
                     clearFilterParams();
-                    // The DatePicker component contains bits of state that represent the selected date
-                    // as represented internally to the component and displayed externally to the DOM. Directly
-                    // changing the value of the date via props does not cause the internal state to be updated.
-                    // This hack forces the DatePicker component to be fully re-mounted whenever the filters are
-                    // cleared, therefore resetting the external date display.
-                    setResetCount(resetCount + 1);
+                    (document.querySelector(
+                      "input[id=start-date]"
+                    ) as HTMLInputElement).value = "";
+                    (document.querySelector(
+                      "input[id=end-date]"
+                    ) as HTMLInputElement).value = "";
                   }}
                 >
                   Clear filters
@@ -407,15 +406,19 @@ export const DetachedTestResultsList = ({
                       {startDateError}
                     </span>
                   )}
-                  <DatePicker
+                  <input
                     id="start-date"
-                    key={resetCount}
-                    name="start-date"
-                    defaultValue={filterParams.startDate || ""}
-                    data-testid="start-date"
-                    minDate="2000-01-01T00:00"
-                    maxDate={moment().format("YYYY-MM-DDThh:mm")}
-                    onChange={processStartDate}
+                    type="date"
+                    className="usa-input"
+                    min="2000-01-01"
+                    max={moment().format("YYYY-MM-DD")}
+                    aria-label="Start Date"
+                    onChange={(e) => processStartDate(e.target.value)}
+                    defaultValue={
+                      filterParams.startDate
+                        ? moment(filterParams.startDate).format("YYYY-MM-DD")
+                        : ""
+                    }
                   />
                 </div>
                 <div className="usa-form-group date-filter-group">
@@ -426,15 +429,19 @@ export const DetachedTestResultsList = ({
                       {endDateError}
                     </span>
                   )}
-                  <DatePicker
+                  <input
                     id="end-date"
-                    key={resetCount + 1}
-                    name="end-date"
-                    defaultValue={filterParams.endDate || ""}
-                    data-testid="end-date"
-                    minDate={filterParams.startDate || "2000-01-01T00:00"}
-                    maxDate={moment().format("YYYY-MM-DDThh:mm")}
-                    onChange={processEndDate}
+                    type="date"
+                    className="usa-input"
+                    min="2000-01-01"
+                    max={moment().format("YYYY-MM-DD")}
+                    aria-label="End Date"
+                    onChange={(e) => processEndDate(e.target.value)}
+                    defaultValue={
+                      filterParams.endDate
+                        ? moment(filterParams.endDate).format("YYYY-MM-DD")
+                        : ""
+                    }
                   />
                 </div>
                 <Select

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -85,6 +85,7 @@ interface DetachedTestResultsListProps {
   setFilterParams: (filter: keyof FilterParams) => (val: string | null) => void;
   clearFilterParams: () => void;
   activeFacilityId: string;
+  maxDate?: string;
 }
 
 const getResultCountText = (
@@ -122,6 +123,7 @@ export const DetachedTestResultsList = ({
   filterParams,
   setFilterParams,
   clearFilterParams,
+  maxDate = moment().format("YYYY-MM-DD"),
 }: DetachedTestResultsListProps) => {
   const [printModalId, setPrintModalId] = useState(undefined);
   const [markCorrectionId, setMarkCorrectionId] = useState(undefined);
@@ -195,9 +197,13 @@ export const DetachedTestResultsList = ({
   useDebouncedEffect(
     () => setFilterParams("startDate")(startDate),
     [startDate],
-    500
+    SEARCH_DEBOUNCE_TIME
   );
-  useDebouncedEffect(() => setFilterParams("endDate")(endDate), [endDate], 500);
+  useDebouncedEffect(
+    () => setFilterParams("endDate")(endDate),
+    [endDate],
+    SEARCH_DEBOUNCE_TIME
+  );
 
   const onInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     if (event.target.value === "") {
@@ -423,7 +429,7 @@ export const DetachedTestResultsList = ({
                     type="date"
                     className="usa-input"
                     min="2000-01-01"
-                    max={moment().format("YYYY-MM-DD")}
+                    max={maxDate}
                     aria-label="Start Date"
                     onChange={(e) => processStartDate(e.target.value)}
                     defaultValue={
@@ -446,7 +452,7 @@ export const DetachedTestResultsList = ({
                     type="date"
                     className="usa-input"
                     min="2000-01-01"
-                    max={moment().format("YYYY-MM-DD")}
+                    max={maxDate}
                     aria-label="End Date"
                     onChange={(e) => processEndDate(e.target.value)}
                     defaultValue={

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -297,6 +297,14 @@ export const DetachedTestResultsList = ({
         const startDate = moment(value, "YYYY-MM-DD").startOf("day");
         setStartDateError(undefined);
         setStartDate(startDate.toISOString());
+        // if(endDateError){
+        //   // try to clear it
+        //   console.log("clear");
+        //   const endDate = (document.querySelector(
+        //       "input[id=end-date]"
+        //   ) as HTMLInputElement).value;
+        //   processEndDate(endDate);
+        // }
       }
     } else {
       setStartDate("");
@@ -304,6 +312,7 @@ export const DetachedTestResultsList = ({
   };
 
   const processEndDate = (value: string | undefined) => {
+    // console.log("processing ", value);
     if (value) {
       if (!isValidDate(value)) {
         setEndDateError("Date must be in format MM/DD/YYYY");
@@ -314,7 +323,7 @@ export const DetachedTestResultsList = ({
           endDate.isBefore(moment(filterParams.startDate))
         ) {
           setEndDateError("End date cannot be before start date");
-          setEndDate("");
+          // setEndDate("0");
         } else {
           setEndDateError(undefined);
           setEndDate(endDate.toISOString());
@@ -394,6 +403,8 @@ export const DetachedTestResultsList = ({
                     (document.querySelector(
                       "input[id=end-date]"
                     ) as HTMLInputElement).value = "";
+                    setStartDateError("");
+                    setEndDateError("");
                   }}
                 >
                   Clear filters

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -136,8 +136,8 @@ export const DetachedTestResultsList = ({
   const [showSuggestion, setShowSuggestion] = useState(true);
   const [startDateError, setStartDateError] = useState<string | undefined>();
   const [endDateError, setEndDateError] = useState<string | undefined>();
-  const [startDate, setStartDate] = useState<string | null>(null);
-  const [endDate, setEndDate] = useState<string | null>(null);
+  const [startDate, setStartDate] = useState<string | null>("0");
+  const [endDate, setEndDate] = useState<string | null>("0");
 
   const [queryString, debounced, setDebounced] = useDebounce("", {
     debounceTime: SEARCH_DEBOUNCE_TIME,
@@ -195,12 +195,20 @@ export const DetachedTestResultsList = ({
   }, [filterParams, data, setDebounced]);
 
   useDebouncedEffect(
-    () => setFilterParams("startDate")(startDate),
+    () => {
+      if (startDate !== "0") {
+        setFilterParams("startDate")(startDate);
+      }
+    },
     [startDate],
     SEARCH_DEBOUNCE_TIME
   );
   useDebouncedEffect(
-    () => setFilterParams("endDate")(endDate),
+    () => {
+      if (endDate !== "0") {
+        setFilterParams("endDate")(endDate);
+      }
+    },
     [endDate],
     SEARCH_DEBOUNCE_TIME
   );

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -27,7 +27,10 @@ import {
 } from "../constants";
 import "./TestResultsList.scss";
 import Button from "../commonComponents/Button/Button";
-import { useDebounce } from "../testQueue/addToQueue/useDebounce";
+import {
+  useDebounce,
+  useDebouncedEffect,
+} from "../testQueue/addToQueue/useDebounce";
 import {
   MIN_SEARCH_CHARACTER_COUNT,
   SEARCH_DEBOUNCE_TIME,
@@ -131,6 +134,8 @@ export const DetachedTestResultsList = ({
   const [showSuggestion, setShowSuggestion] = useState(true);
   const [startDateError, setStartDateError] = useState<string | undefined>();
   const [endDateError, setEndDateError] = useState<string | undefined>();
+  const [startDate, setStartDate] = useState<string | null>(null);
+  const [endDate, setEndDate] = useState<string | null>(null);
 
   const [queryString, debounced, setDebounced] = useDebounce("", {
     debounceTime: SEARCH_DEBOUNCE_TIME,
@@ -186,6 +191,13 @@ export const DetachedTestResultsList = ({
       setShowSuggestion(false);
     }
   }, [filterParams, data, setDebounced]);
+
+  useDebouncedEffect(
+    () => setFilterParams("startDate")(startDate),
+    [startDate],
+    500
+  );
+  useDebouncedEffect(() => setFilterParams("endDate")(endDate), [endDate], 500);
 
   const onInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     if (event.target.value === "") {
@@ -270,10 +282,10 @@ export const DetachedTestResultsList = ({
       } else {
         const startDate = moment(value, "YYYY-MM-DD").startOf("day");
         setStartDateError(undefined);
-        setFilterParams("startDate")(startDate.toISOString());
+        setStartDate(startDate.toISOString());
       }
     } else {
-      setFilterParams("startDate")("");
+      setStartDate("");
     }
   };
 
@@ -288,14 +300,14 @@ export const DetachedTestResultsList = ({
           endDate.isBefore(moment(filterParams.startDate))
         ) {
           setEndDateError("End date cannot be before start date");
-          setFilterParams("endDate")("");
+          setEndDate("");
         } else {
           setEndDateError(undefined);
-          setFilterParams("endDate")(endDate.toISOString());
+          setEndDate(endDate.toISOString());
         }
       }
     } else {
-      setFilterParams("endDate")("");
+      setEndDate("");
     }
   };
 

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -114,56 +114,15 @@ exports[`TestResultsList should render a list of tests 1`] = `
               >
                 Date range (start)
               </label>
-              <div
-                class="usa-date-picker usa-date-picker--initialized"
-                data-testid="date-picker"
-              >
-                <input
-                  aria-hidden="true"
-                  class="usa-input usa-sr-only usa-date-picker__internal-input"
-                  data-testid="date-picker-internal-input"
-                  name="start-date"
-                  readonly=""
-                  tabindex="-1"
-                  type="text"
-                  value=""
-                />
-                <div
-                  class="usa-date-picker__wrapper"
-                  tabindex="-1"
-                >
-                  <input
-                    class="usa-input usa-date-picker__external-input"
-                    data-testid="date-picker-external-input"
-                    id="start-date"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Toggle calendar"
-                    class="usa-date-picker__button"
-                    data-testid="date-picker-button"
-                    type="button"
-                  >
-                     
-                  </button>
-                  <div
-                    aria-modal="true"
-                    class="usa-date-picker__calendar"
-                    data-testid="date-picker-calendar"
-                    hidden=""
-                    role="dialog"
-                    style="top: 0px;"
-                  />
-                  <div
-                    aria-live="polite"
-                    class="usa-sr-only usa-date-picker__status"
-                    data-testid="date-picker-status"
-                    role="status"
-                  />
-                </div>
-              </div>
+              <input
+                aria-label="Start Date"
+                class="usa-input"
+                id="start-date"
+                max="2022-09-26"
+                min="2000-01-01"
+                type="date"
+                value=""
+              />
             </div>
             <div
               class="usa-form-group date-filter-group"
@@ -175,56 +134,15 @@ exports[`TestResultsList should render a list of tests 1`] = `
               >
                 Date range (end)
               </label>
-              <div
-                class="usa-date-picker usa-date-picker--initialized"
-                data-testid="date-picker"
-              >
-                <input
-                  aria-hidden="true"
-                  class="usa-input usa-sr-only usa-date-picker__internal-input"
-                  data-testid="date-picker-internal-input"
-                  name="end-date"
-                  readonly=""
-                  tabindex="-1"
-                  type="text"
-                  value=""
-                />
-                <div
-                  class="usa-date-picker__wrapper"
-                  tabindex="-1"
-                >
-                  <input
-                    class="usa-input usa-date-picker__external-input"
-                    data-testid="date-picker-external-input"
-                    id="end-date"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Toggle calendar"
-                    class="usa-date-picker__button"
-                    data-testid="date-picker-button"
-                    type="button"
-                  >
-                     
-                  </button>
-                  <div
-                    aria-modal="true"
-                    class="usa-date-picker__calendar"
-                    data-testid="date-picker-calendar"
-                    hidden=""
-                    role="dialog"
-                    style="top: 0px;"
-                  />
-                  <div
-                    aria-live="polite"
-                    class="usa-sr-only usa-date-picker__status"
-                    data-testid="date-picker-status"
-                    role="status"
-                  />
-                </div>
-              </div>
+              <input
+                aria-label="End Date"
+                class="usa-input"
+                id="end-date"
+                max="2022-09-26"
+                min="2000-01-01"
+                type="date"
+                value=""
+              />
             </div>
             <div
               class="usa-form-group prime-dropdown "


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4080 
- Existing date picker does not support updating the aria labels and it's modal is not accessible. 

## Changes Proposed

- Replace date picker with input and give each input a specific aria label

## Additional Information

- Debouncing was added to the start & end date fields to avoid too many calls when changing the date. 
- Existing bug/feature that was not able to be resolved: 
Replication steps:
1. Set start date
2. Set end date before start date (error now appears)
3. Set start date before end date (error stays on screen).

## Testing

- Change the dates and ensure that the filter dates are being applied. 
- Ensure that the URL is changing
- Check that clear filter works

## Screenshots / Demos


https://user-images.githubusercontent.com/10108172/192779040-442cc806-31f8-4af3-b37d-57b2645961d5.mp4


<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
