### PR TITLE
make testing_lab_phone_number required in results uploader docs

### DIFF
--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -4389,9 +4389,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             >
               Testing lab phone number
               <span
-                class="text-normal bg-white border-1px border-base font-body-3xs padding-x-1 padding-y-05 text-base margin-left-2 text-ttbottom"
+                class="text-normal bg-white border-1px border-secondary font-body-3xs padding-x-1 padding-y-05 text-secondary margin-left-2 text-ttbottom"
               >
-                Optional
+                Required
               </span>
             </h5>
             <div

--- a/frontend/src/app/testResults/uploads/schema.json
+++ b/frontend/src/app/testResults/uploads/schema.json
@@ -502,7 +502,7 @@
             {
               "name": "Testing lab phone number",
               "colHeader": "testing_lab_phone_number",
-              "required": false,
+              "required": true,
               "requested": false,
               "format": "000-000-0000",
               "examples": ["123-456-7890"]


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- `testing_lab_phone_number` is required by RS

RS requires one of these two columns
- `testing_lab_phone_number`
- `ordering_facility_phone_number`


since we decided to make all `ordering_facility` info optional, we have to make `testing_lab_phone_number` required
![image](https://user-images.githubusercontent.com/4952042/195634342-40494a5b-651a-43f8-8912-4357eb04f922.png)

## Changes Proposed

- Update the docs to make sure its correctly reflected