### PR TITLE
Communicate CSV file size limits on upload page and guide

### DIFF
--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -405,6 +405,10 @@ const CsvSchemaDocumentation = () => {
                 Make sure your spreadsheet is in a CSV format. SimpleReport
                 doesn’t accept .XLS, .XLXS, or other formats.
               </p>
+              <p>
+                Note: If your spreadsheet is larger than 50 MB or 10,000 rows,
+                please separate it into multiple files.
+              </p>
             </li>
             <li className="usa-process-list__item">
               <h3 className="usa-process-list__heading">

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -241,7 +241,8 @@ const Uploads = () => {
               </li>
               <li className="usa-process-list__item margin-bottom-1em">
                 <h2 className="usa-process-list__heading">
-                  Save your spreadsheet in a CSV format
+                  Save your spreadsheet in a CSV format (file size limit is 50
+                  MB or 10,000 rows)
                 </h2>
               </li>
               <li className="usa-process-list__item margin-bottom-1em">

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -6333,6 +6333,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentaton matches snapshot 1`]
             <p>
               Make sure your spreadsheet is in a CSV format. SimpleReport doesn’t accept .XLS, .XLXS, or other formats.
             </p>
+            <p>
+              Note: If your spreadsheet is larger than 50 MB or 10,000 rows, please separate it into multiple files.
+            </p>
           </li>
           <li
             class="usa-process-list__item"


### PR DESCRIPTION
## Related Issue
- Closes #4580 

## Changes Proposed
- Add text to the CSV upload page and the guide to communicate file size and row count limits

## Screenshots / Demos
<img width="809" alt="Screen Shot 2022-11-07 at 12 40 13 PM" src="https://user-images.githubusercontent.com/27730981/200379091-3872b149-3de4-4d7e-9243-d76cdc15fd5b.png">
<img width="559" alt="Screen Shot 2022-11-07 at 12 40 30 PM" src="https://user-images.githubusercontent.com/27730981/200379093-cf8289a0-f071-4910-b9b5-2fb76211a326.png">
