### PR TITLE
add id on error message div

### DIFF
--- a/frontend/src/app/commonComponents/Dropdown.test.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import Dropdown from "./Dropdown";
+
+describe("dropdown", () => {
+  it("should include id on error message", () => {
+    render(
+      <Dropdown
+        options={[{ label: "MockValue", value: "MockValue" }]}
+        onChange={() => {}}
+        selectedValue={""}
+        errorMessage={"MyErrorMessage"}
+        validationStatus={"error"}
+      />
+    );
+    expect(screen.getByText("MockValue").parentElement).toHaveAttribute(
+      "aria-describedby"
+    );
+    const expected = screen
+      .getByText("MockValue")
+      .parentElement?.getAttribute("aria-describedby");
+    expect(screen.getByText("MyErrorMessage")).toHaveAttribute("id", expected);
+  });
+});

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -74,7 +74,7 @@ const Dropdown: React.FC<Props & SelectProps> = ({
             </label>
           )}
           {validationStatus === "error" && (
-            <div className="usa-error-message" role="alert">
+            <div className="usa-error-message" id={`error_${id}`} role="alert">
               <span className="usa-sr-only">Error: </span>
               {errorMessage}
             </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4329 

## Changes Proposed

- add error_id to error message div

## Additional Information

## Testing

- Ensure `aria-describedby` value is on the correct error element

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/10108172/192867561-20c03be0-cae7-47cb-9748-acbfbf81aac1.png)
![image](https://user-images.githubusercontent.com/10108172/192867634-95a745f7-5f9e-4aab-9220-8832cdb9fbcc.png)

No Errors:
![image](https://user-images.githubusercontent.com/10108172/192867692-b9cb707e-c4fe-4398-9a58-ebb7c70859aa.png)


<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
