### PR TITLE
Consolidate duplicate results queries into one call (frontend)

### DIFF
--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -9,7 +9,10 @@ import { showError } from "../utils/srToast";
 import { useImperativeQuery } from "../utils/hooks";
 import { parseDataForCSV } from "../utils/testResultCSV";
 import Button from "../commonComponents/Button/Button";
-import { GetFacilityResultsForCsvDocument } from "../../generated/graphql";
+import {
+  GetFacilityResultsForCsvWithCountDocument,
+  GetFacilityResultsForCsvWithCountQuery,
+} from "../../generated/graphql";
 
 import { ALL_FACILITIES_ID, ResultsQueryVariables } from "./TestResultsList";
 
@@ -30,7 +33,7 @@ export const DownloadResultsCsvModal = ({
 }: DownloadResultsCsvModalProps) => {
   const rowsMaxLimit = 20000;
   const [loading, setLoading] = useState(false);
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState<any[]>([]);
   const csvLink = useRef<
     CSVLink & HTMLAnchorElement & { link: HTMLAnchorElement }
   >(null);
@@ -57,22 +60,30 @@ export const DownloadResultsCsvModal = ({
     ...filterParams,
   };
 
-  const getResults = useImperativeQuery(GetFacilityResultsForCsvDocument, {
-    fetchPolicy: "no-cache",
-  });
+  const getResults = useImperativeQuery<GetFacilityResultsForCsvWithCountQuery>(
+    GetFacilityResultsForCsvWithCountDocument,
+    {
+      fetchPolicy: "no-cache",
+    }
+  );
 
   const downloadResults = async () => {
-    setLoading(true);
     const { data, error } = await getResults(variables);
     if (error) {
       showError("Error downloading results", error.message);
       setLoading(false);
-    } else {
-      const csvResults = parseDataForCSV(data.testResults, multiplexEnabled);
+    } else if (data.testResultsPage && data.testResultsPage.content) {
+      const csvResults = parseDataForCSV(
+        data.testResultsPage.content,
+        multiplexEnabled
+      );
       setResults(csvResults);
       setLoading(false);
       csvLink?.current?.link.click();
       closeModal();
+    } else {
+      showError("Unknown error downloading results");
+      setLoading(false);
     }
   };
 
@@ -147,7 +158,10 @@ export const DownloadResultsCsvModal = ({
               label={disableDownload ? "Go back" : "No, go back"}
             />
             <Button
-              onClick={downloadResults}
+              onClick={async () => {
+                setLoading(true);
+                downloadResults();
+              }}
               disabled={disableDownload}
               icon={faDownload}
               label={loading ? "Loading..." : "Download results"}

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -1,27 +1,24 @@
 import qs from "querystring";
 
 import { MockedProvider } from "@apollo/client/testing";
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import userEvent from "@testing-library/user-event";
 
-import { GetAllFacilitiesDocument } from "../../generated/graphql";
 import { appPermissions } from "../permissions";
+import {
+  GetAllFacilitiesDocument,
+  GetFacilityResultsMultiplexWithCountQuery,
+} from "../../generated/graphql";
 import { SEARCH_DEBOUNCE_TIME } from "../testQueue/constants";
 
 import TestResultsList, {
   ALL_FACILITIES_ID,
   DetachedTestResultsList,
 } from "./TestResultsList";
-import testResults from "./mocks/resultsCovid.mock";
+import COVID_MOCK_DATA from "./mocks/resultsCovid.mock";
 import { mocks, mocksWithMultiplex } from "./mocks/queries.mock";
 import { facilities } from "./mocks/facilities.mock";
 
@@ -43,6 +40,12 @@ const store = mockStore({
   facility: { id: "1", name: "Facility 1" },
 });
 
+const testResults = {
+  data: {
+    testResultsPage: COVID_MOCK_DATA,
+  },
+};
+
 jest.mock("@microsoft/applicationinsights-react-js", () => ({
   useAppInsightsContext: () => {},
   useTrackEvent: jest.fn(),
@@ -61,16 +64,17 @@ describe("TestResultsList", () => {
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
             <DetachedTestResultsList
-              data={{ testResults }}
+              data={
+                testResults.data as GetFacilityResultsMultiplexWithCountQuery
+              }
               pageNumber={1}
               entriesPerPage={20}
-              totalEntries={testResults.length}
+              totalEntries={testResults.data.testResultsPage.totalElements}
               filterParams={{}}
               setFilterParams={() => () => {}}
               clearFilterParams={() => {}}
               activeFacilityId={"1"}
               loading={false}
-              loadingTotalResults={false}
               maxDate="2022-09-26"
             />
           </MockedProvider>
@@ -98,7 +102,7 @@ describe("TestResultsList", () => {
       facility: "1",
     };
 
-    await render(
+    render(
       <MemoryRouter
         initialEntries={[
           { pathname: "/results/1", search: qs.stringify(search) },
@@ -161,7 +165,7 @@ describe("TestResultsList", () => {
       filterFacilityId: "all",
     };
 
-    await render(
+    render(
       <MemoryRouter
         initialEntries={[
           { pathname: "/results/1", search: qs.stringify(search) },
@@ -188,7 +192,7 @@ describe("TestResultsList", () => {
       filterFacilityId: "all",
     };
 
-    await render(
+    render(
       <MemoryRouter
         initialEntries={[
           { pathname: "/results/1", search: qs.stringify(search) },
@@ -226,7 +230,7 @@ describe("TestResultsList", () => {
       filterFacilityId: "all",
     };
 
-    await render(
+    render(
       <MemoryRouter
         initialEntries={[
           { pathname: "/results/1", search: qs.stringify(search) },
@@ -262,7 +266,7 @@ describe("TestResultsList", () => {
       facility: "1",
     };
 
-    await render(
+    render(
       <MemoryRouter
         initialEntries={[
           { pathname: "/results/1", search: qs.stringify(search) },
@@ -294,557 +298,578 @@ describe("TestResultsList", () => {
       screen.getByRole("columnheader", { name: /submitted by/i })
     ).toBeInTheDocument();
   });
+});
 
-  describe("with mocks", () => {
-    beforeEach(() => {
-      render(
-        <WithRouter>
-          <Provider store={store}>
-            <MockedProvider mocks={mocks}>
-              <TestResultsList />
-            </MockedProvider>
-          </Provider>
-        </WithRouter>
-      );
-    });
-
-    it("should call appropriate gql endpoints for pagination", async () => {
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-    });
-
-    it("should be able to filter by patient", async () => {
-      await screen.findByText("Test Results", { exact: false });
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      expect(await screen.findByText("Search by name")).toBeInTheDocument();
-      userEvent.type(screen.getByRole("searchbox"), "Cragell");
-      expect(await screen.findByText("Filter")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Filter"));
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
-      expect(screen.getByRole("searchbox")).toHaveValue(
-        "Cragell, Barb Whitaker"
-      );
-    });
-    it("should be able to filter by result value", async () => {
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-      expect(
-        await screen.findByRole("option", { name: "Negative" })
-      ).toBeInTheDocument();
-      userEvent.selectOptions(screen.getByLabelText("Test result"), [
-        "NEGATIVE",
-      ]);
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
-    });
-    it("should be able to filter by role", async () => {
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      expect(
-        await screen.findByRole("option", { name: "Resident" })
-      ).toBeInTheDocument();
-      userEvent.selectOptions(screen.getByLabelText("Role"), ["RESIDENT"]);
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
-    });
-    it("should be able to filter by facility", async () => {
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      expect(
-        await screen.findByRole("option", { name: "Facility 2" })
-      ).toBeInTheDocument();
-      userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["2"]);
-      expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Cragell, Barb Whitaker")
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
-    });
-    it("should be able to filter by all facilities", async () => {
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(screen.queryByText("Clarkson, Lewis")).not.toBeInTheDocument();
-      expect(
-        await screen.findByRole("option", { name: "All facilities" })
-      ).toBeInTheDocument();
-      userEvent.selectOptions(
-        screen.getByLabelText("Testing facility"),
-        ALL_FACILITIES_ID
-      );
-      expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-    });
-
-    it("should be able to filter by date", async () => {
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-      expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
-      expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
-      userEvent.type(screen.getByText("Date range (start)"), "2021-03-18");
-      userEvent.tab();
-      screen.getByText("Colleer, Barde X");
-      screen.getByText("Gerard, Sam G");
-      await waitFor(() =>
-        expect(
-          screen.queryByText("Cragell, Barb Whitaker")
-        ).not.toBeInTheDocument()
-      );
-      userEvent.type(screen.getByText("Date range (end)"), "2021-03-18");
-      userEvent.tab();
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      await waitFor(() =>
-        expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument()
-      );
-      await waitFor(() =>
-        expect(
-          screen.queryByText("Cragell, Barb Whitaker")
-        ).not.toBeInTheDocument()
-      );
-    });
-    it("should be able to clear patient filter", async () => {
-      await screen.findByText("Test Results", { exact: false });
-
-      // Apply filter
-      expect(await screen.findByText("Search by name")).toBeInTheDocument();
-      userEvent.type(screen.getByRole("searchbox"), "Cragell");
-      expect(await screen.findByText("Filter")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Filter"));
-
-      // Clear filter
-      expect(await screen.findByText("Clear filters")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Clear filters"));
-
-      // All results, filter no longer applied
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    });
-
-    it("should be able to clear date filters", async () => {
-      // Apply filter
-      userEvent.type(screen.getByLabelText("Date range (start)"), "2021-03-18");
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-
-      // Filter applied
-      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Cragell, Barb Whitaker")
-      ).not.toBeInTheDocument();
-
-      expect(screen.getByLabelText("Date range (start)")).toHaveValue(
-        "2021-03-18"
-      );
-      // Clear filter
-      expect(await screen.findByText("Clear filters")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Clear filters"));
-
-      // Filter no longer applied
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-
-      // Date picker no longer displays the selected date
-      expect(screen.getByLabelText("Date range (start)")).toHaveValue("");
-    });
-
-    it("opens the test detail modal from the patient's name", async () => {
-      expect(
-        await screen.findByText("Cragell, Barb Whitaker")
-      ).toBeInTheDocument();
-      const patientNameLink = await screen.findByText("Cragell, Barb Whitaker");
-      userEvent.click(patientNameLink);
-      screen.getByText("Result details");
-      screen.getByText("Test information");
-      expect(
-        await screen.findByText("Barb Whitaker Cragell")
-      ).toBeInTheDocument();
-    });
-
-    it("opens the test detail modal from the actions menu", async () => {
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-      expect(
-        await screen.findByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      const moreActions = within(screen.getByRole("table")).getAllByRole(
-        "button"
-      )[1];
-      userEvent.click(moreActions);
-      const viewDetails = await screen.findByText("View details");
-      userEvent.click(viewDetails);
-      screen.getByText("Result details");
-      screen.getByText("Test information");
-    });
-
-    it("opens the email test results modal", async () => {
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-      expect(
-        screen.getByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      const moreActions = within(screen.getByRole("table")).getAllByRole(
-        "button"
-      )[1];
-      userEvent.click(moreActions);
-      const emailResult = screen.getByText("Email result");
-      userEvent.click(emailResult);
-      await screen.findByText("Email result?");
-    });
-
-    it("opens the download test results modal and shows how many rows the csv will have", async () => {
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-      expect(
-        screen.getByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      const downloadButton = screen.getByText("Download results", {
-        exact: false,
-      });
-      userEvent.click(downloadButton);
-      expect(
-        screen.getByText("Download results without any search filters", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("The CSV file will include 3 rows", { exact: false })
-      ).toBeInTheDocument();
-    });
-
-    it("closes the download test results modal after downloading", async () => {
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-      expect(
-        screen.getByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      const downloadButton = screen.getByText("Download results", {
-        exact: false,
-      });
-      userEvent.click(downloadButton);
-      expect(
-        screen.getByText("Download results without any search filters", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("The CSV file will include 3 rows", { exact: false })
-      ).toBeInTheDocument();
-      const downloadButton2 = within(screen.getByRole("dialog")).getByRole(
-        "button",
-        {
-          name: "Download results",
-          exact: false,
-        }
-      );
-      userEvent.click(downloadButton2);
-      expect(
-        screen.getByText("Loading...", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-      await waitForElementToBeRemoved(() =>
-        screen.queryByText("Download results without any search filters", {
-          exact: false,
-        })
-      );
-    });
-
-    it("opens the download test results modal after applying filters and shows how many rows the csv will have", async () => {
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-      expect(
-        screen.getByText("Test Results", { exact: false })
-      ).toBeInTheDocument();
-      userEvent.selectOptions(screen.getByLabelText("Test result"), [
-        "NEGATIVE",
-      ]);
-      expect(await screen.findByText("Showing 1-2 of 2")).toBeInTheDocument();
-      const downloadButton = screen.getByText("Download results", {
-        exact: false,
-      });
-      userEvent.click(downloadButton);
-      expect(
-        await screen.findByText(
-          "Download results with current search filters applied",
-          {
-            exact: false,
-          }
-        )
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("The CSV file will include 2 rows", { exact: false })
-      ).toBeInTheDocument();
-    });
-
-    describe("patient has no email", () => {
-      it("doesnt show the button to print results", async () => {
-        expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-        expect(
-          screen.getByText("Test Results", { exact: false })
-        ).toBeInTheDocument();
-        const moreActions = within(screen.getByRole("table")).getAllByRole(
-          "button"
-        )[0];
-        userEvent.click(moreActions);
-        expect(screen.queryByText("Email result")).not.toBeInTheDocument();
-      });
-    });
-
-    it("doesn't display anything if no facility is selected", async () => {
-      render(
-        <MemoryRouter>
-          <Provider store={store}>
-            <MockedProvider mocks={mocks}>
-              <TestResultsList />
-            </MockedProvider>
-          </Provider>
-        </MemoryRouter>
-      );
-      expect(
-        await screen.findByText("No facility selected", { exact: false })
-      ).toBeInTheDocument();
-    });
-
-    it("should not display Flu result columns if all rows with multiplex results are filtered", async () => {
-      // facility 1 has no multiplex results
-      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-      expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
-    });
-
-    it("should show multiplex results", async () => {
-      expect(
-        await screen.findByRole("option", { name: "Facility 1" })
-      ).toBeInTheDocument();
-      userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["3"]);
-      expect((await screen.findAllByText("Flu A"))[0]).toBeInTheDocument();
-    });
-
-    describe("return focus after modal close", () => {
-      const clickActionMenu = async () => {
-        expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-        const actionMenuButton = document.querySelectorAll(
-          ".rc-menu-button"
-        )[0];
-        userEvent.click(actionMenuButton as HTMLElement);
-      };
-      it.each([
-        ["Print result", "Close"],
-        ["Text result", "Cancel"],
-        ["Email result", "Cancel"],
-        ["Correct result", "No, go back"],
-      ])("should set focus on %p", async (menuButtonText, closeButtonText) => {
-        await clickActionMenu();
-        userEvent.click(screen.getByText(menuButtonText));
-        await screen.findAllByText(closeButtonText);
-        userEvent.click(screen.getAllByText(closeButtonText)[0]);
-        await waitFor(() =>
-          expect(screen.getByText(menuButtonText)).toHaveFocus()
-        );
-      });
-      it("should set focus on the view details button", async () => {
-        await clickActionMenu();
-        userEvent.click(screen.getByText("View details"));
-        await screen.findByAltText("Close");
-        userEvent.click(screen.getByAltText("Close"));
-        await waitFor(() =>
-          expect(screen.getByText("View details")).toHaveFocus()
-        );
-      });
-    });
-  });
-
-  it("should hide facility filter if user can see only 1 facility", async () => {
-    const localStore = mockStore({
-      organization: {
-        name: "Organization Name",
-      },
-      user: {
-        firstName: "Kim",
-        lastName: "Mendoza",
-      },
-      facilities: [{ id: "1", name: "Facility 1" }],
-      facility: { id: "1", name: "Facility 1" },
-    });
-
-    const localMock = mocks.slice(0, 2).concat([
-      {
-        request: {
-          query: GetAllFacilitiesDocument,
-          variables: {
-            showArchived: false,
-          },
-        },
-        result: {
-          data: {
-            facilities: facilities.slice(0, 1),
-          },
-        },
-      },
-    ]);
-
-    await render(
-      <WithRouter>
-        <Provider store={localStore}>
-          <MockedProvider mocks={localMock}>
-            <TestResultsList />
-          </MockedProvider>
-        </Provider>
-      </WithRouter>
-    );
-
-    expect(screen.queryByLabelText("Testing facility")).not.toBeInTheDocument();
-  });
-
-  it("should hide all facility option if user is not an admin", async () => {
-    const localStore = mockStore({
-      organization: {
-        name: "Organization Name",
-      },
-      user: {
-        firstName: "Kim",
-        lastName: "Mendoza",
-      },
-      facilities: [{ id: "1", name: "Facility 1" }],
-      facility: { id: "1", name: "Facility 1" },
-    });
-
-    await render(
-      <WithRouter>
-        <Provider store={localStore}>
-          <MockedProvider mocks={mocks}>
-            <TestResultsList />
-          </MockedProvider>
-        </Provider>
-      </WithRouter>
-    );
-
-    expect(
-      await screen.findByLabelText("Testing facility")
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Facility 1" })
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("option", { name: "All facilities" })
-    ).not.toBeInTheDocument();
-  });
-
-  describe("end date error", () => {
-    beforeEach(() => {
-      render(
-        <WithRouter>
-          <Provider store={store}>
-            <MockedProvider mocks={mocks}>
-              <TestResultsList />
-            </MockedProvider>
-          </Provider>
-        </WithRouter>
-      );
-    });
-    const setDateRange = async (
-      startDate = "2021-03-17",
-      endDate = "2021-03-18"
-    ) => {
-      userEvent.type(await screen.findByText("Date range (start)"), startDate);
-      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-      userEvent.type(await screen.findByText("Date range (end)"), endDate);
-      new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-    };
-    it("should display error if end date is before the start date", async () => {
-      await setDateRange("2021-03-18", "2021-03-17");
-      expect(
-        screen.getByText("End date cannot be before start date", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-    });
-    it("should display clear error message when clear filters button is pressed", async () => {
-      await setDateRange("2021-03-18", "2021-03-17");
-      expect(
-        screen.getByText("End date cannot be before start date", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-      userEvent.click(screen.getByText("Clear filters"));
-      expect(
-        screen.queryByText("End date cannot be before start date", {
-          exact: false,
-        })
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("clear filter button", () => {
-    const elementToTest = (filterParams: FilterParams) => (
+describe("with mocks", () => {
+  beforeEach(() => {
+    render(
       <WithRouter>
         <Provider store={store}>
           <MockedProvider mocks={mocks}>
-            <DetachedTestResultsList
-              data={{ testResults }}
-              pageNumber={1}
-              entriesPerPage={20}
-              totalEntries={testResults.length}
-              filterParams={filterParams}
-              setFilterParams={() => () => {}}
-              clearFilterParams={() => {}}
-              activeFacilityId={"1"}
-              loading={false}
-              loadingTotalResults={false}
-              maxDate="2022-09-26"
-            />
+            <TestResultsList />
           </MockedProvider>
         </Provider>
       </WithRouter>
     );
-    it("should be disabled when no filters are applied", () => {
-      render(elementToTest({}));
-      expect(screen.getByText("Clear filters")).toBeDisabled();
+  });
+
+  it("should call appropriate gql endpoints for pagination", async () => {
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+  });
+
+  it("should be able to filter by patient", async () => {
+    await screen.findByText("Test Results", { exact: false });
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(await screen.findByText("Search by name")).toBeInTheDocument();
+    userEvent.type(screen.getByRole("searchbox"), "Cragell");
+    expect(await screen.findByText("Filter")).toBeInTheDocument();
+    userEvent.click(screen.getByText("Filter"));
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
+    expect(screen.getByRole("searchbox")).toHaveValue("Cragell, Barb Whitaker");
+  });
+  it("should be able to filter by result value", async () => {
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Negative" })
+    ).toBeInTheDocument();
+    userEvent.selectOptions(screen.getByLabelText("Test result"), ["NEGATIVE"]);
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
+  });
+  it("should be able to filter by role", async () => {
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Resident" })
+    ).toBeInTheDocument();
+    userEvent.selectOptions(screen.getByLabelText("Role"), ["RESIDENT"]);
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
+  });
+  it("should be able to filter by facility", async () => {
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Facility 2" })
+    ).toBeInTheDocument();
+    userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["2"]);
+    expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Cragell, Barb Whitaker")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
+  });
+  it("should be able to filter by all facilities", async () => {
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Clarkson, Lewis")).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "All facilities" })
+    ).toBeInTheDocument();
+    userEvent.selectOptions(
+      screen.getByLabelText("Testing facility"),
+      ALL_FACILITIES_ID
+    );
+    expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+  });
+  it("should be able to filter by date", async () => {
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+    expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
+    expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
+    userEvent.type(screen.getByText("Date range (start)"), "2021-03-18");
+    userEvent.tab();
+    screen.getByText("Colleer, Barde X");
+    screen.getByText("Gerard, Sam G");
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Cragell, Barb Whitaker")
+      ).not.toBeInTheDocument()
+    );
+    userEvent.type(screen.getByText("Date range (end)"), "2021-03-18");
+    userEvent.tab();
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Cragell, Barb Whitaker")
+      ).not.toBeInTheDocument()
+    );
+  });
+  it("should be able to clear patient filter", async () => {
+    await screen.findByText("Test Results", { exact: false });
+
+    // Apply filter
+    expect(await screen.findByText("Search by name")).toBeInTheDocument();
+    userEvent.type(screen.getByRole("searchbox"), "Cragell");
+    expect(await screen.findByText("Filter")).toBeInTheDocument();
+    userEvent.click(screen.getByText("Filter"));
+
+    // Clear filter
+    expect(await screen.findByText("Clear filters")).toBeInTheDocument();
+    userEvent.click(screen.getByText("Clear filters"));
+
+    // All results, filter no longer applied
+
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+  });
+  it("should be able to clear date filters", async () => {
+    // Apply filter
+    userEvent.type(screen.getByLabelText("Date range (start)"), "2021-03-18");
+
+    // Filter applied
+    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Cragell, Barb Whitaker")
+      ).not.toBeInTheDocument();
     });
-    it("should be disabled when testing only filter applied is facility is active facility", () => {
-      render(elementToTest({ filterFacilityId: "1" }));
-      expect(screen.getByText("Clear filters")).toBeDisabled();
+
+    expect(screen.getByLabelText("Date range (start)")).toHaveValue(
+      "2021-03-18"
+    );
+    // Clear filter
+    expect(await screen.findByText("Clear filters")).toBeInTheDocument();
+    userEvent.click(screen.getByText("Clear filters"));
+
+    // Filter no longer applied
+    await waitFor(() => {
+      expect(screen.getByText("Cragell, Barb Whitaker")).toBeInTheDocument();
     });
-    it("should be enabled filters are applied", () => {
-      render(elementToTest({ result: "Positive" }));
-      expect(screen.getByText("Clear filters")).toBeEnabled();
+
+    // Date picker no longer displays the selected date
+    expect(screen.getByLabelText("Date range (start)")).toHaveValue("");
+  });
+  it("opens the test detail modal from the patient's name", async () => {
+    expect(
+      await screen.findByText("Cragell, Barb Whitaker")
+    ).toBeInTheDocument();
+    const patientNameLink = await screen.findByText("Cragell, Barb Whitaker");
+    userEvent.click(patientNameLink);
+    screen.getByText("Result details");
+    screen.getByText("Test information");
+    expect(
+      await screen.findByText("Barb Whitaker Cragell")
+    ).toBeInTheDocument();
+  });
+  it("opens the test detail modal from the actions menu", async () => {
+    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    const moreActions = within(screen.getByRole("table")).getAllByRole(
+      "button"
+    )[1];
+    userEvent.click(moreActions);
+    const viewDetails = await screen.findByText("View details");
+    userEvent.click(viewDetails);
+    screen.getByText("Result details");
+    screen.getByText("Test information");
+  });
+  it("opens the email test results modal", async () => {
+    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+    expect(
+      screen.getByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    const moreActions = within(screen.getByRole("table")).getAllByRole(
+      "button"
+    )[1];
+    userEvent.click(moreActions);
+    const emailResult = screen.getByText("Email result");
+    userEvent.click(emailResult);
+    await screen.findByText("Email result?");
+  });
+  it("opens the download test results modal and shows how many rows the csv will have", async () => {
+    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+    expect(
+      screen.getByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    const downloadButton = screen.getByText("Download results", {
+      exact: false,
     });
+    userEvent.click(downloadButton);
+    expect(
+      screen.getByText("Download results without any search filters", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The CSV file will include 3 rows", { exact: false })
+    ).toBeInTheDocument();
+  });
+  // it("closes the download test results modal after downloading", async () => {
+  // source of the navigation not implemented warning
+  //   expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+  //   expect(
+  //     screen.getByText("Test Results", { exact: false })
+  //   ).toBeInTheDocument();
+  //   const downloadButton = screen.getByText("Download results", {
+  //     exact: false,
+  //   });
+  //   userEvent.click(downloadButton);
+  //   expect(
+  //     screen.getByText("Download results without any search filters", {
+  //       exact: false,
+  //     })
+  //   ).toBeInTheDocument();
+  //   expect(
+  //     screen.getByText("The CSV file will include 3 rows", { exact: false })
+  //   ).toBeInTheDocument();
+  //   const downloadButton2 = within(screen.getByRole("dialog")).getByRole(
+  //     "button",
+  //     {
+  //       name: "Download results",
+  //       exact: false,
+  //     }
+  //   );
+  //   userEvent.click(downloadButton2);
+  //   expect(
+  //     screen.getByText("Loading...", {
+  //       exact: false,
+  //     })
+  //   ).toBeInTheDocument();
+  //   await waitForElementToBeRemoved(() =>
+  //     screen.queryByText("Download results without any search filters", {
+  //       exact: false,
+  //     })
+  //   );
+  // });
+  it("opens the download test results modal after applying filters and shows how many rows the csv will have", async () => {
+    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Test Results", { exact: false })
+    ).toBeInTheDocument();
+    userEvent.selectOptions(screen.getByLabelText("Test result"), ["NEGATIVE"]);
+    expect(await screen.findByText("Showing 1-2 of 2")).toBeInTheDocument();
+    const downloadButton = screen.getByText("Download results", {
+      exact: false,
+    });
+    userEvent.click(downloadButton);
+    expect(
+      await screen.findByText(
+        "Download results with current search filters applied",
+        {
+          exact: false,
+        }
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The CSV file will include 2 rows", { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  describe("patient has no email", () => {
+    it("doesnt show the button to print results", async () => {
+      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      expect(
+        screen.getByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      const moreActions = within(screen.getByRole("table")).getAllByRole(
+        "button"
+      )[0];
+      userEvent.click(moreActions);
+      expect(screen.queryByText("Email result")).not.toBeInTheDocument();
+    });
+  });
+
+  it("doesn't display anything if no facility is selected", async () => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <TestResultsList />
+          </MockedProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(
+      await screen.findByText("No facility selected", { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should not display Flu result columns if all rows with multiplex results are filtered", async () => {
+    // facility 1 has no multiplex results
+    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+    expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
+  });
+
+  it("should show multiplex results", async () => {
+    expect(
+      await screen.findByRole("option", { name: "Facility 1" })
+    ).toBeInTheDocument();
+    userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["3"]);
+    expect((await screen.findAllByText("Flu A"))[0]).toBeInTheDocument();
+  });
+
+  describe("return focus after modal close", () => {
+    const clickActionMenu = async () => {
+      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      const actionMenuButton = document.querySelectorAll(".rc-menu-button")[0];
+      userEvent.click(actionMenuButton as HTMLElement);
+    };
+    it.each([
+      ["Print result", "Close"],
+      ["Text result", "Cancel"],
+      ["Email result", "Cancel"],
+      ["Correct result", "No, go back"],
+    ])("should set focus on %p", async (menuButtonText, closeButtonText) => {
+      // source of the React key prop warning
+      await clickActionMenu();
+      userEvent.click(screen.getByText(menuButtonText));
+      await screen.findAllByText(closeButtonText);
+      userEvent.click(screen.getAllByText(closeButtonText)[0]);
+      await waitFor(() =>
+        expect(screen.getByText(menuButtonText)).toHaveFocus()
+      );
+    });
+    it("should set focus on the view details button", async () => {
+      await clickActionMenu();
+      userEvent.click(screen.getByText("View details"));
+      await screen.findByAltText("Close");
+      userEvent.click(screen.getByAltText("Close"));
+      await waitFor(() =>
+        expect(screen.getByText("View details")).toHaveFocus()
+      );
+    });
+  });
+});
+
+it("should hide facility filter if user can see only 1 facility", async () => {
+  const localStore = mockStore({
+    organization: {
+      name: "Organization Name",
+    },
+    user: {
+      firstName: "Kim",
+      lastName: "Mendoza",
+    },
+    facilities: [{ id: "1", name: "Facility 1" }],
+    facility: { id: "1", name: "Facility 1" },
+  });
+
+  const localMock = mocks.slice(0, 2).concat([
+    {
+      request: {
+        query: GetAllFacilitiesDocument,
+        variables: {
+          showArchived: false,
+        },
+      },
+      result: {
+        data: {
+          facilities: facilities.slice(0, 1),
+        },
+      },
+    },
+  ]);
+
+  render(
+    <WithRouter>
+      <Provider store={localStore}>
+        <MockedProvider mocks={localMock}>
+          <TestResultsList />
+        </MockedProvider>
+      </Provider>
+    </WithRouter>
+  );
+
+  expect(screen.queryByLabelText("Testing facility")).not.toBeInTheDocument();
+});
+
+it("should hide all facility option if user is not an admin", async () => {
+  const localStore = mockStore({
+    organization: {
+      name: "Organization Name",
+    },
+    user: {
+      firstName: "Kim",
+      lastName: "Mendoza",
+    },
+    facilities: [{ id: "1", name: "Facility 1" }],
+    facility: { id: "1", name: "Facility 1" },
+  });
+
+  render(
+    <WithRouter>
+      <Provider store={localStore}>
+        <MockedProvider mocks={mocks}>
+          <TestResultsList />
+        </MockedProvider>
+      </Provider>
+    </WithRouter>
+  );
+
+  expect(await screen.findByLabelText("Testing facility")).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Facility 1" })
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("option", { name: "All facilities" })
+  ).not.toBeInTheDocument();
+});
+
+describe("clear filter button", () => {
+  const elementToTest = (filterParams: FilterParams) => (
+    <WithRouter>
+      <Provider store={store}>
+        <MockedProvider mocks={mocks}>
+          <DetachedTestResultsList
+            data={testResults.data as GetFacilityResultsMultiplexWithCountQuery}
+            pageNumber={1}
+            entriesPerPage={20}
+            totalEntries={testResults.data.testResultsPage.totalElements}
+            filterParams={filterParams}
+            setFilterParams={() => () => {}}
+            clearFilterParams={() => {}}
+            activeFacilityId={"1"}
+            loading={false}
+            maxDate="2022-09-26"
+          />
+        </MockedProvider>
+      </Provider>
+    </WithRouter>
+  );
+  it("should be disabled when no filters are applied", () => {
+    render(elementToTest({}));
+    expect(screen.getByText("Clear filters")).toBeDisabled();
+  });
+  it("should be disabled when testing only filter applied is facility is active facility", () => {
+    render(elementToTest({ filterFacilityId: "1" }));
+    expect(screen.getByText("Clear filters")).toBeDisabled();
+  });
+  it("should be enabled filters are applied", () => {
+    render(elementToTest({ result: "Positive" }));
+    expect(screen.getByText("Clear filters")).toBeEnabled();
+  });
+});
+
+describe("end date error", () => {
+  beforeEach(() => {
+    render(
+      <WithRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <TestResultsList />
+          </MockedProvider>
+        </Provider>
+      </WithRouter>
+    );
+  });
+  const setDateRange = async (
+    startDate = "2021-03-17",
+    endDate = "2021-03-18"
+  ) => {
+    userEvent.type(await screen.findByText("Date range (start)"), startDate);
+    await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+    userEvent.type(await screen.findByText("Date range (end)"), endDate);
+    new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+  };
+  it("should display error if end date is before the start date", async () => {
+    await setDateRange("2021-03-18", "2021-03-17");
+    expect(
+      screen.getByText("End date cannot be before start date", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+  });
+  it("should display clear error message when clear filters button is pressed", async () => {
+    await setDateRange("2021-03-18", "2021-03-17");
+    expect(
+      screen.getByText("End date cannot be before start date", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+    userEvent.click(screen.getByText("Clear filters"));
+    expect(
+      screen.queryByText("End date cannot be before start date", {
+        exact: false,
+      })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("clear filter button", () => {
+  const elementToTest = (filterParams: FilterParams) => (
+    <WithRouter>
+      <Provider store={store}>
+        <MockedProvider mocks={mocks}>
+          <DetachedTestResultsList
+            data={testResults.data as GetFacilityResultsMultiplexWithCountQuery}
+            pageNumber={1}
+            entriesPerPage={20}
+            totalEntries={testResults.data.testResultsPage.totalElements}
+            filterParams={filterParams}
+            setFilterParams={() => () => {}}
+            clearFilterParams={() => {}}
+            activeFacilityId={"1"}
+            loading={false}
+            maxDate="2022-09-26"
+          />
+        </MockedProvider>
+      </Provider>
+    </WithRouter>
+  );
+  it("should be disabled when no filters are applied", () => {
+    render(elementToTest({}));
+    expect(screen.getByText("Clear filters")).toBeDisabled();
+  });
+  it("should be disabled when testing only filter applied is facility is active facility", () => {
+    render(elementToTest({ filterFacilityId: "1" }));
+    expect(screen.getByText("Clear filters")).toBeDisabled();
+  });
+  it("should be enabled filters are applied", () => {
+    render(elementToTest({ result: "Positive" }));
+    expect(screen.getByText("Clear filters")).toBeEnabled();
   });
 });

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -1,17 +1,23 @@
 import qs from "querystring";
 
 import { MockedProvider } from "@apollo/client/testing";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import userEvent from "@testing-library/user-event";
 
-import { appPermissions } from "../permissions";
 import {
   GetAllFacilitiesDocument,
   GetFacilityResultsMultiplexWithCountQuery,
 } from "../../generated/graphql";
+import { appPermissions } from "../permissions";
 import { SEARCH_DEBOUNCE_TIME } from "../testQueue/constants";
 
 import TestResultsList, {
@@ -298,578 +304,559 @@ describe("TestResultsList", () => {
       screen.getByRole("columnheader", { name: /submitted by/i })
     ).toBeInTheDocument();
   });
-});
 
-describe("with mocks", () => {
-  beforeEach(() => {
-    render(
-      <WithRouter>
-        <Provider store={store}>
-          <MockedProvider mocks={mocks}>
-            <TestResultsList />
-          </MockedProvider>
-        </Provider>
-      </WithRouter>
-    );
-  });
+  describe("with mocks", () => {
+    beforeEach(() => {
+      render(
+        <WithRouter>
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <TestResultsList />
+            </MockedProvider>
+          </Provider>
+        </WithRouter>
+      );
+    });
 
-  it("should call appropriate gql endpoints for pagination", async () => {
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-  });
-
-  it("should be able to filter by patient", async () => {
-    await screen.findByText("Test Results", { exact: false });
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    expect(await screen.findByText("Search by name")).toBeInTheDocument();
-    userEvent.type(screen.getByRole("searchbox"), "Cragell");
-    expect(await screen.findByText("Filter")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Filter"));
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
-    expect(screen.getByRole("searchbox")).toHaveValue("Cragell, Barb Whitaker");
-  });
-  it("should be able to filter by result value", async () => {
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Negative" })
-    ).toBeInTheDocument();
-    userEvent.selectOptions(screen.getByLabelText("Test result"), ["NEGATIVE"]);
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
-  });
-  it("should be able to filter by role", async () => {
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Resident" })
-    ).toBeInTheDocument();
-    userEvent.selectOptions(screen.getByLabelText("Role"), ["RESIDENT"]);
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
-  });
-  it("should be able to filter by facility", async () => {
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Facility 2" })
-    ).toBeInTheDocument();
-    userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["2"]);
-    expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Cragell, Barb Whitaker")
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
-  });
-  it("should be able to filter by all facilities", async () => {
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Clarkson, Lewis")).not.toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "All facilities" })
-    ).toBeInTheDocument();
-    userEvent.selectOptions(
-      screen.getByLabelText("Testing facility"),
-      ALL_FACILITIES_ID
-    );
-    expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-  });
-  it("should be able to filter by date", async () => {
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-    expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
-    expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
-    userEvent.type(screen.getByText("Date range (start)"), "2021-03-18");
-    userEvent.tab();
-    screen.getByText("Colleer, Barde X");
-    screen.getByText("Gerard, Sam G");
-    await waitFor(() =>
+    it("should call appropriate gql endpoints for pagination", async () => {
       expect(
-        screen.queryByText("Cragell, Barb Whitaker")
-      ).not.toBeInTheDocument()
-    );
-    userEvent.type(screen.getByText("Date range (end)"), "2021-03-18");
-    userEvent.tab();
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument()
-    );
-    await waitFor(() =>
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
       expect(
-        screen.queryByText("Cragell, Barb Whitaker")
-      ).not.toBeInTheDocument()
-    );
-  });
-  it("should be able to clear patient filter", async () => {
-    await screen.findByText("Test Results", { exact: false });
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+    });
 
-    // Apply filter
-    expect(await screen.findByText("Search by name")).toBeInTheDocument();
-    userEvent.type(screen.getByRole("searchbox"), "Cragell");
-    expect(await screen.findByText("Filter")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Filter"));
-
-    // Clear filter
-    expect(await screen.findByText("Clear filters")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Clear filters"));
-
-    // All results, filter no longer applied
-
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-  });
-  it("should be able to clear date filters", async () => {
-    // Apply filter
-    userEvent.type(screen.getByLabelText("Date range (start)"), "2021-03-18");
-
-    // Filter applied
-    expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
-    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-    await waitFor(() => {
+    it("should be able to filter by patient", async () => {
+      await screen.findByText("Test Results", { exact: false });
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      expect(await screen.findByText("Search by name")).toBeInTheDocument();
+      userEvent.type(screen.getByRole("searchbox"), "Cragell");
+      expect(await screen.findByText("Filter")).toBeInTheDocument();
+      userEvent.click(screen.getByText("Filter"));
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
+      expect(screen.getByRole("searchbox")).toHaveValue(
+        "Cragell, Barb Whitaker"
+      );
+    });
+    it("should be able to filter by result value", async () => {
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+      expect(
+        await screen.findByRole("option", { name: "Negative" })
+      ).toBeInTheDocument();
+      userEvent.selectOptions(screen.getByLabelText("Test result"), [
+        "NEGATIVE",
+      ]);
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument();
+    });
+    it("should be able to filter by role", async () => {
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      expect(
+        await screen.findByRole("option", { name: "Resident" })
+      ).toBeInTheDocument();
+      userEvent.selectOptions(screen.getByLabelText("Role"), ["RESIDENT"]);
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
+    });
+    it("should be able to filter by facility", async () => {
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      expect(
+        await screen.findByRole("option", { name: "Facility 2" })
+      ).toBeInTheDocument();
+      userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["2"]);
+      expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
       expect(
         screen.queryByText("Cragell, Barb Whitaker")
       ).not.toBeInTheDocument();
+      expect(screen.queryByText("Colleer, Barde X")).not.toBeInTheDocument();
+    });
+    it("should be able to filter by all facilities", async () => {
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Clarkson, Lewis")).not.toBeInTheDocument();
+      expect(
+        await screen.findByRole("option", { name: "All facilities" })
+      ).toBeInTheDocument();
+      userEvent.selectOptions(
+        screen.getByLabelText("Testing facility"),
+        ALL_FACILITIES_ID
+      );
+      expect(await screen.findByText("Clarkson, Lewis")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText("Date range (start)")).toHaveValue(
-      "2021-03-18"
-    );
-    // Clear filter
-    expect(await screen.findByText("Clear filters")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Clear filters"));
+    it("should be able to filter by date", async () => {
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+      expect(await screen.findByText("Date range (start)")).toBeInTheDocument();
+      expect(await screen.findByText("Date range (end)")).toBeInTheDocument();
+      userEvent.type(screen.getByText("Date range (start)"), "2021-03-18");
+      userEvent.tab();
+      screen.getByText("Colleer, Barde X");
+      screen.getByText("Gerard, Sam G");
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Cragell, Barb Whitaker")
+        ).not.toBeInTheDocument()
+      );
+      userEvent.type(screen.getByText("Date range (end)"), "2021-03-18");
+      userEvent.tab();
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.queryByText("Gerard, Sam G")).not.toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Cragell, Barb Whitaker")
+        ).not.toBeInTheDocument()
+      );
+    });
+    it("should be able to clear patient filter", async () => {
+      await screen.findByText("Test Results", { exact: false });
 
-    // Filter no longer applied
-    await waitFor(() => {
-      expect(screen.getByText("Cragell, Barb Whitaker")).toBeInTheDocument();
+      // Apply filter
+      expect(await screen.findByText("Search by name")).toBeInTheDocument();
+      userEvent.type(screen.getByRole("searchbox"), "Cragell");
+      expect(await screen.findByText("Filter")).toBeInTheDocument();
+      userEvent.click(screen.getByText("Filter"));
+
+      // Clear filter
+      expect(await screen.findByText("Clear filters")).toBeInTheDocument();
+      userEvent.click(screen.getByText("Clear filters"));
+
+      // All results, filter no longer applied
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
     });
 
-    // Date picker no longer displays the selected date
-    expect(screen.getByLabelText("Date range (start)")).toHaveValue("");
-  });
-  it("opens the test detail modal from the patient's name", async () => {
-    expect(
-      await screen.findByText("Cragell, Barb Whitaker")
-    ).toBeInTheDocument();
-    const patientNameLink = await screen.findByText("Cragell, Barb Whitaker");
-    userEvent.click(patientNameLink);
-    screen.getByText("Result details");
-    screen.getByText("Test information");
-    expect(
-      await screen.findByText("Barb Whitaker Cragell")
-    ).toBeInTheDocument();
-  });
-  it("opens the test detail modal from the actions menu", async () => {
-    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-    expect(
-      await screen.findByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    const moreActions = within(screen.getByRole("table")).getAllByRole(
-      "button"
-    )[1];
-    userEvent.click(moreActions);
-    const viewDetails = await screen.findByText("View details");
-    userEvent.click(viewDetails);
-    screen.getByText("Result details");
-    screen.getByText("Test information");
-  });
-  it("opens the email test results modal", async () => {
-    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-    expect(
-      screen.getByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    const moreActions = within(screen.getByRole("table")).getAllByRole(
-      "button"
-    )[1];
-    userEvent.click(moreActions);
-    const emailResult = screen.getByText("Email result");
-    userEvent.click(emailResult);
-    await screen.findByText("Email result?");
-  });
-  it("opens the download test results modal and shows how many rows the csv will have", async () => {
-    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-    expect(
-      screen.getByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    const downloadButton = screen.getByText("Download results", {
-      exact: false,
-    });
-    userEvent.click(downloadButton);
-    expect(
-      screen.getByText("Download results without any search filters", {
-        exact: false,
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("The CSV file will include 3 rows", { exact: false })
-    ).toBeInTheDocument();
-  });
-  // it("closes the download test results modal after downloading", async () => {
-  // source of the navigation not implemented warning
-  //   expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-  //   expect(
-  //     screen.getByText("Test Results", { exact: false })
-  //   ).toBeInTheDocument();
-  //   const downloadButton = screen.getByText("Download results", {
-  //     exact: false,
-  //   });
-  //   userEvent.click(downloadButton);
-  //   expect(
-  //     screen.getByText("Download results without any search filters", {
-  //       exact: false,
-  //     })
-  //   ).toBeInTheDocument();
-  //   expect(
-  //     screen.getByText("The CSV file will include 3 rows", { exact: false })
-  //   ).toBeInTheDocument();
-  //   const downloadButton2 = within(screen.getByRole("dialog")).getByRole(
-  //     "button",
-  //     {
-  //       name: "Download results",
-  //       exact: false,
-  //     }
-  //   );
-  //   userEvent.click(downloadButton2);
-  //   expect(
-  //     screen.getByText("Loading...", {
-  //       exact: false,
-  //     })
-  //   ).toBeInTheDocument();
-  //   await waitForElementToBeRemoved(() =>
-  //     screen.queryByText("Download results without any search filters", {
-  //       exact: false,
-  //     })
-  //   );
-  // });
-  it("opens the download test results modal after applying filters and shows how many rows the csv will have", async () => {
-    expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+    it("should be able to clear date filters", async () => {
+      // Apply filter
+      userEvent.type(screen.getByLabelText("Date range (start)"), "2021-03-18");
 
-    expect(
-      screen.getByText("Test Results", { exact: false })
-    ).toBeInTheDocument();
-    userEvent.selectOptions(screen.getByLabelText("Test result"), ["NEGATIVE"]);
-    expect(await screen.findByText("Showing 1-2 of 2")).toBeInTheDocument();
-    const downloadButton = screen.getByText("Download results", {
-      exact: false,
-    });
-    userEvent.click(downloadButton);
-    expect(
-      await screen.findByText(
-        "Download results with current search filters applied",
-        {
-          exact: false,
-        }
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("The CSV file will include 2 rows", { exact: false })
-    ).toBeInTheDocument();
-  });
+      // Filter applied
+      expect(await screen.findByText("Colleer, Barde X")).toBeInTheDocument();
+      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Cragell, Barb Whitaker")
+        ).not.toBeInTheDocument();
+      });
 
-  describe("patient has no email", () => {
-    it("doesnt show the button to print results", async () => {
+      expect(screen.getByLabelText("Date range (start)")).toHaveValue(
+        "2021-03-18"
+      );
+      // Clear filter
+      expect(await screen.findByText("Clear filters")).toBeInTheDocument();
+      userEvent.click(screen.getByText("Clear filters"));
+
+      // Filter no longer applied
+      await waitFor(() => {
+        expect(screen.getByText("Cragell, Barb Whitaker")).toBeInTheDocument();
+      });
+
+      // Date picker no longer displays the selected date
+      expect(screen.getByLabelText("Date range (start)")).toHaveValue("");
+    });
+
+    it("opens the test detail modal from the patient's name", async () => {
+      expect(
+        await screen.findByText("Cragell, Barb Whitaker")
+      ).toBeInTheDocument();
+      const patientNameLink = await screen.findByText("Cragell, Barb Whitaker");
+      userEvent.click(patientNameLink);
+      screen.getByText("Result details");
+      screen.getByText("Test information");
+      expect(
+        await screen.findByText("Barb Whitaker Cragell")
+      ).toBeInTheDocument();
+    });
+
+    it("opens the test detail modal from the actions menu", async () => {
+      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      const moreActions = within(screen.getByRole("table")).getAllByRole(
+        "button"
+      )[1];
+      userEvent.click(moreActions);
+      const viewDetails = await screen.findByText("View details");
+      userEvent.click(viewDetails);
+      screen.getByText("Result details");
+      screen.getByText("Test information");
+    });
+
+    it("opens the email test results modal", async () => {
       expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
       expect(
         screen.getByText("Test Results", { exact: false })
       ).toBeInTheDocument();
       const moreActions = within(screen.getByRole("table")).getAllByRole(
         "button"
-      )[0];
+      )[1];
       userEvent.click(moreActions);
-      expect(screen.queryByText("Email result")).not.toBeInTheDocument();
+      const emailResult = screen.getByText("Email result");
+      userEvent.click(emailResult);
+      await screen.findByText("Email result?");
+    });
+
+    it("opens the download test results modal and shows how many rows the csv will have", async () => {
+      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      expect(
+        screen.getByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      const downloadButton = screen.getByText("Download results", {
+        exact: false,
+      });
+      userEvent.click(downloadButton);
+      expect(
+        screen.getByText("Download results without any search filters", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("The CSV file will include 3 rows", { exact: false })
+      ).toBeInTheDocument();
+    });
+
+    it("closes the download test results modal after downloading", async () => {
+      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      expect(
+        screen.getByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      const downloadButton = screen.getByText("Download results", {
+        exact: false,
+      });
+      userEvent.click(downloadButton);
+      expect(
+        screen.getByText("Download results without any search filters", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("The CSV file will include 3 rows", { exact: false })
+      ).toBeInTheDocument();
+      const downloadButton2 = within(screen.getByRole("dialog")).getByRole(
+        "button",
+        {
+          name: "Download results",
+          exact: false,
+        }
+      );
+      userEvent.click(downloadButton2);
+      expect(
+        screen.getByText("Loading...", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      await waitForElementToBeRemoved(() =>
+        screen.queryByText("Download results without any search filters", {
+          exact: false,
+        })
+      );
+    });
+
+    it("opens the download test results modal after applying filters and shows how many rows the csv will have", async () => {
+      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      expect(
+        screen.getByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+      userEvent.selectOptions(screen.getByLabelText("Test result"), [
+        "NEGATIVE",
+      ]);
+      expect(await screen.findByText("Showing 1-2 of 2")).toBeInTheDocument();
+      const downloadButton = screen.getByText("Download results", {
+        exact: false,
+      });
+      userEvent.click(downloadButton);
+      expect(
+        await screen.findByText(
+          "Download results with current search filters applied",
+          {
+            exact: false,
+          }
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("The CSV file will include 2 rows", { exact: false })
+      ).toBeInTheDocument();
+    });
+
+    describe("patient has no email", () => {
+      it("doesnt show the button to print results", async () => {
+        expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+        expect(
+          screen.getByText("Test Results", { exact: false })
+        ).toBeInTheDocument();
+        const moreActions = within(screen.getByRole("table")).getAllByRole(
+          "button"
+        )[0];
+        userEvent.click(moreActions);
+        expect(screen.queryByText("Email result")).not.toBeInTheDocument();
+      });
+    });
+
+    it("doesn't display anything if no facility is selected", async () => {
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <TestResultsList />
+            </MockedProvider>
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(
+        await screen.findByText("No facility selected", { exact: false })
+      ).toBeInTheDocument();
+    });
+
+    it("should not display Flu result columns if all rows with multiplex results are filtered", async () => {
+      // facility 1 has no multiplex results
+      expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
+      expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
+    });
+
+    it("should show multiplex results", async () => {
+      expect(
+        await screen.findByRole("option", { name: "Facility 1" })
+      ).toBeInTheDocument();
+      userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["3"]);
+      expect((await screen.findAllByText("Flu A"))[0]).toBeInTheDocument();
+    });
+
+    describe("return focus after modal close", () => {
+      const clickActionMenu = async () => {
+        expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+        const actionMenuButton = document.querySelectorAll(
+          ".rc-menu-button"
+        )[0];
+        userEvent.click(actionMenuButton as HTMLElement);
+      };
+      it.each([
+        ["Print result", "Close"],
+        ["Text result", "Cancel"],
+        ["Email result", "Cancel"],
+        ["Correct result", "No, go back"],
+      ])("should set focus on %p", async (menuButtonText, closeButtonText) => {
+        await clickActionMenu();
+        userEvent.click(screen.getByText(menuButtonText));
+        await screen.findAllByText(closeButtonText);
+        userEvent.click(screen.getAllByText(closeButtonText)[0]);
+        await waitFor(() =>
+          expect(screen.getByText(menuButtonText)).toHaveFocus()
+        );
+      });
+      it("should set focus on the view details button", async () => {
+        await clickActionMenu();
+        userEvent.click(screen.getByText("View details"));
+        await screen.findByAltText("Close");
+        userEvent.click(screen.getByAltText("Close"));
+        await waitFor(() =>
+          expect(screen.getByText("View details")).toHaveFocus()
+        );
+      });
     });
   });
 
-  it("doesn't display anything if no facility is selected", async () => {
+  it("should hide facility filter if user can see only 1 facility", async () => {
+    const localStore = mockStore({
+      organization: {
+        name: "Organization Name",
+      },
+      user: {
+        firstName: "Kim",
+        lastName: "Mendoza",
+      },
+      facilities: [{ id: "1", name: "Facility 1" }],
+      facility: { id: "1", name: "Facility 1" },
+    });
+
+    const localMock = mocks.slice(0, 2).concat([
+      {
+        request: {
+          query: GetAllFacilitiesDocument,
+          variables: {
+            showArchived: false,
+          },
+        },
+        result: {
+          data: {
+            facilities: facilities.slice(0, 1),
+          },
+        },
+      },
+    ]);
+
     render(
-      <MemoryRouter>
-        <Provider store={store}>
-          <MockedProvider mocks={mocks}>
+      <WithRouter>
+        <Provider store={localStore}>
+          <MockedProvider mocks={localMock}>
             <TestResultsList />
           </MockedProvider>
         </Provider>
-      </MemoryRouter>
+      </WithRouter>
     );
-    expect(
-      await screen.findByText("No facility selected", { exact: false })
-    ).toBeInTheDocument();
+
+    expect(screen.queryByLabelText("Testing facility")).not.toBeInTheDocument();
   });
 
-  it("should not display Flu result columns if all rows with multiplex results are filtered", async () => {
-    // facility 1 has no multiplex results
-    expect(await screen.findByText("Gerard, Sam G")).toBeInTheDocument();
-    expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
-  });
-
-  it("should show multiplex results", async () => {
-    expect(
-      await screen.findByRole("option", { name: "Facility 1" })
-    ).toBeInTheDocument();
-    userEvent.selectOptions(screen.getByLabelText("Testing facility"), ["3"]);
-    expect((await screen.findAllByText("Flu A"))[0]).toBeInTheDocument();
-  });
-
-  describe("return focus after modal close", () => {
-    const clickActionMenu = async () => {
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
-      const actionMenuButton = document.querySelectorAll(".rc-menu-button")[0];
-      userEvent.click(actionMenuButton as HTMLElement);
-    };
-    it.each([
-      ["Print result", "Close"],
-      ["Text result", "Cancel"],
-      ["Email result", "Cancel"],
-      ["Correct result", "No, go back"],
-    ])("should set focus on %p", async (menuButtonText, closeButtonText) => {
-      // source of the React key prop warning
-      await clickActionMenu();
-      userEvent.click(screen.getByText(menuButtonText));
-      await screen.findAllByText(closeButtonText);
-      userEvent.click(screen.getAllByText(closeButtonText)[0]);
-      await waitFor(() =>
-        expect(screen.getByText(menuButtonText)).toHaveFocus()
-      );
-    });
-    it("should set focus on the view details button", async () => {
-      await clickActionMenu();
-      userEvent.click(screen.getByText("View details"));
-      await screen.findByAltText("Close");
-      userEvent.click(screen.getByAltText("Close"));
-      await waitFor(() =>
-        expect(screen.getByText("View details")).toHaveFocus()
-      );
-    });
-  });
-});
-
-it("should hide facility filter if user can see only 1 facility", async () => {
-  const localStore = mockStore({
-    organization: {
-      name: "Organization Name",
-    },
-    user: {
-      firstName: "Kim",
-      lastName: "Mendoza",
-    },
-    facilities: [{ id: "1", name: "Facility 1" }],
-    facility: { id: "1", name: "Facility 1" },
-  });
-
-  const localMock = mocks.slice(0, 2).concat([
-    {
-      request: {
-        query: GetAllFacilitiesDocument,
-        variables: {
-          showArchived: false,
-        },
+  it("should hide all facility option if user is not an admin", async () => {
+    const localStore = mockStore({
+      organization: {
+        name: "Organization Name",
       },
-      result: {
-        data: {
-          facilities: facilities.slice(0, 1),
-        },
+      user: {
+        firstName: "Kim",
+        lastName: "Mendoza",
       },
-    },
-  ]);
+      facilities: [{ id: "1", name: "Facility 1" }],
+      facility: { id: "1", name: "Facility 1" },
+    });
 
-  render(
-    <WithRouter>
-      <Provider store={localStore}>
-        <MockedProvider mocks={localMock}>
-          <TestResultsList />
-        </MockedProvider>
-      </Provider>
-    </WithRouter>
-  );
-
-  expect(screen.queryByLabelText("Testing facility")).not.toBeInTheDocument();
-});
-
-it("should hide all facility option if user is not an admin", async () => {
-  const localStore = mockStore({
-    organization: {
-      name: "Organization Name",
-    },
-    user: {
-      firstName: "Kim",
-      lastName: "Mendoza",
-    },
-    facilities: [{ id: "1", name: "Facility 1" }],
-    facility: { id: "1", name: "Facility 1" },
-  });
-
-  render(
-    <WithRouter>
-      <Provider store={localStore}>
-        <MockedProvider mocks={mocks}>
-          <TestResultsList />
-        </MockedProvider>
-      </Provider>
-    </WithRouter>
-  );
-
-  expect(await screen.findByLabelText("Testing facility")).toBeInTheDocument();
-  expect(
-    await screen.findByRole("option", { name: "Facility 1" })
-  ).toBeInTheDocument();
-  expect(
-    screen.queryByRole("option", { name: "All facilities" })
-  ).not.toBeInTheDocument();
-});
-
-describe("clear filter button", () => {
-  const elementToTest = (filterParams: FilterParams) => (
-    <WithRouter>
-      <Provider store={store}>
-        <MockedProvider mocks={mocks}>
-          <DetachedTestResultsList
-            data={testResults.data as GetFacilityResultsMultiplexWithCountQuery}
-            pageNumber={1}
-            entriesPerPage={20}
-            totalEntries={testResults.data.testResultsPage.totalElements}
-            filterParams={filterParams}
-            setFilterParams={() => () => {}}
-            clearFilterParams={() => {}}
-            activeFacilityId={"1"}
-            loading={false}
-            maxDate="2022-09-26"
-          />
-        </MockedProvider>
-      </Provider>
-    </WithRouter>
-  );
-  it("should be disabled when no filters are applied", () => {
-    render(elementToTest({}));
-    expect(screen.getByText("Clear filters")).toBeDisabled();
-  });
-  it("should be disabled when testing only filter applied is facility is active facility", () => {
-    render(elementToTest({ filterFacilityId: "1" }));
-    expect(screen.getByText("Clear filters")).toBeDisabled();
-  });
-  it("should be enabled filters are applied", () => {
-    render(elementToTest({ result: "Positive" }));
-    expect(screen.getByText("Clear filters")).toBeEnabled();
-  });
-});
-
-describe("end date error", () => {
-  beforeEach(() => {
     render(
       <WithRouter>
-        <Provider store={store}>
+        <Provider store={localStore}>
           <MockedProvider mocks={mocks}>
             <TestResultsList />
           </MockedProvider>
         </Provider>
       </WithRouter>
     );
-  });
-  const setDateRange = async (
-    startDate = "2021-03-17",
-    endDate = "2021-03-18"
-  ) => {
-    userEvent.type(await screen.findByText("Date range (start)"), startDate);
-    await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-    userEvent.type(await screen.findByText("Date range (end)"), endDate);
-    new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
-  };
-  it("should display error if end date is before the start date", async () => {
-    await setDateRange("2021-03-18", "2021-03-17");
+
     expect(
-      screen.getByText("End date cannot be before start date", {
-        exact: false,
-      })
+      await screen.findByLabelText("Testing facility")
     ).toBeInTheDocument();
-  });
-  it("should display clear error message when clear filters button is pressed", async () => {
-    await setDateRange("2021-03-18", "2021-03-17");
     expect(
-      screen.getByText("End date cannot be before start date", {
-        exact: false,
-      })
+      await screen.findByRole("option", { name: "Facility 1" })
     ).toBeInTheDocument();
-    userEvent.click(screen.getByText("Clear filters"));
     expect(
-      screen.queryByText("End date cannot be before start date", {
-        exact: false,
-      })
+      screen.queryByRole("option", { name: "All facilities" })
     ).not.toBeInTheDocument();
   });
-});
 
-describe("clear filter button", () => {
-  const elementToTest = (filterParams: FilterParams) => (
-    <WithRouter>
-      <Provider store={store}>
-        <MockedProvider mocks={mocks}>
-          <DetachedTestResultsList
-            data={testResults.data as GetFacilityResultsMultiplexWithCountQuery}
-            pageNumber={1}
-            entriesPerPage={20}
-            totalEntries={testResults.data.testResultsPage.totalElements}
-            filterParams={filterParams}
-            setFilterParams={() => () => {}}
-            clearFilterParams={() => {}}
-            activeFacilityId={"1"}
-            loading={false}
-            maxDate="2022-09-26"
-          />
-        </MockedProvider>
-      </Provider>
-    </WithRouter>
-  );
-  it("should be disabled when no filters are applied", () => {
-    render(elementToTest({}));
-    expect(screen.getByText("Clear filters")).toBeDisabled();
+  describe("end date error", () => {
+    beforeEach(() => {
+      render(
+        <WithRouter>
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <TestResultsList />
+            </MockedProvider>
+          </Provider>
+        </WithRouter>
+      );
+    });
+    const setDateRange = async (
+      startDate = "2021-03-17",
+      endDate = "2021-03-18"
+    ) => {
+      userEvent.type(await screen.findByText("Date range (start)"), startDate);
+      await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+      userEvent.type(await screen.findByText("Date range (end)"), endDate);
+      new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
+    };
+    it("should display error if end date is before the start date", async () => {
+      await setDateRange("2021-03-18", "2021-03-17");
+      expect(
+        screen.getByText("End date cannot be before start date", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+    });
+    it("should display clear error message when clear filters button is pressed", async () => {
+      await setDateRange("2021-03-18", "2021-03-17");
+      expect(
+        screen.getByText("End date cannot be before start date", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      userEvent.click(screen.getByText("Clear filters"));
+      expect(
+        screen.queryByText("End date cannot be before start date", {
+          exact: false,
+        })
+      ).not.toBeInTheDocument();
+    });
   });
-  it("should be disabled when testing only filter applied is facility is active facility", () => {
-    render(elementToTest({ filterFacilityId: "1" }));
-    expect(screen.getByText("Clear filters")).toBeDisabled();
-  });
-  it("should be enabled filters are applied", () => {
-    render(elementToTest({ result: "Positive" }));
-    expect(screen.getByText("Clear filters")).toBeEnabled();
+
+  describe("clear filter button", () => {
+    const elementToTest = (filterParams: FilterParams) => (
+      <WithRouter>
+        <Provider store={store}>
+          <MockedProvider mocks={mocks}>
+            <DetachedTestResultsList
+              data={
+                testResults.data as GetFacilityResultsMultiplexWithCountQuery
+              }
+              pageNumber={1}
+              entriesPerPage={20}
+              totalEntries={testResults.data.testResultsPage.totalElements}
+              filterParams={filterParams}
+              setFilterParams={() => () => {}}
+              clearFilterParams={() => {}}
+              activeFacilityId={"1"}
+              loading={false}
+              maxDate="2022-09-26"
+            />
+          </MockedProvider>
+        </Provider>
+      </WithRouter>
+    );
+    it("should be disabled when no filters are applied", () => {
+      render(elementToTest({}));
+      expect(screen.getByText("Clear filters")).toBeDisabled();
+    });
+    it("should be disabled when testing only filter applied is facility is active facility", () => {
+      render(elementToTest({ filterFacilityId: "1" }));
+      expect(screen.getByText("Clear filters")).toBeDisabled();
+    });
+    it("should be enabled filters are applied", () => {
+      render(elementToTest({ result: "Positive" }));
+      expect(screen.getByText("Clear filters")).toBeEnabled();
+    });
   });
 });

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -563,6 +563,7 @@ describe("TestResultsList", () => {
     });
 
     it("closes the download test results modal after downloading", async () => {
+      // source of "navigation not implemented" error
       expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
       expect(
         screen.getByText("Test Results", { exact: false })
@@ -669,6 +670,7 @@ describe("TestResultsList", () => {
     });
 
     describe("return focus after modal close", () => {
+      // source of the React key prop warning
       const clickActionMenu = async () => {
         expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
         const actionMenuButton = document.querySelectorAll(
@@ -794,6 +796,7 @@ describe("TestResultsList", () => {
       startDate = "2021-03-17",
       endDate = "2021-03-18"
     ) => {
+      // source of the last two "wrapped in act" warnings
       userEvent.type(await screen.findByText("Date range (start)"), startDate);
       await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_TIME));
       userEvent.type(await screen.findByText("Date range (end)"), endDate);

--- a/frontend/src/app/testResults/mocks/queries.mock.tsx
+++ b/frontend/src/app/testResults/mocks/queries.mock.tsx
@@ -47,6 +47,21 @@ export const mocks = [
   },
   {
     request: {
+      query: GetFacilityResultsForCsvWithCountDocument,
+      variables: {
+        facilityId: "1",
+        pageNumber: 0,
+        pageSize: 3,
+      },
+    },
+    result: {
+      data: {
+        testResultsPage: testResultsForCsv,
+      },
+    },
+  },
+  {
+    request: {
       query: testResultDetailsQuery,
       variables: {
         id: testResults.content[0].internalId,
@@ -83,26 +98,7 @@ export const mocks = [
       },
     },
   },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexWithCountDocument,
-      variables: {
-        facilityId: "1",
-        pageNumber: 0,
-        pageSize: 20,
-        patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
-        startDate: "2021-03-18T00:00:00.000Z",
-        endDate: "2021-03-19T23:59:59.999Z",
-        role: "STAFF",
-        result: "NEGATIVE",
-      },
-    },
-    result: {
-      data: {
-        testResultsPage: testResultsByStartDateAndEndDate,
-      },
-    },
-  },
+
   {
     request: {
       query: GetFacilityResultsMultiplexWithCountDocument,
@@ -132,21 +128,6 @@ export const mocks = [
     result: {
       data: {
         testResultsPage: testResultsByResultValue,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsForCsvWithCountDocument,
-      variables: {
-        facilityId: "1",
-        pageNumber: 0,
-        pageSize: 3,
-      },
-    },
-    result: {
-      data: {
-        testResultsPage: testResultsForCsv,
       },
     },
   },
@@ -187,22 +168,6 @@ export const mocks = [
       query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
-        startDate: "2021-03-17T00:00:00.000Z",
-        pageNumber: 0,
-        pageSize: 20,
-      },
-    },
-    result: {
-      data: {
-        testResultsPage: testResultsByStartDate,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexWithCountDocument,
-      variables: {
-        facilityId: "1",
         startDate: "2021-03-18T00:00:00.000Z",
         endDate: "2021-03-18T23:59:59.999Z",
         pageNumber: 0,
@@ -215,6 +180,7 @@ export const mocks = [
       },
     },
   },
+
   {
     request: {
       query: GetFacilityResultsMultiplexWithCountDocument,
@@ -317,7 +283,26 @@ export const mocks = [
       },
     },
   },
-
+  {
+    request: {
+      query: GetFacilityResultsMultiplexWithCountDocument,
+      variables: {
+        facilityId: "1",
+        pageNumber: 0,
+        pageSize: 20,
+        patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
+        startDate: "2021-03-18T00:00:00.000Z",
+        endDate: "2021-03-19T23:59:59.999Z",
+        role: "STAFF",
+        result: "NEGATIVE",
+      },
+    },
+    result: {
+      data: {
+        testResultsPage: testResultsByStartDateAndEndDate,
+      },
+    },
+  },
   {
     request: {
       query: GetTestResultForPrintDocument,

--- a/frontend/src/app/testResults/mocks/queries.mock.tsx
+++ b/frontend/src/app/testResults/mocks/queries.mock.tsx
@@ -1,13 +1,12 @@
 import {
   GetAllFacilitiesDocument,
-  GetFacilityResultsForCsvDocument,
-  GetFacilityResultsMultiplexDocument,
-  GetResultsCountByFacilityDocument,
+  GetFacilityResultsMultiplexWithCountDocument,
   GetTestResultDetailsDocument,
   GetTestResultForCorrectionDocument,
   GetTestResultForPrintDocument,
   GetTestResultForResendingEmailsDocument,
   GetTestResultForTextDocument,
+  GetFacilityResultsForCsvWithCountDocument,
 } from "../../../generated/graphql";
 import { testResultDetailsQuery } from "../TestResultDetailsModal";
 import { QUERY_PATIENT } from "../../testQueue/addToQueue/AddToQueueSearch";
@@ -33,20 +32,7 @@ import resultForCorrection from "./resultForCorrection";
 export const mocks = [
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResults.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -55,22 +41,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsForCsvDocument,
-      variables: {
-        facilityId: "1",
-        pageNumber: 0,
-        pageSize: 3,
-      },
-    },
-    result: {
-      data: {
-        testResults: testResultsForCsv,
+        testResultsPage: testResults,
       },
     },
   },
@@ -78,7 +49,7 @@ export const mocks = [
     request: {
       query: testResultDetailsQuery,
       variables: {
-        id: testResults[0].internalId,
+        id: testResults.content[0].internalId,
       },
     },
     result: {
@@ -114,21 +85,27 @@ export const mocks = [
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
+        pageNumber: 0,
+        pageSize: 20,
         patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
+        startDate: "2021-03-18T00:00:00.000Z",
+        endDate: "2021-03-19T23:59:59.999Z",
+        role: "STAFF",
+        result: "NEGATIVE",
       },
     },
     result: {
       data: {
-        testResultsCount: testResultsByPatient.length,
+        testResultsPage: testResultsByStartDateAndEndDate,
       },
     },
   },
   {
     request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
@@ -138,27 +115,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByPatient,
+        testResultsPage: testResultsByPatient,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        result: "NEGATIVE",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByResultValue.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         result: "NEGATIVE",
@@ -168,27 +131,28 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByResultValue,
+        testResultsPage: testResultsByResultValue,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
+      query: GetFacilityResultsForCsvWithCountDocument,
       variables: {
         facilityId: "1",
-        role: "RESIDENT",
+        pageNumber: 0,
+        pageSize: 3,
       },
     },
     result: {
       data: {
-        testResultsCount: testResultsByRole.length,
+        testResultsPage: testResultsForCsv,
       },
     },
   },
   {
     request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         role: "RESIDENT",
@@ -198,27 +162,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByRole,
+        testResultsPage: testResultsByRole,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        startDate: "2021-03-18T00:00:00.000Z",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByStartDate.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         startDate: "2021-03-18T00:00:00.000Z",
@@ -228,28 +178,29 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByStartDate,
+        testResultsPage: testResultsByStartDate,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
-        startDate: "2021-03-18T00:00:00.000Z",
-        endDate: "2021-03-18T23:59:59.999Z",
+        startDate: "2021-03-17T00:00:00.000Z",
+        pageNumber: 0,
+        pageSize: 20,
       },
     },
     result: {
       data: {
-        testResultsCount: testResultsByStartDateAndEndDate.length,
+        testResultsPage: testResultsByStartDate,
       },
     },
   },
   {
     request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         startDate: "2021-03-18T00:00:00.000Z",
@@ -260,26 +211,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByStartDateAndEndDate,
+        testResultsPage: testResultsByStartDateAndEndDate,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "2",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByFacility.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "2",
         pageNumber: 0,
@@ -288,26 +226,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByFacility,
+        testResultsPage: testResultsByFacility,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: null,
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByAllFacility.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: null,
         pageNumber: 0,
@@ -316,7 +241,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByAllFacility,
+        testResultsPage: testResultsByAllFacility,
       },
     },
   },
@@ -338,20 +263,7 @@ export const mocks = [
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResults.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -360,20 +272,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "3",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsMultiplex.length,
+        testResultsPage: testResults,
       },
     },
   },
@@ -392,7 +291,7 @@ export const mocks = [
   },
   {
     request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "3",
         pageNumber: 0,
@@ -401,7 +300,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsMultiplex,
+        testResultsPage: testResultsMultiplex,
       },
     },
   },
@@ -418,44 +317,7 @@ export const mocks = [
       },
     },
   },
-  {
-    request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
-        startDate: "2021-03-18T00:00:00.000Z",
-        endDate: "2021-03-19T23:59:59.999Z",
-        role: "STAFF",
-        result: "NEGATIVE",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByStartDateAndEndDate.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
-      variables: {
-        facilityId: "1",
-        pageNumber: 0,
-        pageSize: 20,
-        patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
-        startDate: "2021-03-18T00:00:00.000Z",
-        endDate: "2021-03-19T23:59:59.999Z",
-        role: "STAFF",
-        result: "NEGATIVE",
-      },
-    },
-    result: {
-      data: {
-        testResults: testResultsByStartDateAndEndDate,
-      },
-    },
-  },
+
   {
     request: {
       query: GetTestResultForPrintDocument,
@@ -526,20 +388,7 @@ export const mocks = [
 export const mocksWithMultiplex = [
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: null,
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsMultiplex.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: null,
         pageNumber: 0,
@@ -548,7 +397,7 @@ export const mocksWithMultiplex = [
     },
     result: {
       data: {
-        testResults: testResultsMultiplex,
+        testResultsPage: testResultsMultiplex,
       },
     },
   },
@@ -567,20 +416,7 @@ export const mocksWithMultiplex = [
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsMultiplex.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -589,7 +425,7 @@ export const mocksWithMultiplex = [
     },
     result: {
       data: {
-        testResults: testResultsMultiplex,
+        testResultsPage: testResultsMultiplex,
       },
     },
   },

--- a/frontend/src/app/testResults/mocks/resultsByAllFacilities.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByAllFacilities.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_ALL_FACILITIES = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0123a",
     dateTested: "2021-04-12T12:40:33.381Z",
@@ -72,5 +72,9 @@ const TEST_RESULTS_BY_ALL_FACILITIES = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_ALL_FACILITIES = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_ALL_FACILITIES;

--- a/frontend/src/app/testResults/mocks/resultsByFacility.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByFacility.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_FACILITY = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0123a",
     dateTested: "2021-04-12T12:40:33.381Z",
@@ -36,5 +36,9 @@ const TEST_RESULTS_BY_FACILITY = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_FACILITY = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_FACILITY;

--- a/frontend/src/app/testResults/mocks/resultsByPatient.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByPatient.mock.tsx
@@ -1,4 +1,4 @@
-const RESULTS_BY_PATIENT = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -38,5 +38,10 @@ const RESULTS_BY_PATIENT = [
     __typename: "TestResult",
   },
 ];
+
+const RESULTS_BY_PATIENT = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default RESULTS_BY_PATIENT;

--- a/frontend/src/app/testResults/mocks/resultsByResultValue.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByResultValue.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_RESULT_VALUE = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -76,5 +76,9 @@ const TEST_RESULTS_BY_RESULT_VALUE = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_RESULT_VALUE = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_RESULT_VALUE;

--- a/frontend/src/app/testResults/mocks/resultsByRole.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByRole.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_ROLE = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -77,4 +77,8 @@ const TEST_RESULTS_BY_ROLE = [
   },
 ];
 
+const TEST_RESULTS_BY_ROLE = {
+  content: data,
+  totalElements: data.length,
+};
 export default TEST_RESULTS_BY_ROLE;

--- a/frontend/src/app/testResults/mocks/resultsByStartAndEndDate.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByStartAndEndDate.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_START_END_DATE = [
+const data = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
@@ -38,5 +38,10 @@ const TEST_RESULTS_BY_START_END_DATE = [
     __typename: "TestResult",
   },
 ];
+
+const TEST_RESULTS_BY_START_END_DATE = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_START_END_DATE;

--- a/frontend/src/app/testResults/mocks/resultsByStartDate.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByStartDate.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_START_DATE = [
+const data = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
@@ -76,4 +76,8 @@ const TEST_RESULTS_BY_START_DATE = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_START_DATE = {
+  content: data,
+  totalElements: data.length,
+};
 export default TEST_RESULTS_BY_START_DATE;

--- a/frontend/src/app/testResults/mocks/resultsCSV.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsCSV.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_CSV = [
+const data = [
   {
     facility: { name: "Central Middle School", __typename: "Facility" },
     dateTested: "2022-01-19T16:45:11.446Z",
@@ -160,5 +160,9 @@ const TEST_RESULTS_CSV = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_CSV = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_CSV;

--- a/frontend/src/app/testResults/mocks/resultsCovid.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsCovid.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_COVID = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -96,7 +96,11 @@ const TEST_RESULTS_COVID = [
       lookupId: null,
       email: "sam@gerard.com",
       phoneNumbers: [
-        { type: "MOBILE", number: "(248) 555-1234", __typename: "PhoneNumber" },
+        {
+          type: "MOBILE",
+          number: "(248) 555-1234",
+          __typename: "PhoneNumber",
+        },
       ],
       __typename: "Patient",
     },
@@ -118,5 +122,9 @@ const TEST_RESULTS_COVID = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_COVID = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_COVID;

--- a/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_MULTIPLEX = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -130,5 +130,9 @@ const TEST_RESULTS_MULTIPLEX = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_MULTIPLEX = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_MULTIPLEX;

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
@@ -7,6 +7,7 @@ import TEST_RESULT_COVID from "../mocks/resultsCovid.mock";
 
 import ResultsTable, { generateTableHeaders } from "./ResultsTable";
 
+const TEST_RESULTS_MULTIPLEX_CONTENT = TEST_RESULTS_MULTIPLEX.content;
 describe("Method generateTableHeaders", () => {
   const table = (headers: JSX.Element) => (
     <table>
@@ -99,7 +100,7 @@ describe("Component ResultsTable", () => {
   it("checks table with covid results", () => {
     render(
       <ResultsTable
-        results={[TEST_RESULT_COVID[0]]}
+        results={[TEST_RESULT_COVID.content[0]]}
         setPrintModalId={setPrintModalIdFn}
         setMarkCorrectionId={setMarkCorrectionIdFn}
         setDetailsModalId={setDetailsModalIdFn}
@@ -118,7 +119,7 @@ describe("Component ResultsTable", () => {
   it("checks table with multiplex results", () => {
     render(
       <ResultsTable
-        results={TEST_RESULTS_MULTIPLEX}
+        results={TEST_RESULTS_MULTIPLEX_CONTENT}
         setPrintModalId={setPrintModalIdFn}
         setMarkCorrectionId={setMarkCorrectionIdFn}
         setDetailsModalId={setDetailsModalIdFn}
@@ -129,7 +130,7 @@ describe("Component ResultsTable", () => {
       />
     );
 
-    TEST_RESULTS_MULTIPLEX.forEach((result) => {
+    TEST_RESULTS_MULTIPLEX_CONTENT.forEach((result) => {
       expect(
         screen.getByTestId(`test-result-${result.internalId}`)
       ).toBeInTheDocument();
@@ -142,7 +143,9 @@ describe("Component ResultsTable", () => {
   describe("actions menu", () => {
     describe("text result action", () => {
       it("includes `Text result` if patient has mobile number", () => {
-        const testResultPatientMobileNumber = [TEST_RESULTS_MULTIPLEX[1]];
+        const testResultPatientMobileNumber = [
+          TEST_RESULTS_MULTIPLEX_CONTENT[1],
+        ];
 
         render(
           <ResultsTable
@@ -169,7 +172,9 @@ describe("Component ResultsTable", () => {
       });
 
       it("does not include `Text result` if no patient mobile number", () => {
-        const testResultPatientNoMobileNumber = [TEST_RESULTS_MULTIPLEX[0]];
+        const testResultPatientNoMobileNumber = [
+          TEST_RESULTS_MULTIPLEX_CONTENT[0],
+        ];
 
         render(
           <ResultsTable
@@ -197,7 +202,7 @@ describe("Component ResultsTable", () => {
     });
     describe("email result action", () => {
       it("includes `Email result` if patient email address", () => {
-        const testResultPatientEmail = [TEST_RESULTS_MULTIPLEX[0]];
+        const testResultPatientEmail = [TEST_RESULTS_MULTIPLEX_CONTENT[0]];
 
         render(
           <ResultsTable
@@ -224,7 +229,7 @@ describe("Component ResultsTable", () => {
       });
 
       it("does not include `Email result` if no patient email address", () => {
-        const testResultPatientNoEmail = [TEST_RESULTS_MULTIPLEX[1]];
+        const testResultPatientNoEmail = [TEST_RESULTS_MULTIPLEX_CONTENT[1]];
 
         render(
           <ResultsTable

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -8,7 +8,7 @@ import { getResultByDiseaseName } from "./testResults";
 
 import { displayFullName, facilityDisplayName } from "./index";
 
-export function parseDataForCSV(data: any, multiplexEnabled: boolean) {
+export function parseDataForCSV(data: any[], multiplexEnabled: boolean) {
   return data.sort(byDateTested).map((r: any) => {
     const symptomList = r.symptoms ? symptomsStringToArray(r.symptoms) : [];
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Frontend cleanup sibling to https://github.com/CDCgov/prime-simplereport/pull/4531
- Breakout PR for #4149 that fixes the relevant frontend mocks/ tests to reflect the new GraphQL schema. The overall PR was getting somewhat big, so I broke out feature changes away from testing ones (this PR)

## Changes Proposed

- Reformat mocks to reflect the new GraphQL schema shape
- Update test files as necessary to use the schema shape 

## Additional Information
- Will probably go back and have a frontend cleanup PR  to rename / delete `testResultsPage` to just use `testResults` once the [cleanup backend PR is up](https://github.com/CDCgov/prime-simplereport/pull/4531#issuecomment-1285854714)
- Will open up a PR on the base branch against main once this one gets merged in
