### PR TITLE
batch save for patients on bulk upload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -153,16 +154,58 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
     this.testResultDeliveryPreference = testResultDeliveryPreference;
   }
 
-  public Person(PersonName names, Organization org, Facility fac) {
+  public Person(
+      Organization organization,
+      Optional<Facility> facility,
+      String lookupId,
+      String firstName,
+      String middleName,
+      String lastName,
+      String suffix,
+      LocalDate birthDate,
+      StreetAddress address,
+      String country,
+      PersonRole role,
+      List<String> emails,
+      String race,
+      String ethnicity,
+      List<String> tribalAffiliation,
+      String gender,
+      Boolean residentCongregateSetting,
+      Boolean employedInHealthcare,
+      String preferredLanguage,
+      TestResultDeliveryPreference testResultDeliveryPreference) {
+    super(organization);
+    if (facility.isPresent()) {
+      this.facility = facility.get();
+    }
+    this.lookupId = lookupId;
+    this.nameInfo = new PersonName(firstName, middleName, lastName, suffix);
+    this.birthDate = birthDate;
+    this.address = address;
+    this.country = country;
+    this.role = role;
+    this.emails = emails;
+    this.race = race;
+    this.ethnicity = ethnicity;
+    this.tribalAffiliation = tribalAffiliation;
+    this.gender = gender;
+    this.residentCongregateSetting = residentCongregateSetting;
+    this.employedInHealthcare = employedInHealthcare;
+    this.preferredLanguage = preferredLanguage;
+    this.testResultDeliveryPreference = testResultDeliveryPreference;
+  }
+
+  public Person(PersonName names, Organization org, Facility facility) {
     super(org);
-    this.facility = fac;
+    this.facility = facility;
     this.nameInfo = names;
     this.role = PersonRole.STAFF;
   }
 
-  public Person(PersonName names, Organization org, Facility fac, PersonRole role) {
+  public Person(PersonName names, Organization org, Facility facility, PersonRole role) {
     super(org);
-    this.facility = fac;
+    this.facility = facility;
     this.nameInfo = names;
     this.role = role;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -175,25 +175,29 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
       Boolean employedInHealthcare,
       String preferredLanguage,
       TestResultDeliveryPreference testResultDeliveryPreference) {
-    super(organization);
+    this(
+        organization,
+        lookupId,
+        firstName,
+        middleName,
+        lastName,
+        suffix,
+        birthDate,
+        address,
+        country,
+        role,
+        emails,
+        race,
+        ethnicity,
+        tribalAffiliation,
+        gender,
+        residentCongregateSetting,
+        employedInHealthcare,
+        preferredLanguage,
+        testResultDeliveryPreference);
     if (facility.isPresent()) {
       this.facility = facility.get();
     }
-    this.lookupId = lookupId;
-    this.nameInfo = new PersonName(firstName, middleName, lastName, suffix);
-    this.birthDate = birthDate;
-    this.address = address;
-    this.country = country;
-    this.role = role;
-    this.emails = emails;
-    this.race = race;
-    this.ethnicity = ethnicity;
-    this.tribalAffiliation = tribalAffiliation;
-    this.gender = gender;
-    this.residentCongregateSetting = residentCongregateSetting;
-    this.employedInHealthcare = employedInHealthcare;
-    this.preferredLanguage = preferredLanguage;
-    this.testResultDeliveryPreference = testResultDeliveryPreference;
   }
 
   public Person(PersonName names, Organization org, Facility facility) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -156,7 +155,7 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
 
   public Person(
       Organization organization,
-      Optional<Facility> facility,
+      Facility facility,
       String lookupId,
       String firstName,
       String middleName,
@@ -195,9 +194,7 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
         employedInHealthcare,
         preferredLanguage,
         testResultDeliveryPreference);
-    if (facility.isPresent()) {
-      this.facility = facility.get();
-    }
+    this.facility = facility;
   }
 
   public Person(PersonName names, Organization org, Facility facility) {
@@ -212,6 +209,22 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
     this.facility = facility;
     this.nameInfo = names;
     this.role = role;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person person = (Person) o;
+    return nameInfo.equals(person.nameInfo)
+        && birthDate.equals(person.birthDate)
+        && Objects.equals(facility, person.facility)
+        && Objects.equals(person.getOrganization(), getOrganization());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nameInfo, birthDate, facility, getOrganization());
   }
 
   public void updatePatient(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -219,7 +219,8 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
     return nameInfo.equals(person.nameInfo)
         && birthDate.equals(person.birthDate)
         && Objects.equals(facility, person.facility)
-        && Objects.equals(person.getOrganization(), getOrganization());
+        && Objects.equals(getOrganization(), person.getOrganization())
+        && (isDeleted() == person.isDeleted());
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -225,7 +225,7 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
 
   @Override
   public int hashCode() {
-    return Objects.hash(nameInfo, birthDate, facility, getOrganization());
+    return Objects.hash(nameInfo, birthDate, facility, getOrganization(), isDeleted());
   }
 
   public void updatePatient(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
@@ -154,7 +154,6 @@ public class PatientBulkUploadService {
                 null,
                 null);
         newPatient.setFacility(assignedFacility); // might be null, that's fine
-        patientsList.add(newPatient);
 
         // collect phone numbers and associate them with the patient, then add to phone numbers list
         List<PhoneNumber> newPhoneNumbers =
@@ -170,6 +169,9 @@ public class PatientBulkUploadService {
         if (!newPhoneNumbers.isEmpty()) {
           newPatient.setPrimaryPhone(newPhoneNumbers.get(0));
         }
+
+        // add new patient to the patients list
+        patientsList.add(newPatient);
       } catch (IllegalArgumentException e) {
         String errorMessage = "Error uploading patient roster";
         log.error(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
@@ -152,23 +152,21 @@ public class PatientBulkUploadService {
                 null // testResultDeliveryPreference
                 );
 
-        if (patientsList.contains(newPatient)) {
-          continue;
+        if (!patientsList.contains(newPatient)) {
+          // collect phone numbers and associate them with the patient
+          // then add to phone numbers list and set primary phone, if exists
+          List<PhoneNumber> newPhoneNumbers =
+              _personService.assignPhoneNumbersToPatient(
+                  newPatient,
+                  List.of(
+                      new PhoneNumber(
+                          parsePhoneType(extractedData.getPhoneNumberType().getValue()),
+                          extractedData.getPhoneNumber().getValue())));
+          phoneNumbersList.addAll(newPhoneNumbers);
+          newPhoneNumbers.stream().findFirst().ifPresent(newPatient::setPrimaryPhone);
+
+          patientsList.add(newPatient);
         }
-
-        // collect phone numbers and associate them with the patient
-        // then add to phone numbers list and set primary phone, if exists
-        List<PhoneNumber> newPhoneNumbers =
-            _personService.assignPhoneNumbersToPatient(
-                newPatient,
-                List.of(
-                    new PhoneNumber(
-                        parsePhoneType(extractedData.getPhoneNumberType().getValue()),
-                        extractedData.getPhoneNumber().getValue())));
-        phoneNumbersList.addAll(newPhoneNumbers);
-        newPhoneNumbers.stream().findFirst().ifPresent(newPatient::setPrimaryPhone);
-
-        patientsList.add(newPatient);
       } catch (IllegalArgumentException e) {
         String errorMessage = "Error uploading patient roster";
         log.error(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
@@ -131,16 +131,6 @@ public class PatientBulkUploadService {
           continue;
         }
 
-        // create new person
-        // - pass in the organization they belong to, as saved up above
-        // - set facility on person
-        // add person to person list
-        // create List of Phone numbers for that person following PersonService steps
-        // add phone numbers to phone numbers list
-        // exit while loop
-        // do the save for persons and phone numbers
-        // see how much better it is
-
         // create new person with current organization, then add to new patients list
         Person newPatient =
             new Person(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
@@ -25,7 +25,11 @@ import gov.cdc.usds.simplereport.validators.PatientBulkUploadFileValidator.Patie
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -16,13 +16,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Size;
 import org.springframework.data.domain.PageRequest;
@@ -370,13 +364,11 @@ public class PersonService {
   /** This method associates PhoneNumbers with a new patient and ensures there are no duplicates */
   public List<PhoneNumber> assignPhoneNumbersToPatient(Person person, List<PhoneNumber> incoming) {
     if (incoming == null) {
-      return null;
+      return List.of();
     }
 
     // we don't want to allow a patient to have any duplicate phone numbers
-    List<PhoneNumber> deduplicatedPhoneNumbers = deduplicatePhoneNumbers(person, incoming);
-
-    return deduplicatedPhoneNumbers;
+    return deduplicatePhoneNumbers(person, incoming);
   }
 
   /**

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -264,7 +264,7 @@ public class PersonService {
   }
 
   @AuthorizationConfiguration.RequirePermissionCreatePatientAtFacility
-  public void addPatientsAndPhoneNumbers(List<Person> patients, List<PhoneNumber> phoneNumbers) {
+  public void addPatientsAndPhoneNumbers(Set<Person> patients, List<PhoneNumber> phoneNumbers) {
     _repo.saveAll(patients);
     _phoneRepo.saveAll(phoneNumbers);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -265,10 +265,10 @@ public class PersonService {
 
   @AuthorizationConfiguration.RequirePermissionCreatePatientAtFacility
   public void addPatientsAndPhoneNumbers(Set<Person> patients, List<PhoneNumber> phoneNumbers) {
-    if (patients.size() > 0) {
+    if (!patients.isEmpty()) {
       _repo.saveAll(patients);
     }
-    if (phoneNumbers.size() > 0) {
+    if (!phoneNumbers.isEmpty()) {
       _phoneRepo.saveAll(phoneNumbers);
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -265,8 +265,12 @@ public class PersonService {
 
   @AuthorizationConfiguration.RequirePermissionCreatePatientAtFacility
   public void addPatientsAndPhoneNumbers(Set<Person> patients, List<PhoneNumber> phoneNumbers) {
-    _repo.saveAll(patients);
-    _phoneRepo.saveAll(phoneNumbers);
+    if (patients.size() > 0) {
+      _repo.saveAll(patients);
+    }
+    if (phoneNumbers.size() > 0) {
+      _phoneRepo.saveAll(phoneNumbers);
+    }
   }
 
   @AuthorizationConfiguration.RequirePermissionCreatePatientAtFacility

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -16,13 +16,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Size;
 import org.springframework.data.domain.PageRequest;
@@ -264,6 +258,12 @@ public class PersonService {
   }
 
   @AuthorizationConfiguration.RequirePermissionCreatePatientAtFacility
+  public void addPatientsAndPhoneNumbers(List<Person> patients, List<PhoneNumber> phoneNumbers) {
+    _repo.saveAll(patients);
+    _phoneRepo.saveAll(phoneNumbers);
+  }
+
+  @AuthorizationConfiguration.RequirePermissionCreatePatientAtFacility
   public Person addPatient(
       UUID facilityId,
       String lookupId,
@@ -361,6 +361,18 @@ public class PersonService {
     return savedPerson;
   }
 
+  /** This method associates PhoneNumbers with a new patient and ensures there are no duplicates */
+  public List<PhoneNumber> assignPhoneNumbersToPatient(Person person, List<PhoneNumber> incoming) {
+    if (incoming == null) {
+      return null;
+    }
+
+    // we don't want to allow a patient to have any duplicate phone numbers
+    List<PhoneNumber> deduplicatedPhoneNumbers = deduplicatePhoneNumbers(person, incoming);
+
+    return deduplicatedPhoneNumbers;
+  }
+
   /**
    * This method updates the PhoneNumbers provided by adding/deleting them from the
    * PhoneNumberRepository. It updates the PrimaryPhone on the Person, but does <em>not</em> save
@@ -372,6 +384,22 @@ public class PersonService {
     }
 
     // we don't want to allow a patient to have any duplicate phone numbers
+    List<PhoneNumber> deduplicatedPhoneNumbers = deduplicatePhoneNumbers(person, incoming);
+
+    var existingNumbers = person.getPhoneNumbers();
+
+    if (existingNumbers != null) {
+      _phoneRepo.deleteAll(existingNumbers);
+    }
+
+    _phoneRepo.saveAll(deduplicatedPhoneNumbers);
+
+    if (!deduplicatedPhoneNumbers.isEmpty()) {
+      person.setPrimaryPhone(deduplicatedPhoneNumbers.get(0));
+    }
+  }
+
+  private List<PhoneNumber> deduplicatePhoneNumbers(Person person, List<PhoneNumber> incoming) {
     Set<String> phoneNumbersSeen = new HashSet<>();
     incoming.forEach(
         phoneNumber -> {
@@ -381,18 +409,7 @@ public class PersonService {
           }
           phoneNumbersSeen.add(phoneNumber.getNumber());
         });
-
-    var existingNumbers = person.getPhoneNumbers();
-
-    if (existingNumbers != null) {
-      _phoneRepo.deleteAll(existingNumbers);
-    }
-
-    _phoneRepo.saveAll(incoming);
-
-    if (!incoming.isEmpty()) {
-      person.setPrimaryPhone(incoming.get(0));
-    }
+    return incoming;
   }
 
   @AuthorizationConfiguration.RequirePermissionStartTestForPatientById

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -16,7 +16,13 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Size;
 import org.springframework.data.domain.PageRequest;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceIntegrationTest.java
@@ -99,6 +99,17 @@ class PatientBulkUploadServiceIntegrationTest extends BaseServiceTest<PatientBul
   }
 
   @Test
+  void noPhoneNumberTypes_savesPatient() {
+    // WHEN
+    InputStream inputStream = loadCsv("patientBulkUpload/noPhoneNumberTypes.csv");
+    PatientBulkUploadResponse response = this._service.processPersonCSV(inputStream, null);
+
+    // THEN
+    assertThat(response.getStatus()).isEqualTo(UploadStatus.SUCCESS);
+    assertThat(getPatients()).hasSize(1);
+  }
+
+  @Test
   void duplicatePatient_isNotSaved() {
     // GIVEN
     personService.addPatient(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceIntegrationTest.java
@@ -134,6 +134,17 @@ class PatientBulkUploadServiceIntegrationTest extends BaseServiceTest<PatientBul
   }
 
   @Test
+  void duplicatePatient_isNotAddedToBatch() {
+    // WHEN
+    InputStream inputStream = loadCsv("patientBulkUpload/duplicatePatients.csv");
+    PatientBulkUploadResponse response = this._service.processPersonCSV(inputStream, null);
+
+    // THEN
+    assertThat(response.getStatus()).isEqualTo(UploadStatus.SUCCESS);
+    assertThat(getPatients()).hasSize(1);
+  }
+
+  @Test
   void patientSavedToSingleFacility_successful() {
     // GIVEN
     InputStream inputStream = loadCsv("patientBulkUpload/valid.csv");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -376,7 +376,7 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
     List<PhoneNumber> assignedPhoneNumbers =
         _service.assignPhoneNumbersToPatient(person, phoneNumbers);
 
-    assertEquals(assignedPhoneNumbers.size(), 0);
+    assertEquals(0, assignedPhoneNumbers.size());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -18,6 +18,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import gov.cdc.usds.simplereport.db.repository.PatientRegistrationLinkRepository;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyAllFacilitiesUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportEntryOnlyUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
@@ -296,6 +297,49 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
                     "English",
                     null));
     assertEquals("Duplicate phone number entered", e.getMessage());
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void assignPhoneNumberToPatient_noDuplicates_success() {
+    Facility facility = _dataFactory.createValidFacility(_orgService.getCurrentOrganization());
+    UUID facilityId = facility.getInternalId();
+
+    Person person =
+        _service.addPatient(
+            facilityId,
+            null,
+            "John",
+            null,
+            "Doe",
+            null,
+            LocalDate.of(1990, 01, 01),
+            _dataFactory.getAddress(),
+            "USA",
+            null,
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "English",
+            TestResultDeliveryPreference.NONE);
+    UUID personInternalId = person.getInternalId();
+
+    List<PhoneNumber> phoneNumbers = new ArrayList<>();
+    phoneNumbers.add(new PhoneNumber(PhoneType.MOBILE, "2342342344"));
+    phoneNumbers.add(new PhoneNumber(PhoneType.LANDLINE, "2342342345"));
+    phoneNumbers.add(new PhoneNumber(PhoneType.LANDLINE, "2342342346"));
+
+    List<PhoneNumber> assignedPhoneNumbers =
+        _service.assignPhoneNumbersToPatient(person, phoneNumbers);
+
+    assertEquals(assignedPhoneNumbers.get(0).getPersonInternalID(), personInternalId);
+    assertEquals(assignedPhoneNumbers.get(1).getPersonInternalID(), personInternalId);
+    assertEquals(assignedPhoneNumbers.get(2).getPersonInternalID(), personInternalId);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -343,6 +343,43 @@ class PersonServiceTest extends BaseServiceTest<PersonService> {
   }
 
   @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void assignPhoneNumberToPatient_noNumbers_success() {
+    Facility facility = _dataFactory.createValidFacility(_orgService.getCurrentOrganization());
+    UUID facilityId = facility.getInternalId();
+
+    Person person =
+        _service.addPatient(
+            facilityId,
+            null,
+            "John",
+            null,
+            "Doe",
+            null,
+            LocalDate.of(1990, 01, 01),
+            _dataFactory.getAddress(),
+            "USA",
+            null,
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "English",
+            TestResultDeliveryPreference.NONE);
+
+    List<PhoneNumber> phoneNumbers = new ArrayList<>();
+
+    List<PhoneNumber> assignedPhoneNumbers =
+        _service.assignPhoneNumbersToPatient(person, phoneNumbers);
+
+    assertEquals(assignedPhoneNumbers.size(), 0);
+  }
+
+  @Test
   @WithSimpleReportStandardUser
   void deletePatient_standardUser_successDependsOnFacilityAccess() {
     Facility fac = _dataFactory.createValidFacility(_orgService.getCurrentOrganization());

--- a/backend/src/test/resources/patientBulkUpload/duplicatePatients.csv
+++ b/backend/src/test/resources/patientBulkUpload/duplicatePatients.csv
@@ -1,0 +1,3 @@
+last_name,first_name,middle_name,suffix,race,date_of_birth,biological_sex,ethnicity,street,street_2,city,county,state,zip_code,phone_number,phone_number_type,employed_in_healthcare,resident_congregate_setting,role,email
+Doe,Jane,Amanda,,black or african american,11/3/1980,Female,not hispanic or latino,1234 Main Street,Apt 2,Anchorage,,AK,99501,410-867-5309,mobile,No,No,Staff,jane@testingorg.com
+Doe,Jane,Amanda,,black or african american,11/3/1980,Female,not hispanic or latino,1234 Main Street,Apt 2,Anchorage,,AK,99501,410-867-5309,mobile,No,No,Staff,jane@testingorg.com

--- a/backend/src/test/resources/patientBulkUpload/noPhoneNumberTypes.csv
+++ b/backend/src/test/resources/patientBulkUpload/noPhoneNumberTypes.csv
@@ -1,0 +1,2 @@
+last_name,first_name,middle_name,suffix,race,date_of_birth,biological_sex,ethnicity,street,street_2,city,county,state,zip_code,phone_number,employed_in_healthcare,resident_congregate_setting,role,email
+Doe,Jane,Amanda,,black or african american,11/3/1980,Female,not hispanic or latino,1234 Main Street,Apt 2,Anchorage,,AK,99501,617-456-7890,No,No,Staff,jane@testingorg.com

--- a/backend/src/test/resources/patientBulkUpload/noPhoneNumbers.csv
+++ b/backend/src/test/resources/patientBulkUpload/noPhoneNumbers.csv
@@ -1,2 +1,0 @@
-last_name,first_name,middle_name,suffix,race,date_of_birth,biological_sex,ethnicity,street,street_2,city,county,state,zip_code,phone_number,phone_number_type,employed_in_healthcare,resident_congregate_setting,role,email
-Doe,Jane,Amanda,,black or african american,11/3/1980,Female,not hispanic or latino,1234 Main Street,Apt 2,Anchorage,,AK,99501,410-867-5309,mobile,No,No,Staff,jane@testingorg.com

--- a/backend/src/test/resources/patientBulkUpload/noPhoneNumbers.csv
+++ b/backend/src/test/resources/patientBulkUpload/noPhoneNumbers.csv
@@ -1,0 +1,2 @@
+last_name,first_name,middle_name,suffix,race,date_of_birth,biological_sex,ethnicity,street,street_2,city,county,state,zip_code,phone_number,phone_number_type,employed_in_healthcare,resident_congregate_setting,role,email
+Doe,Jane,Amanda,,black or african american,11/3/1980,Female,not hispanic or latino,1234 Main Street,Apt 2,Anchorage,,AK,99501,410-867-5309,mobile,No,No,Staff,jane@testingorg.com


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue #4662

- Number 1 of 2 PRs. This PR implements batch save, next one will likely be implementing async behavior
- Previously we were calling `repo.save` for every patient in bulk upload, this is very slow because it opened and closed a db connection for every new patient and their associated phone numbers. We want to batch this to improve efficiency.

## Changes Proposed

- Move actions that only need to happen once out of iteration
  - organization and facility only need to be fetched once
- Add patients and phone numbers to a list iteratively during validation, and batch save them with `repo.saveAll` after the iteration is complete

## Additional Information

- I did not delete any existing functions, those are used in other places, therefore should remain backwards compatible.
- These changes decreased processing time approx 75% (locally)
Before - 6.6min
![Screen Shot 2022-11-08 at 4 06 37 PM](https://user-images.githubusercontent.com/89797785/201225564-f3b544af-28f9-413f-a426-f8bc767484b8.png)
After - local, 1.5min
![Screen Shot 2022-11-10 at 5 44 37 PM](https://user-images.githubusercontent.com/89797785/201225524-e027c6f0-01d8-408c-8d1d-e8b5658f4ee8.png)
After - in dev2 environment, 41.66s
![Screen Shot 2022-11-14 at 11 00 50 AM](https://user-images.githubusercontent.com/89797785/201707157-8f248c00-1727-45f8-beab-afce7d223951.png)



## Testing

- Confirm that uploading a CSV works as expected,  **currently deployed on dev2**
  - invalid CSVs work like before
  - valid CSVs work like before but faster
  - make sure duplicate records in the csv don't get saved twice in the db

## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] GraphQL schema changes are backward compatible with older version of the front-end - **no changes here**
- [ ] Changes comply with the SimpleReport Style Guide