### PR TITLE
make ordering facility info optional for test results uploader

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/TestResultFileValidator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/TestResultFileValidator.java
@@ -178,14 +178,14 @@ public class TestResultFileValidator {
       ValueOrError residenceType = getValue(row, "residence_type", false);
       ValueOrError hospitalized = getValue(row, "hospitalized", false);
       ValueOrError icu = getValue(row, "icu", false);
-      ValueOrError orderingFacilityName = getValue(row, "ordering_facility_name", true);
-      ValueOrError orderingFacilityStreet = getValue(row, "ordering_facility_street", true);
+      ValueOrError orderingFacilityName = getValue(row, "ordering_facility_name", false);
+      ValueOrError orderingFacilityStreet = getValue(row, "ordering_facility_street", false);
       ValueOrError orderingFacilityStreet2 = getValue(row, "ordering_facility_street2", false);
-      ValueOrError orderingFacilityCity = getValue(row, "ordering_facility_city", true);
-      ValueOrError orderingFacilityState = getValue(row, "ordering_facility_state", true);
-      ValueOrError orderingFacilityZipCode = getValue(row, "ordering_facility_zip_code", true);
+      ValueOrError orderingFacilityCity = getValue(row, "ordering_facility_city", false);
+      ValueOrError orderingFacilityState = getValue(row, "ordering_facility_state", false);
+      ValueOrError orderingFacilityZipCode = getValue(row, "ordering_facility_zip_code", false);
       ValueOrError orderingFacilityPhoneNumber =
-          getValue(row, "ordering_facility_phone_number", true);
+          getValue(row, "ordering_facility_phone_number", false);
       ValueOrError comment = getValue(row, "comment", false);
       ValueOrError testResultStatus = getValue(row, "test_result_status", false);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultFileValidatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultFileValidatorTest.java
@@ -30,7 +30,7 @@ class TestResultFileValidatorTest {
     // WHEN
     List<FeedbackMessage> errors = testResultFileValidator.validate(input);
     // THEN
-    assertThat(errors).hasSize(42);
+    assertThat(errors).hasSize(36);
 
     List<String> errorMessages =
         errors.stream().map(FeedbackMessage::getMessage).collect(Collectors.toList());
@@ -71,13 +71,7 @@ class TestResultFileValidatorTest {
             "testing_lab_street is a required column.",
             "testing_lab_city is a required column.",
             "testing_lab_state is a required column.",
-            "testing_lab_zip_code is a required column.",
-            "ordering_facility_name is a required column.",
-            "ordering_facility_street is a required column.",
-            "ordering_facility_city is a required column.",
-            "ordering_facility_state is a required column.",
-            "ordering_facility_zip_code is a required column.",
-            "ordering_facility_phone_number is a required column.");
+            "testing_lab_zip_code is a required column.");
   }
 
   @Test

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -4872,9 +4872,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Ordering facility name
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -4943,9 +4943,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Ordering facility street address
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -5078,9 +5078,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Ordering facility city
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -5149,9 +5149,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Ordering facility state
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -5224,9 +5224,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Ordering facility zip code
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -5302,9 +5302,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Ordering facility phone number
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div

--- a/frontend/src/app/testResults/uploads/schema.json
+++ b/frontend/src/app/testResults/uploads/schema.json
@@ -907,7 +907,7 @@
             {
               "name": "Ordering facility name",
               "colHeader": "ordering_facility_name",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": false,
               "acceptedValues": false,
@@ -921,7 +921,7 @@
             {
               "name": "Ordering facility street address",
               "colHeader": "ordering_facility_street",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": false,
               "acceptedValues": false,
@@ -949,7 +949,7 @@
             {
               "name": "Ordering facility city",
               "colHeader": "ordering_facility_city ",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": false,
               "acceptedValues": false,
@@ -963,7 +963,7 @@
             {
               "name": "Ordering facility state",
               "colHeader": "ordering_facility_state",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": true,
               "acceptedValues": false,
@@ -977,7 +977,7 @@
             {
               "name": "Ordering facility zip code",
               "colHeader": "ordering_facility_zip_code",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": true,
               "acceptedValues": false,
@@ -991,7 +991,7 @@
             {
               "name": "Ordering facility phone number",
               "colHeader": "ordering_facility_phone_number",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": true,
               "acceptedValues": false,


### PR DESCRIPTION
# BACKEND/FRONTEND PULL REQUEST

## Related Issue
- #4387
- Based on user feedback/ convo with @lg-king , we decided to make the `ordering facility` info optional since it could be left blank if its the same as `testing lab` info.

## Changes Proposed

- update the validator to make ordering facility fields optional
- update docs to show ordering facility fields as optional

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->