### PR TITLE
add additional headers to report stream uploader

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.test.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.test.ts
@@ -232,7 +232,7 @@ describe("lib", () => {
     it("calls fetch with topic", async () => {
       // GIVEN
       fetchMock.mockResponseOnce("yup");
-      process.env["REPORT_STREAM_TOPIC"] = "mytopic";
+      process.env.REPORT_STREAM_TOPIC = "mytopic";
 
       // WHEN
       await uploadResult("whatever");
@@ -251,7 +251,7 @@ describe("lib", () => {
         body: "whatever"
       });
 
-      delete process.env["REPORT_STREAM_TOPIC"];
+      delete process.env.REPORT_STREAM_TOPIC;
     })
   });
 

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -20,6 +20,7 @@ const {
   REPORT_STREAM_BATCH_MAXIMUM,
   REPORT_STREAM_TOKEN,
   REPORT_STREAM_URL,
+  REPORT_STREAM_CLIENT,
   AZ_STORAGE_ACCOUNT_KEY,
   AZ_STORAGE_ACCOUNT_NAME,
   AZ_STORAGE_QUEUE_SVC_URL,
@@ -127,8 +128,11 @@ export async function uploadResult(body) {
     "x-functions-key": REPORT_STREAM_TOKEN,
     "x-api-version": uploaderVersion,
     "content-type": "text/csv",
-    client: "simple_report",
+    client: REPORT_STREAM_CLIENT
   });
+  if(process.env["REPORT_STREAM_TOPIC"]){
+    headers.set("topic", process.env["REPORT_STREAM_TOPIC"]);
+  }
   return fetch(REPORT_STREAM_URL, {
     method: "POST",
     headers,

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -130,8 +130,8 @@ export async function uploadResult(body) {
     "content-type": "text/csv",
     client: REPORT_STREAM_CLIENT
   });
-  if(process.env["REPORT_STREAM_TOPIC"]){
-    headers.set("topic", process.env["REPORT_STREAM_TOPIC"]);
+  if(process.env.REPORT_STREAM_TOPIC){
+    headers.set("topic", process.env.REPORT_STREAM_TOPIC);
   }
   return fetch(REPORT_STREAM_URL, {
     method: "POST",

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/config.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/config.ts
@@ -26,6 +26,7 @@ export const ENV = (() => {
     REPORT_STREAM_BATCH_MINIMUM: "minimum # of messages to read from the queue",
     REPORT_STREAM_BATCH_MAXIMUM:
       "maximum # of messages to send to ReportStream",
+    REPORT_STREAM_CLIENT: "client name",
     SIMPLE_REPORT_CB_URL: "SimpleReport webhook URL for ReportStream exceptions",
     SIMPLE_REPORT_CB_TOKEN: "API token for the SimpleReport webhook for ReportStream exceptions"
   };

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
@@ -56,4 +56,3 @@ variable "report_stream_client" {
   type    = string
   default = "simple_report"
 }
-

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
@@ -51,3 +51,9 @@ variable "report_stream_batch_maximum" {
 }
 
 variable "lb_subnet_id" {}
+
+variable "report_stream_client" {
+  type    = string
+  default = "simple_report"
+}
+

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -96,6 +96,7 @@ resource "azurerm_function_app" "functions" {
     REPORT_STREAM_TOKEN            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     REPORT_STREAM_BATCH_MINIMUM    = var.report_stream_batch_minimum
     REPORT_STREAM_BATCH_MAXIMUM    = var.report_stream_batch_maximum
+    REPORT_STREAM_CLIENT           = var.report_stream_client
     SIMPLE_REPORT_CB_URL           = local.simple_report_callback_url
     SIMPLE_REPORT_CB_TOKEN         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #4523 
- New headers for flu are needed in the request to report stream

## Changes Proposed

- Make `REPORT_STREAM_CLIENT` and `TOPIC` configurable

## Additional Information

- Additional function app will be created and deployed in ticket #4524 

## Testing

- Regression Testing - Add test events in dev4 and verify there are no issues with the current function app during result uploading to result stream.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
