### PR TITLE
Consolidate duplicate results queries into one call (frontend)

### DIFF
--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -9,7 +9,10 @@ import { showError } from "../utils/srToast";
 import { useImperativeQuery } from "../utils/hooks";
 import { parseDataForCSV } from "../utils/testResultCSV";
 import Button from "../commonComponents/Button/Button";
-import { GetFacilityResultsForCsvDocument } from "../../generated/graphql";
+import {
+  GetFacilityResultsForCsvWithCountDocument,
+  GetFacilityResultsForCsvWithCountQuery,
+} from "../../generated/graphql";
 
 import { ALL_FACILITIES_ID, ResultsQueryVariables } from "./TestResultsList";
 
@@ -30,7 +33,7 @@ export const DownloadResultsCsvModal = ({
 }: DownloadResultsCsvModalProps) => {
   const rowsMaxLimit = 20000;
   const [loading, setLoading] = useState(false);
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState<any[]>([]);
   const csvLink = useRef<
     CSVLink & HTMLAnchorElement & { link: HTMLAnchorElement }
   >(null);
@@ -57,22 +60,30 @@ export const DownloadResultsCsvModal = ({
     ...filterParams,
   };
 
-  const getResults = useImperativeQuery(GetFacilityResultsForCsvDocument, {
-    fetchPolicy: "no-cache",
-  });
+  const getResults = useImperativeQuery<GetFacilityResultsForCsvWithCountQuery>(
+    GetFacilityResultsForCsvWithCountDocument,
+    {
+      fetchPolicy: "no-cache",
+    }
+  );
 
   const downloadResults = async () => {
-    setLoading(true);
     const { data, error } = await getResults(variables);
     if (error) {
       showError("Error downloading results", error.message);
       setLoading(false);
-    } else {
-      const csvResults = parseDataForCSV(data.testResults, multiplexEnabled);
+    } else if (data.testResultsPage && data.testResultsPage.content) {
+      const csvResults = parseDataForCSV(
+        data.testResultsPage.content,
+        multiplexEnabled
+      );
       setResults(csvResults);
       setLoading(false);
       csvLink?.current?.link.click();
       closeModal();
+    } else {
+      showError("Unknown error downloading results");
+      setLoading(false);
     }
   };
 
@@ -147,7 +158,10 @@ export const DownloadResultsCsvModal = ({
               label={disableDownload ? "Go back" : "No, go back"}
             />
             <Button
-              onClick={downloadResults}
+              onClick={async () => {
+                setLoading(true);
+                downloadResults();
+              }}
               disabled={disableDownload}
               icon={faDownload}
               label={loading ? "Loading..." : "Download results"}

--- a/frontend/src/app/testResults/mocks/queries.mock.tsx
+++ b/frontend/src/app/testResults/mocks/queries.mock.tsx
@@ -1,13 +1,12 @@
 import {
   GetAllFacilitiesDocument,
-  GetFacilityResultsForCsvDocument,
-  GetFacilityResultsMultiplexDocument,
-  GetResultsCountByFacilityDocument,
+  GetFacilityResultsMultiplexWithCountDocument,
   GetTestResultDetailsDocument,
   GetTestResultForCorrectionDocument,
   GetTestResultForPrintDocument,
   GetTestResultForResendingEmailsDocument,
   GetTestResultForTextDocument,
+  GetFacilityResultsForCsvWithCountDocument,
 } from "../../../generated/graphql";
 import { testResultDetailsQuery } from "../TestResultDetailsModal";
 import { QUERY_PATIENT } from "../../testQueue/addToQueue/AddToQueueSearch";
@@ -33,20 +32,7 @@ import resultForCorrection from "./resultForCorrection";
 export const mocks = [
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResults.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -55,13 +41,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults,
+        testResultsPage: testResults,
       },
     },
   },
   {
     request: {
-      query: GetFacilityResultsForCsvDocument,
+      query: GetFacilityResultsForCsvWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -70,7 +56,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsForCsv,
+        testResultsPage: testResultsForCsv,
       },
     },
   },
@@ -78,7 +64,7 @@ export const mocks = [
     request: {
       query: testResultDetailsQuery,
       variables: {
-        id: testResults[0].internalId,
+        id: testResults.content[0].internalId,
       },
     },
     result: {
@@ -112,23 +98,10 @@ export const mocks = [
       },
     },
   },
+
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByPatient.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
@@ -138,27 +111,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByPatient,
+        testResultsPage: testResultsByPatient,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        result: "NEGATIVE",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByResultValue.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         result: "NEGATIVE",
@@ -168,27 +127,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByResultValue,
+        testResultsPage: testResultsByResultValue,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        role: "RESIDENT",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByRole.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         role: "RESIDENT",
@@ -198,27 +143,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByRole,
+        testResultsPage: testResultsByRole,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        startDate: "2021-03-18T00:00:00.000Z",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByStartDate.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         startDate: "2021-03-18T00:00:00.000Z",
@@ -228,28 +159,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByStartDate,
+        testResultsPage: testResultsByStartDate,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        startDate: "2021-03-18T00:00:00.000Z",
-        endDate: "2021-03-18T23:59:59.999Z",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByStartDateAndEndDate.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         startDate: "2021-03-18T00:00:00.000Z",
@@ -260,26 +176,14 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByStartDateAndEndDate,
+        testResultsPage: testResultsByStartDateAndEndDate,
       },
     },
   },
+
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "2",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByFacility.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "2",
         pageNumber: 0,
@@ -288,26 +192,13 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByFacility,
+        testResultsPage: testResultsByFacility,
       },
     },
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: null,
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByAllFacility.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: null,
         pageNumber: 0,
@@ -316,7 +207,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByAllFacility,
+        testResultsPage: testResultsByAllFacility,
       },
     },
   },
@@ -338,20 +229,7 @@ export const mocks = [
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResults.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -360,20 +238,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "3",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsMultiplex.length,
+        testResultsPage: testResults,
       },
     },
   },
@@ -392,7 +257,7 @@ export const mocks = [
   },
   {
     request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "3",
         pageNumber: 0,
@@ -401,7 +266,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsMultiplex,
+        testResultsPage: testResultsMultiplex,
       },
     },
   },
@@ -420,25 +285,7 @@ export const mocks = [
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-        patientId: "48c523e8-7c65-4047-955c-e3f65bb8b58a",
-        startDate: "2021-03-18T00:00:00.000Z",
-        endDate: "2021-03-19T23:59:59.999Z",
-        role: "STAFF",
-        result: "NEGATIVE",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsByStartDateAndEndDate.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -452,7 +299,7 @@ export const mocks = [
     },
     result: {
       data: {
-        testResults: testResultsByStartDateAndEndDate,
+        testResultsPage: testResultsByStartDateAndEndDate,
       },
     },
   },
@@ -526,20 +373,7 @@ export const mocks = [
 export const mocksWithMultiplex = [
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: null,
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsMultiplex.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: null,
         pageNumber: 0,
@@ -548,7 +382,7 @@ export const mocksWithMultiplex = [
     },
     result: {
       data: {
-        testResults: testResultsMultiplex,
+        testResultsPage: testResultsMultiplex,
       },
     },
   },
@@ -567,20 +401,7 @@ export const mocksWithMultiplex = [
   },
   {
     request: {
-      query: GetResultsCountByFacilityDocument,
-      variables: {
-        facilityId: "1",
-      },
-    },
-    result: {
-      data: {
-        testResultsCount: testResultsMultiplex.length,
-      },
-    },
-  },
-  {
-    request: {
-      query: GetFacilityResultsMultiplexDocument,
+      query: GetFacilityResultsMultiplexWithCountDocument,
       variables: {
         facilityId: "1",
         pageNumber: 0,
@@ -589,7 +410,7 @@ export const mocksWithMultiplex = [
     },
     result: {
       data: {
-        testResults: testResultsMultiplex,
+        testResultsPage: testResultsMultiplex,
       },
     },
   },

--- a/frontend/src/app/testResults/mocks/resultsByAllFacilities.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByAllFacilities.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_ALL_FACILITIES = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0123a",
     dateTested: "2021-04-12T12:40:33.381Z",
@@ -72,5 +72,9 @@ const TEST_RESULTS_BY_ALL_FACILITIES = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_ALL_FACILITIES = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_ALL_FACILITIES;

--- a/frontend/src/app/testResults/mocks/resultsByFacility.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByFacility.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_FACILITY = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0123a",
     dateTested: "2021-04-12T12:40:33.381Z",
@@ -36,5 +36,9 @@ const TEST_RESULTS_BY_FACILITY = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_FACILITY = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_FACILITY;

--- a/frontend/src/app/testResults/mocks/resultsByPatient.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByPatient.mock.tsx
@@ -1,4 +1,4 @@
-const RESULTS_BY_PATIENT = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -38,5 +38,10 @@ const RESULTS_BY_PATIENT = [
     __typename: "TestResult",
   },
 ];
+
+const RESULTS_BY_PATIENT = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default RESULTS_BY_PATIENT;

--- a/frontend/src/app/testResults/mocks/resultsByResultValue.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByResultValue.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_RESULT_VALUE = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -76,5 +76,9 @@ const TEST_RESULTS_BY_RESULT_VALUE = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_RESULT_VALUE = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_RESULT_VALUE;

--- a/frontend/src/app/testResults/mocks/resultsByRole.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByRole.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_ROLE = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -77,4 +77,8 @@ const TEST_RESULTS_BY_ROLE = [
   },
 ];
 
+const TEST_RESULTS_BY_ROLE = {
+  content: data,
+  totalElements: data.length,
+};
 export default TEST_RESULTS_BY_ROLE;

--- a/frontend/src/app/testResults/mocks/resultsByStartAndEndDate.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByStartAndEndDate.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_START_END_DATE = [
+const data = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
@@ -38,5 +38,10 @@ const TEST_RESULTS_BY_START_END_DATE = [
     __typename: "TestResult",
   },
 ];
+
+const TEST_RESULTS_BY_START_END_DATE = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_BY_START_END_DATE;

--- a/frontend/src/app/testResults/mocks/resultsByStartDate.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsByStartDate.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_BY_START_DATE = [
+const data = [
   {
     internalId: "7c768a5d-ef90-44cd-8050-b96dd77f51d5",
     dateTested: "2021-03-18T19:27:21.052Z",
@@ -76,4 +76,8 @@ const TEST_RESULTS_BY_START_DATE = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_BY_START_DATE = {
+  content: data,
+  totalElements: data.length,
+};
 export default TEST_RESULTS_BY_START_DATE;

--- a/frontend/src/app/testResults/mocks/resultsCSV.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsCSV.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_CSV = [
+const data = [
   {
     facility: { name: "Central Middle School", __typename: "Facility" },
     dateTested: "2022-01-19T16:45:11.446Z",
@@ -160,5 +160,9 @@ const TEST_RESULTS_CSV = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_CSV = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_CSV;

--- a/frontend/src/app/testResults/mocks/resultsCovid.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsCovid.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_COVID = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -96,7 +96,11 @@ const TEST_RESULTS_COVID = [
       lookupId: null,
       email: "sam@gerard.com",
       phoneNumbers: [
-        { type: "MOBILE", number: "(248) 555-1234", __typename: "PhoneNumber" },
+        {
+          type: "MOBILE",
+          number: "(248) 555-1234",
+          __typename: "PhoneNumber",
+        },
       ],
       __typename: "Patient",
     },
@@ -118,5 +122,9 @@ const TEST_RESULTS_COVID = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_COVID = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_COVID;

--- a/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
@@ -1,4 +1,4 @@
-const TEST_RESULTS_MULTIPLEX = [
+const data = [
   {
     internalId: "0969da96-b211-41cd-ba61-002181f0918d",
     dateTested: "2021-03-17T19:27:23.806Z",
@@ -130,5 +130,9 @@ const TEST_RESULTS_MULTIPLEX = [
     __typename: "TestResult",
   },
 ];
+const TEST_RESULTS_MULTIPLEX = {
+  content: data,
+  totalElements: data.length,
+};
 
 export default TEST_RESULTS_MULTIPLEX;

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
@@ -7,6 +7,7 @@ import TEST_RESULT_COVID from "../mocks/resultsCovid.mock";
 
 import ResultsTable, { generateTableHeaders } from "./ResultsTable";
 
+const TEST_RESULTS_MULTIPLEX_CONTENT = TEST_RESULTS_MULTIPLEX.content;
 describe("Method generateTableHeaders", () => {
   const table = (headers: JSX.Element) => (
     <table>
@@ -99,7 +100,7 @@ describe("Component ResultsTable", () => {
   it("checks table with covid results", () => {
     render(
       <ResultsTable
-        results={[TEST_RESULT_COVID[0]]}
+        results={[TEST_RESULT_COVID.content[0]]}
         setPrintModalId={setPrintModalIdFn}
         setMarkCorrectionId={setMarkCorrectionIdFn}
         setDetailsModalId={setDetailsModalIdFn}
@@ -118,7 +119,7 @@ describe("Component ResultsTable", () => {
   it("checks table with multiplex results", () => {
     render(
       <ResultsTable
-        results={TEST_RESULTS_MULTIPLEX}
+        results={TEST_RESULTS_MULTIPLEX_CONTENT}
         setPrintModalId={setPrintModalIdFn}
         setMarkCorrectionId={setMarkCorrectionIdFn}
         setDetailsModalId={setDetailsModalIdFn}
@@ -129,7 +130,7 @@ describe("Component ResultsTable", () => {
       />
     );
 
-    TEST_RESULTS_MULTIPLEX.forEach((result) => {
+    TEST_RESULTS_MULTIPLEX_CONTENT.forEach((result) => {
       expect(
         screen.getByTestId(`test-result-${result.internalId}`)
       ).toBeInTheDocument();
@@ -142,7 +143,9 @@ describe("Component ResultsTable", () => {
   describe("actions menu", () => {
     describe("text result action", () => {
       it("includes `Text result` if patient has mobile number", () => {
-        const testResultPatientMobileNumber = [TEST_RESULTS_MULTIPLEX[1]];
+        const testResultPatientMobileNumber = [
+          TEST_RESULTS_MULTIPLEX_CONTENT[1],
+        ];
 
         render(
           <ResultsTable
@@ -169,7 +172,9 @@ describe("Component ResultsTable", () => {
       });
 
       it("does not include `Text result` if no patient mobile number", () => {
-        const testResultPatientNoMobileNumber = [TEST_RESULTS_MULTIPLEX[0]];
+        const testResultPatientNoMobileNumber = [
+          TEST_RESULTS_MULTIPLEX_CONTENT[0],
+        ];
 
         render(
           <ResultsTable
@@ -197,7 +202,7 @@ describe("Component ResultsTable", () => {
     });
     describe("email result action", () => {
       it("includes `Email result` if patient email address", () => {
-        const testResultPatientEmail = [TEST_RESULTS_MULTIPLEX[0]];
+        const testResultPatientEmail = [TEST_RESULTS_MULTIPLEX_CONTENT[0]];
 
         render(
           <ResultsTable
@@ -224,7 +229,7 @@ describe("Component ResultsTable", () => {
       });
 
       it("does not include `Email result` if no patient email address", () => {
-        const testResultPatientNoEmail = [TEST_RESULTS_MULTIPLEX[1]];
+        const testResultPatientNoEmail = [TEST_RESULTS_MULTIPLEX_CONTENT[1]];
 
         render(
           <ResultsTable

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -8,7 +8,7 @@ import { getResultByDiseaseName } from "./testResults";
 
 import { displayFullName, facilityDisplayName } from "./index";
 
-export function parseDataForCSV(data: any, multiplexEnabled: boolean) {
+export function parseDataForCSV(data: any[], multiplexEnabled: boolean) {
   return data.sort(byDateTested).map((r: any) => {
     const symptomList = r.symptoms ? symptomsStringToArray(r.symptoms) : [];
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Frontend cleanup sibling to https://github.com/CDCgov/prime-simplereport/pull/4531
- Followup to https://github.com/CDCgov/prime-simplereport/pull/4572 that does the actual frontend refactor to dedupe the multiple results calls. Broke out all the code that isn't test related into commit 946c03 to make reviewing easier.

## Changes Proposed
- Replace calls to facility results and results count (multiplex and non-multiplex) with the consolidated query that returns both values in one GQL call
- Refactor types and component logic accordingly to use new GQL shape

## Testing
- Smoke test the results page (loading, download results, filtering) to make sure nothing broke
- Deploy available in `pentest` for smoke testing.

## Additional Information
- Will follow up with the backend and frontend cleanup PR's to take the implementation details (namely references to page, or renaming `testResultsPage`--> `testResults`) and duplicate code paths out. Will make sure [test coverage is up to snuff in those PR's.](https://github.com/CDCgov/prime-simplereport/pull/4531#issuecomment-1285854714)

