### PR TITLE
Fixed a11y errors in spec 01

### DIFF
--- a/cypress/integration/01-organization_sign_up_spec.js
+++ b/cypress/integration/01-organization_sign_up_spec.js
@@ -53,34 +53,13 @@ describe("Organization sign up", () => {
     cy.contains("Support admin");
 
     cy.injectAxe();
-    // failing a11y test - admin
-    cy.checkA11y(
-        {
-          exclude: [],
-        },
-        {
-          rules: {
-            'page-has-heading-one': { enabled: false },
-          },
-        },
-    );
+    cy.checkA11y();
 
     cy.contains("Organizations pending identify verification").click();
     cy.get("[data-cy=pending-orgs-title]").should("be.visible");
 
     cy.contains("td", `${organization.name}`);
-    // failing a11y test - admin
-    cy.checkA11y(
-        {
-          exclude: [],
-        },
-        {
-          rules: {
-            'button-name': { enabled: false },
-            'page-has-heading-one': { enabled: false },
-          },
-        },
-    );
+    cy.checkA11y();
 
     cy.contains("td", `${organization.name}`)
       .siblings()
@@ -103,20 +82,7 @@ describe("Organization sign up", () => {
     cy.get('input[name="justification"]').type("I am a test user").blur();
 
     cy.injectAxe();
-    // failing a11y test - admin
-    cy.checkA11y(
-        {
-          exclude: [],
-        },
-        {
-          rules: {
-            'label-title-only': { enabled: false },
-            'label': { enabled: false },
-            'page-has-heading-one': { enabled: false },
-
-          },
-        },
-    );
+    cy.checkA11y();
 
     cy.contains("Access data").click();
     cy.contains("Support admin");
@@ -128,35 +94,15 @@ describe("Organization sign up", () => {
     cy.contains("Manage facilities").click();
     cy.contains("CLIA number");
 
-    // failing a11y test
     // Test a11y on Manage Facilities tab
     cy.injectAxe();
-    cy.checkA11y(
-        {
-          exclude: [],
-        },
-        {
-          rules: {
-            'page-has-heading-one': { enabled: false },
-          },
-        },
-    );
+    cy.checkA11y();
 
     cy.contains("+ New facility").click();
     cy.contains("Testing facility information");
 
-    // failing a11y test
     // Test a11y on New Facility page
-    cy.checkA11y(
-        {
-          exclude: [],
-        },
-        {
-          rules: {
-            'empty-heading': { enabled: false },
-          },
-        },
-    );
+    cy.checkA11y();
   });
   it("fills out the form for a new facility", () => {
     cy.get('input[name="name"]').type(facility.name);

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -323,7 +323,9 @@ const FacilityForm: React.FC<Props> = (props) => {
                   </>
                 )}
               </div>
-              <h1 className="font-heading-lg margin-y-0">{facility.name}</h1>
+              <h1 className="font-heading-lg margin-y-1">
+                {facility.name || "Add facility"}
+              </h1>
             </div>
             <div
               style={{

--- a/frontend/src/app/supportAdmin/Components/OrganizationComboDropdown.tsx
+++ b/frontend/src/app/supportAdmin/Components/OrganizationComboDropdown.tsx
@@ -60,7 +60,9 @@ const OrganizationComboDropDown: React.FC<Props> = ({
     <div className="prime-container usa-card__container">
       <div className="usa-card__header">
         <h2 className="font-heading-lg" style={{ margin: 0 }}>
-          <Required label="Organization" />
+          <label htmlFor="org-dropdown-select">
+            <Required label="Organization" />
+          </label>
         </h2>
       </div>
       <div className="usa-card__body usa-form usa-form--large">

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -219,6 +219,7 @@ const PendingOrganizations = ({
         <td>
           <button
             className="sr-pending-org-delete-button"
+            aria-label="delete organization"
             data-testid="delete-org-button"
             onClick={() => {
               setOrgToDelete(o);
@@ -255,9 +256,9 @@ const PendingOrganizations = ({
               />
             ) : null}
             <div className="usa-card__header">
-              <h2 data-cy="pending-orgs-title">
+              <h1 data-cy="pending-orgs-title">
                 Edit or verify organization identity
-              </h2>
+              </h1>
             </div>
             <div className="usa-card__body">
               <table className="usa-table usa-table--borderless width-full">

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -258,7 +258,7 @@ const PendingOrganizations = ({
             <div className="usa-card__header">
               <h1
                 data-cy="pending-orgs-title"
-                className="font-ui-lg margin-top-0 margin-bottom-0"
+                className="font-heading-lg margin-top-0 margin-bottom-0"
               >
                 Edit or verify organization identity
               </h1>

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -177,6 +177,13 @@ const PendingOrganizations = ({
         </tr>
       );
     }
+    if (organizations.length === 0) {
+      return (
+        <tr>
+          <td colSpan={7}>No results</td>
+        </tr>
+      );
+    }
 
     const orgsSortedByNewest = [...organizations].sort(
       (a, b) => +new Date(b.createdAt) - +new Date(a.createdAt)
@@ -257,26 +264,20 @@ const PendingOrganizations = ({
               </h1>
             </div>
             <div className="usa-card__body">
-              {organizations.length === 0 ? (
-                <p className="margin-top-4 margin-bottom-4">
-                  No pending organizations found
-                </p>
-              ) : (
-                <table className="usa-table usa-table--borderless width-full">
-                  <thead>
-                    <tr>
-                      <th scope="col">Organization name</th>
-                      <th scope="row">Administrator</th>
-                      <th scope="row">Contact information</th>
-                      <th scope="row">Created</th>
-                      <th scope="col">External ID</th>
-                      <th scope="col" aria-hidden></th>
-                      <th scope="col" aria-hidden></th>
-                    </tr>
-                  </thead>
-                  <tbody>{orgRows()}</tbody>
-                </table>
-              )}
+              <table className="usa-table usa-table--borderless width-full">
+                <thead>
+                  <tr>
+                    <th scope="col">Organization name</th>
+                    <th scope="row">Administrator</th>
+                    <th scope="row">Contact information</th>
+                    <th scope="row">Created</th>
+                    <th scope="col">External ID</th>
+                    <th scope="col" aria-hidden></th>
+                    <th scope="col" aria-hidden></th>
+                  </tr>
+                </thead>
+                <tbody aria-live={"polite"}>{orgRows()}</tbody>
+              </table>
             </div>
           </div>
         </div>

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -256,7 +256,10 @@ const PendingOrganizations = ({
               />
             ) : null}
             <div className="usa-card__header">
-              <h1 data-cy="pending-orgs-title">
+              <h1
+                data-cy="pending-orgs-title"
+                className="font-ui-lg margin-top-0 margin-bottom-0"
+              >
                 Edit or verify organization identity
               </h1>
             </div>
@@ -269,7 +272,7 @@ const PendingOrganizations = ({
                     <th scope="row">Contact information</th>
                     <th scope="row">Created</th>
                     <th scope="col">External ID</th>
-                    <th scope="col"></th>
+                    <th scope="col" aria-hidden></th>
                   </tr>
                 </thead>
                 <tbody>{orgRows()}</tbody>

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -177,13 +177,6 @@ const PendingOrganizations = ({
         </tr>
       );
     }
-    if (organizations.length === 0) {
-      return (
-        <tr>
-          <td>No results</td>
-        </tr>
-      );
-    }
 
     const orgsSortedByNewest = [...organizations].sort(
       (a, b) => +new Date(b.createdAt) - +new Date(a.createdAt)
@@ -264,19 +257,26 @@ const PendingOrganizations = ({
               </h1>
             </div>
             <div className="usa-card__body">
-              <table className="usa-table usa-table--borderless width-full">
-                <thead>
-                  <tr>
-                    <th scope="col">Organization name</th>
-                    <th scope="row">Administrator</th>
-                    <th scope="row">Contact information</th>
-                    <th scope="row">Created</th>
-                    <th scope="col">External ID</th>
-                    <th scope="col" aria-hidden></th>
-                  </tr>
-                </thead>
-                <tbody>{orgRows()}</tbody>
-              </table>
+              {organizations.length === 0 ? (
+                <p className="margin-top-4 margin-bottom-4">
+                  No pending organizations found
+                </p>
+              ) : (
+                <table className="usa-table usa-table--borderless width-full">
+                  <thead>
+                    <tr>
+                      <th scope="col">Organization name</th>
+                      <th scope="row">Administrator</th>
+                      <th scope="row">Contact information</th>
+                      <th scope="row">Created</th>
+                      <th scope="col">External ID</th>
+                      <th scope="col" aria-hidden></th>
+                      <th scope="col" aria-hidden></th>
+                    </tr>
+                  </thead>
+                  <tbody>{orgRows()}</tbody>
+                </table>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -8,7 +8,7 @@ const SupportAdmin = () => {
           <div className="prime-container card-container">
             <div className="usa-card__header">
               <div>
-                <h2>Support admin</h2>
+                <h1>Support admin</h1>
               </div>
             </div>
             <div className="usa-card__body">

--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -8,7 +8,7 @@ const SupportAdmin = () => {
           <div className="prime-container card-container">
             <div className="usa-card__header">
               <div>
-                <h1 className="font-ui-lg margin-top-0 margin-bottom-0">
+                <h1 className="font-heading-lg margin-top-0 margin-bottom-0">
                   Support admin
                 </h1>
               </div>

--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -8,7 +8,9 @@ const SupportAdmin = () => {
           <div className="prime-container card-container">
             <div className="usa-card__header">
               <div>
-                <h1>Support admin</h1>
+                <h1 className="font-ui-lg margin-top-0 margin-bottom-0">
+                  Support admin
+                </h1>
               </div>
             </div>
             <div className="usa-card__body">

--- a/frontend/src/app/supportAdmin/TenantDataAccess/TenantDataAccessForm.tsx
+++ b/frontend/src/app/supportAdmin/TenantDataAccess/TenantDataAccessForm.tsx
@@ -92,7 +92,7 @@ const TenantDataAccessForm: React.FC<Props> = (props) => {
           <div className="prime-container card-container">
             <div className="usa-card__header">
               <div>
-                <h2 className="font-heading-lg">Organization Data Access</h2>
+                <h1 className="font-heading-lg">Organization Data Access</h1>
                 <p className="text-base">
                   This page allows you to reproduce a specific user's issues by
                   accessing their account. Access automatically expires after an


### PR DESCRIPTION
## Related Issue

Fixes #4582 

## Changes Proposed

Changed `h2` heading for `h1` and added font util classes to make them look like a heading 2 in below components:

- supportAdmin/SupportAdmin.tsx
- supportAdmin/TenantDataAccess/TenantDataAccessForm.tsx
- supportAdmin/PendingOrganizations/PendingOrganizations.tsx

Added `aria label` to image button that removes an org in the pending org table.
Added `aria hidden` to table heading that does not contain any text.
Added a `label tag` to the dropdown element in the organization section.
Added temporary heading _"Add facility"_ to the facility form for the scenario of a user adding a new facility.
Removed all the a11y rule exceptions in spec 01.

## Testing
Run cypress spec 01 and verify that no a11y issues are shown.
