### PR TITLE
Eagerly load testorder queue fields to avoid n+1 issues

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/ApiTestOrderDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/ApiTestOrderDataResolver.java
@@ -5,7 +5,6 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
-import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.PatientAnswersRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import java.time.LocalDate;
@@ -26,7 +25,6 @@ public class ApiTestOrderDataResolver {
   public ApiTestOrderDataResolver(
       BatchLoaderRegistry registry,
       PersonRepository personRepository,
-      DeviceTypeRepository deviceTypeRepository,
       PatientAnswersRepository patientAnswersRepository) {
 
     registry
@@ -37,16 +35,6 @@ public class ApiTestOrderDataResolver {
                   personRepository.findAllByInternalIdIn(uuids).stream()
                       .collect(Collectors.toMap(Person::getInternalId, s -> s));
 
-              return Mono.just(found);
-            });
-
-    registry
-        .forTypePair(UUID.class, DeviceType.class)
-        .registerMappedBatchLoader(
-            (uuids, batchLoaderEnvironment) -> {
-              Map<UUID, DeviceType> found =
-                  deviceTypeRepository.findAllByInternalIdIn(uuids).stream()
-                      .collect(Collectors.toMap(DeviceType::getInternalId, s -> s));
               return Mono.just(found);
             });
 
@@ -100,13 +88,12 @@ public class ApiTestOrderDataResolver {
   }
 
   @SchemaMapping(typeName = "TestOrder", field = "deviceType")
-  public CompletableFuture<DeviceType> deviceType(
-      ApiTestOrder apiTestOrder, DataLoader<UUID, DeviceType> loader) {
-    return loader.load(apiTestOrder.getWrapped().getDeviceType().getInternalId());
+  public DeviceType deviceType(ApiTestOrder apiTestOrder) {
+    return apiTestOrder.getWrapped().getDeviceType();
   }
 
   @SchemaMapping(typeName = "TestOrder", field = "results")
-  public Set<Result> getResults(ApiTestOrder apiTestOrder) {
+  public Set<Result> results(ApiTestOrder apiTestOrder) {
     return apiTestOrder.getWrapped().getPendingResultSet();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -26,7 +26,8 @@ public interface TestOrderRepository
   String RESULT_RECENT_ORDER = " order by q.updatedAt desc ";
 
   @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)
-  @EntityGraph(attributePaths = {"patient"})
+  @EntityGraph(
+      attributePaths = {"patient", "deviceType", "specimenType", "results", "deviceSpecimen"})
   List<TestOrder> fetchQueue(Organization org, Facility facility);
 
   @Query(BASE_ORG_QUERY + IS_PENDING + " and q.patient = :patient")


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- this will address this [ #4915 page](https://prime-cdc.pagerduty.com/incidents/Q2AZKTHCDYNTNB?utm_source=slack&utm_campaign=channel)

## Testing

- remove `TestOrder.deviceType` dataloader and switch it to eagerly loading
- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---

