### PR TITLE
make tribal affiliation optional when creating csv

### DIFF
--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -138,4 +138,18 @@ describe("parseDataForCSV", () => {
       multiplexResult
     );
   });
+  it("parse data does not fail if tribalAffiliation is null", () => {
+    const multiplexEnabled = false;
+    expect(
+      parseDataForCSV(
+        [
+          {
+            ...data[0],
+            patient: { ...data[0].patient, tribalAffiliation: null },
+          },
+        ],
+        multiplexEnabled
+      )
+    ).toEqual(result);
+  });
 });

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -72,7 +72,8 @@ export function parseDataForCSV(data: any, multiplexEnabled: boolean) {
       "Patient gender": r.patient.gender,
       "Patient race": r.patient.race,
       "Patient ethnicity": r.patient.ethnicity,
-      "Patient tribal affiliation": r.patient.tribalAffiliation.join(", "),
+      "Patient tribal affiliation":
+        r.patient.tribalAffiliation?.join(", ") || "",
       "Patient is a resident in a congregate setting":
         r.patient.residentCongregateSetting,
       "Patient is employed in healthcare": r.patient.employedInHealthcare,


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #4289 

## Changes Proposed

- Make tribal affiliation optional, if no value is provided an empty string should be there.

## Additional Information

- The error mentioned, occurs when tribal affiliation is null. I was not able to replicate the issues in my local/dev without manually editing the database. 
- Adding this anyways just in case there is some edge case where this happens.

## Testing

- Download a CSV with tribe affiliated patients and non-tribe affiliated patients.

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
