### PR TITLE
Add axe testing for cypress

### DIFF
--- a/cypress/integration/01-organization_sign_up_spec.js
+++ b/cypress/integration/01-organization_sign_up_spec.js
@@ -110,7 +110,7 @@ describe("Organization sign up", () => {
     ).click();
 
     // failing a11y test
-    // Also found in 02-add_patient_spec.js
+    // Also found in specs 02 and 05
     // Test a11y on the confirm address modal
     // cy.checkA11y();
 

--- a/cypress/integration/01-organization_sign_up_spec.js
+++ b/cypress/integration/01-organization_sign_up_spec.js
@@ -23,7 +23,7 @@ describe("Organization sign up", () => {
   it("navigates to the sign up form", () => {
     cy.visit("/sign-up");
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // Sign up page
 
     cy.contains("Sign up for SimpleReport");
     cy.contains("My organization is new to SimpleReport").click();
@@ -31,7 +31,7 @@ describe("Organization sign up", () => {
   });
   it("fills out the org info form", () => {
     cy.contains("Sign up for SimpleReport in three steps");
-    cy.checkA11y();
+    cy.checkA11y(); // Sign up form
 
     cy.get('input[name="name"]').type(organization.name);
     cy.get('select[name="state"]').select("CA");
@@ -44,14 +44,44 @@ describe("Organization sign up", () => {
   it("submits successfully", () => {
     cy.get("button.submit-button").click();
     cy.contains("Identity verification consent");
-    cy.checkA11y();
+    cy.checkA11y(); // Identity verification page
   });
   it("navigates to the support pending org table and verifies the org", () => {
     cy.removeOrganizationAccess();
     cy.visit("/admin");
 
+    cy.contains("Support admin");
+
+    cy.injectAxe();
+    // failing a11y test - admin
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
+
     cy.contains("Organizations pending identify verification").click();
     cy.get("[data-cy=pending-orgs-title]").should("be.visible");
+
+    cy.contains("td", `${organization.name}`);
+    // failing a11y test - admin
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'button-name': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
+
     cy.contains("td", `${organization.name}`)
       .siblings()
       .contains("Edit/Verify")
@@ -71,6 +101,23 @@ describe("Organization sign up", () => {
       `${organization.name}{enter}`
     );
     cy.get('input[name="justification"]').type("I am a test user").blur();
+
+    cy.injectAxe();
+    // failing a11y test - admin
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'label-title-only': { enabled: false },
+            'label': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+
+          },
+        },
+    );
+
     cy.contains("Access data").click();
     cy.contains("Support admin");
   });

--- a/cypress/integration/01-organization_sign_up_spec.js
+++ b/cypress/integration/01-organization_sign_up_spec.js
@@ -83,15 +83,33 @@ describe("Organization sign up", () => {
 
     // failing a11y test
     // Test a11y on Manage Facilities tab
-    // cy.injectAxe();
-    // cy.checkA11y();
+    cy.injectAxe();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
 
     cy.contains("+ New facility").click();
     cy.contains("Testing facility information");
 
     // failing a11y test
     // Test a11y on New Facility page
-    // cy.checkA11y();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'empty-heading': { enabled: false },
+          },
+        },
+    );
   });
   it("fills out the form for a new facility", () => {
     cy.get('input[name="name"]').type(facility.name);
@@ -110,9 +128,20 @@ describe("Organization sign up", () => {
     ).click();
 
     // failing a11y test
-    // Also found in specs 02 and 05
+    // Also found in specs 01, 02, 05, 08
     // Test a11y on the confirm address modal
-    // cy.checkA11y();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'aria-dialog-name': { enabled: false },
+            'landmark-one-main': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
 
     cy.get(".modal__container #save-confirmed-address").click();
     cy.contains("+ New facility");

--- a/cypress/integration/01-organization_sign_up_spec.js
+++ b/cypress/integration/01-organization_sign_up_spec.js
@@ -22,12 +22,17 @@ describe("Organization sign up", () => {
   });
   it("navigates to the sign up form", () => {
     cy.visit("/sign-up");
+    cy.injectAxe();
+    cy.checkA11y();
+
     cy.contains("Sign up for SimpleReport");
     cy.contains("My organization is new to SimpleReport").click();
     cy.contains("Continue").click();
   });
   it("fills out the org info form", () => {
     cy.contains("Sign up for SimpleReport in three steps");
+    cy.checkA11y();
+
     cy.get('input[name="name"]').type(organization.name);
     cy.get('select[name="state"]').select("CA");
     cy.get('select[name="type"]').select("Camp");
@@ -39,10 +44,12 @@ describe("Organization sign up", () => {
   it("submits successfully", () => {
     cy.get("button.submit-button").click();
     cy.contains("Identity verification consent");
+    cy.checkA11y();
   });
   it("navigates to the support pending org table and verifies the org", () => {
     cy.removeOrganizationAccess();
     cy.visit("/admin");
+
     cy.contains("Organizations pending identify verification").click();
     cy.get("[data-cy=pending-orgs-title]").should("be.visible");
     cy.contains("td", `${organization.name}`)
@@ -57,6 +64,7 @@ describe("Organization sign up", () => {
   });
   it("spoofs into the org", () => {
     cy.visit("/admin");
+
     cy.contains("Organization data").click();
     cy.get("[data-testid='combo-box-input']").clear();
     cy.get("[data-testid='combo-box-input']").type(
@@ -71,8 +79,19 @@ describe("Organization sign up", () => {
     cy.contains("Support admin");
     cy.get("#desktop-settings-button").click();
     cy.contains("Manage facilities").click();
+    cy.contains("CLIA number");
+
+    // failing a11y test
+    // Test a11y on Manage Facilities tab
+    // cy.injectAxe();
+    // cy.checkA11y();
+
     cy.contains("+ New facility").click();
     cy.contains("Testing facility information");
+
+    // failing a11y test
+    // Test a11y on New Facility page
+    // cy.checkA11y();
   });
   it("fills out the form for a new facility", () => {
     cy.get('input[name="name"]').type(facility.name);
@@ -89,6 +108,12 @@ describe("Organization sign up", () => {
     cy.get(
       '.modal__container input[name="addressSelect-facility"][value="userAddress"]+label'
     ).click();
+
+    // failing a11y test
+    // Also found in 02-add_patient_spec.js
+    // Test a11y on the confirm address modal
+    // cy.checkA11y();
+
     cy.get(".modal__container #save-confirmed-address").click();
     cy.contains("+ New facility");
   });
@@ -96,5 +121,9 @@ describe("Organization sign up", () => {
     cy.visit("/");
     cy.get("#desktop-patient-nav-link").click();
     cy.contains("No results");
+
+    // Test a11y on the People page
+    cy.injectAxe();
+    cy.checkA11y();
   });
 });

--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -51,9 +51,20 @@ describe("Adding a patient", () => {
     ).click();
 
     // failing a11y test
-    // Also found in 01-organization_sign_up_spec.js
+    // Also found in specs 01, 02, 05, 08
     // Test a11y on the confirm address modal
-    // cy.checkA11y();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'aria-dialog-name': { enabled: false },
+            'landmark-one-main': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
 
     cy.get(".modal__container #save-confirmed-address").click();
     cy.get(".usa-card__header").contains("People");
@@ -62,9 +73,17 @@ describe("Adding a patient", () => {
     cy.get(".prime-container").contains(patient.fullName);
 
     // failing a11y test
-    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
-    // error applies to the toast, take out the wait
-    cy.wait(5000);
-    cy.checkA11y();
+    // error applies to the toast
+    // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'heading-order': { enabled: false },
+          },
+        },
+    );
   });
 });

--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -17,7 +17,7 @@ describe("Adding a patient", () => {
     cy.get("#add-patient-button").click();
     cy.get(".prime-edit-patient").contains("Add new person");
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // Patient form
   });
   it("fills out some of the form fields", () => {
     cy.get('input[name="firstName"]').type(patient.firstName);
@@ -75,6 +75,7 @@ describe("Adding a patient", () => {
     // failing a11y test
     // error applies to the toast
     // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+    // Test a11y on the People page
     cy.checkA11y(
         {
           exclude: [],

--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -61,8 +61,9 @@ describe("Adding a patient", () => {
     cy.get("#search-field-small").type(patient.lastName);
     cy.get(".prime-container").contains(patient.fullName);
 
+    // failing a11y test
     // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
-    // error applies to the toast
+    // error applies to the toast, take out the wait
     cy.wait(5000);
     cy.checkA11y();
   });

--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -61,7 +61,8 @@ describe("Adding a patient", () => {
     cy.get("#search-field-small").type(patient.lastName);
     cy.get(".prime-container").contains(patient.fullName);
 
-    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive
+    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
+    // error applies to the toast
     cy.wait(5000);
     cy.checkA11y();
   });

--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -16,6 +16,8 @@ describe("Adding a patient", () => {
     cy.get(".prime-container");
     cy.get("#add-patient-button").click();
     cy.get(".prime-edit-patient").contains("Add new person");
+    cy.injectAxe();
+    cy.checkA11y();
   });
   it("fills out some of the form fields", () => {
     cy.get('input[name="firstName"]').type(patient.firstName);
@@ -47,10 +49,20 @@ describe("Adding a patient", () => {
     cy.get(
       '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
     ).click();
+
+    // failing a11y test
+    // Also found in 01-organization_sign_up_spec.js
+    // Test a11y on the confirm address modal
+    // cy.checkA11y();
+
     cy.get(".modal__container #save-confirmed-address").click();
     cy.get(".usa-card__header").contains("People");
     cy.get(".usa-card__header").contains("Showing");
     cy.get("#search-field-small").type(patient.lastName);
     cy.get(".prime-container").contains(patient.fullName);
+
+    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive
+    cy.wait(5000);
+    cy.checkA11y();
   });
 });

--- a/cypress/integration/03-conduct_test_spec.js
+++ b/cypress/integration/03-conduct_test_spec.js
@@ -17,7 +17,7 @@ describe("Conducting a test", () => {
     cy.get(".results-dropdown").contains(lastName)
 
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // Conduct Tests page
   });
   it("begins a test", () => {
     cy.get(".results-dropdown").within(() => {
@@ -30,6 +30,7 @@ describe("Conducting a test", () => {
     );
 
     // failing a11y test
+    // Test a11y on the AoE modal
     cy.checkA11y(
         {
           exclude: [],
@@ -52,7 +53,7 @@ describe("Conducting a test", () => {
     queueCard = "div.prime-queue-item:last-of-type";
     cy.get(queueCard).contains("COVID-19 results");
 
-    cy.checkA11y();
+    cy.checkA11y(); // Test Card page
   });
   it("completes the test", () => {
     cy.get(queueCard).within(() => {
@@ -69,6 +70,7 @@ describe("Conducting a test", () => {
     // failing a11y test
     // error applies to the toast
     // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+    // Test a11y on the Results page
     cy.checkA11y(
         {
           exclude: [],

--- a/cypress/integration/03-conduct_test_spec.js
+++ b/cypress/integration/03-conduct_test_spec.js
@@ -30,7 +30,17 @@ describe("Conducting a test", () => {
     );
 
     // failing a11y test
-    // cy.checkA11y();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'label': { enabled: false },
+            'landmark-one-main': { enabled: false },
+          },
+        },
+    );
   });
   it("fills out the pretest questions and submits", () => {
     cy.get(".ReactModal__Content").within(() => {
@@ -57,10 +67,20 @@ describe("Conducting a test", () => {
     cy.get(".usa-table").contains(patientName);
 
     // failing a11y test
-    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
-    // error applies to the toast, take out the wait
-    cy.wait(5000);
-    cy.checkA11y();
+    // error applies to the toast
+    // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            // error applies to the toast
+            'heading-order': { enabled: false },
+            'landmark-unique': { enabled: false },
+          },
+        },
+    );
   });
   it("stores the patient link", () => {
     cy.get(".sr-test-result-row").then(($row) => {

--- a/cypress/integration/03-conduct_test_spec.js
+++ b/cypress/integration/03-conduct_test_spec.js
@@ -56,8 +56,9 @@ describe("Conducting a test", () => {
     cy.get("#desktop-results-nav-link").click();
     cy.get(".usa-table").contains(patientName);
 
+    // failing a11y test
     // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
-    // error applies to the toast
+    // error applies to the toast, take out the wait
     cy.wait(5000);
     cy.checkA11y();
   });

--- a/cypress/integration/03-conduct_test_spec.js
+++ b/cypress/integration/03-conduct_test_spec.js
@@ -14,7 +14,10 @@ describe("Conducting a test", () => {
     cy.get(".usa-nav-container");
     cy.get("#desktop-conduct-test-nav-link").click();
     cy.get("#search-field-small").type(lastName);
-    cy.get(".results-dropdown").contains(lastName);
+    cy.get(".results-dropdown").contains(lastName)
+
+    cy.injectAxe();
+    cy.checkA11y();
   });
   it("begins a test", () => {
     cy.get(".results-dropdown").within(() => {
@@ -25,6 +28,9 @@ describe("Conducting a test", () => {
     cy.get(".ReactModal__Content").contains(
       "Are you experiencing any of the following symptoms?"
     );
+
+    // failing a11y test
+    // cy.checkA11y();
   });
   it("fills out the pretest questions and submits", () => {
     cy.get(".ReactModal__Content").within(() => {
@@ -35,6 +41,8 @@ describe("Conducting a test", () => {
     cy.get(".prime-home").contains(patientName);
     queueCard = "div.prime-queue-item:last-of-type";
     cy.get(queueCard).contains("COVID-19 results");
+
+    cy.checkA11y();
   });
   it("completes the test", () => {
     cy.get(queueCard).within(() => {
@@ -47,6 +55,11 @@ describe("Conducting a test", () => {
   it("shows the result on the results table", () => {
     cy.get("#desktop-results-nav-link").click();
     cy.get(".usa-table").contains(patientName);
+
+    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
+    // error applies to the toast
+    cy.wait(5000);
+    cy.checkA11y();
   });
   it("stores the patient link", () => {
     cy.get(".sr-test-result-row").then(($row) => {

--- a/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -16,6 +16,8 @@ describe("Getting a test result from a patient link", () => {
   });
   it("successfully navigates to the patient link", () => {
     cy.visit(patientLink);
+    cy.injectAxe();
+    cy.checkA11y();
   });
   it("accepts the terms of service", () => {
     cy.contains("Terms of service");

--- a/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -16,6 +16,8 @@ describe("Getting a test result from a patient link", () => {
   });
   it("successfully navigates to the patient link", () => {
     cy.visit(patientLink);
+  });
+  it("contains no accessibility issues", () => {
     cy.injectAxe();
     cy.checkA11y();
   });

--- a/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -38,6 +38,9 @@ describe("Getting a test result from a patient link", () => {
     const birthMonth = dob.month() + 1;
     const birthDay = dob.date();
     const birthYear = dob.year();
+
+    cy.checkA11y();
+
     cy.get('input[name="birthMonth"]').type(birthMonth);
     cy.get('input[name="birthDay"]').type(birthDay);
     cy.get('input[name="birthYear"]').type(birthYear);
@@ -48,5 +51,7 @@ describe("Getting a test result from a patient link", () => {
     cy.contains("Test result");
     cy.contains("Test date");
     cy.contains("Test device");
+
+    cy.checkA11y();
   });
 });

--- a/cypress/integration/04-get_result_from_patient_link_spec.js
+++ b/cypress/integration/04-get_result_from_patient_link_spec.js
@@ -19,7 +19,7 @@ describe("Getting a test result from a patient link", () => {
   });
   it("contains no accessibility issues", () => {
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // PXP page
   });
   it("accepts the terms of service", () => {
     cy.contains("Terms of service");
@@ -39,7 +39,7 @@ describe("Getting a test result from a patient link", () => {
     const birthDay = dob.date();
     const birthYear = dob.year();
 
-    cy.checkA11y();
+    cy.checkA11y(); // DoB entry page
 
     cy.get('input[name="birthMonth"]').type(birthMonth);
     cy.get('input[name="birthDay"]').type(birthDay);
@@ -52,6 +52,6 @@ describe("Getting a test result from a patient link", () => {
     cy.contains("Test date");
     cy.contains("Test device");
 
-    cy.checkA11y();
+    cy.checkA11y(); // Result page
   });
 });

--- a/cypress/integration/05-self_registration_spec.js
+++ b/cypress/integration/05-self_registration_spec.js
@@ -10,6 +10,7 @@ describe("Patient self registration", () => {
     cy.contains("Patients can now register themselves online");
 
     // failing a11y test
+    // Test a11y on the Patient self registration page
     cy.injectAxe();
     cy.checkA11y(
         {
@@ -29,13 +30,13 @@ describe("Patient self registration", () => {
     cy.contains("Terms of service");
 
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // Terms of Service
   });
   it("accepts the terms of service", () => {
     cy.contains("I agree").click();
     cy.get("#registration-container").contains("General information");
 
-    cy.checkA11y();
+    cy.checkA11y(); // Info form
   });
   it("fills out some of the form fields", () => {
     cy.get('input[name="firstName"]').type(patient.firstName);
@@ -86,6 +87,6 @@ describe("Patient self registration", () => {
       "thanks for completing your patient profile"
     );
 
-    cy.checkA11y();
+    cy.checkA11y(); // Confirmation page
   });
 });

--- a/cypress/integration/05-self_registration_spec.js
+++ b/cypress/integration/05-self_registration_spec.js
@@ -10,15 +10,25 @@ describe("Patient self registration", () => {
     cy.contains("Patients can now register themselves online");
 
     // failing a11y test
-    // cy.injectAxe();
-    // cy.checkA11y();
+    cy.injectAxe();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'button-name': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
 
     cy.get("#org-link").then(($link) => cy.visit($link.val()));
   });
   it("loads terms of service", () => {
     cy.contains("Terms of service");
 
-    cy.injectAxe(); // this can be removed when the preceding test is fixed
+    cy.injectAxe();
     cy.checkA11y();
   });
   it("accepts the terms of service", () => {
@@ -56,9 +66,20 @@ describe("Patient self registration", () => {
     ).click();
 
     // failing a11y test
-    // Also found in 01-organization_sign_up_spec.js
+    // Also found in specs 01, 02, 05, 08
     // Test a11y on the confirm address modal
-    // cy.checkA11y();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'aria-dialog-name': { enabled: false },
+            'landmark-one-main': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
 
     cy.get(".modal__container #save-confirmed-address").click();
     cy.get("#self-reg-confirmation").contains(

--- a/cypress/integration/05-self_registration_spec.js
+++ b/cypress/integration/05-self_registration_spec.js
@@ -8,14 +8,24 @@ describe("Patient self registration", () => {
     cy.visit("/settings");
     cy.contains("Patient self-registration").click();
     cy.contains("Patients can now register themselves online");
+
+    // failing a11y test
+    // cy.injectAxe();
+    // cy.checkA11y();
+
     cy.get("#org-link").then(($link) => cy.visit($link.val()));
   });
   it("loads terms of service", () => {
     cy.contains("Terms of service");
+
+    cy.injectAxe(); // this can be removed when the preceding test is fixed
+    cy.checkA11y();
   });
   it("accepts the terms of service", () => {
     cy.contains("I agree").click();
     cy.get("#registration-container").contains("General information");
+
+    cy.checkA11y();
   });
   it("fills out some of the form fields", () => {
     cy.get('input[name="firstName"]').type(patient.firstName);
@@ -44,9 +54,17 @@ describe("Patient self registration", () => {
     cy.get(
       '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
     ).click();
+
+    // failing a11y test
+    // Also found in 01-organization_sign_up_spec.js
+    // Test a11y on the confirm address modal
+    // cy.checkA11y();
+
     cy.get(".modal__container #save-confirmed-address").click();
     cy.get("#self-reg-confirmation").contains(
       "thanks for completing your patient profile"
     );
+
+    cy.checkA11y();
   });
 });

--- a/cypress/integration/06-organization_settings.js
+++ b/cypress/integration/06-organization_settings.js
@@ -7,8 +7,17 @@ describe("Updating organization settings", () => {
     cy.get(".prime-container").contains("Manage organization");
 
     // failing a11y test
-    // cy.injectAxe();
-    // cy.checkA11y();
+    cy.injectAxe();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
   });
   it("attempts an empty selection for organization type", () => {
     cy.get('select[name="type"]').select("- Select -");

--- a/cypress/integration/06-organization_settings.js
+++ b/cypress/integration/06-organization_settings.js
@@ -7,6 +7,7 @@ describe("Updating organization settings", () => {
     cy.get(".prime-container").contains("Manage organization");
 
     // failing a11y test
+    // Test a11y on the Manage organization page
     cy.injectAxe();
     cy.checkA11y(
         {

--- a/cypress/integration/06-organization_settings.js
+++ b/cypress/integration/06-organization_settings.js
@@ -5,6 +5,10 @@ describe("Updating organization settings", () => {
   it("navigates to the org settings page", () => {
     cy.visit("/settings/organization");
     cy.get(".prime-container").contains("Manage organization");
+
+    // failing a11y test
+    // cy.injectAxe();
+    // cy.checkA11y();
   });
   it("attempts an empty selection for organization type", () => {
     cy.get('select[name="type"]').select("- Select -");

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -102,8 +102,6 @@ describe("Okta account creation", () => {
     });
     it("enters a verification code", () => {
       cy.verifySecurityCode("033457");
-      cy.injectAxe();
-      cy.checkA11y();
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -79,6 +79,7 @@ describe("Okta account creation", () => {
       cy.contains("Create your password");
     });
     it("contains no accessibility violations", () => {
+      // We only need to check a11y once for this page workflow
       cy.injectAxe();
       cy.checkA11y();
     });

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -77,30 +77,38 @@ describe("Okta account creation", () => {
     it("navigates to the activation link", () => {
       cy.visit("/uac/?activationToken=h971awbXda7y7jGaxN8f");
       cy.contains("Create your password");
-    });
-    it("contains no accessibility violations", () => {
-      // Test a11y on the Account Creation page
-      // We only need to check a11y once for this page workflow
       cy.injectAxe();
       cy.checkA11y();
     });
     it("sets a password", () => {
       cy.setPassword();
+      cy.injectAxe();
+      cy.checkA11y();
     });
     it("sets a security question", () => {
       cy.setSecurityQuestion();
+      cy.injectAxe();
+      cy.checkA11y();
     });
     it("selects SMS MFA", () => {
       cy.mfaSelect("sms");
+      cy.injectAxe();
+      cy.checkA11y();
     });
     it("enters a phone number", () => {
       cy.enterPhoneNumber();
+      cy.injectAxe();
+      cy.checkA11y();
     });
     it("enters a verification code", () => {
       cy.verifySecurityCode("033457");
+      cy.injectAxe();
+      cy.checkA11y();
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
+      cy.injectAxe();
+      cy.checkA11y();
     });
   });
 

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -78,6 +78,10 @@ describe("Okta account creation", () => {
       cy.visit("/uac/?activationToken=h971awbXda7y7jGaxN8f");
       cy.contains("Create your password");
     });
+    it("contains no accessibility violations", () => {
+      cy.injectAxe();
+      cy.checkA11y();
+    });
     it("sets a password", () => {
       cy.setPassword();
     });

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -79,6 +79,7 @@ describe("Okta account creation", () => {
       cy.contains("Create your password");
     });
     it("contains no accessibility violations", () => {
+      // Test a11y on the Account Creation page
       // We only need to check a11y once for this page workflow
       cy.injectAxe();
       cy.checkA11y();

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -16,6 +16,8 @@ Cypress.Commands.add("setPassword", () => {
   cy.get('input[name="confirm-password"]').type(pass);
   cy.get(submitButton).click();
   cy.contains("Select your security question");
+  cy.injectAxe();
+  cy.checkA11y();
 });
 
 Cypress.Commands.add("setSecurityQuestion", () => {
@@ -25,6 +27,8 @@ Cypress.Commands.add("setSecurityQuestion", () => {
   cy.get('input[name="answer"]').type("Jane Doe");
   cy.get(submitButton).click();
   cy.contains("Set up authentication");
+  cy.injectAxe();
+  cy.checkA11y();
 });
 
 Cypress.Commands.add("mfaSelect", (choice) => {
@@ -37,6 +41,8 @@ Cypress.Commands.add("mfaSelect", (choice) => {
 
 Cypress.Commands.add("enterPhoneNumber", () => {
   cy.contains("Get your security code via");
+  cy.injectAxe();
+  cy.checkA11y();
   cy.get('input[name="phone-number"]').type("530867530");
   cy.contains("Get your security code via").click();
   cy.contains("Enter a valid phone number");
@@ -47,11 +53,15 @@ Cypress.Commands.add("enterPhoneNumber", () => {
 
 Cypress.Commands.add("scanQrCode", () => {
   cy.contains("Get your security code via");
+  cy.injectAxe();
+  cy.checkA11y();
   cy.get(submitButton).click();
 });
 
 Cypress.Commands.add("verifySecurityCode", (code) => {
   cy.contains("Verify your security code.");
+  cy.injectAxe();
+  cy.checkA11y();
   cy.get('input[name="security-code"]').type(code);
   cy.get(submitButton).first().click();
 });
@@ -82,23 +92,23 @@ describe("Okta account creation", () => {
     });
     it("sets a password", () => {
       cy.setPassword();
-      cy.injectAxe();
-      cy.checkA11y();
+      // cy.injectAxe();
+      // cy.checkA11y();
     });
     it("sets a security question", () => {
       cy.setSecurityQuestion();
-      cy.injectAxe();
-      cy.checkA11y();
+      // cy.injectAxe();
+      // cy.checkA11y();
     });
     it("selects SMS MFA", () => {
       cy.mfaSelect("sms");
-      cy.injectAxe();
-      cy.checkA11y();
+      // cy.injectAxe();
+      // cy.checkA11y();
     });
     it("enters a phone number", () => {
       cy.enterPhoneNumber();
-      cy.injectAxe();
-      cy.checkA11y();
+      // cy.injectAxe();
+      // cy.checkA11y();
     });
     it("enters a verification code", () => {
       cy.verifySecurityCode("033457");
@@ -135,6 +145,8 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
+      cy.injectAxe();
+      cy.checkA11y();
     });
   });
 
@@ -163,6 +175,8 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
+      cy.injectAxe();
+      cy.checkA11y();
     });
   });
 
@@ -191,6 +205,8 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
+      cy.injectAxe();
+      cy.checkA11y();
     });
   });
 
@@ -216,6 +232,8 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
+      cy.injectAxe();
+      cy.checkA11y();
     });
   });
 });

--- a/cypress/integration/07-account_creation_spec.js
+++ b/cypress/integration/07-account_creation_spec.js
@@ -92,23 +92,15 @@ describe("Okta account creation", () => {
     });
     it("sets a password", () => {
       cy.setPassword();
-      // cy.injectAxe();
-      // cy.checkA11y();
     });
     it("sets a security question", () => {
       cy.setSecurityQuestion();
-      // cy.injectAxe();
-      // cy.checkA11y();
     });
     it("selects SMS MFA", () => {
       cy.mfaSelect("sms");
-      // cy.injectAxe();
-      // cy.checkA11y();
     });
     it("enters a phone number", () => {
       cy.enterPhoneNumber();
-      // cy.injectAxe();
-      // cy.checkA11y();
     });
     it("enters a verification code", () => {
       cy.verifySecurityCode("033457");

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -22,7 +22,7 @@ describe("edit patient and save and start test", () => {
     cy.contains("General information");
 
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // Edit Patient page
   });
   it("edits the patient and clicks save and start test and verifies AoE form is correctly filled in", () => {
     cy.get('input[value="male"]+label').click();
@@ -47,6 +47,7 @@ describe("edit patient and save and start test", () => {
     // failing a11y test
     // error applies to the toast
     // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+    // Test a11y on the AoE form
     cy.checkA11y(
         {
           exclude: [],
@@ -69,6 +70,7 @@ describe("edit patient and save and start test", () => {
     cy.url().should("include", "queue");
 
     // failing a11y test
+    // Test a11y on the Test Queue page
     cy.checkA11y(
         {
           // failing a11y test
@@ -102,7 +104,7 @@ describe("add patient and save and start test", () => {
     cy.get(".prime-edit-patient").contains("Add new person");
 
     cy.injectAxe();
-    cy.checkA11y();
+    cy.checkA11y(); // New Patient page
   });
   it("fills out form fields and clicks save and start test and verifies AoE form is correctly filled in", () => {
     cy.get('input[name="firstName"]').type(patient.firstName);

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -44,27 +44,47 @@ describe("edit patient and save and start test", () => {
   it("completes AoE form and verifies queue", () => {
     cy.contains("New loss of taste").click();
 
-    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
+    // failing a11y test
     // error applies to the toast
-    // cy.wait(5000);
-    // failing a11y test - additional failures besides the one we need to wait for
-    // cy.checkA11y();
+    // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            // error applies to the toast
+            'heading-order': { enabled: false },
+            'landmark-one-main': { enabled: false },
+            'landmark-unique': { enabled: false },
+            // failing a11y test
+            // the following error is unrelated to the toast
+            'label': { enabled: false },
+          },
+        },
+    );
 
     cy.contains("button", "Continue").click();
     cy.get(".prime-home").contains(patientName);
     cy.url().should("include", "queue");
 
     // failing a11y test
-    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
-    // error applies to the toast, take out the wait
-    cy.wait(10000);
     cy.checkA11y(
         {
           // failing a11y test
-          // this element returns a duplicate-id error, which the SimpleReport team in the past deemed not relevant
-          // If this is deemed to not be a false positive in the future, please remove the exclusion and fix the problem
+          // this element returns a duplicate-id error, each test card needs a unique id
           // It may also be possible to remove the offending duplicate id if it is not used
           exclude: ['.prime-test-name.usa-card__header.grid-row'],
+        },
+        {
+          rules: {
+            // failing a11y test
+            // error applies to the toast
+            // observe this by adding cy.wait(5000); to wait for the toasts to disappear
+            'heading-order': { enabled: false },
+            'landmark-one-main': { enabled: false },
+            'landmark-unique': { enabled: false },
+          },
         },
     );
   });
@@ -104,9 +124,20 @@ describe("add patient and save and start test", () => {
     ).click();
 
     // failing a11y test
-    // Also found in 01-organization_sign_up_spec.js
+    // Also found in specs 01, 02, 05, 08
     // Test a11y on the confirm address modal
-    // cy.checkA11y();
+    cy.checkA11y(
+        {
+          exclude: [],
+        },
+        {
+          rules: {
+            'aria-dialog-name': { enabled: false },
+            'landmark-one-main': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+          },
+        },
+    );
 
     cy.get(".modal__container #save-confirmed-address").click();
     cy.url().should("include", "queue");

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -61,9 +61,9 @@ describe("edit patient and save and start test", () => {
     cy.checkA11y(
         {
           // failing a11y test
-          // this element returns a duplicate-id error, which the SimpleReport team at some point deemed not relevant due to the page structure
+          // this element returns a duplicate-id error, which the SimpleReport team in the past deemed not relevant
           // If this is deemed to not be a false positive in the future, please remove the exclusion and fix the problem
-          // It may also be possible to remove the offending id if it is not used
+          // It may also be possible to remove the offending duplicate id if it is not used
           exclude: ['.prime-test-name.usa-card__header.grid-row'],
         },
     );

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -19,6 +19,10 @@ describe("edit patient and save and start test", () => {
     cy.get("#desktop-patient-nav-link").click();
     cy.get("#search-field-small").type(lastName);
     cy.get(".sr-patient-list").contains(lastName).click();
+    cy.contains("General information");
+
+    cy.injectAxe();
+    cy.checkA11y();
   });
   it("edits the patient and clicks save and start test and verifies AoE form is correctly filled in", () => {
     cy.get('input[value="male"]+label').click();
@@ -39,9 +43,30 @@ describe("edit patient and save and start test", () => {
   });
   it("completes AoE form and verifies queue", () => {
     cy.contains("New loss of taste").click();
+
+    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
+    // error applies to the toast
+    // cy.wait(5000);
+    // failing a11y test - additional failures besides the one we need to wait for
+    // cy.checkA11y();
+
     cy.contains("button", "Continue").click();
     cy.get(".prime-home").contains(patientName);
     cy.url().should("include", "queue");
+
+    // failing a11y test
+    // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
+    // error applies to the toast, take out the wait
+    cy.wait(5000);
+    cy.checkA11y(
+        {
+          // failing a11y test
+          // this element returns a duplicate-id error, which the SimpleReport team at some point deemed not relevant due to the page structure
+          // If this is deemed to not be a false positive in the future, please remove the exclusion and fix the problem
+          // It may also be possible to remove the offending id if it is not used
+          exclude: ['.prime-test-name.usa-card__header.grid-row'],
+        },
+    );
   });
 });
 
@@ -55,6 +80,9 @@ describe("add patient and save and start test", () => {
     cy.get("#desktop-patient-nav-link").click();
     cy.get("#add-patient-button").click();
     cy.get(".prime-edit-patient").contains("Add new person");
+
+    cy.injectAxe();
+    cy.checkA11y();
   });
   it("fills out form fields and clicks save and start test and verifies AoE form is correctly filled in", () => {
     cy.get('input[name="firstName"]').type(patient.firstName);
@@ -74,6 +102,12 @@ describe("add patient and save and start test", () => {
     cy.get(
       '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
     ).click();
+
+    // failing a11y test
+    // Also found in 01-organization_sign_up_spec.js
+    // Test a11y on the confirm address modal
+    // cy.checkA11y();
+
     cy.get(".modal__container #save-confirmed-address").click();
     cy.url().should("include", "queue");
     cy.get('input[name="testResultDeliverySms"][value="SMS"]').should(

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -57,7 +57,7 @@ describe("edit patient and save and start test", () => {
     // failing a11y test
     // if we don't wait 5 seconds for the toasts to disappear, we get a false positive for the page
     // error applies to the toast, take out the wait
-    cy.wait(5000);
+    cy.wait(10000);
     cy.checkA11y(
         {
           // failing a11y test

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -6,14 +6,17 @@
         "@types/faker": "^5.5.9",
         "cypress": "^9.2.1",
         "cypress-localstorage-commands": "^1.6.1",
+        "eslint-plugin-cypress": "^2.12.1",
         "faker": "^5.5.3",
-        "otplib": "^12.0.1",
-        "eslint-plugin-cypress": "^2.12.1"
+        "otplib": "^12.0.1"
     },
     "scripts": {
         "e2e:local": "env $(cat ./../.env | grep -v \"#\" | xargs) CYPRESS_SKIP_OKTA=true CYPRESS_CHECK_COMMIT=$(git rev-parse HEAD) CYPRESS_CHECK_URL=/health/commit cypress open --project ./../ --config-file cypress.json --config baseUrl=http://localhost:3000",
         "e2e:local:okta": "env $(cat ./../.env | grep -v \"#\" | xargs) CYPRESS_CHECK_COMMIT=$(git rev-parse HEAD) CYPRESS_CHECK_URL=/health/commit cypress open --project ./../ --config-file cypress.json --config baseUrl=http://localhost:3000",
         "e2e:nginx": "env $(cat ./../.env | grep -v \"#\" | xargs) CYPRESS_SKIP_OKTA=true CYPRESS_CHECK_COMMIT=$(git rev-parse HEAD) CYPRESS_CHECK_URL=/health/commit cypress open --project ./../ --config-file cypress.json --config baseUrl=https://localhost.simplereport.gov/app",
         "e2e:nginx:okta": "env $(cat ./../.env | grep -v \"#\" | xargs) CYPRESS_CHECK_COMMIT=$(git rev-parse HEAD) CYPRESS_CHECK_URL=/health/commit cypress open --project ./../ --config-file cypress.json --config baseUrl=https://localhost.simplereport.gov/app"
+    },
+    "dependencies": {
+        "cypress-axe": "^1.0.0"
     }
 }

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -17,6 +17,7 @@
         "e2e:nginx:okta": "env $(cat ./../.env | grep -v \"#\" | xargs) CYPRESS_CHECK_COMMIT=$(git rev-parse HEAD) CYPRESS_CHECK_URL=/health/commit cypress open --project ./../ --config-file cypress.json --config baseUrl=https://localhost.simplereport.gov/app"
     },
     "dependencies": {
+        "axe-core": "^4.4.3",
         "cypress-axe": "^1.0.0"
     }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
+import 'cypress-axe';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import "./commands";
 import 'cypress-axe';
+import 'axe-core';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,7 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import "./commands";
 import 'cypress-axe';
-import 'axe-core';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -346,6 +346,11 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cypress-axe@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.0.0.tgz#ab4e9486eaa3bb956a90a1ae40d52df42827b4f0"
+  integrity sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==
+
 cypress-localstorage-commands@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/cypress-localstorage-commands/-/cypress-localstorage-commands-1.7.0.tgz#39840973de0a861d50b82f9fa548331db5973f5f"

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -183,6 +183,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axe-core@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
+  integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"

--- a/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
+++ b/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
@@ -42,34 +42,42 @@ const TermsOfService: React.FunctionComponent<Props> = ({
         className
       )}
     >
-      <form className="grid-container maxw-tablet usa-prose">
-        <h1 className="font-heading-lg margin-top-3">
-          {t("testResult.tos.header")}
-        </h1>
-        <Trans
-          t={t}
-          parent="p"
-          className="margin-top-105"
-          i18nKey="testResult.tos.introText"
-          components={[<a href="https://simplereport.gov/">SimpleReport</a>]}
-        />
-        <div className="tos-content prime-formgroup usa-prose height-card-lg overflow-x-hidden font-body-3xs">
-          <ToS />
-        </div>
-        <p id="tos-consent-message">{t("testResult.tos.consent")}</p>
-        <Button
-          id="tos-consent-button"
-          label={t("testResult.tos.submit")}
-          ariaDescribedBy={"tos-consent-message"}
-          onClick={() => {
-            if (onAgree) {
-              onAgree();
-            } else {
-              setNextPage(true);
-            }
-          }}
-        />
-      </form>
+      <main>
+        <form className="grid-container maxw-tablet usa-prose">
+          <h3 className="font-heading-lg margin-top-3">
+            {t("testResult.tos.header")}
+          </h3>
+          <h2 className="font-heading-lg margin-top-3">
+            {t("testResult.tos.header")}
+          </h2>
+          <h1 className="font-heading-lg margin-top-3">
+            {t("testResult.tos.header")}
+          </h1>
+          <Trans
+            t={t}
+            parent="p"
+            className="margin-top-105"
+            i18nKey="testResult.tos.introText"
+            components={[<a href="https://simplereport.gov/">SimpleReport</a>]}
+          />
+          <div className="tos-content prime-formgroup usa-prose height-card-lg overflow-x-hidden font-body-3xs">
+            <ToS />
+          </div>
+          <p id="tos-consent-message">{t("testResult.tos.consent")}</p>
+          <Button
+            id="tos-consent-button"
+            label={t("testResult.tos.submit")}
+            ariaDescribedBy={"tos-consent-message"}
+            onClick={() => {
+              if (onAgree) {
+                onAgree();
+              } else {
+                setNextPage(true);
+              }
+            }}
+          />
+        </form>
+      </main>
     </div>
   );
 };

--- a/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
+++ b/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
@@ -42,42 +42,34 @@ const TermsOfService: React.FunctionComponent<Props> = ({
         className
       )}
     >
-      <main>
-        <form className="grid-container maxw-tablet usa-prose">
-          <h3 className="font-heading-lg margin-top-3">
-            {t("testResult.tos.header")}
-          </h3>
-          <h2 className="font-heading-lg margin-top-3">
-            {t("testResult.tos.header")}
-          </h2>
-          <h1 className="font-heading-lg margin-top-3">
-            {t("testResult.tos.header")}
-          </h1>
-          <Trans
-            t={t}
-            parent="p"
-            className="margin-top-105"
-            i18nKey="testResult.tos.introText"
-            components={[<a href="https://simplereport.gov/">SimpleReport</a>]}
-          />
-          <div className="tos-content prime-formgroup usa-prose height-card-lg overflow-x-hidden font-body-3xs">
-            <ToS />
-          </div>
-          <p id="tos-consent-message">{t("testResult.tos.consent")}</p>
-          <Button
-            id="tos-consent-button"
-            label={t("testResult.tos.submit")}
-            ariaDescribedBy={"tos-consent-message"}
-            onClick={() => {
-              if (onAgree) {
-                onAgree();
-              } else {
-                setNextPage(true);
-              }
-            }}
-          />
-        </form>
-      </main>
+      <form className="grid-container maxw-tablet usa-prose">
+        <h1 className="font-heading-lg margin-top-3">
+          {t("testResult.tos.header")}
+        </h1>
+        <Trans
+          t={t}
+          parent="p"
+          className="margin-top-105"
+          i18nKey="testResult.tos.introText"
+          components={[<a href="https://simplereport.gov/">SimpleReport</a>]}
+        />
+        <div className="tos-content prime-formgroup usa-prose height-card-lg overflow-x-hidden font-body-3xs">
+          <ToS />
+        </div>
+        <p id="tos-consent-message">{t("testResult.tos.consent")}</p>
+        <Button
+          id="tos-consent-button"
+          label={t("testResult.tos.submit")}
+          ariaDescribedBy={"tos-consent-message"}
+          onClick={() => {
+            if (onAgree) {
+              onAgree();
+            } else {
+              setNextPage(true);
+            }
+          }}
+        />
+      </form>
     </div>
   );
 };


### PR DESCRIPTION
# TESTING/DEVOPS PULL REQUEST

## Related Issue #4530

- Adds axe accessibility testing to existing cypress e2e workflow tests

## Changes Proposed

- Added npm `cypress-axe` and `axe-core` dependencies to dev
- Added `cy.checkA11y()` for each page/screen/modal visited in the e2e flow for each spec
- **Note that no new workflows were added, so if there wasn't an existing e2e test for a page, that page is not getting accessibility tested.** Additional workflow testing with accessibility can be added in the future. This PR is intended to just build on what already exists.
- For existing issues, rather than comment out the `checkA11y()`, I've added an `exclude` and/or `rules` block to the check, which allows the excluded areas to fail.  This way, we can ignore existing problems, but still test the rest of the page to catch regressions. These will need to be taken out once the underlying issues have been resolved.

## Additional Information

For future reference:
- `checkA11y()` can produce strange results if called too early (e.g. the page hasn't loaded).
- a11y tests are most reliable directly after an assertion like `.get` or `.contains` that does not do an action (like a `.click`), just checks that what we expect was loaded - again this avoids strange issues due to a page not loading in time.

Testing for admin pages - these are rife with errors
- I've added tests for these and marked them `// failing a11y test - admin`. Because these are not public facing they are low priority, we won't create a ticket for these at this time 

I've left `// failing a11y test` comments to indicate that a test should be enabled, but will fail without an accessibility fix on the page or component in question. When the following tickets are worked, it should be easy to identify what needs to be fixed by looking for these comments.

Creating tickets for:
 - Toast, which causes errors on multiple pages.
 - Address verification Modal, which appears on multiple pages. Once this is resolved, the exclusions/rules for these tests across specs can be removed
 - Tickets for each other spec that is failing due to other isolated a11y issues - these are isolated to the pages being tested and can be worked independently

## Testing

- Try running the e2es on locally and check out the last run in the pipeline PR check
- Confirm that I've covered pages visited in the e2e workflows - at this time I don't want to add any new workflows, just test what we are currently visiting.


### Documentation
- I'll be adding a wiki page for a11y testing - [New wiki page is here](https://github.com/CDCgov/prime-simplereport/wiki/Accessibility-Auditing)

