### PR TITLE
Run lighthouse on demo, not training

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -25,5 +25,5 @@ jobs:
         configPath: ./lighthouserc.yml
         runs: 1
       env:
-        SITE_URL: https://training.simplereport.gov
-        FACILITY_ID: ?facility=adddb27d-3be3-48b7-b959-ea506fd92ce6
+        SITE_URL: https://demo.simplereport.gov
+        FACILITY_ID: ?facility=14fab3c1-070e-4e86-8ec7-4a1fc8e13477


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- We have a Lighthouse action that runs daily on `training` ([see past runs here](https://github.com/CDCgov/prime-simplereport/actions/runs/3140119986/jobs/5101195353)). In theory, it navigates to a couple different URLs on the site and measures page latency/performance, accessibility, etc. In practice, it just continues to hit the "this is a training site" modal, so doesn't tell us anything about the underlying components on the page.
- This changes the Lighthouse action to run against `demo` instead, which doesn't have a warning modal. I also updated the facility UUID to a valid demo id.

## Changes Proposed

- Hopefully, enable Lighthouse to start producing useful information on its daily runs
