### PR TITLE
Add alt-text on test card icons

### DIFF
--- a/frontend/src/app/commonComponents/TextWithTooltip.tsx
+++ b/frontend/src/app/commonComponents/TextWithTooltip.tsx
@@ -30,7 +30,7 @@ export const TextWithTooltip = ({
       <button
         className={`usa-button usa-button--unstyled ${className}`}
         ref={ref}
-        aria-label={buttonLabel}
+        aria-label={`${buttonLabel} tooltip`}
         {...tooltipProps}
       >
         {children}
@@ -49,7 +49,11 @@ export const TextWithTooltip = ({
       wrapperclasses="usa-text-with-tooltip"
     >
       {text}
-      <FontAwesomeIcon className="info-circle-icon" icon={faInfoCircle} />
+      <FontAwesomeIcon
+        alt-text="info"
+        className="info-circle-icon"
+        icon={faInfoCircle}
+      />
     </Tooltip>
   );
 };

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -650,8 +650,13 @@ const QueueItem = ({
       aria-label={`Close test for ${patientFullName}`}
     >
       <span className="fa-layers">
-        <FontAwesomeIcon icon={"circle"} size="2x" inverse />
-        <FontAwesomeIcon icon={"times-circle"} size="2x" />
+        <FontAwesomeIcon
+          alt-text="close-circle"
+          icon={"circle"}
+          size="2x"
+          inverse
+        />
+        <FontAwesomeIcon alt-text="close-x" icon={"times-circle"} size="2x" />
       </span>
     </button>
   );
@@ -909,7 +914,6 @@ const QueueItem = ({
                       label={
                         <>
                           <span>Device</span>
-
                           <TextWithTooltip
                             buttonLabel="Device"
                             tooltip="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -240,7 +240,7 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
         aria-label="Start timer"
       >
         <span role="timer">{mmss(countdown)}</span>{" "}
-        <FontAwesomeIcon icon={faStopwatch} />
+        <FontAwesomeIcon alt-text="stopwatch" icon={faStopwatch} />
       </button>
     );
   }
@@ -253,7 +253,7 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
         aria-label="Reset timer"
       >
         <span role="timer">{mmss(countdown)}</span>{" "}
-        <FontAwesomeIcon icon={faRedo} />
+        <FontAwesomeIcon alt-text="reset" icon={faRedo} />
       </button>
     );
   }

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`TestQueue should render the test queue 1`] = `
               class="fa-layers"
             >
               <svg
+                alt-text="close-circle"
                 aria-hidden="true"
                 class="svg-inline--fa fa-circle fa-w-16 fa-inverse fa-2x "
                 data-icon="circle"
@@ -97,6 +98,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 />
               </svg>
               <svg
+                alt-text="close-x"
                 aria-hidden="true"
                 class="svg-inline--fa fa-times-circle fa-w-16 fa-2x "
                 data-icon="times-circle"
@@ -156,6 +158,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   </span>
                    
                   <svg
+                    alt-text="stopwatch"
                     aria-hidden="true"
                     class="svg-inline--fa fa-stopwatch fa-w-14 "
                     data-icon="stopwatch"
@@ -277,7 +280,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         >
                           <button
                             aria-describedby="tooltip-211111"
-                            aria-label="Device"
+                            aria-label="Device tooltip"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -286,6 +289,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             wrapperclasses="usa-text-with-tooltip"
                           >
                             <svg
+                              alt-text="info"
                               aria-hidden="true"
                               class="svg-inline--fa fa-info-circle fa-w-16 info-circle-icon"
                               data-icon="info-circle"
@@ -498,6 +502,7 @@ exports[`TestQueue should render the test queue 1`] = `
               class="fa-layers"
             >
               <svg
+                alt-text="close-circle"
                 aria-hidden="true"
                 class="svg-inline--fa fa-circle fa-w-16 fa-inverse fa-2x "
                 data-icon="circle"
@@ -513,6 +518,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 />
               </svg>
               <svg
+                alt-text="close-x"
                 aria-hidden="true"
                 class="svg-inline--fa fa-times-circle fa-w-16 fa-2x "
                 data-icon="times-circle"
@@ -572,6 +578,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   </span>
                    
                   <svg
+                    alt-text="stopwatch"
                     aria-hidden="true"
                     class="svg-inline--fa fa-stopwatch fa-w-14 "
                     data-icon="stopwatch"
@@ -693,7 +700,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         >
                           <button
                             aria-describedby="tooltip-211111"
-                            aria-label="Device"
+                            aria-label="Device tooltip"
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -702,6 +709,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             wrapperclasses="usa-text-with-tooltip"
                           >
                             <svg
+                              alt-text="info"
                               aria-hidden="true"
                               class="svg-inline--fa fa-info-circle fa-w-16 info-circle-icon"
                               data-icon="info-circle"

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -267,6 +267,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
         </div>
         <div className="grid-col-auto">
           <TextWithTooltip
+            buttonLabel="Results info"
             tooltip="COVID-19 results are reported to your public health department. Flu results are not reported at this time."
             position={isMobile ? "top" : "left"}
           />


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue #4051

- icons on the test card do not have alt text

## Changes Proposed

- Added alt text to the image icons
- Made the tooltip `aria-label` more descriptive
  -  threw in a nicer label for the multiplex result input form while I was at it

## Additional Information

- the ticket was unclear on what the actual violation was, but it seems to boil down to the images not having accessible text, adding `alt-text` to the icons did resolve the accessibility violations deque flagged for the icon buttons. `alt-text` for images is overall best practice, so I think this is a good solution (as opposed to putting `aria-label`s all over)
- as the ticket suggests, the svg's themselves being `aria-hidden="true"` does not seem to be an issue (deque agrees), as the actual buttons themselves are focusable and have valid `aria-label`s. It does make sense that the icons themselves (which have a valid `role="img"`) should be `aria-hidden="true"` since it's the button action and label that make the interaction accessible.

## Testing

- Confirm that this is no longer a flagged issue in deque, and can successfully tab through and focus on the buttons via the screen reader tree
- currently deploying to `sr-dev4`

## Screenshots / Demos

- tooltip icon

![Screen Shot 2022-10-04 at 4 20 42 PM](https://user-images.githubusercontent.com/89797785/193918682-53d8c2fc-ffa6-4774-87fa-6120b03ed00f.png)

- close icon

![Screen Shot 2022-10-04 at 4 18 42 PM](https://user-images.githubusercontent.com/89797785/193918951-caaf5456-8633-41ae-9ab9-fc11a52cd690.png)

- timer icon

![Screen Shot 2022-10-04 at 4 19 32 PM](https://user-images.githubusercontent.com/89797785/193918817-4d4bb784-1322-48f3-b2c6-f240c23be8f6.png)

## Checklist for Author and Reviewer
- [ ] Modified components are accessible

<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
