### PR TITLE
disable clear filter button until there are filters

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -656,19 +656,20 @@ describe("TestResultsList", () => {
     });
 
     describe("return focus after modal close", () => {
-      beforeEach(async () => {
+      const clickActionMenu = async () => {
         expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
         const actionMenuButton = document.querySelectorAll(
           ".rc-menu-button"
         )[0];
         userEvent.click(actionMenuButton as HTMLElement);
-      });
+      };
       it.each([
         ["Print result", "Close"],
         ["Text result", "Cancel"],
         ["Email result", "Cancel"],
         ["Correct result", "No, go back"],
       ])("should set focus on %p", async (menuButtonText, closeButtonText) => {
+        await clickActionMenu();
         userEvent.click(screen.getByText(menuButtonText));
         await screen.findAllByText(closeButtonText);
         userEvent.click(screen.getAllByText(closeButtonText)[0]);
@@ -677,6 +678,7 @@ describe("TestResultsList", () => {
         );
       });
       it("should set focus on the view details button", async () => {
+        await clickActionMenu();
         userEvent.click(screen.getByText("View details"));
         await screen.findByAltText("Close");
         userEvent.click(screen.getByAltText("Close"));

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -809,4 +809,40 @@ describe("TestResultsList", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("clear filter button", () => {
+    const elementToTest = (filterParams: FilterParams) => (
+      <WithRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <DetachedTestResultsList
+              data={{ testResults }}
+              pageNumber={1}
+              entriesPerPage={20}
+              totalEntries={testResults.length}
+              filterParams={filterParams}
+              setFilterParams={() => () => {}}
+              clearFilterParams={() => {}}
+              activeFacilityId={"1"}
+              loading={false}
+              loadingTotalResults={false}
+              maxDate="2022-09-26"
+            />
+          </MockedProvider>
+        </Provider>
+      </WithRouter>
+    );
+    it("should be disabled when no filters are applied", () => {
+      render(elementToTest({}));
+      expect(screen.getByText("Clear filters")).toBeDisabled();
+    });
+    it("should be disabled when testing only filter applied is facility is active facility", () => {
+      render(elementToTest({ filterFacilityId: "1" }));
+      expect(screen.getByText("Clear filters")).toBeDisabled();
+    });
+    it("should be enabled filters are applied", () => {
+      render(elementToTest({ result: "Positive" }));
+      expect(screen.getByText("Clear filters")).toBeEnabled();
+    });
+  });
 });

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -411,11 +411,11 @@ export const DetachedTestResultsList = ({
                 onClick={() => {
                   setDebounced("");
                   clearFilterParams();
-                  (document.querySelector(
-                    "input[id=start-date]"
+                  (document.getElementById(
+                    "start-date"
                   ) as HTMLInputElement).value = "";
-                  (document.querySelector(
-                    "input[id=end-date]"
+                  (document.getElementById(
+                    "end-date"
                   ) as HTMLInputElement).value = "";
                   setStartDateError("");
                   setEndDateError("");

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -420,6 +420,11 @@ export const DetachedTestResultsList = ({
                   setStartDateError("");
                   setEndDateError("");
                 }}
+                disabled={
+                  Object.keys(filterParams).length === 0 ||
+                  (Object.keys(filterParams).length === 1 &&
+                    filterParams.filterFacilityId === activeFacilityId)
+                }
               >
                 Clear filters
               </Button>

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`TestResultsList should render a list of tests 1`] = `
               Download results
             </button>
             <button
-              class="usa-button sr-active-button"
+              aria-disabled="true"
+              class="usa-button usa-button-disabled sr-active-button"
+              disabled=""
               type="button"
             >
               <svg


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4086 

## Changes Proposed

- Disable "Clear Filter" button when either: no filters have been applied OR only filter facility = active facility id 

## Additional Information

- Filters that are not applied (like an incomplete date or just characters in search by name) do not make the clear filter button available.

## Testing

- Add filters and clear them (With the button)
- Add filters and clear them manually (unselect them)

## Screenshots / Demos


https://user-images.githubusercontent.com/10108172/193658837-f832d8dd-aae4-4602-81b4-b3915979e812.mp4



<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
