### PR TITLE
Increase backend API gateway timeouts to 60 seconds

### DIFF
--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -111,7 +111,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     cookie_based_affinity               = "Disabled"
     port                                = 80
     protocol                            = "Http"
-    request_timeout                     = 20
+    request_timeout                     = 60
     pick_host_name_from_backend_address = true
   }
 
@@ -120,7 +120,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     cookie_based_affinity               = "Disabled"
     port                                = 443
     protocol                            = "Https"
-    request_timeout                     = 20
+    request_timeout                     = 60
     pick_host_name_from_backend_address = true
   }
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #4494.

## Changes Proposed

- Extend timeout of backend http pool to 60 seconds.
- Extend timeout of backend https pool to 60 seconds.

## Additional Information

- Static timeouts and redirect timeouts were left alone. If needed, those can be raised, as well, with very minor code changes.

## Testing

- Settings can be manually verified in the "Backend Settings" blade of the associated Application Gateway object within Azure. Only the `api` pools will have the changes needed; `static` pools will not. For comparison purposes, the original value was 20 seconds.
- Functional testing can be achieved by running a large upload action.


## Checklist for Primary Reviewer
### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)

### Cloud
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
