### PR TITLE
Make facility form name attr unique

### DIFF
--- a/cypress/integration/01-organization_sign_up_spec.js
+++ b/cypress/integration/01-organization_sign_up_spec.js
@@ -76,15 +76,15 @@ describe("Organization sign up", () => {
   });
   it("fills out the form for a new facility", () => {
     cy.get('input[name="name"]').type(facility.name);
-    cy.get('input[name="phone"]').first().type("5308675309");
-    cy.get('input[name="street"]').first().type("123 Beach Way");
-    cy.get('input[name="zipCode"]').first().type("90210");
-    cy.get('select[name="state"]').first().select("CA");
+    cy.get('input[name="facility-phone"]').first().type("5308675309");
+    cy.get('input[name="facility-street"]').first().type("123 Beach Way");
+    cy.get('input[name="facility-zipCode"]').first().type("90210");
+    cy.get('select[name="facility-state"]').first().select("CA");
     cy.get('input[name="cliaNumber"]').type("12D4567890");
     cy.get('input[name="firstName"]').type("Phil");
     cy.get('input[name="lastName"]').type("McTester");
     cy.get('input[name="NPI"]').type("1234567890");
-    cy.get('input[name="phone"]').last().type("5308675309");
+    cy.get('input[name="op-phone"]').last().type("5308675309");
     cy.contains("Save changes").last().click();
     cy.get(
       '.modal__container input[name="addressSelect-facility"][value="userAddress"]+label'

--- a/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
+++ b/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
@@ -23,7 +23,7 @@ const FacilityInformation: React.FC<Props> = ({
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
-    let fieldName = getSubStrAfterChar(e.target.name, "-", 2);
+    let fieldName = getSubStrAfterChar(e.target.name, "-");
     updateFacility({ ...facility, [fieldName]: e.target.value });
   };
 

--- a/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
+++ b/frontend/src/app/Settings/Facility/Components/FacilityInformation.tsx
@@ -5,6 +5,7 @@ import Dropdown from "../../../commonComponents/Dropdown";
 import TextInput from "../../../commonComponents/TextInput";
 import { FacilityErrors } from "../facilitySchema";
 import { ValidateField } from "../FacilityForm";
+import { getSubStrAfterChar } from "../../../utils/text";
 
 interface Props {
   facility: Facility;
@@ -22,7 +23,8 @@ const FacilityInformation: React.FC<Props> = ({
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
-    updateFacility({ ...facility, [e.target.name]: e.target.value });
+    let fieldName = getSubStrAfterChar(e.target.name, "-", 2);
+    updateFacility({ ...facility, [fieldName]: e.target.value });
   };
 
   return (
@@ -44,7 +46,7 @@ const FacilityInformation: React.FC<Props> = ({
       />
       <TextInput
         label="Phone number"
-        name="phone"
+        name="facility-phone"
         value={facility.phone}
         required
         onChange={onChange}
@@ -68,7 +70,7 @@ const FacilityInformation: React.FC<Props> = ({
       />
       <TextInput
         label="Street address 1"
-        name="street"
+        name="facility-street"
         value={facility.street}
         required
         onChange={onChange}
@@ -80,19 +82,19 @@ const FacilityInformation: React.FC<Props> = ({
       />
       <TextInput
         label="Street address 2"
-        name="streetTwo"
+        name="facility-streetTwo"
         value={facility.streetTwo || ""}
         onChange={onChange}
       />
       <TextInput
         label="City"
-        name="city"
+        name="facility-city"
         value={facility.city || ""}
         onChange={onChange}
       />
       <TextInput
         label="ZIP code"
-        name="zipCode"
+        name="facility-zipCode"
         value={facility.zipCode}
         required
         onChange={onChange}
@@ -105,7 +107,7 @@ const FacilityInformation: React.FC<Props> = ({
       />
       <Dropdown
         label="State"
-        name="state"
+        name="facility-state"
         selectedValue={facility.state}
         options={stateCodes.map((c) => ({ label: c, value: c }))}
         defaultSelect

--- a/frontend/src/app/Settings/Facility/Components/OrderingProvider.tsx
+++ b/frontend/src/app/Settings/Facility/Components/OrderingProvider.tsx
@@ -6,6 +6,7 @@ import { ValidateField } from "../FacilityForm";
 import { FacilityErrors } from "../facilitySchema";
 import Dropdown from "../../../commonComponents/Dropdown";
 import TextInput from "../../../commonComponents/TextInput";
+import { getSubStrAfterChar } from "../../../utils/text";
 
 interface Props {
   facility: Facility;
@@ -23,7 +24,8 @@ const OrderingProvider: React.FC<Props> = ({
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
-    updateProvider({ ...provider, [e.target.name]: e.target.value });
+    let fieldName = getSubStrAfterChar(e.target.name, "-", 2);
+    updateProvider({ ...provider, [fieldName]: e.target.value });
   };
 
   const { orderingProvider: provider } = facility;
@@ -100,7 +102,7 @@ const OrderingProvider: React.FC<Props> = ({
         />
         <TextInput
           label="Phone number"
-          name="phone"
+          name="op-phone"
           required={isRequired}
           value={provider.phone || ""}
           onChange={onChange}
@@ -114,32 +116,32 @@ const OrderingProvider: React.FC<Props> = ({
         />
         <TextInput
           label="Street address 1"
-          name="street"
+          name="op-street"
           value={provider.street || ""}
           onChange={onChange}
         />
         <TextInput
           label="Street address 2"
-          name="streetTwo"
+          name="op-streetTwo"
           value={provider.streetTwo || ""}
           onChange={onChange}
         />
         <TextInput
           label="City"
-          name="city"
+          name="op-city"
           value={provider.city || ""}
           onChange={onChange}
         />
         <TextInput
           label="ZIP code"
-          name="zipCode"
+          name="op-zipCode"
           value={provider.zipCode || ""}
           onChange={onChange}
           className="usa-input--medium"
         />
         <Dropdown
           label="State"
-          name="state"
+          name="op-state"
           selectedValue={provider.state || ""}
           options={stateCodes.map((c) => ({ label: c, value: c }))}
           defaultSelect

--- a/frontend/src/app/Settings/Facility/Components/OrderingProvider.tsx
+++ b/frontend/src/app/Settings/Facility/Components/OrderingProvider.tsx
@@ -24,7 +24,7 @@ const OrderingProvider: React.FC<Props> = ({
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
-    let fieldName = getSubStrAfterChar(e.target.name, "-", 2);
+    let fieldName = getSubStrAfterChar(e.target.name, "-");
     updateProvider({ ...provider, [fieldName]: e.target.value });
   };
 

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -179,8 +179,33 @@ describe("FacilityForm", () => {
       });
       userEvent.clear(facilityNameInput);
       userEvent.tab();
-      const warning = await screen.findByText("Facility name is missing");
-      expect(warning).toBeInTheDocument();
+      const nameWarning = await screen.findByText("Facility name is missing");
+      expect(nameWarning).toBeInTheDocument();
+      userEvent.type(facilityNameInput, "Test facility A");
+
+      const facilityStreetAddressInput = screen.getAllByLabelText(
+        "Street address 1",
+        {
+          exact: false,
+        }
+      )[0];
+      userEvent.clear(facilityStreetAddressInput);
+      userEvent.tab();
+      const streetAddressWarning = await screen.findByText(
+        "Facility street is missing"
+      );
+      expect(streetAddressWarning).toBeInTheDocument();
+      userEvent.type(facilityStreetAddressInput, "123 Main Street");
+
+      const facilityZipCodeInput = screen.getAllByLabelText("ZIP code", {
+        exact: false,
+      })[0];
+      userEvent.clear(facilityZipCodeInput);
+      userEvent.tab();
+      const facilityZipCodeWarning = await screen.findByText(
+        "Facility zip code is missing"
+      );
+      expect(facilityZipCodeWarning).toBeInTheDocument();
     });
 
     it("prevents submit for invalid form", async () => {

--- a/frontend/src/app/utils/text.test.ts
+++ b/frontend/src/app/utils/text.test.ts
@@ -1,4 +1,8 @@
-import { capitalizeText, toLowerCaseHyphenate } from "./text";
+import {
+  capitalizeText,
+  getSubStrAfterChar,
+  toLowerCaseHyphenate,
+} from "./text";
 
 describe("capitalizeText", () => {
   test("empty text", () => {
@@ -31,5 +35,28 @@ describe("toLowerCaseHyphenate", () => {
   test("starts and ends with whitespace", () => {
     const text = " COVID-19 TEST RESULT ";
     expect(toLowerCaseHyphenate(text)).toBe("-covid-19-test-result-");
+  });
+});
+
+describe("getSubStrAfterChar", () => {
+  test("empty text", () => {
+    const text = "";
+    expect(getSubStrAfterChar(text, "a")).toBe("");
+  });
+  test("where no result found", () => {
+    const text = "facility-streetThree";
+    expect(getSubStrAfterChar(text, "!")).toBe("facility-streetThree");
+  });
+  test("where result found", () => {
+    const text = "facility-streetThree";
+    expect(getSubStrAfterChar(text, "-")).toBe("streetThree");
+  });
+  test("where result found multiple times with limit", () => {
+    const text = "facility-streetThree-unitOne";
+    expect(getSubStrAfterChar(text, "-")).toBe("streetThree");
+  });
+  test("where result found multiple times with different limit", () => {
+    const text = "facility-streetThree-unitOne";
+    expect(getSubStrAfterChar(text, "-", 3)).toBe("unitOne");
   });
 });

--- a/frontend/src/app/utils/text.ts
+++ b/frontend/src/app/utils/text.ts
@@ -47,6 +47,14 @@ export function toLowerCaseHyphenate(string: string) {
   return string.toLocaleLowerCase().replace(/\s+/g, "-");
 }
 
+export function getSubStrAfterChar(
+  s: string,
+  strToSplitOn: string,
+  subStrLimit: number = 2
+): string {
+  return s.split(strToSplitOn, subStrLimit).pop() || s;
+}
+
 // From Okta: https://github.com/okta/okta-signin-widget/blob/master/src/util/CryptoUtil.js
 
 /**


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #4092 

## Changes Proposed
- give any shared facility form inputs a unique name whether it is part of the facility section or ordering provider section
- functionality should have remained the same

## Additional Information
- Noticed an existing accessibility issue I did not see a ticket for so created one here: https://app.zenhub.com/workspaces/simplereport-accessibility-61153c23e7546f0010407728/issues/cdcgov/prime-simplereport/4329

## Testing
- Ensure you can continue to edit existing facilities and add new ones
- Error messages show up as intended
- Ensure no new accessibility bugs have been introduced

## Screenshots / Demos
<img width="964" alt="Screen Shot 2022-09-27 at 11 07 08" src="https://user-images.githubusercontent.com/20211771/192613201-c8041168-b161-49b1-b881-f009e3bd2bad.png">
<img width="1511" alt="Screen Shot 2022-09-27 at 11 06 18" src="https://user-images.githubusercontent.com/20211771/192613208-6a3892ba-4806-4062-aad0-eee10f1f74de.png">
