### PR TITLE
Fix list-related accessibility issues in TOS

### DIFF
--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -392,19 +392,23 @@ export const en = {
           },
           definitions: {
             heading: "Definitions",
-            l0: "Entity",
-            p0:
-              "A health care provider or facility; testing site; a state, local, tribal, and territorial public health authority " +
-              "(STLT Public Health Agency); or other organization that is enrolled in and using Simple Report to record and/or " +
-              "transmit data.",
-            l1: "User",
-            p1:
-              "An individual whose personal data is being reported via Simple Report (Individual User), or an individual authorized " +
-              "to act on behalf of the Entity under these Terms (Entity User or Entity Administrator). Simple Report will only designate " +
-              "one User from the Entity as the Entity Administrator. Entity Administrators will have more detailed identity verification " +
-              "than general Entity Users. Once the Entity Administrator has their identity verified, the Entity Administrator can add " +
-              "other general Entity Users or Individual Users to the Application. All roles are referred to as “User” for the purposes " +
-              "of these Terms, unless otherwise indicated.",
+            l0: {
+              title: "Entity:",
+              definition:
+                "A health care provider or facility; testing site; a state, local, tribal, and territorial public health authority " +
+                "(STLT Public Health Agency); or other organization that is enrolled in and using Simple Report to record and/or " +
+                "transmit data.",
+            },
+            l1: {
+              title: "User:",
+              definition:
+                "An individual whose personal data is being reported via Simple Report (Individual User), or an individual authorized " +
+                "to act on behalf of the Entity under these Terms (Entity User or Entity Administrator). Simple Report will only designate " +
+                "one User from the Entity as the Entity Administrator. Entity Administrators will have more detailed identity verification " +
+                "than general Entity Users. Once the Entity Administrator has their identity verified, the Entity Administrator can add " +
+                "other general Entity Users or Individual Users to the Application. All roles are referred to as “User” for the purposes " +
+                "of these Terms, unless otherwise indicated.",
+            },
           },
           dataRights: {
             heading: "Data rights and usage",

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -412,8 +412,8 @@ export const en = {
           },
           dataRights: {
             heading: "Data rights and usage",
-            subheading: "Accounts/Registration",
-            l0: "For entity users",
+            subheading: "Accounts/registration",
+            section0: "For entity users",
             p01:
               "If you are using the Application on behalf of an Entity as either an Entity Administrator or Entity User, you represent " +
               "and warrant that you have authority to bind that Entity to the Terms and by accepting the Terms, you are doing so on " +
@@ -429,12 +429,12 @@ export const en = {
               "keys, tokens, and Entity and Entity User identifications (IDs)) will be issued to you by HHS or CDC. These credentials " +
               "are intended to be used only by you and to identify any software or APIs which you are using. You agree to keep your " +
               "credentials confidential and make reasonable efforts to prevent and discourage other persons from using your credentials.",
-            l1: "For entity administrators",
+            section1: "For entity administrators",
             p1:
               "The Entity Administrator agrees to verify the identity of other Entity Users who are added and to inactivate any other " +
               "Entity Users who should no longer have access. The Administrator also agrees to set permissions appropriately to determine " +
               "the minimum access necessary for each other Entity User to complete their required job duties.",
-            l2: "For individual users",
+            section2: "For individual users",
             p2:
               "Entity Administrators will grant Individual Users access to the Application. Individual Users can use the Application " +
               "to access and review their own information or information about others as may be permitted by applicable law (e.g., on " +

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -392,10 +392,19 @@ export const en = {
           },
           definitions: {
             heading: "Definitions",
-            l0:
-              "Entity: A health care provider or facility; testing site; a state, local, tribal, and territorial public health authority (STLT Public Health Agency); or other organization that is enrolled in and using Simple Report to record and/or transmit data.",
-            l1:
-              "User: An individual whose personal data is being reported via Simple Report (Individual User), or an individual authorized to act on behalf of the Entity under these Terms (Entity User or Entity Administrator). Simple Report will only designate one User from the Entity as the Entity Administrator. Entity Administrators will have more detailed identity verification than general Entity Users. Once the Entity Administrator has their identity verified, the Entity Administrator can add other general Entity Users or Individual Users to the Application. All roles are referred to as “User” for the purposes of these Terms, unless otherwise indicated.",
+            l0: "Entity",
+            p0:
+              "A health care provider or facility; testing site; a state, local, tribal, and territorial public health authority " +
+              "(STLT Public Health Agency); or other organization that is enrolled in and using Simple Report to record and/or " +
+              "transmit data.",
+            l1: "User",
+            p1:
+              "An individual whose personal data is being reported via Simple Report (Individual User), or an individual authorized " +
+              "to act on behalf of the Entity under these Terms (Entity User or Entity Administrator). Simple Report will only designate " +
+              "one User from the Entity as the Entity Administrator. Entity Administrators will have more detailed identity verification " +
+              "than general Entity Users. Once the Entity Administrator has their identity verified, the Entity Administrator can add " +
+              "other general Entity Users or Individual Users to the Application. All roles are referred to as “User” for the purposes " +
+              "of these Terms, unless otherwise indicated.",
           },
           dataRights: {
             heading: "Data rights and usage",

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -392,19 +392,10 @@ export const en = {
           },
           definitions: {
             heading: "Definitions",
-            l0: "Entity",
-            p0:
-              "A health care provider or facility; testing site; a state, local, tribal, and territorial public health authority " +
-              "(STLT Public Health Agency); or other organization that is enrolled in and using Simple Report to record and/or " +
-              "transmit data.",
-            l1: "User",
-            p1:
-              "An individual whose personal data is being reported via Simple Report (Individual User), or an individual authorized " +
-              "to act on behalf of the Entity under these Terms (Entity User or Entity Administrator). Simple Report will only designate " +
-              "one User from the Entity as the Entity Administrator. Entity Administrators will have more detailed identity verification " +
-              "than general Entity Users. Once the Entity Administrator has their identity verified, the Entity Administrator can add " +
-              "other general Entity Users or Individual Users to the Application. All roles are referred to as “User” for the purposes " +
-              "of these Terms, unless otherwise indicated.",
+            l0:
+              "Entity: A health care provider or facility; testing site; a state, local, tribal, and territorial public health authority (STLT Public Health Agency); or other organization that is enrolled in and using Simple Report to record and/or transmit data.",
+            l1:
+              "User: An individual whose personal data is being reported via Simple Report (Individual User), or an individual authorized to act on behalf of the Entity under these Terms (Entity User or Entity Administrator). Simple Report will only designate one User from the Entity as the Entity Administrator. Entity Administrators will have more detailed identity verification than general Entity Users. Once the Entity Administrator has their identity verified, the Entity Administrator can add other general Entity Users or Individual Users to the Application. All roles are referred to as “User” for the purposes of these Terms, unless otherwise indicated.",
           },
           dataRights: {
             heading: "Data rights and usage",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -420,16 +420,16 @@ export const es: LanguageConfig = {
           },
           dataRights: {
             heading: "Derechos y uso de los datos",
-            subheading: "Cuentas/Inscripción",
-            l0: "Para los usuarios de entidades",
+            subheading: "Cuentas/inscripción",
+            section0: "Para los usuarios de entidades",
             p01:
               "Si usted está usando la aplicación en nombre de una entidad, como administrador o como usuario, usted declara y garantiza que tiene la autoridad para hacer que esa entidad cumpla con los términos, y al aceptar los términos lo hace en nombre de esa entidad (y cada mención de “usted” en los términos se refiere a usted y esa entidad).",
             p02:
               "Para acceder a la aplicación, como parte del proceso de inscripción y para continuar usándola, es probable que se le pida que proporcione cierta información (como los detalles de identificación o contacto). Toda esa información que usted dé a los CDC o el HHS debe ser correcta y estar actualizada. Debe informarnos con prontitud sobre cualquier cambio y actualizar su información en la aplicación o escribir a <0>support@simplereport.gov</0>, para que podamos mantenerlo informado de cualquier cambio en la aplicación o en estos términos que podrían afectar su uso de la aplicación. Es probable que usemos la información de contacto que usted proporcione para comunicarnos con respecto a la facilidad de uso, a fin de mejorar el producto y el servicio. Después de la inscripción de la entidad y la creación de cuentas de usuarios de una entidad en la aplicación, el HHS o los CDC le proporcionarán credenciales (como contraseñas, claves, identificadores e identificaciones para la entidad y los usuarios de la identidad). Estas credenciales son para que solo usted las use y para identificar cualquier software o interfaz de programación (API, por sus siglas en inglés) que usted esté usando. Usted acepta mantener sus credenciales de manera confidencial y hacer lo razonablemente posible para prevenir y desalentar que otras personas usen sus credenciales.",
-            l1: "Para los administradores de entidades",
+            section1: "Para los administradores de entidades",
             p1:
               "El administrador de una entidad acepta verificar la identidad de otros usuarios de la entidad que sean agregados y desactivar las cuentas de otros usuarios de la entidad que ya no deberían tener acceso. El administrador también acepta establecer los permisos adecuadamente para determinar el acceso mínimo necesario para cada usuario de la entidad, a fin de que puedan cumplir con los deberes requeridos en su puesto de trabajo.",
-            l2: "Para los usuarios individuales",
+            section2: "Para los usuarios individuales",
             p2:
               "Los administradores de la entidad les darán a los usuarios individuales acceso a la aplicación. Los usuarios individuales pueden usar la aplicación para acceder y revisar su propia información o la información de otras personas, según lo permitan las leyes vigentes (p. ej., en nombre de un menor o como tutor legal).  Como se ha mencionado, todos los usuarios deben aceptar y cumplir con estos términos una vez que se hayan inscrito y usen la aplicación.",
           },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -407,10 +407,12 @@ export const es: LanguageConfig = {
           },
           definitions: {
             heading: "Definiciones",
-            l0:
-              "Entidad: Un proveedor o establecimiento de atención médica; un lugar donde se hagan pruebas; una autoridad de salud pública estatal, local, tribal o territorial (agencia de salud pública STLT); u otra institución que esté inscrita en SimpleReport y la use para registrar o transmitir datos.",
-            l1:
-              "Usuario: Una persona cuyos datos personales se estén notificando vía SimpleReport (usuario individual) o una persona autorizada para actuar en nombre de la entidad bajo estos términos (usuario de una entidad o administrador de una entidad). SimpleReport solo designará a un usuario de la entidad como el administrador de la entidad. Los administradores de entidades tendrán una verificación de identidad más detallada que los usuarios generales de las entidades. Una vez que se haya verificado la identidad del administrador de la entidad, esta persona podrá añadir a otros usuarios de la entidad o usuarios individuales a la aplicación. A efectos de estos términos, todas las funciones se denominan como las de un “usuario”, a menos que se indique lo contrario.",
+            l0: "Entidad",
+            p0:
+              "Un proveedor o establecimiento de atención médica; un lugar donde se hagan pruebas; una autoridad de salud pública estatal, local, tribal o territorial (agencia de salud pública STLT); u otra institución que esté inscrita en SimpleReport y la use para registrar o transmitir datos.",
+            l1: "Usuario",
+            p1:
+              "Una persona cuyos datos personales se estén notificando vía SimpleReport (usuario individual) o una persona autorizada para actuar en nombre de la entidad bajo estos términos (usuario de una entidad o administrador de una entidad). SimpleReport solo designará a un usuario de la entidad como el administrador de la entidad. Los administradores de entidades tendrán una verificación de identidad más detallada que los usuarios generales de las entidades. Una vez que se haya verificado la identidad del administrador de la entidad, esta persona podrá añadir a otros usuarios de la entidad o usuarios individuales a la aplicación. A efectos de estos términos, todas las funciones se denominan como las de un “usuario”, a menos que se indique lo contrario.",
           },
           dataRights: {
             heading: "Derechos y uso de los datos",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -407,12 +407,10 @@ export const es: LanguageConfig = {
           },
           definitions: {
             heading: "Definiciones",
-            l0: "Entidad",
-            p0:
-              "Un proveedor o establecimiento de atención médica; un lugar donde se hagan pruebas; una autoridad de salud pública estatal, local, tribal o territorial (agencia de salud pública STLT); u otra institución que esté inscrita en SimpleReport y la use para registrar o transmitir datos.",
-            l1: "Usuario",
-            p1:
-              "Una persona cuyos datos personales se estén notificando vía SimpleReport (usuario individual) o una persona autorizada para actuar en nombre de la entidad bajo estos términos (usuario de una entidad o administrador de una entidad). SimpleReport solo designará a un usuario de la entidad como el administrador de la entidad. Los administradores de entidades tendrán una verificación de identidad más detallada que los usuarios generales de las entidades. Una vez que se haya verificado la identidad del administrador de la entidad, esta persona podrá añadir a otros usuarios de la entidad o usuarios individuales a la aplicación. A efectos de estos términos, todas las funciones se denominan como las de un “usuario”, a menos que se indique lo contrario.",
+            l0:
+              "Entidad: Un proveedor o establecimiento de atención médica; un lugar donde se hagan pruebas; una autoridad de salud pública estatal, local, tribal o territorial (agencia de salud pública STLT); u otra institución que esté inscrita en SimpleReport y la use para registrar o transmitir datos.",
+            l1:
+              "Usuario: Una persona cuyos datos personales se estén notificando vía SimpleReport (usuario individual) o una persona autorizada para actuar en nombre de la entidad bajo estos términos (usuario de una entidad o administrador de una entidad). SimpleReport solo designará a un usuario de la entidad como el administrador de la entidad. Los administradores de entidades tendrán una verificación de identidad más detallada que los usuarios generales de las entidades. Una vez que se haya verificado la identidad del administrador de la entidad, esta persona podrá añadir a otros usuarios de la entidad o usuarios individuales a la aplicación. A efectos de estos términos, todas las funciones se denominan como las de un “usuario”, a menos que se indique lo contrario.",
           },
           dataRights: {
             heading: "Derechos y uso de los datos",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -407,12 +407,16 @@ export const es: LanguageConfig = {
           },
           definitions: {
             heading: "Definiciones",
-            l0: "Entidad",
-            p0:
-              "Un proveedor o establecimiento de atención médica; un lugar donde se hagan pruebas; una autoridad de salud pública estatal, local, tribal o territorial (agencia de salud pública STLT); u otra institución que esté inscrita en SimpleReport y la use para registrar o transmitir datos.",
-            l1: "Usuario",
-            p1:
-              "Una persona cuyos datos personales se estén notificando vía SimpleReport (usuario individual) o una persona autorizada para actuar en nombre de la entidad bajo estos términos (usuario de una entidad o administrador de una entidad). SimpleReport solo designará a un usuario de la entidad como el administrador de la entidad. Los administradores de entidades tendrán una verificación de identidad más detallada que los usuarios generales de las entidades. Una vez que se haya verificado la identidad del administrador de la entidad, esta persona podrá añadir a otros usuarios de la entidad o usuarios individuales a la aplicación. A efectos de estos términos, todas las funciones se denominan como las de un “usuario”, a menos que se indique lo contrario.",
+            l0: {
+              title: "Entidad:",
+              definition:
+                "Un proveedor o establecimiento de atención médica; un lugar donde se hagan pruebas; una autoridad de salud pública estatal, local, tribal o territorial (agencia de salud pública STLT); u otra institución que esté inscrita en SimpleReport y la use para registrar o transmitir datos.",
+            },
+            l1: {
+              title: "Usuario:",
+              definition:
+                "Una persona cuyos datos personales se estén notificando vía SimpleReport (usuario individual) o una persona autorizada para actuar en nombre de la entidad bajo estos términos (usuario de una entidad o administrador de una entidad). SimpleReport solo designará a un usuario de la entidad como el administrador de la entidad. Los administradores de entidades tendrán una verificación de identidad más detallada que los usuarios generales de las entidades. Una vez que se haya verificado la identidad del administrador de la entidad, esta persona podrá añadir a otros usuarios de la entidad o usuarios individuales a la aplicación. A efectos de estos términos, todas las funciones se denominan como las de un “usuario”, a menos que se indique lo contrario.",
+            },
           },
           dataRights: {
             heading: "Derechos y uso de los datos",

--- a/frontend/src/patientApp/timeOfTest/ToS.tsx
+++ b/frontend/src/patientApp/timeOfTest/ToS.tsx
@@ -37,9 +37,7 @@ function ToS() {
       <h3 id="accounts-registration">
         {t("testResult.tos.document.dataRights.subheading")}
       </h3>
-      <ul>
-        <li>{t("testResult.tos.document.dataRights.l0")}</li>
-      </ul>
+      <h4>{t("testResult.tos.document.dataRights.section0")}</h4>
       <p>{t("testResult.tos.document.dataRights.p01")}</p>
       <Trans
         t={t}
@@ -51,13 +49,9 @@ function ToS() {
           </a>,
         ]}
       />
-      <ul>
-        <li>{t("testResult.tos.document.dataRights.l1")}</li>
-      </ul>
+      <h4>{t("testResult.tos.document.dataRights.section1")}</h4>
       <p>{t("testResult.tos.document.dataRights.p1")}</p>
-      <ul>
-        <li>{t("testResult.tos.document.dataRights.l2")}</li>
-      </ul>
+      <h4>{t("testResult.tos.document.dataRights.section2")}</h4>
       <p>{t("testResult.tos.document.dataRights.p2")}</p>
       <h3 id="privacy">{t("testResult.tos.document.privacy.heading")}</h3>
       <Trans

--- a/frontend/src/patientApp/timeOfTest/ToS.tsx
+++ b/frontend/src/patientApp/timeOfTest/ToS.tsx
@@ -23,12 +23,8 @@ function ToS() {
       </h2>
       <ul>
         <li>{t("testResult.tos.document.definitions.l0")}</li>
-      </ul>
-      <p>{t("testResult.tos.document.definitions.p0")}</p>
-      <ul>
         <li>{t("testResult.tos.document.definitions.l1")}</li>
       </ul>
-      <p>{t("testResult.tos.document.definitions.p1")}</p>
       <h2 id="data-rights-and-usage">
         {t("testResult.tos.document.dataRights.heading")}
       </h2>

--- a/frontend/src/patientApp/timeOfTest/ToS.tsx
+++ b/frontend/src/patientApp/timeOfTest/ToS.tsx
@@ -83,26 +83,24 @@ function ToS() {
       <h3 id="other-responsibilities">
         {t("testResult.tos.document.otherResponsibilities.heading")}
       </h3>
+      <h4>
+        {t("testResult.tos.document.otherResponsibilities.ul.preheading1")}
+      </h4>
       <ul>
-        <li>
-          {t("testResult.tos.document.otherResponsibilities.ul.preheading1")}
-        </li>
-        <ul>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li0")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li1")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li2")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li3")}</li>
-        </ul>
-        <li>
-          {t("testResult.tos.document.otherResponsibilities.ul.preheading2")}
-        </li>
-        <ul>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li4")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li5")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li6")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li7")}</li>
-          <li>{t("testResult.tos.document.otherResponsibilities.ul.li8")}</li>
-        </ul>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li0")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li1")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li2")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li3")}</li>
+      </ul>
+      <h4>
+        {t("testResult.tos.document.otherResponsibilities.ul.preheading2")}
+      </h4>
+      <ul>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li4")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li5")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li6")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li7")}</li>
+        <li>{t("testResult.tos.document.otherResponsibilities.ul.li8")}</li>
       </ul>
       <h2 id="service-management">
         {t("testResult.tos.document.serviceManagement.heading")}

--- a/frontend/src/patientApp/timeOfTest/ToS.tsx
+++ b/frontend/src/patientApp/timeOfTest/ToS.tsx
@@ -22,13 +22,15 @@ function ToS() {
         {t("testResult.tos.document.definitions.heading")}
       </h2>
       <ul>
-        <li>{t("testResult.tos.document.definitions.l0")}</li>
+        <li>
+          <b>{t("testResult.tos.document.definitions.l0.title")}</b>{" "}
+          {t("testResult.tos.document.definitions.l0.definition")}
+        </li>
+        <li>
+          <b>{t("testResult.tos.document.definitions.l1.title")}</b>{" "}
+          {t("testResult.tos.document.definitions.l1.definition")}
+        </li>
       </ul>
-      <p>{t("testResult.tos.document.definitions.p0")}</p>
-      <ul>
-        <li>{t("testResult.tos.document.definitions.l1")}</li>
-      </ul>
-      <p>{t("testResult.tos.document.definitions.p1")}</p>
       <h2 id="data-rights-and-usage">
         {t("testResult.tos.document.dataRights.heading")}
       </h2>

--- a/frontend/src/patientApp/timeOfTest/ToS.tsx
+++ b/frontend/src/patientApp/timeOfTest/ToS.tsx
@@ -23,8 +23,12 @@ function ToS() {
       </h2>
       <ul>
         <li>{t("testResult.tos.document.definitions.l0")}</li>
+      </ul>
+      <p>{t("testResult.tos.document.definitions.p0")}</p>
+      <ul>
         <li>{t("testResult.tos.document.definitions.l1")}</li>
       </ul>
+      <p>{t("testResult.tos.document.definitions.p1")}</p>
       <h2 id="data-rights-and-usage">
         {t("testResult.tos.document.dataRights.heading")}
       </h2>

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -1069,11 +1069,11 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
   }
 
   h3 {
-    font-size: size("body", "sm");
+    font-size: size("body", "xs");
   }
 
   h4 {
-    font-size: size("body", "xs");
+    font-size: size("body", "3xs");
   }
 }
 

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -1071,6 +1071,10 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
   h3 {
     font-size: size("body", "sm");
   }
+
+  h4 {
+    font-size: size("body", "xs");
+  }
 }
 
 .patient__header {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Closes #3979 

## Changes Proposed

- Consolidate list items and paragraph text in "Definitions," and bold defined words
- Change list items to subheadings in "Data rights and usage"
- Make "Accounts/registration" sentence case for consistency
- Switch user types to subheadings in "Other responsibilities," and change indentation of list items underneath
- change font size for level 4 headers in TOS

## Testing

I will deploy to `dev2`. Check that changes look right for both English and Spanish versions of the TOS. You can access this page by finding the patient self-registration link in the org admin settings and pasting it in your browser.

## Screenshots / Demos
Screenshot of new subheadings with proposed font size:
![Screen Shot 2022-10-04 at 11 28 03 AM](https://user-images.githubusercontent.com/6401323/193900238-0ad7be4c-06d2-4b31-9a91-f62c4157a70e.png)

## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved

### Content
- [ ] Any content changes have been approved by content team
