### PR TITLE
enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,25 +36,25 @@ updates:
       - "DanielSass"
       - "rin-skylight"
 
-  # - package-ecosystem: "github-actions"
-  #   directory: "/.github/workflows"
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "emyl3"
-      # - "rin-skylight"
-      # - "emmastephenson"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "emyl3"
+      - "rin-skylight"
+      - "emmastephenson"
 
-  # - package-ecosystem: "github-actions"
-  #   directory: "/.github/actions"
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "emyl3"
-      # - "rin-skylight"
-      # - "emmastephenson"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "emyl3"
+      - "rin-skylight"
+      - "emmastephenson"
 
   # - package-ecosystem: "gradle"
   #   directory: "/backend"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- github-actions #3078
- Get dependabot going for the github-actions

## Changes Proposed

- This should allow dependabot to open PRs to help guide and encourage us to stay up to date on github actions. In general, these should be some of the easier things to upgrade.

## Additional Information

- I'm enabling only some dependabot ecosystems at a time to keep ourselves from being overwhelmed.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---