### PR TITLE
Test out teams / round robin review for backend dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,13 +60,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "alismx"
-      - "BobanL"
-      - "DanielSass"
-      - "mehansen"
-      - "rin-skylight"
-      - "zdeveloper"
-      - "emmastephenson"
+      - "SimpleReport-BackendReviews"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Instead of assigning the entire list as reviewers on every Dependabot Gradle PR, assigning the team **should** force GitHub to select two members of the team for each review.

## Changes Proposed

- Future dependabot PRs for Gradle should only have two assigned reviewers

## Additional Information

Current settings for this team:
![Screen Shot 2022-10-14 at 11 42 25 AM](https://user-images.githubusercontent.com/80282552/195918339-2c1c14ce-e131-40ee-b88e-ee14c2649637.png)

## Testing

- I'm going to attempt to assign the team as reviewer on this PR and we'll see if it works!
