### PR TITLE
Add DOD clia validation

### DIFF
--- a/frontend/src/app/utils/clia.ts
+++ b/frontend/src/app/utils/clia.ts
@@ -20,6 +20,8 @@ export function isValidCLIANumber(input: string, state: string): boolean {
     return true;
   } else if (state === "WY" && input === "12Z3456789") {
     return true;
+  } else if (input.substring(0, 3) === "DOD") {
+    cliaNumberValidator = /^DOD\d{7}$/;
   } else {
     cliaNumberValidator = /^\d{2}D\d{7}$/;
   }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #4401 

## Changes Proposed

- Update CLIA validator to accept DOD CLIA numbers

## Additional Information

- We got another request about this in the support inbox today
- ReportStream is able to accept any alphanumeric with length 10, so this will still pass their filters

## Testing

- Able to add a facility with a DOD CLIA # 
