### PR TITLE
Validate bulk test result CSV in full

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/TestResultFileValidator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/TestResultFileValidator.java
@@ -40,7 +40,7 @@ public class TestResultFileValidator {
 
     List<FeedbackMessage> errors = new ArrayList<>();
 
-    while (valueIterator.hasNext() && errors.isEmpty()) {
+    while (valueIterator.hasNext()) {
       final Map<String, String> row = getNextRow(valueIterator);
 
       ValueOrError patientId = getValue(row, "patient_id", false);


### PR DESCRIPTION
## Related Issue
- Closes #4621 

## Changes Proposed
- This behavior is not a bug, as it was originally identified
- The test result file validator was explicitly halting validation upon encountering a row with one or more errors
- This was confusing to some users, as they did not receive all of the information necessary to correct their input
- The validator class now examines the full file before displaying _all_ validation errors to the user

## Additional Information
- The error response could end up being pretty massive on a very large file, but I don't think this requires any special consideration at this time

## Testing
- Give it a try in the browser!


https://user-images.githubusercontent.com/27730981/200376159-8e5d390b-3a87-4dcd-bd60-8098ec30f531.mov

