### PR TITLE
Fix maintenance banner action

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -20,7 +20,7 @@ on:
         required: true
         default: "prod"  
 
-ENV:
+env:
   NODE_VERSION: 18
 
 jobs:


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Maintenance banner Github action failing to run
<img width="1019" alt="Screen Shot 2022-12-05 at 2 27 52 PM" src="https://user-images.githubusercontent.com/80282552/205756320-0cc77861-84c4-4c97-a22d-b31ab97a3780.png">

## Changes Proposed

- Change from "ENV" to "env" as defined in the [GH documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#env)
- This appears to be the only workflow file where this is an issue
- Guessing the regression happened after one of the dependabot PRs to update our action version - maybe Github got stricter about typing?

## Testing

- Not sure how to test actions outside the UI; going to give this a shot on one of the `dev` environments after it's merged