### PR TITLE
add dependabot config for npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,7 @@ updates:
       # - "alismx"
       # - "emyl3"
       # - "rin-skylight"
+      # - "emmastephenson"
 
   # - package-ecosystem: "github-actions"
   #   directory: "/.github/actions"
@@ -53,6 +54,7 @@ updates:
       # - "alismx"
       # - "emyl3"
       # - "rin-skylight"
+      # - "emmastephenson"
 
   # - package-ecosystem: "gradle"
   #   directory: "/backend"
@@ -65,30 +67,31 @@ updates:
       # - "mehansen"
       # - "rin-skylight"
       # - "zdeveloper"
+      # - "emmastephenson"
 
-  # - package-ecosystem: "npm"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "BobanL"
-      # - "emyl3"
-      # - "fzhao99"
-      # - "georgehager"
-      # - "rin-skylight"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "BobanL"
+      - "emyl3"
+      - "fzhao99"
+      - "georgehager"
+      - "rin-skylight"
       
-  # - package-ecosystem: "npm"
-  #   directory: "/frontend"
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-  #     - "alismx"
-  #     - "BobanL"
-  #     - "emyl3"
-  #     - "fzhao99"
-  #     - "georgehager"
-  #     - "rin-skylight"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "BobanL"
+      - "emyl3"
+      - "fzhao99"
+      - "georgehager"
+      - "rin-skylight"
       
   # - package-ecosystem: "npm"
   #   directory: "/cypress"


### PR DESCRIPTION

# DEVOPS PULL REQUEST

## Related Issue

- NPM #3078
- Get dependabot going for the frontend, this is being done next to help drive [this PR](https://github.com/CDCgov/prime-simplereport/pull/4348) forward.

## Changes Proposed

- This should allow dependabot to open PRs to help guide and encourage frontend upgrades

## Additional Information

- I'm enabling only some dependabot ecosystems at a time to keep ourselves from being overwhelmed.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---