### PR TITLE
Remove -upgrade and -migrate-state from terraform init :arrow_up_down: 

### DIFF
--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -43,7 +43,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -42,7 +42,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -42,7 +42,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -42,7 +42,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -42,7 +42,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -47,7 +47,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -52,7 +52,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -47,7 +47,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -47,7 +47,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform Init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Terraform deploy (infrastructure and staging slot)

--- a/.github/workflows/rollbackDB.yml
+++ b/.github/workflows/rollbackDB.yml
@@ -56,7 +56,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform init
         run: make init-${{ env.DEPLOY_ENV }}
       - name: Launch DB Rollback Container Instance

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -31,7 +31,7 @@ jobs:
           echo "OKTA_API_TOKEN=${{ secrets.OKTA_API_TOKEN }}" >> "$GITHUB_ENV"
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform Init
         run: make init-${{ github.event.inputs.env }}
       - name: Build ReportStream function app

--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform fmt
         run: terraform fmt -check -recursive
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform Init
         run: |
           for d in $TERRAFORM_DIRS
@@ -71,7 +71,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v1
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
-          terraform_version: 1.1.4
+          terraform_version: 1.3.3
       - name: Terraform Init
         if: ${{ github.actor != 'dependabot[bot]' }}
         run: make init-prod

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -42,9 +42,14 @@ api.tfvars: /dev/null
 	echo "deploy_timestamp=\"$(shell date +%Y-%m-%dT%H:%M:%S%z) \"" >> $@; \
 	echo "deploy_actor=\"$(GITHUB_ACTOR)\"" >> $@;
 
+# init-%: .valid-env-%
+# 	terraform -chdir=$*/persistent init
+# 	terraform -chdir=$* init
+
+# Passes the -upgrade and -migration flags to terraform init
 init-%: .valid-env-%
-	terraform -chdir=$*/persistent init
-	terraform -chdir=$* init
+	terraform -chdir=$*/persistent init -upgrade -migrate-state
+	terraform -chdir=$* init -upgrade -migrate-state
 
 plan-%: .valid-env-% api.tfvars
 	terraform -chdir=$*/persistent plan -lock-timeout=30m

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -42,14 +42,14 @@ api.tfvars: /dev/null
 	echo "deploy_timestamp=\"$(shell date +%Y-%m-%dT%H:%M:%S%z) \"" >> $@; \
 	echo "deploy_actor=\"$(GITHUB_ACTOR)\"" >> $@;
 
-# init-%: .valid-env-%
-# 	terraform -chdir=$*/persistent init
-# 	terraform -chdir=$* init
+init-%: .valid-env-%
+	terraform -chdir=$*/persistent init
+	terraform -chdir=$* init
 
 # Passes the -upgrade and -migration flags to terraform init
-init-%: .valid-env-%
-	terraform -chdir=$*/persistent init -upgrade -migrate-state
-	terraform -chdir=$* init -upgrade -migrate-state
+# init-%: .valid-env-%
+# 	terraform -chdir=$*/persistent init -upgrade -migrate-state
+# 	terraform -chdir=$* init -upgrade -migrate-state
 
 plan-%: .valid-env-% api.tfvars
 	terraform -chdir=$*/persistent plan -lock-timeout=30m

--- a/ops/demo/persistent/_config.tf
+++ b/ops/demo/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/dev/persistent/_config.tf
+++ b/ops/dev/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/dev2/persistent/_config.tf
+++ b/ops/dev2/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/dev3/persistent/_config.tf
+++ b/ops/dev3/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/dev4/persistent/_config.tf
+++ b/ops/dev4/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/global/.terraform.lock.hcl
+++ b/ops/global/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.92.0"
   constraints = "~> 2.92.0"
   hashes = [
+    "h1:4hZBxKHENrIx59+2OVuw8kT/+QcD8c2pkHrnPRmXvog=",
     "h1:l2EJ5Hub3P/kadpXDj76dJoVacFurIC2IdyP9vwTeOU=",
     "zh:0de2206cf0a876fe61b0693075a4dbe73f45b52dd8749f61a743e562aa56505d",
     "zh:28aa7999b8592e6a1c51ee8e52690e594a64fe124413af01fb3e8f4f88b77b9a",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/okta/okta" {
   constraints = "~> 3.19"
   hashes = [
     "h1:8HRYuoSxNfjBibIG694sobQltviECxd0tAM8FQ3dFik=",
+    "h1:YE7o8kKunwCuUgWslZZK6bUMC6Tl4e/yoMQ4m0weh5Y=",
     "zh:0a78531c7d299d7c9a3e051335aed59ab0b38edd835e6b96cd56130735505ff9",
     "zh:1214d567846da9922bf9841476f56e15cf4a42fe17c4d61e2547d83e090ac701",
     "zh:1565bfd5ab681e770a95ebb7277f2acea64b340cdddc1a8c9ec82b70b29f47d0",
@@ -47,6 +49,7 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
   constraints = "~> 2.1"
   hashes = [
     "h1:/NOmfITclc4rTqxZ4ViSaobvLbqXOpvWWHnZK8MbO0A=",
+    "h1:97MvqBs60CppewPARVaXFu1iNENnalKFnGOYKhBIUzc=",
     "zh:1047f05a7bd16407ce58f9be5dc059722034fa17b17b67d6189063b33e01d3b1",
     "zh:2ac5d8636ac2513a18b615ef67540c6c4fe820bcd1bdcf00acd31c2f18e502e7",
     "zh:352024de11cb9225d18687eb0a53a4e8d3779af84d7fed651c6981517d7568e6",

--- a/ops/global/_config.tf
+++ b/ops/global/_config.tf
@@ -19,7 +19,7 @@ terraform {
       version = "~> 2.1"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 provider "azurerm" {

--- a/ops/global/vault_global.tf
+++ b/ops/global/vault_global.tf
@@ -1,12 +1,12 @@
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "sr" {
-  location            = data.azurerm_resource_group.rg.location
-  name                = "simple-report-global"
-  resource_group_name = data.azurerm_resource_group.rg.name
-  sku_name            = "standard"
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  purge_protection_enabled   = true
+  location                 = data.azurerm_resource_group.rg.location
+  name                     = "simple-report-global"
+  resource_group_name      = data.azurerm_resource_group.rg.name
+  sku_name                 = "standard"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  purge_protection_enabled = true
 
   tags = local.management_tags
 }

--- a/ops/global/vault_global.tf
+++ b/ops/global/vault_global.tf
@@ -6,6 +6,7 @@ resource "azurerm_key_vault" "sr" {
   resource_group_name = data.azurerm_resource_group.rg.name
   sku_name            = "standard"
   tenant_id           = data.azurerm_client_config.current.tenant_id
+  purge_protection_enabled   = true
 
   tags = local.management_tags
 }

--- a/ops/pentest/_config.tf
+++ b/ops/pentest/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~> 2.92.0"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 provider "azurerm" {

--- a/ops/pentest/persistent/_config.tf
+++ b/ops/pentest/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/prod/_config.tf
+++ b/ops/prod/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~> 2.92.0"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 provider "azurerm" {

--- a/ops/prod/persistent/_config.tf
+++ b/ops/prod/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -100,6 +100,5 @@ terraform {
       version = "~> 2.92.0"
     }
   }
-  required_version = "~> 1.1.4"
-  # required_version = "~> 1.3.2"
+  required_version = "~> 1.3.3"
 }

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -101,4 +101,5 @@ terraform {
     }
   }
   required_version = "~> 1.1.4"
+  # required_version = "~> 1.3.2"
 }

--- a/ops/services/monitoring/_var.tf
+++ b/ops/services/monitoring/_var.tf
@@ -30,7 +30,7 @@ variable "app_url" {
 
 variable "ai_ingest_cap_gb" {
   description = "Cap for data ingested into Application Insights, per day."
-  default     = 100
+  default     = 50
 }
 
 variable "ai_retention_days" {

--- a/ops/services/monitoring/_var.tf
+++ b/ops/services/monitoring/_var.tf
@@ -30,7 +30,7 @@ variable "app_url" {
 
 variable "ai_ingest_cap_gb" {
   description = "Cap for data ingested into Application Insights, per day."
-  default     = 50
+  default     = 100
 }
 
 variable "ai_retention_days" {

--- a/ops/services/monitoring/main.tf
+++ b/ops/services/monitoring/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_application_insights" "app_insights" {
   location            = var.rg_location
   resource_group_name = var.rg_name
   name                = "prime-simple-report-${var.env}-insights"
-  disable_ip_masking  = true
+  disable_ip_masking  = false
 
   daily_data_cap_in_gb = var.ai_ingest_cap_gb
   retention_in_days    = var.ai_retention_days

--- a/ops/services/okta-app/versions.tf
+++ b/ops/services/okta-app/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "okta/okta"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }

--- a/ops/services/okta-global/versions.tf
+++ b/ops/services/okta-global/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "okta/okta"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }

--- a/ops/services/pagerduty/versions.tf
+++ b/ops/services/pagerduty/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "pagerduty/pagerduty"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }

--- a/ops/stg/_config.tf
+++ b/ops/stg/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~> 2.92.0"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 provider "azurerm" {

--- a/ops/stg/persistent/_config.tf
+++ b/ops/stg/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/test/.terraform.lock.hcl
+++ b/ops/test/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.92.0"
   constraints = "~> 2.92.0"
   hashes = [
-    "h1:l2EJ5Hub3P/kadpXDj76dJoVacFurIC2IdyP9vwTeOU=",
+    "h1:4hZBxKHENrIx59+2OVuw8kT/+QcD8c2pkHrnPRmXvog=",
     "zh:0de2206cf0a876fe61b0693075a4dbe73f45b52dd8749f61a743e562aa56505d",
     "zh:28aa7999b8592e6a1c51ee8e52690e594a64fe124413af01fb3e8f4f88b77b9a",
     "zh:374c9d9a001e3b9987866b6f565232a29c6b8d7993ddc2d7813d5ea852eef306",
@@ -17,23 +17,5 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:be34006c07fd933e8d48ff2e1ab99412ebe6a75e6ef6d03c1cba69d357e38933",
     "zh:e2361908ac5c903d4fc58476f641ce3e908e076b396328c19e59fe973ce3915c",
     "zh:f94099fb71b7911196970a0c07b01abfa28efd7c4bd05f44f046bbe06eef5e6f",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.1.0"
-  hashes = [
-    "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
-    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
-    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
-    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
-    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
-    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
-    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
-    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
-    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
-    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
-    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
-    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
   ]
 }

--- a/ops/test/_config.tf
+++ b/ops/test/_config.tf
@@ -14,8 +14,7 @@ terraform {
       version = "~> 2.92.0"
     }
   }
-  required_version = "~> 1.1.4"
-  # required_version = "~> 1.3.2"
+  required_version = "~> 1.3.3"
 }
 
 provider "azurerm" {

--- a/ops/test/_config.tf
+++ b/ops/test/_config.tf
@@ -15,6 +15,7 @@ terraform {
     }
   }
   required_version = "~> 1.1.4"
+  # required_version = "~> 1.3.2"
 }
 
 provider "azurerm" {

--- a/ops/test/persistent/_config.tf
+++ b/ops/test/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 

--- a/ops/training/_config.tf
+++ b/ops/training/_config.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~> 2.92.0"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 provider "azurerm" {

--- a/ops/training/persistent/_config.tf
+++ b/ops/training/persistent/_config.tf
@@ -18,7 +18,7 @@ terraform {
       version = "~> 3.19"
     }
   }
-  required_version = "~> 1.1.4"
+  required_version = "~> 1.3.3"
 }
 
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Changes Proposed

- Comments the terraform init version with the upgrade and migrate state flags. We only use these during upgrades. This will be merged after [the terraform upgrade PR](https://github.com/CDCgov/prime-simplereport/pull/4566) is fully deployed.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
