### PR TITLE
Add ability to dismiss toast notifications (#4058)

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -4,8 +4,7 @@ import iconSprite from "../../../../node_modules/uswds/dist/img/sprite.svg";
 import Button from "../../commonComponents/Button/Button";
 import RequiredMessage from "../../commonComponents/RequiredMessage";
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showError } from "../../utils/srToast";
 import { stateCodes, urls } from "../../../config/constants";
 import { getStateNameFromCode, requiresOrderProvider } from "../../utils/state";
 import {
@@ -84,14 +83,10 @@ export const useFacilityValidation = (facility: Facility) => {
         {} as FacilityErrors
       );
       setErrors(errors);
-      const alert = (
-        <Alert
-          type="error"
-          title="Form Errors"
-          body="Please check the form to make sure you complete all of the required fields."
-        />
+      showError(
+        "Please check the form to make sure you complete all of the required fields.",
+        "Form Errors"
       );
-      showNotification(alert);
       let firstError = document.querySelector("[aria-invalid=true]");
       (firstError as HTMLElement)?.focus();
       return "error";
@@ -220,16 +215,7 @@ const FacilityForm: React.FC<Props> = (props) => {
     );
 
     if (!isValidZipForState) {
-      const alert = (
-        <Alert
-          type="error"
-          title="Form Errors"
-          body="Invalid ZIP code for this state"
-        />
-      );
-
-      showNotification(alert);
-
+      showError("Invalid ZIP code for this state", "Form Errors");
       return;
     }
 

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -4,8 +4,7 @@ import { Navigate, useParams } from "react-router-dom";
 import { useDispatch } from "react-redux";
 
 import { updateFacility } from "../../store";
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showSuccess } from "../../utils/srToast";
 import { getAppInsights } from "../../TelemetryService";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
 
@@ -239,15 +238,10 @@ const FacilityFormContainer: any = (props: Props) => {
           ? savedFacility.data.updateFacility.id
           : savedFacility.data.addFacility.id,
     }));
-    const alert = (
-      <Alert
-        type="success"
-        title="Updated Facility"
-        body="The settings for the facility have been updated"
-      />
+    showSuccess(
+      "The settings for the facility have been updated",
+      "Updated Facility"
     );
-
-    showNotification(alert);
     updateSaveSuccess(true);
   };
 

--- a/frontend/src/app/Settings/ManageOrganization.tsx
+++ b/frontend/src/app/Settings/ManageOrganization.tsx
@@ -5,7 +5,7 @@ import Button from "../commonComponents/Button/Button";
 import RequiredMessage from "../commonComponents/RequiredMessage";
 import Alert from "../commonComponents/Alert";
 import Select from "../commonComponents/Select";
-import { showNotification } from "../utils";
+import { showError } from "../utils/srToast";
 import { OrganizationTypeEnum } from "../signUp/Organization/utils";
 
 import { EditableOrganization } from "./ManageOrganizationContainer";
@@ -58,21 +58,16 @@ const ManageOrganization: React.FC<Props> = (props) => {
     if (validName && validType) {
       props.onSave(organization);
     } else {
-      showNotification(
-        <Alert
-          type="error"
-          title="Information missing"
-          body={
-            <ul>
-              {[errors["name"], errors["type"]]
-                .filter((msg) => !!msg)
-                .map((msg) => (
-                  <li key={msg}>{msg}</li>
-                ))}
-            </ul>
-          }
-        />
+      let ulAlertBody = (
+        <ul>
+          {[errors["name"], errors["type"]]
+            .filter((msg) => !!msg)
+            .map((msg) => (
+              <li key={msg}>{msg}</li>
+            ))}
+        </ul>
       );
+      showError(ulAlertBody, "Information missing");
     }
   };
 

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -1,10 +1,9 @@
-import React, { ComponentProps } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { gql, useQuery, useMutation } from "@apollo/client";
 
-import Alert from "../commonComponents/Alert";
 import { getAppInsights } from "../TelemetryService";
-import { showNotification } from "../utils";
+import { showError, showSuccess } from "../utils/srToast";
 import { RootState, updateOrganization } from "../store";
 
 import ManageOrganization from "./ManageOrganization";
@@ -70,22 +69,19 @@ const ManageOrganizationContainer: any = () => {
       ? () => adminSetOrganization({ variables: { name, type } })
       : () => setOrganization({ variables: { type } });
 
-    const alertProps: ComponentProps<typeof Alert> = {
-      type: "success",
-      title: "Updated organization",
-      body: "The settings for the organization have been updated",
-    };
-
     try {
       await mutation();
       dispatch(updateOrganization({ name }));
     } catch (e: any) {
-      alertProps.type = "error";
-      alertProps.title = "Error updating organization";
-      alertProps.body =
-        "There was an eroror updating the organization settings";
+      showError(
+        "There was an error updating the organization settings",
+        "Error updating organization"
+      );
     }
-    showNotification(<Alert {...alertProps} />);
+    showSuccess(
+      "The settings for the organization have been updated",
+      "Updated organization"
+    );
   };
 
   return (

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -72,16 +72,16 @@ const ManageOrganizationContainer: any = () => {
     try {
       await mutation();
       dispatch(updateOrganization({ name }));
+      showSuccess(
+        "The settings for the organization have been updated",
+        "Updated organization"
+      );
     } catch (e: any) {
       showError(
         "There was an error updating the organization settings",
         "Error updating organization"
       );
     }
-    showSuccess(
-      "The settings for the organization have been updated",
-      "Updated organization"
-    );
   };
 
   return (

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { ApolloQueryResult } from "@apollo/client";
 
-import Alert from "../../commonComponents/Alert";
 import Button from "../../commonComponents/Button/Button";
-import { showNotification, displayFullName } from "../../utils";
+import { displayFullName } from "../../utils";
+import { showSuccess } from "../../utils/srToast";
 import reload from "../../utils/reload";
 import {
   UserPermission,
@@ -197,13 +197,7 @@ const ManageUsers: React.FC<Props> = ({
           userWithPermissions?.lastName
         );
         setIsUpdating(false);
-        showNotification(
-          <Alert
-            type="success"
-            title="Changes Saved"
-            body={`${fullName}'s settings have been saved`}
-          />
-        );
+        showSuccess(`${fullName}'s settings have been saved`, "Changes Saved");
       })
       .catch(setError);
   };
@@ -239,12 +233,9 @@ const ManageUsers: React.FC<Props> = ({
 
       await getUsers();
       const fullName = displayFullName(firstName, "", lastName);
-      showNotification(
-        <Alert
-          type="success"
-          title={`Invitation sent to ${fullName}`}
-          body={`They will receive an invitation to create an account at the email address provided`}
-        />
+      showSuccess(
+        "They will receive an invitation to create an account at the email address provided",
+        `Invitation sent to ${fullName}`
       );
       updateShowAddUserModal(false);
       setAddedUserId(addedUser);
@@ -273,9 +264,7 @@ const ManageUsers: React.FC<Props> = ({
       });
       const fullName = displayFullName(firstName, "", lastName);
       updateEditUserNameModal(false);
-      showNotification(
-        <Alert type="success" title={`User name changed to ${fullName}`} />
-      );
+      showSuccess("", `User name changed to ${fullName}`);
       queryUserWithPermissions();
     } catch (e: any) {
       setError(e);
@@ -291,12 +280,7 @@ const ManageUsers: React.FC<Props> = ({
         },
       });
       updateEditUserEmailModal(false);
-      showNotification(
-        <Alert
-          type="success"
-          title={`User email address changed to ${emailAddress}`}
-        />
-      );
+      showSuccess("", `User email address changed to ${emailAddress}`);
       await getUsers();
     } catch (e: any) {}
   };
@@ -314,9 +298,7 @@ const ManageUsers: React.FC<Props> = ({
         userWithPermissions?.lastName
       );
       updateShowResetPasswordModal(false);
-      showNotification(
-        <Alert type="success" title={`Password reset for ${fullName}`} />
-      );
+      showSuccess("", `Password reset for ${fullName}`);
     } catch (e: any) {
       setError(e);
     }
@@ -335,9 +317,7 @@ const ManageUsers: React.FC<Props> = ({
         userWithPermissions?.lastName
       );
       updateShowResetMfaModal(false);
-      showNotification(
-        <Alert type="success" title={`MFA reset for ${fullName}`} />
-      );
+      showSuccess("", `MFA reset for ${fullName}`);
     } catch (e: any) {
       setError(e);
     }
@@ -358,9 +338,7 @@ const ManageUsers: React.FC<Props> = ({
       );
       updateShowDeleteUserModal(false);
       setDeletedUserId(userId);
-      showNotification(
-        <Alert type="success" title={`User account removed for ${fullName}`} />
-      );
+      showSuccess("", `User account removed for ${fullName}`);
       await getUsers();
     } catch (e: any) {
       setError(e);
@@ -381,9 +359,7 @@ const ManageUsers: React.FC<Props> = ({
       );
       updateShowReactivateUserModal(false);
       reload();
-      showNotification(
-        <Alert type="success" title={`${fullName} has been reactivated.`} />
-      );
+      showSuccess("", `${fullName} has been reactivated.`);
     } catch (e: any) {
       setError(e);
     }
@@ -402,12 +378,7 @@ const ManageUsers: React.FC<Props> = ({
         userWithPermissions?.lastName
       );
       updateShowResendUserActivationEmailModal(false);
-      showNotification(
-        <Alert
-          type="success"
-          title={`${fullName} has been sent a new invitation.`}
-        />
-      );
+      showSuccess("", `${fullName} has been sent a new invitation.`);
     } catch (e: any) {
       setError(e);
     }

--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect } from "react";
-import { ToastContainer } from "react-toastify";
 
-import "react-toastify/dist/ReactToastify.css";
 import { getUrl } from "../../utils/url";
 import USAGovBanner from "../USAGovBanner";
+import SRToastContainer from "../SRToastContainer";
 
 declare global {
   interface Window {
@@ -51,13 +50,7 @@ const Page: React.FC<Props> = ({ header, children, isPatientApp }) => {
       </header>
       <main id="main-wrapper">
         {children}
-        <ToastContainer
-          autoClose={5000}
-          closeButton={false}
-          limit={2}
-          position="bottom-center"
-          hideProgressBar={true}
-        />
+        <SRToastContainer />
       </main>
       <footer>
         {/*  Disabling Touchpoints until we have designs that specify how to contact Support */}

--- a/frontend/src/app/commonComponents/SRToastContainer.scss
+++ b/frontend/src/app/commonComponents/SRToastContainer.scss
@@ -1,0 +1,45 @@
+.Toastify {
+  &__toast-container {
+    max-width: 40rem;
+    width: auto;
+  }
+
+  &__toast {
+    padding: 0;
+  }
+
+  &__close-button {
+    height: 1.5rem;
+    margin-top: 0.5rem;
+    margin-right: 0.5rem;
+    opacity: 1;
+    width: 1.5rem;
+
+    &:hover {
+      opacity: 0.3;
+    }
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .sr-alert {
+    &--error {
+      background-color: #f4e3db;
+    }
+
+    &--success {
+      background-color: #ecf3ec;
+
+      .usa-alert--success {
+        outline: none;
+      }
+    }
+  }
+
+  .usa-alert {
+    max-width: 37.5rem;
+  }
+}

--- a/frontend/src/app/commonComponents/SRToastContainer.test.tsx
+++ b/frontend/src/app/commonComponents/SRToastContainer.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+
+import { showError, showSuccess } from "../utils/srToast";
+
+import SRToastContainer from "./SRToastContainer";
+
+const renderSRToastContainer = () => {
+  return render(<SRToastContainer />);
+};
+
+describe("SRToastContainer", () => {
+  it("contains the error defaults", async () => {
+    const view = renderSRToastContainer();
+    await showError();
+    expect(
+      await screen.findByText("Problems saving data to server")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Please check for missing data or typos.")
+    ).toBeInTheDocument();
+    expect(view).toMatchSnapshot();
+  });
+
+  it("contains the success defaults", async () => {
+    const view = renderSRToastContainer();
+    await showSuccess("A new patient has been added.", "Success");
+    expect(
+      await screen.findByText("A new patient has been added.")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Success")).toBeInTheDocument();
+    expect(view).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/commonComponents/SRToastContainer.tsx
+++ b/frontend/src/app/commonComponents/SRToastContainer.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { ToastContainer } from "react-toastify";
+
+import "react-toastify/dist/ReactToastify.css";
+import "./SRToastContainer.scss";
+
+const SRToastContainer = () => {
+  const autoClose = 5000;
+  const closeButton = true;
+  const hideProgressBar = true;
+  const limit = 2;
+  const position = "bottom-left";
+
+  return (
+    <ToastContainer
+      autoClose={autoClose}
+      closeButton={closeButton}
+      hideProgressBar={hideProgressBar}
+      limit={limit}
+      position={position}
+    />
+  );
+};
+
+export default SRToastContainer;

--- a/frontend/src/app/commonComponents/__snapshots__/SRToastContainer.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/SRToastContainer.test.tsx.snap
@@ -1,0 +1,355 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SRToastContainer contains the error defaults 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="Toastify"
+      >
+        <div
+          class="Toastify__toast-container Toastify__toast-container--bottom-left"
+        >
+          <div
+            class="Toastify__toast Toastify__toast--default sr-alert--error Toastify__bounce-enter--bottom-left"
+            id="{\\"type\\":\\"error\\",\\"title\\":\\"Problems saving data to server\\",\\"body\\":\\"Please check for missing data or typos.\\"}"
+            style="animation-fill-mode: forwards; animation-duration: 750ms;"
+          >
+            <div
+              class="Toastify__toast-body"
+              role="alert"
+            >
+              <div
+                class="usa-alert usa-alert--error"
+                role="alert"
+              >
+                <div
+                  class="usa-alert__body"
+                >
+                  <h3
+                    class="usa-alert__heading"
+                  >
+                    Problems saving data to server
+                  </h3>
+                  <div
+                    class="usa-alert__text"
+                  >
+                    Please check for missing data or typos.
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="close"
+              class="Toastify__close-button Toastify__close-button--default"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 14 16"
+              >
+                <path
+                  d="M7.71 8.23l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75L1 11.98l3.75-3.75L1 4.48 2.48 3l3.75 3.75L9.98 3l1.48 1.48-3.75 3.75z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+            <div
+              class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--default"
+              style="animation-duration: 5000ms; animation-play-state: running; opacity: 0;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Toastify"
+    >
+      <div
+        class="Toastify__toast-container Toastify__toast-container--bottom-left"
+      >
+        <div
+          class="Toastify__toast Toastify__toast--default sr-alert--error Toastify__bounce-enter--bottom-left"
+          id="{\\"type\\":\\"error\\",\\"title\\":\\"Problems saving data to server\\",\\"body\\":\\"Please check for missing data or typos.\\"}"
+          style="animation-fill-mode: forwards; animation-duration: 750ms;"
+        >
+          <div
+            class="Toastify__toast-body"
+            role="alert"
+          >
+            <div
+              class="usa-alert usa-alert--error"
+              role="alert"
+            >
+              <div
+                class="usa-alert__body"
+              >
+                <h3
+                  class="usa-alert__heading"
+                >
+                  Problems saving data to server
+                </h3>
+                <div
+                  class="usa-alert__text"
+                >
+                  Please check for missing data or typos.
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="close"
+            class="Toastify__close-button Toastify__close-button--default"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 14 16"
+            >
+              <path
+                d="M7.71 8.23l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75L1 11.98l3.75-3.75L1 4.48 2.48 3l3.75 3.75L9.98 3l1.48 1.48-3.75 3.75z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <div
+            class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--default"
+            style="animation-duration: 5000ms; animation-play-state: running; opacity: 0;"
+          />
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`SRToastContainer contains the success defaults 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="Toastify"
+      >
+        <div
+          class="Toastify__toast-container Toastify__toast-container--bottom-left"
+        >
+          <div
+            class="Toastify__toast Toastify__toast--default sr-alert--success Toastify__bounce-enter--bottom-left"
+            id="{\\"type\\":\\"success\\",\\"title\\":\\"Success\\",\\"body\\":\\"A new patient has been added.\\"}"
+            style="animation-fill-mode: forwards; animation-duration: 750ms;"
+          >
+            <div
+              class="Toastify__toast-body"
+              role="alert"
+            >
+              <div
+                class="usa-alert usa-alert--success"
+                role="region"
+              >
+                <div
+                  class="usa-alert__body"
+                >
+                  <h3
+                    class="usa-alert__heading"
+                  >
+                    Success
+                  </h3>
+                  <div
+                    class="usa-alert__text"
+                  >
+                    A new patient has been added.
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="close"
+              class="Toastify__close-button Toastify__close-button--default"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 14 16"
+              >
+                <path
+                  d="M7.71 8.23l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75L1 11.98l3.75-3.75L1 4.48 2.48 3l3.75 3.75L9.98 3l1.48 1.48-3.75 3.75z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+            <div
+              class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--default"
+              style="animation-duration: 5000ms; animation-play-state: running; opacity: 0;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Toastify"
+    >
+      <div
+        class="Toastify__toast-container Toastify__toast-container--bottom-left"
+      >
+        <div
+          class="Toastify__toast Toastify__toast--default sr-alert--success Toastify__bounce-enter--bottom-left"
+          id="{\\"type\\":\\"success\\",\\"title\\":\\"Success\\",\\"body\\":\\"A new patient has been added.\\"}"
+          style="animation-fill-mode: forwards; animation-duration: 750ms;"
+        >
+          <div
+            class="Toastify__toast-body"
+            role="alert"
+          >
+            <div
+              class="usa-alert usa-alert--success"
+              role="region"
+            >
+              <div
+                class="usa-alert__body"
+              >
+                <h3
+                  class="usa-alert__heading"
+                >
+                  Success
+                </h3>
+                <div
+                  class="usa-alert__text"
+                >
+                  A new patient has been added.
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="close"
+            class="Toastify__close-button Toastify__close-button--default"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 14 16"
+            >
+              <path
+                d="M7.71 8.23l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75L1 11.98l3.75-3.75L1 4.48 2.48 3l3.75 3.75L9.98 3l1.48 1.48-3.75 3.75z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <div
+            class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--default"
+            style="animation-duration: 5000ms; animation-play-state: running; opacity: 0;"
+          />
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -7,8 +7,8 @@ import { useSelector } from "react-redux";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
 import { PATIENT_TERM, PATIENT_TERM_CAP } from "../../config/constants";
-import { showNotification, dedupeAndCompactStrings } from "../utils";
-import Alert from "../commonComponents/Alert";
+import { dedupeAndCompactStrings } from "../utils";
+import { showSuccess } from "../utils/srToast";
 import Button from "../commonComponents/Button/Button";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { useDocumentTitle } from "../utils/hooks";
@@ -248,13 +248,9 @@ const AddPatient = () => {
         emails: dedupeAndCompactStrings(person.emails || []),
       },
     });
-
-    showNotification(
-      <Alert
-        type="success"
-        title={`${PATIENT_TERM_CAP} record created`}
-        body="New information record has been created."
-      />
+    showSuccess(
+      "New information record has been created.",
+      `${PATIENT_TERM_CAP} record created`
     );
 
     if (startTest) {

--- a/frontend/src/app/patients/ArchivePersonModal.test.tsx
+++ b/frontend/src/app/patients/ArchivePersonModal.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import ReactDOM from "react-dom";
+import { MockedProvider } from "@apollo/client/testing";
+import userEvent from "@testing-library/user-event";
+
+import { ArchivePersonDocument } from "../../generated/graphql";
+import * as srToast from "../utils/srToast";
+
+import { Patient } from "./ManagePatients";
+import ArchivePersonModal from "./ArchivePersonModal";
+
+const mockPerson: Patient = {
+  internalId: "7b968f75-e2fb-43a5-ae8b-c7e0f4873d3a",
+  firstName: "Guy",
+  lastName: "Abramcik",
+  middleName: "Christine Michael",
+  birthDate: "1992-11-26",
+  isDeleted: false,
+  role: "STAFF",
+  lastTest: {
+    dateAdded: "2022-01-06 13:56:20.255",
+    result: "",
+    dateTested: "2022-01-07 13:56:20.255",
+    deviceTypeModel: "",
+    deviceTypeName: "",
+    facilityName: "",
+  },
+};
+
+const archivePersonMutation = {
+  request: {
+    query: ArchivePersonDocument,
+    variables: {
+      id: "7b968f75-e2fb-43a5-ae8b-c7e0f4873d3a",
+      deleted: true,
+    },
+  },
+  result: {
+    data: {
+      setPatientIsDeleted: {
+        internalId: "c912d4d4-cbe6-4d80-9d24-c14ba1f7f180",
+        deleted: true,
+      },
+    },
+  },
+};
+
+const setup = () => {
+  ReactDOM.createPortal = jest.fn((element, _node) => {
+    return element;
+  }) as any;
+  return render(
+    <MockedProvider mocks={[archivePersonMutation]}>
+      <ArchivePersonModal person={mockPerson} closeModal={() => {}} />
+    </MockedProvider>
+  );
+};
+
+describe("ArchivePersonModal", () => {
+  it("contains the defaults", async () => {
+    let view = setup();
+    expect(
+      await screen.findByText("Abramcik, Guy Christine Michael")
+    ).toBeInTheDocument();
+    expect(view).toMatchSnapshot();
+  });
+
+  it("shows a success message when archiving", async () => {
+    let alertSpy: jest.SpyInstance = jest.spyOn(srToast, "showSuccess");
+    setup();
+    userEvent.click(screen.getByText("Yes, I'm sure"));
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith("", "Record archived");
+    });
+  });
+});

--- a/frontend/src/app/patients/ArchivePersonModal.tsx
+++ b/frontend/src/app/patients/ArchivePersonModal.tsx
@@ -3,9 +3,9 @@ import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
 
 import Button from "../commonComponents/Button/Button";
-import { displayFullName, showNotification } from "../utils";
+import { displayFullName } from "../utils";
+import { showSuccess } from "../utils/srToast";
 import "./ArchivePersonModal.scss";
-import Alert from "../commonComponents/Alert";
 
 import { Patient } from "./ManagePatients";
 
@@ -41,8 +41,7 @@ const ArchivePersonModal = ({ person, closeModal }: Props) => {
       },
     })
       .then(() => {
-        const alert = <Alert type="success" title="Record archived" body="" />;
-        showNotification(alert);
+        showSuccess("", "Record archived");
       })
       .finally(() => {
         closeModal();

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../constants";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import RequiredMessage from "../../commonComponents/RequiredMessage";
-import { showError } from "../../utils";
+import { showError } from "../../utils/srToast";
 import FormGroup from "../../commonComponents/FormGroup";
 import {
   PersonErrors,

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -5,12 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
 import { PATIENT_TERM_CAP } from "../../config/constants";
-import {
-  displayFullName,
-  showNotification,
-  dedupeAndCompactStrings,
-} from "../utils";
-import Alert from "../commonComponents/Alert";
+import { displayFullName, dedupeAndCompactStrings } from "../utils";
+import { showSuccess } from "../utils/srToast";
 import Button from "../commonComponents/Button/Button";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { useDocumentTitle } from "../utils/hooks";
@@ -247,12 +243,9 @@ const EditPatient = (props: Props) => {
         emails: dedupeAndCompactStrings(person.emails || []),
       },
     });
-    showNotification(
-      <Alert
-        type="success"
-        title={`${PATIENT_TERM_CAP} record saved`}
-        body="Information record has been updated."
-      />
+    showSuccess(
+      "Information record has been updated.",
+      `${PATIENT_TERM_CAP} record saved`
     );
 
     if (startTest) {

--- a/frontend/src/app/patients/PatientUpload.test.tsx
+++ b/frontend/src/app/patients/PatientUpload.test.tsx
@@ -5,8 +5,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter as Router } from "react-router-dom";
 
 import { FileUploadService } from "../../fileUploadService/FileUploadService";
-import * as utils from "../utils/index";
-import Alert from "../commonComponents/Alert";
+import * as srToast from "../utils/srToast";
 
 import PatientUpload from "./PatientUpload";
 
@@ -19,80 +18,57 @@ const store = mockStore({
   ],
 });
 
-describe("Patient Upload", () => {
-  const csvFile = new File(["foo"], "patients.csv");
-  const onSuccessCallback = jest.fn();
-  let alertSpy: jest.SpyInstance;
-  let uploadSpy: jest.SpyInstance;
-  let uploadPatientsResponse: () => Response;
+const csvFile = new File(["foo"], "patients.csv");
+const onSuccessCallback = jest.fn();
+let alertSpy: jest.SpyInstance;
+let uploadSpy: jest.SpyInstance;
+let uploadPatientsResponse: () => Response;
 
-  beforeEach(() => {
-    alertSpy = jest.spyOn(utils, "showNotification");
-    uploadSpy = jest
-      .spyOn(FileUploadService, "uploadPatients")
-      .mockImplementation(() => {
-        return Promise.resolve(uploadPatientsResponse());
-      });
-
-    render(
-      <Router
-        initialEntries={[{ pathname: "/", search: "?facility=1" }]}
-        initialIndex={0}
-      >
-        <Provider store={store}>
-          <PatientUpload onSuccess={onSuccessCallback} />
-        </Provider>
-      </Router>
-    );
-  });
-
-  describe("when successful", () => {
-    it("should upload the csv file and show message", async () => {
-      //Given
-      uploadPatientsResponse = () =>
-        new Response("Successfully uploaded 1 record(s)", { status: 200 });
-      const fileInput = screen.getByTestId("patient-file-input");
-
-      //When
-      userEvent.upload(fileInput, csvFile);
-
-      //Then
-      expect(uploadSpy).toHaveBeenCalledWith(csvFile, "");
-      await waitFor(() => {
-        expect(alertSpy).toHaveBeenCalledWith(
-          <Alert
-            body="Successfully uploaded 1 record(s)"
-            title="Patients uploaded"
-            type="success"
-          />
-        );
-      });
-
-      expect(onSuccessCallback).toHaveBeenCalled();
+const setup = (toastAlertTypeFn: "showError" | "showSuccess") => {
+  alertSpy = jest.spyOn(srToast, toastAlertTypeFn);
+  uploadSpy = jest
+    .spyOn(FileUploadService, "uploadPatients")
+    .mockImplementation(() => {
+      return Promise.resolve(uploadPatientsResponse());
     });
-  });
+  render(
+    <Router
+      initialEntries={[{ pathname: "/", search: "?facility=1" }]}
+      initialIndex={0}
+    >
+      <Provider store={store}>
+        <PatientUpload onSuccess={onSuccessCallback} />
+      </Provider>
+    </Router>
+  );
+};
 
-  describe("when failure", () => {
-    it("should show error message", async () => {
-      //Given
-      uploadPatientsResponse = () =>
-        new Response("Invalid csv", { status: 400 });
-      const fileInput = screen.getByTestId("patient-file-input");
+describe("When successful patient upload", () => {
+  it("should upload the csv file and show success message", async () => {
+    setup("showSuccess");
 
-      //When
-      userEvent.upload(fileInput, csvFile);
+    //Given
+    uploadPatientsResponse = () =>
+      new Response("Successfully uploaded 1 record(s)", { status: 200 });
+    const fileInput = screen.getByTestId("patient-file-input");
 
-      //Then
-      await waitFor(() => {
-        expect(alertSpy).toHaveBeenCalledWith(
-          <Alert body="Invalid csv" title="Error" type="error" />
-        );
-      });
-      expect(onSuccessCallback).not.toHaveBeenCalled();
+    //When
+    userEvent.upload(fileInput, csvFile);
+
+    //Then
+    expect(uploadSpy).toHaveBeenCalledWith(csvFile, "");
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Successfully uploaded 1 record(s)",
+        "Patients uploaded"
+      );
     });
+    expect(onSuccessCallback).toHaveBeenCalled();
   });
 
   it("should send request with facility id if requested", async () => {
+    setup("showSuccess");
+
     // Given
     uploadPatientsResponse = () =>
       new Response("Successfully uploaded 1 record(s)", { status: 200 });
@@ -108,5 +84,24 @@ describe("Patient Upload", () => {
 
     // Then
     expect(uploadSpy).toHaveBeenCalledWith(csvFile, "1");
+  });
+});
+
+describe("When failed patient upload", () => {
+  it("should show error message", async () => {
+    setup("showError");
+
+    //Given
+    uploadPatientsResponse = () => new Response("Invalid csv", { status: 400 });
+    const fileInput = screen.getByTestId("patient-file-input");
+
+    //When
+    userEvent.upload(fileInput, csvFile);
+
+    //Then
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith("Invalid csv", "Error");
+    });
+    expect(onSuccessCallback).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/patients/PatientUpload.tsx
+++ b/frontend/src/app/patients/PatientUpload.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 
-import { showError, showNotification } from "../utils";
-import Alert from "../commonComponents/Alert";
+import { showError, showSuccess } from "../utils/srToast";
 import { FileUploadService } from "../../fileUploadService/FileUploadService";
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import Checkboxes from "../commonComponents/Checkboxes";
@@ -29,13 +28,12 @@ const PatientUpload = ({ onSuccess }: Props) => {
     FileUploadService.uploadPatients(fileList[0], facilityId).then(
       async (response) => {
         const successful = response.status === 200;
-        showNotification(
-          <Alert
-            type={successful ? "success" : "error"}
-            title={successful ? "Patients uploaded" : "Error"}
-            body={await response.text()}
-          />
-        );
+        const alertMsg = await response.text();
+        if (successful) {
+          showSuccess(alertMsg, "Patients uploaded");
+        } else {
+          showError(alertMsg, "Error");
+        }
         successful && onSuccess();
       }
     );

--- a/frontend/src/app/patients/__snapshots__/ArchivePersonModal.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/ArchivePersonModal.test.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArchivePersonModal contains the defaults 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body
+    aria-hidden="true"
+    class="ReactModal__Body--open"
+  >
+    <div
+      data-react-modal-body-trap=""
+      style="position: absolute; opacity: 0;"
+      tabindex="0"
+    />
+    <div>
+      <div
+        class="ReactModal__Overlay sr-archive-person-modal-overlay"
+      >
+        <div
+          aria-label="Archive record"
+          aria-modal="true"
+          class="ReactModal__Content sr-archive-person-modal-content"
+          role="dialog"
+          tabindex="-1"
+        >
+          <p>
+            Are you sure you want to archive the record for
+             
+            <b>
+              Abramcik, Guy Christine Michael
+            </b>
+            ?
+          </p>
+          <div
+            class="sr-archive-person-buttons"
+          >
+            <button
+              class="usa-button usa-button--unstyled"
+              type="button"
+            >
+              No, go back
+            </button>
+            <button
+              class="usa-button"
+              type="button"
+            >
+              Yes, I'm sure
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-react-modal-body-trap=""
+      style="position: absolute; opacity: 0;"
+      tabindex="0"
+    />
+    <div
+      class="ReactModalPortal"
+    />
+  </body>,
+  "container": <div>
+    <div
+      class="ReactModal__Overlay sr-archive-person-modal-overlay"
+    >
+      <div
+        aria-label="Archive record"
+        aria-modal="true"
+        class="ReactModal__Content sr-archive-person-modal-content"
+        role="dialog"
+        tabindex="-1"
+      >
+        <p>
+          Are you sure you want to archive the record for
+           
+          <b>
+            Abramcik, Guy Christine Michael
+          </b>
+          ?
+        </p>
+        <div
+          class="sr-archive-person-buttons"
+        >
+          <button
+            class="usa-button usa-button--unstyled"
+            type="button"
+          >
+            No, go back
+          </button>
+          <button
+            class="usa-button"
+            type="button"
+          >
+            Yes, I'm sure
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -3,8 +3,7 @@ import { useState } from "react";
 import { Card } from "../../commonComponents/Card/Card";
 import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
 import Button from "../../commonComponents/Button/Button";
-import { showNotification } from "../../utils";
-import Alert from "../../commonComponents/Alert";
+import { showError } from "../../utils/srToast";
 import { isFormValid, isFieldValid } from "../../utils/yupHelpers";
 import Input from "../../commonComponents/Input";
 import {
@@ -84,14 +83,10 @@ const PersonalDetailsForm = ({
       return;
     }
     setErrors(validation.errors);
-    const alert = (
-      <Alert
-        type="error"
-        title="Form Errors"
-        body="Please check the form to make sure you complete all of the required fields."
-      />
+    showError(
+      "Please check the form to make sure you complete all of the required fields.",
+      "Form Errors"
     );
-    showNotification(alert);
     setSaving(false);
     let elementsWithErrors = Array.from(
       document.querySelectorAll("[aria-invalid=true]")

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
@@ -6,7 +6,7 @@ import { Card } from "../../commonComponents/Card/Card";
 import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import Button from "../../commonComponents/Button/Button";
-import { showNotification } from "../../utils";
+import { showError } from "../../utils/srToast";
 import Alert from "../../commonComponents/Alert";
 import { isFormValid, isFieldValid } from "../../utils/yupHelpers";
 import StepIndicator from "../../commonComponents/StepIndicator";
@@ -88,14 +88,10 @@ const QuestionsForm: React.FC<Props> = ({
       return;
     }
     setErrors(validation.errors);
-    const alert = (
-      <Alert
-        type="error"
-        title="Form Errors"
-        body="Please check the form to make sure you complete all of the required fields."
-      />
+    showError(
+      "Please check the form to make sure you complete all of the required fields.",
+      "Form Errors"
     );
-    showNotification(alert);
   };
 
   return (

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -4,9 +4,8 @@ import { Navigate } from "react-router-dom";
 import { Card } from "../../commonComponents/Card/Card";
 import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
 import Button from "../../commonComponents/Button/Button";
-import { showNotification } from "../../utils";
+import { showError } from "../../utils/srToast";
 import { useDocumentTitle } from "../../utils/hooks";
-import Alert from "../../commonComponents/Alert";
 import { isFormValid, isFieldValid } from "../../utils/yupHelpers";
 import Input from "../../commonComponents/Input";
 import {
@@ -97,14 +96,10 @@ const OrganizationForm = () => {
       return;
     }
     setErrors(validation.errors);
-    const alert = (
-      <Alert
-        type="error"
-        title="Form Errors"
-        body="Please check the form to make sure you complete all of the required fields."
-      />
+    showError(
+      "Please check the form to make sure you complete all of the required fields.",
+      "Form Errors"
     );
-    showNotification(alert);
     setLoading(false);
     let firstError = document.querySelector("[aria-invalid=true]");
     (firstError as HTMLElement)?.focus();

--- a/frontend/src/app/supportAdmin/AddOrganizationAdmin/AddOrganizationAdminFormContainer.tsx
+++ b/frontend/src/app/supportAdmin/AddOrganizationAdmin/AddOrganizationAdminFormContainer.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { Navigate } from "react-router-dom";
 
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showSuccess } from "../../utils/srToast";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
 import {
   useAddUserMutation,
@@ -46,14 +45,10 @@ const AddOrganizationAdminFormContainer = () => {
         email: admin.email,
       },
     }).then(() => {
-      const alert = (
-        <Alert
-          type="success"
-          title="Added Organization Admin"
-          body="The organization admin has been added"
-        />
+      showSuccess(
+        "The organization admin has been added",
+        "Added Organization Admin"
       );
-      showNotification(alert);
       setSubmitted(true);
     });
   };

--- a/frontend/src/app/supportAdmin/AddOrganizationAdmin/FacilityAdmin.tsx
+++ b/frontend/src/app/supportAdmin/AddOrganizationAdmin/FacilityAdmin.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useState } from "react";
 
-import Alert from "../../commonComponents/Alert";
 import Input from "../../commonComponents/Input";
-import { showNotification } from "../../utils";
+import { showError } from "../../utils/srToast";
 import { camelToSentenceCase } from "../../utils/text";
 
 import {
@@ -53,14 +52,10 @@ export const useFacilityAdminValidation = (admin: FacilityAdmin) => {
         {} as FacilityAdminErrors
       );
       setErrors(newErrors);
-      const alert = (
-        <Alert
-          type="error"
-          title="Form Errors"
-          body="Please check the form to make sure you complete all of the required fields."
-        />
+      showError(
+        "Please check the form to make sure you complete all of the required fields.",
+        "Form Errors"
       );
-      showNotification(alert);
       return "error";
     }
   };

--- a/frontend/src/app/supportAdmin/Components/OrganizationComboDropdown.tsx
+++ b/frontend/src/app/supportAdmin/Components/OrganizationComboDropdown.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { ComboBox } from "@trussworks/react-uswds";
 
 import Required from "../../commonComponents/Required";
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showError } from "../../utils/srToast";
 
 export interface OrganizationOption {
   name: string;
@@ -24,14 +23,7 @@ export const useOrganizationDropDownValidation = (
       return "combo box cleared";
     }
     if (organizationExternalId === null || organizationExternalId === "") {
-      const alert = (
-        <Alert
-          type="error"
-          title="Form Errors"
-          body="Please select an organization."
-        />
-      );
-      showNotification(alert);
+      showError("Please select an organization.", "Form Errors");
       return "error";
     }
 

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceTypeFormContainer.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceTypeFormContainer.tsx
@@ -6,8 +6,7 @@ import {
   useGetSpecimenTypesQuery,
   useGetSupportedDiseasesQuery,
 } from "../../../generated/graphql";
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showError, showSuccess } from "../../utils/srToast";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
 
@@ -26,12 +25,9 @@ const DeviceTypeFormContainer = () => {
 
   const saveDeviceType = (device: Device) => {
     if (device.testLength <= 0 || device.testLength > 999) {
-      showNotification(
-        <Alert
-          type="error"
-          title="Create device failed"
-          body="Failed to create device. Invalid test length"
-        />
+      showError(
+        "Failed to create device. Invalid test length",
+        "Create device failed"
       );
     } else {
       if (!device.internalId) {
@@ -39,14 +35,7 @@ const DeviceTypeFormContainer = () => {
           variables: device,
           fetchPolicy: "no-cache",
         }).then(() => {
-          const alert = (
-            <Alert
-              type="success"
-              title="Created Device"
-              body="The device has been created"
-            />
-          );
-          showNotification(alert);
+          showSuccess("The device has been created", "Created Device");
           setSubmitted(true);
         });
       } else {

--- a/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.tsx
@@ -10,8 +10,7 @@ import {
   useUpdateDeviceTypeMutation,
 } from "../../../generated/graphql";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
-import { showNotification } from "../../utils";
-import Alert from "../../commonComponents/Alert";
+import { showError, showSuccess } from "../../utils/srToast";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
 
 import DeviceForm, { Device } from "./DeviceForm";
@@ -32,12 +31,9 @@ const ManageDeviceTypeFormContainer = () => {
 
   const updateDevice = (device: Device) => {
     if (device.testLength <= 0 || device.testLength > 999) {
-      showNotification(
-        <Alert
-          type="error"
-          title="Update device failed"
-          body="Failed to update device. Invalid test length"
-        />
+      showError(
+        "Failed to update device. Invalid test length",
+        "Update device failed"
       );
     } else {
       if (device.internalId) {
@@ -49,14 +45,7 @@ const ManageDeviceTypeFormContainer = () => {
           variables,
           fetchPolicy: "no-cache",
         }).then(() => {
-          const alert = (
-            <Alert
-              type="success"
-              title="Updated device"
-              body="The device has been updated"
-            />
-          );
-          showNotification(alert);
+          showSuccess("The device has been updated", "Updated device");
           setSubmitted(true);
         });
       } else {

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -2,12 +2,12 @@ import { PhoneNumberUtil, PhoneNumberFormat } from "google-libphonenumber";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import Alert from "../../commonComponents/Alert";
 import Button from "../../commonComponents/Button/Button";
 import {
   PendingOrganization,
   useEditPendingOrganizationMutation,
 } from "../../../generated/graphql";
+import { showSuccess } from "../../utils/srToast";
 
 import {
   PendingOrganizationFormValues,
@@ -27,7 +27,6 @@ interface Props {
   ) => Promise<void>;
   loading: boolean;
   refetch: () => void;
-  showNotification: (notif: JSX.Element) => void;
 }
 
 const phoneUtil = PhoneNumberUtil.getInstance();
@@ -38,7 +37,6 @@ const PendingOrganizations = ({
   submitDeletion,
   loading,
   refetch,
-  showNotification,
 }: Props) => {
   const [orgToVerify, setOrgToVerify] = useState<PendingOrganization | null>(
     null
@@ -98,7 +96,7 @@ const PendingOrganizations = ({
     setIsUpdating(false);
     setOrgToVerify(null);
     const updateMessage = `${org.name} details updated`;
-    showNotification(<Alert type="success" title={updateMessage} body="" />);
+    showSuccess("", updateMessage);
     return Promise.resolve(updatedOrg);
   };
 

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.tsx
@@ -1,6 +1,5 @@
 import "./PendingOrganizationsList.scss";
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showSuccess } from "../../utils/srToast";
 import {
   useGetPendingOrganizationsQuery,
   useMarkPendingOrganizationAsDeletedMutation,
@@ -27,13 +26,7 @@ const PendingOrganizationsContainer = () => {
       })
     )
       .then(() => {
-        showNotification(
-          <Alert
-            type="success"
-            title={`Identity verified for ${name}`}
-            body=""
-          />
-        );
+        showSuccess("", `Identity verified for ${name}`);
       })
       .finally(() => {
         refetch();
@@ -57,13 +50,7 @@ const PendingOrganizationsContainer = () => {
       })
     )
       .then(() => {
-        showNotification(
-          <Alert
-            type="success"
-            title={`${name} successfully deleted`}
-            body=""
-          />
-        );
+        showSuccess("", `${name} successfully deleted`);
       })
       .finally(() => {
         refetch();
@@ -80,7 +67,6 @@ const PendingOrganizationsContainer = () => {
       submitDeletion={submitDeletion}
       loading={loading}
       refetch={refetch}
-      showNotification={showNotification}
     />
   );
 };

--- a/frontend/src/app/supportAdmin/TenantDataAccess/TenantDataAccessFormContainer.tsx
+++ b/frontend/src/app/supportAdmin/TenantDataAccess/TenantDataAccessFormContainer.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { Navigate } from "react-router-dom";
 
-import Alert from "../../commonComponents/Alert";
-import { showNotification } from "../../utils";
+import { showSuccess } from "../../utils/srToast";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
 import {
   useGetOrganizationsQuery,
@@ -45,14 +44,10 @@ const TenantDataAccessFormContainer = () => {
         justification: justification,
       },
     }).then(() => {
-      const alert = (
-        <Alert
-          type="success"
-          title="Tenant Data Access Updated"
-          body="You now have access to tenant data for the requested organization."
-        />
+      showSuccess(
+        "You now have access to tenant data for the requested organization.",
+        "Tenant Data Access Updated"
       );
-      showNotification(alert);
       setSubmitted(true);
     });
   };

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -9,13 +9,14 @@ import { MemoryRouter } from "react-router-dom";
 import * as flaggedMock from "flagged";
 
 import { getAppInsights } from "../TelemetryService";
-import * as utils from "../utils/index";
+import * as srToast from "../utils/srToast";
 import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 import {
   AddMultiplexResultDocument as SUBMIT_TEST_RESULT,
   EditQueueItemMultiplexResultDocument as EDIT_QUEUE_ITEM,
 } from "../../generated/graphql";
 import * as generatedGraphql from "../../generated/graphql";
+import SRToastContainer from "../commonComponents/SRToastContainer";
 
 import QueueItem from "./QueueItem";
 
@@ -464,7 +465,7 @@ describe("QueueItem", () => {
   describe("SMS delivery failure", () => {
     let alertSpy: jest.SpyInstance;
     beforeEach(() => {
-      alertSpy = jest.spyOn(utils, "showNotification");
+      alertSpy = jest.spyOn(srToast, "showError");
     });
 
     afterEach(() => {
@@ -568,13 +569,7 @@ describe("QueueItem", () => {
               </Provider>
             </MockedProvider>
           </MemoryRouter>
-          <ToastContainer
-            autoClose={5000}
-            closeButton={false}
-            limit={2}
-            position="bottom-center"
-            hideProgressBar={true}
-          />
+          <SRToastContainer />
         </>
       );
 
@@ -609,6 +604,12 @@ describe("QueueItem", () => {
       expect(submitTestMockIsDone).toBe(true);
 
       // Verify alert is displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "The phone number provided may not be valid or may not be able to accept text messages",
+          "Unable to text result to Potter, Harry James"
+        );
+      });
       expect(
         await screen.findByText(
           "Unable to text result to Potter, Harry James",

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -21,11 +21,11 @@ import {
   useEditQueueItemMultiplexResultMutation,
   useAddMultiplexResultMutation,
 } from "../../generated/graphql";
-import Alert from "../commonComponents/Alert";
 import Button from "../commonComponents/Button/Button";
 import Dropdown from "../commonComponents/Dropdown";
 import CovidResultInputForm from "../testResults/CovidResultInputForm";
-import { displayFullName, showNotification } from "../utils";
+import { displayFullName } from "../utils";
+import { showError, showSuccess } from "../utils/srToast";
 import { RootState } from "../store";
 import { getAppInsights } from "../TelemetryService";
 import { formatDate } from "../utils/date";
@@ -354,18 +354,12 @@ const QueueItem = ({
     };
 
     if (response?.data?.addMultiplexResult.deliverySuccess === false) {
-      let deliveryFailureAlert = (
-        <Alert
-          type="error"
-          title={`Unable to text result to ${patientFullName}`}
-          body="The phone number provided may not be valid or may not be able to accept text messages"
-        />
-      );
-      showNotification(deliveryFailureAlert);
+      let deliveryFailureTitle = `Unable to text result to ${patientFullName}`;
+      let deliveryFailureMsg =
+        "The phone number provided may not be valid or may not be able to accept text messages";
+      showError(deliveryFailureMsg, deliveryFailureTitle);
     }
-
-    let alert = <Alert type="success" title={title} body={body} />;
-    showNotification(alert);
+    showSuccess(body, title);
   };
 
   const onTestResultSubmit = async (forceSubmit: boolean = false) => {
@@ -381,9 +375,7 @@ const QueueItem = ({
             )}`
           : "Test date can't be in the future";
 
-      showNotification(
-        <Alert type="error" title="Invalid test date" body={message} />
-      );
+      showError(message, "Invalid test date");
 
       setSaveState("error");
       return;

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -4,7 +4,7 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 
-import { showError } from "../utils";
+import { showError } from "../utils/srToast";
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
@@ -7,6 +7,7 @@ import { MemoryRouter } from "react-router-dom";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
 import { Patient } from "../../patients/ManagePatients";
 import { getAppInsights } from "../../TelemetryService";
+import * as srToast from "../../utils/srToast";
 
 import AddToQueueSearch, {
   ADD_PATIENT_TO_QUEUE,
@@ -152,12 +153,23 @@ describe("AddToSearchQueue - add to queue", () => {
   });
 
   it("adds patient to queue from search form", async () => {
+    let alertSpy: jest.SpyInstance = jest.spyOn(
+      srToast,
+      "showAlertNotification"
+    );
     userEvent.type(screen.getByRole("searchbox", { exact: false }), "bar");
 
     userEvent.click(screen.getAllByRole("button")[1]);
 
     expect(queryPatientMockIsDone).toBe(true);
     expect(addPatientMockIsDone).toBe(true);
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        "success",
+        "Cragell, Barb Whitaker was added to the queue",
+        "Newly added patients go to the bottom of the queue"
+      );
+    });
   });
 
   it("tracks custom telemetry event", async () => {

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -7,14 +7,13 @@ import React, {
 } from "react";
 import { gql, useMutation, useLazyQuery, useQuery } from "@apollo/client";
 
-import Alert from "../../commonComponents/Alert";
 import {
   QUEUE_NOTIFICATION_TYPES,
   ALERT_CONTENT,
   MIN_SEARCH_CHARACTER_COUNT,
   SEARCH_DEBOUNCE_TIME,
 } from "../constants";
-import { showNotification } from "../../utils";
+import { showAlertNotification } from "../../utils/srToast";
 import { useOutsideClick } from "../../utils/hooks";
 import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
@@ -244,8 +243,7 @@ const AddToQueueSearchBox = ({
             patient
           ),
         };
-        const alert = <Alert type={type} title={title} body={body} />;
-        showNotification(alert);
+        showAlertNotification(type, title, body);
         refetchQueue();
         setStartTestPatientId(null);
         if (createOrUpdate === "create") {

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CSVLink } from "react-csv";
 import { useFeature } from "flagged";
 
-import { showError } from "../utils";
+import { showError } from "../utils/srToast";
 import { useImperativeQuery } from "../utils/hooks";
 import { parseDataForCSV } from "../utils/testResultCSV";
 import Button from "../commonComponents/Button/Button";

--- a/frontend/src/app/testResults/EmailTestResultModal.test.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as utils from "../utils";
+import * as srToast from "../utils/srToast";
 
 import EmailTestResultModal from "./EmailTestResultModal";
 
@@ -48,7 +48,7 @@ describe("EmailTestResultModal", () => {
   let alertSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    alertSpy = jest.spyOn(utils, "showAlertNotification");
+    alertSpy = jest.spyOn(srToast, "showAlertNotification");
   });
 
   afterEach(() => {

--- a/frontend/src/app/testResults/EmailTestResultModal.tsx
+++ b/frontend/src/app/testResults/EmailTestResultModal.tsx
@@ -7,7 +7,7 @@ import {
   useGetTestResultForResendingEmailsQuery,
   useResendTestResultsEmailMutation,
 } from "../../generated/graphql";
-import { showAlertNotification } from "../utils";
+import { showAlertNotification } from "../utils/srToast";
 import "./EmailTestResultModal.scss";
 import { formatDateLong } from "../utils/date";
 

--- a/frontend/src/app/testResults/TestResultCorrectionModal.tsx
+++ b/frontend/src/app/testResults/TestResultCorrectionModal.tsx
@@ -4,13 +4,13 @@ import Modal from "react-modal";
 import { useNavigate } from "react-router-dom";
 
 import Button from "../commonComponents/Button/Button";
-import { displayFullName, showNotification } from "../utils";
+import { displayFullName } from "../utils";
+import { showSuccess } from "../utils/srToast";
 import "./TestResultCorrectionModal.scss";
 import {
   InjectedQueryWrapperProps,
   QueryWrapper,
 } from "../commonComponents/QueryWrapper";
-import Alert from "../commonComponents/Alert";
 import Dropdown from "../commonComponents/Dropdown";
 import RadioGroup from "../commonComponents/RadioGroup";
 import Required from "../commonComponents/Required";
@@ -140,10 +140,7 @@ export const DetachedTestResultCorrectionModal = ({
       },
     })
       .then(() => {
-        const alert = (
-          <Alert type="success" title="Result marked as error" body="" />
-        );
-        showNotification(alert);
+        showSuccess("", "Result marked as error");
       })
       .finally(() => {
         closeModal();
@@ -159,12 +156,9 @@ export const DetachedTestResultCorrectionModal = ({
       },
     })
       .then(() => {
-        const alert = (
-          // TODO: better text here, maybe indicating to user that the test should now
-          // be available in the queue
-          <Alert type="success" title="Result marked as correction" body="" />
-        );
-        showNotification(alert);
+        // TODO: better text here, maybe indicating to user that the test should now
+        // be available in the queue
+        showSuccess("", "Result marked as correction");
       })
       .finally(() => {
         setTimeout(() => {

--- a/frontend/src/app/testResults/TestResultTextModal.test.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.test.tsx
@@ -7,7 +7,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 
-import * as utils from "../utils";
+import * as srToast from "../utils/srToast";
 
 import TestResultTextModal, {
   DetachedTestResultTextModal,
@@ -27,7 +27,7 @@ describe("TestResultTextModal", () => {
   let alertSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    alertSpy = jest.spyOn(utils, "showAlertNotification");
+    alertSpy = jest.spyOn(srToast, "showAlertNotification");
   });
 
   afterEach(() => {

--- a/frontend/src/app/testResults/TestResultTextModal.tsx
+++ b/frontend/src/app/testResults/TestResultTextModal.tsx
@@ -2,7 +2,7 @@ import { gql, useMutation } from "@apollo/client";
 import Modal from "react-modal";
 
 import Button from "../commonComponents/Button/Button";
-import { showAlertNotification } from "../utils";
+import { showAlertNotification } from "../utils/srToast";
 import { formatFullName } from "../utils/user";
 import "./TestResultCorrectionModal.scss";
 import {

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button, FormGroup, FileInput } from "@trussworks/react-uswds";
 
-import { showError } from "../../utils";
+import { showError } from "../../utils/srToast";
 import { FeedbackMessage } from "../../../generated/graphql";
 import { useDocumentTitle } from "../../utils/hooks";
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";

--- a/frontend/src/app/utils/index.tsx
+++ b/frontend/src/app/utils/index.tsx
@@ -1,7 +1,3 @@
-import { toast } from "react-toastify";
-
-import Alert, { AlertType } from "../commonComponents/Alert";
-
 export const displayFullName = (
   first: string | null | undefined,
   middle: string | null | undefined,
@@ -40,37 +36,4 @@ export const dedupeAndCompactStrings = (strings: string[]) => {
 
     return acc;
   }, []);
-};
-
-export const showNotification = (children: JSX.Element) => {
-  try {
-    // id will de-dup. just use whole message as id
-    const toastId = JSON.stringify(children.props).substr(0, 512);
-    toast(children, { toastId });
-    toast.clearWaitingQueue(); // don't pile up messages
-  } catch (err: any) {
-    console.error(err, err.stack);
-  }
-};
-
-export const showAlertNotification = (
-  type: AlertType,
-  title?: string,
-  message?: string
-) => {
-  showNotification(
-    <Alert
-      type={type}
-      title={title}
-      body={message ? message.substr(0, 512) : undefined}
-    />
-  );
-};
-
-export const showError = (
-  message = "Please check for missing data or typos.",
-  title = "Problems saving data to server"
-) => {
-  const err_msg = message.substr(0, 512);
-  showNotification(<Alert type="error" title={title} body={err_msg} />);
 };

--- a/frontend/src/app/utils/srToast.tsx
+++ b/frontend/src/app/utils/srToast.tsx
@@ -1,0 +1,38 @@
+import { toast } from "react-toastify";
+
+import Alert, { AlertType } from "../commonComponents/Alert";
+
+import { get512Characters } from "./text";
+
+const showNotification = (children: JSX.Element, status?: AlertType) => {
+  try {
+    // id will de-dup. just use whole message as id
+    const toastId = get512Characters(JSON.stringify(children.props));
+    const toastCustomClassName = status ? `sr-alert--${status}` : "";
+    toast(children, { toastId: toastId, className: toastCustomClassName });
+    toast.clearWaitingQueue(); // don't pile up messages
+  } catch (err: any) {
+    console.error(err, err.stack);
+  }
+};
+
+export const showAlertNotification = (
+  type: AlertType,
+  title?: string,
+  message?: string | JSX.Element
+) => {
+  const isStringMsg = typeof message === "string";
+  const alertBody = isStringMsg ? get512Characters(message) : message;
+  showNotification(<Alert type={type} title={title} body={alertBody} />, type);
+};
+
+export const showError = (
+  message: string | JSX.Element = "Please check for missing data or typos.",
+  title: string = "Problems saving data to server"
+) => {
+  showAlertNotification("error", title, message);
+};
+
+export const showSuccess = (message: string | JSX.Element, title: string) => {
+  showAlertNotification("success", title, message);
+};

--- a/frontend/src/app/utils/text.test.ts
+++ b/frontend/src/app/utils/text.test.ts
@@ -2,6 +2,7 @@ import {
   capitalizeText,
   getSubStrAfterChar,
   toLowerCaseHyphenate,
+  get512Characters,
 } from "./text";
 
 describe("capitalizeText", () => {
@@ -35,6 +36,26 @@ describe("toLowerCaseHyphenate", () => {
   test("starts and ends with whitespace", () => {
     const text = " COVID-19 TEST RESULT ";
     expect(toLowerCaseHyphenate(text)).toBe("-covid-19-test-result-");
+  });
+});
+
+describe("get512Characters", () => {
+  test("empty text", () => {
+    const text = "";
+    expect(get512Characters(text)).toBe("");
+  });
+  test("> 512 characters", () => {
+    // this is a 514 character string
+    const text =
+      "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus ele";
+    // removes the last two characters
+    expect(get512Characters(text)).toBe(text.slice(0, -2));
+    expect(get512Characters(text).length).toBe(512);
+  });
+  test("< 512 characters", () => {
+    const text = "COVID-19 TEST RESULT";
+    expect(get512Characters(text)).toBe("COVID-19 TEST RESULT");
+    expect(get512Characters(text).length).toBe(text.length);
   });
 });
 

--- a/frontend/src/app/utils/text.ts
+++ b/frontend/src/app/utils/text.ts
@@ -47,6 +47,10 @@ export function toLowerCaseHyphenate(string: string) {
   return string.toLocaleLowerCase().replace(/\s+/g, "-");
 }
 
+export function get512Characters(s: string) {
+  return s.substring(0, 512);
+}
+
 export function getSubStrAfterChar(
   s: string,
   strToSplitOn: string,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -26,7 +26,7 @@ import SignUpApp from "./app/signUp/SignUpApp";
 import HealthChecks from "./app/HealthChecks";
 import * as serviceWorker from "./serviceWorker";
 import { store } from "./app/store";
-import { showError } from "./app/utils";
+import { showError } from "./app/utils/srToast";
 import {
   getAppInsights,
   ai,

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -5,7 +5,7 @@ import moment from "moment";
 import "react-toastify/dist/ReactToastify.css";
 import { useTranslation } from "react-i18next";
 
-import { showError } from "../../app/utils";
+import { showError } from "../../app/utils/srToast";
 import { formatFullName } from "../../app/utils/user";
 import PatientHeader from "../PatientHeader";
 import { PxpApi, SelfRegistrationData } from "../PxpApiService";

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -839,20 +839,6 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
   white-space: nowrap;
 }
 
-// toast
-
-.Toastify__toast {
-  padding: 3px;
-
-  &-container {
-    width: auto;
-  }
-
-  &--default {
-    color: #1b1b1b;
-  }
-}
-
 .usa-table--borderless th:first-child {
   padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #4058 

## Changes Proposed
- add an "X" button to the toast notifications so a user can close them without having to wait for them to auto close
- update the designs to match the [figma](https://www.figma.com/file/NPSPM5SBzQ7Ra3mmr9M9cB/SimpleReport-Public-Site?node-id=12545%3A34043)
- create a `<SRToastContainer>` component that has all the defaults for `<ToastContainer>`
- create a `showSuccess` and use `showError` to display toast notifications to avoid having to passing `<Alert>`s 

## Additional Information
- Noticed some patterns in the support admin pages where we were showing toast notifications but a user would never actually see this because they are immediately redirected (e.g. https://github.com/CDCgov/prime-simplereport/pull/4451#discussion_r995092415) If we want to fix this up in a separate story, please let me know and I can create an issue for it.
- Kenny noticed while archiving a test, that the toaster message appears right before the screen reloads. the toaster should appear after the screen reloads to give the user time to view the message.
- Considering the two bullet points above, we may want a story to check/clean up the toast message display experience throughout the app.
- As seen in the comments for the original issue linked above, Kenny decided and asked that the toast notification be moved to the bottom left hand corner and to keep the auto close at 5 seconds.

## Testing
- Go to all different parts of the app that generate a success or error message (e.g. Results tab, /sign-up, Manage organization form, patient bulk upload with errors etc...)
- Ensure the change has not introduced any new accessibility concerns

## Screenshots / Demos
<img width="579" alt="Screen Shot 2022-10-13 at 19 55 20" src="https://user-images.githubusercontent.com/20211771/195738053-29874e7f-caf9-4d73-8ec6-1368f3260cab.png">

<img width="704" alt="Screen Shot 2022-10-13 at 19 54 58" src="https://user-images.githubusercontent.com/20211771/195738061-59fe2997-c643-44b0-9610-9ec630deecdb.png">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
