### PR TITLE
Change copy of person to patient

### DIFF
--- a/cypress/integration/02-add_patient_spec.js
+++ b/cypress/integration/02-add_patient_spec.js
@@ -15,7 +15,7 @@ describe("Adding a patient", () => {
     cy.get("#desktop-patient-nav-link").click();
     cy.get(".prime-container");
     cy.get("#add-patient-button").click();
-    cy.get(".prime-edit-patient").contains("Add new person");
+    cy.get(".prime-edit-patient").contains("Add new patient");
     cy.injectAxe();
     cy.checkA11y(); // Patient form
   });
@@ -67,7 +67,7 @@ describe("Adding a patient", () => {
     );
 
     cy.get(".modal__container #save-confirmed-address").click();
-    cy.get(".usa-card__header").contains("People");
+    cy.get(".usa-card__header").contains("Patients");
     cy.get(".usa-card__header").contains("Showing");
     cy.get("#search-field-small").type(patient.lastName);
     cy.get(".prime-container").contains(patient.fullName);

--- a/cypress/integration/08-save_and_start_test_spec.js
+++ b/cypress/integration/08-save_and_start_test_spec.js
@@ -99,7 +99,7 @@ describe("add patient and save and start test", () => {
     cy.get(".usa-nav-container");
     cy.get("#desktop-patient-nav-link").click();
     cy.get("#add-patient-button").click();
-    cy.get(".prime-edit-patient").contains("Add new person");
+    cy.get(".prime-edit-patient").contains("Add new patient");
 
     cy.injectAxe();
     cy.checkA11y(); // New Patient page
@@ -185,8 +185,8 @@ describe("edit patient from test queue", () => {
   });
 });
 
-describe("start test from people page for patient already in queue", () => {
-  it("navigates to people page, selects Start test, and verifies link to test queue", () => {
+describe("start test from patients page for patient already in queue", () => {
+  it("navigates to patients page, selects Start test, and verifies link to test queue", () => {
     cy.visit("/");
     cy.get(".usa-nav-container");
     cy.get("#desktop-patient-nav-link").click();

--- a/frontend/src/app/analytics/AggregateResultsTable.tsx
+++ b/frontend/src/app/analytics/AggregateResultsTable.tsx
@@ -3,6 +3,8 @@
 // Make the table sortable
 // Link backend queries in correctly
 
+import { PATIENT_TERM_PLURAL } from "../../config/constants";
+
 interface Props {
   tableName: string;
   tableType: string;
@@ -62,7 +64,7 @@ const AggregateResultsTable: React.FC<Props> = ({
               Tests conducted
             </th>
             <th scope="col" role="columnheader" className="text-center">
-              Number of people tested
+              Number of {PATIENT_TERM_PLURAL} tested
             </th>
             <th scope="col" role="columnheader" className="text-center">
               Positive tests

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -5,6 +5,7 @@ import createMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 
 import { GetTopLevelDashboardMetricsNewDocument } from "../../generated/graphql";
+import { PATIENT_TERM_PLURAL } from "../../config/constants";
 
 import {
   Analytics,
@@ -285,7 +286,7 @@ describe("Analytics", () => {
     const startDate = screen.getByTestId("startDate") as HTMLInputElement;
     const endDate = screen.getByTestId("endDate") as HTMLInputElement;
     userEvent.type(startDate, "2021-07-01");
-    await screen.findByText("All people tested");
+    await screen.findByText(`All ${PATIENT_TERM_PLURAL} tested`);
     await userEvent.type(endDate, "2021-07-31");
     expect(await screen.findByText("14982")).toBeInTheDocument();
     expect(await screen.findByText("953")).toBeInTheDocument();

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -7,6 +7,7 @@ import Dropdown from "../commonComponents/Dropdown";
 import { useGetTopLevelDashboardMetricsNewQuery } from "../../generated/graphql";
 import "./Analytics.scss";
 import { formatDate } from "../utils/date";
+import { PATIENT_TERM_PLURAL } from "../../config/constants";
 
 const getDateFromDaysAgo = (daysAgo: number): Date => {
   const date = new Date();
@@ -233,7 +234,9 @@ export const Analytics = (props: Props) => {
               ) : (
                 <>
                   <h2>{facilityName}</h2>
-                  <p className="margin-bottom-0">All people tested</p>
+                  <p className="margin-bottom-0">
+                    All {PATIENT_TERM_PLURAL} tested
+                  </p>
                   <p className="padding-top-1">{`${startDate} \u2013 ${endDate}`}</p>
                   <div className="grid-row grid-gap">
                     <div className="grid-col-3">

--- a/frontend/src/app/patients/AddPatient.test.tsx
+++ b/frontend/src/app/patients/AddPatient.test.tsx
@@ -13,6 +13,7 @@ import userEvent from "@testing-library/user-event";
 
 import * as smartyStreets from "../utils/smartyStreets";
 import SRToastContainer from "../commonComponents/SRToastContainer";
+import { PATIENT_TERM } from "../../config/constants";
 
 import AddPatient, { ADD_PATIENT, PATIENT_EXISTS } from "./AddPatient";
 
@@ -134,7 +135,7 @@ describe("AddPatient", () => {
     });
     it("does not show the form title", () => {
       expect(
-        screen.queryByText("Add new person", {
+        screen.queryByText(`Add new ${PATIENT_TERM}`, {
           exact: false,
         })
       ).not.toBeInTheDocument();
@@ -239,7 +240,11 @@ describe("AddPatient", () => {
     });
     it("shows the form title", async () => {
       expect(
-        (await screen.findAllByText("Add new person", { exact: false }))[0]
+        (
+          await screen.findAllByText(`Add new ${PATIENT_TERM}`, {
+            exact: false,
+          })
+        )[0]
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -6,7 +6,11 @@ import moment from "moment";
 import { useSelector } from "react-redux";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
-import { PATIENT_TERM, PATIENT_TERM_CAP } from "../../config/constants";
+import {
+  PATIENT_TERM,
+  PATIENT_TERM_CAP,
+  PATIENT_TERM_PLURAL_CAP,
+} from "../../config/constants";
 import { dedupeAndCompactStrings } from "../utils";
 import { showSuccess } from "../utils/srToast";
 import Button from "../commonComponents/Button/Button";
@@ -350,7 +354,7 @@ const AddPatient = () => {
                     <use xlinkHref={iconSprite + "#arrow_back"}></use>
                   </svg>
                   <LinkWithQuery to={`/patients`} className="margin-left-05">
-                    People
+                    {PATIENT_TERM_PLURAL_CAP}
                   </LinkWithQuery>
                 </div>
                 <div className="prime-edit-patient-heading margin-y-0">

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -15,6 +15,7 @@ import configureStore from "redux-mock-store";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 
 import SRToastContainer from "../commonComponents/SRToastContainer";
+import { PATIENT_TERM_CAP } from "../../config/constants";
 
 import EditPatient, { GET_PATIENT, UPDATE_PATIENT } from "./EditPatient";
 import EditPatientContainer from "./EditPatientContainer";
@@ -663,7 +664,7 @@ describe("EditPatient", () => {
     });
     it("shows Conduct tests link and hides Save and start test button", async () => {
       expect(await screen.findByText("Conduct tests")).toBeInTheDocument();
-      expect(screen.queryByText("People")).not.toBeInTheDocument();
+      expect(screen.queryByText(PATIENT_TERM_CAP)).not.toBeInTheDocument();
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -4,7 +4,10 @@ import { NavigateOptions, NavLink, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import iconSprite from "../../../node_modules/uswds/dist/img/sprite.svg";
-import { PATIENT_TERM_CAP } from "../../config/constants";
+import {
+  PATIENT_TERM_CAP,
+  PATIENT_TERM_PLURAL_CAP,
+} from "../../config/constants";
 import { displayFullName, dedupeAndCompactStrings } from "../utils";
 import { showSuccess } from "../utils/srToast";
 import Button from "../commonComponents/Button/Button";
@@ -319,7 +322,7 @@ const EditPatient = (props: Props) => {
                           to={`/patients`}
                           className="margin-left-05"
                         >
-                          People
+                          {PATIENT_TERM_PLURAL_CAP}
                         </LinkWithQuery>
                       )}
                     </div>

--- a/frontend/src/app/patients/ManagePatients.test.tsx
+++ b/frontend/src/app/patients/ManagePatients.test.tsx
@@ -16,6 +16,8 @@ import {
 } from "react-router-dom";
 import createMockStore from "redux-mock-store";
 
+import { PATIENT_TERM, PATIENT_TERM_CAP } from "../../config/constants";
+
 import ManagePatients, {
   patientQuery,
   patientsCountQuery,
@@ -78,7 +80,7 @@ describe("ManagePatients", () => {
     expect(await screen.findByText(patients[0].lastName, { exact: false }));
     const btn = await screen.findByText("Filter", { exact: false });
     userEvent.click(btn);
-    const input = await screen.findByLabelText("Person");
+    const input = await screen.findByLabelText(PATIENT_TERM_CAP);
     userEvent.type(input, "Al");
     await waitForElementToBeRemoved(() =>
       screen.queryByText("Abramcik", { exact: false })
@@ -104,7 +106,7 @@ describe("ManagePatients", () => {
 
       const menu = (await screen.findAllByText("More actions"))[0];
       userEvent.click(menu);
-      userEvent.click(await screen.findByText("Archive person"));
+      userEvent.click(await screen.findByText(`Archive ${PATIENT_TERM}`));
 
       expect(
         screen.getByText("Yes, I'm sure", { exact: false })

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -7,7 +7,11 @@ import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
 import { NavigateOptions, useNavigate } from "react-router-dom";
 
 import { displayFullName } from "../utils";
-import { PATIENT_TERM, PATIENT_TERM_PLURAL_CAP } from "../../config/constants";
+import {
+  PATIENT_TERM,
+  PATIENT_TERM_CAP,
+  PATIENT_TERM_PLURAL_CAP,
+} from "../../config/constants";
 import { daysSince } from "../utils/date";
 import { capitalizeText } from "../utils/text";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
@@ -225,7 +229,7 @@ export const DetachedManagePatients = ({
                       }),
                   },
                   {
-                    name: "Archive person",
+                    name: `Archive ${PATIENT_TERM}`,
                     action: () => setArchivePerson(patient),
                   },
                 ]}
@@ -282,7 +286,7 @@ export const DetachedManagePatients = ({
             </div>
             <div className="display-flex flex-row bg-base-lightest padding-x-3 padding-y-2">
               <SearchInput
-                label="Person"
+                label={PATIENT_TERM_CAP}
                 onInputChange={(e) => {
                   setDebounced(e.target.value);
                 }}

--- a/frontend/src/app/patients/ManagePatientsContainer.tsx
+++ b/frontend/src/app/patients/ManagePatientsContainer.tsx
@@ -5,11 +5,12 @@ import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { hasPermission, appPermissions } from "../permissions";
 import { RootState } from "../store";
 import { useDocumentTitle } from "../utils/hooks";
+import { PATIENT_TERM_PLURAL_CAP } from "../../config/constants";
 
 import ManagePatients from "./ManagePatients";
 
 const ManagePatientsContainer = () => {
-  useDocumentTitle("People");
+  useDocumentTitle(PATIENT_TERM_PLURAL_CAP);
   const { pageNumber } = useParams();
   const currentPage = pageNumber ? +pageNumber : 1;
   const [facility] = useSelectedFacility();

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -41,7 +41,7 @@ Object {
                         class="margin-left-05"
                         href="/patients"
                       >
-                        People
+                        Patients
                       </a>
                     </div>
                     <div
@@ -2618,7 +2618,7 @@ Object {
                       class="margin-left-05"
                       href="/patients"
                     >
-                      People
+                      Patients
                     </a>
                   </div>
                   <div

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -15,6 +15,7 @@ import {
   RemovePatientFromQueueDocument,
 } from "../../generated/graphql";
 import { appPermissions } from "../permissions";
+import { PATIENT_TERM } from "../../config/constants";
 
 import TestQueue from "./TestQueue";
 import { QUERY_PATIENT } from "./addToQueue/AddToQueueSearch";
@@ -64,7 +65,9 @@ describe("TestQueue", () => {
         </MockedProvider>
       </MemoryRouter>
     );
-    await screen.findByLabelText("Search for a person to start their test");
+    await screen.findByLabelText(
+      `Search for a ${PATIENT_TERM} to start their test`
+    );
     expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
     expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
     expect(container).toMatchSnapshot();
@@ -125,7 +128,7 @@ describe("TestQueue", () => {
 
     expect(
       await screen.findByText(
-        "There are no tests running. Search for a person to start their test."
+        `There are no tests running. Search for a ${PATIENT_TERM} to start their test.`
       )
     ).toBeInTheDocument();
     expect(
@@ -167,7 +170,7 @@ describe("TestQueue", () => {
 
     expect(
       await screen.findByText(
-        "There are no tests running. Search for a person to start their test."
+        `There are no tests running. Search for a ${PATIENT_TERM} to start their test.`
       )
     ).toBeInTheDocument();
     expect(
@@ -187,7 +190,9 @@ describe("TestQueue", () => {
         </MemoryRouter>
       );
 
-      await screen.findByLabelText("Search for a person to start their test");
+      await screen.findByLabelText(
+        `Search for a ${PATIENT_TERM} to start their test`
+      );
       expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
       expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
 

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -9,12 +9,14 @@ import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { appPermissions, hasPermission } from "../permissions";
+import { PATIENT_TERM } from "../../config/constants";
 
 import AddToQueueSearch, {
   StartTestProps,
 } from "./addToQueue/AddToQueueSearch";
 import QueueItem from "./QueueItem";
 import { AoEAnswers, TestQueuePerson } from "./AoEForm/AoEForm";
+
 import "./TestQueue.scss";
 
 const pollInterval = 10_000;
@@ -40,7 +42,8 @@ const emptyQueueMessage = (canUseCsvUploader: boolean) => {
       <div className="grid-row">
         <div className="usa-card__body">
           <p>
-            There are no tests running. Search for a person to start their test.
+            There are no tests running. Search for a {PATIENT_TERM} to start
+            their test.
           </p>
           {canUseCsvUploader && (
             <p>

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`TestQueue should render the test queue 1`] = `
               class="usa-sr-only"
               for="search-field-small"
             >
-              Search for a person to start their test
+              Search for a patient to start their test
             </label>
             <div>
               <input
@@ -36,7 +36,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 class="usa-input"
                 id="search-field-small"
                 name="search"
-                placeholder="Search for a person to start their test"
+                placeholder="Search for a patient to start their test"
                 type="search"
                 value=""
               />

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -18,6 +18,7 @@ import { useOutsideClick } from "../../utils/hooks";
 import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
 import { getAppInsights } from "../../TelemetryService";
+import { PATIENT_TERM } from "../../../config/constants";
 
 import SearchResults from "./SearchResults";
 import SearchInput from "./SearchInput";
@@ -262,7 +263,7 @@ const AddToQueueSearchBox = ({
         onInputChange={onInputChange}
         queryString={debounced}
         disabled={!allowQuery}
-        placeholder={"Search for a person to start their test"}
+        placeholder={`Search for a ${PATIENT_TERM} to start their test`}
       />
       <SearchResults
         page="queue"

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Patient } from "../../patients/ManagePatients";
+import { PATIENT_TERM } from "../../../config/constants";
 
 import SearchResults from "./SearchResults";
 
@@ -107,8 +108,8 @@ describe("SearchResults", () => {
         </RouterWithFacility>
       );
 
-      expect(screen.getByText("Add new patient")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Add new patient"));
+      expect(screen.getByText(`Add new ${PATIENT_TERM}`)).toBeInTheDocument();
+      userEvent.click(screen.getByText(`Add new ${PATIENT_TERM}`));
       expect(
         screen.getByText(
           `Redirected to /add-patient?facility=${mockFacilityID}`

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -8,6 +8,7 @@ import { displayFullName } from "../../utils";
 import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
 import { getFacilityIdFromUrl } from "../../utils/url";
+import { PATIENT_TERM } from "../../../config/constants";
 
 interface SearchResultsProps {
   patients: Patient[];
@@ -104,7 +105,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
           Check for spelling errors or
           <Button
             className="margin-left-1"
-            label="Add new patient"
+            label={`Add new ${PATIENT_TERM}`}
             onClick={() => {
               setRedirect(`/add-patient?facility=${activeFacilityId}`);
             }}

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -275,7 +275,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
                 scope="col"
               >
-                Person
+                Patient
               </th>
               <th
                 class="test-date-cell"
@@ -325,7 +325,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
                 scope="col"
               >
-                Person
+                Patient
               </th>
               <th
                 class="test-date-cell"

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,7 +1,7 @@
-export const PATIENT_TERM = "person";
-export const PATIENT_TERM_CAP = "Person";
-export const PATIENT_TERM_PLURAL = "people";
-export const PATIENT_TERM_PLURAL_CAP = "People";
+export const PATIENT_TERM = "patient";
+export const PATIENT_TERM_CAP = "Patient";
+export const PATIENT_TERM_PLURAL = "patients";
+export const PATIENT_TERM_PLURAL_CAP = "Patients";
 
 // NOTE: Any time SimpleReport goes live in a new state, this file must be updated.
 // Otherwise, organizations will not be able to create facilities in the new state.


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #1427 

## Changes Proposed
- Updates any usages of "people"/"person" in the copy of the app to say "patients"/"patient"
- Default to using the patient variable constant in case we do end up changing the wording again 😅 

## Additional Information
- to keep this PR small, I chose only to update the copy (anything user-facing) and NOT update names of variables etc...

## Testing
- It is available on dev4 for testing!
- Go to pages listed [here](https://docs.google.com/spreadsheets/d/12zkWLB9Yjg4igvD0wVVu4yVnPMoSEpxyLSLgVNyaOuU/edit#gid=1203830487) and ensure all references to "people"/"person" now say "patients"/"patient"
- Check other parts of the app outside of the list defined in the spreadsheet in case we missed anything 😄 

## Screenshots / Demos
Dashboard
<img width="1031" alt="Screen Shot 2022-11-01 at 10 03 21" src="https://user-images.githubusercontent.com/20211771/199266804-3269e232-ed41-457f-b285-6d52f9bed821.png">

Conduct tests
<img width="1263" alt="Screen Shot 2022-11-01 at 10 03 30" src="https://user-images.githubusercontent.com/20211771/199266963-953362e2-5c29-4779-a672-18c5bc3f2af0.png">

Test results
<img width="1466" alt="Screen Shot 2022-11-01 at 10 03 36" src="https://user-images.githubusercontent.com/20211771/199266705-546b7445-6855-46a6-8e0e-40b497325b7a.png">

Patients
<img width="1171" alt="Screen Shot 2022-11-01 at 10 04 02" src="https://user-images.githubusercontent.com/20211771/199266521-fe5717ad-1728-4c6b-9d73-d6d29383dbfa.png">

Edit patient
<img width="1111" alt="Screen Shot 2022-11-03 at 09 15 26" src="https://user-images.githubusercontent.com/20211771/199744473-e91e3503-5a88-49b8-8ea2-ff96df0cc9e0.png">


Add new patient
<img width="1093" alt="Screen Shot 2022-11-01 at 10 03 55" src="https://user-images.githubusercontent.com/20211771/199266611-0eec8e61-d60e-4f76-8ba9-94d2271ff9d6.png">


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
