### PR TITLE
Clean up flagged unused variables and methods

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -53,7 +53,7 @@ public class UserMutationResolver {
       @Argument String email,
       @Argument Role role) {
     name = Translators.consolidateNameArguments(name, firstName, middleName, lastName, suffix);
-    UserInfo user = _us.createUserInCurrentOrg(email, name, role, true);
+    UserInfo user = _us.createUserInCurrentOrg(email, name, role);
     return new User(user);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/authentication/DemoOktaAuthentication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/authentication/DemoOktaAuthentication.java
@@ -9,6 +9,7 @@ import gov.cdc.usds.simplereport.api.model.useraccountcreation.FactorAndQrCode;
 import gov.cdc.usds.simplereport.api.model.useraccountcreation.UserAccountStatus;
 import gov.cdc.usds.simplereport.config.BeanProfiles;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
@@ -250,7 +251,7 @@ public class DemoOktaAuthentication implements OktaAuthentication {
   public void validateFactor(String userId, String factorId)
       throws OktaAuthenticationFailureException {
     DemoMfa mfa = this.idToUserMap.get(userId).getMfa();
-    if (mfa == null || factorId != mfa.getFactorId()) {
+    if (mfa == null || !Objects.equals(factorId, mfa.getFactorId())) {
       throw new OktaAuthenticationFailureException("Could not retrieve factor.");
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -243,7 +243,7 @@ public class ApiUserService {
         apiUser.getInternalId(),
         getCurrentApiUser().getInternalId().toString());
 
-    return new UserInfo(apiUser, orgRoles, isAdmin(apiUser));
+    return new UserInfo(apiUser, orgRoles, isAdmin);
   }
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUser

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -81,16 +81,13 @@ public class ApiUserService {
   }
 
   @AuthorizationConfiguration.RequirePermissionManageUsers
-  public UserInfo createUserInCurrentOrg(
-      String username, PersonName name, Role role, boolean active) {
+  public UserInfo createUserInCurrentOrg(String username, PersonName name, Role role) {
     Organization org = _orgService.getCurrentOrganization();
 
     Optional<ApiUser> found = _apiUserRepo.findByLoginEmailIncludeArchived(username.toLowerCase());
-    if (found.isPresent()) {
-      return reprovisionUser(found.get(), name, org, role);
-    }
-
-    return createUserHelper(username, name, org, role);
+    return found
+        .map(apiUser -> reprovisionUser(apiUser, name, org, role))
+        .orElseGet(() -> createUserHelper(username, name, org, role));
   }
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
@@ -240,7 +237,6 @@ public class ApiUserService {
     Optional<OrganizationRoleClaims> roleClaims = _oktaRepo.updateUserEmail(userIdentity, email);
     Optional<OrganizationRoles> orgRoles = roleClaims.map(_orgService::getOrganizationRoles);
     boolean isAdmin = isAdmin(apiUser);
-    UserInfo user = new UserInfo(apiUser, orgRoles, isAdmin);
 
     log.info(
         "User with id={} updated by user with id={}",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -19,7 +19,6 @@ import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.test_util.DbTruncator;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,11 +57,8 @@ public abstract class BaseFullStackTest {
   @Autowired protected DiseaseService _diseaseService;
   @Autowired private SupportedDiseaseRepository _diseaseRepo;
 
-  protected Date _testStart;
-
   @BeforeEach
   void initTestStart() {
-    _testStart = new Date();
     reset(auditLoggerServiceSpy);
     _diseaseService.initDiseases();
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -354,7 +354,6 @@ class TestResultTest extends BaseGraphqlTest {
             "organization-level-metrics", "GetOrganizationLevelDashboardMetrics", variables, null);
 
     JsonNode metrics = result.get("organizationLevelDashboardMetrics");
-    System.out.println(metrics);
     assertEquals(1L, metrics.get("organizationPositiveTestCount").asLong());
     assertEquals(3L, metrics.get("organizationNegativeTestCount").asLong());
     assertEquals(4L, metrics.get("organizationTotalTestCount").asLong());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/reportstream/ReportStreamCallbackControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/reportstream/ReportStreamCallbackControllerTest.java
@@ -25,8 +25,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 class ReportStreamCallbackControllerTest extends BaseFullStackTest {
   @Autowired private MockMvc mockMvc;
 
-  @Autowired private ReportStreamCallbackController reportStreamCallbackController;
-
   private Organization org;
   private Facility site;
   private Person person;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/auxiliary/PatientSelfRegistrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/auxiliary/PatientSelfRegistrationTest.java
@@ -163,9 +163,6 @@ class PatientSelfRegistrationTest {
             null);
 
     HashSet<PatientSelfRegistration> hs = new HashSet<>();
-    System.out.println(a.hashCode());
-    System.out.println(a2.hashCode());
-    System.out.println(b.hashCode());
     hs.add(a);
     hs.add(a2);
     hs.add(b);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -119,7 +119,6 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     _repo.save(secondEvent);
 
     flush();
-    TestEvent found = _repo.findFirst1ByPatientOrderByCreatedAtDesc(patient);
     var savedSecondEvent = _repo.findById(secondEvent.getInternalId()).get();
     assertEquals(TestResult.UNDETERMINED, savedSecondEvent.getCovidTestResult().orElseThrow());
     List<TestEvent> foundTestReports2 =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -134,10 +134,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
     UserInfo newUserInfo =
         _service.createUserInCurrentOrg(
-            "newuser@example.com",
-            new PersonName("First", "Middle", "Last", "Jr"),
-            Role.USER,
-            true);
+            "newuser@example.com", new PersonName("First", "Middle", "Last", "Jr"), Role.USER);
 
     assertEquals("newuser@example.com", newUserInfo.getEmail());
 
@@ -161,7 +158,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
     UserInfo reprovisionedUserInfo =
         _service.createUserInCurrentOrg(
-            "nobody@example.com", new PersonName("First", "Middle", "Last", "Jr"), Role.USER, true);
+            "nobody@example.com", new PersonName("First", "Middle", "Last", "Jr"), Role.USER);
 
     // the user will be re-enabled and updated
     assertEquals("nobody@example.com", reprovisionedUserInfo.getEmail());
@@ -185,7 +182,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
             ConflictingUserException.class,
             () ->
                 _service.createUserInCurrentOrg(
-                    "allfacilities@example.com", personName, Role.USER, true));
+                    "allfacilities@example.com", personName, Role.USER));
 
     assertEquals("A user with this email address already exists.", caught.getMessage());
   }
@@ -206,8 +203,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     AccessDeniedException caught =
         assertThrows(
             AccessDeniedException.class,
-            () ->
-                _service.createUserInCurrentOrg("captain@pirate.com", personName, Role.USER, true));
+            () -> _service.createUserInCurrentOrg("captain@pirate.com", personName, Role.USER));
 
     assertEquals("Unable to add user.", caught.getMessage());
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -93,10 +93,6 @@ public abstract class BaseServiceTest<T> {
     _diseaseService.initDiseases();
   }
 
-  protected void reset() {
-    _truncator.truncateAll();
-  }
-
   protected static void assertSecurityError(Executable e) {
     AccessDeniedException exception = assertThrows(AccessDeniedException.class, e);
     assertEquals(SPRING_SECURITY_DENIED, exception.getMessage());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -56,7 +56,6 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
   @Test
   void sendAccountReminderEmails_concurrencyLock_success()
       throws InterruptedException, ExecutionException, SQLException {
-    String email = "fake@example.org";
     OrganizationQueueItem unverifiedQueuedOrg = _dataFactory.createOrganizationQueueItem();
     initAndBackdateUnverifiedQueuedOrg(unverifiedQueuedOrg);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1658,6 +1658,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
     Person p = _dataFactory.createMinimalPerson(org, facility);
+    var notExpected_allPos =
+        _dataFactory.createMultiplexTestEvent(
+            p, facility, TestResult.POSITIVE, TestResult.POSITIVE, TestResult.POSITIVE, false);
     var expected_allNeg =
         _dataFactory.createMultiplexTestEvent(
             p, facility, TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
@@ -1673,6 +1676,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     var actualInternalIds = res.stream().map(TestEvent::getInternalId).collect(Collectors.toList());
     assertTrue(actualInternalIds.containsAll(expected));
     assertEquals(expected.size(), actualInternalIds.size());
+    assertFalse(actualInternalIds.contains(notExpected_allPos.getInternalId()));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1160,12 +1160,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // count queries
     long startQueryCount = _hibernateQueryInterceptor.getQueryCount();
-    int firstQueryResults =
-        _service
-            .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50)
-            .toList()
-            .size();
+    _service.getFacilityTestEventsResults(
+        facility.getInternalId(), null, null, null, null, null, 0, 50);
     long firstPassTotal = _hibernateQueryInterceptor.getQueryCount() - startQueryCount;
 
     // add more data
@@ -1177,12 +1173,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // count queries again and make sure queries made didn't increase
     startQueryCount = _hibernateQueryInterceptor.getQueryCount();
-    int secondQueryResults =
-        _service
-            .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50)
-            .toList()
-            .size();
+    _service.getFacilityTestEventsResults(
+        facility.getInternalId(), null, null, null, null, null, 0, 50);
     long secondPassTotal = _hibernateQueryInterceptor.getQueryCount() - startQueryCount;
     assertEquals(firstPassTotal, secondPassTotal);
   }
@@ -1268,18 +1260,17 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Facility facility = _organizationService.getFacilities(org).get(0);
     DeviceSpecimenType device = _dataFactory.getGenericDeviceSpecimen();
     facility.addDefaultDeviceSpecimen(device);
-    Person p = _dataFactory.createFullPerson(org);
-    TestEvent _e = _dataFactory.createTestEvent(p, facility);
-    TestOrder _o = _e.getTestOrder();
+    Person person = _dataFactory.createFullPerson(org);
+    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
 
     String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    TestEvent deleteMarkerEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
+    TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
     assertNotNull(deleteMarkerEvent);
 
     assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
     assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
 
-    assertEquals(_e.getTestOrder().getInternalId(), _e.getTestOrderId());
+    assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
 
     List<TestEvent> events_before =
         _service
@@ -1289,7 +1280,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertEquals(1, events_before.size());
 
     // verify the original order was updated
-    TestEvent refreshedTestResult = _service.getTestResult(_e.getInternalId());
+    TestEvent refreshedTestResult = _service.getTestResult(testEvent.getInternalId());
     TestOrder onlySavedOrder = refreshedTestResult.getTestOrder();
     TestEvent mostRecentEvent = onlySavedOrder.getTestEvent();
     assertEquals(reasonMsg, onlySavedOrder.getReasonForCorrection());
@@ -1667,9 +1658,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
     Person p = _dataFactory.createMinimalPerson(org, facility);
-    var notExpected_allPos =
-        _dataFactory.createMultiplexTestEvent(
-            p, facility, TestResult.POSITIVE, TestResult.POSITIVE, TestResult.POSITIVE, false);
     var expected_allNeg =
         _dataFactory.createMultiplexTestEvent(
             p, facility, TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceIntegrationTest.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.TestResultUpload;
 import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
@@ -44,7 +43,6 @@ class TestResultUploadServiceIntegrationTest extends BaseServiceTest<TestResultU
     mockCreationTime("2020-01-01 00:00");
     initSampleData();
     Organization currentOrganization = organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createValidFacility(currentOrganization);
 
     mockCreationTime("2020-02-17 00:00");
     uploadRepository.save(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/SmsServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/SmsServiceTest.java
@@ -36,7 +36,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
@@ -76,8 +75,6 @@ class SmsServiceTest extends BaseServiceTest<SmsService> {
   @Captor ArgumentCaptor<PhoneNumber> toNumber;
 
   @Captor ArgumentCaptor<String> message;
-
-  private OngoingStubbing<String> thenAnswer;
 
   @Test
   @WithSimpleReportEntryOnlyAllFacilitiesUser

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -312,40 +312,6 @@ public class TestDataFactory {
     return _personRepo.save(p);
   }
 
-  @Transactional
-  public Person createFullPersonEmails(Organization org, List<String> emails) {
-    // consts are to keep style check happy othewise it complains about
-    // "magic numbers"
-    Person p =
-        new Person(
-            org,
-            "HELLOTHERE",
-            "Fred",
-            null,
-            "Astaire",
-            null,
-            DEFAULT_BDAY,
-            getAddress(),
-            "USA",
-            PersonRole.RESIDENT,
-            emails,
-            "white",
-            "not_hispanic",
-            null,
-            "male",
-            false,
-            false,
-            "English",
-            TestResultDeliveryPreference.SMS);
-    _personRepo.save(p);
-
-    if (emails != null) {
-      p.setPrimaryEmail(emails.get(0));
-    }
-
-    return _personRepo.save(p);
-  }
-
   private Specification<Person> personFilter(PersonName n) {
     return (root, query, cb) ->
         cb.and(
@@ -553,11 +519,6 @@ public class TestDataFactory {
     return _patientRegistrationLinkRepository.save(prl);
   }
 
-  @Transactional
-  public AskOnEntrySurvey getAoESurveyForTestOrder(UUID id) {
-    return _testOrderRepo.findById(id).orElseThrow().getAskOnEntrySurvey().getSurvey();
-  }
-
   public DeviceType createDeviceType(
       String name, String manufacturer, String model, String loincCode, String swabType) {
     return _deviceRepo.save(new DeviceType(name, manufacturer, model, loincCode, swabType, 15));
@@ -598,10 +559,6 @@ public class TestDataFactory {
 
   public DeviceSpecimenType createDeviceSpecimen(DeviceType device, SpecimenType specimen) {
     return _deviceSpecimenRepo.save(new DeviceSpecimenType(device, specimen));
-  }
-
-  public SupportedDisease createSupportedDisease(String name, String loinc) {
-    return _supportedDiseaseRepo.save(new SupportedDisease(name, loinc));
   }
 
   public StreetAddress getAddress() {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixing several issues flagged in the Feb 2022 Fortify scan:
   - Fixes #3378
   - Fixes #3377
   - Fixes #3380
   - Fixes #3375

## Changes Proposed

- Remove a number of unused variables in tests
- Remove some unused test methods
- Remove some unnecessary print statements in tests
- Refactor ApiUserService call to remove `isActive`, since that value was unused in the method
- Properly assert on string equality in DemoAuthenticationConfiguration

## Testing

- All backend tests pass