### PR TITLE
change non-required test results csv date fields to optional

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/TestResultFileValidator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/TestResultFileValidator.java
@@ -144,11 +144,11 @@ public class TestResultFileValidator {
       ValueOrError testPerformedCode = getValue(row, "test_performed_code", true);
       ValueOrError testResult = getValue(row, "test_result", true);
       ValueOrError orderTestDate = getValue(row, "order_test_date", true);
-      ValueOrError specimenCollectionDate = getValue(row, "specimen_collection_date", true);
+      ValueOrError specimenCollectionDate = getValue(row, "specimen_collection_date", false);
       ValueOrError testingLabSpecimenReceivedDate =
-          getValue(row, "testing_lab_specimen_received_date", true);
+          getValue(row, "testing_lab_specimen_received_date", false);
       ValueOrError testResultDate = getValue(row, "test_result_date", true);
-      ValueOrError dateResultReleased = getValue(row, "date_result_released", true);
+      ValueOrError dateResultReleased = getValue(row, "date_result_released", false);
       ValueOrError specimenType = getValue(row, "specimen_type", true);
       ValueOrError orderingProviderId = getValue(row, "ordering_provider_id", true);
       ValueOrError orderingProviderLastName = getValue(row, "ordering_provider_last_name", true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultFileValidatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultFileValidatorTest.java
@@ -30,7 +30,7 @@ class TestResultFileValidatorTest {
     // WHEN
     List<FeedbackMessage> errors = testResultFileValidator.validate(input);
     // THEN
-    assertThat(errors).hasSize(36);
+    assertThat(errors).hasSize(33);
 
     List<String> errorMessages =
         errors.stream().map(FeedbackMessage::getMessage).collect(Collectors.toList());
@@ -53,10 +53,7 @@ class TestResultFileValidatorTest {
             "test_performed_code is a required column.",
             "test_result is a required column.",
             "order_test_date is a required column.",
-            "specimen_collection_date is a required column.",
-            "testing_lab_specimen_received_date is a required column.",
             "test_result_date is a required column.",
-            "date_result_released is a required column.",
             "specimen_type is a required column.",
             "ordering_provider_id is a required column.",
             "ordering_provider_last_name is a required column.",

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -2292,9 +2292,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Specimen collection date
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -2366,9 +2366,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Testing lab specimen received date
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div
@@ -2514,9 +2514,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Date result released
               <span
-                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
               >
-                Required
+                Optional
               </span>
             </h4>
             <div

--- a/frontend/src/app/testResults/uploads/schema.json
+++ b/frontend/src/app/testResults/uploads/schema.json
@@ -378,7 +378,7 @@
             {
               "name": "Specimen collection date",
               "colHeader": "specimen_collection_date",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": true,
               "acceptedValues": false,
@@ -393,7 +393,7 @@
             {
               "name": "Testing lab specimen received date",
               "colHeader": "testing_lab_specimen_received_date",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": true,
               "acceptedValues": false,
@@ -423,7 +423,7 @@
             {
               "name": "Date result released",
               "colHeader": "date_result_released",
-              "required": true,
+              "required": false,
               "requested": false,
               "acceptedFormat": true,
               "acceptedValues": false,


### PR DESCRIPTION
# BACKEND/FRONTEND PULL REQUEST

## Related Issue
- resolves https://github.com/CDCgov/prime-simplereport/issues/4393
- Based on user feedback/ convo with @lg-king , we decided to make the following date fields optional since it could be left blank if its the same as order_test_date.

  - `date_result_released`
  - `testing_lab_specimen_received_date`
  - `specimen_collection_date`

## Changes Proposed

- update the validator to make the fields optional
- update docs to show the fields as optional

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->