### PR TITLE
Dependabot loves IaC :robot: 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -197,14 +197,13 @@ updates:
       # - "alismx"
       # - "rin-skylight"
 
-  # - package-ecosystem: "terraform"
-  #   directory: "/ops/global"
-  #   open-pull-requests-limit: 2
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "rin-skylight"
+  - package-ecosystem: "terraform"
+    directory: "/ops/global"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "rin-skylight"
 
   # - package-ecosystem: "terraform"
   #   directory: "/ops/pentest"
@@ -251,14 +250,13 @@ updates:
       # - "alismx"
       # - "rin-skylight"
 
-  # - package-ecosystem: "terraform"
-  #   directory: "/ops/services/okta-global"
-  #   open-pull-requests-limit: 2
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "rin-skylight"
+  - package-ecosystem: "terraform"
+    directory: "/ops/services/okta-global"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "rin-skylight"
 
   # - package-ecosystem: "terraform"
   #   directory: "/ops/services/pagerduty"
@@ -287,23 +285,23 @@ updates:
       # - "alismx"
       # - "rin-skylight"
 
-  # - package-ecosystem: "terraform"
-  #   directory: "/ops/test"
-  #   open-pull-requests-limit: 2
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "rin-skylight"
+  - package-ecosystem: "terraform"
+    directory: "/ops/test"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "rin-skylight"
 
-  # - package-ecosystem: "terraform"
-  #   directory: "/ops/test/persistent"
-  #   open-pull-requests-limit: 2
-  #   schedule:
-  #     interval: "weekly"
-  #   reviewers:
-      # - "alismx"
-      # - "rin-skylight"
+  - package-ecosystem: "terraform"
+    directory: "/ops/test/persistent"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alismx"
+      - "rin-skylight"
 
   # - package-ecosystem: "terraform"
   #   directory: "/ops/training"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #3078 

## Changes Proposed

- Enable Dependabot for Terraform directories. 

## Additional Information

- By only enabling it for the global directories and the test directories, we won't be overloaded by tf PRs. The upgrades should be the same across the board.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->