### PR TITLE
make the alert title a div rather than a h3

### DIFF
--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -82,7 +82,6 @@ describe("Adding a patient", () => {
         },
         {
           rules: {
-            'heading-order': { enabled: false },
           },
         },
     );

--- a/cypress/integration/03-conduct_test_spec.js
+++ b/cypress/integration/03-conduct_test_spec.js
@@ -78,7 +78,6 @@ describe("Conducting a test", () => {
         {
           rules: {
             // error applies to the toast
-            'heading-order': { enabled: false },
             'landmark-unique': { enabled: false },
           },
         },

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -55,7 +55,6 @@ describe("edit patient and save and start test", () => {
         {
           rules: {
             // error applies to the toast
-            'heading-order': { enabled: false },
             'landmark-one-main': { enabled: false },
             'landmark-unique': { enabled: false },
             // failing a11y test
@@ -83,7 +82,6 @@ describe("edit patient and save and start test", () => {
             // failing a11y test
             // error applies to the toast
             // observe this by adding cy.wait(5000); to wait for the toasts to disappear
-            'heading-order': { enabled: false },
             'landmark-one-main': { enabled: false },
             'landmark-unique': { enabled: false },
           },

--- a/frontend/src/app/commonComponents/Alert.tsx
+++ b/frontend/src/app/commonComponents/Alert.tsx
@@ -56,7 +56,7 @@ const Alert = ({
       role={role ? role : type === "error" ? "alert" : "region"}
     >
       <div className="usa-alert__body">
-        {title && <h3 className="usa-alert__heading">{title}</h3>}
+        {title && <div className="usa-alert__heading text-bold">{title}</div>}
         <div className="usa-alert__text">{body || children}</div>
       </div>
     </div>

--- a/frontend/src/app/commonComponents/__snapshots__/SRToastContainer.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/SRToastContainer.test.tsx.snap
@@ -27,11 +27,11 @@ Object {
                 <div
                   class="usa-alert__body"
                 >
-                  <h3
-                    class="usa-alert__heading"
+                  <div
+                    class="usa-alert__heading text-bold"
                   >
                     Problems saving data to server
-                  </h3>
+                  </div>
                   <div
                     class="usa-alert__text"
                   >
@@ -87,11 +87,11 @@ Object {
               <div
                 class="usa-alert__body"
               >
-                <h3
-                  class="usa-alert__heading"
+                <div
+                  class="usa-alert__heading text-bold"
                 >
                   Problems saving data to server
-                </h3>
+                </div>
                 <div
                   class="usa-alert__text"
                 >
@@ -204,11 +204,11 @@ Object {
                 <div
                   class="usa-alert__body"
                 >
-                  <h3
-                    class="usa-alert__heading"
+                  <div
+                    class="usa-alert__heading text-bold"
                   >
                     Success
-                  </h3>
+                  </div>
                   <div
                     class="usa-alert__text"
                   >
@@ -264,11 +264,11 @@ Object {
               <div
                 class="usa-alert__body"
               >
-                <h3
-                  class="usa-alert__heading"
+                <div
+                  class="usa-alert__heading text-bold"
                 >
                   Success
-                </h3>
+                </div>
                 <div
                   class="usa-alert__text"
                 >


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Our toast fails accessibility because it does not follow [heading order](https://dequeuniversity.com/rules/axe/4.0/heading-order)
- Resolves #4564 

## Changes Proposed

- Replace h3 with div & bold the text

## Additional Information


## Testing

- Ensure the alerts look identical
- Check that e2e tests pass without ignoring heading order rule

## Screenshots / Demos

Now:
![image](https://user-images.githubusercontent.com/10108172/199259495-543ff325-e065-4641-a3f9-c43cf61734a1.png)
Before:
![image](https://user-images.githubusercontent.com/10108172/199259640-b3ac57e6-26b9-458e-bf1d-405bb9bbe633.png)