### PR TITLE
Fix link to devicelookup page with LinkWithQuery

### DIFF
--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -204,9 +204,9 @@ const CsvSchemaDocumentation = () => {
               </a>
             </li>
             <li>
-              <a href="/csv/codelookup" className="usa-link">
+              <LinkWithQuery to={`/csv/codelookup`}>
                 Device code lookup tool
-              </a>
+              </LinkWithQuery>
             </li>
             <li>
               <a href="mailto:support@simplereport.gov" className="usa-link">

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
           </li>
           <li>
             <a
-              class="usa-link"
+              class=""
               href="/csv/codelookup"
             >
               Device code lookup tool


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolves https://github.com/CDCgov/prime-simplereport/issues/4408
## Changes Proposed

- LinkWithQuery with query preserves the `facilityId`, so you don't have to select it again
- fix broken route

