### PR TITLE
Remove the test result upload pilot user enums

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Role.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Role.java
@@ -27,11 +27,6 @@ public enum Role {
    */
   USER(OrganizationRole.USER),
   /**
-   * This is a specific role for users who are in the test result bulk upload feature pilot and have
-   * the ability to submit test results as a CSV
-   */
-  TEST_RESULT_UPLOAD_USER(OrganizationRole.TEST_RESULT_UPLOAD_USER),
-  /**
    * This is the organization admin role: if you have this role, then you have the ability to change
    * your role, so other roles you may have are moot.
    */

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
@@ -56,10 +56,6 @@ public enum OrganizationRole implements Principal {
           UserPermission.SUBMIT_TEST,
           UserPermission.UPLOAD_RESULTS_SPREADSHEET)),
 
-  /** This is the role for users in the pilot for the test result bulk upload feature. */
-  TEST_RESULT_UPLOAD_USER(
-      "test-result-upload-pilot user", EnumSet.of(UserPermission.UPLOAD_RESULTS_SPREADSHEET)),
-
   /**
    * This is the organization admin role: if you have this role, then you have the ability to change
    * your role, so other roles you may have are moot. This role's permissions take precedence over

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TenantDataAccessService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TenantDataAccessService.java
@@ -63,7 +63,6 @@ public class TenantDataAccessService {
     // authority names for the org being accessed (assume org-level admin in the tenant)
     authorities.add(prefix + org.getExternalId() + ":" + OrganizationRole.getDefault());
     authorities.add(prefix + org.getExternalId() + ":" + OrganizationRole.ADMIN);
-    authorities.add(prefix + org.getExternalId() + ":" + OrganizationRole.TEST_RESULT_UPLOAD_USER);
 
     PermissionsData permissionsData = new PermissionsData(authorities);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TenantDataAccessServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TenantDataAccessServiceTest.java
@@ -32,11 +32,7 @@ class TenantDataAccessServiceTest extends BaseServiceTest<TenantDataAccessServic
     OrganizationRoleClaims claims = claimsOpt.get();
     assertEquals(org.getExternalId(), claims.getOrganizationExternalId());
     assertEquals(
-        Set.of(
-            OrganizationRole.NO_ACCESS,
-            OrganizationRole.TEST_RESULT_UPLOAD_USER,
-            OrganizationRole.ADMIN),
-        claims.getGrantedRoles());
+        Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ADMIN), claims.getGrantedRoles());
   }
 
   @Test
@@ -68,11 +64,6 @@ class TenantDataAccessServiceTest extends BaseServiceTest<TenantDataAccessServic
             + OrganizationRole.getDefault());
     expectedAuthorities.add(
         _authProperties.getRolePrefix() + org.getExternalId() + ":" + OrganizationRole.ADMIN);
-    expectedAuthorities.add(
-        _authProperties.getRolePrefix()
-            + org.getExternalId()
-            + ":"
-            + OrganizationRole.TEST_RESULT_UPLOAD_USER);
 
     return expectedAuthorities;
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

cleaning up the role we created for the CSV upload pilot program now that the feature has gone GA
a followup to #4625 

## Changes Proposed

clean up the TEST_RESULT_UPLOAD_USER role enums as they aren't being used anywhere anymore

## Additional Information

working on a script to delete all existing `TEST_RESULT_UPLOAD_USER` groups (Okta admin UI doesn't make it easy to find those groups or delete them in bulk), but having those unused groups doesn't cause any failures so not a blocking priority


## Testing

see [Emma's comment](https://github.com/CDCgov/prime-simplereport/pull/4625#issuecomment-1297342813) on the prior PR for testing. I also deployed to `dev2` and put myself in the `SR-DEV2-TENANT:AZ-Mount-Olympus-Healthcare-78cdcd01-e483-4f14-b92d-ffdd86bf7d91:TEST_RESULT_UPLOAD_USER` Okta group and verified no regression in loading the app or viewing the upload history

## Checklist for Primary Reviewer
- [x] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [x] Changes comply with the SimpleReport Style Guide