### PR TITLE
Remove search button on Patients page

### DIFF
--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -297,6 +297,7 @@ export const DetachedManagePatients = ({
                 queryString={debounced || ""}
                 className="display-inline-block"
                 focusOnMount
+                showSubmitButton={false}
               />
             </div>
             <div className="usa-card__body sr-patient-list">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #3847

## Changes Proposed
Removes the search button on the "Patients" page because it was not needed to search for patients in the first place

## Additional Information


## Testing
- Go to the "Patients" tab and search for a patient
- Search should work as intended

## Screenshots / Demos
**Before**
<img width="975" alt="Screen Shot 2022-12-06 at 12 56 34" src="https://user-images.githubusercontent.com/20211771/205998022-97c6b278-10a7-46f9-8661-5f5436ace62b.png">

**After**
<img width="997" alt="Screen Shot 2022-12-06 at 12 55 57" src="https://user-images.githubusercontent.com/20211771/205998070-ebabc7f4-4b63-4cfb-a7f8-b8d8d73c9d63.png">


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
