### PR TITLE
Clean up toast container references

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -7,11 +7,11 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
 
 import * as clia from "../../utils/clia";
 import * as state from "../../utils/state";
 import * as smartyStreets from "../../utils/smartyStreets";
+import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import FacilityForm from "./FacilityForm";
 
@@ -734,13 +734,7 @@ describe("FacilityForm", () => {
               saveFacility={saveFacility}
             />
           </MemoryRouter>
-          <ToastContainer
-            autoClose={5000}
-            closeButton={false}
-            limit={2}
-            position="bottom-center"
-            hideProgressBar={true}
-          />
+          <SRToastContainer />
         </>
       );
 

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -10,9 +10,9 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
-import { ToastContainer } from "react-toastify";
 
 import * as smartyStreets from "../utils/smartyStreets";
+import SRToastContainer from "../commonComponents/SRToastContainer";
 
 import AddPatient, { ADD_PATIENT, PATIENT_EXISTS } from "./AddPatient";
 
@@ -233,13 +233,7 @@ describe("AddPatient", () => {
               </RouterWithFacility>
             </MockedProvider>
           </Provider>
-          <ToastContainer
-            autoClose={5000}
-            closeButton={false}
-            limit={2}
-            position="bottom-center"
-            hideProgressBar={true}
-          />
+          <SRToastContainer />
         </>
       );
     });

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -13,7 +13,8 @@ import { MockedProvider } from "@apollo/client/testing";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
+
+import SRToastContainer from "../commonComponents/SRToastContainer";
 
 import EditPatient, { GET_PATIENT, UPDATE_PATIENT } from "./EditPatient";
 import EditPatientContainer from "./EditPatientContainer";
@@ -299,13 +300,7 @@ describe("EditPatient", () => {
               </MockedProvider>
             </Provider>
           </MemoryRouter>
-          <ToastContainer
-            autoClose={5000}
-            closeButton={false}
-            limit={2}
-            position="bottom-center"
-            hideProgressBar={true}
-          />
+          <SRToastContainer />
         </>
       );
 

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceTypeFormContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceTypeFormContainer.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ToastContainer } from "react-toastify";
 
 import { SpecimenType } from "../../../generated/graphql";
+import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import DeviceTypeFormContainer from "./DeviceTypeFormContainer";
 
@@ -76,13 +76,7 @@ describe("DeviceTypeFormContainer", () => {
     container = render(
       <>
         <DeviceTypeFormContainer />
-        <ToastContainer
-          autoClose={5000}
-          closeButton={false}
-          limit={2}
-          position="bottom-center"
-          hideProgressBar={true}
-        />
+        <SRToastContainer />
       </>
     );
   });

--- a/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ToastContainer } from "react-toastify";
 
 import { DeviceType, SpecimenType } from "../../../generated/graphql";
+import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import ManageDeviceTypeFormContainer from "./ManageDeviceTypeFormContainer";
 
@@ -131,13 +131,7 @@ describe("ManageDeviceTypeFormContainer", () => {
     container = render(
       <>
         <ManageDeviceTypeFormContainer />
-        <ToastContainer
-          autoClose={5000}
-          closeButton={false}
-          limit={2}
-          position="bottom-center"
-          hideProgressBar={true}
-        />
+        <SRToastContainer />
       </>
     );
   });

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -1,6 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { Provider } from "react-redux";
-import { ToastContainer } from "react-toastify";
 import configureStore, { MockStoreEnhanced } from "redux-mock-store";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import moment from "moment";
@@ -417,13 +416,7 @@ describe("QueueItem", () => {
               </Provider>
             </MockedProvider>
           </MemoryRouter>
-          <ToastContainer
-            autoClose={5000}
-            closeButton={false}
-            limit={2}
-            position="bottom-center"
-            hideProgressBar={true}
-          />
+          <SRToastContainer />
         </>
       );
     });
@@ -698,13 +691,7 @@ describe("QueueItem", () => {
             </Provider>
           </MockedProvider>
         </MemoryRouter>
-        <ToastContainer
-          autoClose={5000}
-          closeButton={false}
-          limit={2}
-          position="bottom-center"
-          hideProgressBar={true}
-        />
+        <SRToastContainer />
       </>
     );
 

--- a/frontend/src/app/testResults/uploads/Uploads.test.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.test.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 import createMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
 
 import { FileUploadService } from "../../../fileUploadService/FileUploadService";
+import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import Uploads from "./Uploads";
 
@@ -28,7 +28,7 @@ const validFile = () => file(validFileContents);
 const TestContainer = () => (
   <Provider store={store}>
     <MemoryRouter>
-      <ToastContainer />
+      <SRToastContainer />
       <Uploads />
     </MemoryRouter>
   </Provider>
@@ -132,7 +132,7 @@ describe("Uploads", () => {
       await render(
         <Provider store={store}>
           <MemoryRouter>
-            <ToastContainer />
+            <SRToastContainer />
             <Uploads />
           </MemoryRouter>
         </Provider>

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookupContainer.test.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookupContainer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { ToastContainer } from "react-toastify";
+
+import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import DeviceLookupContainer from "./DeviceLookupContainer";
 
@@ -35,13 +36,7 @@ describe("DeviceLookupContainer", () => {
     render(
       <>
         <DeviceLookupContainer />
-        <ToastContainer
-          autoClose={5000}
-          closeButton={false}
-          limit={2}
-          position={"bottom-center"}
-          hideProgressBar={true}
-        />
+        <SRToastContainer />
       </>
     );
   });

--- a/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
+++ b/frontend/src/patientApp/selfRegistration/SelfRegistration.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
 import moment from "moment";
 import "react-toastify/dist/ReactToastify.css";
 import { useTranslation } from "react-i18next";
@@ -134,13 +133,6 @@ export const SelfRegistration = () => {
                 )}
               </div>
             </RegistrationContainer>
-            <ToastContainer
-              autoClose={5000}
-              closeButton={false}
-              limit={2}
-              position="bottom-center"
-              hideProgressBar={true}
-            />
           </div>
         }
         isPatientApp={true}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Missed cleanup from #4058 😅 

## Changes Proposed
- Removes references to `<ToastContainer>` in favor of `<SRToastContainer>` which contains all the default settings for toast notifications
- Removes the extra toast container in the patient self registration

## Additional Information
N/A

## Testing
- Go to patient self registration 
- Navigate to the form
- Submit the patient self registration form with errors
- You should only see the toast notification in the bottom, left-hand corner

## Screenshots / Demos
https://user-images.githubusercontent.com/20211771/196778771-5b24d6a9-cb14-4c2c-b10a-89c4965c0b84.mov