### PR TITLE
set max-request-size to 60MB from default of 10MB

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -52,6 +52,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 50MB
+      max-request-size: 60MB
 server:
   error:
     include-stacktrace: never


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

per [convo](https://skylight-hq.slack.com/archives/C02HKNHGCP6/p1667237915003529) with @mehansen and @nathancrtr turns out

- max-request-size [defaults](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/servlet/MultipartProperties.html) to 10MB
- max-request-size overrides max-file-size (based on our tests)

## Changes Proposed

- set max-request-size = 10 + max-file-size = 60MB