### PR TITLE
Add accessibility checks to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -126,6 +126,10 @@
 
 <!---
 ## Checklist for Author and Reviewer
+### Accessibility
+- [ ] Any large changes have been run through Deque manual testing
+- [ ] All changes have passed Lighthouse verification
+
 ### Design
 - [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
 - [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -128,7 +128,7 @@
 ## Checklist for Author and Reviewer
 ### Accessibility
 - [ ] Any large changes have been run through Deque manual testing
-- [ ] All changes have passed Lighthouse verification
+- [ ] All changes have run through the Deque automated testing
 
 ### Design
 - [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved


### PR DESCRIPTION
Updating the PR checklist to include accessibility items.

Future plan is to create a wiki page with common accessibility issues to keep in mind when developing and link it to the template, so this change is just step 1.

Once we have Lighthouse running, we can change the second checklist item to just a review of the Lighthouse results.