### PR TITLE
Use teams for dependabot, take 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "simplereport-backendreviews"
+      - "cdcgov/simplereport-backendreviews"
       - "alixmx"
       - "rin-skylight"
 
@@ -72,7 +72,7 @@ updates:
     reviewers:
       - "alismx"
       - "rin-skylight"
-      - "simplereport-frontendreviews"
+      - "cdcgov/simplereport-frontendreviews"
       
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -82,7 +82,7 @@ updates:
     reviewers:
       - "alismx"
       - "rin-skylight"
-      - "simplereport-frontendreviews"
+      - "cdcgov/simplereport-frontendreviews"
       
   # - package-ecosystem: "npm"
   #   directory: "/cypress"


### PR DESCRIPTION
Someday we're going to hit the right syntax for requesting dependabot reviews from a team...maybe that day will be today

I finally looked at the docs and we do need the org name prefixed:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers:~:text=%2D%20%22my%2Dorg/python%2Dteam%22

The first attempt at this used `@CDCgov/simplereport-backendreviewers` and apparently we need `cdcgov/simplereport-backendreviewers` instead (no `@`) 🤦 