### PR TITLE
switch bulk results uploader to async

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubClient.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DataHubClient.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
     configuration = DataHubClientConfiguration.class)
 public interface DataHubClient {
 
-  @PostMapping(value = "/api/reports", consumes = "text/csv")
+  @PostMapping(value = "/api/reports?processing=async", consumes = "text/csv")
   UploadResponse uploadCSV(@Param("file") byte[] file);
 
   @PostMapping(value = "/api/token")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
@@ -85,7 +85,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
     assert responseFile != null;
     var mockResponse = IOUtils.toString(responseFile, StandardCharsets.UTF_8);
     stubFor(
-        WireMock.post(WireMock.urlEqualTo("/api/reports"))
+        WireMock.post(WireMock.urlEqualTo("/api/reports?processing=async"))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(HttpStatus.OK)
@@ -128,7 +128,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   void feignBadRequest_returnsErrorMessage() throws IOException {
     try (var x = loadCsv("responses/datahub-error-response.json")) {
       stubFor(
-          WireMock.post(WireMock.urlEqualTo("/api/reports"))
+          WireMock.post(WireMock.urlEqualTo("/api/reports?processing=async"))
               .willReturn(
                   WireMock.aResponse()
                       .withStatus(HttpStatus.BAD_REQUEST)
@@ -149,7 +149,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   void feignGeneralError_returnsFailureStatus() throws IOException {
 
     stubFor(
-        WireMock.post(WireMock.urlEqualTo("/api/reports"))
+        WireMock.post(WireMock.urlEqualTo("/api/reports?processing=async"))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(HttpStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- resolves #4471


## Changes Proposed
- switch file uploads to async
- we still get back the report id, and errors and warnings with this setting

Time Measurement: (Large file 1173 records) in dev4
with async **7.29s**
without async - azure-gateway-timeout (currently set to 20 seconds)
Note that rs staging is a lot slower than prod

## Additional Information
warnings/errors from rs still work!
![image](https://user-images.githubusercontent.com/4952042/195905752-22675689-5621-4c92-b978-ea095e246111.png)
