### PR TITLE
correctly show uploading status for big files

### DIFF
--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -106,6 +106,11 @@ const Uploads = () => {
     }
 
     FileUploadService.uploadResults(file).then(async (res) => {
+      setIsSubmitting(false);
+      setFileInputResetValue(fileInputResetValue + 1);
+      setFile(undefined);
+      setButtonIsDisabled(true);
+
       if (res.status !== 200) {
         setErrorMessageText(
           "There was a server error. Your file has not been accepted."
@@ -128,11 +133,6 @@ const Uploads = () => {
         }
       }
     });
-
-    setFileInputResetValue(fileInputResetValue + 1);
-    setFile(undefined);
-    setButtonIsDisabled(true);
-    setIsSubmitting(false);
   };
 
   return (


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- partially resolve #4471 
- as far as reducing the time for processing, I have contacted the RS team to switch us to the async upload for the test-results bulk upload sender (check slack RS engineering channel), hoping that will cut the processing time tremendously as it did for our regular queue based sender

## Changes Proposed

- correctly show loading message

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
