### PR TITLE
handle 400 errors

### DIFF
--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -38,8 +38,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -38,6 +38,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -40,8 +40,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -40,8 +40,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -40,8 +40,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -40,8 +40,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -40,8 +40,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev7/main.tf
+++ b/ops/dev7/main.tf
@@ -40,8 +40,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/dev7/main.tf
+++ b/ops/dev7/main.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -38,8 +38,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -38,6 +38,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -283,3 +283,32 @@ requests
     threshold = 0
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_uploader_400" {
+  name                = "${var.env}-report_stream_uploader_400"
+  description         = "${local.env_title} alert when the publish function results in a 400"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+
+  action {
+    action_group = var.action_group_ids
+  }
+
+  data_source_id = var.app_insights_id
+  enabled        = contains(var.disabled_alerts, "report_stream_uploader_400") ? false : true
+
+  query = <<-QUERY
+customEvents
+| order by timestamp desc
+| extend httpStatus = toint(customDimensions["status"])
+| where httpStatus == 400
+  QUERY
+
+  severity    = 1
+  frequency   = 5
+  time_window = 6
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 0
+  }
+}

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -301,7 +301,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_uploader_4
 customEvents
 | order by timestamp desc
 | extend httpStatus = toint(customDimensions["status"])
-| where httpStatus == 400
+| where httpStatus == 400 and name == "ReportStream Upload Failed"
   QUERY
 
   severity    = 1

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.test.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.test.ts
@@ -21,6 +21,7 @@ jest.mock("../config", () => ({
     AZ_STORAGE_ACCOUNT_NAME: "hola",
     AZ_STORAGE_ACCOUNT_KEY: "bonjour",
     TEST_EVENT_QUEUE_NAME: "ciao",
+    FILE_ERROR_QUEUE_NAME: "cheese",
     REPORT_STREAM_URL: "https://nope.url/1234",
     REPORT_STREAM_TOKEN: "merhaba",
     REPORT_STREAM_BATCH_MINIMUM: "hallo",
@@ -77,7 +78,7 @@ describe("main function export", () => {
       await fn(context);
 
       // THEN
-      expect(getQueueClientMock).toHaveBeenCalledTimes(2);
+      expect(getQueueClientMock).toHaveBeenCalledTimes(3);
       expect(minimumMessagesAvailableMock).toHaveBeenCalled();
       expect(dequeueMessagesMock).not.toHaveBeenCalled();
     });
@@ -94,7 +95,7 @@ describe("main function export", () => {
     await fn(context);
 
     // THEN
-    expect(getQueueClientMock).toHaveBeenCalledTimes(2);
+    expect(getQueueClientMock).toHaveBeenCalledTimes(3);
     expect(minimumMessagesAvailableMock).toHaveBeenCalled();
     expect(dequeueMessagesMock).toHaveBeenCalled();
     expect(uploadResultMock).toHaveBeenCalled();
@@ -122,7 +123,7 @@ describe("main function export", () => {
     }
 
     // THEN
-    expect(getQueueClientMock).toHaveBeenCalledTimes(2);
+    expect(getQueueClientMock).toHaveBeenCalledTimes(3);
     expect(minimumMessagesAvailableMock).toHaveBeenCalled();
     expect(dequeueMessagesMock).toHaveBeenCalled();
     expect(uploadResultMock).toHaveBeenCalled();
@@ -139,7 +140,7 @@ describe("main function export", () => {
     await fn(context);
 
     // THEN
-    expect(getQueueClientMock).toHaveBeenCalledTimes(2);
+    expect(getQueueClientMock).toHaveBeenCalledTimes(3);
     expect(appInsights.defaultClient.trackEvent).toHaveBeenCalledWith(
       expect.objectContaining({ name: "Test Event Parse Failure" })
     );

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.test.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.test.ts
@@ -186,7 +186,6 @@ describe("main function export", () => {
     // WHEN
     try {
       await fn(context);
-      expect(0).toBe(1);
     } catch (e) {
       expect(e).toBeDefined();
     }

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.test.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.test.ts
@@ -66,7 +66,7 @@ describe("main function export", () => {
       .mockReturnValue({} as QueueClient);
     deleteMessagesMock = jest.spyOn(lib, "deleteSuccessfullyParsedMessages");
     reportExceptionsMock = jest.spyOn(lib, "reportExceptions");
-    fileFailureMock = jest.spyOn(lib, "publishToFileErrorQueue");
+    fileFailureMock = jest.spyOn(lib, "publishToQueue");
   });
 
   beforeEach(() => {

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -117,7 +117,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
 
     if(postResult.status === 400) {
       //publish messages to file failure queue
-      const response = await publishToFileErrorQueue(fileErrorQueue, messages);
+      await publishToFileErrorQueue(fileErrorQueue, messages);
       //delete messages from the main queue
       await deleteSuccessfullyParsedMessages(context, publishingQueue, messages, parseFailure);
     }

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -17,7 +17,7 @@ const {
   REPORT_STREAM_URL,
   TEST_EVENT_QUEUE_NAME,
   REPORTING_EXCEPTION_QUEUE_NAME,
-  FILE_ERROR_QUEUE_NAME,
+  PUBLISHING_ERROR_QUEUE_NAME,
 } = ENV;
 
 appInsights.setup();
@@ -29,7 +29,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
   const tagOverrides = { "ai.operation.id": context.traceContext.traceparent };
   const publishingQueue = getQueueClient(TEST_EVENT_QUEUE_NAME);
   const exceptionQueue = getQueueClient(REPORTING_EXCEPTION_QUEUE_NAME);
-  const fileErrorQueue = getQueueClient(FILE_ERROR_QUEUE_NAME);
+  const fileErrorQueue = getQueueClient(PUBLISHING_ERROR_QUEUE_NAME);
 
   if (!(await minimumMessagesAvailable(context, publishingQueue))) {
     return;

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -28,7 +28,6 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
   const tagOverrides = { "ai.operation.id": context.traceContext.traceparent };
   const publishingQueue = getQueueClient(TEST_EVENT_QUEUE_NAME);
   const exceptionQueue = getQueueClient(REPORTING_EXCEPTION_QUEUE_NAME);
-  //todo figure out a better name for this queue
   const fileErrorQueue = getQueueClient(FILE_ERROR_QUEUE_NAME);
 
   if (!(await minimumMessagesAvailable(context, publishingQueue))) {

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -7,7 +7,7 @@ import {
   dequeueMessages,
   getQueueClient,
   minimumMessagesAvailable,
-  publishToFileErrorQueue,
+  publishToQueue,
   reportExceptions,
   uploadResult,
 } from "./lib";
@@ -29,7 +29,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
   const tagOverrides = { "ai.operation.id": context.traceContext.traceparent };
   const publishingQueue = getQueueClient(TEST_EVENT_QUEUE_NAME);
   const exceptionQueue = getQueueClient(REPORTING_EXCEPTION_QUEUE_NAME);
-  const fileErrorQueue = getQueueClient(PUBLISHING_ERROR_QUEUE_NAME);
+  const publishingErrorQueue = getQueueClient(PUBLISHING_ERROR_QUEUE_NAME);
 
   if (!(await minimumMessagesAvailable(context, publishingQueue))) {
     return;
@@ -117,7 +117,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
 
     if(postResult.status === 400) {
       //publish messages to file failure queue
-      await publishToFileErrorQueue(fileErrorQueue, messages);
+      await publishToQueue(publishingErrorQueue, messages);
       //delete messages from the main queue
       await deleteSuccessfullyParsedMessages(context, publishingQueue, messages, parseFailure);
     }

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -6,7 +6,7 @@ import {
   deleteSuccessfullyParsedMessages,
   dequeueMessages,
   getQueueClient,
-  minimumMessagesAvailable,
+  minimumMessagesAvailable, publishToFileErrorQueue,
   reportExceptions,
   uploadResult,
 } from "./lib";
@@ -16,6 +16,7 @@ const {
   REPORT_STREAM_URL,
   TEST_EVENT_QUEUE_NAME,
   REPORTING_EXCEPTION_QUEUE_NAME,
+  FILE_ERROR_QUEUE_NAME,
 } = ENV;
 
 appInsights.setup();
@@ -27,6 +28,8 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
   const tagOverrides = { "ai.operation.id": context.traceContext.traceparent };
   const publishingQueue = getQueueClient(TEST_EVENT_QUEUE_NAME);
   const exceptionQueue = getQueueClient(REPORTING_EXCEPTION_QUEUE_NAME);
+  //todo figure out a better name for this queue
+  const fileErrorQueue = getQueueClient(FILE_ERROR_QUEUE_NAME);
 
   if (!(await minimumMessagesAvailable(context, publishingQueue))) {
     return;
@@ -111,6 +114,15 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
       },
       tagOverrides,
     });
+
+    if(postResult.status === 400) {
+      //
+      //publish messages to file failure queue
+      await publishToFileErrorQueue(context, fileErrorQueue, messages);
+      //delete messages from the main queue
+      await deleteSuccessfullyParsedMessages(context, publishingQueue, messages, parseFailure);
+    }
+
     throw new Error(errorText);
   }
 };

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -6,7 +6,8 @@ import {
   deleteSuccessfullyParsedMessages,
   dequeueMessages,
   getQueueClient,
-  minimumMessagesAvailable, publishToFileErrorQueue,
+  minimumMessagesAvailable,
+  publishToFileErrorQueue,
   reportExceptions,
   uploadResult,
 } from "./lib";
@@ -116,7 +117,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
 
     if(postResult.status === 400) {
       //publish messages to file failure queue
-      await publishToFileErrorQueue(context, fileErrorQueue, messages);
+      const response = await publishToFileErrorQueue(fileErrorQueue, messages);
       //delete messages from the main queue
       await deleteSuccessfullyParsedMessages(context, publishingQueue, messages, parseFailure);
     }

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -43,7 +43,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
   });
 
   const { csvPayload, parseFailure, parseFailureCount, parseSuccessCount } =
-    convertToCsv(messages, context);
+    convertToCsv(messages);
 
   if (parseFailureCount > 0) {
     telemetry.trackEvent({

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -43,7 +43,7 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
   });
 
   const { csvPayload, parseFailure, parseFailureCount, parseSuccessCount } =
-    convertToCsv(messages);
+    convertToCsv(messages, context);
 
   if (parseFailureCount > 0) {
     telemetry.trackEvent({

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/index.ts
@@ -116,7 +116,6 @@ const QueueBatchedTestEventPublisher: AzureFunction = async function (
     });
 
     if(postResult.status === 400) {
-      //
       //publish messages to file failure queue
       await publishToFileErrorQueue(context, fileErrorQueue, messages);
       //delete messages from the main queue

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.test.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.test.ts
@@ -204,7 +204,7 @@ describe("lib", () => {
 
       // WHEN
       const { csvPayload, parseFailure, parseFailureCount, parseSuccessCount } =
-        convertToCsv(messages, context);
+        convertToCsv(messages);
 
       // THEN
       expect(parseSuccessCount).toBe(3);

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.test.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.test.ts
@@ -204,7 +204,7 @@ describe("lib", () => {
 
       // WHEN
       const { csvPayload, parseFailure, parseFailureCount, parseSuccessCount } =
-        convertToCsv(messages);
+        convertToCsv(messages, context);
 
       // THEN
       expect(parseSuccessCount).toBe(3);

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -207,7 +207,7 @@ export async function reportExceptions(
 }
 
 export async function publishToFileErrorQueue( context: Context, queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
-  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(JSON.stringify(m.messageText)).toString("base64"))));
+  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(m.messageText).toString("base64"))));
 }
 
 const responsesFrom = function (

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -207,7 +207,7 @@ export async function reportExceptions(
 }
 
 export async function publishToFileErrorQueue( context: Context, queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
-  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(JSON.stringify(m)).toString("base64"))));
+  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(JSON.stringify(m.messageText)).toString("base64"))));
 }
 
 const responsesFrom = function (

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -206,7 +206,7 @@ export async function reportExceptions(
   );
 }
 
-export async function publishToFileErrorQueue( context: Context, queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
+export async function publishToFileErrorQueue(queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
   return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(m.messageText).toString("utf-8"))));
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -100,7 +100,7 @@ export async function dequeueMessages(
   return messages;
 }
 
-export function convertToCsv(messages: DequeuedMessageItem[]) {
+export function convertToCsv(messages: DequeuedMessageItem[], context: Context) {
   const parseFailure: { [k: string]: boolean } = {};
   let parseFailureCount = 0;
   const messageTexts = messages
@@ -108,6 +108,7 @@ export function convertToCsv(messages: DequeuedMessageItem[]) {
       try {
         return JSON.parse(m.messageText);
       } catch (e) {
+        context.log(e.message);
         parseFailure[m.messageId] = true;
         parseFailureCount++;
         return undefined;

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -206,7 +206,7 @@ export async function reportExceptions(
   );
 }
 
-export async function publishToFileErrorQueue(queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
+export async function publishToQueue(queueClient: QueueClient, messages: DequeuedMessageItem[]) {
   return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(m.messageText).toString("utf-8"))));
 }
 

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -100,7 +100,7 @@ export async function dequeueMessages(
   return messages;
 }
 
-export function convertToCsv(messages: DequeuedMessageItem[], context: Context) {
+export function convertToCsv(messages: DequeuedMessageItem[]) {
   const parseFailure: { [k: string]: boolean } = {};
   let parseFailureCount = 0;
   const messageTexts = messages
@@ -108,7 +108,6 @@ export function convertToCsv(messages: DequeuedMessageItem[], context: Context) 
       try {
         return JSON.parse(m.messageText);
       } catch (e) {
-        context.log(e.message);
         parseFailure[m.messageId] = true;
         parseFailureCount++;
         return undefined;
@@ -208,7 +207,7 @@ export async function reportExceptions(
 }
 
 export async function publishToFileErrorQueue( context: Context, queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
-  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(m.messageText).toString("base64"))));
+  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(m.messageText).toString("utf-8"))));
 }
 
 const responsesFrom = function (

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/QueueBatchedReportStreamUploader/lib.ts
@@ -206,6 +206,10 @@ export async function reportExceptions(
   );
 }
 
+export async function publishToFileErrorQueue( context: Context, queueClient: QueueClient,  messages: DequeuedMessageItem[]) {
+  return Promise.all(messages.map((m) => queueClient.sendMessage(Buffer.from(JSON.stringify(m)).toString("base64"))));
+}
+
 const responsesFrom = function (
   context: Context,
   err: ReportStreamError,

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/config.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/config.ts
@@ -22,6 +22,7 @@ export const ENV = (() => {
     TEST_EVENT_QUEUE_NAME: "storage queue resource name for Test Events",
     REPORTING_EXCEPTION_QUEUE_NAME:
       "storage queue resource name for exceptions in publishing to ReportStream",
+    FILE_ERROR_QUEUE_NAME: "storage queue resource name for file errors in publishing to ReportStream",
     REPORT_STREAM_URL: "ReportStream URL to which tests should be reported",
     REPORT_STREAM_TOKEN: "ReportStream API key",
     REPORT_STREAM_BATCH_MINIMUM: "minimum # of messages to read from the queue",

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/config.ts
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/config.ts
@@ -22,7 +22,7 @@ export const ENV = (() => {
     TEST_EVENT_QUEUE_NAME: "storage queue resource name for Test Events",
     REPORTING_EXCEPTION_QUEUE_NAME:
       "storage queue resource name for exceptions in publishing to ReportStream",
-    FILE_ERROR_QUEUE_NAME: "storage queue resource name for file errors in publishing to ReportStream",
+    PUBLISHING_ERROR_QUEUE_NAME: "storage queue resource name for HTTP 400 errors in publishing to ReportStream",
     REPORT_STREAM_URL: "ReportStream URL to which tests should be reported",
     REPORT_STREAM_TOKEN: "ReportStream API key",
     REPORT_STREAM_BATCH_MINIMUM: "minimum # of messages to read from the queue",

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
@@ -35,9 +35,9 @@ variable "test_event_queue_name" {
   default = "test-event-publishing"
 }
 
-variable "file_error_queue_name" {
+variable "publishing_error_queue_name" {
   type    = string
-  default = "test-event-file-error"
+  default = "test-event-publishing-error"
 }
 
 variable "reporting_exception_queue_name" {

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
@@ -35,6 +35,11 @@ variable "test_event_queue_name" {
   default = "test-event-publishing"
 }
 
+variable "file_error_queue_name" {
+  type    = string
+  default = "test-event-file-error"
+}
+
 variable "reporting_exception_queue_name" {
   type    = string
   default = "test-event-publishing-exceptions"

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -91,6 +91,7 @@ resource "azurerm_function_app" "functions" {
     AZ_STORAGE_ACCOUNT_KEY         = data.azurerm_storage_account.app.primary_access_key
     AZ_STORAGE_QUEUE_CXN_STRING    = data.azurerm_storage_account.app.primary_connection_string
     TEST_EVENT_QUEUE_NAME          = var.test_event_queue_name
+    FILE_ERROR_QUEUE_NAME          = var.file_error_queue_name
     REPORTING_EXCEPTION_QUEUE_NAME = var.reporting_exception_queue_name
     REPORT_STREAM_URL              = local.report_stream_url
     REPORT_STREAM_TOKEN            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -91,7 +91,7 @@ resource "azurerm_function_app" "functions" {
     AZ_STORAGE_ACCOUNT_KEY         = data.azurerm_storage_account.app.primary_access_key
     AZ_STORAGE_QUEUE_CXN_STRING    = data.azurerm_storage_account.app.primary_connection_string
     TEST_EVENT_QUEUE_NAME          = var.test_event_queue_name
-    FILE_ERROR_QUEUE_NAME          = var.file_error_queue_name
+    PUBLISHING_ERROR_QUEUE_NAME    = var.publishing_error_queue_name
     REPORTING_EXCEPTION_QUEUE_NAME = var.reporting_exception_queue_name
     REPORT_STREAM_URL              = local.report_stream_url
     REPORT_STREAM_TOKEN            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -38,8 +38,8 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
-resource "azurerm_storage_queue" "test_event_file_error_queue" {
-  name                 = "test-event-file-error"
+resource "azurerm_storage_queue" "test-event-publishing-error" {
+  name                 = "test-event-publishing-error"
   storage_account_name = azurerm_storage_account.app.name
 }
 

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -38,6 +38,11 @@ resource "azurerm_storage_queue" "test_event_exceptions_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "test_event_file_error_queue" {
+  name                 = "test-event-file-error"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_queue" "fhir_data_queue" {
   name                 = "fhir-data-publishing"
   storage_account_name = azurerm_storage_account.app.name


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- fixes #4295 

## Changes Proposed

- New queue created
- When a 400 error happens all the current messages (in the function) go into the new queue
- When this happens (should be very rare) manual intervention will be required.
- Write up a doc on the process for that manual intervention

## Additional Information

- Parsing out the line number is less straight forward than I would have hoped which is why I'm going the route of just putting the entire file in the new queue.  Would be interested to hear people's thoughts on that.

## Testing

- I'm taking over `dev3` for the sake of testing this.  Might be a longer lived testing process than most PRs.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

# DEVOPS CHANGES

- Creating a new queue to hold problematic records destined for report stream.
- Create an alert to fire when this happens as it will require manual intervention

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->