### PR TITLE
admin/standard users can use the bulk test results uploader

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -68,7 +68,7 @@ public class TestResultUploadService {
   private static final ObjectMapper mapper =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-  @AuthorizationConfiguration.RequirePermissionCSVUpload
+  @AuthorizationConfiguration.RequirePermissionReadResultListForTestEvent
   public TestResultUpload processResultCSV(InputStream csvStream) {
 
     TestResultUpload result = new TestResultUpload(UploadStatus.FAILURE);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
@@ -76,7 +76,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
 
   @Test
   @DirtiesContext
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void integrationTest_returnsSuccessfulResult() throws IOException {
     var responseFile =
         TestResultUploadServiceTest.class
@@ -109,7 +109,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void ioException_CaughtAndThrowsCsvException() throws IOException {
 
     var input = mock(InputStream.class);
@@ -124,7 +124,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
 
   @Test
   @DirtiesContext
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void feignBadRequest_returnsErrorMessage() throws IOException {
     try (var x = loadCsv("responses/datahub-error-response.json")) {
       stubFor(
@@ -145,7 +145,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
 
   @Test
   @DirtiesContext
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void feignGeneralError_returnsFailureStatus() throws IOException {
 
     stubFor(
@@ -165,7 +165,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  @SliceTestConfiguration.WithSimpleReportStandardUser
+  @SliceTestConfiguration.WithSimpleReportEntryOnlyUser
   void unauthorizedUser_NotAuthorizedResponse() throws IOException {
     try (InputStream input = loadCsv("test-upload-test-results.csv")) {
       assertThrows(AccessDeniedException.class, () -> this._service.processResultCSV(input));
@@ -197,7 +197,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void uploadService_getUploadSubmission_throwsOnInvalid() {
     var uuid = UUID.randomUUID();
 
@@ -206,7 +206,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
 
   @Test
   @DirtiesContext
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void uploadService_getUploadSubmission_rsClientOk() {
     UUID reportId = UUID.randomUUID();
 
@@ -249,7 +249,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  @SliceTestConfiguration.WithSimpleReportCsvUploadPilotUser
+  @SliceTestConfiguration.WithSimpleReportStandardUser
   void uploadService_getUploadSubmission_fileInvalidData() {
     // GIVEN
     InputStream invalidInput = new ByteArrayInputStream("invalid".getBytes());

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -156,7 +156,6 @@ const App = () => {
   const canViewPeople = appPermissions.people.canView;
   const canEditPeople = appPermissions.people.canEdit;
   const canViewSettings = appPermissions.settings.canView;
-  const canUseCsvUploaderPilot = appPermissions.featureFlags.SrCsvUploaderPilot;
 
   return (
     <>
@@ -217,7 +216,7 @@ const App = () => {
                 path="results/upload/submit"
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canUseCsvUploaderPilot}
+                    requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper
@@ -233,7 +232,7 @@ const App = () => {
                 path="results/upload/submit/guide"
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canUseCsvUploaderPilot}
+                    requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper
@@ -250,7 +249,7 @@ const App = () => {
                 path="results/upload/submissions/submission/:id"
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canUseCsvUploaderPilot}
+                    requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper
@@ -266,7 +265,7 @@ const App = () => {
                 path={"results/upload/submissions"}
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canUseCsvUploaderPilot}
+                    requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper
@@ -282,7 +281,7 @@ const App = () => {
                 path={"results/upload/submissions/:pageNumber"}
                 element={
                   <ProtectedRoute
-                    requiredPermissions={canUseCsvUploaderPilot}
+                    requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -187,9 +187,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <TestResultsList />
                       </ResultsNavWrapper>
                     }
@@ -203,9 +201,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <CleanTestResultsList />
                       </ResultsNavWrapper>
                     }
@@ -219,9 +215,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <Uploads />
                       </ResultsNavWrapper>
                     }
@@ -235,9 +229,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <Schema />
                       </ResultsNavWrapper>
                     }
@@ -252,9 +244,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <Submission />
                       </ResultsNavWrapper>
                     }
@@ -268,9 +258,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <Submissions />
                       </ResultsNavWrapper>
                     }
@@ -284,9 +272,7 @@ const App = () => {
                     requiredPermissions={canViewResults}
                     userPermissions={data.whoami.permissions}
                     element={
-                      <ResultsNavWrapper
-                        userPermissions={data.whoami.permissions}
-                      >
+                      <ResultsNavWrapper>
                         <Submissions />
                       </ResultsNavWrapper>
                     }

--- a/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
@@ -17,13 +17,13 @@ const ROLES: RoleButton[] = [
     value: "ADMIN",
     label: "Admin",
     labelDescription:
-      "Full access: Conduct tests, manage test results and patient profiles,  manage account settings, users, and testing facilities. ",
+      "Full access: Conduct tests, bulk upload results, manage test results and patient profiles,  manage account settings, users, and testing facilities. ",
   },
   {
     value: "USER",
     label: "Standard user",
     labelDescription:
-      "Conduct tests, manage test results, and patient profiles",
+      "Conduct tests, bulk upload results, manage test results, and patient profiles",
   },
   {
     value: "ENTRY_ONLY",

--- a/frontend/src/app/testResults/ResultsNavWrapper.test.tsx
+++ b/frontend/src/app/testResults/ResultsNavWrapper.test.tsx
@@ -1,17 +1,13 @@
 import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
-import { appPermissions } from "../permissions";
-
 import ResultsNavWrapper from "./ResultsNavWrapper";
 
 describe("ResultsNav", () => {
   it("displays the results sub nav when user has the permission", () => {
     const { container } = render(
       <MemoryRouter>
-        <ResultsNavWrapper
-          userPermissions={appPermissions.featureFlags.SrCsvUploaderPilot}
-        >
+        <ResultsNavWrapper>
           <>Testing 123</>
         </ResultsNavWrapper>
       </MemoryRouter>

--- a/frontend/src/app/testResults/ResultsNavWrapper.tsx
+++ b/frontend/src/app/testResults/ResultsNavWrapper.tsx
@@ -1,29 +1,16 @@
 import React, { ReactElement } from "react";
 
-import { appPermissions } from "../permissions";
-import { UserPermission } from "../../generated/graphql";
-
 import ResultsNav from "./ResultsNav";
 
 type Props = {
   children: ReactElement;
-  userPermissions?: UserPermission[];
 };
 
-const ResultsNavWrapper = ({ children, userPermissions }: Props) => {
-  const canUseCsvUploaderPilot = appPermissions.featureFlags.SrCsvUploaderPilot;
-
-  let showSubTabs = false;
-  if (userPermissions !== undefined) {
-    showSubTabs = canUseCsvUploaderPilot.every((requiredPermission) =>
-      userPermissions.includes(requiredPermission)
-    );
-  }
-
+const ResultsNavWrapper = ({ children }: Props) => {
   return (
     <main className="prime-home">
       <div className="grid-container results-wide-container">
-        {showSubTabs && <ResultsNav />}
+        <ResultsNav />
         {children}
       </div>
     </main>

--- a/frontend/src/app/testResults/__snapshots__/ResultsNavWrapper.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/ResultsNavWrapper.test.tsx.snap
@@ -61,6 +61,45 @@ exports[`ResultsNav doesnt display the results sub nav when user doesnt have the
     <div
       class="grid-container results-wide-container"
     >
+      <nav
+        aria-label="Secondary navigation"
+        class="prime-secondary-nav"
+      >
+        <ul
+          class="usa-nav__secondary-links prime-nav"
+        >
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/1"
+            >
+              View test results
+            </a>
+          </li>
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/upload/submit"
+            >
+              Upload spreadsheet
+            </a>
+          </li>
+          <li
+            class="usa-nav__secondary-item"
+          >
+            <a
+              class=""
+              href="/results/upload/submissions"
+            >
+              View upload history
+            </a>
+          </li>
+        </ul>
+      </nav>
       Testing 123
     </div>
   </main>


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #4374
- this **will not be merged** until all other[ `GA Release` tagged tickets](https://github.com/CDCgov/prime-simplereport/labels/GA%20release) are closed
- there will be a follow up PR to remove the CSV upload permission entirely
https://github.com/CDCgov/prime-simplereport/blob/3e00ffe7d3cda898b5e7a2fa1de24e9d7b6b0063/backend/src/main/java/gov/cdc/usds/simplereport/config/AuthorizationConfiguration.java#L458-L461

## Changes Proposed

- show the screens to users who `canViewResults` (only admin and standard users has that permission)
- make upload service use `RequirePermissionReadResultListForTestEvent` (only admin and standard users has that permission)


## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
