### PR TITLE
Shift order of dependabot reviewers for backend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,9 +60,9 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "cdcgov/simplereport-backendreviews"
       - "alixmx"
       - "rin-skylight"
+      - "cdcgov/simplereport-backendreviews"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
The backend Dependabot PR failed to tag the backend review team this morning (again), see [#4666](https://github.com/CDCgov/prime-simplereport/pull/4666#issuecomment-1305749601):

![Screen Shot 2022-11-07 at 8 50 09 AM](https://user-images.githubusercontent.com/80282552/200368334-8a1bca90-2def-4907-81a9-878fddd37abb.png)

The error was that the team wasn't a collaborator on the repository, but it certainly is:
![Screen Shot 2022-11-07 at 8 53 57 AM](https://user-images.githubusercontent.com/80282552/200368375-797b6420-1266-4e04-be3e-8039a5fe4df6.png)

I figured the same thing would've happened to the frontend dependabot PRs, but those seem to have used the team just fine. The only other difference I can see in the configuration is that on the frontend directories, the frontend team is listed last, and in the backend directories the team is listed first. There's absolutely nothing [in the docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) to suggest that order matters, but I figured it can't hurt to try.
