### PR TITLE
Make patient name a header on test cards

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -786,18 +786,20 @@ const QueueItem = ({
                 id="patient-name-header"
               >
                 <div className="card-header">
-                  <Button
-                    variant="unstyled"
-                    className="card-name"
-                    onClick={() => {
-                      navigate({
-                        pathname: `/patient/${patient.internalId}`,
-                        search: `?facility=${facilityId}&fromQueue=true`,
-                      });
-                    }}
-                  >
-                    {patientFullName}
-                  </Button>
+                  <h2>
+                    <Button
+                      variant="unstyled"
+                      className="card-name"
+                      onClick={() => {
+                        navigate({
+                          pathname: `/patient/${patient.internalId}`,
+                          search: `?facility=${facilityId}&fromQueue=true`,
+                        });
+                      }}
+                    >
+                      {patientFullName}
+                    </Button>
+                  </h2>
                   <div className="card-dob">
                     Date of birth:
                     <span className="card-date">

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -133,12 +133,14 @@ exports[`TestQueue should render the test queue 1`] = `
                 <div
                   class="card-header"
                 >
-                  <button
-                    class="usa-button usa-button--unstyled card-name"
-                    type="button"
-                  >
-                    Doe, John A
-                  </button>
+                  <h2>
+                    <button
+                      class="usa-button usa-button--unstyled card-name"
+                      type="button"
+                    >
+                      Doe, John A
+                    </button>
+                  </h2>
                   <div
                     class="card-dob"
                   >
@@ -381,11 +383,11 @@ exports[`TestQueue should render the test queue 1`] = `
               <form
                 class="usa-form maxw-none"
               >
-                <h2
+                <h3
                   class="prime-radio__title"
                 >
                   COVID-19 results
-                </h2>
+                </h3>
                 <div
                   class="usa-form-group prime-radio__group"
                 >
@@ -553,12 +555,14 @@ exports[`TestQueue should render the test queue 1`] = `
                 <div
                   class="card-header"
                 >
-                  <button
-                    class="usa-button usa-button--unstyled card-name"
-                    type="button"
-                  >
-                    Smith, Jane
-                  </button>
+                  <h2>
+                    <button
+                      class="usa-button usa-button--unstyled card-name"
+                      type="button"
+                    >
+                      Smith, Jane
+                    </button>
+                  </h2>
                   <div
                     class="card-dob"
                   >
@@ -801,11 +805,11 @@ exports[`TestQueue should render the test queue 1`] = `
               <form
                 class="usa-form maxw-none"
               >
-                <h2
+                <h3
                   class="prime-radio__title"
                 >
                   COVID-19 results
-                </h2>
+                </h3>
                 <div
                   class="usa-form-group prime-radio__group"
                 >

--- a/frontend/src/app/testResults/CovidResultInputForm.tsx
+++ b/frontend/src/app/testResults/CovidResultInputForm.tsx
@@ -69,7 +69,7 @@ const CovidResultInputForm: React.FC<Props> = ({
 
   return (
     <form className="usa-form maxw-none">
-      <h2 className="prime-radio__title">COVID-19 results</h2>
+      <h3 className="prime-radio__title">COVID-19 results</h3>
       <RadioGroup
         legend="Test result"
         legendSrOnly


### PR DESCRIPTION
## Related Issue
- Closes #4054 

## Changes Proposed
- Make the patient name on a test card a valid HTML header
    - This is an `h2`, since the `Conduct Tests` header is this view's `h1`
    - The test card previously contained the label for the results radio group as an `h2`; this was downshifted to `h3` with no effect on the styling

## Testing
- How should reviewers verify this PR?

## Screenshots / Demos
- 
