### PR TITLE
Add CSV Uploader permission to default site admin user in demo environment

### DIFF
--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -119,7 +119,7 @@ simple-report:
         last-name: Bobberoo
       authorization:
         organization-external-id: ${SR_DEMO_USER_ORG:DIS_ORG}
-        granted-roles: ${SR_DEMO_USER_ROLE:ADMIN}
+        granted-roles: ${SR_DEMO_USER_ROLE:ADMIN},${SR_DEMO_USER_ROLE:TEST_RESULT_UPLOAD_USER}
     alternate-users:
       - identity:
           username: ruby@example.com


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- We want to be able to easily test and demonstrate the CSV Uploader in the `demo` environment

## Changes Proposed
- Adds `TEST_RESULT_UPLOAD_USER` to the set of granted roles for the default site admin user in the `application-create-sample-data.yaml` file

## Testing
- **TODO** - watch this space