### PR TITLE
Enable exception handler function

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -71,25 +71,25 @@ resource "azurerm_function_app" "functions" {
   }
 
   app_settings = {
-    https_only                                           = true
-    FUNCTIONS_WORKER_RUNTIME                             = "node"
-    WEBSITE_NODE_DEFAULT_VERSION                         = "~14"
-    FUNCTION_APP_EDIT_MODE                               = "readonly"
-    HASH                                                 = azurerm_storage_blob.appcode.content_md5
-    WEBSITE_RUN_FROM_PACKAGE                             = "https://${data.azurerm_storage_account.app.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
-    APPINSIGHTS_INSTRUMENTATIONKEY                       = data.azurerm_application_insights.app.instrumentation_key
-    AZ_STORAGE_QUEUE_SVC_URL                             = "https://${data.azurerm_storage_account.app.name}.queue.core.windows.net/"
-    AZ_STORAGE_ACCOUNT_NAME                              = data.azurerm_storage_account.app.name
-    AZ_STORAGE_ACCOUNT_KEY                               = data.azurerm_storage_account.app.primary_access_key
-    AZ_STORAGE_QUEUE_CXN_STRING                          = data.azurerm_storage_account.app.primary_connection_string
-    TEST_EVENT_QUEUE_NAME                                = var.test_event_queue_name
-    REPORTING_EXCEPTION_QUEUE_NAME                       = var.reporting_exception_queue_name
-    REPORT_STREAM_URL                                    = local.report_stream_url
-    REPORT_STREAM_TOKEN                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
-    REPORT_STREAM_BATCH_MINIMUM                          = var.report_stream_batch_minimum
-    REPORT_STREAM_BATCH_MAXIMUM                          = var.report_stream_batch_maximum
-    SIMPLE_REPORT_CB_URL                                 = local.simple_report_callback_url
-    SIMPLE_REPORT_CB_TOKEN                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
+    https_only                     = true
+    FUNCTIONS_WORKER_RUNTIME       = "node"
+    WEBSITE_NODE_DEFAULT_VERSION   = "~14"
+    FUNCTION_APP_EDIT_MODE         = "readonly"
+    HASH                           = azurerm_storage_blob.appcode.content_md5
+    WEBSITE_RUN_FROM_PACKAGE       = "https://${data.azurerm_storage_account.app.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
+    APPINSIGHTS_INSTRUMENTATIONKEY = data.azurerm_application_insights.app.instrumentation_key
+    AZ_STORAGE_QUEUE_SVC_URL       = "https://${data.azurerm_storage_account.app.name}.queue.core.windows.net/"
+    AZ_STORAGE_ACCOUNT_NAME        = data.azurerm_storage_account.app.name
+    AZ_STORAGE_ACCOUNT_KEY         = data.azurerm_storage_account.app.primary_access_key
+    AZ_STORAGE_QUEUE_CXN_STRING    = data.azurerm_storage_account.app.primary_connection_string
+    TEST_EVENT_QUEUE_NAME          = var.test_event_queue_name
+    REPORTING_EXCEPTION_QUEUE_NAME = var.reporting_exception_queue_name
+    REPORT_STREAM_URL              = local.report_stream_url
+    REPORT_STREAM_TOKEN            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
+    REPORT_STREAM_BATCH_MINIMUM    = var.report_stream_batch_minimum
+    REPORT_STREAM_BATCH_MAXIMUM    = var.report_stream_batch_maximum
+    SIMPLE_REPORT_CB_URL           = local.simple_report_callback_url
+    SIMPLE_REPORT_CB_TOKEN         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
   }
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -90,7 +90,6 @@ resource "azurerm_function_app" "functions" {
     REPORT_STREAM_BATCH_MAXIMUM                          = var.report_stream_batch_maximum
     SIMPLE_REPORT_CB_URL                                 = local.simple_report_callback_url
     SIMPLE_REPORT_CB_TOKEN                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
-    "AzureWebJobs.ReportStreamExceptionHandler.Disabled" = "1"
   }
 }
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

#3907 

- Will be emptying the existing queue before deploying to prod

## Changes Proposed

- Enable the queue

## Additional Information

- plan is to empty the prod queue before deploying

## Testing

- Look at azure logs / metrics for the exception handler function
- Verify errors/warnings are making into the db via metabase

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->