### PR TITLE
add result to the end of the disease name

### DIFF
--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -78,7 +78,9 @@ const pxpAppResultList = (
 ) => {
   return (
     <>
-      <h2 className="font-heading-sm">{setDiseaseName(diseaseName, t)}</h2>
+      <h2 className="font-heading-sm">
+        {setDiseaseName(diseaseName, t)} result
+      </h2>
       <p className="margin-top-05 text-uppercase">
         {setResult(result, t)}
         <span>

--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -79,7 +79,7 @@ const pxpAppResultList = (
   return (
     <>
       <h2 className="font-heading-sm">
-        {setDiseaseName(diseaseName, t)} result
+        {setDiseaseName(diseaseName, t) + " " + t("testResult.resultLiteral")}
       </h2>
       <p className="margin-top-05 text-uppercase">
         {setResult(result, t)}

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -247,6 +247,7 @@ export const en = {
       },
     },
     testResult: {
+      resultLiteral: "result",
       result: "SARS-CoV-2 result",
       covidResultHeader: "Test result: COVID-19",
       multiplexResultHeader: "Test results: COVID-19 and flu",

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -258,6 +258,7 @@ export const es: LanguageConfig = {
       },
     },
     testResult: {
+      resultLiteral: "resultado",
       result: "Resultado de SARS-CoV-2",
       covidResultHeader: "Resultado de la prueba: COVID-19",
       multiplexResultHeader:

--- a/frontend/src/patientApp/timeOfTest/TestResult.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.test.tsx
@@ -64,7 +64,7 @@ describe("TestResult - COVID-19 only", () => {
       within(patientApp).getByText("Abbott BinaxNOW (Antigen)")
     ).toBeInTheDocument();
     expect(within(patientApp).getByText("Bob M Barker")).toBeInTheDocument();
-    expect(within(patientApp).getByText("COVID-19")).toBeInTheDocument();
+    expect(within(patientApp).getByText("COVID-19 result")).toBeInTheDocument();
     expect(within(patientApp).getByText("Download result")).toBeInTheDocument();
   });
   it("should show a positive result", () => {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Closes #3987 

## Changes Proposed

- add result to the end of disease name

## Additional Information

## Testing

- Check patient experience results page for both to ensure the header is updated. 

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/10108172/194346924-02b5588b-2414-4ad8-af4a-9e129182a0fb.png)

<!---
## Checklist for Author and Reviewer
### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
