### PR TITLE
Address n+1 in deviceType swabtypes/supportedDiseases

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
@@ -58,7 +58,6 @@ public class DeviceTypeDataLoaderService {
 
     return found;
   }
-  ;
 
   Map<UUID, List<SpecimenType>> getSpecimenTypes(Set<UUID> deviceTypeIds) {
     // get all deviceType and specimenType to deviceType mapping from db

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
@@ -1,0 +1,102 @@
+package gov.cdc.usds.simplereport.api.devicetype;
+
+import static java.util.Collections.emptyList;
+
+import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
+import gov.cdc.usds.simplereport.db.model.SupportedDisease;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSupportedDiseaseRepository;
+import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
+import gov.cdc.usds.simplereport.service.DiseaseService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class DeviceTypeDataLoaderService {
+
+  final DeviceSupportedDiseaseRepository deviceSupportedDiseaseRepository;
+  final DiseaseService diseaseService;
+  final DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
+  final SpecimenTypeRepository specimenTypeRepository;
+
+  Map<UUID, List<SupportedDisease>> getSupportedDiseases(Set<UUID> deviceTypeIds) {
+    // load cached supportedDisease
+    Map<UUID, SupportedDisease> supportedDiseasesMap =
+        diseaseService.getCachedSupportedDiseasesMap();
+
+    // load deviceType -> [supportedDisease]
+    List<DeviceSupportedDisease> allByDeviceTypeIdIn =
+        deviceSupportedDiseaseRepository.findAllByDeviceTypeIdIn(deviceTypeIds);
+    Map<UUID, List<DeviceSupportedDisease>> deviceTypeIdSupportedDiseaseIdsMapping =
+        allByDeviceTypeIdIn.stream()
+            .collect(Collectors.groupingBy(DeviceSupportedDisease::getDeviceTypeId));
+
+    Map<UUID, List<SupportedDisease>> found = new HashMap<>();
+
+    // this makes sure we return an empty array if no supported diseases exist
+    deviceTypeIds.forEach(deviceTypeId -> found.put(deviceTypeId, emptyList()));
+
+    deviceTypeIdSupportedDiseaseIdsMapping.forEach(
+        (deviceTypeId, deviceSupportedDiseaseIds) -> {
+          List<SupportedDisease> deviceSupportedDiseases =
+              deviceSupportedDiseaseIds.stream()
+                  .map(
+                      deviceSupportedDisease ->
+                          supportedDiseasesMap.get(deviceSupportedDisease.getSupportedDiseaseId()))
+                  .collect(Collectors.toList());
+          found.put(deviceTypeId, deviceSupportedDiseases);
+        });
+
+    return found;
+  }
+  ;
+
+  Map<UUID, List<SpecimenType>> getSpecimenTypes(Set<UUID> deviceTypeIds) {
+    // get all deviceType and specimenType to deviceType mapping from db
+    List<DeviceTypeSpecimenTypeMapping> deviceTypeSpecimenTypeList =
+        deviceSpecimenTypeNewRepository.findAllByDeviceTypeIdIn(deviceTypeIds);
+
+    // load all needed specimen types ids
+    List<UUID> specimenTypeIds =
+        deviceTypeSpecimenTypeList.stream()
+            .map(DeviceTypeSpecimenTypeMapping::getSpecimenTypeId)
+            .distinct()
+            .collect(Collectors.toList());
+
+    // load needed specimen types from db
+    Map<UUID, SpecimenType> specimenTypeMap =
+        specimenTypeRepository.findAllByInternalIdIn(specimenTypeIds).stream()
+            .collect(Collectors.toMap(SpecimenType::getInternalId, specimenType -> specimenType));
+
+    // calc map of deviceType to specimenTypes
+    Map<UUID, List<DeviceTypeSpecimenTypeMapping>> deviceTypeIdSpecimenTypeIdsMapping =
+        deviceTypeSpecimenTypeList.stream()
+            .collect(Collectors.groupingBy(DeviceTypeSpecimenTypeMapping::getDeviceTypeId));
+
+    Map<UUID, List<SpecimenType>> found = new HashMap<>();
+    // this makes sure we return an empty array if no supported diseases exist
+    deviceTypeIds.forEach(deviceTypeId -> found.put(deviceTypeId, emptyList()));
+
+    deviceTypeIdSpecimenTypeIdsMapping.forEach(
+        (deviceTypeId, deviceTypeSpecimenTypeMappingList) -> {
+          List<SpecimenType> specimenTypes =
+              deviceTypeSpecimenTypeMappingList.stream()
+                  .map(
+                      deviceTypeSpecimenTypeMapping ->
+                          specimenTypeMap.get(deviceTypeSpecimenTypeMapping.getSpecimenTypeId()))
+                  .collect(Collectors.toList());
+          found.put(deviceTypeId, specimenTypes);
+        });
+
+    return found;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
@@ -31,7 +31,7 @@ public class DeviceTypeDataLoaderService {
   Map<UUID, List<SupportedDisease>> getSupportedDiseases(Set<UUID> deviceTypeIds) {
     // load cached supportedDisease
     Map<UUID, SupportedDisease> supportedDiseasesMap =
-        diseaseService.getCachedSupportedDiseasesMap();
+        diseaseService.getKnownSupportedDiseasesMap();
 
     // load deviceType -> [supportedDisease]
     List<DeviceSupportedDisease> allByDeviceTypeIdIn =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
@@ -42,7 +42,7 @@ public class DeviceTypeDataResolver {
 
               // load cached supportedDisease
               Map<UUID, SupportedDisease> supportedDiseasesMap =
-                  diseaseService.getSupportedDiseasesMap();
+                  diseaseService.getCachedSupportedDiseasesMap();
 
               // load deviceType -> [supportedDisease]
               List<DeviceSupportedDisease> allByDeviceTypeIdIn =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
@@ -1,0 +1,137 @@
+package gov.cdc.usds.simplereport.api.devicetype;
+
+import static java.util.Collections.emptyList;
+
+import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
+import gov.cdc.usds.simplereport.db.model.SupportedDisease;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSupportedDiseaseRepository;
+import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
+import gov.cdc.usds.simplereport.service.DiseaseService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.dataloader.DataLoader;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.graphql.execution.BatchLoaderRegistry;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Mono;
+
+@Controller
+public class DeviceTypeDataResolver {
+
+  public DeviceTypeDataResolver(
+      BatchLoaderRegistry registry,
+      DeviceSupportedDiseaseRepository deviceSupportedDiseaseRepository,
+      DiseaseService diseaseService,
+      DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository,
+      SpecimenTypeRepository specimenTypeRepository) {
+
+    Class<List<SupportedDisease>> supportedDiseasesListClazz = (Class) List.class;
+    registry
+        .forTypePair(UUID.class, supportedDiseasesListClazz)
+        .withName("deviceTypeSupportedDiseasesLoader")
+        .registerMappedBatchLoader(
+            (deviceTypeIds, batchLoaderEnvironment) -> {
+
+              // load cached supportedDisease
+              Map<UUID, SupportedDisease> supportedDiseasesMap =
+                  diseaseService.getSupportedDiseasesMap();
+
+              // load deviceType -> [supportedDisease]
+              List<DeviceSupportedDisease> allByDeviceTypeIdIn =
+                  deviceSupportedDiseaseRepository.findAllByDeviceTypeIdIn(deviceTypeIds);
+              Map<UUID, List<DeviceSupportedDisease>> deviceTypeIdSupportedDiseaseIdsMapping =
+                  allByDeviceTypeIdIn.stream()
+                      .collect(Collectors.groupingBy(DeviceSupportedDisease::getDeviceTypeId));
+
+              Map<UUID, List<SupportedDisease>> found = new HashMap<>();
+
+              // this makes sure we return an empty array if no supported diseases exist
+              deviceTypeIds.forEach(deviceTypeId -> found.put(deviceTypeId, emptyList()));
+
+              deviceTypeIdSupportedDiseaseIdsMapping.forEach(
+                  (deviceTypeId, deviceSupportedDiseaseIds) -> {
+                    List<SupportedDisease> deviceSupportedDiseases =
+                        deviceSupportedDiseaseIds.stream()
+                            .map(
+                                deviceSupportedDisease ->
+                                    supportedDiseasesMap.get(
+                                        deviceSupportedDisease.getSupportedDiseaseId()))
+                            .collect(Collectors.toList());
+                    found.put(deviceTypeId, deviceSupportedDiseases);
+                  });
+
+              return Mono.just(found);
+            });
+
+    Class<List<SpecimenType>> specimenTypesListClazz = (Class) List.class;
+    registry
+        .forTypePair(UUID.class, specimenTypesListClazz)
+        .withName("deviceTypeSpecimenTypesLoader")
+        .registerMappedBatchLoader(
+            (deviceTypeIds, batchLoaderEnvironment) -> {
+
+              // get all deviceType and specimenType to deviceType mapping from db
+              List<DeviceTypeSpecimenTypeMapping> deviceTypeSpecimenTypeList =
+                  deviceSpecimenTypeNewRepository.findAllByDeviceTypeIdIn(deviceTypeIds);
+
+              // load all needed specimen types ids
+              List<UUID> specimenTypeIds =
+                  deviceTypeSpecimenTypeList.stream()
+                      .map(DeviceTypeSpecimenTypeMapping::getSpecimenTypeId)
+                      .distinct()
+                      .collect(Collectors.toList());
+
+              // load needed specimen types from db
+              Map<UUID, SpecimenType> specimenTypeMap =
+                  specimenTypeRepository.findAllByInternalIdIn(specimenTypeIds).stream()
+                      .collect(
+                          Collectors.toMap(
+                              SpecimenType::getInternalId, specimenType -> specimenType));
+
+              // calc map of deviceType to specimenTypes
+              Map<UUID, List<DeviceTypeSpecimenTypeMapping>> deviceTypeIdSpecimenTypeIdsMapping =
+                  deviceTypeSpecimenTypeList.stream()
+                      .collect(
+                          Collectors.groupingBy(DeviceTypeSpecimenTypeMapping::getDeviceTypeId));
+
+              Map<UUID, List<SpecimenType>> found = new HashMap<>();
+              // this makes sure we return an empty array if no supported diseases exist
+              deviceTypeIds.forEach(deviceTypeId -> found.put(deviceTypeId, emptyList()));
+
+              deviceTypeIdSpecimenTypeIdsMapping.forEach(
+                  (deviceTypeId, deviceTypeSpecimenTypeMappingList) -> {
+                    List<SpecimenType> specimenTypes =
+                        deviceTypeSpecimenTypeMappingList.stream()
+                            .map(
+                                deviceTypeSpecimenTypeMapping ->
+                                    specimenTypeMap.get(
+                                        deviceTypeSpecimenTypeMapping.getSpecimenTypeId()))
+                            .collect(Collectors.toList());
+                    found.put(deviceTypeId, specimenTypes);
+                  });
+
+              return Mono.just(found);
+            });
+  }
+
+  @SchemaMapping(typeName = "DeviceType", field = "supportedDiseases")
+  public CompletableFuture<List<SupportedDisease>> supportedDiseases(
+      DeviceType deviceType,
+      DataLoader<UUID, List<SupportedDisease>> deviceTypeSupportedDiseasesLoader) {
+    return deviceTypeSupportedDiseasesLoader.load(deviceType.getInternalId());
+  }
+
+  @SchemaMapping(typeName = "DeviceType", field = "swabTypes")
+  public CompletableFuture<List<SpecimenType>> swabTypes(
+      DeviceType deviceType, DataLoader<UUID, List<SpecimenType>> deviceTypeSpecimenTypesLoader) {
+    return deviceTypeSpecimenTypesLoader.load(deviceType.getInternalId());
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
@@ -1,22 +1,11 @@
 package gov.cdc.usds.simplereport.api.devicetype;
 
-import static java.util.Collections.emptyList;
-
-import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
-import gov.cdc.usds.simplereport.db.repository.DeviceSupportedDiseaseRepository;
-import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
-import gov.cdc.usds.simplereport.service.DiseaseService;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import org.dataloader.DataLoader;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.graphql.execution.BatchLoaderRegistry;
@@ -27,99 +16,23 @@ import reactor.core.publisher.Mono;
 public class DeviceTypeDataResolver {
 
   public DeviceTypeDataResolver(
-      BatchLoaderRegistry registry,
-      DeviceSupportedDiseaseRepository deviceSupportedDiseaseRepository,
-      DiseaseService diseaseService,
-      DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository,
-      SpecimenTypeRepository specimenTypeRepository) {
+      BatchLoaderRegistry registry, DeviceTypeDataLoaderService deviceTypeDataLoaderService) {
 
     Class<List<SupportedDisease>> supportedDiseasesListClazz = (Class) List.class;
     registry
         .forTypePair(UUID.class, supportedDiseasesListClazz)
         .withName("deviceTypeSupportedDiseasesLoader")
         .registerMappedBatchLoader(
-            (deviceTypeIds, batchLoaderEnvironment) -> {
-
-              // load cached supportedDisease
-              Map<UUID, SupportedDisease> supportedDiseasesMap =
-                  diseaseService.getCachedSupportedDiseasesMap();
-
-              // load deviceType -> [supportedDisease]
-              List<DeviceSupportedDisease> allByDeviceTypeIdIn =
-                  deviceSupportedDiseaseRepository.findAllByDeviceTypeIdIn(deviceTypeIds);
-              Map<UUID, List<DeviceSupportedDisease>> deviceTypeIdSupportedDiseaseIdsMapping =
-                  allByDeviceTypeIdIn.stream()
-                      .collect(Collectors.groupingBy(DeviceSupportedDisease::getDeviceTypeId));
-
-              Map<UUID, List<SupportedDisease>> found = new HashMap<>();
-
-              // this makes sure we return an empty array if no supported diseases exist
-              deviceTypeIds.forEach(deviceTypeId -> found.put(deviceTypeId, emptyList()));
-
-              deviceTypeIdSupportedDiseaseIdsMapping.forEach(
-                  (deviceTypeId, deviceSupportedDiseaseIds) -> {
-                    List<SupportedDisease> deviceSupportedDiseases =
-                        deviceSupportedDiseaseIds.stream()
-                            .map(
-                                deviceSupportedDisease ->
-                                    supportedDiseasesMap.get(
-                                        deviceSupportedDisease.getSupportedDiseaseId()))
-                            .collect(Collectors.toList());
-                    found.put(deviceTypeId, deviceSupportedDiseases);
-                  });
-
-              return Mono.just(found);
-            });
+            (deviceTypeIds, batchLoaderEnvironment) ->
+                Mono.just(deviceTypeDataLoaderService.getSupportedDiseases(deviceTypeIds)));
 
     Class<List<SpecimenType>> specimenTypesListClazz = (Class) List.class;
     registry
         .forTypePair(UUID.class, specimenTypesListClazz)
         .withName("deviceTypeSpecimenTypesLoader")
         .registerMappedBatchLoader(
-            (deviceTypeIds, batchLoaderEnvironment) -> {
-
-              // get all deviceType and specimenType to deviceType mapping from db
-              List<DeviceTypeSpecimenTypeMapping> deviceTypeSpecimenTypeList =
-                  deviceSpecimenTypeNewRepository.findAllByDeviceTypeIdIn(deviceTypeIds);
-
-              // load all needed specimen types ids
-              List<UUID> specimenTypeIds =
-                  deviceTypeSpecimenTypeList.stream()
-                      .map(DeviceTypeSpecimenTypeMapping::getSpecimenTypeId)
-                      .distinct()
-                      .collect(Collectors.toList());
-
-              // load needed specimen types from db
-              Map<UUID, SpecimenType> specimenTypeMap =
-                  specimenTypeRepository.findAllByInternalIdIn(specimenTypeIds).stream()
-                      .collect(
-                          Collectors.toMap(
-                              SpecimenType::getInternalId, specimenType -> specimenType));
-
-              // calc map of deviceType to specimenTypes
-              Map<UUID, List<DeviceTypeSpecimenTypeMapping>> deviceTypeIdSpecimenTypeIdsMapping =
-                  deviceTypeSpecimenTypeList.stream()
-                      .collect(
-                          Collectors.groupingBy(DeviceTypeSpecimenTypeMapping::getDeviceTypeId));
-
-              Map<UUID, List<SpecimenType>> found = new HashMap<>();
-              // this makes sure we return an empty array if no supported diseases exist
-              deviceTypeIds.forEach(deviceTypeId -> found.put(deviceTypeId, emptyList()));
-
-              deviceTypeIdSpecimenTypeIdsMapping.forEach(
-                  (deviceTypeId, deviceTypeSpecimenTypeMappingList) -> {
-                    List<SpecimenType> specimenTypes =
-                        deviceTypeSpecimenTypeMappingList.stream()
-                            .map(
-                                deviceTypeSpecimenTypeMapping ->
-                                    specimenTypeMap.get(
-                                        deviceTypeSpecimenTypeMapping.getSpecimenTypeId()))
-                            .collect(Collectors.toList());
-                    found.put(deviceTypeId, specimenTypes);
-                  });
-
-              return Mono.just(found);
-            });
+            (deviceTypeIds, batchLoaderEnvironment) ->
+                Mono.just(deviceTypeDataLoaderService.getSpecimenTypes(deviceTypeIds)));
   }
 
   @SchemaMapping(typeName = "DeviceType", field = "supportedDiseases")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimenTypeNewId.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSpecimenTypeNewId.java
@@ -1,0 +1,15 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class DeviceSpecimenTypeNewId implements Serializable {
+  private UUID deviceTypeId;
+  private UUID specimenTypeId;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSupportedDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSupportedDisease.java
@@ -1,0 +1,26 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@IdClass(DeviceSupportedDiseaseId.class)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceSupportedDisease {
+
+  @Id
+  @Column(name = "device_type_id", nullable = false)
+  private UUID deviceTypeId;
+
+  @Id
+  @Column(name = "supported_disease_id", nullable = false)
+  private UUID supportedDiseaseId;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSupportedDiseaseId.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceSupportedDiseaseId.java
@@ -1,0 +1,15 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class DeviceSupportedDiseaseId implements Serializable {
+  private UUID deviceTypeId;
+  private UUID supportedDiseaseId;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeSpecimenTypeMapping.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeSpecimenTypeMapping.java
@@ -1,0 +1,28 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "device_specimen_type")
+@IdClass(DeviceSpecimenTypeNewId.class)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceTypeSpecimenTypeMapping {
+
+  @Id
+  @Column(name = "device_type_id", nullable = false)
+  private UUID deviceTypeId;
+
+  @Id
+  @Column(name = "specimen_type_id", nullable = false)
+  private UUID specimenTypeId;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeNewRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeNewRepository.java
@@ -1,0 +1,12 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DeviceSpecimenTypeNewRepository
+    extends CrudRepository<DeviceTypeSpecimenTypeMapping, UUID> {
+
+  List<DeviceTypeSpecimenTypeMapping> findAllByDeviceTypeIdIn(Iterable<UUID> uuids);
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSupportedDiseaseRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSupportedDiseaseRepository.java
@@ -1,0 +1,12 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DeviceSupportedDiseaseRepository
+    extends CrudRepository<DeviceSupportedDisease, UUID> {
+
+  List<DeviceSupportedDisease> findAllByDeviceTypeIdIn(Iterable<UUID> uuids);
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
@@ -11,6 +11,8 @@ public interface SpecimenTypeRepository extends EternalAuditedEntityRepository<S
 
   SpecimenType findByInternalId(UUID internalID);
 
+  List<SpecimenType> findAllByInternalIdIn(List<UUID> uuids);
+
   @Deprecated // this doesn't check for soft-deletion! But we need that behavior for the
   // backward-compatibility shim code.
   Optional<SpecimenType> findByTypeCode(String swabType);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SupportedDiseaseRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SupportedDiseaseRepository.java
@@ -10,4 +10,7 @@ public interface SupportedDiseaseRepository extends CrudRepository<SupportedDise
   List<SupportedDisease> findAllByName(String name);
 
   Optional<SupportedDisease> findByName(String name);
+
+  @Override
+  List<SupportedDisease> findAll();
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -5,6 +5,7 @@ import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import javax.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
@@ -32,15 +33,9 @@ public class DiseaseService {
     fluA = _supportedDiseaseRepo.findByName("Flu A").orElse(null);
     fluB = _supportedDiseaseRepo.findByName("Flu B").orElse(null);
 
-    if (covid != null) {
-      supportedDiseaseMap.put(covid.getInternalId(), covid);
-    }
-    if (fluA != null) {
-      supportedDiseaseMap.put(fluA.getInternalId(), fluA);
-    }
-    if (fluB != null) {
-      supportedDiseaseMap.put(fluB.getInternalId(), fluB);
-    }
+    Optional.ofNullable(covid).ifPresent(sd -> supportedDiseaseMap.put(sd.getInternalId(), sd));
+    Optional.ofNullable(fluA).ifPresent(sd -> supportedDiseaseMap.put(sd.getInternalId(), sd));
+    Optional.ofNullable(fluB).ifPresent(sd -> supportedDiseaseMap.put(sd.getInternalId(), sd));
   }
 
   public List<SupportedDisease> fetchSupportedDiseases() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -2,7 +2,10 @@ package gov.cdc.usds.simplereport.service;
 
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import javax.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,14 +25,24 @@ public class DiseaseService {
   private SupportedDisease fluA;
   private SupportedDisease fluB;
 
+  private final Map<UUID, SupportedDisease> supportedDiseaseMap = new HashMap<>();
+
   public void initDiseases() {
     covid = _supportedDiseaseRepo.findByName("COVID-19").orElse(null);
     fluA = _supportedDiseaseRepo.findByName("Flu A").orElse(null);
     fluB = _supportedDiseaseRepo.findByName("Flu B").orElse(null);
+
+    supportedDiseaseMap.put(covid.getInternalId(), covid);
+    supportedDiseaseMap.put(fluA.getInternalId(), fluA);
+    supportedDiseaseMap.put(fluB.getInternalId(), fluB);
   }
 
   public List<SupportedDisease> fetchSupportedDiseases() {
     return (List<SupportedDisease>) _supportedDiseaseRepo.findAll();
+  }
+
+  public Map<UUID, SupportedDisease> getSupportedDiseasesMap() {
+    return supportedDiseaseMap;
   }
 
   public SupportedDisease getDiseaseByName(String name) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -42,7 +42,7 @@ public class DiseaseService {
     return _supportedDiseaseRepo.findAll();
   }
 
-  public Map<UUID, SupportedDisease> getCachedSupportedDiseasesMap() {
+  public Map<UUID, SupportedDisease> getKnownSupportedDiseasesMap() {
     return supportedDiseaseMap;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -32,16 +32,22 @@ public class DiseaseService {
     fluA = _supportedDiseaseRepo.findByName("Flu A").orElse(null);
     fluB = _supportedDiseaseRepo.findByName("Flu B").orElse(null);
 
-    supportedDiseaseMap.put(covid.getInternalId(), covid);
-    supportedDiseaseMap.put(fluA.getInternalId(), fluA);
-    supportedDiseaseMap.put(fluB.getInternalId(), fluB);
+    if (covid != null) {
+      supportedDiseaseMap.put(covid.getInternalId(), covid);
+    }
+    if (fluA != null) {
+      supportedDiseaseMap.put(fluA.getInternalId(), fluA);
+    }
+    if (fluB != null) {
+      supportedDiseaseMap.put(fluB.getInternalId(), fluB);
+    }
   }
 
   public List<SupportedDisease> fetchSupportedDiseases() {
-    return (List<SupportedDisease>) _supportedDiseaseRepo.findAll();
+    return _supportedDiseaseRepo.findAll();
   }
 
-  public Map<UUID, SupportedDisease> getSupportedDiseasesMap() {
+  public Map<UUID, SupportedDisease> getCachedSupportedDiseasesMap() {
     return supportedDiseaseMap;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -1,0 +1,115 @@
+package gov.cdc.usds.simplereport.api.devicetype;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
+import gov.cdc.usds.simplereport.db.model.SupportedDisease;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSupportedDiseaseRepository;
+import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
+import gov.cdc.usds.simplereport.service.DiseaseService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class DeviceTypeDataLoaderHelperTest {
+
+  @Mock DeviceSupportedDiseaseRepository deviceSupportedDiseaseRepository;
+  @Mock DiseaseService diseaseService;
+  @Mock DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
+  @Mock SpecimenTypeRepository specimenTypeRepository;
+
+  @InjectMocks private DeviceTypeDataLoaderService deviceTypeDataLoaderService;
+
+  @Test
+  void getSupportedDiseases_happyPath() {
+    // GIVEN
+    UUID device1Id = UUID.randomUUID();
+    UUID device2Id = UUID.randomUUID();
+    UUID device3Id = UUID.randomUUID();
+    Set<UUID> deviceSet = Set.of(device1Id, device2Id, device3Id);
+    UUID supportedDisease1Id = UUID.randomUUID();
+    UUID supportedDisease2Id = UUID.randomUUID();
+
+    SupportedDisease supportedDisease2 = mock(SupportedDisease.class);
+    SupportedDisease supportedDisease1 = mock(SupportedDisease.class);
+
+    when(supportedDisease1.getInternalId()).thenReturn(supportedDisease1Id);
+    when(supportedDisease2.getInternalId()).thenReturn(supportedDisease2Id);
+
+    when(diseaseService.getCachedSupportedDiseasesMap())
+        .thenReturn(
+            Map.of(
+                supportedDisease1Id, supportedDisease1,
+                supportedDisease2Id, supportedDisease2));
+
+    when(deviceSupportedDiseaseRepository.findAllByDeviceTypeIdIn(deviceSet))
+        .thenReturn(
+            List.of(
+                new DeviceSupportedDisease(device1Id, supportedDisease1Id),
+                new DeviceSupportedDisease(device2Id, supportedDisease1Id),
+                new DeviceSupportedDisease(device2Id, supportedDisease2Id)));
+
+    // WHEN
+    Map<UUID, List<SupportedDisease>> supportedDiseases =
+        deviceTypeDataLoaderService.getSupportedDiseases(deviceSet);
+
+    // THEN
+    assertThat(supportedDiseases)
+        .hasSize(3)
+        .containsEntry(device1Id, List.of(supportedDisease1))
+        .containsEntry(device2Id, List.of(supportedDisease1, supportedDisease2))
+        .containsEntry(device3Id, emptyList());
+  }
+
+  @Test
+  void getSpecimenTypes_happyPath() {
+    // GIVEN
+    UUID device1Id = UUID.randomUUID();
+    UUID device2Id = UUID.randomUUID();
+    UUID device3Id = UUID.randomUUID();
+    Set<UUID> deviceSet = Set.of(device1Id, device2Id, device3Id);
+
+    UUID specimenType1Id = UUID.randomUUID();
+    UUID specimenType2Id = UUID.randomUUID();
+    List<UUID> specimenIdList = List.of(specimenType1Id, specimenType2Id);
+    SpecimenType specimenType1 = mock(SpecimenType.class);
+    SpecimenType specimenType2 = mock(SpecimenType.class);
+
+    when(specimenType1.getInternalId()).thenReturn(specimenType1Id);
+    when(specimenType2.getInternalId()).thenReturn(specimenType2Id);
+
+    when(deviceSpecimenTypeNewRepository.findAllByDeviceTypeIdIn(deviceSet))
+        .thenReturn(
+            List.of(
+                new DeviceTypeSpecimenTypeMapping(device1Id, specimenType1Id),
+                new DeviceTypeSpecimenTypeMapping(device2Id, specimenType1Id),
+                new DeviceTypeSpecimenTypeMapping(device2Id, specimenType2Id)));
+
+    when(specimenTypeRepository.findAllByInternalIdIn(specimenIdList))
+        .thenReturn(List.of(specimenType1, specimenType2));
+
+    // WHEN
+    Map<UUID, List<SpecimenType>> specimenTypes =
+        deviceTypeDataLoaderService.getSpecimenTypes(deviceSet);
+
+    // THEN
+    assertThat(specimenTypes)
+        .hasSize(3)
+        .containsEntry(device1Id, List.of(specimenType1))
+        .containsEntry(device2Id, List.of(specimenType1, specimenType2))
+        .containsEntry(device3Id, emptyList());
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -43,13 +43,13 @@ class DeviceTypeDataLoaderHelperTest {
     UUID supportedDisease1Id = UUID.randomUUID();
     UUID supportedDisease2Id = UUID.randomUUID();
 
-    SupportedDisease supportedDisease2 = mock(SupportedDisease.class);
     SupportedDisease supportedDisease1 = mock(SupportedDisease.class);
+    SupportedDisease supportedDisease2 = mock(SupportedDisease.class);
 
     when(supportedDisease1.getInternalId()).thenReturn(supportedDisease1Id);
     when(supportedDisease2.getInternalId()).thenReturn(supportedDisease2Id);
 
-    when(diseaseService.getCachedSupportedDiseasesMap())
+    when(diseaseService.getKnownSupportedDiseasesMap())
         .thenReturn(
             Map.of(
                 supportedDisease1Id, supportedDisease1,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
@@ -1,8 +1,12 @@
 package gov.cdc.usds.simplereport.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import gov.cdc.usds.simplereport.db.model.SupportedDisease;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
@@ -23,5 +27,20 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
   void retrievesFluB_successful() {
     assertNotNull(_service.fluB());
     assertEquals("Flu B", _service.fluB().getName());
+  }
+
+  @Test
+  void retrievesSupportedDiseasesMap_successful() {
+    Map<UUID, SupportedDisease> supportedDiseasesMap = _service.getCachedSupportedDiseasesMap();
+
+    assertNotNull(supportedDiseasesMap);
+    assertThat(supportedDiseasesMap).hasSize(3);
+
+    assertThat(supportedDiseasesMap.get(_service.covid().getInternalId()))
+        .isEqualTo(_service.covid());
+    assertThat(supportedDiseasesMap.get(_service.fluA().getInternalId()))
+        .isEqualTo(_service.fluA());
+    assertThat(supportedDiseasesMap.get(_service.fluB().getInternalId()))
+        .isEqualTo(_service.fluB());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
@@ -33,14 +33,11 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
   void retrievesSupportedDiseasesMap_successful() {
     Map<UUID, SupportedDisease> supportedDiseasesMap = _service.getCachedSupportedDiseasesMap();
 
-    assertNotNull(supportedDiseasesMap);
-    assertThat(supportedDiseasesMap).hasSize(3);
-
     assertThat(supportedDiseasesMap)
-        .containsEntry(_service.covid().getInternalId(), _service.covid());
-    assertThat(supportedDiseasesMap)
-        .containsEntry(_service.fluA().getInternalId(), _service.fluA());
-    assertThat(supportedDiseasesMap)
+        .isNotNull()
+        .hasSize(3)
+        .containsEntry(_service.covid().getInternalId(), _service.covid())
+        .containsEntry(_service.fluA().getInternalId(), _service.fluA())
         .containsEntry(_service.fluB().getInternalId(), _service.fluB());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
@@ -36,11 +36,11 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
     assertNotNull(supportedDiseasesMap);
     assertThat(supportedDiseasesMap).hasSize(3);
 
-    assertThat(supportedDiseasesMap.get(_service.covid().getInternalId()))
-        .isEqualTo(_service.covid());
-    assertThat(supportedDiseasesMap.get(_service.fluA().getInternalId()))
-        .isEqualTo(_service.fluA());
-    assertThat(supportedDiseasesMap.get(_service.fluB().getInternalId()))
-        .isEqualTo(_service.fluB());
+    assertThat(supportedDiseasesMap)
+        .containsEntry(_service.covid().getInternalId(), _service.covid());
+    assertThat(supportedDiseasesMap)
+        .containsEntry(_service.fluA().getInternalId(), _service.fluA());
+    assertThat(supportedDiseasesMap)
+        .containsEntry(_service.fluB().getInternalId(), _service.fluB());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
@@ -31,7 +31,7 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
 
   @Test
   void retrievesSupportedDiseasesMap_successful() {
-    Map<UUID, SupportedDisease> supportedDiseasesMap = _service.getCachedSupportedDiseasesMap();
+    Map<UUID, SupportedDisease> supportedDiseasesMap = _service.getKnownSupportedDiseasesMap();
 
     assertThat(supportedDiseasesMap)
         .isNotNull()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./backend/db-setup/.pgpass/:/usr/local/lib/.pgpass
       - ./backend/db-setup/snapshots/:/usr/local/lib/snapshots/
       - ./backend/db-setup/generate_db_data.py:/usr/local/lib/generate_db_data.py
-    command: -p ${SR_DB_PORT:-5432}
+    command: -p ${SR_DB_PORT:-5432} -c log_statement=all
     expose:
       - "${SR_DB_PORT:-5432}"
     ports:


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352 
- this is needed to make sure the changes proposed in https://github.com/CDCgov/prime-simplereport/pull/4728 will not cause any n+1 queries
- this adds data loader to `DeviceType.swabTypes` and `DeviceType.supportedDiseases`
- Test coverage will remain low due to composite ID pojos

#### How does `DeviceType.swabTypes` dataloader work: (2 queries total to db)

- load DeviceTypeSpecimenTypeMapping (joint table DeviceType <> SpecimenType) for the deviceTypes
- load all relevant SpecimenTypes from the joint table
- then map the loaded SpecimenTypes to the devices using the joint table

#### How does `DeviceType.supportedDiseases` dataloader work: (1 query total to db)

- load cached SupportedDiseases
- load all relevant DeviceSupportedDisease (joint table DeviceType <> SupportedDisease) for the deviceTypes
- then map the cached supportedDiseases to the devices using the joint table


## Testing

- You can run the following query and notice how there are less queries made when loading deviceTypes
```graphql
query getDeviceTypeList {
  deviceType {
    internalId
    name
    loincCode
    manufacturer
    model
    testLength
    swabTypes {
      internalId
      name
      typeCode
      collectionLocationName
      collectionLocationCode
    }
    supportedDiseases {
      internalId
      name
    }
  }
}
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---