### PR TITLE
fix country code validation

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -45,6 +45,9 @@ public class CsvValidatorUtils {
               STATE_CODES.stream().map(String::toLowerCase),
               CANADIAN_STATE_CODES.stream().map(String::toLowerCase))
           .collect(Collectors.toSet());
+
+  private static final Set<String> VALID_COUNTRY_CODES =
+      COUNTRY_CODES.stream().map(String::toLowerCase).collect(Collectors.toSet());
   private static final String UNKNOWN_LITERAL = "unknown";
   private static final String OTHER_LITERAL = "other";
   private static final String REFUSED_LITERAL = "refused";
@@ -165,7 +168,7 @@ public class CsvValidatorUtils {
   }
 
   public static List<FeedbackMessage> validateCountry(ValueOrError input) {
-    return validateInSet(input, COUNTRY_CODES);
+    return validateInSet(input, VALID_COUNTRY_CODES);
   }
 
   public static List<FeedbackMessage> validateTestResultStatus(ValueOrError input) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -45,7 +45,6 @@ public class CsvValidatorUtils {
               STATE_CODES.stream().map(String::toLowerCase),
               CANADIAN_STATE_CODES.stream().map(String::toLowerCase))
           .collect(Collectors.toSet());
-
   private static final Set<String> VALID_COUNTRY_CODES =
       COUNTRY_CODES.stream().map(String::toLowerCase).collect(Collectors.toSet());
   private static final String UNKNOWN_LITERAL = "unknown";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.validators;
 
-import static gov.cdc.usds.simplereport.api.Translators.COUNTRY_CODES;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.ValueOrError;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.getValue;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateCountry;
@@ -68,7 +67,7 @@ class CsvValidatorUtilsTest {
 
   @Test
   void validCountryCode() {
-    var countryCode = new ValueOrError(COUNTRY_CODES.stream().findAny().get(), "country");
-    assertThat(validateCountry(countryCode)).hasSize(0);
+    var countryCode = new ValueOrError("USA", "country");
+    assertThat(validateCountry(countryCode)).isEmpty();
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -1,7 +1,9 @@
 package gov.cdc.usds.simplereport.validators;
 
+import static gov.cdc.usds.simplereport.api.Translators.COUNTRY_CODES;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.ValueOrError;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.getValue;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateCountry;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateEthnicity;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateZipCode;
@@ -62,5 +64,11 @@ class CsvValidatorUtilsTest {
     ValueOrError actual = getValue(row, "biological_sex", true);
     String expectedMessage = "biological_sex is a required column.";
     assertThat(actual.getError().get(0).getMessage()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void validCountryCode() {
+    var countryCode = new ValueOrError(COUNTRY_CODES.stream().findAny().get(), "country");
+    assertThat(validateCountry(countryCode)).hasSize(0);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- When trying to upload a CSV file, it was throwing an error on country code stating that "USA" was invalid. 
- The [`COUNTRY_CODE` set](https://github.com/CDCgov/prime-simplereport/blob/main/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java#L287) is all upper case, but in the [validation](https://github.com/CDCgov/prime-simplereport/blob/ae2aca4a256a9f293f8db44fc8d5ba248fb2d3e7/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java#L323) it compares that value with a to lower case value.

## Changes Proposed

- Make a lower case version of country_code.  

## Testing

- This can be tested by attempting to upload a csv file locally on main vs this branch. You can use the curl command below but just change the file location for `file=@"/Users/boban/Downloads/valid_new.csv"' `
```
curl --location --request POST 'http://localhost:8080/upload/patients' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Authorization: Bearer SR-DEMO-LOGIN bob@example.com' \
--header 'Connection: keep-alive' \
--header 'Origin: http://localhost:3000' \
--header 'Referer: http://localhost:3000/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36' \
--header 'sec-ch-ua: "Google Chrome";v="107", "Chromium";v="107", "Not=A?Brand";v="24"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--header 'x-ms-session-id;' \
--header 'Cookie: SESSION=NTA0YTkzOWUtY2IyYS00NDdkLWE1ZjctMTkzZTkzODdiZDQ1; userId=00u42i8xnpPMNBCoZ1d7' \
--form 'file=@"/Users/boban/Downloads/valid_new.csv"' \
--form 'rawFacilityId=""'
```
- (NEW) ![image](https://user-images.githubusercontent.com/10108172/201128373-588497a8-8c9b-4804-bf50-6d8d69dc7a0e.png)
- (OLD) 
![image](https://user-images.githubusercontent.com/10108172/201129107-7f69ce2e-c01b-457b-9baa-a784e22f14b1.png)

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

