### PR TITLE
Refactor test queue

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -4,7 +4,6 @@ import gov.cdc.usds.simplereport.api.model.facets.LocatedWrapper;
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
-import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
 import java.util.List;
 import java.util.Optional;
@@ -45,10 +44,6 @@ public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapp
 
   public DeviceType getDefaultDeviceType() {
     return getWrapped().getDefaultDeviceType();
-  }
-
-  public SpecimenType getDefaultSpecimenType() {
-    return getWrapped().getDefaultSpecimenType();
   }
 
   public DeviceSpecimenType getDefaultDeviceSpecimen() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -4,6 +4,7 @@ import gov.cdc.usds.simplereport.api.model.facets.LocatedWrapper;
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,10 @@ public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapp
 
   public DeviceType getDefaultDeviceType() {
     return getWrapped().getDefaultDeviceType();
+  }
+
+  public SpecimenType getDefaultSpecimenType() {
+    return getWrapped().getDefaultSpecimenType();
   }
 
   public DeviceSpecimenType getDefaultDeviceSpecimen() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -11,6 +11,7 @@ import gov.cdc.usds.simplereport.service.model.OrganizationRoles;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
@@ -87,5 +88,13 @@ public class OrganizationResolver {
       facilities.addAll(_organizationService.getArchivedFacilities());
     }
     return facilities.stream().map(ApiFacility::new).collect(Collectors.toSet());
+  }
+
+  @QueryMapping
+  public Optional<ApiFacility> facility(@Argument UUID id) {
+    Set<Facility> facilities = _organizationService.getAccessibleFacilities();
+    Optional<Facility> facility =
+        facilities.stream().filter(f -> f.getInternalId().equals(id)).findFirst();
+    return facility.map(ApiFacility::new);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/ApiTestOrderDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/ApiTestOrderDataResolver.java
@@ -5,6 +5,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.PatientAnswersRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import java.time.LocalDate;
@@ -90,6 +91,11 @@ public class ApiTestOrderDataResolver {
   @SchemaMapping(typeName = "TestOrder", field = "deviceType")
   public DeviceType deviceType(ApiTestOrder apiTestOrder) {
     return apiTestOrder.getWrapped().getDeviceType();
+  }
+
+  @SchemaMapping(typeName = "TestOrder", field = "specimenType")
+  public SpecimenType specimenType(ApiTestOrder apiTestOrder) {
+    return apiTestOrder.getWrapped().getSpecimenType();
   }
 
   @SchemaMapping(typeName = "TestOrder", field = "results")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -55,6 +55,19 @@ public class QueueMutationResolver {
   }
 
   @MutationMapping
+  public AddTestResultResponse submitQueueItem(
+      @Argument UUID deviceTypeId,
+      @Argument UUID specimenTypeId,
+      @Argument List<MultiplexResultInput> results,
+      @Argument UUID patientId,
+      @Argument Date dateTested) {
+    UUID deviceSpecimenTypeId =
+        _dts.getDeviceSpecimenType(deviceTypeId, specimenTypeId).getInternalId();
+
+    return _tos.addMultiplexResult(deviceSpecimenTypeId, results, patientId, dateTested);
+  }
+
+  @MutationMapping
   public ApiTestOrder editQueueItemMultiplexResult(
       @Argument UUID id,
       @Argument String deviceId,
@@ -64,6 +77,20 @@ public class QueueMutationResolver {
     UUID dst = getDeviceSpecimenTypeId(deviceId, deviceSpecimenType);
 
     return new ApiTestOrder(_tos.editQueueItemMultiplexResult(id, dst, results, dateTested));
+  }
+
+  @MutationMapping
+  public ApiTestOrder editQueueItem(
+      @Argument UUID id,
+      @Argument UUID deviceTypeId,
+      @Argument UUID specimenTypeId,
+      @Argument List<MultiplexResultInput> results,
+      @Argument Date dateTested) {
+    UUID deviceSpecimenTypeId =
+        _dts.getDeviceSpecimenType(deviceTypeId, specimenTypeId).getInternalId();
+
+    return new ApiTestOrder(
+        _tos.editQueueItemMultiplexResult(id, deviceSpecimenTypeId, results, dateTested));
   }
 
   @MutationMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -115,6 +115,10 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
     return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getDeviceType();
   }
 
+  public SpecimenType getDefaultSpecimenType() {
+    return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getSpecimenType();
+  }
+
   public void addDeviceType(DeviceType device) {
     initializeDeviceTypesSet();
     configuredDeviceTypes.add(device);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -115,6 +115,10 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
     return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getDeviceType();
   }
 
+  public SpecimenType getDefaultSpecimenType() {
+    return defaultSpecimenType;
+  }
+
   public void addDeviceType(DeviceType device) {
     initializeDeviceTypesSet();
     configuredDeviceTypes.add(device);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -115,10 +115,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
     return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getDeviceType();
   }
 
-  public SpecimenType getDefaultSpecimenType() {
-    return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getSpecimenType();
-  }
-
   public void addDeviceType(DeviceType device) {
     initializeDeviceTypesSet();
     configuredDeviceTypes.add(device);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
@@ -24,5 +24,9 @@ public interface DeviceSpecimenTypeRepository
   @EntityGraph(attributePaths = {"deviceType", "specimenType"})
   Optional<DeviceSpecimenType> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId);
 
+  @EntityGraph(attributePaths = {"deviceType", "specimenType"})
+  Optional<DeviceSpecimenType> findByDeviceTypeInternalIdAndSpecimenTypeInternalIdOrderByCreatedAt(
+      UUID deviceTypeId, UUID specimenTypeId);
+
   List<DeviceSpecimenType> findAllByDeviceType(DeviceType deviceType);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -99,8 +99,7 @@ public class DeviceTypeService {
             deviceTypeId, specimenTypeId)
         .orElseThrow(
             () ->
-                new IllegalGraphqlArgumentException(
-                    "Device is not configured with a specimen type"));
+                new IllegalGraphqlArgumentException("Not a valid device and specimen combination"));
   }
 
   @Transactional(readOnly = false)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -93,6 +93,16 @@ public class DeviceTypeService {
                     "Device is not configured with a specimen type"));
   }
 
+  public DeviceSpecimenType getDeviceSpecimenType(UUID deviceTypeId, UUID specimenTypeId) {
+    return _deviceSpecimenRepo
+        .findByDeviceTypeInternalIdAndSpecimenTypeInternalIdOrderByCreatedAt(
+            deviceTypeId, specimenTypeId)
+        .orElseThrow(
+            () ->
+                new IllegalGraphqlArgumentException(
+                    "Device is not configured with a specimen type"));
+  }
+
   @Transactional(readOnly = false)
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public DeviceType updateDeviceType(UpdateDeviceType updateDevice) {

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -29,11 +29,12 @@ type Facility {
   zipCode: String
   phone: String
   email: String
-  deviceTypes: [DeviceType]
+  deviceTypes: [DeviceType!]!
   defaultDeviceSpecimen: ID
   deviceSpecimenTypes: [DeviceSpecimenType]
     @deprecated(reason: "kept for compatibility")
-  defaultDeviceType: DeviceType @deprecated(reason: "kept for compatibility")
+  defaultDeviceType: DeviceType
+  defaultSpecimenType: SpecimenType
   orderingProvider: Provider
   patientSelfRegistrationLink: String
   isDeleted: Boolean
@@ -86,7 +87,7 @@ type DeviceType {
   swabType: String
   swabTypes: [SpecimenType!]!
   supportedDiseases: [SupportedDisease!]!
-  testLength: Int
+  testLength: Int!
 }
 
 type SupportedDisease {
@@ -181,8 +182,8 @@ type Patient
   @requiredPermissions(
     anyOf: ["READ_PATIENT_LIST", "SEARCH_PATIENTS", "UPDATE_TEST"]
   ) {
-  id: ID
-  internalId: ID @deprecated(reason: "alias for 'id'")
+  id: ID!
+  internalId: ID! @deprecated(reason: "alias for 'id'")
   facility: Facility
   lookupId: String
   name: NameInfo
@@ -227,18 +228,19 @@ type Patient
 }
 # TestResult and TestOrder should have the same properties
 type TestOrder {
-  id: ID
-  internalId: ID @deprecated(reason: "alias for 'id'")
-  patient: Patient
-  dateAdded: String
+  id: ID!
+  internalId: ID! @deprecated(reason: "alias for 'id'")
+  patient: Patient!
+  dateAdded: String!
   pregnancy: String
   noSymptoms: Boolean
   symptoms: String
   symptomOnset: LocalDate
-  deviceType: DeviceType
-  deviceSpecimenType: DeviceSpecimenType
+  deviceType: DeviceType!
+  specimenType: SpecimenType!
+  deviceSpecimenType: DeviceSpecimenType!
   result: String @deprecated(reason: "use results as source of truth")
-  results: [MultiplexResult]
+  results: [MultiplexResult!]!
   dateTested: DateTime
   correctionStatus: String
   reasonForCorrection: String
@@ -368,6 +370,7 @@ type Query {
     showArchived: Boolean = false
       @requiredPermissions(allOf: ["VIEW_ARCHIVED_FACILITIES"])
   ): [Facility]
+  facility(id: ID!): Facility
   patients(
     facilityId: ID
     pageNumber: Int = 0
@@ -399,7 +402,7 @@ type Query {
     birthDate: LocalDate!
     facilityId: ID
   ): Boolean
-  queue(facilityId: ID!): [TestOrder]
+  queue(facilityId: ID!): [TestOrder!]!
     @requiredPermissions(anyOf: ["START_TEST", "UPDATE_TEST", "SUBMIT_TEST"])
   specimenTypes: [SpecimenType!]!
   testResults(
@@ -673,10 +676,24 @@ type Mutation {
     patientId: ID!
     dateTested: DateTime
   ): AddTestResultResponse @requiredPermissions(allOf: ["SUBMIT_TEST"])
+  submitQueueItem(
+    deviceTypeId: ID!
+    specimenTypeId: ID!
+    results: [MultiplexResultInput]!
+    patientId: ID!
+    dateTested: DateTime
+  ): AddTestResultResponse @requiredPermissions(allOf: ["SUBMIT_TEST"])
   editQueueItemMultiplexResult(
     id: ID!
     deviceId: String
     deviceSpecimenType: ID
+    results: [MultiplexResultInput]
+    dateTested: DateTime
+  ): TestOrder @requiredPermissions(allOf: ["UPDATE_TEST"])
+  editQueueItem(
+    id: ID!
+    deviceTypeId: ID
+    specimenTypeId: ID
     results: [MultiplexResultInput]
     dateTested: DateTime
   ): TestOrder @requiredPermissions(allOf: ["UPDATE_TEST"])

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -34,7 +34,6 @@ type Facility {
   deviceSpecimenTypes: [DeviceSpecimenType]
     @deprecated(reason: "kept for compatibility")
   defaultDeviceType: DeviceType
-  defaultSpecimenType: SpecimenType
   orderingProvider: Provider
   patientSelfRegistrationLink: String
   isDeleted: Boolean

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -401,7 +401,7 @@ type Query {
     birthDate: LocalDate!
     facilityId: ID
   ): Boolean
-  queue(facilityId: ID!): [TestOrder!]!
+  queue(facilityId: ID!): [TestOrder]
     @requiredPermissions(anyOf: ["START_TEST", "UPDATE_TEST", "SUBMIT_TEST"])
   specimenTypes: [SpecimenType!]!
   testResults(

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -33,7 +33,7 @@ type Facility {
   defaultDeviceSpecimen: ID
   deviceSpecimenTypes: [DeviceSpecimenType]
     @deprecated(reason: "kept for compatibility")
-  defaultDeviceType: DeviceType
+  defaultDeviceType: DeviceType @deprecated(reason: "kept for compatibility")
   orderingProvider: Provider
   patientSelfRegistrationLink: String
   isDeleted: Boolean

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -99,7 +99,7 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     MultiplexResultInput multiplexResultInput =
         new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE);
     args.put("results", List.of(multiplexResultInput));
-    runQuery("add-multiplex-result-mutation", args, "Something went wrong");
+    runQuery("submit-queue-item", args, "Something went wrong");
     verify(auditLoggerServiceSpy).logEvent(_eventCaptor.capture());
     ConsoleApiAuditEvent event = _eventCaptor.getValue();
     assertEquals(List.of("addMultiplexResult"), event.getGraphqlErrorPaths());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -96,13 +96,14 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
     useOrgUserAllFacilityAccess();
     HashMap<String, Object> args = patientArgs();
     args.put("deviceId", facility.getDefaultDeviceType().getInternalId().toString());
+    args.put("specimenId", facility.getDefaultSpecimenType().getInternalId().toString());
     MultiplexResultInput multiplexResultInput =
         new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE);
     args.put("results", List.of(multiplexResultInput));
     runQuery("submit-queue-item", args, "Something went wrong");
     verify(auditLoggerServiceSpy).logEvent(_eventCaptor.capture());
     ConsoleApiAuditEvent event = _eventCaptor.getValue();
-    assertEquals(List.of("addMultiplexResult"), event.getGraphqlErrorPaths());
+    assertEquals(List.of("submitQueueItem"), event.getGraphqlErrorPaths());
   }
 
   // I tweaked the behavior to not return the original error message in order to improve security

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -70,10 +71,25 @@ class QueueManagementTest extends BaseGraphqlTest {
     ArrayNode queueData = fetchQueue();
     assertEquals(1, queueData.size());
     JsonNode queueEntry = queueData.get(0);
-    String symptomOnset = queueEntry.get("symptomOnset").asText();
-    assertEquals("2020-11-30", symptomOnset);
-    // this assertion is kind of extra, should be on a patient management
-    // test instead
+    System.out.println(queueEntry);
+
+    assertNotNull(queueEntry.get("internalId").asText());
+    assertNotNull(queueEntry.get("dateAdded").asText());
+    assertNotNull(queueEntry.get("symptoms").asText());
+    assertEquals("2020-11-30", queueEntry.get("symptomOnset").asText());
+    assertEquals("ORIGINAL", queueEntry.get("correctionStatus").asText());
+
+    assertNotNull(queueEntry.get("deviceType").get("internalId").asText());
+    assertEquals("LumiraDX", queueEntry.get("deviceType").get("name").asText());
+    assertEquals(
+        "LumiraDx SARS-CoV-2 Ag Test*", queueEntry.get("deviceType").get("model").asText());
+    assertEquals("15", queueEntry.get("deviceType").get("testLength").asText());
+
+    assertNotNull(queueEntry.get("specimenType").get("internalId").asText());
+    assertEquals("Swab of the Nose", queueEntry.get("specimenType").get("name").asText());
+    assertEquals("445297001", queueEntry.get("specimenType").get("typeCode").asText());
+
+    assertNotNull(queueEntry.get("patient").get("internalId").asText());
     assertEquals("1899-05-10", queueEntry.get("patient").get("birthDate").asText());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -14,6 +14,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.MultiplexResultInput;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
@@ -121,6 +122,7 @@ class TestResultTest extends BaseGraphqlTest {
   void submitTestResult() {
     Person p = _dataFactory.createFullPerson(_org);
     DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
     _dataFactory.createTestOrder(p, _site);
     String dateTested = "2020-12-31T14:30:30.001Z";
 
@@ -128,13 +130,15 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p.getInternalId().toString(),
             "results",
             negativeCovidResult,
             "dateTested",
             dateTested);
-    submitMultiplexResult(variables, Optional.empty());
+    submitQueueItem(variables, Optional.empty());
 
     ArrayNode testResults = fetchTestResults(getFacilityScopedArguments());
 
@@ -146,6 +150,7 @@ class TestResultTest extends BaseGraphqlTest {
   void submitAndFetchMultiplexResult() {
     Person p = _dataFactory.createFullPerson(_org);
     DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
     Map<String, Boolean> symptoms = Map.of("25064002", true);
     LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
     _dataFactory.createTestOrder(
@@ -162,13 +167,15 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p.getInternalId().toString(),
             "results",
             results,
             "dateTested",
             dateTested);
-    submitMultiplexResult(variables, Optional.empty());
+    submitQueueItem(variables, Optional.empty());
 
     ArrayNode testResults = fetchTestResultsMultiplex(getFacilityScopedArguments());
 
@@ -205,6 +212,7 @@ class TestResultTest extends BaseGraphqlTest {
     Person p1 = _dataFactory.createFullPerson(_org);
     Person p2 = _dataFactory.createMinimalPerson(_org, _site);
     DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
     _dataFactory.createTestOrder(p1, _site);
     _dataFactory.createTestOrder(p2, _site);
     String dateTested = "2020-12-31T14:30:30.001Z";
@@ -216,6 +224,8 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p1.getInternalId().toString(),
             "results",
@@ -226,6 +236,8 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p2.getInternalId().toString(),
             "results",
@@ -233,12 +245,12 @@ class TestResultTest extends BaseGraphqlTest {
             "dateTested",
             dateTested);
 
-    submitMultiplexResult(submitP1Variables, Optional.of(ACCESS_ERROR));
-    submitMultiplexResult(submitP2Variables, Optional.of(ACCESS_ERROR));
+    submitQueueItem(submitP1Variables, Optional.of(ACCESS_ERROR));
+    submitQueueItem(submitP2Variables, Optional.of(ACCESS_ERROR));
 
     updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-    submitMultiplexResult(submitP1Variables, Optional.empty());
-    submitMultiplexResult(submitP2Variables, Optional.empty());
+    submitQueueItem(submitP1Variables, Optional.empty());
+    submitQueueItem(submitP2Variables, Optional.empty());
 
     updateSelfPrivileges(Role.USER, false, Set.of());
     Map<String, Object> fetchVariables = getFacilityScopedArguments();
@@ -288,7 +300,10 @@ class TestResultTest extends BaseGraphqlTest {
         _dataFactory.createMinimalPerson(_org, _secondSite, "Lindsay", "L", "Wasserman", "");
 
     DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
+
     DeviceType secondSiteDevice = _secondSite.getDefaultDeviceType();
+    SpecimenType secondSiteSpecimen = _secondSite.getDefaultSpecimenType();
 
     _dataFactory.createTestOrder(p1, _site);
     _dataFactory.createTestOrder(p2, _site);
@@ -300,6 +315,8 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p1.getInternalId().toString(),
             "results",
@@ -310,6 +327,8 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p2.getInternalId().toString(),
             "results",
@@ -320,6 +339,8 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             secondSiteDevice.getInternalId().toString(),
+            "specimenId",
+            secondSiteSpecimen.getInternalId().toString(),
             "patientId",
             p3.getInternalId().toString(),
             "results",
@@ -330,16 +351,18 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             secondSiteDevice.getInternalId().toString(),
+            "specimenId",
+            secondSiteSpecimen.getInternalId().toString(),
             "patientId",
             p4.getInternalId().toString(),
             "results",
             negativeCovidResult,
             "dateTested",
             dateTested);
-    submitMultiplexResult(submitP1Variables, Optional.empty());
-    submitMultiplexResult(submitP2Variables, Optional.empty());
-    submitMultiplexResult(submitP3Variables, Optional.empty());
-    submitMultiplexResult(submitP4Variables, Optional.empty());
+    submitQueueItem(submitP1Variables, Optional.empty());
+    submitQueueItem(submitP2Variables, Optional.empty());
+    submitQueueItem(submitP3Variables, Optional.empty());
+    submitQueueItem(submitP4Variables, Optional.empty());
 
     String startDate = "2020-01-01";
     String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
@@ -383,6 +406,7 @@ class TestResultTest extends BaseGraphqlTest {
     Person p1 = _dataFactory.createFullPerson(_org);
     Person p2 = _dataFactory.createMinimalPerson(_org, _site);
     DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
     _dataFactory.createTestOrder(p1, _site);
     _dataFactory.createTestOrder(p2, _site);
     String dateTested = "2020-12-31T14:30:30.001Z";
@@ -391,6 +415,8 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p1.getInternalId().toString(),
             "results",
@@ -401,14 +427,16 @@ class TestResultTest extends BaseGraphqlTest {
         Map.of(
             "deviceId",
             d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
             "patientId",
             p2.getInternalId().toString(),
             "results",
             negativeCovidResult,
             "dateTested",
             dateTested);
-    submitMultiplexResult(submitP1Variables, Optional.empty());
-    submitMultiplexResult(submitP2Variables, Optional.empty());
+    submitQueueItem(submitP1Variables, Optional.empty());
+    submitQueueItem(submitP2Variables, Optional.empty());
 
     String startDate = "2020-01-01";
     String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
@@ -451,9 +479,9 @@ class TestResultTest extends BaseGraphqlTest {
     return new HashMap<>(Map.of("facilityId", _site.getInternalId().toString()));
   }
 
-  private ObjectNode submitMultiplexResult(
+  private ObjectNode submitQueueItem(
       Map<String, Object> variables, Optional<String> expectedError) {
-    return runQuery("add-multiplex-result-mutation", variables, expectedError.orElse(null));
+    return runQuery("submit-queue-item", variables, expectedError.orElse(null));
   }
 
   private ArrayNode fetchTestResults(Map<String, Object> variables) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -53,7 +53,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
     Map<String, Object> variables =
         Map.of(
             "deviceId", facility.getDefaultDeviceType().getInternalId().toString(),
-            "specimenId", facility.getDefaultDeviceSpecimen().getInternalId().toString(),
+            "specimenId", facility.getDefaultSpecimenType().getInternalId().toString(),
             "patientId", patient.getInternalId().toString(),
             "results",
                 List.of(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -53,6 +53,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
     Map<String, Object> variables =
         Map.of(
             "deviceId", facility.getDefaultDeviceType().getInternalId().toString(),
+            "specimenId", facility.getDefaultDeviceSpecimen().getInternalId().toString(),
             "patientId", patient.getInternalId().toString(),
             "results",
                 List.of(
@@ -365,6 +366,6 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
   }
 
   private JsonNode submitTestResult(Map<String, Object> variables, Optional<String> expectedError) {
-    return runQuery("add-multiplex-result-mutation", variables, expectedError.orElse(null));
+    return runQuery("submit-queue-item", variables, expectedError.orElse(null));
   }
 }

--- a/backend/src/test/resources/graphql-test/edit-queue-item.graphql
+++ b/backend/src/test/resources/graphql-test/edit-queue-item.graphql
@@ -1,7 +1,8 @@
-mutation EditQueueItemMultiplexResult($id: ID!, $deviceId: String, $results: [MultiplexResultInput], $dateTested: DateTime) {
-  editQueueItemMultiplexResult(
+mutation editQueueItem($id: ID!, $deviceId: ID!, $specimenId: ID!, $results: [MultiplexResultInput], $dateTested: DateTime) {
+  editQueueItem(
     id: $id,
-    deviceId: $deviceId,
+    deviceTypeId: $deviceId,
+    specimenTypeId: $specimenId
     results: $results,
     dateTested: $dateTested
   ) {

--- a/backend/src/test/resources/graphql-test/queue-dates-query.graphql
+++ b/backend/src/test/resources/graphql-test/queue-dates-query.graphql
@@ -44,4 +44,23 @@ query fetchFacilityQueue($facilityId: ID!) {
     correctionStatus
     reasonForCorrection
   }
+  facility(id: $facilityId) {
+    name
+    id
+    deviceTypes {
+      internalId
+      name
+      testLength
+      supportedDiseases {
+        internalId
+        name
+        loinc
+      }
+      swabTypes {
+        internalId
+        name
+        typeCode
+      }
+    }
+  }
 }

--- a/backend/src/test/resources/graphql-test/queue-dates-query.graphql
+++ b/backend/src/test/resources/graphql-test/queue-dates-query.graphql
@@ -1,11 +1,47 @@
- query fetchFacilityQueue($facilityId: ID!) {
-    queue(facilityId: $facilityId) {
+query fetchFacilityQueue($facilityId: ID!) {
+  queue(facilityId: $facilityId) {
+    internalId
+    pregnancy
+    dateAdded
+    symptoms
+    symptomOnset
+    noSymptoms
+    deviceType {
       internalId
-      patient {
-        internalId
-        birthDate
-      }
-      symptomOnset
-      dateTested
+      name
+      model
+      testLength
     }
+    specimenType {
+      internalId
+      name
+      typeCode
+    }
+    patient {
+      internalId
+      telephone
+      birthDate
+      firstName
+      middleName
+      lastName
+      gender
+      testResultDelivery
+      preferredLanguage
+      email
+      emails
+      phoneNumbers {
+        type
+        number
+      }
+    }
+    results {
+      disease {
+        name
+      }
+      testResult
+    }
+    dateTested
+    correctionStatus
+    reasonForCorrection
+  }
 }

--- a/backend/src/test/resources/graphql-test/submit-queue-item.graphql
+++ b/backend/src/test/resources/graphql-test/submit-queue-item.graphql
@@ -1,7 +1,8 @@
-mutation addMultiplexResult($deviceId: String!, $results: [MultiplexResultInput]!, $patientId: ID!, $dateTested: DateTime) {
-  addMultiplexResult(
+mutation submitQueueItem($deviceId: ID!, $specimenId: ID!, $results: [MultiplexResultInput]!, $patientId: ID!, $dateTested: DateTime) {
+  submitQueueItem(
     patientId: $patientId,
-    deviceId: $deviceId,
+    deviceTypeId: $deviceId,
+    specimenTypeId: $specimenId,
     results: $results,
     dateTested: $dateTested
   ) {

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -17,7 +17,7 @@ import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import jwtDecode from "jwt-decode";
 
 import {
-  GetFacilityQueueMultiplexDocument,
+  GetFacilityQueueDocument,
   GetTopLevelDashboardMetricsNewDocument,
 } from "../generated/graphql";
 
@@ -141,7 +141,7 @@ const WhoAmIQueryMock = {
 };
 const facilityQueryMock = {
   request: {
-    query: GetFacilityQueueMultiplexDocument,
+    query: GetFacilityQueueDocument,
     fetchPolicy: "no-cache",
     variables: {
       facilityId: "fec4de56-f4cc-4c61-b3d5-76869ca71296",

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -18,6 +18,7 @@ import jwtDecode from "jwt-decode";
 
 import {
   GetFacilityQueueDocument,
+  GetFacilityQueueQuery,
   GetTopLevelDashboardMetricsNewDocument,
 } from "../generated/graphql";
 
@@ -150,34 +151,27 @@ const facilityQueryMock = {
   result: {
     data: {
       queue: [],
-      organization: {
-        testingFacility: [
+      facility: {
+        id: "fec4de56-f4cc-4c61-b3d5-76869ca71296",
+        name: "Testing site",
+        deviceTypes: [
           {
-            id: "fec4de56-f4cc-4c61-b3d5-76869ca71296",
-            deviceTypes: [
-              {
-                internalId: "d70bb3b8-96bd-40d9-a3ce-b266a7edb91d",
-                name: "Quidel Sofia 2",
-                model: "Sofia 2 SARS Antigen FIA",
-                testLength: 15,
-              },
-              {
-                internalId: "5e44dcef-8cc6-44f4-a200-a5b8169ab60a",
-                name: "LumiraDX",
-                model: "LumiraDx SARS-CoV-2 Ag Test*",
-                testLength: 15,
-              },
-            ],
-            defaultDeviceType: {
-              internalId: "5e44dcef-8cc6-44f4-a200-a5b8169ab60a",
-              name: "LumiraDX",
-              model: "LumiraDx SARS-CoV-2 Ag Test*",
-              testLength: 15,
-            },
+            internalId: "d70bb3b8-96bd-40d9-a3ce-b266a7edb91d",
+            name: "Quidel Sofia 2",
+            testLength: 15,
+            supportedDiseases: [],
+            swabTypes: [],
+          },
+          {
+            internalId: "5e44dcef-8cc6-44f4-a200-a5b8169ab60a",
+            name: "LumiraDX",
+            testLength: 15,
+            supportedDiseases: [],
+            swabTypes: [],
           },
         ],
       },
-    },
+    } as GetFacilityQueueQuery,
   },
 };
 const WhoAmIErrorQueryMock = {

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.test.tsx
@@ -4,63 +4,17 @@ import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import { GetManagedFacilitiesDocument } from "../../../generated/graphql";
+import {
+  GetManagedFacilitiesDocument,
+  GetManagedFacilitiesQuery,
+} from "../../../generated/graphql";
 
 import ManageFacilitiesContainer from "./ManageFacilitiesContainer";
-import { deviceTypes } from "./FacilityFormContainer.test";
 
-const deviceSpecimenTypes: DeviceSpecimenType[] = [
-  {
-    internalId: "1",
-    deviceType: {
-      internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
-      name: "Fake Device 1",
-      supportedDiseases: [],
-    },
-    specimenType: {
-      internalId: "fake-specimen-id-1",
-      name: "Fake Specimen 1",
-    },
-  },
-  {
-    internalId: "2",
-    deviceType: {
-      internalId: "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
-      name: "Fake Device 2",
-      supportedDiseases: [],
-    },
-    specimenType: {
-      internalId: "fake-specimen-id-1",
-      name: "Fake Specimen 1",
-    },
-  },
-];
-
-const mockFacility: Facility = {
+const mockFacility = {
   id: "c0d32060-0580-4f8f-9e3d-2e16d65c1629",
   cliaNumber: "99D1234567",
   name: "Testing Site",
-  street: "1001 Rodeo Dr",
-  streetTwo: "qwqweqwe123123",
-  city: "Los Angeles",
-  state: "CA",
-  zipCode: "90000",
-  phone: "(516) 432-1390",
-  email: "testingsite@disorg.com",
-  deviceTypes,
-  orderingProvider: {
-    firstName: "Fred",
-    middleName: null,
-    lastName: "Flintstone",
-    suffix: null,
-    NPI: "PEBBLES",
-    street: "123 Main Street",
-    streetTwo: "",
-    city: "Oz",
-    state: "KS",
-    zipCode: "12345",
-    phone: "(202) 555-1212",
-  },
 };
 
 const store = configureStore([])({
@@ -89,42 +43,10 @@ const mock = [
               id: mockFacility.id,
               cliaNumber: mockFacility.cliaNumber,
               name: mockFacility.name,
-              street: mockFacility.street,
-              streetTwo: mockFacility.streetTwo,
-              city: mockFacility.city,
-              state: mockFacility.state,
-              zipCode: mockFacility.zipCode,
-              phone: mockFacility.phone,
-              email: mockFacility.email,
-              defaultDeviceType: {
-                internalId: deviceSpecimenTypes[0].internalId,
-              },
-              deviceTypes: [
-                {
-                  internalId: deviceSpecimenTypes[0].internalId,
-                },
-                {
-                  internalId: deviceSpecimenTypes[1].internalId,
-                },
-              ],
-              deviceSpecimenTypes,
-              orderingProvider: {
-                firstName: "Fred",
-                middleName: null,
-                lastName: "Flintstone",
-                suffix: null,
-                NPI: "PEBBLES",
-                street: "123 Main Street",
-                streetTwo: "",
-                city: "Oz",
-                state: "KS",
-                zipCode: "12345",
-                phone: "(202) 555-1212",
-              },
             },
           ],
         },
-      },
+      } as GetManagedFacilitiesQuery,
     },
   },
 ];

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -92,6 +92,7 @@ describe("update existing devices", () => {
             model: "Model A",
             manufacturer: "Celoxitin",
             loincCode: "1234-1",
+            testLength: 15,
             swabTypes: [{ internalId: "123", name: "nose", typeCode: "n123" }],
             supportedDiseases: [
               { internalId: "123", name: "COVID-19", loinc: "1234-1" },
@@ -103,6 +104,7 @@ describe("update existing devices", () => {
             model: "Model B",
             manufacturer: "Curentz",
             loincCode: "1234-2",
+            testLength: 15,
             swabTypes: [{ internalId: "456", name: "eye", typeCode: "e456" }],
             supportedDiseases: [
               { internalId: "123", name: "COVID-19", loinc: "1234-1" },
@@ -114,6 +116,7 @@ describe("update existing devices", () => {
             model: "Model C",
             manufacturer: "Vitamin Tox",
             loincCode: "1234-3",
+            testLength: 15,
             swabTypes: [{ internalId: "789", name: "mouth", typeCode: "m789" }],
             supportedDiseases: [
               { internalId: "123", name: "COVID-19", loinc: "1234-1" },

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -384,9 +384,11 @@ describe("QueueItem", () => {
 
     // swab on the queue item is auto selected
     expect(
-      ((await screen.findByText(
-        queueItemInfo.specimenType.name
-      )) as HTMLOptionElement).selected
+      (
+        (await screen.findByText(
+          queueItemInfo.specimenType.name
+        )) as HTMLOptionElement
+      ).selected
     ).toBeTruthy();
 
     userEvent.selectOptions(swabDropdown, "Nasopharyngeal swab");

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -93,7 +93,6 @@ describe("QueueItem", () => {
       name: device1Name,
       model: "LumiraDx SARS-CoV-2 Ag Test*",
       testLength: 15,
-      supportedDiseases: [],
     },
     specimenType: {
       internalId: specimen1Id,

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -5,19 +5,27 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import moment from "moment";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import * as flaggedMock from "flagged";
 
 import { getAppInsights } from "../TelemetryService";
 import * as srToast from "../utils/srToast";
-import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 import {
-  AddMultiplexResultDocument as SUBMIT_TEST_RESULT,
-  EditQueueItemMultiplexResultDocument as EDIT_QUEUE_ITEM,
+  SubmitQueueItemDocument as SUBMIT_TEST_RESULT,
+  EditQueueItemDocument as EDIT_QUEUE_ITEM,
+  PhoneType,
+  SubmitQueueItemMutationVariables as SUBMIT_QUEUE_ITEM_VARIABLES,
+  EditQueueItemMutationVariables as EDIT_QUEUE_ITEM_VARIABLES,
+  SubmitQueueItemMutation as SUBMIT_QUEUE_ITEM_DATA,
+  EditQueueItemMutation as EDIT_QUEUE_ITEM_DATA,
 } from "../../generated/graphql";
-import * as generatedGraphql from "../../generated/graphql";
 import SRToastContainer from "../commonComponents/SRToastContainer";
+import PrimeErrorBoundary from "../PrimeErrorBoundary";
+import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 
-import QueueItem from "./QueueItem";
+import QueueItem, {
+  QueriedFacility,
+  QueriedTestOrder,
+  QueueItemProps,
+} from "./QueueItem";
 
 jest.mock("../TelemetryService", () => ({
   getAppInsights: jest.fn(),
@@ -33,16 +41,245 @@ jest.mock("react-router-dom", () => {
 });
 
 const updatedDateString = "2021-03-10";
-const dateStringBeforeWarningThreshold = "2001-01-01";
 const updatedTimeString = "10:05";
 
 const setStartTestPatientIdMock = jest.fn();
+
+const device1Name = "LumiraDX";
+const device2Name = "Abbott BinaxNow";
+const device3Name = "BD Veritor";
+const device4Name = "Multiplex";
+
+const device1Id = "ee4f40b7-ac32-4709-be0a-56dd77bb9609";
+const device2Id = "5c711888-ba37-4b2e-b347-311ca364efdb";
+const device3Id = "32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10";
+const device4Id = "67109f6f-eaee-49d3-b8ff-c61b79a9da8e";
+
+const deletedDeviceId = "8ab0cafa-8e36-48d6-91fc-6352405e1d91";
+const deletedDeviceName = "Deleted";
+
+const specimen1Name = "Swab of internal nose";
+const specimen1Id = "8596682d-6053-4720-8a39-1f5d19ff4ed9";
+const specimen2Name = "Nasopharyngeal swab";
+const specimen2Id = "f127ef55-4133-4556-9bca-33615d071e8d";
+
+const deletedSpecimenId = "fddb9ef4-7606-4621-b7a2-20772bac5136";
+
+const getDeciceTypeDropdown = async () =>
+  (await screen.findByTestId("device-type-dropdown")) as HTMLSelectElement;
+
+async function getSpecimenTypeDropdown() {
+  return (await screen.findByTestId(
+    "specimen-type-dropdown"
+  )) as HTMLSelectElement;
+}
 
 describe("QueueItem", () => {
   let nowFn = Date.now;
   let store: MockStoreEnhanced<unknown, {}>;
   const mockStore = configureStore([]);
   const trackEventMock = jest.fn();
+
+  const queueItemInfo: QueriedTestOrder = {
+    internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
+    pregnancy: "60001007",
+    dateAdded: "2022-11-08 13:33:07.503",
+    symptoms:
+      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
+    symptomOnset: null,
+    noSymptoms: true,
+    deviceType: {
+      internalId: device1Id,
+      name: device1Name,
+      model: "LumiraDx SARS-CoV-2 Ag Test*",
+      testLength: 15,
+      supportedDiseases: [],
+    },
+    specimenType: {
+      internalId: specimen1Id,
+      name: specimen1Name,
+      typeCode: "445297001",
+    },
+    patient: {
+      internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
+      telephone: "(571) 867-5309",
+      birthDate: "2015-09-20",
+      firstName: "Althea",
+      middleName: "Hedda Mclaughlin",
+      lastName: "Dixon",
+      gender: "refused",
+      testResultDelivery: null,
+      preferredLanguage: null,
+      email: "sywaporoce@mailinator.com",
+      emails: ["sywaporoce@mailinator.com"],
+      phoneNumbers: [
+        {
+          type: PhoneType.Mobile,
+          number: "(553) 223-0559",
+        },
+        {
+          type: PhoneType.Landline,
+          number: "(669) 789-0799",
+        },
+      ],
+    },
+    results: [],
+    dateTested: null,
+    correctionStatus: "ORIGINAL",
+    reasonForCorrection: null,
+  };
+
+  const facilityInfo: QueriedFacility = {
+    id: "f02cfff5-1921-4293-beff-e2a5d03e1fda",
+    name: "Testing Site",
+    deviceTypes: [
+      {
+        internalId: device1Id,
+        name: device1Name,
+        testLength: 15,
+        supportedDiseases: [
+          {
+            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+            loinc: "96741-4",
+            name: "COVID-19",
+          },
+        ],
+        swabTypes: [
+          {
+            name: specimen1Name,
+            internalId: specimen1Id,
+            typeCode: "445297001",
+          },
+          {
+            name: specimen2Name,
+            internalId: specimen2Id,
+            typeCode: "258500001",
+          },
+        ],
+      },
+      {
+        internalId: device2Id,
+        name: device2Name,
+        testLength: 15,
+        supportedDiseases: [
+          {
+            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+            loinc: "96741-4",
+            name: "COVID-19",
+          },
+        ],
+        swabTypes: [
+          {
+            name: specimen1Name,
+            internalId: specimen1Id,
+            typeCode: "445297001",
+          },
+        ],
+      },
+      {
+        internalId: device3Id,
+        name: device3Name,
+        testLength: 15,
+        supportedDiseases: [
+          {
+            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+            loinc: "96741-4",
+            name: "COVID-19",
+          },
+        ],
+        swabTypes: [
+          {
+            name: specimen1Name,
+            internalId: specimen1Id,
+            typeCode: "445297001",
+          },
+          {
+            name: specimen2Name,
+            internalId: specimen2Id,
+            typeCode: "258500001",
+          },
+        ],
+      },
+      {
+        internalId: device4Id,
+        name: device4Name,
+        testLength: 15,
+        supportedDiseases: [
+          {
+            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+            loinc: "96741-4",
+            name: "COVID-19",
+          },
+          {
+            internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
+            loinc: "LP14239-5",
+            name: "Flu A",
+          },
+          {
+            internalId: "14924488-268f-47db-bea6-aa706971a098",
+            loinc: "LP14240-3",
+            name: "Flu B",
+          },
+        ],
+        swabTypes: [
+          {
+            name: specimen1Name,
+            internalId: specimen1Id,
+            typeCode: "445297001",
+          },
+          {
+            name: specimen2Name,
+            internalId: specimen2Id,
+            typeCode: "258500001",
+          },
+        ],
+      },
+    ],
+  };
+
+  const devicesMap = new Map();
+  facilityInfo.deviceTypes.map((d) => devicesMap.set(d.internalId, d));
+
+  const testProps: QueueItemProps = {
+    refetchQueue: jest.fn().mockReturnValue(null),
+    queueItem: queueItemInfo,
+    facility: facilityInfo,
+    devicesMap: devicesMap,
+    startTestPatientId: "",
+    setStartTestPatientId: setStartTestPatientIdMock,
+  };
+
+  type testRenderProps = {
+    props?: QueueItemProps;
+    mocks?: any;
+  };
+
+  const renderQueueItem = async (
+    { props, mocks }: testRenderProps = { props: testProps, mocks: undefined }
+  ) => {
+    props = props || testProps;
+
+    render(
+      <PrimeErrorBoundary>
+        <Provider store={store}>
+          <MemoryRouter>
+            <MockedProvider mocks={mocks} addTypename={false}>
+              <QueueItem
+                refetchQueue={props.refetchQueue}
+                queueItem={props.queueItem}
+                startTestPatientId={props.startTestPatientId}
+                setStartTestPatientId={props.setStartTestPatientId}
+                facility={props.facility}
+                devicesMap={props.devicesMap}
+              />
+            </MockedProvider>
+          </MemoryRouter>
+        </Provider>
+        <SRToastContainer />
+      </PrimeErrorBoundary>
+    );
+    await new Promise((resolve) => setTimeout(resolve, 501));
+  };
 
   beforeEach(() => {
     store = mockStore({
@@ -63,187 +300,72 @@ describe("QueueItem", () => {
     jest.spyOn(console, "error").mockRestore();
   });
 
-  it("correctly renders the test queue", () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
-    expect(screen.getByText("Potter, Harry James")).toBeInTheDocument();
-    expect(screen.getByTestId("timer")).toHaveTextContent("10:00");
+  it("correctly renders the test queue", async () => {
+    await renderQueueItem();
+    expect(
+      screen.getByText("Dixon, Althea Hedda Mclaughlin")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("timer")).toHaveTextContent("15:00");
   });
 
   it("scroll to patient and highlight when startTestPatientId is present", async () => {
     let scrollIntoViewMock = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
-    render(
-      <MemoryRouter>
-        <MockedProvider>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId={testProps.internalId}
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
+    await renderQueueItem({
+      props: {
+        ...testProps,
+        startTestPatientId: queueItemInfo.patient.internalId,
+      },
+    });
 
-    const testCard = await screen.findByTestId(`test-card-${internalId}`);
+    const testCard = await screen.findByTestId(
+      `test-card-${queueItemInfo.patient.internalId}`
+    );
     expect(testCard).toHaveClass("prime-queue-item__info");
     expect(testCard).toBeInTheDocument();
     expect(scrollIntoViewMock).toBeCalled();
   });
 
-  it("navigates to edit the user when clicking their name", () => {
-    render(
-      <MockedProvider>
-        <MemoryRouter>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MemoryRouter>
-      </MockedProvider>
-    );
-    const patientName = screen.getByText("Potter, Harry James");
+  it("navigates to edit the user when clicking their name", async () => {
+    await renderQueueItem();
+    const patientName = screen.getByText("Dixon, Althea Hedda Mclaughlin");
     expect(patientName).toBeInTheDocument();
     userEvent.click(patientName);
     expect(mockNavigate).toHaveBeenCalledWith({
-      pathname: "/patient/f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554",
-      search: "?facility=Hogwarts+123&fromQueue=true",
+      pathname: `/patient/${queueItemInfo.patient.internalId}`,
+      search: `?facility=${facilityInfo.id}&fromQueue=true`,
     });
   });
 
   it("updates the timer when a device is changed", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider addTypename={false}>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
+    await renderQueueItem();
 
     userEvent.type(
       screen.getAllByLabelText("Device", { exact: false })[1],
       "lumira"
     );
 
-    expect(await screen.findByTestId("timer")).toHaveTextContent("10:00");
+    expect(await screen.findByTestId("timer")).toHaveTextContent("15:00");
   });
 
   it("renders dropdown of device types", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider addTypename={false}>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
+    await renderQueueItem();
 
-    const deviceDropdown = (
-      await screen.findAllByLabelText("Device", { exact: false })
-    )[1];
+    const deviceDropdown = (await screen.findByTestId(
+      "device-type-dropdown"
+    )) as HTMLSelectElement;
 
-    userEvent.selectOptions(deviceDropdown, "Access Bio CareStart");
+    expect(deviceDropdown.options.length).toEqual(4);
+    expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
+    expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
+    expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
+    expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+
+    userEvent.selectOptions(deviceDropdown, "Abbott BinaxNow");
 
     expect(
-      ((await screen.findByText("Access Bio CareStart")) as HTMLOptionElement)
+      ((await screen.findByText("Abbott BinaxNow")) as HTMLOptionElement)
         .selected
     ).toBeTruthy();
     expect(
@@ -252,203 +374,483 @@ describe("QueueItem", () => {
   });
 
   it("renders dropdown of swab types configured with selected device", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider addTypename={false}>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
-    const swabDropdown = await screen.findByLabelText("Swab type");
+    await renderQueueItem();
+    const swabDropdown = (await screen.findByTestId(
+      "specimen-type-dropdown"
+    )) as HTMLSelectElement;
 
-    // First device is selected
+    expect(swabDropdown.options.length).toEqual(2);
+    expect(swabDropdown.options[0].label).toEqual("Nasopharyngeal swab");
+    expect(swabDropdown.options[1].label).toEqual("Swab of internal nose");
+
+    // swab on the queue item is auto selected
     expect(
-      ((await screen.findByText("Access Bio CareStart")) as HTMLOptionElement)
+      ((await screen.findByText(
+        queueItemInfo.specimenType.name
+      )) as HTMLOptionElement).selected
+    ).toBeTruthy();
+
+    userEvent.selectOptions(swabDropdown, "Nasopharyngeal swab");
+
+    expect(
+      ((await screen.findByText("Nasopharyngeal swab")) as HTMLOptionElement)
         .selected
     ).toBeTruthy();
+  });
 
-    userEvent.selectOptions(swabDropdown, "specimen-1");
+  it("correctly handles when device is deleted from facility", async () => {
+    const mocks = [
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: deletedDeviceId,
+            specimenTypeId: specimen1Id,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: deletedDeviceId,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device1Id,
+            specimenTypeId: specimen1Id,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device1Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+    ];
+
+    const props = {
+      ...testProps,
+      queueItem: {
+        ...testProps.queueItem,
+        deviceType: {
+          internalId: deletedDeviceId,
+          name: deletedDeviceName,
+          model: "test",
+          testLength: 12,
+          supportedDiseases: [
+            {
+              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+              loinc: "96741-4",
+              name: "COVID-19",
+            },
+          ],
+        },
+        correctionStatus: "CORRECTED",
+        reasonForCorrection: TestCorrectionReason.INCORRECT_RESULT,
+      },
+    };
+
+    await renderQueueItem({ props, mocks });
 
     expect(
-      ((await screen.findByText("Specimen 1")) as HTMLOptionElement).selected
-    ).toBeTruthy();
-
-    // Configured on the other device - should not appear in dropdown
-    expect(
-      screen.queryByText("Specimen 2") as HTMLOptionElement
+      screen.queryByText("Please select a device")
     ).not.toBeInTheDocument();
+    const deviceDropdown = await getDeciceTypeDropdown();
+    expect(deviceDropdown.options.length).toEqual(5);
+    expect(deviceDropdown.options[0].label).toEqual("");
+    expect(deviceDropdown.options[1].label).toEqual("Abbott BinaxNow");
+    expect(deviceDropdown.options[2].label).toEqual("BD Veritor");
+    expect(deviceDropdown.options[3].label).toEqual("LumiraDX");
+    expect(deviceDropdown.options[4].label).toEqual("Multiplex");
+    expect(deviceDropdown.value).toEqual("");
+
+    const swabDropdown = await getSpecimenTypeDropdown();
+    expect(swabDropdown.options.length).toEqual(0);
+    expect(swabDropdown).toBeDisabled();
+
+    // select results
+    userEvent.click(screen.getByLabelText("Positive", { exact: false }));
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
+    //try to submit results
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeEnabled();
+    userEvent.click(submitButton);
+
+    // notice the error message
+    expect(screen.getByText("Please select a device")).toBeInTheDocument();
+
+    userEvent.selectOptions(deviceDropdown, device1Id);
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
+    // error goes away after selecting a valid device
+    expect(
+      screen.queryByText("Please select a device")
+    ).not.toBeInTheDocument();
+
+    await waitFor(
+      () => {
+        expect(submitButton).toBeEnabled();
+      },
+      { timeout: 1000 }
+    );
+  });
+
+  it("correctly handles when swab is deleted from device", async () => {
+    const mocks = [
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device2Id,
+            specimenTypeId: deletedSpecimenId,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device2Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device1Id,
+            specimenTypeId: specimen1Id,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device1Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+    ];
+
+    const props = {
+      ...testProps,
+      queueItem: {
+        ...testProps.queueItem,
+        deviceType: {
+          internalId: device2Id,
+          name: device2Name,
+          model: "test",
+          testLength: 12,
+          supportedDiseases: [
+            {
+              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+              loinc: "96741-4",
+              name: "COVID-19",
+            },
+          ],
+        },
+        specimenType: {
+          name: "deleted",
+          internalId: deletedSpecimenId,
+          typeCode: "12345",
+        },
+        correctionStatus: "CORRECTED",
+        reasonForCorrection: TestCorrectionReason.INCORRECT_RESULT,
+      },
+    };
+
+    await renderQueueItem({ props, mocks });
+
+    expect(
+      screen.queryByText("Please select a swab type")
+    ).not.toBeInTheDocument();
+    const deviceDropdown = await getDeciceTypeDropdown();
+    expect(deviceDropdown.options.length).toEqual(4);
+    expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
+    expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
+    expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
+    expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+    expect(deviceDropdown.value).toEqual(device2Id);
+
+    const swabDropdown = await getSpecimenTypeDropdown();
+    expect(swabDropdown.options.length).toEqual(2);
+    expect(swabDropdown.options[0].label).toEqual("");
+    expect(swabDropdown.options[1].label).toEqual("Swab of internal nose");
+
+    // select results
+    userEvent.click(screen.getByLabelText("Positive", { exact: false }));
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
+    //try to submit results
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeEnabled();
+    userEvent.click(submitButton);
+
+    // notice the error message
+    expect(screen.getByText("Please select a swab type")).toBeInTheDocument();
+
+    userEvent.selectOptions(swabDropdown, specimen1Id);
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
+    // error goes away after selecting a valid device
+    expect(
+      screen.queryByText("Please select a swab type")
+    ).not.toBeInTheDocument();
+    expect(submitButton).toBeEnabled();
   });
 
   describe("on device specimen type change", () => {
-    let editQueueMockIsDone = false;
-    beforeEach(() => {
-      editQueueMockIsDone = false;
-
-      const editQueueMocks = [
-        {
-          request: {
-            query: EDIT_QUEUE_ITEM,
-            variables: {
-              id: internalId,
-              deviceSpecimenType: "device-specimen-2",
-              deviceId: "lumira",
-              results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
-            },
-          },
-          result: () => {
-            editQueueMockIsDone = true;
-
-            return {
-              data: {
-                editQueueItemMultiplexResult: {
-                  results: [
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "POSITIVE",
-                    },
-                  ],
-                  dateTested: null,
-                  deviceType: {
-                    internalId: internalId,
-                    testLength: 10,
-                  },
-                  deviceSpecimenType: {
-                    internalId: "device-specimen-2",
-                    deviceType: deviceTwo,
-                    specimenType: {},
-                  },
-                },
-              },
-            };
-          },
+    const mocks = [
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device1Id,
+            specimenTypeId: specimen1Id,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
         },
-        {
-          request: {
-            query: EDIT_QUEUE_ITEM,
-            variables: {
-              id: internalId,
-              deviceSpecimenType: "device-specimen-3",
-              deviceId: "multiplex",
-              results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
-            },
-          },
-          result: () => {
-            editQueueMockIsDone = true;
-
-            return {
-              data: {
-                editQueueItemMultiplexResult: {
-                  results: [
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "POSITIVE",
-                    },
-                  ],
-                  dateTested: null,
-                  deviceType: {
-                    internalId: internalId,
-                    testLength: 10,
-                  },
-                  deviceSpecimenType: {
-                    internalId: "device-specimen-3",
-                    deviceType: deviceThree,
-                    specimenType: {},
-                  },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
                 },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device1Id,
+                testLength: 10,
               },
-            };
-          },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
         },
-      ];
+      },
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device3Id,
+            specimenTypeId: specimen1Id,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device3Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device3Id,
+            specimenTypeId: specimen2Id,
+            results: [{ diseaseName: "COVID-19", testResult: "POSITIVE" }],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device3Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device4Id,
+            specimenTypeId: specimen1Id,
+            results: [],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "POSITIVE",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device4Id,
+                testLength: 10,
+                supportedDiseases: [
+                  {
+                    internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+                    loinc: "96741-4",
+                    name: "COVID-19",
+                  },
+                  {
+                    internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
+                    loinc: "LP14239-5",
+                    name: "Flu A",
+                  },
+                  {
+                    internalId: "14924488-268f-47db-bea6-aa706971a098",
+                    loinc: "LP14240-3",
+                    name: "Flu B",
+                  },
+                ],
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+    ];
 
-      render(
-        <>
-          <MemoryRouter>
-            <MockedProvider mocks={editQueueMocks} addTypename={false}>
-              <Provider store={store}>
-                <QueueItem
-                  internalId={testProps.internalId}
-                  patient={testProps.patient}
-                  askOnEntry={testProps.askOnEntry}
-                  selectedDeviceId={testProps.selectedDeviceId}
-                  selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-                  selectedDeviceSpecimenTypeId={
-                    testProps.selectedDeviceSpecimenTypeId
-                  }
-                  deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-                  selectedTestResults={[
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "POSITIVE",
-                    },
-                  ]}
-                  devices={testProps.devices}
-                  refetchQueue={testProps.refetchQueue}
-                  facilityId={testProps.facilityId}
-                  dateTestedProp={testProps.dateTestedProp}
-                  facilityName="Foo facility"
-                  setStartTestPatientId={setStartTestPatientIdMock}
-                  startTestPatientId=""
-                />
-              </Provider>
-            </MockedProvider>
-          </MemoryRouter>
-          <SRToastContainer />
-        </>
-      );
-    });
-    it("updates test order on device specimen type change", async () => {
-      const deviceDropdown = (
-        await screen.findAllByLabelText("Device", { exact: false })
-      )[1];
+    it("updates test order on device type and specimen type change", async () => {
+      await renderQueueItem({ mocks });
+
+      const deviceDropdown = await getDeciceTypeDropdown();
+      expect(deviceDropdown.options.length).toEqual(4);
+      expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
+      expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
+      expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
+      expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+
+      // select results
+      userEvent.click(screen.getByLabelText("Positive", { exact: false }));
+      await new Promise((resolve) => setTimeout(resolve, 501));
 
       // Change device type
-      userEvent.selectOptions(deviceDropdown, "LumiraDX");
-      userEvent.click(screen.getByLabelText("Positive", { exact: false }));
+      userEvent.selectOptions(deviceDropdown, device3Name);
+      await new Promise((resolve) => setTimeout(resolve, 501));
 
-      await waitFor(() => expect(editQueueMockIsDone).toBe(true));
+      // Change specimen type
+      const swabDropdown = await getSpecimenTypeDropdown();
+      expect(swabDropdown.options.length).toEqual(2);
+      expect(swabDropdown.options[0].label).toEqual("Nasopharyngeal swab");
+      expect(swabDropdown.options[1].label).toEqual("Swab of internal nose");
+
+      userEvent.selectOptions(swabDropdown, specimen2Name);
+      await new Promise((resolve) => setTimeout(resolve, 501));
+
+      expect(deviceDropdown.value).toEqual(device3Id);
+      expect(swabDropdown.value).toEqual(specimen2Id);
+
+      await waitFor(
+        () => {
+          expect(screen.getByText("Submit")).toBeEnabled();
+        },
+        { timeout: 1000 }
+      );
     });
+
     it("adds radio buttons for Flu A and Flu B when a multiplex device is chosen", async () => {
-      jest.spyOn(flaggedMock, "useFeature").mockReturnValue(true);
+      await renderQueueItem({ mocks });
 
       expect(screen.queryByText("Flu A")).not.toBeInTheDocument();
       expect(screen.queryByText("Flu B")).not.toBeInTheDocument();
-      const deviceDropdown = (
-        await screen.findAllByLabelText("Device", { exact: false })
-      )[1];
 
-      // Change device type
-      userEvent.selectOptions(deviceDropdown, "MultiplexMate");
-      userEvent.click(
-        screen.getAllByLabelText("Positive", { exact: false })[0]
-      );
+      const deviceDropdown = await getDeciceTypeDropdown();
+      expect(deviceDropdown.options.length).toEqual(4);
+      expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
+      expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
+      expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
+      expect(deviceDropdown.options[3].label).toEqual("Multiplex");
 
-      await waitFor(() => expect(editQueueMockIsDone).toBe(true));
+      // Change device type to a multiplex device
+      userEvent.selectOptions(deviceDropdown, device4Name);
+      await new Promise((resolve) => setTimeout(resolve, 501));
 
-      expect(await screen.findByText("Flu A")).toBeInTheDocument();
-      expect(await screen.findByText("Flu B")).toBeInTheDocument();
-
-      jest.resetAllMocks();
+      expect(screen.getByText("Flu A")).toBeInTheDocument();
+      expect(screen.getByText("Flu B")).toBeInTheDocument();
     });
   });
 
@@ -463,73 +865,75 @@ describe("QueueItem", () => {
     });
 
     it("displays delivery failure alert on submit for invalid patient phone number", async () => {
-      let submitTestMockIsDone = false;
-
-      const submitTestResultMocks = [
+      const mocks = [
         {
           request: {
-            query: SUBMIT_TEST_RESULT,
+            query: EDIT_QUEUE_ITEM,
             variables: {
-              patientId: internalId,
-              deviceId: internalId,
-              deviceSpecimenType: "device-specimen-1",
+              id: queueItemInfo.internalId,
+              deviceTypeId: device1Id,
+              specimenTypeId: specimen1Id,
               results: [
                 { diseaseName: "COVID-19", testResult: "UNDETERMINED" },
               ],
               dateTested: null,
-            },
+            } as EDIT_QUEUE_ITEM_VARIABLES,
           },
-          result: () => {
-            submitTestMockIsDone = true;
-            return {
-              data: {
-                addMultiplexResult: {
-                  testResult: {
-                    internalId: internalId,
+          result: {
+            data: {
+              editQueueItem: {
+                results: [
+                  {
+                    disease: { name: "COVID-19" },
+                    testResult: "UNDETERMINED",
                   },
-                  deliverySuccess: false,
+                ],
+                dateTested: null,
+                deviceType: {
+                  internalId: device1Id,
+                  testLength: 10,
                 },
               },
-            };
+            } as EDIT_QUEUE_ITEM_DATA,
+          },
+        },
+        {
+          request: {
+            query: SUBMIT_TEST_RESULT,
+            variables: {
+              patientId: queueItemInfo.patient.internalId,
+              deviceTypeId: device1Id,
+              specimenTypeId: specimen1Id,
+              results: [
+                { diseaseName: "COVID-19", testResult: "UNDETERMINED" },
+              ],
+              dateTested: null,
+            } as SUBMIT_QUEUE_ITEM_VARIABLES,
+          },
+          result: {
+            data: {
+              submitQueueItem: {
+                testResult: {
+                  internalId: queueItemInfo.internalId,
+                },
+                deliverySuccess: false,
+              },
+            } as SUBMIT_QUEUE_ITEM_DATA,
           },
         },
       ];
 
-      render(
-        <>
-          <MemoryRouter>
-            <MockedProvider mocks={submitTestResultMocks} addTypename={false}>
-              <Provider store={store}>
-                <QueueItem
-                  internalId={testProps.internalId}
-                  patient={testProps.patient}
-                  askOnEntry={testProps.askOnEntry}
-                  selectedDeviceId={testProps.selectedDeviceId}
-                  selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-                  selectedDeviceSpecimenTypeId={
-                    testProps.selectedDeviceSpecimenTypeId
-                  }
-                  deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-                  selectedTestResults={[
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "UNDETERMINED",
-                    },
-                  ]}
-                  devices={testProps.devices}
-                  refetchQueue={testProps.refetchQueue}
-                  facilityId={testProps.facilityId}
-                  dateTestedProp={testProps.dateTestedProp}
-                  facilityName="Foo facility"
-                  setStartTestPatientId={setStartTestPatientIdMock}
-                  startTestPatientId=""
-                />
-              </Provider>
-            </MockedProvider>
-          </MemoryRouter>
-          <SRToastContainer />
-        </>
-      );
+      const props = {
+        ...testProps,
+        queueItem: {
+          ...testProps.queueItem,
+          pregnancy: null,
+          symptomOnset: null,
+          noSymptoms: null,
+        },
+      };
+
+      await renderQueueItem({ props, mocks });
 
       // Select result
       userEvent.click(
@@ -543,6 +947,7 @@ describe("QueueItem", () => {
 
       // Submit
       userEvent.click(screen.getByText("Submit"));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
 
       userEvent.click(
         screen.getByText("Submit anyway", {
@@ -553,24 +958,23 @@ describe("QueueItem", () => {
       // Displays submitting indicator
       expect(
         await screen.findByText(
-          "Submitting test data for Potter, Harry James..."
+          "Submitting test data for Dixon, Althea Hedda Mclaughlin..."
         )
       ).toBeInTheDocument();
 
       // Wait for MockedProvider to populate the mocked result
       await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(submitTestMockIsDone).toBe(true);
 
       // Verify alert is displayed
       await waitFor(() => {
         expect(alertSpy).toHaveBeenCalledWith(
           "The phone number provided may not be valid or may not be able to accept text messages",
-          "Unable to text result to Potter, Harry James"
+          "Unable to text result to Dixon, Althea Hedda Mclaughlin"
         );
       });
       expect(
         await screen.findByText(
-          "Unable to text result to Potter, Harry James",
+          "Unable to text result to Dixon, Althea Hedda Mclaughlin",
           {
             exact: false,
           }
@@ -579,44 +983,18 @@ describe("QueueItem", () => {
 
       // Submitting indicator and card are gone
       expect(
-        await screen.findByText("Potter, Harry James")
+        await screen.findByText("Dixon, Althea Hedda Mclaughlin")
       ).toBeInTheDocument();
       expect(
         await screen.findByText(
-          "Submitting test data for Potter, Harry James..."
+          "Submitting test data for Dixon, Althea Hedda Mclaughlin..."
         )
       ).toBeInTheDocument();
     });
   });
 
   it("updates custom test date/time", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider addTypename={false}>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
+    await renderQueueItem();
     const toggle = await screen.findByLabelText("Current date/time");
     userEvent.click(toggle);
     const dateInput = screen.getByTestId("test-date");
@@ -626,160 +1004,138 @@ describe("QueueItem", () => {
     userEvent.type(dateInput, `${updatedDateString}T00:00`);
     userEvent.type(timeInput, updatedTimeString);
   });
+
   it("does not allow future date for test date", async () => {
-    render(
-      <>
-        <MemoryRouter>
-          <MockedProvider addTypename={false}>
-            <Provider store={store}>
-              <QueueItem
-                internalId={testProps.internalId}
-                patient={testProps.patient}
-                askOnEntry={testProps.askOnEntry}
-                selectedDeviceId={testProps.selectedDeviceId}
-                selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-                selectedDeviceSpecimenTypeId={
-                  testProps.selectedDeviceSpecimenTypeId
-                }
-                deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-                selectedTestResults={[
-                  { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
-                ]}
-                devices={testProps.devices}
-                refetchQueue={testProps.refetchQueue}
-                facilityId={testProps.facilityId}
-                dateTestedProp={testProps.dateTestedProp}
-                facilityName="Foo facility"
-                setStartTestPatientId={setStartTestPatientIdMock}
-                startTestPatientId=""
-              />
-            </Provider>
-          </MockedProvider>
-        </MemoryRouter>
-        <SRToastContainer />
-      </>
-    );
+    const mocks = [
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device1Id,
+            specimenTypeId: specimen1Id,
+            results: [],
+            dateTested: null,
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "UNDETERMINED",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device1Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+      {
+        request: {
+          query: EDIT_QUEUE_ITEM,
+          variables: {
+            id: queueItemInfo.internalId,
+            deviceTypeId: device1Id,
+            specimenTypeId: specimen1Id,
+            results: [],
+            dateTested: "2022-07-15T12:35:00.000Z",
+          } as EDIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            editQueueItem: {
+              results: [
+                {
+                  disease: { name: "COVID-19" },
+                  testResult: "UNDETERMINED",
+                },
+              ],
+              dateTested: null,
+              deviceType: {
+                internalId: device1Id,
+                testLength: 10,
+              },
+            },
+          } as EDIT_QUEUE_ITEM_DATA,
+        },
+      },
+      {
+        request: {
+          query: SUBMIT_TEST_RESULT,
+          variables: {
+            patientId: queueItemInfo.patient.internalId,
+            deviceTypeId: queueItemInfo.deviceType.internalId,
+            specimenTypeId: queueItemInfo.specimenType.internalId,
+            results: [{ diseaseName: "COVID-19", testResult: "UNDETERMINED" }],
+            dateTested: "2022-07-15T12:35:00.000Z",
+          } as SUBMIT_QUEUE_ITEM_VARIABLES,
+        },
+        result: {
+          data: {
+            submitQueueItem: {
+              testResult: {
+                internalId: queueItemInfo.internalId,
+              },
+              deliverySuccess: true,
+            },
+          } as SUBMIT_QUEUE_ITEM_DATA,
+        },
+      },
+    ];
+
+    await renderQueueItem({ mocks });
 
     const toggle = await screen.findByLabelText("Current date/time");
     userEvent.click(toggle);
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
     const dateInput = screen.getByTestId("test-date");
     expect(dateInput).toBeInTheDocument();
     const timeInput = screen.getByTestId("test-time");
     expect(timeInput).toBeInTheDocument();
 
     // Select result
-    userEvent.click(
-      screen.getByLabelText("Inconclusive", {
-        exact: false,
-      })
-    );
+    userEvent.click(screen.getByLabelText("Inconclusive", { exact: true }));
 
     // There is a 500ms debounce on queue item update operations
     await new Promise((resolve) => setTimeout(resolve, 501));
 
     // Input invalid (future date) - can't submit
-    userEvent.type(dateInput, moment().add(5, "days").format("YYYY-MM-DD"));
-    dateInput.blur();
+    const futureDateTime = moment({
+      year: 2050,
+      month: 6,
+      day: 15,
+      hour: 12,
+      minute: 35,
+    });
+    userEvent.type(dateInput, futureDateTime.format("YYYY-MM-DD"));
+    userEvent.type(timeInput, futureDateTime.format("hh:mm"));
 
-    // 500ms debounce on queue item update operations
-    await new Promise((resolve) => setTimeout(resolve, 501));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Submit")).toBeEnabled();
+      },
+      { timeout: 1000 }
+    );
 
     // Submit test
     userEvent.click(await screen.findByText("Submit"));
 
+    // 500ms debounce on queue item update operations
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
     // Toast alert should appear
-    await waitFor(async () => {
-      expect(await screen.findByText("Invalid test date")).toBeInTheDocument();
-    });
-  });
-
-  it("formats card with warning state if selected date input is more than six months ago", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider addTypename={false}>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
-    const dateInput = screen.getByTestId("test-date");
-    const timeInput = screen.getByTestId("test-time");
-
-    userEvent.type(dateInput, `${dateStringBeforeWarningThreshold}T00:00`);
-    const testCard = await screen.findByTestId(`test-card-${internalId}`);
-
-    expect(testCard).toHaveClass("prime-queue-item__ready");
-    expect(dateInput).toHaveClass("card-correction-input");
-    expect(timeInput).toHaveClass("card-correction-input");
-    expect(screen.getByTestId("test-correction-header")).toBeInTheDocument();
-  });
-
-  it("highlights the test card where the validation failure occurs", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={[
-                { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
-              ]}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
-
-    // Enter an invalid (future) date on the first test card
-    const toggle = await screen.findByLabelText("Current date/time");
-    userEvent.click(toggle);
-    const dateInput = await screen.findByTestId("test-date");
-    expect(dateInput).toBeInTheDocument();
-    userEvent.type(dateInput, moment().add(5, "days").format("YYYY-MM-DD"));
-    dateInput.blur();
-
-    await waitFor(async () =>
-      expect(await screen.findByText("Submit")).toBeEnabled()
-    );
-
-    userEvent.click(await screen.findByText("Submit"));
-
+    expect(await screen.findByText("Invalid test date")).toBeInTheDocument();
     const updatedTestCard = await screen.findByTestId(
-      `test-card-${internalId}`
+      `test-card-${queueItemInfo.patient.internalId}`
     );
     expect(updatedTestCard).toHaveClass("prime-queue-item__error");
     const dateLabel = await screen.findByText("Test date and time");
@@ -788,35 +1144,42 @@ describe("QueueItem", () => {
     expect(updatedDateInput).toHaveClass("card-test-input__error");
   });
 
-  it("highlights test corrections and includes corrector name and reason for correction", async () => {
-    render(
-      <MockedProvider>
-        <Provider store={store}>
-          <QueueItem
-            internalId={testProps.internalId}
-            patient={testProps.patient}
-            askOnEntry={testProps.askOnEntry}
-            selectedDeviceId={testProps.selectedDeviceId}
-            selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-            selectedDeviceSpecimenTypeId={
-              testProps.selectedDeviceSpecimenTypeId
-            }
-            deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-            selectedTestResults={testProps.selectedTestResults}
-            devices={testProps.devices}
-            refetchQueue={testProps.refetchQueue}
-            facilityId={testProps.facilityId}
-            dateTestedProp={testProps.dateTestedProp}
-            facilityName="Foo facility"
-            isCorrection={true}
-            reasonForCorrection={TestCorrectionReason.INCORRECT_RESULT}
-            startTestPatientId={null}
-            setStartTestPatientId={() => {}}
-          />
-        </Provider>
-      </MockedProvider>
+  it("formats card with warning state if selected date input is more than six months ago", async () => {
+    await renderQueueItem();
+
+    const toggle = await screen.findByLabelText("Current date/time");
+    userEvent.click(toggle);
+
+    const dateInput = screen.getByTestId("test-date");
+    const timeInput = screen.getByTestId("test-time");
+
+    const oldDate = moment({ year: 2022, month: 1, day: 1 });
+
+    userEvent.type(dateInput, oldDate.format("YYYY-MM-DD"));
+    const testCard = await screen.findByTestId(
+      `test-card-${queueItemInfo.patient.internalId}`
     );
-    const testCard = await screen.findByTestId(`test-card-${internalId}`);
+
+    expect(testCard).toHaveClass("prime-queue-item__ready");
+    expect(dateInput).toHaveClass("card-correction-input");
+    expect(timeInput).toHaveClass("card-correction-input");
+    expect(screen.getByTestId("test-correction-header")).toBeInTheDocument();
+  });
+
+  it("highlights test corrections and includes corrector name and reason for correction", async () => {
+    const props = {
+      ...testProps,
+      queueItem: {
+        ...testProps.queueItem,
+        correctionStatus: "CORRECTED",
+        reasonForCorrection: TestCorrectionReason.INCORRECT_RESULT,
+      },
+    };
+
+    await renderQueueItem({ props });
+    const testCard = await screen.findByTestId(
+      `test-card-${queueItemInfo.patient.internalId}`
+    );
 
     // Card is highlighted for visibility
     expect(testCard).toHaveClass("prime-queue-item__ready");
@@ -829,83 +1192,30 @@ describe("QueueItem", () => {
   });
 
   it("displays person's mobile phone numbers", async () => {
-    render(
-      <MemoryRouter>
-        <MockedProvider addTypename={false}>
-          <Provider store={store}>
-            <QueueItem
-              internalId={testProps.internalId}
-              patient={testProps.patient}
-              askOnEntry={testProps.askOnEntry}
-              selectedDeviceId={testProps.selectedDeviceId}
-              selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-              selectedDeviceSpecimenTypeId={
-                testProps.selectedDeviceSpecimenTypeId
-              }
-              deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-              selectedTestResults={testProps.selectedTestResults}
-              devices={testProps.devices}
-              refetchQueue={testProps.refetchQueue}
-              facilityId={testProps.facilityId}
-              dateTestedProp={testProps.dateTestedProp}
-              facilityName="Foo facility"
-              setStartTestPatientId={setStartTestPatientIdMock}
-              startTestPatientId=""
-            />
-          </Provider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
+    await renderQueueItem();
 
     const questionnaire = await screen.findByText("Test questionnaire");
     userEvent.click(questionnaire);
+
     await screen.findByText("Required fields are marked", { exact: false });
     expect(
-      screen.getByText(testProps.patient.phoneNumbers[0].number, {
+      screen.getByText(testProps.queueItem.patient.phoneNumbers![0]!.number!, {
         exact: false,
       })
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(testProps.patient.phoneNumbers[1].number)
+      screen.queryByText(testProps.queueItem.patient.phoneNumbers![1]!.number!)
     ).not.toBeInTheDocument();
   });
 
   describe("telemetry", () => {
-    beforeEach(() => {
-      render(
-        <MemoryRouter>
-          <MockedProvider addTypename={false}>
-            <Provider store={store}>
-              <QueueItem
-                internalId={testProps.internalId}
-                patient={testProps.patient}
-                askOnEntry={testProps.askOnEntry}
-                selectedDeviceId={testProps.selectedDeviceId}
-                selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-                selectedDeviceSpecimenTypeId={
-                  testProps.selectedDeviceSpecimenTypeId
-                }
-                deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-                selectedTestResults={[
-                  { disease: { name: "COVID-19" }, testResult: "UNDETERMINED" },
-                ]}
-                devices={testProps.devices}
-                refetchQueue={testProps.refetchQueue}
-                facilityId={testProps.facilityId}
-                dateTestedProp={testProps.dateTestedProp}
-                facilityName="Foo facility"
-                setStartTestPatientId={setStartTestPatientIdMock}
-                startTestPatientId=""
-              />
-            </Provider>
-          </MockedProvider>
-        </MemoryRouter>
-      );
+    beforeEach(async () => {
+      await renderQueueItem();
     });
 
     it("tracks removal of patient from queue as custom event", () => {
       const button = screen.getByLabelText(
-        `Close test for Potter, Harry James`
+        `Close test for Dixon, Althea Hedda Mclaughlin`
       );
       userEvent.click(button);
       const iAmSure = screen.getByText("Yes, I'm sure");
@@ -928,7 +1238,8 @@ describe("QueueItem", () => {
 
       // Submit
       userEvent.click(screen.getByText("Submit"));
-      userEvent.click(screen.getByText(/Submit anyway/i));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       expect(trackEventMock).toHaveBeenCalledWith({
         name: "Submit Test Result",
       });
@@ -952,318 +1263,4 @@ describe("QueueItem", () => {
       });
     });
   });
-  describe("when a multiplex device is chosen", () => {
-    beforeEach(() => {
-      jest.spyOn(flaggedMock, "useFeature").mockReturnValue(true);
-
-      const selectedTestResults: MultiplexResult[] = [
-        {
-          disease: { name: "COVID-19" },
-          testResult: "POSITIVE",
-        },
-        { disease: { name: "Flu A" }, testResult: "NEGATIVE" },
-        { disease: { name: "Flu B" }, testResult: "NEGATIVE" },
-      ];
-      const editQueueMocks = [
-        {
-          request: {
-            query: EDIT_QUEUE_ITEM,
-            variables: {
-              id: internalId,
-              deviceSpecimenType: "device-specimen-3",
-              deviceId: "multiplex",
-              results: [
-                { diseaseName: "COVID-19", testResult: "POSITIVE" },
-                {
-                  diseaseName: "Flu A",
-                  testResult: "POSITIVE",
-                },
-                { diseaseName: "Flu B", testResult: "NEGATIVE" },
-              ],
-            },
-          },
-          result: () => {
-            return {
-              data: {
-                editQueueItemMultiplexResult: {
-                  results: [
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "POSITIVE",
-                    },
-                    {
-                      disease: { name: "Flu A" },
-                      testResult: "POSITIVE",
-                    },
-                    {
-                      disease: { name: "Flu B" },
-                      testResult: "NEGATIVE",
-                    },
-                  ],
-                  dateTested: null,
-                  deviceType: {
-                    internalId: internalId,
-                    testLength: 10,
-                  },
-                  deviceSpecimenType: {
-                    internalId: "device-specimen-3",
-                    deviceType: deviceThree,
-                    specimenType: {},
-                  },
-                },
-              },
-            };
-          },
-        },
-        {
-          request: {
-            query: EDIT_QUEUE_ITEM,
-            variables: {
-              id: internalId,
-              deviceSpecimenType: "device-specimen-3",
-              deviceId: "multiplex",
-              results: [
-                { diseaseName: "COVID-19", testResult: "POSITIVE" },
-                {
-                  diseaseName: "Flu A",
-                  testResult: "NEGATIVE",
-                },
-                { diseaseName: "Flu B", testResult: "POSITIVE" },
-              ],
-            },
-          },
-          result: () => {
-            return {
-              data: {
-                editQueueItemMultiplexResult: {
-                  results: [
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "POSITIVE",
-                    },
-                    {
-                      disease: { name: "Flu A" },
-                      testResult: "NEGATIVE",
-                    },
-                    {
-                      disease: { name: "Flu B" },
-                      testResult: "POSITIVE",
-                    },
-                  ],
-                  dateTested: null,
-                  deviceType: {
-                    internalId: internalId,
-                    testLength: 10,
-                  },
-                  deviceSpecimenType: {
-                    internalId: "device-specimen-3",
-                    deviceType: deviceThree,
-                    specimenType: {},
-                  },
-                },
-              },
-            };
-          },
-        },
-        {
-          request: {
-            query: EDIT_QUEUE_ITEM,
-            variables: {
-              id: internalId,
-              deviceSpecimenType: "device-specimen-3",
-              deviceId: "multiplex",
-              results: [
-                { diseaseName: "COVID-19", testResult: "UNDETERMINED" },
-                {
-                  diseaseName: "Flu A",
-                  testResult: "UNDETERMINED",
-                },
-                { diseaseName: "Flu B", testResult: "UNDETERMINED" },
-              ],
-            },
-          },
-          result: () => {
-            return {
-              data: {
-                editQueueItemMultiplexResult: {
-                  results: [
-                    {
-                      disease: { name: "COVID-19" },
-                      testResult: "UNDETERMINED",
-                    },
-                    {
-                      disease: { name: "Flu A" },
-                      testResult: "UNDETERMINED",
-                    },
-                    {
-                      disease: { name: "Flu B" },
-                      testResult: "UNDETERMINED",
-                    },
-                  ],
-                  dateTested: null,
-                  deviceType: {
-                    internalId: internalId,
-                    testLength: 10,
-                  },
-                  deviceSpecimenType: {
-                    internalId: "device-specimen-3",
-                    deviceType: deviceThree,
-                    specimenType: {},
-                  },
-                },
-              },
-            };
-          },
-        },
-      ];
-      render(
-        <MemoryRouter>
-          <MockedProvider mocks={editQueueMocks} addTypename={false}>
-            <Provider store={store}>
-              <QueueItem
-                internalId={testProps.internalId}
-                patient={testProps.patient}
-                askOnEntry={testProps.askOnEntry}
-                selectedDeviceId="multiplex"
-                selectedDeviceTestLength={testProps.selectedDeviceTestLength}
-                selectedDeviceSpecimenTypeId="device-specimen-3"
-                deviceSpecimenTypes={testProps.deviceSpecimenTypes}
-                selectedTestResults={selectedTestResults}
-                devices={testProps.devices}
-                refetchQueue={testProps.refetchQueue}
-                facilityId={testProps.facilityId}
-                dateTestedProp={testProps.dateTestedProp}
-                facilityName="Foo facility"
-                setStartTestPatientId={setStartTestPatientIdMock}
-                startTestPatientId=""
-              />
-            </Provider>
-          </MockedProvider>
-        </MemoryRouter>
-      );
-    });
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-
-    it("renders radio buttons with results for Flu A and Flu B", () => {
-      expect(screen.getByText("Flu A")).toBeInTheDocument();
-      expect(screen.getByText("Flu B")).toBeInTheDocument();
-
-      expect(screen.getAllByLabelText("Positive (+)")[0]).toBeChecked();
-      expect(screen.getAllByLabelText("Positive (+)")[1]).not.toBeChecked();
-      expect(screen.getAllByLabelText("Positive (+)")[2]).not.toBeChecked();
-      expect(screen.getAllByLabelText("Negative (-)")[0]).not.toBeChecked();
-      expect(screen.getAllByLabelText("Negative (-)")[1]).toBeChecked();
-      expect(screen.getAllByLabelText("Negative (-)")[2]).toBeChecked();
-      expect(
-        screen.getByLabelText("inconclusive", { exact: false })
-      ).not.toBeChecked();
-    });
-
-    it("updates the result when a new radio is clicked", async () => {
-      expect(screen.getAllByLabelText("Positive (+)")[1]).not.toBeChecked();
-      userEvent.click(screen.getAllByLabelText("Positive (+)")[1]);
-
-      const editQueueSpy = jest.spyOn(
-        generatedGraphql,
-        "useEditQueueItemMultiplexResultMutation"
-      );
-      await waitFor(() => expect(editQueueSpy).toHaveBeenCalled());
-    });
-  });
 });
-
-const internalId = "f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554";
-const deviceOne = {
-  name: "Access Bio CareStart",
-  internalId: internalId,
-  testLength: 10,
-  supportedDiseases: [{ internalId: "1", name: "COVID-19" }],
-};
-
-const deviceTwo = {
-  name: "LumiraDX",
-  internalId: "lumira",
-  testLength: 15,
-  supportedDiseases: [{ internalId: "1", name: "COVID-19" }],
-};
-
-const deviceThree = {
-  name: "MultiplexMate",
-  internalId: "multiplex",
-  testLength: 15,
-  supportedDiseases: [
-    { internalId: "1", name: "COVID-19" },
-    { internalId: "2", name: "Flu A" },
-    {
-      internalId: "3",
-      name: "Flu B",
-    },
-  ],
-};
-
-const testProps = {
-  internalId: internalId,
-  patient: {
-    internalId: internalId,
-    firstName: "Harry",
-    middleName: "James",
-    lastName: "Potter",
-    telephone: "fakenumber",
-    birthDate: "1990-07-31",
-    phoneNumbers: [
-      {
-        number: "a-mobile-number",
-        type: "MOBILE",
-      },
-      {
-        number: "a-landline-number",
-        type: "LANDLINE",
-      },
-    ],
-    email: "foo",
-    emails: ["foo"],
-    gender: "male" as Gender,
-    testResultDelivery: "sms",
-  },
-  devices: [deviceOne, deviceTwo],
-  askOnEntry: {
-    symptoms: "{}",
-  } as any,
-  testResultPreference: "SMS",
-  selectedDeviceId: internalId,
-  selectedDeviceTestLength: 10,
-  selectedDeviceSpecimenTypeId: "device-specimen-1",
-  selectedTestResults: [] as any,
-  dateTestedProp: "",
-  refetchQueue: jest.fn().mockReturnValue(null),
-  facilityId: "Hogwarts+123",
-  patientLinkId: "",
-  deviceSpecimenTypes: [
-    {
-      internalId: "device-specimen-1",
-      deviceType: deviceOne,
-      specimenType: {
-        internalId: "specimen-1",
-        name: "Specimen 1",
-      },
-    },
-    {
-      internalId: "device-specimen-2",
-      deviceType: deviceTwo,
-      specimenType: {
-        internalId: "specimen-2",
-        name: "Specimen 2",
-      },
-    },
-    {
-      internalId: "device-specimen-3",
-      deviceType: deviceThree,
-      specimenType: {
-        internalId: "specimen-3",
-        name: "Specimen 3",
-      },
-    },
-  ] as DeviceSpecimenType[],
-};

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -485,9 +485,6 @@ describe("QueueItem", () => {
 
     await renderQueueItem({ props, mocks });
 
-    expect(
-      screen.queryByText("Please select a device")
-    ).not.toBeInTheDocument();
     const deviceDropdown = await getDeciceTypeDropdown();
     expect(deviceDropdown.options.length).toEqual(5);
     expect(deviceDropdown.options[0].label).toEqual("");
@@ -501,14 +498,18 @@ describe("QueueItem", () => {
     expect(swabDropdown.options.length).toEqual(0);
     expect(swabDropdown).toBeDisabled();
 
-    // select results
-    userEvent.click(screen.getByLabelText("Positive", { exact: false }));
-    await new Promise((resolve) => setTimeout(resolve, 501));
+    // disables submitting results and changing date
+    const submitButton = screen.getByText("Submit") as HTMLInputElement;
+    const positiveResult = screen.getByLabelText("Positive", {
+      exact: false,
+    }) as HTMLInputElement;
+    const currentDateTimeButton = screen.getByLabelText("Current date/time", {
+      exact: false,
+    }) as HTMLInputElement;
 
-    //try to submit results
-    const submitButton = screen.getByText("Submit");
-    expect(submitButton).toBeEnabled();
-    userEvent.click(submitButton);
+    expect(submitButton).toBeDisabled();
+    expect(positiveResult).toBeDisabled();
+    expect(currentDateTimeButton).toBeDisabled();
 
     // notice the error message
     expect(screen.getByText("Please select a device")).toBeInTheDocument();
@@ -521,12 +522,14 @@ describe("QueueItem", () => {
       screen.queryByText("Please select a device")
     ).not.toBeInTheDocument();
 
-    await waitFor(
-      () => {
-        expect(submitButton).toBeEnabled();
-      },
-      { timeout: 1000 }
-    );
+    // enable selecting date/time and results
+    expect(positiveResult).toBeEnabled();
+    expect(currentDateTimeButton).toBeEnabled();
+
+    // enables submitting of results after selecting one
+    userEvent.click(positiveResult);
+    await new Promise((resolve) => setTimeout(resolve, 501));
+    expect(submitButton).toBeEnabled();
   });
 
   it("correctly handles when swab is deleted from device", async () => {
@@ -620,9 +623,6 @@ describe("QueueItem", () => {
 
     await renderQueueItem({ props, mocks });
 
-    expect(
-      screen.queryByText("Please select a swab type")
-    ).not.toBeInTheDocument();
     const deviceDropdown = await getDeciceTypeDropdown();
     expect(deviceDropdown.options.length).toEqual(4);
     expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
@@ -636,14 +636,18 @@ describe("QueueItem", () => {
     expect(swabDropdown.options[0].label).toEqual("");
     expect(swabDropdown.options[1].label).toEqual("Swab of internal nose");
 
-    // select results
-    userEvent.click(screen.getByLabelText("Positive", { exact: false }));
-    await new Promise((resolve) => setTimeout(resolve, 501));
+    // disables submitting results and changing date
+    const currentDateTimeButton = screen.getByLabelText("Current date/time", {
+      exact: false,
+    }) as HTMLInputElement;
+    const positiveResult = screen.getByLabelText("Positive", {
+      exact: false,
+    }) as HTMLInputElement;
+    const submitButton = screen.getByText("Submit") as HTMLInputElement;
 
-    //try to submit results
-    const submitButton = screen.getByText("Submit");
-    expect(submitButton).toBeEnabled();
-    userEvent.click(submitButton);
+    expect(currentDateTimeButton).toBeDisabled();
+    expect(positiveResult).toBeDisabled();
+    expect(submitButton).toBeDisabled();
 
     // notice the error message
     expect(screen.getByText("Please select a swab type")).toBeInTheDocument();
@@ -655,6 +659,14 @@ describe("QueueItem", () => {
     expect(
       screen.queryByText("Please select a swab type")
     ).not.toBeInTheDocument();
+
+    // enable selecting date/time and results
+    expect(positiveResult).toBeEnabled();
+    expect(currentDateTimeButton).toBeEnabled();
+
+    // enables submitting of results after selecting one
+    userEvent.click(positiveResult);
+    await new Promise((resolve) => setTimeout(resolve, 501));
     expect(submitButton).toBeEnabled();
   });
 

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -294,16 +294,10 @@ const QueueItem = ({
   useEffect(() => {
     if (deviceTypeIsInvalid()) {
       setDeviceTypeErrorMessage("Please select a device");
-
       setSaveState("error");
-      return;
-    }
-
-    if (specimenTypeIsInvalid()) {
+    } else if (specimenTypeIsInvalid()) {
       setSpecimenTypeErrorMessage("Please select a swab type");
-
       setSaveState("error");
-      return;
     }
     // eslint-disable-next-line
   }, [devicesMap, deviceId, specimenId]);

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -91,7 +91,9 @@ export const findResultByDiseaseName = (
   results.find((r: MultiplexResultInput) => r.diseaseName === name)
     ?.testResult ?? null;
 
-export type QueriedTestOrder = GetFacilityQueueQuery["queue"][number];
+export type QueriedTestOrder = NonNullable<
+  NonNullable<GetFacilityQueueQuery["queue"]>[number]
+>;
 export type QueriedDeviceType = NonNullable<
   GetFacilityQueueQuery["facility"]
 >["deviceTypes"][number];

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -292,6 +292,23 @@ const QueueItem = ({
   }, [deviceId]);
 
   useEffect(() => {
+    if (deviceTypeIsInvalid()) {
+      setDeviceTypeErrorMessage("Please select a device");
+
+      setSaveState("error");
+      return;
+    }
+
+    if (specimenTypeIsInvalid()) {
+      setSpecimenTypeErrorMessage("Please select a swab type");
+
+      setSaveState("error");
+      return;
+    }
+    // eslint-disable-next-line
+  }, [devicesMap, deviceId, specimenId]);
+
+  useEffect(() => {
     let debounceTimer: ReturnType<typeof setTimeout>;
     if (dirtyState) {
       setDirtyState(false);
@@ -375,6 +392,7 @@ const QueueItem = ({
     showSuccess(body, title);
   };
 
+  const deviceTypeIsInvalid = () => !devicesMap.has(deviceId);
   const specimenTypeIsInvalid = () =>
     devicesMap.has(deviceId) &&
     devicesMap
@@ -391,20 +409,6 @@ const QueueItem = ({
           : "Test date can't be in the future";
 
       showError(message, "Invalid test date");
-
-      setSaveState("error");
-      return;
-    }
-
-    if (!devicesMap.has(deviceId)) {
-      setDeviceTypeErrorMessage("Please select a device");
-
-      setSaveState("error");
-      return;
-    }
-
-    if (specimenTypeIsInvalid()) {
-      setSpecimenTypeErrorMessage("Please select a swab type");
 
       setSaveState("error");
       return;
@@ -791,6 +795,9 @@ const QueueItem = ({
                             onChange={(event) =>
                               handleDateChange(event.target.value)
                             }
+                            disabled={
+                              deviceTypeIsInvalid() || specimenTypeIsInvalid()
+                            }
                           />
                           <input
                             hidden={shouldUseCurrentDateTime}
@@ -806,6 +813,9 @@ const QueueItem = ({
                             step="60"
                             value={moment(dateTested).format("HH:mm")}
                             onChange={(e) => handleTimeChange(e.target.value)}
+                            disabled={
+                              deviceTypeIsInvalid() || specimenTypeIsInvalid()
+                            }
                           />
                         </>
                       )}
@@ -820,6 +830,9 @@ const QueueItem = ({
                               onUseCurrentDateChange(e.target.checked)
                             }
                             aria-label="Use current date and time"
+                            disabled={
+                              deviceTypeIsInvalid() || specimenTypeIsInvalid()
+                            }
                           />
                           <label
                             className="usa-checkbox__label margin-0 margin-right-05em"
@@ -936,7 +949,11 @@ const QueueItem = ({
                   queueItemId={queueItem.internalId}
                   testResults={cacheTestResults}
                   isSubmitDisabled={
-                    loading || saveState === "editing" || saveState === "saving"
+                    loading ||
+                    saveState === "editing" ||
+                    saveState === "saving" ||
+                    deviceTypeIsInvalid() ||
+                    specimenTypeIsInvalid()
                   }
                   onSubmit={onTestResultSubmit}
                   onChange={onTestResultChange}
@@ -946,7 +963,11 @@ const QueueItem = ({
                   queueItemId={queueItem.internalId}
                   testResults={cacheTestResults}
                   isSubmitDisabled={
-                    loading || saveState === "editing" || saveState === "saving"
+                    loading ||
+                    saveState === "editing" ||
+                    saveState === "saving" ||
+                    deviceTypeIsInvalid() ||
+                    specimenTypeIsInvalid()
                   }
                   onSubmit={onTestResultSubmit}
                   onChange={onTestResultChange}

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -422,7 +422,7 @@ const QueueItem = ({
     try {
       const result = await submitTestResult({
         variables: {
-          patientId: queueItem.patient?.internalId!,
+          patientId: queueItem.patient?.internalId,
           deviceTypeId: deviceId,
           specimenTypeId: specimenId,
           results: cacheTestResults,

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useMutation } from "@apollo/client";
 import Modal from "react-modal";
@@ -12,14 +6,14 @@ import classnames from "classnames";
 import moment, { Moment } from "moment";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { throttle } from "lodash";
-import { useFeature } from "flagged";
+import { isEqual } from "lodash";
 
 import {
   MultiplexResultInput,
   useRemovePatientFromQueueMutation,
-  useEditQueueItemMultiplexResultMutation,
-  useAddMultiplexResultMutation,
+  useEditQueueItemMutation,
+  useSubmitQueueItemMutation,
+  GetFacilityQueueQuery,
 } from "../../generated/graphql";
 import Button from "../commonComponents/Button/Button";
 import Dropdown from "../commonComponents/Dropdown";
@@ -46,19 +40,11 @@ import {
 } from "./TestTimer";
 import AoEModalForm from "./AoEForm/AoEModalForm";
 import "./QueueItem.scss";
-import { AoEAnswers, TestQueuePerson } from "./AoEForm/AoEForm";
+import { AoEAnswers } from "./AoEForm/AoEForm";
 import { QueueItemSubmitLoader } from "./QueueItemSubmitLoader";
 import { UPDATE_AOE } from "./addToQueue/AddToQueueSearch";
 
 const EARLIEST_TEST_DATE = new Date("01/01/2020 12:00:00 AM");
-
-interface EditQueueItemParams {
-  id: string;
-  deviceId?: string;
-  deviceSpecimenType: string;
-  results?: MultiplexResultInput[];
-  dateTested?: string;
-}
 
 interface AreYouSureProps {
   cancelText: string;
@@ -105,12 +91,19 @@ export const findResultByDiseaseName = (
   results.find((r: MultiplexResultInput) => r.diseaseName === name)
     ?.testResult ?? null;
 
+export type QueriedTestOrder = GetFacilityQueueQuery["queue"][number];
+export type QueriedDeviceType = NonNullable<
+  GetFacilityQueueQuery["facility"]
+>["deviceTypes"][number];
+export type QueriedFacility = GetFacilityQueueQuery["facility"];
+type QueriedSupportedDiseases = QueriedTestOrder["deviceType"]["supportedDiseases"][number];
+
 const convertFromMultiplexResponse = (
-  responseResult: MultiplexResult[]
+  responseResult: QueriedTestOrder["results"]
 ): MultiplexResultInput[] => {
   const multiplexResultInputs: MultiplexResultInput[] = responseResult.map(
     (result) => ({
-      diseaseName: result.disease.name,
+      diseaseName: result.disease?.name,
       testResult: result.testResult,
     })
   );
@@ -121,62 +114,38 @@ if (process.env.NODE_ENV !== "test") {
   Modal.setAppElement("#root");
 }
 
+export type DevicesMap = Map<string, QueriedDeviceType>;
+
 export interface QueueItemProps {
-  internalId: string;
-  patient: TestQueuePerson;
+  queueItem: QueriedTestOrder;
   startTestPatientId: string | null;
   setStartTestPatientId: any;
-  devices: {
-    name: string;
-    internalId: string;
-    testLength: number;
-  }[];
-  deviceSpecimenTypes: DeviceSpecimenType[];
-  askOnEntry: AoEAnswers;
-  selectedDeviceId: string;
-  selectedDeviceSpecimenTypeId: string;
-  selectedDeviceTestLength: number;
-  selectedTestResults: MultiplexResult[];
-  dateTestedProp: string;
+  facility: QueriedFacility;
   refetchQueue: () => void;
-  facilityName: string | undefined;
-  facilityId: string;
-  isCorrection?: boolean;
-  reasonForCorrection?: TestCorrectionReason;
+  devicesMap: DevicesMap;
 }
 
 interface updateQueueItemProps {
   deviceId?: string;
-  deviceSpecimenType: string;
+  specimenTypeId?: string;
   testLength?: number;
   results?: MultiplexResultInput[];
-  dateTested?: string;
+  dateTested: string | null;
 }
 
 type SaveState = "idle" | "editing" | "saving" | "error";
 
 const QueueItem = ({
-  internalId,
-  patient,
+  refetchQueue,
+  queueItem,
   startTestPatientId,
   setStartTestPatientId,
-  deviceSpecimenTypes,
-  askOnEntry,
-  selectedDeviceId,
-  selectedDeviceSpecimenTypeId,
-  selectedDeviceTestLength,
-  selectedTestResults,
-  refetchQueue,
-  facilityName,
-  facilityId,
-  dateTestedProp,
-  isCorrection = false,
-  reasonForCorrection,
+  facility,
+  devicesMap,
 }: QueueItemProps) => {
-  const appInsights = getAppInsights();
+  const testCardElement = useRef() as React.MutableRefObject<HTMLDivElement>;
   const navigate = useNavigate();
-  const multiplexFlag = useFeature("multiplexEnabled");
-
+  const appInsights = getAppInsights();
   const trackRemovePatientFromQueue = () => {
     if (appInsights) {
       appInsights.trackEvent({ name: "Remove Patient From Queue" });
@@ -193,96 +162,160 @@ const QueueItem = ({
     }
   };
 
-  const [mutationError, updateMutationError] = useState(null);
-  const [removePatientFromQueue] = useRemovePatientFromQueueMutation();
-  const [submitTestResult, { loading }] = useAddMultiplexResultMutation();
-  const [updateAoe] = useMutation(UPDATE_AOE);
-  const [editQueueItem] = useEditQueueItemMultiplexResultMutation();
+  const isCorrection = queueItem.correctionStatus === "CORRECTED";
+  const reasonForCorrection = queueItem.reasonForCorrection as TestCorrectionReason;
+  const selectedDeviceTestLength = queueItem.deviceType.testLength;
 
+  const [removePatientFromQueue] = useRemovePatientFromQueueMutation();
+  const [submitTestResult, { loading }] = useSubmitQueueItemMutation();
+  const [updateAoe] = useMutation(UPDATE_AOE);
+  const [editQueueItem] = useEditQueueItemMutation();
+
+  const DEBOUNCE_TIME = 300;
+
+  const [mutationError, updateMutationError] = useState(null);
   const [saveState, setSaveState] = useState<SaveState>("idle");
 
   const [isAoeModalOpen, updateIsAoeModalOpen] = useState(false);
-  const [aoeAnswers, setAoeAnswers] = useState(askOnEntry);
-  useEffect(() => {
-    setAoeAnswers(askOnEntry);
-  }, [askOnEntry]);
+  const [aoeAnswers, setAoeAnswers] = useState({
+    noSymptoms: queueItem.noSymptoms,
+    symptoms: queueItem.symptoms,
+    symptomOnset: queueItem.symptomOnset,
+    pregnancy: queueItem.pregnancy,
+  } as AoEAnswers);
 
-  const [deviceId, updateDeviceId] = useState<string>(selectedDeviceId);
-  const [specimenId, updateSpecimenId] = useState<string>("");
-  const [deviceSpecimenTypeId, updateDeviceSpecimenTypeId] = useState(
-    selectedDeviceSpecimenTypeId
+  const [deviceId, updateDeviceId] = useState<string>(
+    queueItem.deviceType.internalId
   );
-  const [supportsMultipleDiseases, updateSupportsMultipleDiseases] =
-    useState(false);
+  const [deviceTypeErrorMessage, setDeviceTypeErrorMessage] = useState<
+    string | null
+  >(null);
+  const [specimenId, updateSpecimenId] = useState<string>(
+    queueItem.specimenType.internalId
+  );
+  const [specimenTypeErrorMessage, setSpecimenTypeErrorMessage] = useState<
+    string | null
+  >(null);
+  const [supportsMultipleDiseases, updateSupportsMultipleDiseases] = useState(
+    queueItem.deviceType.supportedDiseases.filter(
+      (d: any) => d.name !== "COVID-19"
+    ).length > 0
+  );
 
-  // Populate device+specimen state variables from selected device specimen type
+  const [cacheTestResults, setCacheTestResults] = useState(
+    convertFromMultiplexResponse(queueItem.results)
+  );
+
+  const [dateTested, updateDateTested] = useState<string | null>(
+    queueItem.dateTested || null
+  );
+  const shouldUseCurrentDateTime = dateTested === null;
+
+  // this tracks if the ui made any edits, this needs to publish update to backend
+  const [dirtyState, setDirtyState] = useState(false);
+
+  const updateQueueItem = (props: updateQueueItemProps) => {
+    return editQueueItem({
+      variables: {
+        id: queueItem.internalId,
+        deviceTypeId: props.deviceId,
+        results: props.results,
+        dateTested: props.dateTested,
+        specimenTypeId: props.specimenTypeId,
+      },
+    })
+      .then((response) => {
+        if (!response.data) throw Error("updateQueueItem null response");
+
+        const newDeviceId = response?.data?.editQueueItem?.deviceType;
+        if (newDeviceId && newDeviceId.internalId !== deviceId) {
+          updateDeviceId(newDeviceId.internalId);
+          updateTimer(queueItem.internalId, newDeviceId.testLength);
+        }
+      })
+      .catch(updateMutationError);
+  };
+
+  const updateDeviceMultiplexSupport = (
+    supportedDiseases: QueriedSupportedDiseases[]
+  ) => {
+    const updatedDiseaseSupport =
+      supportedDiseases.filter((d: any) => d.name !== "COVID-19").length > 0;
+    if (supportsMultipleDiseases !== updatedDiseaseSupport) {
+      updateSupportsMultipleDiseases(updatedDiseaseSupport);
+    }
+  };
+
   useEffect(() => {
-    // Asserting this type should be OK - the parent component is responsible
-    // for removing invalid or deleted device specimen types from the collection
-    // passed in as props
-    const deviceSpecimenType = deviceSpecimenTypes.find(
-      (dst) => dst.internalId === deviceSpecimenTypeId
-    ) as DeviceSpecimenType;
+    // Update test card changes from server
 
-    let supportsMultipleDiseases;
-    if (
-      multiplexFlag &&
-      deviceSpecimenType.deviceType.supportedDiseases.filter(
-        (d: any) => d.name !== "COVID-19"
-      ).length > 0
-    ) {
-      supportsMultipleDiseases = true;
-    } else {
-      supportsMultipleDiseases = false;
+    if (deviceId !== queueItem.deviceType.internalId) {
+      updateDeviceId(queueItem.deviceType.internalId);
+    }
+    if (specimenId !== queueItem.specimenType.internalId) {
+      updateSpecimenId(queueItem.specimenType.internalId);
     }
 
-    updateDeviceSpecimenTypeId(deviceSpecimenType.internalId);
-    updateDeviceId(deviceSpecimenType.deviceType.internalId);
-    updateSpecimenId(deviceSpecimenType.specimenType.internalId);
-    updateSupportsMultipleDiseases(supportsMultipleDiseases);
-  }, [deviceSpecimenTypes, deviceSpecimenTypeId, multiplexFlag]);
+    //update date tested fields
+    if (dateTested !== queueItem.dateTested) {
+      updateDateTested(queueItem.dateTested);
+    }
 
-  const testCardElement = useRef() as React.MutableRefObject<HTMLDivElement>;
+    //update results
+    const updatedResults = convertFromMultiplexResponse(queueItem.results);
+    if (!isEqual(cacheTestResults, updatedResults)) {
+      setCacheTestResults(updatedResults);
+    }
 
-  useEffect(() => {
-    if (startTestPatientId === patient.internalId) {
+    //update aoe
+    const askOnEntry = {
+      noSymptoms: queueItem.noSymptoms,
+      symptoms: queueItem.symptoms,
+      symptomOnset: queueItem.symptomOnset,
+      pregnancy: queueItem.pregnancy,
+    } as AoEAnswers;
+    if (aoeAnswers !== askOnEntry) {
+      setAoeAnswers(askOnEntry);
+    }
+
+    if (startTestPatientId === queueItem.patient.internalId) {
       testCardElement.current.scrollIntoView({ behavior: "smooth" });
     }
-  });
+    // eslint-disable-next-line
+  }, [queueItem, startTestPatientId]);
 
-  const deviceTypes = deviceSpecimenTypes
-    .map((d) => d.deviceType)
-    .reduce((allDevices, device: DeviceType) => {
-      const id = device.internalId;
+  useEffect(() => {
+    if (devicesMap.has(deviceId)) {
+      updateDeviceMultiplexSupport(devicesMap.get(deviceId)!.supportedDiseases);
+    }
+    // eslint-disable-next-line
+  }, [deviceId]);
 
-      if (!(id in allDevices)) {
-        allDevices[id] = device;
-      }
-
-      return allDevices;
-    }, {} as Record<string, DeviceType>);
-
-  const [deviceTestLength, updateDeviceTestLength] = useState(
-    selectedDeviceTestLength
-  );
-
-  const [useCurrentDateTime, updateUseCurrentDateTime] = useState<
-    "true" | "false"
-  >(dateTestedProp ? "false" : "true");
-  // this is an ISO string
-  // always assume the current date unless provided something else
-  const [dateTested, updateDateTested] = useState<string | undefined>(
-    dateTestedProp || undefined
-  );
+  useEffect(() => {
+    let debounceTimer: ReturnType<typeof setTimeout>;
+    if (dirtyState) {
+      setDirtyState(false);
+      setSaveState("editing");
+      debounceTimer = setTimeout(async () => {
+        await updateQueueItem({
+          deviceId,
+          dateTested,
+          specimenTypeId: specimenId,
+          results: cacheTestResults,
+        });
+        setSaveState("idle");
+      }, DEBOUNCE_TIME);
+    }
+    return () => {
+      clearTimeout(debounceTimer);
+      setSaveState("idle");
+    };
+    // eslint-disable-next-line
+  }, [deviceId, specimenId, dateTested, cacheTestResults]);
 
   const organization = useSelector<RootState, Organization>(
     (state: any) => state.organization as Organization
   );
-
-  // helper method to work around the annoying string-booleans
-  function shouldUseCurrentDateTime() {
-    return useCurrentDateTime === "true";
-  }
 
   // `Array.prototype.sort`-friendly callback for devices and swab types
   function alphabetizeByName(
@@ -313,23 +346,6 @@ const QueueItem = ({
     return dateTested > EARLIEST_TEST_DATE && dateTested < new Date();
   }
 
-  /***
-   * Handle caching of results
-   */
-
-  const [cacheTestResults, setCacheTestResults] = useState(
-    convertFromMultiplexResponse(selectedTestResults)
-  );
-  const multiplexResultInputsRef =
-    useRef<MultiplexResultInput[]>(cacheTestResults); // persistent reference to use in Effect
-
-  useEffect(() => {
-    // update cache when selectedTestResults prop update
-    setCacheTestResults(convertFromMultiplexResponse(selectedTestResults));
-    multiplexResultInputsRef.current =
-      convertFromMultiplexResponse(selectedTestResults);
-  }, [selectedTestResults]);
-
   const covidResult = findResultByDiseaseName(cacheTestResults, "COVID-19");
   const [confirmationType, setConfirmationType] = useState<
     "submitResult" | "removeFromQueue" | "none"
@@ -346,11 +362,11 @@ const QueueItem = ({
   const testResultsSubmitted = (response: any) => {
     let { title, body } = {
       ...ALERT_CONTENT[QUEUE_NOTIFICATION_TYPES.SUBMITTED_RESULT__SUCCESS](
-        patient
+        queueItem.patient
       ),
     };
 
-    if (response?.data?.addMultiplexResult.deliverySuccess === false) {
+    if (response?.data?.submitQueueItem.deliverySuccess === false) {
       let deliveryFailureTitle = `Unable to text result to ${patientFullName}`;
       let deliveryFailureMsg =
         "The phone number provided may not be valid or may not be able to accept text messages";
@@ -359,12 +375,14 @@ const QueueItem = ({
     showSuccess(body, title);
   };
 
+  const specimenTypeIsInvalid = () =>
+    devicesMap.has(deviceId) &&
+    devicesMap
+      .get(deviceId)!
+      .swabTypes.filter((s) => s.internalId === specimenId).length === 0;
+
   const onTestResultSubmit = async (forceSubmit: boolean = false) => {
-    if (
-      dateTested &&
-      !shouldUseCurrentDateTime() &&
-      !isValidCustomDateTested(dateTested)
-    ) {
+    if (dateTested && !isValidCustomDateTested(dateTested)) {
       const message =
         new Date(dateTested) < EARLIEST_TEST_DATE
           ? `Test date must be after ${moment(EARLIEST_TEST_DATE).format(
@@ -373,6 +391,20 @@ const QueueItem = ({
           : "Test date can't be in the future";
 
       showError(message, "Invalid test date");
+
+      setSaveState("error");
+      return;
+    }
+
+    if (!devicesMap.has(deviceId)) {
+      setDeviceTypeErrorMessage("Please select a device");
+
+      setSaveState("error");
+      return;
+    }
+
+    if (specimenTypeIsInvalid()) {
+      setSpecimenTypeErrorMessage("Please select a swab type");
 
       setSaveState("error");
       return;
@@ -388,20 +420,18 @@ const QueueItem = ({
     }
     setConfirmationType("none");
     try {
-      const results = Object.assign([], cacheTestResults);
-
       const result = await submitTestResult({
         variables: {
-          patientId: patient.internalId,
-          deviceId: deviceId,
-          deviceSpecimenType: deviceSpecimenTypeId,
-          results,
-          dateTested: shouldUseCurrentDateTime() ? null : dateTested,
+          patientId: queueItem.patient?.internalId!,
+          deviceTypeId: deviceId,
+          specimenTypeId: specimenId,
+          results: cacheTestResults,
+          dateTested: dateTested,
         },
       });
       testResultsSubmitted(result);
       refetchQueue();
-      removeTimer(internalId);
+      removeTimer(queueItem.internalId);
       setStartTestPatientId(null);
     } catch (error: any) {
       setSaveState("error");
@@ -409,141 +439,37 @@ const QueueItem = ({
     }
   };
 
-  const updateQueueItem = useCallback(
-    (props: updateQueueItemProps) => {
-      return editQueueItem({
-        variables: {
-          id: internalId,
-          deviceId: props.deviceId,
-          results: props.results,
-          dateTested: props.dateTested,
-          deviceSpecimenType: props.deviceSpecimenType,
-        },
-      })
-        .then((response) => {
-          if (!response.data) throw Error("updateQueueItem null response");
-          updateDeviceSpecimenTypeId(
-            response?.data?.editQueueItemMultiplexResult?.deviceSpecimenType
-              ?.internalId ?? ""
-          );
-          updateTimer(
-            internalId,
-            response?.data?.editQueueItemMultiplexResult?.deviceSpecimenType
-              ?.deviceType.testLength as number
-          );
-          updateDeviceTestLength(
-            (response?.data?.editQueueItemMultiplexResult?.deviceSpecimenType
-              ?.deviceType?.testLength as number) ?? 15
-          );
-        })
-        .catch(updateMutationError);
-    },
-    [editQueueItem, internalId]
-  );
-
   const onDeviceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const deviceSpecimenTypesForDevice = deviceSpecimenTypes.filter(
-      (dst) => dst.deviceType.internalId === e.currentTarget.value
-    );
-    // When changing devices, the target device may not be configured with the current swab type
-    // In that case, just grab from the top of the list
-    const newDeviceTypeSpecimen =
-      deviceSpecimenTypesForDevice.find(
-        (dst) => dst.specimenType.internalId === specimenId
-      ) || deviceSpecimenTypesForDevice[0];
-
-    updateDeviceSpecimenTypeId(newDeviceTypeSpecimen.internalId);
+    const deviceId = e.currentTarget.value;
+    updateDeviceId(deviceId);
+    devicesMap.has(deviceId) &&
+      updateSpecimenId(devicesMap.get(deviceId)!.swabTypes[0].internalId);
+    setDeviceTypeErrorMessage(null);
+    setDirtyState(true);
   };
 
   const onSpecimenChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newDeviceSpecimenType = deviceSpecimenTypes.find(
-      (dst) =>
-        dst.specimenType.internalId === e.currentTarget.value &&
-        dst.deviceType.internalId === deviceId
-    );
-
-    updateDeviceSpecimenTypeId(newDeviceSpecimenType?.internalId);
+    updateSpecimenId(e.currentTarget.value);
+    setSpecimenTypeErrorMessage(null);
+    setDirtyState(true);
   };
 
   const onDateTestedChange = (date: moment.Moment) => {
-    const newDateTested = date.toISOString();
-
     // the date string returned from the server is only precise to seconds; moment's
     // toISOString method returns millisecond precision. as a result, an onChange event
     // was being fired when this component initialized, sending an EditQueueItem to
     // the back end w/ the same data that it already had. this prevents it:
-    if (moment(dateTested).isSame(date)) {
-      return;
+    if (!moment(dateTested).isSame(date)) {
+      // Save any date given as input to React state, valid or otherwise. Validation
+      // is performed on submit
+      updateDateTested(date.toISOString());
+      setDirtyState(true);
     }
-
-    // Save any date given as input to React state, valid or otherwise. Validation
-    // is performed on submit
-    updateDateTested(newDateTested);
-    setSelectedDate(date);
   };
-
-  const isMounted = useRef(false);
-  const DEBOUNCE_TIME = 300;
-
-  useEffect(() => {
-    const results = Object.assign([], multiplexResultInputsRef.current);
-
-    let debounceTimer: ReturnType<typeof setTimeout>;
-    if (!isMounted.current) {
-      isMounted.current = true;
-    } else {
-      setSaveState("editing");
-      debounceTimer = setTimeout(async () => {
-        await updateQueueItem({
-          deviceId,
-          dateTested,
-          deviceSpecimenType: deviceSpecimenTypeId,
-          results,
-        });
-        setSaveState("idle");
-      }, DEBOUNCE_TIME);
-    }
-    return () => {
-      clearTimeout(debounceTimer);
-      setSaveState("idle");
-    };
-  }, [
-    deviceId,
-    deviceSpecimenTypeId,
-    dateTested,
-    updateQueueItem,
-    multiplexResultInputsRef,
-  ]);
-
-  const editQueueItemService = (resultsFromForm: MultiplexResultInput[]) => {
-    editQueueItem({
-      variables: {
-        id: internalId,
-        deviceId: deviceId,
-        results: resultsFromForm,
-        dateTested: dateTested,
-        deviceSpecimenType: deviceSpecimenTypeId,
-      } as EditQueueItemParams,
-    });
-  };
-
-  const throttleEditQueueItemService = useMemo(
-    () => throttle(editQueueItemService, 500),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
-  useEffect(() => {
-    return () => {
-      throttleEditQueueItemService.cancel();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const onTestResultChange = (resultsFromForm: MultiplexResultInput[]) => {
-    throttleEditQueueItemService(resultsFromForm);
     setCacheTestResults(resultsFromForm);
-    multiplexResultInputsRef.current = Object.assign([], resultsFromForm);
+    setDirtyState(true);
   };
 
   const removeFromQueue = () => {
@@ -558,7 +484,7 @@ const QueueItem = ({
     })
       .then(() => refetchQueue())
       .then(() => setStartTestPatientId(null))
-      .then(() => removeTimer(internalId))
+      .then(() => removeTimer(queueItem.internalId))
       .catch((error) => {
         updateMutationError(error);
       })
@@ -589,50 +515,35 @@ const QueueItem = ({
       variables: {
         ...answers,
         symptomOnset,
-        patientId: patient.internalId,
+        patientId: queueItem.patient.internalId,
       },
     })
       .then(() => refetchQueue())
       .catch(updateMutationError);
   };
 
-  const onUseCurrentDateChange = () => {
-    // if we want to use a custom date
-    if (shouldUseCurrentDateTime()) {
-      setSelectedDate(moment());
-      updateUseCurrentDateTime("false");
-    }
-    // if we want to use the current date time
-    else {
-      updateDateTested(undefined);
+  const onUseCurrentDateChange = (checked: boolean) => {
+    if (checked) {
+      // if we want to use the current date time
+      updateDateTested(null);
       setBeforeDateWarning(false);
-      updateUseCurrentDateTime("true");
+    } else {
+      // if we want to use a custom date
+      updateDateTested(moment().toISOString());
     }
+    setDirtyState(true);
   };
 
-  const deviceLookup: Map<DeviceType, SpecimenType[]> = useMemo(
-    () =>
-      deviceSpecimenTypes.reduce((allDevices, { deviceType, specimenType }) => {
-        const device = deviceTypes[deviceType.internalId];
-        allDevices.get(device)?.push(specimenType);
-
-        return allDevices;
-      }, new Map(Object.values(deviceTypes).map((device) => [device, [] as SpecimenType[]]))),
-    // adding `deviceTypes` to dependency list will cause an infinite loop of state updates
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [deviceSpecimenTypes]
-  );
-
   const patientFullName = displayFullName(
-    patient.firstName,
-    patient.middleName,
-    patient.lastName
+    queueItem.patient.firstName,
+    queueItem.patient.middleName,
+    queueItem.patient.lastName
   );
 
   const closeButton = (
     <button
       onClick={() => {
-        setRemovePatientId(patient.internalId);
+        setRemovePatientId(queueItem.patient.internalId);
         setConfirmationType("removeFromQueue");
       }}
       className="prime-close-button"
@@ -658,15 +569,14 @@ const QueueItem = ({
     isBeforeDateWarningThreshold(moment(dateTested))
   );
 
-  const [selectedDate, setSelectedDate] = useState(
-    dateTested ? moment(dateTested) : moment()
-  );
-
   const handleDateChange = (date: string) => {
     if (date) {
-      const newDate = moment(date)
-        .hour(selectedDate.hours())
-        .minute(selectedDate.minutes());
+      const newDate = moment(date);
+      if (dateTested) {
+        const oldDateTested = moment(dateTested);
+        newDate.hour(oldDateTested.hours());
+        newDate.minute(oldDateTested.minutes());
+      }
 
       if (isBeforeDateWarningThreshold(newDate)) {
         setBeforeDateWarning(true);
@@ -684,13 +594,13 @@ const QueueItem = ({
 
   const handleTimeChange = (timeStamp: string) => {
     const [hours, minutes] = timeStamp.split(":");
-    const newDate = moment(selectedDate)
+    const newDate = moment(dateTested)
       .hours(parseInt(hours))
       .minutes(parseInt(minutes));
     onDateTestedChange(newDate);
   };
 
-  const timer = useTestTimer(internalId, deviceTestLength);
+  const timer = useTestTimer(queueItem.internalId, selectedDeviceTestLength);
 
   function cardColorDisplay() {
     const prefix = "prime-queue-item__";
@@ -703,7 +613,7 @@ const QueueItem = ({
     if (timer.countdown < 0 && covidResult === "UNKNOWN") {
       return prefix + "ready";
     }
-    if (startTestPatientId === patient.internalId) {
+    if (startTestPatientId === queueItem.patient.internalId) {
       return prefix + "info";
     }
     if (dateBeforeWarnThreshold) {
@@ -725,16 +635,43 @@ const QueueItem = ({
 
   const timerContext = {
     organizationName: organization.name,
-    facilityName: facilityName,
-    patientId: patient.internalId,
-    testOrderId: internalId,
+    facilityName: facility!.name,
+    patientId: queueItem.patient.internalId,
+    testOrderId: queueItem.internalId,
   };
+
+  let deviceTypeOptions = [...facility!.deviceTypes]
+    .sort(alphabetizeByName)
+    .map((d) => ({
+      label: d.name,
+      value: d.internalId,
+    }));
+
+  if (!devicesMap.has(deviceId)) {
+    // this adds an empty option for when the device has been deleted from the facility, but it's on the test order
+    deviceTypeOptions = [{ label: "", value: "" }, ...deviceTypeOptions];
+  }
+
+  let specimenTypeOptions =
+    deviceId && devicesMap.has(deviceId)
+      ? [...devicesMap.get(deviceId)!.swabTypes]
+          .sort(alphabetizeByName)
+          .map((s: SpecimenType) => ({
+            label: s.name,
+            value: s.internalId,
+          }))
+      : [];
+
+  if (specimenTypeIsInvalid()) {
+    // this adds a empty option for when the specimen has been deleted from the device, but it's on the test order
+    specimenTypeOptions = [{ label: "", value: "" }, ...specimenTypeOptions];
+  }
 
   return (
     <React.Fragment>
       <div
         className={containerClasses}
-        data-testid={`test-card-${patient.internalId}`}
+        data-testid={`test-card-${queueItem.patient.internalId}`}
       >
         <QueueItemSubmitLoader
           show={saveState === "saving"}
@@ -772,7 +709,7 @@ const QueueItem = ({
             >
               <div
                 className="grid-row prime-test-name usa-card__header"
-                id={`patient-name-header-${patient.internalId}`}
+                id={`patient-name-header-${queueItem.patient.internalId}`}
               >
                 <div className="card-header">
                   <h2>
@@ -781,8 +718,8 @@ const QueueItem = ({
                       className="card-name"
                       onClick={() => {
                         navigate({
-                          pathname: `/patient/${patient.internalId}`,
-                          search: `?facility=${facilityId}&fromQueue=true`,
+                          pathname: `/patient/${queueItem.patient.internalId}`,
+                          search: `?facility=${facility!.id}&fromQueue=true`,
                         });
                       }}
                     >
@@ -793,7 +730,7 @@ const QueueItem = ({
                     Date of birth:
                     <span className="card-date">
                       {" "}
-                      {moment(patient.birthDate).format("MM/DD/yyyy")}
+                      {moment(queueItem.patient.birthDate).format("MM/DD/yyyy")}
                     </span>
                   </div>
                 </div>
@@ -811,7 +748,7 @@ const QueueItem = ({
                     {isAoeModalOpen && (
                       <AoEModalForm
                         onClose={closeAoeModal}
-                        patient={patient}
+                        patient={queueItem.patient}
                         loadState={aoeAnswers}
                         saveCallback={saveAoeCallback}
                       />
@@ -824,62 +761,69 @@ const QueueItem = ({
                   <div className="desktop:grid-col-fill flex-col-container">
                     <div
                       className={classnames(
-                        saveState === "error" && "queue-item-error-message",
+                        saveState === "error" &&
+                          !deviceTypeErrorMessage &&
+                          !specimenTypeErrorMessage &&
+                          "queue-item-error-message",
                         dateBeforeWarnThreshold && "card-correction-label"
                       )}
                     >
                       Test date and time
                     </div>
                     <div className="test-date-time-container">
-                      <input
-                        hidden={useCurrentDateTime !== "false"}
-                        className={classnames(
-                          "card-test-input",
-                          saveState === "error" && "card-test-input__error",
-                          dateBeforeWarnThreshold && "card-correction-input"
-                        )}
-                        aria-label="Test date"
-                        id={`test-date-${patient.internalId}`}
-                        data-testid="test-date"
-                        name="test-date"
-                        type="date"
-                        min={formatDate(new Date("Jan 1, 2020"))}
-                        max={formatDate(moment().toDate())}
-                        value={formatDate(selectedDate.toDate())}
-                        onChange={(event) =>
-                          handleDateChange(event.target.value)
-                        }
-                      />
-                      <input
-                        hidden={useCurrentDateTime !== "false"}
-                        className={classnames(
-                          "card-test-input",
-                          saveState === "error" && "card-test-input__error",
-                          dateBeforeWarnThreshold && "card-correction-input"
-                        )}
-                        name={"test-time"}
-                        aria-label="Test time"
-                        data-testid="test-time"
-                        type="time"
-                        step="60"
-                        value={selectedDate.format("HH:mm")}
-                        onChange={(e) => handleTimeChange(e.target.value)}
-                      />
-
+                      {!shouldUseCurrentDateTime && (
+                        <>
+                          <input
+                            hidden={shouldUseCurrentDateTime}
+                            className={classnames(
+                              "card-test-input",
+                              saveState === "error" && "card-test-input__error",
+                              dateBeforeWarnThreshold && "card-correction-input"
+                            )}
+                            aria-label="Test date"
+                            id={`test-date-${queueItem.patient.internalId}`}
+                            data-testid="test-date"
+                            name="test-date"
+                            type="date"
+                            min={formatDate(new Date("Jan 1, 2020"))}
+                            max={formatDate(moment().toDate())}
+                            value={formatDate(moment(dateTested).toDate())}
+                            onChange={(event) =>
+                              handleDateChange(event.target.value)
+                            }
+                          />
+                          <input
+                            hidden={shouldUseCurrentDateTime}
+                            className={classnames(
+                              "card-test-input",
+                              saveState === "error" && "card-test-input__error",
+                              dateBeforeWarnThreshold && "card-correction-input"
+                            )}
+                            name={"test-time"}
+                            aria-label="Test time"
+                            data-testid="test-time"
+                            type="time"
+                            step="60"
+                            value={moment(dateTested).format("HH:mm")}
+                            onChange={(e) => handleTimeChange(e.target.value)}
+                          />
+                        </>
+                      )}
                       <div className="check-box-container">
                         <div className="usa-checkbox">
                           <input
-                            id={`current-date-check-${patient.internalId}`}
+                            id={`current-date-check-${queueItem.patient.internalId}`}
                             className="usa-checkbox__input margin"
-                            value={useCurrentDateTime}
-                            checked={useCurrentDateTime === "true"}
+                            checked={shouldUseCurrentDateTime}
                             type="checkbox"
-                            onChange={onUseCurrentDateChange}
+                            onChange={(e) =>
+                              onUseCurrentDateChange(e.target.checked)
+                            }
                             aria-label="Use current date and time"
                           />
                           <label
                             className="usa-checkbox__label margin-0 margin-right-05em"
-                            htmlFor={`current-date-check-${patient.internalId}`}
+                            htmlFor={`current-date-check-${queueItem.patient.internalId}`}
                           >
                             Current date/time
                           </label>
@@ -891,17 +835,12 @@ const QueueItem = ({
                 <div
                   className={classnames(
                     "queue-item__form prime-ul grid-row",
-                    useCurrentDateTime === "false" && "queue-item__form--open"
+                    !shouldUseCurrentDateTime && "queue-item__form--open"
                   )}
                 >
                   <div className="prime-li flex-align-self-end tablet:grid-col-4 padding-right-2">
                     <Dropdown
-                      options={Array.from(deviceLookup.keys())
-                        .sort(alphabetizeByName)
-                        .map((d: DeviceType) => ({
-                          label: d.name,
-                          value: d.internalId,
-                        }))}
+                      options={deviceTypeOptions}
                       label={
                         <>
                           <span>Device</span>
@@ -916,25 +855,27 @@ const QueueItem = ({
                       selectedValue={deviceId}
                       onChange={onDeviceChange}
                       className="card-dropdown"
+                      data-testid="device-type-dropdown"
+                      errorMessage={deviceTypeErrorMessage}
+                      validationStatus={
+                        deviceTypeErrorMessage ? "error" : "success"
+                      }
                     />
                   </div>
                   <div className="prime-li flex-align-self-end tablet:grid-col-5 padding-right-2">
                     <Dropdown
-                      options={(
-                        deviceLookup.get(
-                          deviceTypes[deviceId]
-                        ) as SpecimenType[]
-                      )
-                        .sort(alphabetizeByName)
-                        .map((s: SpecimenType) => ({
-                          label: s.name,
-                          value: s.internalId,
-                        }))}
+                      options={specimenTypeOptions}
                       label="Swab type"
                       name="swabType"
                       selectedValue={specimenId}
                       onChange={onSpecimenChange}
                       className="card-dropdown"
+                      data-testid="specimen-type-dropdown"
+                      disabled={specimenTypeOptions.length === 0}
+                      errorMessage={specimenTypeErrorMessage}
+                      validationStatus={
+                        specimenTypeErrorMessage ? "error" : "success"
+                      }
                     />
                   </div>
                 </div>
@@ -990,9 +931,9 @@ const QueueItem = ({
                   )}
                 </AreYouSure>
               )}
-              {multiplexFlag && supportsMultipleDiseases ? (
+              {supportsMultipleDiseases ? (
                 <MultiplexResultInputForm
-                  queueItemId={internalId}
+                  queueItemId={queueItem.internalId}
                   testResults={cacheTestResults}
                   isSubmitDisabled={
                     loading || saveState === "editing" || saveState === "saving"
@@ -1002,7 +943,7 @@ const QueueItem = ({
                 />
               ) : (
                 <CovidResultInputForm
-                  queueItemId={internalId}
+                  queueItemId={queueItem.internalId}
                   testResults={cacheTestResults}
                   isSubmitDisabled={
                     loading || saveState === "editing" || saveState === "saving"

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -165,7 +165,8 @@ const QueueItem = ({
   };
 
   const isCorrection = queueItem.correctionStatus === "CORRECTED";
-  const reasonForCorrection = queueItem.reasonForCorrection as TestCorrectionReason;
+  const reasonForCorrection =
+    queueItem.reasonForCorrection as TestCorrectionReason;
   const selectedDeviceTestLength = queueItem.deviceType.testLength;
 
   const [removePatientFromQueue] = useRemovePatientFromQueueMutation();
@@ -198,9 +199,8 @@ const QueueItem = ({
   const [specimenTypeErrorMessage, setSpecimenTypeErrorMessage] = useState<
     string | null
   >(null);
-  const [supportsMultipleDiseases, updateSupportsMultipleDiseases] = useState(
-    false
-  );
+  const [supportsMultipleDiseases, updateSupportsMultipleDiseases] =
+    useState(false);
 
   const [cacheTestResults, setCacheTestResults] = useState(
     convertFromMultiplexResponse(queueItem.results)

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -96,7 +96,7 @@ export type QueriedDeviceType = NonNullable<
   GetFacilityQueueQuery["facility"]
 >["deviceTypes"][number];
 export type QueriedFacility = GetFacilityQueueQuery["facility"];
-type QueriedSupportedDiseases = QueriedTestOrder["deviceType"]["supportedDiseases"][number];
+type QueriedSupportedDiseases = QueriedDeviceType["supportedDiseases"][number];
 
 const convertFromMultiplexResponse = (
   responseResult: QueriedTestOrder["results"]
@@ -197,9 +197,7 @@ const QueueItem = ({
     string | null
   >(null);
   const [supportsMultipleDiseases, updateSupportsMultipleDiseases] = useState(
-    queueItem.deviceType.supportedDiseases.filter(
-      (d: any) => d.name !== "COVID-19"
-    ).length > 0
+    false
   );
 
   const [cacheTestResults, setCacheTestResults] = useState(

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -56,7 +56,6 @@ describe("TestQueue", () => {
   });
 
   it("should render the test queue", async () => {
-    // jest.useFakeTimers().setSystemTime(new Date("2021-08-01 08:20").getTime());
     const { container } = render(
       <MemoryRouter>
         <MockedProvider mocks={mocks}>
@@ -230,95 +229,7 @@ describe("TestQueue", () => {
       expect(within(modal).getByText("8178675911")).toBeInTheDocument();
     });
   });
-
-  // describe("device selection", () => {
-  //   it("should select another swab type for the selected device if configured swab not available", async () => {
-  //     const deviceSpecimenNotAvailableResult = { ...result };
-  //
-  //     // Default device specimen for facility is not a valid type in the `deviceSpecimenTypes` array
-  //     // returned by GraphQL. The component should select another of the facility's devices to
-  //     // populate the dropdown initially
-  //     deviceSpecimenNotAvailableResult.data.organization.testingFacility[0].defaultDeviceSpecimen =
-  //       "c0c7b042-9a4f-47cd-b280-46c0daa51c86";
-  //     deviceSpecimenNotAvailableResult.data.deviceSpecimenTypes.pop();
-  //
-  //     const mock = {
-  //       request: {
-  //         query: GetFacilityQueueDocument,
-  //         variables: {
-  //           facilityId: "a1",
-  //         },
-  //       },
-  //       result: deviceSpecimenNotAvailableResult,
-  //     };
-  //
-  //     render(
-  //       <MemoryRouter>
-  //         <MockedProvider mocks={[mock]}>
-  //           <Provider store={store}>
-  //             <TestQueue activeFacilityId="a1" />
-  //           </Provider>
-  //         </MockedProvider>
-  //       </MemoryRouter>
-  //     );
-  //
-  //     expect(
-  //       ((await screen.findAllByText("Quidel Sofia 2"))[0] as HTMLOptionElement)
-  //         .selected
-  //     ).toBeTruthy();
-  //
-  //     expect(
-  //       ((
-  //         await screen.findAllByText("Nasopharyngeal swab")
-  //       )[0] as HTMLOptionElement).selected
-  //     ).toBeTruthy();
-  //   });
-  //
-  //   it("should select another device if the configured device has no associated swab types", async () => {
-  //     const deviceNotAvailableResult = { ...result };
-  //
-  //     // The device configured as the facility default has no associated swab types - dropdown
-  //     // should be populated with another valid device+swab type combo
-  //     deviceNotAvailableResult.data.queue[0].deviceType = {
-  //       internalId: internalId,
-  //       model: "lumira",
-  //       name: "LumiraDx",
-  //       testLength: 15,
-  //       __typename: "DeviceType",
-  //     };
-  //
-  //     deviceNotAvailableResult.data.deviceSpecimenTypes.shift();
-  //
-  //     const mock = {
-  //       request: {
-  //         query: GetFacilityQueueDocument,
-  //         variables: {
-  //           facilityId: "a1",
-  //         },
-  //       },
-  //       result: deviceNotAvailableResult,
-  //     };
-  //
-  //     render(
-  //       <MemoryRouter>
-  //         <MockedProvider mocks={[mock]}>
-  //           <Provider store={store}>
-  //             <TestQueue activeFacilityId="a1" />
-  //           </Provider>
-  //         </MockedProvider>
-  //       </MemoryRouter>
-  //     );
-  //
-  //     // The facility's default device is "LumiraDx", but that device has no associated swabs
-  //     expect(
-  //       ((await screen.findAllByText("Quidel Sofia 2"))[0] as HTMLOptionElement)
-  //         .selected
-  //     ).toBeTruthy();
-  //   });
-  // });
 });
-
-const internalId = "f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554";
 
 const symptoms = JSON.stringify({
   "64531003": "false",

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -1,6 +1,7 @@
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
@@ -11,7 +12,7 @@ import { Provider } from "react-redux";
 import configureStore, { MockStoreEnhanced } from "redux-mock-store";
 
 import {
-  GetFacilityQueueMultiplexDocument,
+  GetFacilityQueueDocument,
   RemovePatientFromQueueDocument,
 } from "../../generated/graphql";
 import { appPermissions } from "../permissions";
@@ -55,7 +56,7 @@ describe("TestQueue", () => {
   });
 
   it("should render the test queue", async () => {
-    jest.useFakeTimers().setSystemTime(new Date("2021-08-01 08:20").getTime());
+    // jest.useFakeTimers().setSystemTime(new Date("2021-08-01 08:20").getTime());
     const { container } = render(
       <MemoryRouter>
         <MockedProvider mocks={mocks}>
@@ -65,9 +66,19 @@ describe("TestQueue", () => {
         </MockedProvider>
       </MemoryRouter>
     );
-    await screen.findByLabelText(
-      `Search for a ${PATIENT_TERM} to start their test`
+    await new Promise((resolve) => setTimeout(resolve, 501));
+
+    await waitFor(
+      async () => {
+        expect(
+          screen.getByLabelText(
+            `Search for a ${PATIENT_TERM} to start their test`
+          )
+        ).toBeInTheDocument();
+      },
+      { timeout: 1000 }
     );
+
     expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
     expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
     expect(container).toMatchSnapshot();
@@ -220,93 +231,91 @@ describe("TestQueue", () => {
     });
   });
 
-  describe("device selection", () => {
-    it("should select another swab type for the selected device if configured swab not available", async () => {
-      const deviceSpecimenNotAvailableResult = { ...result };
-
-      // Default device specimen for facility is not a valid type in the `deviceSpecimenTypes` array
-      // returned by GraphQL. The component should select another of the facility's devices to
-      // populate the dropdown initially
-      deviceSpecimenNotAvailableResult.data.organization.testingFacility[0].defaultDeviceSpecimen =
-        "c0c7b042-9a4f-47cd-b280-46c0daa51c86";
-      deviceSpecimenNotAvailableResult.data.deviceSpecimenTypes.pop();
-
-      const mock = {
-        request: {
-          query: GetFacilityQueueMultiplexDocument,
-          variables: {
-            facilityId: "a1",
-          },
-        },
-        result: deviceSpecimenNotAvailableResult,
-      };
-
-      render(
-        <MemoryRouter>
-          <MockedProvider mocks={[mock]}>
-            <Provider store={store}>
-              <TestQueue activeFacilityId="a1" />
-            </Provider>
-          </MockedProvider>
-        </MemoryRouter>
-      );
-
-      expect(
-        ((await screen.findAllByText("Quidel Sofia 2"))[0] as HTMLOptionElement)
-          .selected
-      ).toBeTruthy();
-
-      expect(
-        (
-          (
-            await screen.findAllByText("Nasopharyngeal swab")
-          )[0] as HTMLOptionElement
-        ).selected
-      ).toBeTruthy();
-    });
-
-    it("should select another device if the configured device has no associated swab types", async () => {
-      const deviceNotAvailableResult = { ...result };
-
-      // The device configured as the facility default has no associated swab types - dropdown
-      // should be populated with another valid device+swab type combo
-      deviceNotAvailableResult.data.queue[0].deviceType = {
-        internalId: internalId,
-        model: "lumira",
-        name: "LumiraDx",
-        testLength: 15,
-        __typename: "DeviceType",
-      };
-
-      deviceNotAvailableResult.data.deviceSpecimenTypes.shift();
-
-      const mock = {
-        request: {
-          query: GetFacilityQueueMultiplexDocument,
-          variables: {
-            facilityId: "a1",
-          },
-        },
-        result: deviceNotAvailableResult,
-      };
-
-      render(
-        <MemoryRouter>
-          <MockedProvider mocks={[mock]}>
-            <Provider store={store}>
-              <TestQueue activeFacilityId="a1" />
-            </Provider>
-          </MockedProvider>
-        </MemoryRouter>
-      );
-
-      // The facility's default device is "LumiraDx", but that device has no associated swabs
-      expect(
-        ((await screen.findAllByText("Quidel Sofia 2"))[0] as HTMLOptionElement)
-          .selected
-      ).toBeTruthy();
-    });
-  });
+  // describe("device selection", () => {
+  //   it("should select another swab type for the selected device if configured swab not available", async () => {
+  //     const deviceSpecimenNotAvailableResult = { ...result };
+  //
+  //     // Default device specimen for facility is not a valid type in the `deviceSpecimenTypes` array
+  //     // returned by GraphQL. The component should select another of the facility's devices to
+  //     // populate the dropdown initially
+  //     deviceSpecimenNotAvailableResult.data.organization.testingFacility[0].defaultDeviceSpecimen =
+  //       "c0c7b042-9a4f-47cd-b280-46c0daa51c86";
+  //     deviceSpecimenNotAvailableResult.data.deviceSpecimenTypes.pop();
+  //
+  //     const mock = {
+  //       request: {
+  //         query: GetFacilityQueueDocument,
+  //         variables: {
+  //           facilityId: "a1",
+  //         },
+  //       },
+  //       result: deviceSpecimenNotAvailableResult,
+  //     };
+  //
+  //     render(
+  //       <MemoryRouter>
+  //         <MockedProvider mocks={[mock]}>
+  //           <Provider store={store}>
+  //             <TestQueue activeFacilityId="a1" />
+  //           </Provider>
+  //         </MockedProvider>
+  //       </MemoryRouter>
+  //     );
+  //
+  //     expect(
+  //       ((await screen.findAllByText("Quidel Sofia 2"))[0] as HTMLOptionElement)
+  //         .selected
+  //     ).toBeTruthy();
+  //
+  //     expect(
+  //       ((
+  //         await screen.findAllByText("Nasopharyngeal swab")
+  //       )[0] as HTMLOptionElement).selected
+  //     ).toBeTruthy();
+  //   });
+  //
+  //   it("should select another device if the configured device has no associated swab types", async () => {
+  //     const deviceNotAvailableResult = { ...result };
+  //
+  //     // The device configured as the facility default has no associated swab types - dropdown
+  //     // should be populated with another valid device+swab type combo
+  //     deviceNotAvailableResult.data.queue[0].deviceType = {
+  //       internalId: internalId,
+  //       model: "lumira",
+  //       name: "LumiraDx",
+  //       testLength: 15,
+  //       __typename: "DeviceType",
+  //     };
+  //
+  //     deviceNotAvailableResult.data.deviceSpecimenTypes.shift();
+  //
+  //     const mock = {
+  //       request: {
+  //         query: GetFacilityQueueDocument,
+  //         variables: {
+  //           facilityId: "a1",
+  //         },
+  //       },
+  //       result: deviceNotAvailableResult,
+  //     };
+  //
+  //     render(
+  //       <MemoryRouter>
+  //         <MockedProvider mocks={[mock]}>
+  //           <Provider store={store}>
+  //             <TestQueue activeFacilityId="a1" />
+  //           </Provider>
+  //         </MockedProvider>
+  //       </MemoryRouter>
+  //     );
+  //
+  //     // The facility's default device is "LumiraDx", but that device has no associated swabs
+  //     expect(
+  //       ((await screen.findAllByText("Quidel Sofia 2"))[0] as HTMLOptionElement)
+  //         .selected
+  //     ).toBeTruthy();
+  //   });
+  // });
 });
 
 const internalId = "f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554";
@@ -372,25 +381,21 @@ const createPatient = ({
     gender: "female",
     testResultDelivery: "",
     preferredLanguage: [],
-    __typename: "Patient",
   },
   deviceType: {
-    internalId: "0f3d7426-3476-4800-97e7-3de8a93b090c",
-    model: "quidel",
-    name: "Quidel Sofia 2",
-    testLength: 10,
-    __typename: "DeviceType",
+    internalId: "ee4f40b7-ac32-4709-be0a-56dd77bb9609",
+    name: "LumiraDX",
+    model: "LumiraDx SARS-CoV-2 Ag Test*",
+    testLength: 15,
+    supportedDiseases: [],
   },
-  deviceSpecimenType: {
-    internalId,
+  specimenType: {
+    internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+    name: "Swab of internal nose",
+    typeCode: "445297001",
   },
   results: [],
   dateTested: null,
-  patientLink: {
-    internalId: "7df95d14-c9ca-406e-bed7-85da05d5eea1",
-    __typename: "PatientLink",
-  },
-  __typename: "TestOrder",
 });
 
 // Mock data taken from network request tab in Chrome devtools
@@ -412,106 +417,120 @@ const result = {
         resultId: "def",
       }),
     ],
-    organization: {
-      testingFacility: [
+    facility: {
+      id: "f02cfff5-1921-4293-beff-e2a5d03e1fda",
+      name: "Testing Site",
+      deviceTypes: [
         {
-          id: "a1",
-          deviceTypes: [
+          internalId: "ee4f40b7-ac32-4709-be0a-56dd77bb9609",
+          name: "LumiraDX",
+          testLength: 15,
+          supportedDiseases: [
             {
-              internalId,
-              testLength: 15,
-              model: "lumira",
-              name: "LumiraDX",
-              __typename: "DeviceType",
-            },
-            {
-              internalId: "0f3d7426-3476-4800-97e7-3de8a93b090c",
-              testLength: 15,
-              model: "quidel",
-              name: "Quidel Sofia 2",
-              __typename: "DeviceType",
+              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+              loinc: "96741-4",
+              name: "COVID-19",
             },
           ],
-          defaultDeviceSpecimen: internalId,
-          __typename: "Facility",
+          swabTypes: [
+            {
+              name: "Swab of internal nose",
+              internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+              typeCode: "445297001",
+            },
+            {
+              name: "Nasopharyngeal swab",
+              internalId: "f127ef55-4133-4556-9bca-33615d071e8d",
+              typeCode: "258500001",
+            },
+          ],
         },
         {
-          id: "a2",
-          deviceTypes: [
+          internalId: "5c711888-ba37-4b2e-b347-311ca364efdb",
+          name: "Abbott BinaxNow",
+          testLength: 15,
+          supportedDiseases: [
             {
-              internalId,
-              testLength: 15,
-              model: "lumira",
-              name: "LumiraDX",
-              __typename: "DeviceType",
+              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+              loinc: "96741-4",
+              name: "COVID-19",
             },
           ],
-          defaultDeviceSpecimen: internalId,
-          __typename: "Facility",
+          swabTypes: [
+            {
+              name: "Swab of internal nose",
+              internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+              typeCode: "445297001",
+            },
+          ],
+        },
+        {
+          internalId: "32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10",
+          name: "BD Veritor",
+          testLength: 15,
+          supportedDiseases: [
+            {
+              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+              loinc: "96741-4",
+              name: "COVID-19",
+            },
+          ],
+          swabTypes: [
+            {
+              name: "Swab of internal nose",
+              internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+              typeCode: "445297001",
+            },
+            {
+              name: "Nasopharyngeal swab",
+              internalId: "f127ef55-4133-4556-9bca-33615d071e8d",
+              typeCode: "258500001",
+            },
+          ],
+        },
+        {
+          internalId: "67109f6f-eaee-49d3-b8ff-c61b79a9da8e",
+          name: "Multiplex",
+          testLength: 15,
+          supportedDiseases: [
+            {
+              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+              loinc: "96741-4",
+              name: "COVID-19",
+            },
+            {
+              internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
+              loinc: "LP14239-5",
+              name: "Flu A",
+            },
+            {
+              internalId: "14924488-268f-47db-bea6-aa706971a098",
+              loinc: "LP14240-3",
+              name: "Flu B",
+            },
+          ],
+          swabTypes: [
+            {
+              name: "Swab of internal nose",
+              internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+              typeCode: "445297001",
+            },
+            {
+              name: "Nasopharyngeal swab",
+              internalId: "f127ef55-4133-4556-9bca-33615d071e8d",
+              typeCode: "258500001",
+            },
+          ],
         },
       ],
-      __typename: "Organization",
     },
-    deviceSpecimenTypes: [
-      {
-        internalId: "3d5c0c67-cddb-4344-8037-18008d6fe809",
-        deviceType: {
-          internalId: internalId,
-          model: "lumira",
-          name: "LumiraDx",
-          testLength: 15,
-          supportedDiseases: [{ internalId: "1", name: "COVID-19" }],
-          __typename: "DeviceType",
-        },
-        specimenType: {
-          internalId: "6aa957dc-add2-4938-8788-935aec3276d4",
-          name: "Swab of internal nose",
-          __typename: "SpecimenType",
-        },
-        __typename: "DeviceSpecimenType",
-      },
-      {
-        internalId: "f8b9d9d6-c318-4c54-a516-76f0d9a25d32",
-        deviceType: {
-          internalId: "0f3d7426-3476-4800-97e7-3de8a93b090c",
-          model: "quidel",
-          name: "Quidel Sofia 2",
-          testLength: 10,
-          supportedDiseases: [{ internalId: "1", name: "COVID-19" }],
-          __typename: "DeviceType",
-        },
-        specimenType: {
-          internalId: "6e4ccb35-d177-4ea0-9226-653358f1e081",
-          name: "Nasopharyngeal swab",
-          __typename: "SpecimenType",
-        },
-        __typename: "DeviceSpecimenType",
-      },
-      {
-        internalId: "c0c7b042-9a4f-47cd-b280-46c0daa51c86",
-        deviceType: {
-          internalId: "0f3d7426-3476-4800-97e7-3de8a93b090c",
-          model: "quidel",
-          name: "Quidel Sofia 2",
-          testLength: 10,
-          supportedDiseases: [{ internalId: "1", name: "COVID-19" }],
-          __typename: "DeviceType",
-        },
-        specimenType: {
-          internalId: "6aa957dc-add2-4938-8788-935aec3276d4",
-          name: "Swab of internal nose",
-          __typename: "SpecimenType",
-        },
-        __typename: "DeviceSpecimenType",
-      },
-    ],
   },
 };
 
 const mocks = [
   {
     request: {
-      query: GetFacilityQueueMultiplexDocument,
+      query: GetFacilityQueueDocument,
       variables: {
         facilityId: "a1",
       },
@@ -541,7 +560,7 @@ const mocks = [
   },
   {
     request: {
-      query: GetFacilityQueueMultiplexDocument,
+      query: GetFacilityQueueDocument,
       variables: {
         facilityId: "a1",
       },
@@ -555,7 +574,7 @@ const mocks = [
   },
   {
     request: {
-      query: GetFacilityQueueMultiplexDocument,
+      query: GetFacilityQueueDocument,
       variables: {
         facilityId: "a2",
       },

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -64,19 +64,13 @@ interface Props {
 }
 
 const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
-  const {
-    data,
-    loading,
-    error,
-    refetch,
-    startPolling,
-    stopPolling,
-  } = useGetFacilityQueueQuery({
-    fetchPolicy: "no-cache",
-    variables: {
-      facilityId: activeFacilityId,
-    },
-  });
+  const { data, loading, error, refetch, startPolling, stopPolling } =
+    useGetFacilityQueueQuery({
+      fetchPolicy: "no-cache",
+      variables: {
+        facilityId: activeFacilityId,
+      },
+    });
 
   const location = useLocation();
   const [startTestPatientId, setStartTestPatientId] = useState<string | null>(

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -187,10 +187,11 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     );
   };
 
-  const patientsInQueue: string[] =
-    data?.queue
-      .map((q) => q?.patient.internalId)
-      .filter((element): element is string => !!element) || [];
+  const patientsInQueue: string[] = data?.queue
+    ? data?.queue
+        .map((q) => q?.patient.internalId)
+        .filter((element): element is string => !!element)
+    : [];
 
   return (
     <div className="prime-home flex-1">

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -1,22 +1,21 @@
 import React, { useEffect, useState } from "react";
-import { gql, useQuery } from "@apollo/client";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 import { showError } from "../utils/srToast";
-import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
-import { TestCorrectionReason } from "../testResults/TestResultCorrectionModal";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { appPermissions, hasPermission } from "../permissions";
 import { PATIENT_TERM } from "../../config/constants";
+import {
+  useGetFacilityQueueQuery,
+  GetFacilityQueueQuery,
+} from "../../generated/graphql";
 
 import AddToQueueSearch, {
   StartTestProps,
 } from "./addToQueue/AddToQueueSearch";
-import QueueItem from "./QueueItem";
-import { AoEAnswers, TestQueuePerson } from "./AoEForm/AoEForm";
-
+import QueueItem, { DevicesMap } from "./QueueItem";
 import "./TestQueue.scss";
 
 const pollInterval = 10_000;
@@ -60,113 +59,26 @@ const emptyQueueMessage = (canUseCsvUploader: boolean) => {
   );
 };
 
-export const queueQuery = gql`
-  query GetFacilityQueueMultiplex($facilityId: ID!) {
-    queue(facilityId: $facilityId) {
-      internalId
-      pregnancy
-      dateAdded
-      symptoms
-      symptomOnset
-      noSymptoms
-      deviceType {
-        internalId
-        name
-        model
-        testLength
-      }
-      deviceSpecimenType {
-        internalId
-      }
-      patient {
-        internalId
-        telephone
-        birthDate
-        firstName
-        middleName
-        lastName
-        gender
-        testResultDelivery
-        preferredLanguage
-        email
-        emails
-        phoneNumbers {
-          type
-          number
-        }
-      }
-      results {
-        disease {
-          name
-        }
-        testResult
-      }
-      dateTested
-      correctionStatus
-      reasonForCorrection
-    }
-    organization {
-      testingFacility {
-        id
-        deviceTypes {
-          internalId
-          name
-          model
-          testLength
-        }
-        defaultDeviceSpecimen
-      }
-    }
-    deviceSpecimenTypes {
-      internalId
-      deviceType {
-        internalId
-        name
-        testLength
-        supportedDiseases {
-          name
-        }
-      }
-      specimenType {
-        internalId
-        name
-      }
-    }
-  }
-`;
-
 interface Props {
   activeFacilityId: string;
 }
 
-export interface QueueItemData extends AoEAnswers {
-  internalId: string;
-  dateAdded: string;
-  deviceType: {
-    internalId: string;
-    testLength: number;
-  };
-  deviceSpecimenType: DeviceSpecimenType;
-  patient: TestQueuePerson;
-  results: MultiplexResult[];
-  dateTested: string;
-  correctionStatus: string;
-  reasonForCorrection: TestCorrectionReason;
-}
-
 const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
-  const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
-    queueQuery,
-    {
-      fetchPolicy: "no-cache",
-      variables: {
-        facilityId: activeFacilityId,
-      },
-    }
-  );
+  const {
+    data,
+    loading,
+    error,
+    refetch,
+    startPolling,
+    stopPolling,
+  } = useGetFacilityQueueQuery({
+    fetchPolicy: "no-cache",
+    variables: {
+      facilityId: activeFacilityId,
+    },
+  });
 
   const location = useLocation();
-  const [selectedFacility] = useSelectedFacility();
   const [startTestPatientId, setStartTestPatientId] = useState<string | null>(
     null
   );
@@ -192,7 +104,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   if (error) {
     throw error;
   }
-  if (loading) {
+  if (loading || !data) {
     return (
       <div
         className="prime-home display-flex flex-justify-center flex-1"
@@ -206,110 +118,53 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     );
   }
 
-  const facility = data.organization.testingFacility.find(
-    (f: { id: string }) => f.id === activeFacilityId
-  );
+  const facility = data.facility;
 
   if (!facility) {
     return <p>Facility not found</p>;
   }
 
-  if (facility.deviceTypes.length === 0) {
+  if (!facility.deviceTypes || facility.deviceTypes.length === 0) {
     showError(
       "This facility does not have any testing devices. Go into Settings -> Manage facilities and add a device."
     );
   }
 
-  const deviceIds: string[] = facility.deviceTypes.map(
-    (d: DeviceType) => d.internalId
-  );
-
   let shouldRenderQueue =
-    data.queue.length > 0 && facility.deviceTypes.length > 0;
+    data &&
+    data.queue &&
+    data.queue.length > 0 &&
+    facility &&
+    facility.deviceTypes &&
+    facility.deviceTypes.length > 0;
 
-  const createQueueItems = (patientQueue: QueueItemData[]) => {
+  const devicesMap: DevicesMap = new Map();
+  facility.deviceTypes.map((d) => devicesMap.set(d.internalId, d));
+
+  const createQueueItems = (patientQueue: GetFacilityQueueQuery["queue"]) => {
     const queue =
       shouldRenderQueue &&
-      patientQueue.map(
-        ({
-          internalId,
-          deviceType,
-          deviceSpecimenType,
-          patient,
-          results,
-          dateTested,
-          correctionStatus,
-          reasonForCorrection,
-          ...questions
-        }) => {
-          // Get possible device specimen types for this facility
-          const deviceSpecimenTypes: DeviceSpecimenType[] =
-            data.deviceSpecimenTypes.filter(
-              (d: DeviceSpecimenType) =>
-                deviceIds.includes(d.deviceType.internalId) &&
-                // Facility may be configured with a device that does not have
-                // any associated swab types - remove them from the set of
-                // options
-                deviceIds.some(
-                  (deviceId) => d.deviceType.internalId === deviceId
-                )
-            );
+      patientQueue &&
+      patientQueue.map((queueItem) => {
+        if (!queueItem) return <></>;
 
-          // The `deviceSpecimenType` for a test queue entry does not carry full
-          // device and swab data - if the device specimen no longer exists, we'll
-          // get a server error trying to follow its associations, so we have to
-          // do this in-memory
-          let selectedDeviceSpecimenType = deviceSpecimenTypes.find(
-            (dst) => dst.internalId === deviceSpecimenType.internalId
-          );
-
-          // The selected device specimen type for a test has been removed by an admin
-          if (!selectedDeviceSpecimenType) {
-            selectedDeviceSpecimenType =
-              deviceSpecimenTypes.find(
-                (dst) => dst.deviceType.internalId === deviceType.internalId
-              ) || deviceSpecimenTypes[0];
-          }
-
-          let selectedTestResults: MultiplexResult[] = results;
-
-          return (
-            <CSSTransition
-              key={internalId}
-              onExiting={onExiting}
-              timeout={transitionDuration}
-            >
-              <QueueItem
-                internalId={internalId}
-                patient={patient}
-                startTestPatientId={startTestPatientId}
-                setStartTestPatientId={setStartTestPatientId}
-                askOnEntry={questions}
-                selectedDeviceSpecimenTypeId={
-                  selectedDeviceSpecimenType.internalId
-                }
-                selectedDeviceId={
-                  selectedDeviceSpecimenType.deviceType.internalId
-                }
-                selectedDeviceTestLength={
-                  // `testLength` is not nullable and is always returned by
-                  // the facility queue GraphQL query
-                  selectedDeviceSpecimenType.deviceType.testLength as number
-                }
-                selectedTestResults={selectedTestResults}
-                devices={facility.deviceTypes}
-                deviceSpecimenTypes={deviceSpecimenTypes}
-                refetchQueue={refetch}
-                facilityName={selectedFacility?.name}
-                facilityId={activeFacilityId}
-                dateTestedProp={dateTested}
-                isCorrection={correctionStatus === "CORRECTED"}
-                reasonForCorrection={reasonForCorrection}
-              />
-            </CSSTransition>
-          );
-        }
-      );
+        return (
+          <CSSTransition
+            key={queueItem.internalId}
+            onExiting={onExiting}
+            timeout={transitionDuration}
+          >
+            <QueueItem
+              refetchQueue={refetch}
+              queueItem={queueItem}
+              startTestPatientId={startTestPatientId}
+              setStartTestPatientId={setStartTestPatientId}
+              facility={facility}
+              devicesMap={devicesMap}
+            />
+          </CSSTransition>
+        );
+      });
 
     return (
       <TransitionGroup
@@ -332,9 +187,10 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     );
   };
 
-  const patientsInQueue = data.queue.map(
-    (q: QueueItemData) => q.patient.internalId
-  );
+  const patientsInQueue: string[] =
+    data?.queue
+      .map((q) => q?.patient.internalId)
+      .filter((element): element is string => !!element) || [];
 
   return (
     <div className="prime-home flex-1">

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   <span
                     role="timer"
                   >
-                    10:00
+                    15:00
                   </span>
                    
                   <svg
@@ -218,28 +218,6 @@ exports[`TestQueue should render the test queue 1`] = `
                     <div
                       class="test-date-time-container"
                     >
-                      <input
-                        aria-label="Test date"
-                        class="card-test-input"
-                        data-testid="test-date"
-                        hidden=""
-                        id="test-date-abc"
-                        max="2021-08-01"
-                        min="2020-01-01"
-                        name="test-date"
-                        type="date"
-                        value="2021-08-01"
-                      />
-                      <input
-                        aria-label="Test time"
-                        class="card-test-input"
-                        data-testid="test-time"
-                        hidden=""
-                        name="test-time"
-                        step="60"
-                        type="time"
-                        value="08:20"
-                      />
                       <div
                         class="check-box-container"
                       >
@@ -252,7 +230,6 @@ exports[`TestQueue should render the test queue 1`] = `
                             class="usa-checkbox__input margin"
                             id="current-date-check-abc"
                             type="checkbox"
-                            value="true"
                           />
                           <label
                             class="usa-checkbox__label margin-0 margin-right-05em"
@@ -327,18 +304,29 @@ exports[`TestQueue should render the test queue 1`] = `
                       <select
                         aria-required="false"
                         class="usa-select"
+                        data-testid="device-type-dropdown"
                         id="1"
                         name="testDevice"
                       >
                         <option
-                          value="f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
+                          value="5c711888-ba37-4b2e-b347-311ca364efdb"
                         >
-                          LumiraDx
+                          Abbott BinaxNow
                         </option>
                         <option
-                          value="0f3d7426-3476-4800-97e7-3de8a93b090c"
+                          value="32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10"
                         >
-                          Quidel Sofia 2
+                          BD Veritor
+                        </option>
+                        <option
+                          value="ee4f40b7-ac32-4709-be0a-56dd77bb9609"
+                        >
+                          LumiraDX
+                        </option>
+                        <option
+                          value="67109f6f-eaee-49d3-b8ff-c61b79a9da8e"
+                        >
+                          Multiplex
                         </option>
                       </select>
                     </div>
@@ -358,16 +346,17 @@ exports[`TestQueue should render the test queue 1`] = `
                       <select
                         aria-required="false"
                         class="usa-select"
+                        data-testid="specimen-type-dropdown"
                         id="2"
                         name="swabType"
                       >
                         <option
-                          value="6e4ccb35-d177-4ea0-9226-653358f1e081"
+                          value="f127ef55-4133-4556-9bca-33615d071e8d"
                         >
                           Nasopharyngeal swab
                         </option>
                         <option
-                          value="6aa957dc-add2-4938-8788-935aec3276d4"
+                          value="8596682d-6053-4720-8a39-1f5d19ff4ed9"
                         >
                           Swab of internal nose
                         </option>
@@ -583,7 +572,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   <span
                     role="timer"
                   >
-                    10:00
+                    15:00
                   </span>
                    
                   <svg
@@ -640,28 +629,6 @@ exports[`TestQueue should render the test queue 1`] = `
                     <div
                       class="test-date-time-container"
                     >
-                      <input
-                        aria-label="Test date"
-                        class="card-test-input"
-                        data-testid="test-date"
-                        hidden=""
-                        id="test-date-def"
-                        max="2021-08-01"
-                        min="2020-01-01"
-                        name="test-date"
-                        type="date"
-                        value="2021-08-01"
-                      />
-                      <input
-                        aria-label="Test time"
-                        class="card-test-input"
-                        data-testid="test-time"
-                        hidden=""
-                        name="test-time"
-                        step="60"
-                        type="time"
-                        value="08:20"
-                      />
                       <div
                         class="check-box-container"
                       >
@@ -674,7 +641,6 @@ exports[`TestQueue should render the test queue 1`] = `
                             class="usa-checkbox__input margin"
                             id="current-date-check-def"
                             type="checkbox"
-                            value="true"
                           />
                           <label
                             class="usa-checkbox__label margin-0 margin-right-05em"
@@ -749,18 +715,29 @@ exports[`TestQueue should render the test queue 1`] = `
                       <select
                         aria-required="false"
                         class="usa-select"
+                        data-testid="device-type-dropdown"
                         id="4"
                         name="testDevice"
                       >
                         <option
-                          value="f5c7658d-a0d5-4ec5-a1c9-eafc85fe7554"
+                          value="5c711888-ba37-4b2e-b347-311ca364efdb"
                         >
-                          LumiraDx
+                          Abbott BinaxNow
                         </option>
                         <option
-                          value="0f3d7426-3476-4800-97e7-3de8a93b090c"
+                          value="32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10"
                         >
-                          Quidel Sofia 2
+                          BD Veritor
+                        </option>
+                        <option
+                          value="ee4f40b7-ac32-4709-be0a-56dd77bb9609"
+                        >
+                          LumiraDX
+                        </option>
+                        <option
+                          value="67109f6f-eaee-49d3-b8ff-c61b79a9da8e"
+                        >
+                          Multiplex
                         </option>
                       </select>
                     </div>
@@ -780,16 +757,17 @@ exports[`TestQueue should render the test queue 1`] = `
                       <select
                         aria-required="false"
                         class="usa-select"
+                        data-testid="specimen-type-dropdown"
                         id="5"
                         name="swabType"
                       >
                         <option
-                          value="6e4ccb35-d177-4ea0-9226-653358f1e081"
+                          value="f127ef55-4133-4556-9bca-33615d071e8d"
                         >
                           Nasopharyngeal swab
                         </option>
                         <option
-                          value="6aa957dc-add2-4938-8788-935aec3276d4"
+                          value="8596682d-6053-4720-8a39-1f5d19ff4ed9"
                         >
                           Swab of internal nose
                         </option>

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -3,61 +3,123 @@ mutation RemovePatientFromQueue($patientId: ID!) {
     removePatientFromQueue(patientId: $patientId)
   }
 
-mutation EditQueueItemMultiplexResult(
-    $id: ID!
-    $deviceId: String
-    $deviceSpecimenType: ID
-    $results: [MultiplexResultInput]
-    $dateTested: DateTime
+mutation EditQueueItem(
+  $id: ID!
+  $deviceTypeId: ID
+  $specimenTypeId: ID
+  $results: [MultiplexResultInput]
+  $dateTested: DateTime
+) {
+  editQueueItem(
+    id: $id
+    deviceTypeId: $deviceTypeId
+    specimenTypeId: $specimenTypeId
+    results: $results
+    dateTested: $dateTested
   ) {
-    editQueueItemMultiplexResult(
-      id: $id
-      deviceId: $deviceId
-      deviceSpecimenType: $deviceSpecimenType
-      results: $results
-      dateTested: $dateTested
-    ) {
-      results {
-        disease {
-          name
-        }
-        testResult
+    results {
+      disease {
+        name
       }
-      dateTested
-      deviceType {
-        internalId
-        testLength
-      }
-      deviceSpecimenType {
-        internalId
-        deviceType {
-          internalId
-          testLength
-        }
-        specimenType {
-          internalId
-        }
-      }
+      testResult
+    }
+    dateTested
+    deviceType {
+      internalId
+      testLength
     }
   }
+}
 
-mutation AddMultiplexResult(
-    $patientId: ID!
-    $deviceId: String!
-    $deviceSpecimenType: ID
-    $results: [MultiplexResultInput]!
-    $dateTested: DateTime
+mutation SubmitQueueItem(
+  $patientId: ID!
+  $deviceTypeId: ID!
+  $specimenTypeId: ID!
+  $results: [MultiplexResultInput]!
+  $dateTested: DateTime
+) {
+  submitQueueItem(
+    patientId: $patientId
+    deviceTypeId: $deviceTypeId
+    specimenTypeId: $specimenTypeId
+    results: $results
+    dateTested: $dateTested
   ) {
-    addMultiplexResult(
-      patientId: $patientId
-      deviceId: $deviceId
-      deviceSpecimenType: $deviceSpecimenType
-      results: $results
-      dateTested: $dateTested
-    ) {
-      testResult {
+    testResult {
+      internalId
+    }
+    deliverySuccess
+  }
+}
+
+query GetFacilityQueue($facilityId: ID!) {
+  queue(facilityId: $facilityId) {
+    internalId
+    pregnancy
+    dateAdded
+    symptoms
+    symptomOnset
+    noSymptoms
+    deviceType {
+      internalId
+      name
+      model
+      testLength
+      supportedDiseases {
         internalId
+        name
+        loinc
       }
-      deliverySuccess
+    }
+    specimenType {
+      internalId
+      name
+      typeCode
+    }
+    patient {
+      internalId
+      telephone
+      birthDate
+      firstName
+      middleName
+      lastName
+      gender
+      testResultDelivery
+      preferredLanguage
+      email
+      emails
+      phoneNumbers {
+        type
+        number
+      }
+    }
+    results {
+      disease {
+        name
+      }
+      testResult
+    }
+    dateTested
+    correctionStatus
+    reasonForCorrection
+  }
+  facility(id: $facilityId) {
+    name
+    id
+    deviceTypes {
+      internalId
+      name
+      testLength
+      supportedDiseases {
+        internalId
+        name
+        loinc
+      }
+      swabTypes {
+        internalId
+        name
+        typeCode
+      }
     }
   }
+}

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -65,11 +65,6 @@ query GetFacilityQueue($facilityId: ID!) {
       name
       model
       testLength
-      supportedDiseases {
-        internalId
-        name
-        loinc
-      }
     }
     specimenType {
       internalId

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookup.test.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookup.test.tsx
@@ -19,6 +19,7 @@ const devices = [
     model: "Model A",
     manufacturer: "Celoxitin",
     loincCode: "1234-1",
+    testLength: 15,
     swabTypes: [{ internalId: "123", name: "nose", typeCode: "n123" }],
     supportedDiseases: [
       { internalId: "123", name: "COVID-19", loinc: "1234-1" },
@@ -30,6 +31,7 @@ const devices = [
     model: "Giselle",
     manufacturer: "yo-mama",
     loincCode: "8675309",
+    testLength: 15,
     swabTypes: [{ internalId: "123", name: "nose", typeCode: "nose-code" }],
     supportedDiseases: [],
   },

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -115,6 +115,7 @@ export type Facility = {
   cliaNumber?: Maybe<Scalars["String"]>;
   county?: Maybe<Scalars["String"]>;
   defaultDeviceSpecimen?: Maybe<Scalars["ID"]>;
+  /** @deprecated kept for compatibility */
   defaultDeviceType?: Maybe<DeviceType>;
   /** @deprecated kept for compatibility */
   deviceSpecimenTypes?: Maybe<Array<Maybe<DeviceSpecimenType>>>;

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,17 +1,14 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -107,7 +104,7 @@ export type DeviceType = {
   supportedDiseases: Array<SupportedDisease>;
   swabType?: Maybe<Scalars["String"]>;
   swabTypes: Array<SpecimenType>;
-  testLength?: Maybe<Scalars["Int"]>;
+  testLength: Scalars["Int"];
 };
 
 export type Facility = {
@@ -117,11 +114,11 @@ export type Facility = {
   cliaNumber?: Maybe<Scalars["String"]>;
   county?: Maybe<Scalars["String"]>;
   defaultDeviceSpecimen?: Maybe<Scalars["ID"]>;
-  /** @deprecated kept for compatibility */
   defaultDeviceType?: Maybe<DeviceType>;
+  defaultSpecimenType?: Maybe<SpecimenType>;
   /** @deprecated kept for compatibility */
   deviceSpecimenTypes?: Maybe<Array<Maybe<DeviceSpecimenType>>>;
-  deviceTypes?: Maybe<Array<Maybe<DeviceType>>>;
+  deviceTypes: Array<DeviceType>;
   email?: Maybe<Scalars["String"]>;
   id: Scalars["ID"];
   isDeleted?: Maybe<Scalars["Boolean"]>;
@@ -172,6 +169,7 @@ export type Mutation = {
   createOrganizationRegistrationLink?: Maybe<Scalars["String"]>;
   createSpecimenType?: Maybe<SpecimenType>;
   editPendingOrganization?: Maybe<Scalars["String"]>;
+  editQueueItem?: Maybe<TestOrder>;
   editQueueItemMultiplexResult?: Maybe<TestOrder>;
   markFacilityAsDeleted?: Maybe<Scalars["String"]>;
   markOrganizationAsDeleted?: Maybe<Scalars["String"]>;
@@ -191,6 +189,7 @@ export type Mutation = {
   setPatientIsDeleted?: Maybe<Patient>;
   setRegistrationLinkIsDeleted?: Maybe<Scalars["String"]>;
   setUserIsDeleted?: Maybe<User>;
+  submitQueueItem?: Maybe<AddTestResultResponse>;
   updateDeviceType?: Maybe<DeviceType>;
   updateFacility?: Maybe<Facility>;
   updateFacilityNew?: Maybe<Scalars["String"]>;
@@ -411,6 +410,14 @@ export type MutationEditPendingOrganizationArgs = {
   orgExternalId: Scalars["String"];
 };
 
+export type MutationEditQueueItemArgs = {
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
+  deviceTypeId?: InputMaybe<Scalars["ID"]>;
+  id: Scalars["ID"];
+  results?: InputMaybe<Array<InputMaybe<MultiplexResultInput>>>;
+  specimenTypeId?: InputMaybe<Scalars["ID"]>;
+};
+
 export type MutationEditQueueItemMultiplexResultArgs = {
   dateTested?: InputMaybe<Scalars["DateTime"]>;
   deviceId?: InputMaybe<Scalars["String"]>;
@@ -497,6 +504,14 @@ export type MutationSetRegistrationLinkIsDeletedArgs = {
 export type MutationSetUserIsDeletedArgs = {
   deleted: Scalars["Boolean"];
   id: Scalars["ID"];
+};
+
+export type MutationSubmitQueueItemArgs = {
+  dateTested?: InputMaybe<Scalars["DateTime"]>;
+  deviceTypeId: Scalars["ID"];
+  patientId: Scalars["ID"];
+  results: Array<InputMaybe<MultiplexResultInput>>;
+  specimenTypeId: Scalars["ID"];
 };
 
 export type MutationUpdateDeviceTypeArgs = {
@@ -677,9 +692,9 @@ export type Patient = {
   facility?: Maybe<Facility>;
   firstName?: Maybe<Scalars["String"]>;
   gender?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["ID"]>;
+  id: Scalars["ID"];
   /** @deprecated alias for 'id' */
-  internalId?: Maybe<Scalars["ID"]>;
+  internalId: Scalars["ID"];
   isDeleted?: Maybe<Scalars["Boolean"]>;
   lastName?: Maybe<Scalars["String"]>;
   lastTest?: Maybe<TestResult>;
@@ -761,6 +776,7 @@ export type Query = {
   deviceType: Array<DeviceType>;
   deviceTypes: Array<DeviceType>;
   facilities?: Maybe<Array<Maybe<Facility>>>;
+  facility?: Maybe<Facility>;
   /** @deprecated this information is already loaded from the 'whoami' endpoint */
   organization?: Maybe<Organization>;
   organizationLevelDashboardMetrics?: Maybe<OrganizationLevelDashboardMetrics>;
@@ -771,7 +787,7 @@ export type Query = {
   patients?: Maybe<Array<Maybe<Patient>>>;
   patientsCount?: Maybe<Scalars["Int"]>;
   pendingOrganizations: Array<PendingOrganization>;
-  queue?: Maybe<Array<Maybe<TestOrder>>>;
+  queue: Array<TestOrder>;
   specimenType?: Maybe<Array<Maybe<SpecimenType>>>;
   specimenTypes: Array<SpecimenType>;
   supportedDiseases: Array<SupportedDisease>;
@@ -790,6 +806,10 @@ export type Query = {
 
 export type QueryFacilitiesArgs = {
   showArchived?: InputMaybe<Scalars["Boolean"]>;
+};
+
+export type QueryFacilityArgs = {
+  id: Scalars["ID"];
 };
 
 export type QueryOrganizationLevelDashboardMetricsArgs = {
@@ -943,20 +963,21 @@ export type TestDescriptionNameArgs = {
 export type TestOrder = {
   __typename?: "TestOrder";
   correctionStatus?: Maybe<Scalars["String"]>;
-  dateAdded?: Maybe<Scalars["String"]>;
+  dateAdded: Scalars["String"];
   dateTested?: Maybe<Scalars["DateTime"]>;
-  deviceSpecimenType?: Maybe<DeviceSpecimenType>;
-  deviceType?: Maybe<DeviceType>;
-  id?: Maybe<Scalars["ID"]>;
+  deviceSpecimenType: DeviceSpecimenType;
+  deviceType: DeviceType;
+  id: Scalars["ID"];
   /** @deprecated alias for 'id' */
-  internalId?: Maybe<Scalars["ID"]>;
+  internalId: Scalars["ID"];
   noSymptoms?: Maybe<Scalars["Boolean"]>;
-  patient?: Maybe<Patient>;
+  patient: Patient;
   pregnancy?: Maybe<Scalars["String"]>;
   reasonForCorrection?: Maybe<Scalars["String"]>;
   /** @deprecated use results as source of truth */
   result?: Maybe<Scalars["String"]>;
-  results?: Maybe<Array<Maybe<MultiplexResult>>>;
+  results: Array<MultiplexResult>;
+  specimenType: SpecimenType;
   symptomOnset?: Maybe<Scalars["LocalDate"]>;
   symptoms?: Maybe<Scalars["String"]>;
 };
@@ -1134,18 +1155,11 @@ export type GetFacilitiesQuery = {
           zipCode?: string | null | undefined;
           phone?: string | null | undefined;
           email?: string | null | undefined;
-          deviceTypes?:
-            | Array<
-                | {
-                    __typename?: "DeviceType";
-                    name: string;
-                    internalId: string;
-                  }
-                | null
-                | undefined
-              >
-            | null
-            | undefined;
+          deviceTypes: Array<{
+            __typename?: "DeviceType";
+            name: string;
+            internalId: string;
+          }>;
           orderingProvider?:
             | {
                 __typename?: "Provider";
@@ -1529,7 +1543,7 @@ export type AddPatientMutation = {
   addPatient?:
     | {
         __typename?: "Patient";
-        internalId?: string | null | undefined;
+        internalId: string;
         facility?: { __typename?: "Facility"; id: string } | null | undefined;
       }
     | null
@@ -1544,7 +1558,7 @@ export type ArchivePersonMutationVariables = Exact<{
 export type ArchivePersonMutation = {
   __typename?: "Mutation";
   setPatientIsDeleted?:
-    | { __typename?: "Patient"; internalId?: string | null | undefined }
+    | { __typename?: "Patient"; internalId: string }
     | null
     | undefined;
 };
@@ -1634,7 +1648,7 @@ export type UpdatePatientMutationVariables = Exact<{
 export type UpdatePatientMutation = {
   __typename?: "Mutation";
   updatePatient?:
-    | { __typename?: "Patient"; internalId?: string | null | undefined }
+    | { __typename?: "Patient"; internalId: string }
     | null
     | undefined;
 };
@@ -1664,7 +1678,7 @@ export type GetPatientsByFacilityQuery = {
     | Array<
         | {
             __typename?: "Patient";
-            internalId?: string | null | undefined;
+            internalId: string;
             firstName?: string | null | undefined;
             lastName?: string | null | undefined;
             middleName?: string | null | undefined;
@@ -1749,7 +1763,7 @@ export type GetDeviceTypeListQuery = {
     loincCode: string;
     manufacturer: string;
     model: string;
-    testLength?: number | null | undefined;
+    testLength: number;
     swabTypes: Array<{
       __typename?: "SpecimenType";
       internalId: string;
@@ -1876,145 +1890,6 @@ export type SetCurrentUserTenantDataAccessOpMutation = {
     | undefined;
 };
 
-export type GetFacilityQueueMultiplexQueryVariables = Exact<{
-  facilityId: Scalars["ID"];
-}>;
-
-export type GetFacilityQueueMultiplexQuery = {
-  __typename?: "Query";
-  queue?:
-    | Array<
-        | {
-            __typename?: "TestOrder";
-            internalId?: string | null | undefined;
-            pregnancy?: string | null | undefined;
-            dateAdded?: string | null | undefined;
-            symptoms?: string | null | undefined;
-            symptomOnset?: any | null | undefined;
-            noSymptoms?: boolean | null | undefined;
-            dateTested?: any | null | undefined;
-            correctionStatus?: string | null | undefined;
-            reasonForCorrection?: string | null | undefined;
-            deviceType?:
-              | {
-                  __typename?: "DeviceType";
-                  internalId: string;
-                  name: string;
-                  model: string;
-                  testLength?: number | null | undefined;
-                }
-              | null
-              | undefined;
-            deviceSpecimenType?:
-              | { __typename?: "DeviceSpecimenType"; internalId: string }
-              | null
-              | undefined;
-            patient?:
-              | {
-                  __typename?: "Patient";
-                  internalId?: string | null | undefined;
-                  telephone?: string | null | undefined;
-                  birthDate?: any | null | undefined;
-                  firstName?: string | null | undefined;
-                  middleName?: string | null | undefined;
-                  lastName?: string | null | undefined;
-                  gender?: string | null | undefined;
-                  testResultDelivery?:
-                    | TestResultDeliveryPreference
-                    | null
-                    | undefined;
-                  preferredLanguage?: string | null | undefined;
-                  email?: string | null | undefined;
-                  emails?: Array<string | null | undefined> | null | undefined;
-                  phoneNumbers?:
-                    | Array<
-                        | {
-                            __typename?: "PhoneNumber";
-                            type?: PhoneType | null | undefined;
-                            number?: string | null | undefined;
-                          }
-                        | null
-                        | undefined
-                      >
-                    | null
-                    | undefined;
-                }
-              | null
-              | undefined;
-            results?:
-              | Array<
-                  | {
-                      __typename?: "MultiplexResult";
-                      testResult?: string | null | undefined;
-                      disease?:
-                        | { __typename?: "SupportedDisease"; name: string }
-                        | null
-                        | undefined;
-                    }
-                  | null
-                  | undefined
-                >
-              | null
-              | undefined;
-          }
-        | null
-        | undefined
-      >
-    | null
-    | undefined;
-  organization?:
-    | {
-        __typename?: "Organization";
-        testingFacility: Array<{
-          __typename?: "Facility";
-          id: string;
-          defaultDeviceSpecimen?: string | null | undefined;
-          deviceTypes?:
-            | Array<
-                | {
-                    __typename?: "DeviceType";
-                    internalId: string;
-                    name: string;
-                    model: string;
-                    testLength?: number | null | undefined;
-                  }
-                | null
-                | undefined
-              >
-            | null
-            | undefined;
-        }>;
-      }
-    | null
-    | undefined;
-  deviceSpecimenTypes?:
-    | Array<
-        | {
-            __typename?: "DeviceSpecimenType";
-            internalId: string;
-            deviceType: {
-              __typename?: "DeviceType";
-              internalId: string;
-              name: string;
-              testLength?: number | null | undefined;
-              supportedDiseases: Array<{
-                __typename?: "SupportedDisease";
-                name: string;
-              }>;
-            };
-            specimenType: {
-              __typename?: "SpecimenType";
-              internalId: string;
-              name: string;
-            };
-          }
-        | null
-        | undefined
-      >
-    | null
-    | undefined;
-};
-
 export type GetPatientQueryVariables = Exact<{
   internalId: Scalars["ID"];
 }>;
@@ -2024,7 +1899,7 @@ export type GetPatientQuery = {
   patient?:
     | {
         __typename?: "Patient";
-        internalId?: string | null | undefined;
+        internalId: string;
         firstName?: string | null | undefined;
         lastName?: string | null | undefined;
         middleName?: string | null | undefined;
@@ -2063,7 +1938,7 @@ export type GetPatientsByFacilityForQueueQuery = {
     | Array<
         | {
             __typename?: "Patient";
-            internalId?: string | null | undefined;
+            internalId: string;
             firstName?: string | null | undefined;
             lastName?: string | null | undefined;
             middleName?: string | null | undefined;
@@ -2134,83 +2009,156 @@ export type RemovePatientFromQueueMutation = {
   removePatientFromQueue?: string | null | undefined;
 };
 
-export type EditQueueItemMultiplexResultMutationVariables = Exact<{
+export type EditQueueItemMutationVariables = Exact<{
   id: Scalars["ID"];
-  deviceId?: InputMaybe<Scalars["String"]>;
-  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
+  deviceTypeId?: InputMaybe<Scalars["ID"]>;
+  specimenTypeId?: InputMaybe<Scalars["ID"]>;
   results?: InputMaybe<
     Array<InputMaybe<MultiplexResultInput>> | InputMaybe<MultiplexResultInput>
   >;
   dateTested?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
-export type EditQueueItemMultiplexResultMutation = {
+export type EditQueueItemMutation = {
   __typename?: "Mutation";
-  editQueueItemMultiplexResult?:
+  editQueueItem?:
     | {
         __typename?: "TestOrder";
         dateTested?: any | null | undefined;
-        results?:
-          | Array<
-              | {
-                  __typename?: "MultiplexResult";
-                  testResult?: string | null | undefined;
-                  disease?:
-                    | { __typename?: "SupportedDisease"; name: string }
-                    | null
-                    | undefined;
-                }
-              | null
-              | undefined
-            >
-          | null
-          | undefined;
-        deviceType?:
-          | {
-              __typename?: "DeviceType";
-              internalId: string;
-              testLength?: number | null | undefined;
-            }
-          | null
-          | undefined;
-        deviceSpecimenType?:
-          | {
-              __typename?: "DeviceSpecimenType";
-              internalId: string;
-              deviceType: {
-                __typename?: "DeviceType";
-                internalId: string;
-                testLength?: number | null | undefined;
-              };
-              specimenType: { __typename?: "SpecimenType"; internalId: string };
-            }
-          | null
-          | undefined;
+        results: Array<{
+          __typename?: "MultiplexResult";
+          testResult?: string | null | undefined;
+          disease?:
+            | { __typename?: "SupportedDisease"; name: string }
+            | null
+            | undefined;
+        }>;
+        deviceType: {
+          __typename?: "DeviceType";
+          internalId: string;
+          testLength: number;
+        };
       }
     | null
     | undefined;
 };
 
-export type AddMultiplexResultMutationVariables = Exact<{
+export type SubmitQueueItemMutationVariables = Exact<{
   patientId: Scalars["ID"];
-  deviceId: Scalars["String"];
-  deviceSpecimenType?: InputMaybe<Scalars["ID"]>;
+  deviceTypeId: Scalars["ID"];
+  specimenTypeId: Scalars["ID"];
   results:
     | Array<InputMaybe<MultiplexResultInput>>
     | InputMaybe<MultiplexResultInput>;
   dateTested?: InputMaybe<Scalars["DateTime"]>;
 }>;
 
-export type AddMultiplexResultMutation = {
+export type SubmitQueueItemMutation = {
   __typename?: "Mutation";
-  addMultiplexResult?:
+  submitQueueItem?:
     | {
         __typename?: "AddTestResultResponse";
         deliverySuccess?: boolean | null | undefined;
-        testResult: {
-          __typename?: "TestOrder";
-          internalId?: string | null | undefined;
-        };
+        testResult: { __typename?: "TestOrder"; internalId: string };
+      }
+    | null
+    | undefined;
+};
+
+export type GetFacilityQueueQueryVariables = Exact<{
+  facilityId: Scalars["ID"];
+}>;
+
+export type GetFacilityQueueQuery = {
+  __typename?: "Query";
+  queue: Array<{
+    __typename?: "TestOrder";
+    internalId: string;
+    pregnancy?: string | null | undefined;
+    dateAdded: string;
+    symptoms?: string | null | undefined;
+    symptomOnset?: any | null | undefined;
+    noSymptoms?: boolean | null | undefined;
+    dateTested?: any | null | undefined;
+    correctionStatus?: string | null | undefined;
+    reasonForCorrection?: string | null | undefined;
+    deviceType: {
+      __typename?: "DeviceType";
+      internalId: string;
+      name: string;
+      model: string;
+      testLength: number;
+      supportedDiseases: Array<{
+        __typename?: "SupportedDisease";
+        internalId: string;
+        name: string;
+        loinc: string;
+      }>;
+    };
+    specimenType: {
+      __typename?: "SpecimenType";
+      internalId: string;
+      name: string;
+      typeCode: string;
+    };
+    patient: {
+      __typename?: "Patient";
+      internalId: string;
+      telephone?: string | null | undefined;
+      birthDate?: any | null | undefined;
+      firstName?: string | null | undefined;
+      middleName?: string | null | undefined;
+      lastName?: string | null | undefined;
+      gender?: string | null | undefined;
+      testResultDelivery?: TestResultDeliveryPreference | null | undefined;
+      preferredLanguage?: string | null | undefined;
+      email?: string | null | undefined;
+      emails?: Array<string | null | undefined> | null | undefined;
+      phoneNumbers?:
+        | Array<
+            | {
+                __typename?: "PhoneNumber";
+                type?: PhoneType | null | undefined;
+                number?: string | null | undefined;
+              }
+            | null
+            | undefined
+          >
+        | null
+        | undefined;
+    };
+    results: Array<{
+      __typename?: "MultiplexResult";
+      testResult?: string | null | undefined;
+      disease?:
+        | { __typename?: "SupportedDisease"; name: string }
+        | null
+        | undefined;
+    }>;
+  }>;
+  facility?:
+    | {
+        __typename?: "Facility";
+        name: string;
+        id: string;
+        deviceTypes: Array<{
+          __typename?: "DeviceType";
+          internalId: string;
+          name: string;
+          testLength: number;
+          supportedDiseases: Array<{
+            __typename?: "SupportedDisease";
+            internalId: string;
+            name: string;
+            loinc: string;
+          }>;
+          swabTypes: Array<{
+            __typename?: "SpecimenType";
+            internalId: string;
+            name: string;
+            typeCode: string;
+          }>;
+        }>;
       }
     | null
     | undefined;
@@ -2602,7 +2550,7 @@ export type GetFacilityResultsMultiplexWithCountQuery = {
                   patient?:
                     | {
                         __typename?: "Patient";
-                        internalId?: string | null | undefined;
+                        internalId: string;
                         firstName?: string | null | undefined;
                         middleName?: string | null | undefined;
                         lastName?: string | null | undefined;
@@ -3137,8 +3085,7 @@ export function useUpdateFacilityMutation(
 export type UpdateFacilityMutationHookResult = ReturnType<
   typeof useUpdateFacilityMutation
 >;
-export type UpdateFacilityMutationResult =
-  Apollo.MutationResult<UpdateFacilityMutation>;
+export type UpdateFacilityMutationResult = Apollo.MutationResult<UpdateFacilityMutation>;
 export type UpdateFacilityMutationOptions = Apollo.BaseMutationOptions<
   UpdateFacilityMutation,
   UpdateFacilityMutationVariables
@@ -3251,8 +3198,7 @@ export function useAddFacilityMutation(
 export type AddFacilityMutationHookResult = ReturnType<
   typeof useAddFacilityMutation
 >;
-export type AddFacilityMutationResult =
-  Apollo.MutationResult<AddFacilityMutation>;
+export type AddFacilityMutationResult = Apollo.MutationResult<AddFacilityMutation>;
 export type AddFacilityMutationOptions = Apollo.BaseMutationOptions<
   AddFacilityMutation,
   AddFacilityMutationVariables
@@ -3419,8 +3365,7 @@ export function useAdminSetOrganizationMutation(
 export type AdminSetOrganizationMutationHookResult = ReturnType<
   typeof useAdminSetOrganizationMutation
 >;
-export type AdminSetOrganizationMutationResult =
-  Apollo.MutationResult<AdminSetOrganizationMutation>;
+export type AdminSetOrganizationMutationResult = Apollo.MutationResult<AdminSetOrganizationMutation>;
 export type AdminSetOrganizationMutationOptions = Apollo.BaseMutationOptions<
   AdminSetOrganizationMutation,
   AdminSetOrganizationMutationVariables
@@ -3467,8 +3412,7 @@ export function useSetOrganizationMutation(
 export type SetOrganizationMutationHookResult = ReturnType<
   typeof useSetOrganizationMutation
 >;
-export type SetOrganizationMutationResult =
-  Apollo.MutationResult<SetOrganizationMutation>;
+export type SetOrganizationMutationResult = Apollo.MutationResult<SetOrganizationMutation>;
 export type SetOrganizationMutationOptions = Apollo.BaseMutationOptions<
   SetOrganizationMutation,
   SetOrganizationMutationVariables
@@ -3593,8 +3537,7 @@ export function useUpdateUserPrivilegesMutation(
 export type UpdateUserPrivilegesMutationHookResult = ReturnType<
   typeof useUpdateUserPrivilegesMutation
 >;
-export type UpdateUserPrivilegesMutationResult =
-  Apollo.MutationResult<UpdateUserPrivilegesMutation>;
+export type UpdateUserPrivilegesMutationResult = Apollo.MutationResult<UpdateUserPrivilegesMutation>;
 export type UpdateUserPrivilegesMutationOptions = Apollo.BaseMutationOptions<
   UpdateUserPrivilegesMutation,
   UpdateUserPrivilegesMutationVariables
@@ -3643,8 +3586,7 @@ export function useResetUserPasswordMutation(
 export type ResetUserPasswordMutationHookResult = ReturnType<
   typeof useResetUserPasswordMutation
 >;
-export type ResetUserPasswordMutationResult =
-  Apollo.MutationResult<ResetUserPasswordMutation>;
+export type ResetUserPasswordMutationResult = Apollo.MutationResult<ResetUserPasswordMutation>;
 export type ResetUserPasswordMutationOptions = Apollo.BaseMutationOptions<
   ResetUserPasswordMutation,
   ResetUserPasswordMutationVariables
@@ -3694,8 +3636,7 @@ export function useSetUserIsDeletedMutation(
 export type SetUserIsDeletedMutationHookResult = ReturnType<
   typeof useSetUserIsDeletedMutation
 >;
-export type SetUserIsDeletedMutationResult =
-  Apollo.MutationResult<SetUserIsDeletedMutation>;
+export type SetUserIsDeletedMutationResult = Apollo.MutationResult<SetUserIsDeletedMutation>;
 export type SetUserIsDeletedMutationOptions = Apollo.BaseMutationOptions<
   SetUserIsDeletedMutation,
   SetUserIsDeletedMutationVariables
@@ -3744,8 +3685,7 @@ export function useReactivateUserMutation(
 export type ReactivateUserMutationHookResult = ReturnType<
   typeof useReactivateUserMutation
 >;
-export type ReactivateUserMutationResult =
-  Apollo.MutationResult<ReactivateUserMutation>;
+export type ReactivateUserMutationResult = Apollo.MutationResult<ReactivateUserMutation>;
 export type ReactivateUserMutationOptions = Apollo.BaseMutationOptions<
   ReactivateUserMutation,
   ReactivateUserMutationVariables
@@ -3807,8 +3747,7 @@ export function useAddUserToCurrentOrgMutation(
 export type AddUserToCurrentOrgMutationHookResult = ReturnType<
   typeof useAddUserToCurrentOrgMutation
 >;
-export type AddUserToCurrentOrgMutationResult =
-  Apollo.MutationResult<AddUserToCurrentOrgMutation>;
+export type AddUserToCurrentOrgMutationResult = Apollo.MutationResult<AddUserToCurrentOrgMutation>;
 export type AddUserToCurrentOrgMutationOptions = Apollo.BaseMutationOptions<
   AddUserToCurrentOrgMutation,
   AddUserToCurrentOrgMutationVariables
@@ -3986,8 +3925,7 @@ export function useResendActivationEmailMutation(
 export type ResendActivationEmailMutationHookResult = ReturnType<
   typeof useResendActivationEmailMutation
 >;
-export type ResendActivationEmailMutationResult =
-  Apollo.MutationResult<ResendActivationEmailMutation>;
+export type ResendActivationEmailMutationResult = Apollo.MutationResult<ResendActivationEmailMutation>;
 export type ResendActivationEmailMutationOptions = Apollo.BaseMutationOptions<
   ResendActivationEmailMutation,
   ResendActivationEmailMutationVariables
@@ -4052,8 +3990,7 @@ export function useUpdateUserNameMutation(
 export type UpdateUserNameMutationHookResult = ReturnType<
   typeof useUpdateUserNameMutation
 >;
-export type UpdateUserNameMutationResult =
-  Apollo.MutationResult<UpdateUserNameMutation>;
+export type UpdateUserNameMutationResult = Apollo.MutationResult<UpdateUserNameMutation>;
 export type UpdateUserNameMutationOptions = Apollo.BaseMutationOptions<
   UpdateUserNameMutation,
   UpdateUserNameMutationVariables
@@ -4104,8 +4041,7 @@ export function useEditUserEmailMutation(
 export type EditUserEmailMutationHookResult = ReturnType<
   typeof useEditUserEmailMutation
 >;
-export type EditUserEmailMutationResult =
-  Apollo.MutationResult<EditUserEmailMutation>;
+export type EditUserEmailMutationResult = Apollo.MutationResult<EditUserEmailMutation>;
 export type EditUserEmailMutationOptions = Apollo.BaseMutationOptions<
   EditUserEmailMutation,
   EditUserEmailMutationVariables
@@ -4154,8 +4090,7 @@ export function useResetUserMfaMutation(
 export type ResetUserMfaMutationHookResult = ReturnType<
   typeof useResetUserMfaMutation
 >;
-export type ResetUserMfaMutationResult =
-  Apollo.MutationResult<ResetUserMfaMutation>;
+export type ResetUserMfaMutationResult = Apollo.MutationResult<ResetUserMfaMutation>;
 export type ResetUserMfaMutationOptions = Apollo.BaseMutationOptions<
   ResetUserMfaMutation,
   ResetUserMfaMutationVariables
@@ -4421,8 +4356,7 @@ export function useAddPatientMutation(
 export type AddPatientMutationHookResult = ReturnType<
   typeof useAddPatientMutation
 >;
-export type AddPatientMutationResult =
-  Apollo.MutationResult<AddPatientMutation>;
+export type AddPatientMutationResult = Apollo.MutationResult<AddPatientMutation>;
 export type AddPatientMutationOptions = Apollo.BaseMutationOptions<
   AddPatientMutation,
   AddPatientMutationVariables
@@ -4472,8 +4406,7 @@ export function useArchivePersonMutation(
 export type ArchivePersonMutationHookResult = ReturnType<
   typeof useArchivePersonMutation
 >;
-export type ArchivePersonMutationResult =
-  Apollo.MutationResult<ArchivePersonMutation>;
+export type ArchivePersonMutationResult = Apollo.MutationResult<ArchivePersonMutation>;
 export type ArchivePersonMutationOptions = Apollo.BaseMutationOptions<
   ArchivePersonMutation,
   ArchivePersonMutationVariables
@@ -4689,8 +4622,7 @@ export function useUpdatePatientMutation(
 export type UpdatePatientMutationHookResult = ReturnType<
   typeof useUpdatePatientMutation
 >;
-export type UpdatePatientMutationResult =
-  Apollo.MutationResult<UpdatePatientMutation>;
+export type UpdatePatientMutationResult = Apollo.MutationResult<UpdatePatientMutation>;
 export type UpdatePatientMutationOptions = Apollo.BaseMutationOptions<
   UpdatePatientMutation,
   UpdatePatientMutationVariables
@@ -4983,8 +4915,7 @@ export function useCreateDeviceTypeMutation(
 export type CreateDeviceTypeMutationHookResult = ReturnType<
   typeof useCreateDeviceTypeMutation
 >;
-export type CreateDeviceTypeMutationResult =
-  Apollo.MutationResult<CreateDeviceTypeMutation>;
+export type CreateDeviceTypeMutationResult = Apollo.MutationResult<CreateDeviceTypeMutation>;
 export type CreateDeviceTypeMutationOptions = Apollo.BaseMutationOptions<
   CreateDeviceTypeMutation,
   CreateDeviceTypeMutationVariables
@@ -5060,8 +4991,7 @@ export function useUpdateDeviceTypeMutation(
 export type UpdateDeviceTypeMutationHookResult = ReturnType<
   typeof useUpdateDeviceTypeMutation
 >;
-export type UpdateDeviceTypeMutationResult =
-  Apollo.MutationResult<UpdateDeviceTypeMutation>;
+export type UpdateDeviceTypeMutationResult = Apollo.MutationResult<UpdateDeviceTypeMutation>;
 export type UpdateDeviceTypeMutationOptions = Apollo.BaseMutationOptions<
   UpdateDeviceTypeMutation,
   UpdateDeviceTypeMutationVariables
@@ -5363,8 +5293,7 @@ export function useSetOrgIdentityVerifiedMutation(
 export type SetOrgIdentityVerifiedMutationHookResult = ReturnType<
   typeof useSetOrgIdentityVerifiedMutation
 >;
-export type SetOrgIdentityVerifiedMutationResult =
-  Apollo.MutationResult<SetOrgIdentityVerifiedMutation>;
+export type SetOrgIdentityVerifiedMutationResult = Apollo.MutationResult<SetOrgIdentityVerifiedMutation>;
 export type SetOrgIdentityVerifiedMutationOptions = Apollo.BaseMutationOptions<
   SetOrgIdentityVerifiedMutation,
   SetOrgIdentityVerifiedMutationVariables
@@ -5380,11 +5309,10 @@ export const MarkPendingOrganizationAsDeletedDocument = gql`
     )
   }
 `;
-export type MarkPendingOrganizationAsDeletedMutationFn =
-  Apollo.MutationFunction<
-    MarkPendingOrganizationAsDeletedMutation,
-    MarkPendingOrganizationAsDeletedMutationVariables
-  >;
+export type MarkPendingOrganizationAsDeletedMutationFn = Apollo.MutationFunction<
+  MarkPendingOrganizationAsDeletedMutation,
+  MarkPendingOrganizationAsDeletedMutationVariables
+>;
 
 /**
  * __useMarkPendingOrganizationAsDeletedMutation__
@@ -5419,13 +5347,11 @@ export function useMarkPendingOrganizationAsDeletedMutation(
 export type MarkPendingOrganizationAsDeletedMutationHookResult = ReturnType<
   typeof useMarkPendingOrganizationAsDeletedMutation
 >;
-export type MarkPendingOrganizationAsDeletedMutationResult =
-  Apollo.MutationResult<MarkPendingOrganizationAsDeletedMutation>;
-export type MarkPendingOrganizationAsDeletedMutationOptions =
-  Apollo.BaseMutationOptions<
-    MarkPendingOrganizationAsDeletedMutation,
-    MarkPendingOrganizationAsDeletedMutationVariables
-  >;
+export type MarkPendingOrganizationAsDeletedMutationResult = Apollo.MutationResult<MarkPendingOrganizationAsDeletedMutation>;
+export type MarkPendingOrganizationAsDeletedMutationOptions = Apollo.BaseMutationOptions<
+  MarkPendingOrganizationAsDeletedMutation,
+  MarkPendingOrganizationAsDeletedMutationVariables
+>;
 export const EditPendingOrganizationDocument = gql`
   mutation EditPendingOrganization(
     $externalId: String!
@@ -5487,8 +5413,7 @@ export function useEditPendingOrganizationMutation(
 export type EditPendingOrganizationMutationHookResult = ReturnType<
   typeof useEditPendingOrganizationMutation
 >;
-export type EditPendingOrganizationMutationResult =
-  Apollo.MutationResult<EditPendingOrganizationMutation>;
+export type EditPendingOrganizationMutationResult = Apollo.MutationResult<EditPendingOrganizationMutation>;
 export type EditPendingOrganizationMutationOptions = Apollo.BaseMutationOptions<
   EditPendingOrganizationMutation,
   EditPendingOrganizationMutationVariables
@@ -5572,11 +5497,10 @@ export const SetCurrentUserTenantDataAccessOpDocument = gql`
     }
   }
 `;
-export type SetCurrentUserTenantDataAccessOpMutationFn =
-  Apollo.MutationFunction<
-    SetCurrentUserTenantDataAccessOpMutation,
-    SetCurrentUserTenantDataAccessOpMutationVariables
-  >;
+export type SetCurrentUserTenantDataAccessOpMutationFn = Apollo.MutationFunction<
+  SetCurrentUserTenantDataAccessOpMutation,
+  SetCurrentUserTenantDataAccessOpMutationVariables
+>;
 
 /**
  * __useSetCurrentUserTenantDataAccessOpMutation__
@@ -5611,137 +5535,10 @@ export function useSetCurrentUserTenantDataAccessOpMutation(
 export type SetCurrentUserTenantDataAccessOpMutationHookResult = ReturnType<
   typeof useSetCurrentUserTenantDataAccessOpMutation
 >;
-export type SetCurrentUserTenantDataAccessOpMutationResult =
-  Apollo.MutationResult<SetCurrentUserTenantDataAccessOpMutation>;
-export type SetCurrentUserTenantDataAccessOpMutationOptions =
-  Apollo.BaseMutationOptions<
-    SetCurrentUserTenantDataAccessOpMutation,
-    SetCurrentUserTenantDataAccessOpMutationVariables
-  >;
-export const GetFacilityQueueMultiplexDocument = gql`
-  query GetFacilityQueueMultiplex($facilityId: ID!) {
-    queue(facilityId: $facilityId) {
-      internalId
-      pregnancy
-      dateAdded
-      symptoms
-      symptomOnset
-      noSymptoms
-      deviceType {
-        internalId
-        name
-        model
-        testLength
-      }
-      deviceSpecimenType {
-        internalId
-      }
-      patient {
-        internalId
-        telephone
-        birthDate
-        firstName
-        middleName
-        lastName
-        gender
-        testResultDelivery
-        preferredLanguage
-        email
-        emails
-        phoneNumbers {
-          type
-          number
-        }
-      }
-      results {
-        disease {
-          name
-        }
-        testResult
-      }
-      dateTested
-      correctionStatus
-      reasonForCorrection
-    }
-    organization {
-      testingFacility {
-        id
-        deviceTypes {
-          internalId
-          name
-          model
-          testLength
-        }
-        defaultDeviceSpecimen
-      }
-    }
-    deviceSpecimenTypes {
-      internalId
-      deviceType {
-        internalId
-        name
-        testLength
-        supportedDiseases {
-          name
-        }
-      }
-      specimenType {
-        internalId
-        name
-      }
-    }
-  }
-`;
-
-/**
- * __useGetFacilityQueueMultiplexQuery__
- *
- * To run a query within a React component, call `useGetFacilityQueueMultiplexQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFacilityQueueMultiplexQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFacilityQueueMultiplexQuery({
- *   variables: {
- *      facilityId: // value for 'facilityId'
- *   },
- * });
- */
-export function useGetFacilityQueueMultiplexQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFacilityQueueMultiplexQuery,
-    GetFacilityQueueMultiplexQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetFacilityQueueMultiplexQuery,
-    GetFacilityQueueMultiplexQueryVariables
-  >(GetFacilityQueueMultiplexDocument, options);
-}
-export function useGetFacilityQueueMultiplexLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFacilityQueueMultiplexQuery,
-    GetFacilityQueueMultiplexQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetFacilityQueueMultiplexQuery,
-    GetFacilityQueueMultiplexQueryVariables
-  >(GetFacilityQueueMultiplexDocument, options);
-}
-export type GetFacilityQueueMultiplexQueryHookResult = ReturnType<
-  typeof useGetFacilityQueueMultiplexQuery
->;
-export type GetFacilityQueueMultiplexLazyQueryHookResult = ReturnType<
-  typeof useGetFacilityQueueMultiplexLazyQuery
->;
-export type GetFacilityQueueMultiplexQueryResult = Apollo.QueryResult<
-  GetFacilityQueueMultiplexQuery,
-  GetFacilityQueueMultiplexQueryVariables
+export type SetCurrentUserTenantDataAccessOpMutationResult = Apollo.MutationResult<SetCurrentUserTenantDataAccessOpMutation>;
+export type SetCurrentUserTenantDataAccessOpMutationOptions = Apollo.BaseMutationOptions<
+  SetCurrentUserTenantDataAccessOpMutation,
+  SetCurrentUserTenantDataAccessOpMutationVariables
 >;
 export const GetPatientDocument = gql`
   query GetPatient($internalId: ID!) {
@@ -5961,8 +5758,7 @@ export function useAddPatientToQueueMutation(
 export type AddPatientToQueueMutationHookResult = ReturnType<
   typeof useAddPatientToQueueMutation
 >;
-export type AddPatientToQueueMutationResult =
-  Apollo.MutationResult<AddPatientToQueueMutation>;
+export type AddPatientToQueueMutationResult = Apollo.MutationResult<AddPatientToQueueMutation>;
 export type AddPatientToQueueMutationOptions = Apollo.BaseMutationOptions<
   AddPatientToQueueMutation,
   AddPatientToQueueMutationVariables
@@ -6075,24 +5871,23 @@ export function useRemovePatientFromQueueMutation(
 export type RemovePatientFromQueueMutationHookResult = ReturnType<
   typeof useRemovePatientFromQueueMutation
 >;
-export type RemovePatientFromQueueMutationResult =
-  Apollo.MutationResult<RemovePatientFromQueueMutation>;
+export type RemovePatientFromQueueMutationResult = Apollo.MutationResult<RemovePatientFromQueueMutation>;
 export type RemovePatientFromQueueMutationOptions = Apollo.BaseMutationOptions<
   RemovePatientFromQueueMutation,
   RemovePatientFromQueueMutationVariables
 >;
-export const EditQueueItemMultiplexResultDocument = gql`
-  mutation EditQueueItemMultiplexResult(
+export const EditQueueItemDocument = gql`
+  mutation EditQueueItem(
     $id: ID!
-    $deviceId: String
-    $deviceSpecimenType: ID
+    $deviceTypeId: ID
+    $specimenTypeId: ID
     $results: [MultiplexResultInput]
     $dateTested: DateTime
   ) {
-    editQueueItemMultiplexResult(
+    editQueueItem(
       id: $id
-      deviceId: $deviceId
-      deviceSpecimenType: $deviceSpecimenType
+      deviceTypeId: $deviceTypeId
+      specimenTypeId: $specimenTypeId
       results: $results
       dateTested: $dateTested
     ) {
@@ -6107,79 +5902,67 @@ export const EditQueueItemMultiplexResultDocument = gql`
         internalId
         testLength
       }
-      deviceSpecimenType {
-        internalId
-        deviceType {
-          internalId
-          testLength
-        }
-        specimenType {
-          internalId
-        }
-      }
     }
   }
 `;
-export type EditQueueItemMultiplexResultMutationFn = Apollo.MutationFunction<
-  EditQueueItemMultiplexResultMutation,
-  EditQueueItemMultiplexResultMutationVariables
+export type EditQueueItemMutationFn = Apollo.MutationFunction<
+  EditQueueItemMutation,
+  EditQueueItemMutationVariables
 >;
 
 /**
- * __useEditQueueItemMultiplexResultMutation__
+ * __useEditQueueItemMutation__
  *
- * To run a mutation, you first call `useEditQueueItemMultiplexResultMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useEditQueueItemMultiplexResultMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useEditQueueItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditQueueItemMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [editQueueItemMultiplexResultMutation, { data, loading, error }] = useEditQueueItemMultiplexResultMutation({
+ * const [editQueueItemMutation, { data, loading, error }] = useEditQueueItemMutation({
  *   variables: {
  *      id: // value for 'id'
- *      deviceId: // value for 'deviceId'
- *      deviceSpecimenType: // value for 'deviceSpecimenType'
+ *      deviceTypeId: // value for 'deviceTypeId'
+ *      specimenTypeId: // value for 'specimenTypeId'
  *      results: // value for 'results'
  *      dateTested: // value for 'dateTested'
  *   },
  * });
  */
-export function useEditQueueItemMultiplexResultMutation(
+export function useEditQueueItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    EditQueueItemMultiplexResultMutation,
-    EditQueueItemMultiplexResultMutationVariables
+    EditQueueItemMutation,
+    EditQueueItemMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    EditQueueItemMultiplexResultMutation,
-    EditQueueItemMultiplexResultMutationVariables
-  >(EditQueueItemMultiplexResultDocument, options);
+    EditQueueItemMutation,
+    EditQueueItemMutationVariables
+  >(EditQueueItemDocument, options);
 }
-export type EditQueueItemMultiplexResultMutationHookResult = ReturnType<
-  typeof useEditQueueItemMultiplexResultMutation
+export type EditQueueItemMutationHookResult = ReturnType<
+  typeof useEditQueueItemMutation
 >;
-export type EditQueueItemMultiplexResultMutationResult =
-  Apollo.MutationResult<EditQueueItemMultiplexResultMutation>;
-export type EditQueueItemMultiplexResultMutationOptions =
-  Apollo.BaseMutationOptions<
-    EditQueueItemMultiplexResultMutation,
-    EditQueueItemMultiplexResultMutationVariables
-  >;
-export const AddMultiplexResultDocument = gql`
-  mutation AddMultiplexResult(
+export type EditQueueItemMutationResult = Apollo.MutationResult<EditQueueItemMutation>;
+export type EditQueueItemMutationOptions = Apollo.BaseMutationOptions<
+  EditQueueItemMutation,
+  EditQueueItemMutationVariables
+>;
+export const SubmitQueueItemDocument = gql`
+  mutation SubmitQueueItem(
     $patientId: ID!
-    $deviceId: String!
-    $deviceSpecimenType: ID
+    $deviceTypeId: ID!
+    $specimenTypeId: ID!
     $results: [MultiplexResultInput]!
     $dateTested: DateTime
   ) {
-    addMultiplexResult(
+    submitQueueItem(
       patientId: $patientId
-      deviceId: $deviceId
-      deviceSpecimenType: $deviceSpecimenType
+      deviceTypeId: $deviceTypeId
+      specimenTypeId: $specimenTypeId
       results: $results
       dateTested: $dateTested
     ) {
@@ -6190,52 +5973,175 @@ export const AddMultiplexResultDocument = gql`
     }
   }
 `;
-export type AddMultiplexResultMutationFn = Apollo.MutationFunction<
-  AddMultiplexResultMutation,
-  AddMultiplexResultMutationVariables
+export type SubmitQueueItemMutationFn = Apollo.MutationFunction<
+  SubmitQueueItemMutation,
+  SubmitQueueItemMutationVariables
 >;
 
 /**
- * __useAddMultiplexResultMutation__
+ * __useSubmitQueueItemMutation__
  *
- * To run a mutation, you first call `useAddMultiplexResultMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useAddMultiplexResultMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useSubmitQueueItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSubmitQueueItemMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [addMultiplexResultMutation, { data, loading, error }] = useAddMultiplexResultMutation({
+ * const [submitQueueItemMutation, { data, loading, error }] = useSubmitQueueItemMutation({
  *   variables: {
  *      patientId: // value for 'patientId'
- *      deviceId: // value for 'deviceId'
- *      deviceSpecimenType: // value for 'deviceSpecimenType'
+ *      deviceTypeId: // value for 'deviceTypeId'
+ *      specimenTypeId: // value for 'specimenTypeId'
  *      results: // value for 'results'
  *      dateTested: // value for 'dateTested'
  *   },
  * });
  */
-export function useAddMultiplexResultMutation(
+export function useSubmitQueueItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    AddMultiplexResultMutation,
-    AddMultiplexResultMutationVariables
+    SubmitQueueItemMutation,
+    SubmitQueueItemMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    AddMultiplexResultMutation,
-    AddMultiplexResultMutationVariables
-  >(AddMultiplexResultDocument, options);
+    SubmitQueueItemMutation,
+    SubmitQueueItemMutationVariables
+  >(SubmitQueueItemDocument, options);
 }
-export type AddMultiplexResultMutationHookResult = ReturnType<
-  typeof useAddMultiplexResultMutation
+export type SubmitQueueItemMutationHookResult = ReturnType<
+  typeof useSubmitQueueItemMutation
 >;
-export type AddMultiplexResultMutationResult =
-  Apollo.MutationResult<AddMultiplexResultMutation>;
-export type AddMultiplexResultMutationOptions = Apollo.BaseMutationOptions<
-  AddMultiplexResultMutation,
-  AddMultiplexResultMutationVariables
+export type SubmitQueueItemMutationResult = Apollo.MutationResult<SubmitQueueItemMutation>;
+export type SubmitQueueItemMutationOptions = Apollo.BaseMutationOptions<
+  SubmitQueueItemMutation,
+  SubmitQueueItemMutationVariables
+>;
+export const GetFacilityQueueDocument = gql`
+  query GetFacilityQueue($facilityId: ID!) {
+    queue(facilityId: $facilityId) {
+      internalId
+      pregnancy
+      dateAdded
+      symptoms
+      symptomOnset
+      noSymptoms
+      deviceType {
+        internalId
+        name
+        model
+        testLength
+        supportedDiseases {
+          internalId
+          name
+          loinc
+        }
+      }
+      specimenType {
+        internalId
+        name
+        typeCode
+      }
+      patient {
+        internalId
+        telephone
+        birthDate
+        firstName
+        middleName
+        lastName
+        gender
+        testResultDelivery
+        preferredLanguage
+        email
+        emails
+        phoneNumbers {
+          type
+          number
+        }
+      }
+      results {
+        disease {
+          name
+        }
+        testResult
+      }
+      dateTested
+      correctionStatus
+      reasonForCorrection
+    }
+    facility(id: $facilityId) {
+      name
+      id
+      deviceTypes {
+        internalId
+        name
+        testLength
+        supportedDiseases {
+          internalId
+          name
+          loinc
+        }
+        swabTypes {
+          internalId
+          name
+          typeCode
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetFacilityQueueQuery__
+ *
+ * To run a query within a React component, call `useGetFacilityQueueQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetFacilityQueueQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetFacilityQueueQuery({
+ *   variables: {
+ *      facilityId: // value for 'facilityId'
+ *   },
+ * });
+ */
+export function useGetFacilityQueueQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetFacilityQueueQuery,
+    GetFacilityQueueQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetFacilityQueueQuery, GetFacilityQueueQueryVariables>(
+    GetFacilityQueueDocument,
+    options
+  );
+}
+export function useGetFacilityQueueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetFacilityQueueQuery,
+    GetFacilityQueueQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetFacilityQueueQuery,
+    GetFacilityQueueQueryVariables
+  >(GetFacilityQueueDocument, options);
+}
+export type GetFacilityQueueQueryHookResult = ReturnType<
+  typeof useGetFacilityQueueQuery
+>;
+export type GetFacilityQueueLazyQueryHookResult = ReturnType<
+  typeof useGetFacilityQueueLazyQuery
+>;
+export type GetFacilityQueueQueryResult = Apollo.QueryResult<
+  GetFacilityQueueQuery,
+  GetFacilityQueueQueryVariables
 >;
 export const GetTestResultForCorrectionDocument = gql`
   query getTestResultForCorrection($id: ID!) {
@@ -6356,8 +6262,7 @@ export function useMarkTestAsErrorMutation(
 export type MarkTestAsErrorMutationHookResult = ReturnType<
   typeof useMarkTestAsErrorMutation
 >;
-export type MarkTestAsErrorMutationResult =
-  Apollo.MutationResult<MarkTestAsErrorMutation>;
+export type MarkTestAsErrorMutationResult = Apollo.MutationResult<MarkTestAsErrorMutation>;
 export type MarkTestAsErrorMutationOptions = Apollo.BaseMutationOptions<
   MarkTestAsErrorMutation,
   MarkTestAsErrorMutationVariables
@@ -6407,8 +6312,7 @@ export function useMarkTestAsCorrectionMutation(
 export type MarkTestAsCorrectionMutationHookResult = ReturnType<
   typeof useMarkTestAsCorrectionMutation
 >;
-export type MarkTestAsCorrectionMutationResult =
-  Apollo.MutationResult<MarkTestAsCorrectionMutation>;
+export type MarkTestAsCorrectionMutationResult = Apollo.MutationResult<MarkTestAsCorrectionMutation>;
 export type MarkTestAsCorrectionMutationOptions = Apollo.BaseMutationOptions<
   MarkTestAsCorrectionMutation,
   MarkTestAsCorrectionMutationVariables
@@ -6717,8 +6621,7 @@ export function useResendTestResultsEmailMutation(
 export type ResendTestResultsEmailMutationHookResult = ReturnType<
   typeof useResendTestResultsEmailMutation
 >;
-export type ResendTestResultsEmailMutationResult =
-  Apollo.MutationResult<ResendTestResultsEmailMutation>;
+export type ResendTestResultsEmailMutationResult = Apollo.MutationResult<ResendTestResultsEmailMutation>;
 export type ResendTestResultsEmailMutationOptions = Apollo.BaseMutationOptions<
   ResendTestResultsEmailMutation,
   ResendTestResultsEmailMutationVariables
@@ -6979,13 +6882,13 @@ export function useGetFacilityResultsMultiplexWithCountLazyQuery(
 export type GetFacilityResultsMultiplexWithCountQueryHookResult = ReturnType<
   typeof useGetFacilityResultsMultiplexWithCountQuery
 >;
-export type GetFacilityResultsMultiplexWithCountLazyQueryHookResult =
-  ReturnType<typeof useGetFacilityResultsMultiplexWithCountLazyQuery>;
-export type GetFacilityResultsMultiplexWithCountQueryResult =
-  Apollo.QueryResult<
-    GetFacilityResultsMultiplexWithCountQuery,
-    GetFacilityResultsMultiplexWithCountQueryVariables
-  >;
+export type GetFacilityResultsMultiplexWithCountLazyQueryHookResult = ReturnType<
+  typeof useGetFacilityResultsMultiplexWithCountLazyQuery
+>;
+export type GetFacilityResultsMultiplexWithCountQueryResult = Apollo.QueryResult<
+  GetFacilityResultsMultiplexWithCountQuery,
+  GetFacilityResultsMultiplexWithCountQueryVariables
+>;
 export const GetAllFacilitiesDocument = gql`
   query GetAllFacilities($showArchived: Boolean) {
     facilities(showArchived: $showArchived) {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2089,12 +2089,6 @@ export type GetFacilityQueueQuery = {
       name: string;
       model: string;
       testLength: number;
-      supportedDiseases: Array<{
-        __typename?: "SupportedDisease";
-        internalId: string;
-        name: string;
-        loinc: string;
-      }>;
     };
     specimenType: {
       __typename?: "SpecimenType";
@@ -6034,11 +6028,6 @@ export const GetFacilityQueueDocument = gql`
         name
         model
         testLength
-        supportedDiseases {
-          internalId
-          name
-          loinc
-        }
       }
       specimenType {
         internalId

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -788,7 +788,7 @@ export type Query = {
   patients?: Maybe<Array<Maybe<Patient>>>;
   patientsCount?: Maybe<Scalars["Int"]>;
   pendingOrganizations: Array<PendingOrganization>;
-  queue: Array<TestOrder>;
+  queue?: Maybe<Array<Maybe<TestOrder>>>;
   specimenType?: Maybe<Array<Maybe<SpecimenType>>>;
   specimenTypes: Array<SpecimenType>;
   supportedDiseases: Array<SupportedDisease>;
@@ -2072,65 +2072,75 @@ export type GetFacilityQueueQueryVariables = Exact<{
 
 export type GetFacilityQueueQuery = {
   __typename?: "Query";
-  queue: Array<{
-    __typename?: "TestOrder";
-    internalId: string;
-    pregnancy?: string | null | undefined;
-    dateAdded: string;
-    symptoms?: string | null | undefined;
-    symptomOnset?: any | null | undefined;
-    noSymptoms?: boolean | null | undefined;
-    dateTested?: any | null | undefined;
-    correctionStatus?: string | null | undefined;
-    reasonForCorrection?: string | null | undefined;
-    deviceType: {
-      __typename?: "DeviceType";
-      internalId: string;
-      name: string;
-      model: string;
-      testLength: number;
-    };
-    specimenType: {
-      __typename?: "SpecimenType";
-      internalId: string;
-      name: string;
-      typeCode: string;
-    };
-    patient: {
-      __typename?: "Patient";
-      internalId: string;
-      telephone?: string | null | undefined;
-      birthDate?: any | null | undefined;
-      firstName?: string | null | undefined;
-      middleName?: string | null | undefined;
-      lastName?: string | null | undefined;
-      gender?: string | null | undefined;
-      testResultDelivery?: TestResultDeliveryPreference | null | undefined;
-      preferredLanguage?: string | null | undefined;
-      email?: string | null | undefined;
-      emails?: Array<string | null | undefined> | null | undefined;
-      phoneNumbers?:
-        | Array<
-            | {
-                __typename?: "PhoneNumber";
-                type?: PhoneType | null | undefined;
-                number?: string | null | undefined;
-              }
-            | null
-            | undefined
-          >
+  queue?:
+    | Array<
+        | {
+            __typename?: "TestOrder";
+            internalId: string;
+            pregnancy?: string | null | undefined;
+            dateAdded: string;
+            symptoms?: string | null | undefined;
+            symptomOnset?: any | null | undefined;
+            noSymptoms?: boolean | null | undefined;
+            dateTested?: any | null | undefined;
+            correctionStatus?: string | null | undefined;
+            reasonForCorrection?: string | null | undefined;
+            deviceType: {
+              __typename?: "DeviceType";
+              internalId: string;
+              name: string;
+              model: string;
+              testLength: number;
+            };
+            specimenType: {
+              __typename?: "SpecimenType";
+              internalId: string;
+              name: string;
+              typeCode: string;
+            };
+            patient: {
+              __typename?: "Patient";
+              internalId: string;
+              telephone?: string | null | undefined;
+              birthDate?: any | null | undefined;
+              firstName?: string | null | undefined;
+              middleName?: string | null | undefined;
+              lastName?: string | null | undefined;
+              gender?: string | null | undefined;
+              testResultDelivery?:
+                | TestResultDeliveryPreference
+                | null
+                | undefined;
+              preferredLanguage?: string | null | undefined;
+              email?: string | null | undefined;
+              emails?: Array<string | null | undefined> | null | undefined;
+              phoneNumbers?:
+                | Array<
+                    | {
+                        __typename?: "PhoneNumber";
+                        type?: PhoneType | null | undefined;
+                        number?: string | null | undefined;
+                      }
+                    | null
+                    | undefined
+                  >
+                | null
+                | undefined;
+            };
+            results: Array<{
+              __typename?: "MultiplexResult";
+              testResult?: string | null | undefined;
+              disease?:
+                | { __typename?: "SupportedDisease"; name: string }
+                | null
+                | undefined;
+            }>;
+          }
         | null
-        | undefined;
-    };
-    results: Array<{
-      __typename?: "MultiplexResult";
-      testResult?: string | null | undefined;
-      disease?:
-        | { __typename?: "SupportedDisease"; name: string }
-        | null
-        | undefined;
-    }>;
-  }>;
+        | undefined
+      >
+    | null
+    | undefined;
   facility?:
     | {
         __typename?: "Facility";

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -6,10 +6,12 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -3090,7 +3092,8 @@ export function useUpdateFacilityMutation(
 export type UpdateFacilityMutationHookResult = ReturnType<
   typeof useUpdateFacilityMutation
 >;
-export type UpdateFacilityMutationResult = Apollo.MutationResult<UpdateFacilityMutation>;
+export type UpdateFacilityMutationResult =
+  Apollo.MutationResult<UpdateFacilityMutation>;
 export type UpdateFacilityMutationOptions = Apollo.BaseMutationOptions<
   UpdateFacilityMutation,
   UpdateFacilityMutationVariables
@@ -3203,7 +3206,8 @@ export function useAddFacilityMutation(
 export type AddFacilityMutationHookResult = ReturnType<
   typeof useAddFacilityMutation
 >;
-export type AddFacilityMutationResult = Apollo.MutationResult<AddFacilityMutation>;
+export type AddFacilityMutationResult =
+  Apollo.MutationResult<AddFacilityMutation>;
 export type AddFacilityMutationOptions = Apollo.BaseMutationOptions<
   AddFacilityMutation,
   AddFacilityMutationVariables
@@ -3370,7 +3374,8 @@ export function useAdminSetOrganizationMutation(
 export type AdminSetOrganizationMutationHookResult = ReturnType<
   typeof useAdminSetOrganizationMutation
 >;
-export type AdminSetOrganizationMutationResult = Apollo.MutationResult<AdminSetOrganizationMutation>;
+export type AdminSetOrganizationMutationResult =
+  Apollo.MutationResult<AdminSetOrganizationMutation>;
 export type AdminSetOrganizationMutationOptions = Apollo.BaseMutationOptions<
   AdminSetOrganizationMutation,
   AdminSetOrganizationMutationVariables
@@ -3417,7 +3422,8 @@ export function useSetOrganizationMutation(
 export type SetOrganizationMutationHookResult = ReturnType<
   typeof useSetOrganizationMutation
 >;
-export type SetOrganizationMutationResult = Apollo.MutationResult<SetOrganizationMutation>;
+export type SetOrganizationMutationResult =
+  Apollo.MutationResult<SetOrganizationMutation>;
 export type SetOrganizationMutationOptions = Apollo.BaseMutationOptions<
   SetOrganizationMutation,
   SetOrganizationMutationVariables
@@ -3542,7 +3548,8 @@ export function useUpdateUserPrivilegesMutation(
 export type UpdateUserPrivilegesMutationHookResult = ReturnType<
   typeof useUpdateUserPrivilegesMutation
 >;
-export type UpdateUserPrivilegesMutationResult = Apollo.MutationResult<UpdateUserPrivilegesMutation>;
+export type UpdateUserPrivilegesMutationResult =
+  Apollo.MutationResult<UpdateUserPrivilegesMutation>;
 export type UpdateUserPrivilegesMutationOptions = Apollo.BaseMutationOptions<
   UpdateUserPrivilegesMutation,
   UpdateUserPrivilegesMutationVariables
@@ -3591,7 +3598,8 @@ export function useResetUserPasswordMutation(
 export type ResetUserPasswordMutationHookResult = ReturnType<
   typeof useResetUserPasswordMutation
 >;
-export type ResetUserPasswordMutationResult = Apollo.MutationResult<ResetUserPasswordMutation>;
+export type ResetUserPasswordMutationResult =
+  Apollo.MutationResult<ResetUserPasswordMutation>;
 export type ResetUserPasswordMutationOptions = Apollo.BaseMutationOptions<
   ResetUserPasswordMutation,
   ResetUserPasswordMutationVariables
@@ -3641,7 +3649,8 @@ export function useSetUserIsDeletedMutation(
 export type SetUserIsDeletedMutationHookResult = ReturnType<
   typeof useSetUserIsDeletedMutation
 >;
-export type SetUserIsDeletedMutationResult = Apollo.MutationResult<SetUserIsDeletedMutation>;
+export type SetUserIsDeletedMutationResult =
+  Apollo.MutationResult<SetUserIsDeletedMutation>;
 export type SetUserIsDeletedMutationOptions = Apollo.BaseMutationOptions<
   SetUserIsDeletedMutation,
   SetUserIsDeletedMutationVariables
@@ -3690,7 +3699,8 @@ export function useReactivateUserMutation(
 export type ReactivateUserMutationHookResult = ReturnType<
   typeof useReactivateUserMutation
 >;
-export type ReactivateUserMutationResult = Apollo.MutationResult<ReactivateUserMutation>;
+export type ReactivateUserMutationResult =
+  Apollo.MutationResult<ReactivateUserMutation>;
 export type ReactivateUserMutationOptions = Apollo.BaseMutationOptions<
   ReactivateUserMutation,
   ReactivateUserMutationVariables
@@ -3752,7 +3762,8 @@ export function useAddUserToCurrentOrgMutation(
 export type AddUserToCurrentOrgMutationHookResult = ReturnType<
   typeof useAddUserToCurrentOrgMutation
 >;
-export type AddUserToCurrentOrgMutationResult = Apollo.MutationResult<AddUserToCurrentOrgMutation>;
+export type AddUserToCurrentOrgMutationResult =
+  Apollo.MutationResult<AddUserToCurrentOrgMutation>;
 export type AddUserToCurrentOrgMutationOptions = Apollo.BaseMutationOptions<
   AddUserToCurrentOrgMutation,
   AddUserToCurrentOrgMutationVariables
@@ -3930,7 +3941,8 @@ export function useResendActivationEmailMutation(
 export type ResendActivationEmailMutationHookResult = ReturnType<
   typeof useResendActivationEmailMutation
 >;
-export type ResendActivationEmailMutationResult = Apollo.MutationResult<ResendActivationEmailMutation>;
+export type ResendActivationEmailMutationResult =
+  Apollo.MutationResult<ResendActivationEmailMutation>;
 export type ResendActivationEmailMutationOptions = Apollo.BaseMutationOptions<
   ResendActivationEmailMutation,
   ResendActivationEmailMutationVariables
@@ -3995,7 +4007,8 @@ export function useUpdateUserNameMutation(
 export type UpdateUserNameMutationHookResult = ReturnType<
   typeof useUpdateUserNameMutation
 >;
-export type UpdateUserNameMutationResult = Apollo.MutationResult<UpdateUserNameMutation>;
+export type UpdateUserNameMutationResult =
+  Apollo.MutationResult<UpdateUserNameMutation>;
 export type UpdateUserNameMutationOptions = Apollo.BaseMutationOptions<
   UpdateUserNameMutation,
   UpdateUserNameMutationVariables
@@ -4046,7 +4059,8 @@ export function useEditUserEmailMutation(
 export type EditUserEmailMutationHookResult = ReturnType<
   typeof useEditUserEmailMutation
 >;
-export type EditUserEmailMutationResult = Apollo.MutationResult<EditUserEmailMutation>;
+export type EditUserEmailMutationResult =
+  Apollo.MutationResult<EditUserEmailMutation>;
 export type EditUserEmailMutationOptions = Apollo.BaseMutationOptions<
   EditUserEmailMutation,
   EditUserEmailMutationVariables
@@ -4095,7 +4109,8 @@ export function useResetUserMfaMutation(
 export type ResetUserMfaMutationHookResult = ReturnType<
   typeof useResetUserMfaMutation
 >;
-export type ResetUserMfaMutationResult = Apollo.MutationResult<ResetUserMfaMutation>;
+export type ResetUserMfaMutationResult =
+  Apollo.MutationResult<ResetUserMfaMutation>;
 export type ResetUserMfaMutationOptions = Apollo.BaseMutationOptions<
   ResetUserMfaMutation,
   ResetUserMfaMutationVariables
@@ -4361,7 +4376,8 @@ export function useAddPatientMutation(
 export type AddPatientMutationHookResult = ReturnType<
   typeof useAddPatientMutation
 >;
-export type AddPatientMutationResult = Apollo.MutationResult<AddPatientMutation>;
+export type AddPatientMutationResult =
+  Apollo.MutationResult<AddPatientMutation>;
 export type AddPatientMutationOptions = Apollo.BaseMutationOptions<
   AddPatientMutation,
   AddPatientMutationVariables
@@ -4411,7 +4427,8 @@ export function useArchivePersonMutation(
 export type ArchivePersonMutationHookResult = ReturnType<
   typeof useArchivePersonMutation
 >;
-export type ArchivePersonMutationResult = Apollo.MutationResult<ArchivePersonMutation>;
+export type ArchivePersonMutationResult =
+  Apollo.MutationResult<ArchivePersonMutation>;
 export type ArchivePersonMutationOptions = Apollo.BaseMutationOptions<
   ArchivePersonMutation,
   ArchivePersonMutationVariables
@@ -4627,7 +4644,8 @@ export function useUpdatePatientMutation(
 export type UpdatePatientMutationHookResult = ReturnType<
   typeof useUpdatePatientMutation
 >;
-export type UpdatePatientMutationResult = Apollo.MutationResult<UpdatePatientMutation>;
+export type UpdatePatientMutationResult =
+  Apollo.MutationResult<UpdatePatientMutation>;
 export type UpdatePatientMutationOptions = Apollo.BaseMutationOptions<
   UpdatePatientMutation,
   UpdatePatientMutationVariables
@@ -4920,7 +4938,8 @@ export function useCreateDeviceTypeMutation(
 export type CreateDeviceTypeMutationHookResult = ReturnType<
   typeof useCreateDeviceTypeMutation
 >;
-export type CreateDeviceTypeMutationResult = Apollo.MutationResult<CreateDeviceTypeMutation>;
+export type CreateDeviceTypeMutationResult =
+  Apollo.MutationResult<CreateDeviceTypeMutation>;
 export type CreateDeviceTypeMutationOptions = Apollo.BaseMutationOptions<
   CreateDeviceTypeMutation,
   CreateDeviceTypeMutationVariables
@@ -4996,7 +5015,8 @@ export function useUpdateDeviceTypeMutation(
 export type UpdateDeviceTypeMutationHookResult = ReturnType<
   typeof useUpdateDeviceTypeMutation
 >;
-export type UpdateDeviceTypeMutationResult = Apollo.MutationResult<UpdateDeviceTypeMutation>;
+export type UpdateDeviceTypeMutationResult =
+  Apollo.MutationResult<UpdateDeviceTypeMutation>;
 export type UpdateDeviceTypeMutationOptions = Apollo.BaseMutationOptions<
   UpdateDeviceTypeMutation,
   UpdateDeviceTypeMutationVariables
@@ -5298,7 +5318,8 @@ export function useSetOrgIdentityVerifiedMutation(
 export type SetOrgIdentityVerifiedMutationHookResult = ReturnType<
   typeof useSetOrgIdentityVerifiedMutation
 >;
-export type SetOrgIdentityVerifiedMutationResult = Apollo.MutationResult<SetOrgIdentityVerifiedMutation>;
+export type SetOrgIdentityVerifiedMutationResult =
+  Apollo.MutationResult<SetOrgIdentityVerifiedMutation>;
 export type SetOrgIdentityVerifiedMutationOptions = Apollo.BaseMutationOptions<
   SetOrgIdentityVerifiedMutation,
   SetOrgIdentityVerifiedMutationVariables
@@ -5314,10 +5335,11 @@ export const MarkPendingOrganizationAsDeletedDocument = gql`
     )
   }
 `;
-export type MarkPendingOrganizationAsDeletedMutationFn = Apollo.MutationFunction<
-  MarkPendingOrganizationAsDeletedMutation,
-  MarkPendingOrganizationAsDeletedMutationVariables
->;
+export type MarkPendingOrganizationAsDeletedMutationFn =
+  Apollo.MutationFunction<
+    MarkPendingOrganizationAsDeletedMutation,
+    MarkPendingOrganizationAsDeletedMutationVariables
+  >;
 
 /**
  * __useMarkPendingOrganizationAsDeletedMutation__
@@ -5352,11 +5374,13 @@ export function useMarkPendingOrganizationAsDeletedMutation(
 export type MarkPendingOrganizationAsDeletedMutationHookResult = ReturnType<
   typeof useMarkPendingOrganizationAsDeletedMutation
 >;
-export type MarkPendingOrganizationAsDeletedMutationResult = Apollo.MutationResult<MarkPendingOrganizationAsDeletedMutation>;
-export type MarkPendingOrganizationAsDeletedMutationOptions = Apollo.BaseMutationOptions<
-  MarkPendingOrganizationAsDeletedMutation,
-  MarkPendingOrganizationAsDeletedMutationVariables
->;
+export type MarkPendingOrganizationAsDeletedMutationResult =
+  Apollo.MutationResult<MarkPendingOrganizationAsDeletedMutation>;
+export type MarkPendingOrganizationAsDeletedMutationOptions =
+  Apollo.BaseMutationOptions<
+    MarkPendingOrganizationAsDeletedMutation,
+    MarkPendingOrganizationAsDeletedMutationVariables
+  >;
 export const EditPendingOrganizationDocument = gql`
   mutation EditPendingOrganization(
     $externalId: String!
@@ -5418,7 +5442,8 @@ export function useEditPendingOrganizationMutation(
 export type EditPendingOrganizationMutationHookResult = ReturnType<
   typeof useEditPendingOrganizationMutation
 >;
-export type EditPendingOrganizationMutationResult = Apollo.MutationResult<EditPendingOrganizationMutation>;
+export type EditPendingOrganizationMutationResult =
+  Apollo.MutationResult<EditPendingOrganizationMutation>;
 export type EditPendingOrganizationMutationOptions = Apollo.BaseMutationOptions<
   EditPendingOrganizationMutation,
   EditPendingOrganizationMutationVariables
@@ -5502,10 +5527,11 @@ export const SetCurrentUserTenantDataAccessOpDocument = gql`
     }
   }
 `;
-export type SetCurrentUserTenantDataAccessOpMutationFn = Apollo.MutationFunction<
-  SetCurrentUserTenantDataAccessOpMutation,
-  SetCurrentUserTenantDataAccessOpMutationVariables
->;
+export type SetCurrentUserTenantDataAccessOpMutationFn =
+  Apollo.MutationFunction<
+    SetCurrentUserTenantDataAccessOpMutation,
+    SetCurrentUserTenantDataAccessOpMutationVariables
+  >;
 
 /**
  * __useSetCurrentUserTenantDataAccessOpMutation__
@@ -5540,11 +5566,13 @@ export function useSetCurrentUserTenantDataAccessOpMutation(
 export type SetCurrentUserTenantDataAccessOpMutationHookResult = ReturnType<
   typeof useSetCurrentUserTenantDataAccessOpMutation
 >;
-export type SetCurrentUserTenantDataAccessOpMutationResult = Apollo.MutationResult<SetCurrentUserTenantDataAccessOpMutation>;
-export type SetCurrentUserTenantDataAccessOpMutationOptions = Apollo.BaseMutationOptions<
-  SetCurrentUserTenantDataAccessOpMutation,
-  SetCurrentUserTenantDataAccessOpMutationVariables
->;
+export type SetCurrentUserTenantDataAccessOpMutationResult =
+  Apollo.MutationResult<SetCurrentUserTenantDataAccessOpMutation>;
+export type SetCurrentUserTenantDataAccessOpMutationOptions =
+  Apollo.BaseMutationOptions<
+    SetCurrentUserTenantDataAccessOpMutation,
+    SetCurrentUserTenantDataAccessOpMutationVariables
+  >;
 export const GetPatientDocument = gql`
   query GetPatient($internalId: ID!) {
     patient(id: $internalId) {
@@ -5763,7 +5791,8 @@ export function useAddPatientToQueueMutation(
 export type AddPatientToQueueMutationHookResult = ReturnType<
   typeof useAddPatientToQueueMutation
 >;
-export type AddPatientToQueueMutationResult = Apollo.MutationResult<AddPatientToQueueMutation>;
+export type AddPatientToQueueMutationResult =
+  Apollo.MutationResult<AddPatientToQueueMutation>;
 export type AddPatientToQueueMutationOptions = Apollo.BaseMutationOptions<
   AddPatientToQueueMutation,
   AddPatientToQueueMutationVariables
@@ -5876,7 +5905,8 @@ export function useRemovePatientFromQueueMutation(
 export type RemovePatientFromQueueMutationHookResult = ReturnType<
   typeof useRemovePatientFromQueueMutation
 >;
-export type RemovePatientFromQueueMutationResult = Apollo.MutationResult<RemovePatientFromQueueMutation>;
+export type RemovePatientFromQueueMutationResult =
+  Apollo.MutationResult<RemovePatientFromQueueMutation>;
 export type RemovePatientFromQueueMutationOptions = Apollo.BaseMutationOptions<
   RemovePatientFromQueueMutation,
   RemovePatientFromQueueMutationVariables
@@ -5951,7 +5981,8 @@ export function useEditQueueItemMutation(
 export type EditQueueItemMutationHookResult = ReturnType<
   typeof useEditQueueItemMutation
 >;
-export type EditQueueItemMutationResult = Apollo.MutationResult<EditQueueItemMutation>;
+export type EditQueueItemMutationResult =
+  Apollo.MutationResult<EditQueueItemMutation>;
 export type EditQueueItemMutationOptions = Apollo.BaseMutationOptions<
   EditQueueItemMutation,
   EditQueueItemMutationVariables
@@ -6019,7 +6050,8 @@ export function useSubmitQueueItemMutation(
 export type SubmitQueueItemMutationHookResult = ReturnType<
   typeof useSubmitQueueItemMutation
 >;
-export type SubmitQueueItemMutationResult = Apollo.MutationResult<SubmitQueueItemMutation>;
+export type SubmitQueueItemMutationResult =
+  Apollo.MutationResult<SubmitQueueItemMutation>;
 export type SubmitQueueItemMutationOptions = Apollo.BaseMutationOptions<
   SubmitQueueItemMutation,
   SubmitQueueItemMutationVariables
@@ -6262,7 +6294,8 @@ export function useMarkTestAsErrorMutation(
 export type MarkTestAsErrorMutationHookResult = ReturnType<
   typeof useMarkTestAsErrorMutation
 >;
-export type MarkTestAsErrorMutationResult = Apollo.MutationResult<MarkTestAsErrorMutation>;
+export type MarkTestAsErrorMutationResult =
+  Apollo.MutationResult<MarkTestAsErrorMutation>;
 export type MarkTestAsErrorMutationOptions = Apollo.BaseMutationOptions<
   MarkTestAsErrorMutation,
   MarkTestAsErrorMutationVariables
@@ -6312,7 +6345,8 @@ export function useMarkTestAsCorrectionMutation(
 export type MarkTestAsCorrectionMutationHookResult = ReturnType<
   typeof useMarkTestAsCorrectionMutation
 >;
-export type MarkTestAsCorrectionMutationResult = Apollo.MutationResult<MarkTestAsCorrectionMutation>;
+export type MarkTestAsCorrectionMutationResult =
+  Apollo.MutationResult<MarkTestAsCorrectionMutation>;
 export type MarkTestAsCorrectionMutationOptions = Apollo.BaseMutationOptions<
   MarkTestAsCorrectionMutation,
   MarkTestAsCorrectionMutationVariables
@@ -6621,7 +6655,8 @@ export function useResendTestResultsEmailMutation(
 export type ResendTestResultsEmailMutationHookResult = ReturnType<
   typeof useResendTestResultsEmailMutation
 >;
-export type ResendTestResultsEmailMutationResult = Apollo.MutationResult<ResendTestResultsEmailMutation>;
+export type ResendTestResultsEmailMutationResult =
+  Apollo.MutationResult<ResendTestResultsEmailMutation>;
 export type ResendTestResultsEmailMutationOptions = Apollo.BaseMutationOptions<
   ResendTestResultsEmailMutation,
   ResendTestResultsEmailMutationVariables
@@ -6882,13 +6917,13 @@ export function useGetFacilityResultsMultiplexWithCountLazyQuery(
 export type GetFacilityResultsMultiplexWithCountQueryHookResult = ReturnType<
   typeof useGetFacilityResultsMultiplexWithCountQuery
 >;
-export type GetFacilityResultsMultiplexWithCountLazyQueryHookResult = ReturnType<
-  typeof useGetFacilityResultsMultiplexWithCountLazyQuery
->;
-export type GetFacilityResultsMultiplexWithCountQueryResult = Apollo.QueryResult<
-  GetFacilityResultsMultiplexWithCountQuery,
-  GetFacilityResultsMultiplexWithCountQueryVariables
->;
+export type GetFacilityResultsMultiplexWithCountLazyQueryHookResult =
+  ReturnType<typeof useGetFacilityResultsMultiplexWithCountLazyQuery>;
+export type GetFacilityResultsMultiplexWithCountQueryResult =
+  Apollo.QueryResult<
+    GetFacilityResultsMultiplexWithCountQuery,
+    GetFacilityResultsMultiplexWithCountQueryVariables
+  >;
 export const GetAllFacilitiesDocument = gql`
   query GetAllFacilities($showArchived: Boolean) {
     facilities(showArchived: $showArchived) {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -115,7 +116,6 @@ export type Facility = {
   county?: Maybe<Scalars["String"]>;
   defaultDeviceSpecimen?: Maybe<Scalars["ID"]>;
   defaultDeviceType?: Maybe<DeviceType>;
-  defaultSpecimenType?: Maybe<SpecimenType>;
   /** @deprecated kept for compatibility */
   deviceSpecimenTypes?: Maybe<Array<Maybe<DeviceSpecimenType>>>;
   deviceTypes: Array<DeviceType>;

--- a/frontend/src/stories/testQueue/QueueItem.stories.tsx
+++ b/frontend/src/stories/testQueue/QueueItem.stories.tsx
@@ -256,18 +256,35 @@ CompletedIndicator.args = {
   },
 };
 
-export const FailOnSubmit = Template.bind({});
-FailOnSubmit.args = {
+export const InvalidDevice = Template.bind({});
+InvalidDevice.args = {
   ...defaultProps,
   queueItem: {
     ...queueItemInfo,
-    patient: {
-      ...queueItemInfo.patient,
-      internalId: "this-should-fail",
-    },
-    internalId: "completed-timer",
     noSymptoms: true,
     pregnancy: "no",
     results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
+    deviceType: {
+      internalId: "invalid",
+      name: "invalid",
+      model: "invalid",
+      testLength: 15,
+    },
+  },
+};
+
+export const InvalidSpecimen = Template.bind({});
+InvalidSpecimen.args = {
+  ...defaultProps,
+  queueItem: {
+    ...queueItemInfo,
+    noSymptoms: true,
+    pregnancy: "no",
+    results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
+    specimenType: {
+      internalId: "invalid",
+      name: "invalid",
+      typeCode: "invalid",
+    },
   },
 };

--- a/frontend/src/stories/testQueue/QueueItem.stories.tsx
+++ b/frontend/src/stories/testQueue/QueueItem.stories.tsx
@@ -1,10 +1,13 @@
 import { Meta, Story } from "@storybook/react";
-import { uniqueId } from "lodash";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import createMockStore from "redux-mock-store";
 
-import QueueItem, { QueueItemProps } from "../../app/testQueue/QueueItem";
+import QueueItem, {
+  DevicesMap,
+  QueueItemProps,
+} from "../../app/testQueue/QueueItem";
+import { PhoneType } from "../../generated/graphql";
 import { getMocks, StoryGraphQLProvider } from "../storyMocks";
 
 const mockStore = createMockStore([]);
@@ -46,121 +49,225 @@ const Template: Story<QueueItemProps> = (args) => {
   );
 };
 
-const device = {
-  name: "TestPro 4000",
-  internalId: "tp4000",
-  testLength: 0.1,
-  supportedDiseases: [{ internalId: "d1", name: "COVID-19", loinc: "12345" }],
+const facilityInfo = {
+  id: "f02cfff5-1921-4293-beff-e2a5d03e1fda",
+  name: "Testing Site",
+  deviceTypes: [
+    {
+      internalId: "ee4f40b7-ac32-4709-be0a-56dd77bb9609",
+      name: "LumiraDX",
+      testLength: 15,
+      supportedDiseases: [
+        {
+          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+          loinc: "96741-4",
+          name: "COVID-19",
+        },
+      ],
+      swabTypes: [
+        {
+          name: "Swab of internal nose",
+          internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+          typeCode: "445297001",
+        },
+        {
+          name: "Nasopharyngeal swab",
+          internalId: "f127ef55-4133-4556-9bca-33615d071e8d",
+          typeCode: "258500001",
+        },
+      ],
+    },
+    {
+      internalId: "5c711888-ba37-4b2e-b347-311ca364efdb",
+      name: "Abbott BinaxNow",
+      testLength: 15,
+      supportedDiseases: [
+        {
+          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+          loinc: "96741-4",
+          name: "COVID-19",
+        },
+      ],
+      swabTypes: [
+        {
+          name: "Swab of internal nose",
+          internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+          typeCode: "445297001",
+        },
+      ],
+    },
+    {
+      internalId: "32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10",
+      name: "BD Veritor",
+      testLength: 15,
+      supportedDiseases: [
+        {
+          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+          loinc: "96741-4",
+          name: "COVID-19",
+        },
+      ],
+      swabTypes: [
+        {
+          name: "Swab of internal nose",
+          internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+          typeCode: "445297001",
+        },
+        {
+          name: "Nasopharyngeal swab",
+          internalId: "f127ef55-4133-4556-9bca-33615d071e8d",
+          typeCode: "258500001",
+        },
+      ],
+    },
+    {
+      internalId: "67109f6f-eaee-49d3-b8ff-c61b79a9da8e",
+      name: "Multiplex",
+      testLength: 15,
+      supportedDiseases: [
+        {
+          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
+          loinc: "96741-4",
+          name: "COVID-19",
+        },
+        {
+          internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
+          loinc: "LP14239-5",
+          name: "Flu A",
+        },
+        {
+          internalId: "14924488-268f-47db-bea6-aa706971a098",
+          loinc: "LP14240-3",
+          name: "Flu B",
+        },
+      ],
+      swabTypes: [
+        {
+          name: "Swab of internal nose",
+          internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+          typeCode: "445297001",
+        },
+        {
+          name: "Nasopharyngeal swab",
+          internalId: "f127ef55-4133-4556-9bca-33615d071e8d",
+          typeCode: "258500001",
+        },
+      ],
+    },
+  ],
 };
 
-const defaultProps: QueueItemProps = {
-  internalId: "abc-123",
+const devicesMap: DevicesMap = new Map();
+facilityInfo.deviceTypes.map((d) => devicesMap.set(d.internalId, d));
+
+const queueItemInfo = {
+  internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
+  pregnancy: null,
+  dateAdded: "2022-11-08 13:33:07.503",
+  symptoms:
+    '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
+  symptomOnset: null,
+  noSymptoms: null,
+  deviceType: {
+    internalId: "ee4f40b7-ac32-4709-be0a-56dd77bb9609",
+    name: "LumiraDX",
+    model: "LumiraDx SARS-CoV-2 Ag Test*",
+    testLength: 15,
+    supportedDiseases: [],
+  },
+  specimenType: {
+    internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
+    name: "Swab of internal nose",
+    typeCode: "445297001",
+  },
   patient: {
-    internalId: "def-456",
+    internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
     firstName: "Jennifer",
     middleName: "K",
     lastName: "Finley",
     telephone: "571-867-5309",
     birthDate: "2002-07-21",
+    gender: "refused",
+    testResultDelivery: null,
+    preferredLanguage: null,
+    email: "sywaporoce@mailinator.com",
+    emails: ["sywaporoce@mailinator.com"],
     phoneNumbers: [
       {
-        number: "571-867-5309",
-        type: "MOBILE",
+        type: PhoneType.Mobile,
+        number: "(553) 223-0559",
+      },
+      {
+        type: PhoneType.Landline,
+        number: "(669) 789-0799",
       },
     ],
-    email: "jennifer@finley.com",
-    emails: ["jennifer@finley.com"],
-    testResultDelivery: "SMS",
-    gender: "male",
   },
-  devices: [device],
-  deviceSpecimenTypes: [
-    {
-      internalId: "fake-dst-id",
-      deviceType: device,
-      specimenType: {
-        internalId: "fake-swab-id",
-        name: "Fake Swab Type",
-      },
-    },
-  ],
-  selectedDeviceSpecimenTypeId: "fake-dst-id",
-  // askOnEntry prop is incorrectly typed as "string" in the component
-  askOnEntry: {
-    noSymptoms: undefined,
-    pregnancy: "no",
-    symptoms: "{}",
-  } as any,
-  selectedDeviceId: "tp4000",
-  selectedDeviceTestLength: 0.1,
-  selectedTestResults: [
-    { disease: { name: "COVID-19" }, testResult: "UNKNOWN" },
-  ],
-  dateTestedProp: "",
+  results: [],
+  dateTested: null,
+  correctionStatus: "ORIGINAL",
+  reasonForCorrection: null,
+};
+const defaultProps: QueueItemProps = {
+  queueItem: queueItemInfo,
+  facility: facilityInfo,
+  devicesMap: devicesMap,
   refetchQueue: () => {},
-  facilityName: "Facility Name",
-  facilityId: "100",
-  setStartTestPatientId: () => {},
-  startTestPatientId: "",
+  startTestPatientId: null,
+  setStartTestPatientId: null,
 };
 
 export const Unstarted = Template.bind({});
 Unstarted.args = {
   ...defaultProps,
-  internalId: uniqueId(),
 };
 
 export const FilledOut = Template.bind({});
 FilledOut.args = {
   ...defaultProps,
-  internalId: uniqueId(),
-  askOnEntry: {
+  queueItem: {
+    ...queueItemInfo,
     noSymptoms: true,
     pregnancy: "no",
-    symptoms: "{}",
-  } as any,
-  dateTestedProp: "2021-03-03T14:40:00Z",
+    dateTested: "2021-03-03T14:40:00Z",
+  },
 };
 
 export const ReadyIndicator = Template.bind({});
 ReadyIndicator.args = {
   ...defaultProps,
-  internalId: "completed-timer",
-  askOnEntry: {
+  queueItem: {
+    ...queueItemInfo,
+    internalId: "completed-timer",
     noSymptoms: true,
     pregnancy: "no",
-    symptoms: "{}",
-  } as any,
+  },
 };
 
 export const CompletedIndicator = Template.bind({});
 CompletedIndicator.args = {
   ...defaultProps,
-  internalId: "completed-timer",
-  askOnEntry: {
+  queueItem: {
+    ...queueItemInfo,
+    internalId: "completed-timer",
     noSymptoms: true,
     pregnancy: "no",
-    symptoms: "{}",
-  } as any,
-  selectedTestResults: [
-    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-  ],
+    results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
+  },
 };
 
 export const FailOnSubmit = Template.bind({});
 FailOnSubmit.args = {
   ...defaultProps,
-  internalId: "completed_timer",
-  askOnEntry: {
+  queueItem: {
+    ...queueItemInfo,
+    patient: {
+      ...queueItemInfo.patient,
+      internalId: "this-should-fail",
+    },
+    internalId: "completed-timer",
     noSymptoms: true,
     pregnancy: "no",
-    symptoms: "{}",
-  } as any,
-  selectedTestResults: [
-    { disease: { name: "COVID-19" }, testResult: "NEGATIVE" },
-  ],
-  patient: {
-    ...defaultProps.patient,
-    internalId: "this-should-fail",
+    results: [{ disease: { name: "COVID-19" }, testResult: "NEGATIVE" }],
   },
 };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- part of #3352
- this removes ui dependence on DeviceSpecimenType

## Changes Proposed

- Optimize the queries for loading deviceTypes and simplify code drastically
- Query devices for the active facility only (huge performance boost, especially in orgs with a lot of facilities)
- Fix bug related to swab not updating on the card when its updated by someone else
- Fix bug where use current date is not updated on the card when its updated by someone else
- Handle the case when a device is deleted from the facility but its still on the card
- Handle the case when a specimen type is removed from the device but it was on the card

## Additional Information

- there will be followup work to remove DeviceSpecimenTypes from the backend

before
```graphql
query GetFacilityQueueMultiplex($facilityId: ID!) {
    queue(facilityId: $facilityId) {
      internalId
      pregnancy
      dateAdded
      symptoms
      symptomOnset
      noSymptoms
      deviceType {
        internalId
        name
        model
        testLength
      }
      deviceSpecimenType {
        internalId
      }
      patient {
        internalId
        telephone
        birthDate
        firstName
        middleName
        lastName
        gender
        testResultDelivery
        preferredLanguage
        email
        emails
        phoneNumbers {
          type
          number
        }
      }
      results {
        disease {
          name
        }
        testResult
      }
      dateTested
      correctionStatus
      reasonForCorrection
    }
    organization {
      testingFacility {
        id
        deviceTypes {
          internalId
          name
          model
          testLength
        }
        defaultDeviceSpecimen
      }
    }
    deviceSpecimenTypes {
      internalId
      deviceType {
        internalId
        name
        testLength
        supportedDiseases {
          name
        }
      }
      specimenType {
        internalId
        name
      }
    }
  }
```
after
```graphql
query GetFacilityQueue($facilityId: ID!) {
  queue(facilityId: $facilityId) {
    internalId
    pregnancy
    dateAdded
    symptoms
    symptomOnset
    noSymptoms
    deviceType {
      internalId
      name
      model
      testLength
    }
    specimenType {
      internalId
      name
      typeCode
    }
    patient {
      internalId
      telephone
      birthDate
      firstName
      middleName
      lastName
      gender
      testResultDelivery
      preferredLanguage
      email
      emails
      phoneNumbers {
        type
        number
      }
    }
    results {
      disease {
        name
      }
      testResult
    }
    dateTested
    correctionStatus
    reasonForCorrection
  }
  facility(id: $facilityId) {
    name
    id
    deviceTypes {
      internalId
      name
      testLength
      supportedDiseases {
        internalId
        name
        loinc
      }
      swabTypes {
        internalId
        name
        typeCode
      }
    }
  }
}
```

## Testing

- How should reviewers verify this PR?
- This PR mainly affects the test queue functionality, starting/submitting a test will cover its UI interactions

## Screenshots / Demos

![Screenshot from 2022-11-30 12-23-31](https://user-images.githubusercontent.com/4952042/204878426-c361f422-ccaf-4800-a425-736e34d2654b.png)

![Screenshot from 2022-11-30 12-24-03](https://user-images.githubusercontent.com/4952042/204878401-a6305ff1-3502-4bd4-8ec9-dc21d901b8db.png)


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
