### PR TITLE
allow youtube in Content-Security-Policy

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,6 +10,7 @@
             style-src 'self' 'unsafe-inline';
             img-src 'self' https://touchpoints.app.cloud.gov https://hhs-prime.okta.com data:;
             connect-src 'self'  https://us-street.api.smartystreets.com https://us-zipcode.api.smartystreets.com www.google-analytics.com https://touchpoints.app.cloud.gov https://dc.services.visualstudio.com/v2/track https://*.applicationinsights.azure.com %REACT_APP_BACKEND_URL%/ ;
+            frame-src 'self' https://www.youtube.com;
         ">
         <% } %>
     <meta charset="utf-8" />


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- follow up to #4253
- our `Content-Security-Policy` is blocking youtube iframes

## Changes Proposed

- add `youtube.com` as an `iframe-src` to `Content-Security-Policy`

## Screenshots / Demos

- before
![image](https://user-images.githubusercontent.com/4952042/194332879-a30ce8cc-b4b9-403e-9902-a2a0d93e150e.png)

- after
![image](https://user-images.githubusercontent.com/4952042/194334057-f992df99-37c3-4625-9972-1d77d5054e85.png)

<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
