### PR TITLE
Fix accessibility issues in EmailTestResultModal

### DIFF
--- a/frontend/src/app/testResults/EmailTestResultModal.scss
+++ b/frontend/src/app/testResults/EmailTestResultModal.scss
@@ -4,11 +4,6 @@
   max-height: 90vh;
   padding: 28px 24px;
 
-  .header {
-    font-size: 22px;
-    padding-bottom: 12px;
-  }
-
   .body {
     font-size: 16px;
     padding-bottom: 20px;

--- a/frontend/src/app/testResults/EmailTestResultModal.test.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.test.tsx
@@ -56,7 +56,8 @@ describe("EmailTestResultModal", () => {
   });
 
   it("should show render", () => {
-    render(
+    let component: any;
+    component = render(
       <EmailTestResultModal
         testResultId={"super-fancy-id"}
         closeModal={mockCloseModal}
@@ -70,6 +71,8 @@ describe("EmailTestResultModal", () => {
     screen.getByText("gesezyx@mailinator.com");
     screen.getByText("Send result");
     screen.getByText("Cancel");
+
+    expect(component).toMatchSnapshot();
   });
 
   describe("clicking on Send result button", () => {

--- a/frontend/src/app/testResults/EmailTestResultModal.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.tsx
@@ -35,7 +35,9 @@ export const EmailTestResultModal = ({ closeModal, testResultId }: Props) => {
       contentLabel="Printable test result"
       onRequestClose={closeModal}
     >
-      <div className="header">Email result?</div>
+      <h1 className="font-sans-lg margin-top-0 margin-bottom-105 text-normal">
+        Email result?
+      </h1>
       {loading ? (
         <p>Loading</p>
       ) : (
@@ -47,7 +49,7 @@ export const EmailTestResultModal = ({ closeModal, testResultId }: Props) => {
             </div>
             <ul className="usa-list usa-list--unstyled">
               {patient.emails?.map((email: string) => (
-                <li className={"line-height-sans-2"} key={email}>
+                <li className="line-height-sans-2" key={email}>
                   {email}
                 </li>
               ))}

--- a/frontend/src/app/testResults/EmailTestResultModal.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.tsx
@@ -45,9 +45,13 @@ export const EmailTestResultModal = ({ closeModal, testResultId }: Props) => {
               {formatFullName(patient)}'s test result from{" "}
               {formatDateLong(dateTested)} will be sent to the following emails:
             </div>
-            {patient.emails?.map((email: string) => (
-              <div key={email}>{email}</div>
-            ))}
+            <ul className="usa-list usa-list--unstyled">
+              {patient.emails?.map((email: string) => (
+                <li className={"line-height-sans-2"} key={email}>
+                  {email}
+                </li>
+              ))}
+            </ul>
           </div>
           <div className="sr-test-correction-buttons">
             <Button variant="unstyled" label="Cancel" onClick={closeModal} />

--- a/frontend/src/app/testResults/__snapshots__/EmailTestResultModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/EmailTestResultModal.test.tsx.snap
@@ -6,11 +6,11 @@ Object {
   "baseElement": <body>
     <div>
       <div>
-        <div
-          class="header"
+        <h1
+          class="font-sans-lg margin-top-0 margin-bottom-105 text-normal"
         >
           Email result?
-        </div>
+        </h1>
         <div
           class="body"
         >
@@ -54,11 +54,11 @@ Object {
   </body>,
   "container": <div>
     <div>
-      <div
-        class="header"
+      <h1
+        class="font-sans-lg margin-top-0 margin-bottom-105 text-normal"
       >
         Email result?
-      </div>
+      </h1>
       <div
         class="body"
       >

--- a/frontend/src/app/testResults/__snapshots__/EmailTestResultModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/EmailTestResultModal.test.tsx.snap
@@ -1,0 +1,154 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmailTestResultModal should show render 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div>
+        <div
+          class="header"
+        >
+          Email result?
+        </div>
+        <div
+          class="body"
+        >
+          <div
+            class="text"
+          >
+            Zelda Francesca Holcomb Gordon
+            's test result from
+             
+            November 2nd, 2021
+             will be sent to the following emails:
+          </div>
+          <ul
+            class="usa-list usa-list--unstyled"
+          >
+            <li
+              class="line-height-sans-2"
+            >
+              gesezyx@mailinator.com
+            </li>
+          </ul>
+        </div>
+        <div
+          class="sr-test-correction-buttons"
+        >
+          <button
+            class="usa-button usa-button--unstyled"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="usa-button"
+            type="button"
+          >
+            Send result
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        class="header"
+      >
+        Email result?
+      </div>
+      <div
+        class="body"
+      >
+        <div
+          class="text"
+        >
+          Zelda Francesca Holcomb Gordon
+          's test result from
+           
+          November 2nd, 2021
+           will be sent to the following emails:
+        </div>
+        <ul
+          class="usa-list usa-list--unstyled"
+        >
+          <li
+            class="line-height-sans-2"
+          >
+            gesezyx@mailinator.com
+          </li>
+        </ul>
+      </div>
+      <div
+        class="sr-test-correction-buttons"
+      >
+        <button
+          class="usa-button usa-button--unstyled"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="usa-button"
+          type="button"
+        >
+          Send result
+        </button>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #4088 
Resolves #4090 

## Changes Proposed
- Display emails in the EmailTest Result modal as a `<li>`
- Change previous <div> with `header` class into a `<h1>`

## Additional Information
N/A

## Testing
- Make sure emails are displayed in a list element in the EmailTestResultModal
- Make sure header of that modal is now an `<h1>`
- Make sure styles have not changed too much 😅  ([see note about one style change here](https://github.com/CDCgov/prime-simplereport/pull/4338/files#r983621429))

## Screenshots / Demos
**Previous:**
<img width="580" alt="Screen Shot 2022-09-29 at 09 14 35" src="https://user-images.githubusercontent.com/20211771/193058395-0e4679ba-6301-47fe-b0a7-463350b7ff52.png">


**New**:
<img width="565" alt="Screen Shot 2022-09-29 at 09 16 08" src="https://user-images.githubusercontent.com/20211771/193058358-3a837022-91c3-4671-b8b3-778a7b1caaf9.png">


<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
