### PR TITLE
check for actor each job

### DIFF
--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   terraform-plan:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -60,17 +60,26 @@ jobs:
       OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+      - name: Dependabot bypass
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        run: |
+          true
       - uses: azure/login@v1
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           terraform_version: 1.1.4
       - name: Terraform Init
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: make init-prod
       - name: Build ReportStream function app
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/build-reportstream-functions
         with:
           deploy-env: ${{env.DEPLOY_ENV}}
       - name: Terraform plan
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: make plan-prod


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Changes Proposed

- This prevents the terraform plan job from running against Dependabot PRs.

## Additional Information

- Initial attempt at a fix: https://github.com/CDCgov/prime-simplereport/pull/4366

## Testing

- [I tested this](https://github.com/CDCgov/prime-simplereport/actions/runs/3191672604/jobs/5208301933) against my user and verified that the job exited successfully and did not run the terraform plan; then I updated the PR to run the check against the Dependabot user.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev,` or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->