### PR TITLE
Dependabot updates!

### DIFF
--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   terraform-plan:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,18 +133,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
       - name: Restore backend cache
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: actions/cache@v3
         with:
           path: |
             backend/build/**
           key: ${{ runner.os }}-backend-coverage-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Restore frontend cache
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: actions/cache@v3
         with:
           path: |
             frontend/coverage/**
           key: ${{ runner.os }}-frontend-coverage-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Restore functions cache
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Prevent Terraform plan and sonar reports from being run.

## Changes Proposed

- Add a gate for the Dependabot actor.

## Additional Information

- We may enable Dependabot to run terraform plans in the future against our test environment as a way to verify the plan. In general, that job isn't needed unless for changes outside of the `ops` directory. It's going to be a little while before we enable Dependabot for Terraform due to some planned work and upgrades that need to take place.
- Sonar coverage doesn't need to be reported because test coverage should stay the same for dependency updates. If additional required changes to complete the dependency update get pushed by a dev (added tests, code changes), the Sonar job will run normally.

## Testing

- Not much to be done.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---