### PR TITLE
Update team name for dependabot reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "CDCgov/simplereport-backendreviews"
+      - "simplereport-backendreviews"
       - "alixmx"
       - "rin-skylight"
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Dependabot didn't successfully request review from the backend reviewers team: https://github.com/CDCgov/prime-simplereport/pull/4536#issuecomment-1285782226
- The team has been added to the repository as a collaborator, so I'm guessing that the team name was the issue here

## Changes Proposed

- Should fix Dependabot so that it correctly requests review from the backendreviews team
