### PR TITLE
Use frontend team for dependabot frontend reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,11 +71,8 @@ updates:
       interval: "weekly"
     reviewers:
       - "alismx"
-      - "BobanL"
-      - "emyl3"
-      - "fzhao99"
-      - "georgehager"
       - "rin-skylight"
+      - "simplereport-frontendreviews"
       
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -84,11 +81,8 @@ updates:
       interval: "weekly"
     reviewers:
       - "alismx"
-      - "BobanL"
-      - "emyl3"
-      - "fzhao99"
-      - "georgehager"
       - "rin-skylight"
+      - "simplereport-frontendreviews"
       
   # - package-ecosystem: "npm"
   #   directory: "/cypress"


### PR DESCRIPTION
Adding the frontend team as a reviewer for Dependabot PRs!

Will also add the team as a repo contributor and turn on round-robin code reviews for it.