### PR TITLE
Embed tutorial uploader video in CSV template guide

### DIFF
--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -120,6 +120,8 @@ const CsvSchemaDocumentation = () => {
             through SimpleReport.
           </p>
           <iframe
+            width="640"
+            height="360"
             title="SimpleReport bulk results uploader tutorial video"
             src="https://www.youtube.com/embed/qqhC7PFBdek"
           />

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -119,6 +119,10 @@ const CsvSchemaDocumentation = () => {
             How to format and upload a CSV file to report test results in bulk
             through SimpleReport.
           </p>
+          <iframe
+            title="SimpleReport bulk results uploader tutorial video"
+            src="https://www.youtube.com/embed/qqhC7PFBdek"
+          />
           <p>
             <strong>In this guide</strong>
           </p>

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -106,6 +106,12 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
         >
           How to format and upload a CSV file to report test results in bulk through SimpleReport.
         </p>
+        <iframe
+          height="360"
+          src="https://www.youtube.com/embed/qqhC7PFBdek"
+          title="SimpleReport bulk results uploader tutorial video"
+          width="640"
+        />
         <p>
           <strong>
             In this guide


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #4253 

## Changes Proposed

Embed video, size is per Victor's specs [here](https://skylight-hq.slack.com/archives/C02HKNHGCP6/p1665004357886899?thread_ts=1664987610.465019&cid=C02HKNHGCP6)

## Additional Information

maybe we want to make video size responsive as on smaller screens the embedded video doesn't look too great

if we think it should, but does not need to block GA, we should make a followup ticket for that

## Testing

unfortunately all the lowers are taken right now, so please check out the screenshots and/or pull the branch

## Screenshots / Demos
![Screen Shot 2022-10-05 at 4 26 30 PM](https://user-images.githubusercontent.com/6401323/194181668-3d8b6880-80c0-4afb-98ed-55e7da1a7abe.png)

this is what the page looks like from a mobile:
![Screen Shot 2022-10-05 at 4 23 26 PM](https://user-images.githubusercontent.com/6401323/194181748-8c69f981-70bd-4c09-9088-00e69052ae32.png)

## Checklist for Author and Reviewer
### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved

### Content
- [x] Any content changes have been approved by content team
