### PR TITLE
update search input label text

### DIFF
--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -292,7 +292,6 @@ export const DetachedManagePatients = ({
                 }}
                 queryString={debounced || ""}
                 className="display-inline-block"
-                placeholder=""
                 focusOnMount
               />
             </div>

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -66,7 +66,7 @@ describe("TestQueue", () => {
         </MockedProvider>
       </MemoryRouter>
     );
-    await screen.findByLabelText("Search");
+    await screen.findByLabelText("Search for a person to start their test");
     expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
     expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
     expect(container).toMatchSnapshot();
@@ -189,7 +189,7 @@ describe("TestQueue", () => {
         </MemoryRouter>
       );
 
-      await screen.findByLabelText("Search");
+      await screen.findByLabelText("Search for a person to start their test");
       expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
       expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
 

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`TestQueue should render the test queue 1`] = `
               class="usa-sr-only"
               for="search-field-small"
             >
-              Search
+              Search for a person to start their test
             </label>
             <div>
               <input

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -264,6 +264,7 @@ const AddToQueueSearchBox = ({
         onInputChange={onInputChange}
         queryString={debounced}
         disabled={!allowQuery}
+        placeholder={"Search for a person to start their test"}
       />
       <SearchResults
         page="queue"

--- a/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
@@ -59,11 +59,7 @@ const SearchInput = ({
             autoComplete="off"
             className="usa-input"
             id="search-field-small"
-            placeholder={
-              placeholder !== undefined
-                ? placeholder
-                : "Search for a person to start their test"
-            }
+            placeholder={placeholder}
             type="search"
             name="search"
             value={queryString}

--- a/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
@@ -52,7 +52,7 @@ const SearchInput = ({
           className={label ? "display-block" : "usa-sr-only"}
           htmlFor="search-field-small"
         >
-          {label || "Search"}
+          {label || placeholder || "Search"}
         </label>
         <div>
           <input

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -441,7 +441,6 @@ export const DetachedTestResultsList = ({
                   queryString={debounced}
                   disabled={!allowQuery}
                   label={"Search by name"}
-                  placeholder={""}
                   className="usa-form-group search-input_without_submit_button"
                   showSubmitButton={false}
                 />

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -98,7 +98,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                       class="usa-input"
                       id="search-field-small"
                       name="search"
-                      placeholder=""
                       type="search"
                       value=""
                     />


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Label text is just "Search" when there is no label provided
- Closes #4068 

## Changes Proposed

- If a placeholder is provided use that text instead of "Search"

## Additional Information

- Refactor placeholder to make it null by default

## Testing

- Ensure there are no accessibility issues with the search input on the "Conduct Test" page

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/10108172/194062835-2da14bc6-4948-4dd6-b1d9-64878b1b6d43.png)