### PR TITLE
remove reference to deleted Role

### DIFF
--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -119,7 +119,7 @@ simple-report:
         last-name: Bobberoo
       authorization:
         organization-external-id: ${SR_DEMO_USER_ORG:DIS_ORG}
-        granted-roles: ${SR_DEMO_USER_ROLE:ADMIN},${SR_DEMO_USER_ROLE:TEST_RESULT_UPLOAD_USER}
+        granted-roles: ${SR_DEMO_USER_ROLE:ADMIN}
     alternate-users:
       - identity:
           username: ruby@example.com

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -116,9 +116,6 @@ public class SliceTestConfiguration {
         SliceTestConfiguration.DEFAULT_ROLE_PREFIX + "NO_ACCESS";
     public static final String DEFAULT_ORG_ALL_FACILITIES =
         SliceTestConfiguration.DEFAULT_ROLE_PREFIX + "ALL_FACILITIES";
-
-    public static final String DEFAULT_ORG_CSV_UPLOAD =
-        SliceTestConfiguration.DEFAULT_ROLE_PREFIX + "TEST_RESULT_UPLOAD_USER";
   }
 
   @Bean


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

booting the backend after my latest push to master will generate the following error in environments that use `application-create-sample-data.yaml`:
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'simple-report.demo-users.default-user.authorization.granted-roles' to java.util.Set<gov.cdc.usds.simplereport.config.authorization.OrganizationRole>:

    Property: simple-report.demo-users.default-user.authorization.granted-roles
    Value: "${SR_DEMO_USER_ROLE:ADMIN},${SR_DEMO_USER_ROLE:TEST_RESULT_UPLOAD_USER}"
    Origin: class path resource [application-create-sample-data.yaml] - 122:24
    Reason: failed to convert java.lang.String to gov.cdc.usds.simplereport.config.authorization.OrganizationRole (caused by java.lang.IllegalArgumentException: No enum constant gov.cdc.usds.simplereport.config.authorization.OrganizationRole.TEST_RESULT_UPLOAD_USER)

Action:

Update your application's configuration. The following values are valid:

    ADMIN
    ALL_FACILITIES
    ENTRY_ONLY
    NO_ACCESS
    USER
```

## Changes Proposed

remove invalid role from our app properties

## Additional Information

breaking PR link https://github.com/CDCgov/prime-simplereport/pull/4639

## Testing

pull branch, boot your local with Okta off