### PR TITLE
[DRAFT] remove deviceSpecimenType from backend

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -1,7 +1,6 @@
 package gov.cdc.usds.simplereport.api.model;
 
 import gov.cdc.usds.simplereport.api.model.facets.LocatedWrapper;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
@@ -36,14 +35,6 @@ public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapp
 
   public List<DeviceType> getDeviceTypes() {
     return getWrapped().getDeviceTypes();
-  }
-
-  public DeviceType getDefaultDeviceType() {
-    return getWrapped().getDefaultDeviceType();
-  }
-
-  public DeviceSpecimenType getDefaultDeviceSpecimen() {
-    return getWrapped().getDefaultDeviceSpecimen();
   }
 
   public ApiProvider getOrderingProvider() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.api.model;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
@@ -30,9 +29,5 @@ public class ApiTestOrder extends WrappedEntity<TestOrder> {
 
   public String getReasonForCorrection() {
     return wrapped.getReasonForCorrection();
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType() {
-    return wrapped.getDeviceSpecimen();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -62,7 +62,7 @@ public class TestEventExport {
     this.specimenType = Optional.ofNullable(testEvent.getSpecimenType());
   }
 
-  private static final String genderUnknown = "U";
+  private String genderUnknown = "U";
   private static final String DEFAULT_LOCATION_CODE = "53342003"; // http://snomed.info/id/53342003
   // "Internal nose structure"
   // values pulled from

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -4,7 +4,6 @@ import static java.lang.Boolean.TRUE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.cdc.usds.simplereport.api.MappingConstants;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -7,7 +7,6 @@ import gov.cdc.usds.simplereport.api.model.ApiTestOrder;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.MultiplexResultInput;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
-import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import java.time.LocalDate;
@@ -28,7 +27,6 @@ public class QueueMutationResolver {
 
   private final TestOrderService testOrderService;
   private final PersonService personService;
-  private final DeviceTypeService deviceTypeService;
 
   @MutationMapping
   public AddTestResultResponse submitQueueItem(
@@ -37,11 +35,8 @@ public class QueueMutationResolver {
       @Argument List<MultiplexResultInput> results,
       @Argument UUID patientId,
       @Argument Date dateTested) {
-    UUID deviceSpecimenTypeId =
-        deviceTypeService.getDeviceSpecimenType(deviceTypeId, specimenTypeId).getInternalId();
-
     return testOrderService.addMultiplexResult(
-        deviceSpecimenTypeId, results, patientId, dateTested);
+        deviceTypeId, specimenTypeId, results, patientId, dateTested);
   }
 
   @MutationMapping
@@ -51,12 +46,9 @@ public class QueueMutationResolver {
       @Argument UUID specimenTypeId,
       @Argument List<MultiplexResultInput> results,
       @Argument Date dateTested) {
-    UUID deviceSpecimenTypeId =
-        deviceTypeService.getDeviceSpecimenType(deviceTypeId, specimenTypeId).getInternalId();
-
     return new ApiTestOrder(
         testOrderService.editQueueItemMultiplexResult(
-            id, deviceSpecimenTypeId, results, dateTested));
+            id, deviceTypeId, specimenTypeId, results, dateTested));
   }
 
   @MutationMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -2,7 +2,6 @@ package gov.cdc.usds.simplereport.config;
 
 import static gov.cdc.usds.simplereport.utils.DeviceTestLengthConverter.determineTestLength;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -134,10 +133,20 @@ public class InitialSetupProperties {
     public Facility makeRealFacility(
         Organization org,
         Provider p,
-        DeviceSpecimenType defaultDeviceSpec,
+        DeviceType defaultDeviceType,
+        SpecimenType defaultSpecimenType,
         List<DeviceType> configured) {
       return new Facility(
-          org, name, cliaNumber, address, telephone, email, p, defaultDeviceSpec, configured);
+          org,
+          name,
+          cliaNumber,
+          address,
+          telephone,
+          email,
+          p,
+          defaultDeviceType,
+          defaultSpecimenType,
+          configured);
     }
 
     public String getName() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -28,10 +28,6 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   private Facility facility;
 
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  @JoinColumn(name = "device_specimen_type_id")
-  private DeviceSpecimenType deviceSpecimen;
-
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "device_type_id")
   private DeviceType deviceType;
 
@@ -60,22 +56,17 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   }
 
   protected BaseTestInfo(BaseTestInfo orig) {
-    this(orig.getPatient(), orig.getFacility(), orig.getDeviceSpecimen());
+    this(orig.getPatient(), orig.getFacility());
   }
 
-  protected BaseTestInfo(Person patient, Facility facility, DeviceSpecimenType deviceSpecimen) {
+  protected BaseTestInfo(Person patient, Facility facility) {
     super();
     this.patient = patient;
     this.facility = facility;
     this.organization = facility.getOrganization();
-    this.deviceSpecimen = deviceSpecimen;
-    this.deviceType = deviceSpecimen.getDeviceType();
-    this.specimenType = deviceSpecimen.getSpecimenType();
+    this.deviceType = facility.getDefaultDeviceType();
+    this.specimenType = facility.getDefaultSpecimenType();
     this.correctionStatus = TestCorrectionStatus.ORIGINAL;
-  }
-
-  protected BaseTestInfo(Person patient, Facility facility) {
-    this(patient, facility, facility.getDefaultDeviceSpecimen());
   }
 
   protected BaseTestInfo(
@@ -106,10 +97,6 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     return specimenType;
   }
 
-  public DeviceSpecimenType getDeviceSpecimen() {
-    return deviceSpecimen;
-  }
-
   // FYI Setters shouldn't be allowed in TestEvent, so they are always *protected*
   // in this base class
   // and exposed only in TestOrder.
@@ -122,10 +109,9 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     this.dateTestedBackdate = dateTestedBackdate;
   }
 
-  protected void setDeviceSpecimen(DeviceSpecimenType deviceSpecimen) {
-    this.deviceSpecimen = deviceSpecimen;
-    this.deviceType = deviceSpecimen.getDeviceType();
-    this.specimenType = deviceSpecimen.getSpecimenType();
+  protected void setDeviceTypeAndSpecimenType(DeviceType device, SpecimenType specimen) {
+    this.deviceType = device;
+    this.specimenType = specimen;
   }
 
   public TestCorrectionStatus getCorrectionStatus() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -4,7 +4,6 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -34,10 +33,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
   private Provider orderingProvider;
 
   @ManyToOne(optional = true, fetch = FetchType.EAGER)
-  @JoinColumn(name = "default_device_specimen_type_id")
-  private DeviceSpecimenType defaultDeviceSpecimen;
-
-  @ManyToOne(optional = true, fetch = FetchType.EAGER)
   @JoinColumn(name = "default_device_type_id")
   private DeviceType defaultDeviceType;
 
@@ -63,7 +58,8 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
       String phone,
       String email,
       Provider orderingProvider,
-      DeviceSpecimenType defaultDeviceSpecimen,
+      DeviceType defaultDeviceType,
+      SpecimenType defaultSpecimenType,
       List<DeviceType> configuredDevices) {
     this(
         org,
@@ -74,7 +70,7 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
         email,
         orderingProvider,
         configuredDevices);
-    this.addDefaultDeviceSpecimen(defaultDeviceSpecimen);
+    this.setDefaultDeviceTypeSpecimenType(defaultDeviceType, defaultSpecimenType);
   }
 
   public Facility(
@@ -105,7 +101,20 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
   }
 
   public DeviceType getDefaultDeviceType() {
-    return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getDeviceType();
+    return this.defaultDeviceType;
+  }
+
+  public void setDefaultDeviceTypeSpecimenType(DeviceType deviceType, SpecimenType specimenType) {
+    if (deviceType != null) {
+      configuredDeviceTypes.add(deviceType);
+    }
+
+    this.defaultDeviceType = deviceType;
+    this.defaultSpecimenType = specimenType;
+  }
+
+  public void removeDefaultDeviceTypeSpecimenType() {
+    this.setDefaultDeviceTypeSpecimenType(null, null);
   }
 
   public SpecimenType getDefaultSpecimenType() {
@@ -120,34 +129,14 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
     return configuredDeviceTypes.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
   }
 
-  public DeviceSpecimenType getDefaultDeviceSpecimen() {
-    return defaultDeviceSpecimen;
-  }
-
-  public void addDefaultDeviceSpecimen(DeviceSpecimenType newDefault) {
-    if (newDefault != null) {
-      configuredDeviceTypes.add(newDefault.getDeviceType());
-      this.defaultDeviceType = newDefault.getDeviceType();
-      this.defaultSpecimenType = newDefault.getSpecimenType();
-    }
-
-    defaultDeviceSpecimen = newDefault;
-  }
-
-  public void removeDefaultDeviceSpecimen() {
-    defaultDeviceSpecimen = null;
-  }
-
   public void removeDeviceType(DeviceType deletedDevice) {
     this.configuredDeviceTypes.remove(deletedDevice);
 
     // If the corresponding device to a facility's default device swab type is removed,
     // set default to null
-    if (this.getDefaultDeviceSpecimen() != null) {
-      UUID defaultDeviceTypeId = this.defaultDeviceSpecimen.getDeviceType().getInternalId();
-      if (defaultDeviceTypeId.equals(deletedDevice.getInternalId())) {
-        this.addDefaultDeviceSpecimen(null);
-      }
+    if (this.getDefaultDeviceType() != null
+        && this.getDefaultDeviceType().getInternalId().equals(deletedDevice.getInternalId())) {
+      this.removeDefaultDeviceTypeSpecimenType();
     }
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -68,7 +68,7 @@ public class TestEvent extends BaseTestInfo {
   }
 
   private TestEvent(TestOrder order, Boolean hasPriorTests) {
-    super(order.getPatient(), order.getFacility(), order.getDeviceSpecimen());
+    super(order.getPatient(), order.getFacility());
     // store a link, and *also* store the object as JSON
     // force load the lazy-loaded phone numbers so values are available to the object mapper
     // when serializing `patientData` (phoneNumbers is default lazy-loaded because of `OneToMany`)
@@ -160,10 +160,6 @@ public class TestEvent extends BaseTestInfo {
 
   public UUID getPriorCorrectedTestEventId() {
     return priorCorrectedTestEventId;
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType() {
-    return order.getDeviceSpecimen();
   }
 
   public Optional<TestResult> getCovidTestResult() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -78,8 +78,8 @@ public class TestOrder extends BaseTestInfo {
   }
 
   @Override
-  public void setDeviceSpecimen(DeviceSpecimenType ds) {
-    super.setDeviceSpecimen(ds);
+  public void setDeviceTypeAndSpecimenType(DeviceType device, SpecimenType specimen) {
+    super.setDeviceTypeAndSpecimenType(device, specimen);
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
@@ -5,7 +5,6 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
@@ -20,13 +19,6 @@ public interface DeviceSpecimenTypeRepository
   @EntityGraph(attributePaths = {"deviceType", "specimenType"})
   @Query(BASE_QUERY + " and e.deviceType = :deviceType and e.specimenType = :specimenType")
   Optional<DeviceSpecimenType> find(DeviceType deviceType, SpecimenType specimenType);
-
-  @EntityGraph(attributePaths = {"deviceType", "specimenType"})
-  Optional<DeviceSpecimenType> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId);
-
-  @EntityGraph(attributePaths = {"deviceType", "specimenType"})
-  Optional<DeviceSpecimenType> findByDeviceTypeInternalIdAndSpecimenTypeInternalIdOrderByCreatedAt(
-      UUID deviceTypeId, UUID specimenTypeId);
 
   List<DeviceSpecimenType> findAllByDeviceType(DeviceType deviceType);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.db.repository;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import java.util.Collection;
@@ -43,6 +42,4 @@ public interface FacilityRepository extends EternalAuditedEntityRepository<Facil
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.organization = :org order by e.facilityName")
   List<Facility> findByOrganizationOrderByFacilityName(Organization org);
-
-  List<Facility> findAllByDefaultDeviceSpecimenIn(List<DeviceSpecimenType> dsts);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -26,8 +26,7 @@ public interface TestOrderRepository
   String RESULT_RECENT_ORDER = " order by q.updatedAt desc ";
 
   @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)
-  @EntityGraph(
-      attributePaths = {"patient", "deviceType", "specimenType", "results", "deviceSpecimen"})
+  @EntityGraph(attributePaths = {"patient", "deviceType", "specimenType", "results"})
   List<TestOrder> fetchQueue(Organization org, Facility facility);
 
   @Query(BASE_ORG_QUERY + IS_PENDING + " and q.patient = :patient")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -100,16 +100,6 @@ public class DeviceTypeService {
       ArrayList<DeviceSpecimenType> toBeDeletedDeviceSpecimenTypes =
           new ArrayList<>(exitingDeviceSpecimenTypes);
       toBeDeletedDeviceSpecimenTypes.removeAll(newDeviceSpecimenTypes);
-
-      /* todo deal with this case
-      // Null out facilities' default device specimen if it was deleted
-      List<Facility> facilitiesToRemoveDefaultDeviceSpecimen =
-          facilityRepository.findAllByDefaultDeviceSpecimenIn(toBeDeletedDeviceSpecimenTypes);
-
-      facilitiesToRemoveDefaultDeviceSpecimen.forEach(
-          Facility::removeDefaultDeviceTypeSpecimenType);
-      */
-
       deviceSpecimenTypeRepository.deleteAll(toBeDeletedDeviceSpecimenTypes);
 
       // create new ones

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -6,12 +6,10 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import java.util.ArrayList;
@@ -19,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,72 +26,31 @@ import org.springframework.transaction.annotation.Transactional;
  * specific facility or organization).
  */
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DeviceTypeService {
 
   public static final String SWAB_TYPE_DELETED_MESSAGE =
       "swab type has been deleted and cannot be used";
-  private DeviceTypeRepository _repo;
-  private DeviceSpecimenTypeRepository _deviceSpecimenRepo;
-  private SpecimenTypeRepository _specimenTypeRepo;
-  private FacilityRepository _facilityRepo;
-  private SupportedDiseaseRepository _supportedDiseaseRepo;
-
-  public DeviceTypeService(
-      DeviceTypeRepository repo,
-      DeviceSpecimenTypeRepository deviceSpecimenRepo,
-      SpecimenTypeRepository specimenTypeRepo,
-      FacilityRepository facilityRepo,
-      SupportedDiseaseRepository supportedDiseaseRepo) {
-    _repo = repo;
-    _deviceSpecimenRepo = deviceSpecimenRepo;
-    _specimenTypeRepo = specimenTypeRepo;
-    _facilityRepo = facilityRepo;
-    _supportedDiseaseRepo = supportedDiseaseRepo;
-  }
+  private final DeviceTypeRepository deviceTypeRepository;
+  private final DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
+  private final SpecimenTypeRepository specimenTypeRepository;
+  private final SupportedDiseaseRepository supportedDiseaseRepository;
 
   @Transactional(readOnly = false)
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public void removeDeviceType(DeviceType d) {
-    _repo.delete(d);
+    deviceTypeRepository.delete(d);
   }
 
   public List<DeviceType> fetchDeviceTypes() {
-    return _repo.findAll();
+    return deviceTypeRepository.findAll();
   }
 
   public DeviceType getDeviceType(UUID internalId) {
-    return _repo
+    return deviceTypeRepository
         .findById(internalId)
         .orElseThrow(() -> new IllegalGraphqlArgumentException("invalid device type ID"));
-  }
-
-  public List<DeviceSpecimenType> getDeviceSpecimenTypes() {
-    return _deviceSpecimenRepo.findAll();
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType(UUID deviceSpecimenTypeId) {
-    return _deviceSpecimenRepo
-        .findById(deviceSpecimenTypeId)
-        .orElseThrow(() -> new IllegalGraphqlArgumentException("invalid device specimen type ID"));
-  }
-
-  public DeviceSpecimenType getFirstDeviceSpecimenTypeForDeviceTypeId(UUID deviceId) {
-    return _deviceSpecimenRepo
-        .findFirstByDeviceTypeInternalIdOrderByCreatedAt(deviceId)
-        .orElseThrow(
-            () ->
-                new IllegalGraphqlArgumentException(
-                    "Device is not configured with a specimen type"));
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType(UUID deviceTypeId, UUID specimenTypeId) {
-    return _deviceSpecimenRepo
-        .findByDeviceTypeInternalIdAndSpecimenTypeInternalIdOrderByCreatedAt(
-            deviceTypeId, specimenTypeId)
-        .orElseThrow(
-            () ->
-                new IllegalGraphqlArgumentException("Not a valid device and specimen combination"));
   }
 
   @Transactional(readOnly = false)
@@ -118,7 +76,7 @@ public class DeviceTypeService {
     if (updateDevice.getSwabTypes() != null) {
       List<SpecimenType> updatedSpecimenTypes =
           updateDevice.getSwabTypes().stream()
-              .map(uuid -> _specimenTypeRepo.findById(uuid))
+              .map(specimenTypeRepository::findById)
               .filter(Optional::isPresent)
               .map(Optional::get)
               .collect(Collectors.toList());
@@ -136,37 +94,40 @@ public class DeviceTypeService {
               .collect(Collectors.toList());
 
       List<DeviceSpecimenType> exitingDeviceSpecimenTypes =
-          _deviceSpecimenRepo.findAllByDeviceType(device);
+          deviceSpecimenTypeRepository.findAllByDeviceType(device);
 
       // delete old ones
       ArrayList<DeviceSpecimenType> toBeDeletedDeviceSpecimenTypes =
           new ArrayList<>(exitingDeviceSpecimenTypes);
       toBeDeletedDeviceSpecimenTypes.removeAll(newDeviceSpecimenTypes);
 
+      /* todo deal with this case
       // Null out facilities' default device specimen if it was deleted
       List<Facility> facilitiesToRemoveDefaultDeviceSpecimen =
-          _facilityRepo.findAllByDefaultDeviceSpecimenIn(toBeDeletedDeviceSpecimenTypes);
+          facilityRepository.findAllByDefaultDeviceSpecimenIn(toBeDeletedDeviceSpecimenTypes);
 
-      facilitiesToRemoveDefaultDeviceSpecimen.forEach(Facility::removeDefaultDeviceSpecimen);
+      facilitiesToRemoveDefaultDeviceSpecimen.forEach(
+          Facility::removeDefaultDeviceTypeSpecimenType);
+      */
 
-      _deviceSpecimenRepo.deleteAll(toBeDeletedDeviceSpecimenTypes);
+      deviceSpecimenTypeRepository.deleteAll(toBeDeletedDeviceSpecimenTypes);
 
       // create new ones
       ArrayList<DeviceSpecimenType> toBeAddedDeviceSpecimenTypes =
           new ArrayList<>(newDeviceSpecimenTypes);
       toBeAddedDeviceSpecimenTypes.removeAll(exitingDeviceSpecimenTypes);
-      _deviceSpecimenRepo.saveAll(toBeAddedDeviceSpecimenTypes);
+      deviceSpecimenTypeRepository.saveAll(toBeAddedDeviceSpecimenTypes);
     }
     if (updateDevice.getSupportedDiseases() != null) {
       List<SupportedDisease> supportedDiseases =
           updateDevice.getSupportedDiseases().stream()
-              .map(uuid -> _supportedDiseaseRepo.findById(uuid))
+              .map(supportedDiseaseRepository::findById)
               .filter(Optional::isPresent)
               .map(Optional::get)
               .collect(Collectors.toList());
       device.setSupportedDiseases(supportedDiseases);
     }
-    return _repo.save(device);
+    return deviceTypeRepository.save(device);
   }
 
   @Transactional(readOnly = false)
@@ -175,7 +136,7 @@ public class DeviceTypeService {
 
     List<SpecimenType> specimenTypes =
         createDevice.getSwabTypes().stream()
-            .map(uuid -> _specimenTypeRepo.findById(uuid).get())
+            .map(uuid -> specimenTypeRepository.findById(uuid).get())
             .collect(Collectors.toList());
 
     specimenTypes.forEach(
@@ -187,13 +148,13 @@ public class DeviceTypeService {
 
     List<SupportedDisease> supportedDiseases =
         createDevice.getSupportedDiseases().stream()
-            .map(uuid -> _supportedDiseaseRepo.findById(uuid))
+            .map(supportedDiseaseRepository::findById)
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());
 
     DeviceType dt =
-        _repo.save(
+        deviceTypeRepository.save(
             new DeviceType(
                 createDevice.getName(),
                 createDevice.getManufacturer(),
@@ -204,10 +165,10 @@ public class DeviceTypeService {
 
     specimenTypes.stream()
         .map(specimenType -> new DeviceSpecimenType(dt, specimenType))
-        .forEach(_deviceSpecimenRepo::save);
+        .forEach(deviceSpecimenTypeRepository::save);
 
     dt.setSupportedDiseases(supportedDiseases);
-    _repo.save(dt);
+    deviceTypeRepository.save(dt);
 
     return dt;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -72,7 +72,8 @@ public class OrganizationInitializingService {
         _props.getConfiguredDeviceTypeNames().stream()
             .map(dsByDeviceName::get)
             .collect(Collectors.toList());
-    DeviceSpecimenType defaultDeviceSpecimen = configuredDs.get(0);
+    DeviceType defaultDeviceType = configuredDs.get(0).getDeviceType();
+    SpecimenType defaultSpecimenType = configuredDs.get(0).getSpecimenType();
 
     List<Organization> emptyOrgs = _props.getOrganizations();
     Map<String, Organization> orgsByExternalId =
@@ -107,7 +108,8 @@ public class OrganizationInitializingService {
                         : f.makeRealFacility(
                             orgsByExternalId.get(f.getOrganizationExternalId()),
                             savedProvider,
-                            defaultDeviceSpecimen,
+                            defaultDeviceType,
+                            defaultSpecimenType,
                             configuredDs.stream()
                                 .map(DeviceSpecimenType::getDeviceType)
                                 .collect(Collectors.toList())))

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -8,7 +8,7 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.AuditedEntity_;
 import gov.cdc.usds.simplereport.db.model.BaseTestInfo_;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
@@ -17,6 +17,7 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Person_;
 import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.Result_;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestEvent_;
@@ -245,24 +246,29 @@ public class TestOrderService {
   @AuthorizationConfiguration.RequirePermissionUpdateTestForTestOrder
   public TestOrder editQueueItemMultiplexResult(
       UUID testOrderId,
-      UUID deviceSpecimenTypeId,
+      UUID deviceTypeId,
+      UUID specimenTypeId,
       List<MultiplexResultInput> results,
       Date dateTested) {
-    lockOrder(testOrderId);
     try {
+      DeviceType deviceType = _deviceTypeService.getDeviceType(deviceTypeId);
+      SpecimenType specimenType =
+          deviceType.getSwabTypes().stream()
+              .filter(swab -> swab.getInternalId().equals(specimenTypeId))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalGraphqlArgumentException(
+                          "invalid device type and specimen type combination"));
+
+      lockOrder(testOrderId);
       TestOrder order = this.getTestOrder(testOrderId);
 
-      if (deviceSpecimenTypeId != null) {
-        DeviceSpecimenType deviceSpecimenType =
-            _deviceTypeService.getDeviceSpecimenType(deviceSpecimenTypeId);
+      order.setDeviceTypeAndSpecimenType(deviceType, specimenType);
+      // Set the most-recently configured device specimen for a facility's
+      // test as facility default
+      order.getFacility().setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
-        if (deviceSpecimenType != null) {
-          order.setDeviceSpecimen(deviceSpecimenType);
-          // Set the most-recently configured device specimen for a facility's
-          // test as facility default
-          order.getFacility().addDefaultDeviceSpecimen(deviceSpecimenType);
-        }
-      }
       if (!results.isEmpty()) {
         editMultiplexResult(order, results);
       }
@@ -275,7 +281,8 @@ public class TestOrderService {
 
   @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
   public AddTestResultResponse addMultiplexResult(
-      UUID deviceSpecimenTypeId,
+      UUID deviceTypeId,
+      UUID specimenTypeId,
       List<MultiplexResultInput> results,
       UUID patientId,
       Date dateTested) {
@@ -284,15 +291,21 @@ public class TestOrderService {
     TestOrder order =
         _testOrderRepo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
 
-    DeviceSpecimenType deviceSpecimenType =
-        _deviceTypeService.getDeviceSpecimenType(deviceSpecimenTypeId);
+    DeviceType deviceType = _deviceTypeService.getDeviceType(deviceTypeId);
+    SpecimenType specimenType =
+        deviceType.getSwabTypes().stream()
+            .filter(swab -> swab.getInternalId().equals(specimenTypeId))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalGraphqlArgumentException(
+                        "invalid device type and specimen type combination"));
 
     lockOrder(order.getInternalId());
-
     TestOrder savedOrder = null;
 
     try {
-      order.setDeviceSpecimen(deviceSpecimenType);
+      order.setDeviceTypeAndSpecimenType(deviceType, specimenType);
       var resultSet = editMultiplexResult(order, results);
       order.setDateTestedBackdate(dateTested);
       order.markComplete();
@@ -418,10 +431,12 @@ public class TestOrderService {
               + "are incompatible with facility of queue");
     }
 
-    if (testFacility.getDefaultDeviceSpecimen() == null) {
-      testFacility.addDefaultDeviceSpecimen(
-          _deviceTypeService.getFirstDeviceSpecimenTypeForDeviceTypeId(
-              testFacility.getDeviceTypes().get(0).getInternalId()));
+    // if test facility doesnt have defaults, grab the first device on that facility
+    if (testFacility.getDefaultDeviceType() == null
+        || testFacility.getDefaultSpecimenType() == null) {
+      testFacility.setDefaultDeviceTypeSpecimenType(
+          testFacility.getDeviceTypes().get(0),
+          testFacility.getDeviceTypes().get(0).getSwabTypes().get(0));
     }
 
     TestOrder newOrder = new TestOrder(patient, testFacility);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -431,7 +431,7 @@ public class TestOrderService {
               + "are incompatible with facility of queue");
     }
 
-    // if test facility doesnt have defaults, grab the first device on that facility
+    // if test facility doesn't have defaults, grab the first device on that facility
     if (testFacility.getDefaultDeviceType() == null
         || testFacility.getDefaultSpecimenType() == null) {
       testFacility.setDefaultDeviceTypeSpecimenType(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -940,18 +940,10 @@ class FhirConverterTest {
         new TestOrder(
             null,
             new Facility(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                Collections.emptyList()));
+                null, null, null, null, null, null, null, null, null, Collections.emptyList()));
     testOrder.markComplete();
-    testOrder.setDeviceTypeAndSpecimenType(new DeviceType(null, null, null, "94533-7", null, 0), null);
+    testOrder.setDeviceTypeAndSpecimenType(
+        new DeviceType(null, null, null, "94533-7", null, 0), null);
     ReflectionTestUtils.setField(testOrder, "internalId", UUID.fromString(internalId));
 
     var actual = convertToServiceRequest(testOrder);
@@ -1149,7 +1141,8 @@ class FhirConverterTest {
   void createFhirBundle_TestEvent_matchesJson() throws IOException {
     var address = new StreetAddress(List.of("1 Main St"), "Chicago", "IL", "60614", "");
     var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", "nasal", 0);
-    var specimenType = new SpecimenType("name", "typeCode");var provider =
+    var specimenType = new SpecimenType("name", "typeCode");
+    var provider =
         new Provider(new PersonName("Michaela", null, "Quinn", ""), "1", address, "7735551235");
     var organization = new Organization("District", "school", "1", true);
     var facility =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -727,8 +726,8 @@ class FhirConverterTest {
                     null,
                     null,
                     null,
-                    new DeviceSpecimenType(
-                        new DeviceType(null, null, null, "95422-2", null, 0), null),
+                    new DeviceType(null, null, null, "95422-2", null, 0),
+                    null,
                     Collections.emptyList())),
             false,
             Collections.emptySet());
@@ -748,15 +747,7 @@ class FhirConverterTest {
             new TestOrder(
                 new Person(null, null, null, null, null),
                 new Facility(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    new DeviceSpecimenType(null, null),
-                    Collections.emptyList())),
+                    null, null, null, null, null, null, null, null, null, Collections.emptyList())),
             false,
             Collections.emptySet());
     var correctedTestEvent =
@@ -775,15 +766,7 @@ class FhirConverterTest {
             new TestOrder(
                 new Person(null, null, null, null, null),
                 new Facility(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    new DeviceSpecimenType(null, null),
-                    Collections.emptyList())),
+                    null, null, null, null, null, null, null, null, null, Collections.emptyList())),
             false,
             Collections.emptySet());
     var correctedTestEvent =
@@ -810,8 +793,8 @@ class FhirConverterTest {
                     null,
                     null,
                     null,
-                    new DeviceSpecimenType(
-                        new DeviceType(null, null, null, "95422-2", null, 0), null),
+                    new DeviceType(null, null, null, "95422-2", null, 0),
+                    null,
                     Collections.emptyList())),
             false,
             Collections.emptySet());
@@ -862,7 +845,8 @@ class FhirConverterTest {
                 null,
                 null,
                 null,
-                new DeviceSpecimenType(new DeviceType(null, null, null, "95422-2", null, 0), null),
+                new DeviceType(null, null, null, "95422-2", null, 0),
+                null,
                 Collections.emptyList()));
 
     var actual = convertToServiceRequest(testOrder);
@@ -887,7 +871,8 @@ class FhirConverterTest {
                 null,
                 null,
                 null,
-                new DeviceSpecimenType(new DeviceType(null, null, null, "95422-2", null, 0), null),
+                new DeviceType(null, null, null, "95422-2", null, 0),
+                null,
                 Collections.emptyList()));
     testOrder.markComplete();
     var actual = convertToServiceRequest(testOrder);
@@ -908,7 +893,8 @@ class FhirConverterTest {
                 null,
                 null,
                 null,
-                new DeviceSpecimenType(new DeviceType(null, null, null, "95422-2", null, 0), null),
+                new DeviceType(null, null, null, "95422-2", null, 0),
+                null,
                 Collections.emptyList()));
     testOrder.cancelOrder();
     var actual = convertToServiceRequest(testOrder);
@@ -922,15 +908,7 @@ class FhirConverterTest {
         new TestOrder(
             new Person(null, null, null, null, new Organization(null, null, null, true)),
             new Facility(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                new DeviceSpecimenType(null, null),
-                Collections.emptyList()));
+                null, null, null, null, null, null, null, null, null, Collections.emptyList()));
     testOrder.cancelOrder();
     var actual = convertToServiceRequest(testOrder);
 
@@ -969,11 +947,11 @@ class FhirConverterTest {
                 null,
                 null,
                 null,
-                new DeviceSpecimenType(null, null),
+                null,
+                null,
                 Collections.emptyList()));
     testOrder.markComplete();
-    testOrder.setDeviceSpecimen(
-        new DeviceSpecimenType(new DeviceType(null, null, null, "94533-7", null, 0), null));
+    testOrder.setDeviceTypeAndSpecimenType(new DeviceType(null, null, null, "94533-7", null, 0), null);
     ReflectionTestUtils.setField(testOrder, "internalId", UUID.fromString(internalId));
 
     var actual = convertToServiceRequest(testOrder);
@@ -1171,9 +1149,7 @@ class FhirConverterTest {
   void createFhirBundle_TestEvent_matchesJson() throws IOException {
     var address = new StreetAddress(List.of("1 Main St"), "Chicago", "IL", "60614", "");
     var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", "nasal", 0);
-    var specimenType = new SpecimenType("name", "typeCode");
-    var deviceSpecimenType = new DeviceSpecimenType(deviceType, specimenType);
-    var provider =
+    var specimenType = new SpecimenType("name", "typeCode");var provider =
         new Provider(new PersonName("Michaela", null, "Quinn", ""), "1", address, "7735551235");
     var organization = new Organization("District", "school", "1", true);
     var facility =
@@ -1185,7 +1161,8 @@ class FhirConverterTest {
             "7735551234",
             "school@example.com",
             provider,
-            deviceSpecimenType,
+            deviceType,
+            specimenType,
             Collections.emptyList());
     var person =
         new Person(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -82,7 +82,8 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
         () -> {
           Organization org = _orgService.getCurrentOrganizationNoCache();
           facility = _orgService.getFacilities(org).get(0);
-          facility.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+          facility.setDefaultDeviceTypeSpecimenType(
+              _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
           patient = _dataFactory.createFullPerson(org);
           TestOrder order = _dataFactory.createTestOrder(patient, facility);
           patientLink = _dataFactory.createPatientLink(order);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
@@ -25,7 +24,6 @@ import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -185,18 +183,7 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
 
   private HashMap<String, Object> getDeviceArgs() {
     String someDeviceType = _deviceService.fetchDeviceTypes().get(0).getInternalId().toString();
-    List<UUID> someDeviceSpecimenTypes =
-        List.of(_deviceService.getDeviceSpecimenTypes().get(0).getInternalId());
-
-    final ObjectMapper mapper = new ObjectMapper();
-
-    Map<String, Object> variables =
-        Map.of(
-            "deviceId",
-            someDeviceType,
-            "deviceSpecimenTypes",
-            mapper.convertValue(someDeviceSpecimenTypes, JsonNode.class));
-
+    Map<String, Object> variables = Map.of("deviceId", someDeviceType);
     return new HashMap<>(variables);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -55,7 +55,8 @@ class QueueManagementTest extends BaseGraphqlTest {
   public void init() {
     _org = _orgService.getCurrentOrganizationNoCache();
     _site = _orgService.getFacilities(_org).get(0);
-    _site.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+    _site.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     positiveCovidResult =
         List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -75,8 +75,8 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
     Organization fakeOrg = new Organization("ABC", "university", "123", true);
     Person p = makeSerializablePerson(fakeOrg);
     Provider mccoy = new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222");
-    DeviceType d = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15);
-    DeviceSpecimenType dst = new DeviceSpecimenType(d, new SpecimenType());
+    DeviceType device = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15);
+    SpecimenType specimenType = new SpecimenType();
     StreetAddress addy =
         new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
     p.setFacility(
@@ -88,8 +88,9 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
             "555-867-5309",
             "facility@test.com",
             mccoy,
-            dst,
-            List.of(d)));
+            device,
+            specimenType,
+            List.of(device)));
     JsonContent<Person> serialized = _tester.write(p);
     assertThat(serialized)
         .extractingJsonPathStringValue("lastName")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -33,7 +32,6 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
     DeviceType bill = _devices.save(new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15));
     DeviceType percy = _devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", "E", 15));
     SpecimenType spec = _specimens.save(new SpecimenType("Troll Bogies", "0001111234"));
-    DeviceSpecimenType billbogies = _deviceSpecimens.save(new DeviceSpecimenType(bill, spec));
     Provider mccoy =
         _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
     configuredDevices.add(bill);
@@ -49,13 +47,14 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
                 "555-867-5309",
                 "facility@test.com",
                 mccoy,
-                billbogies,
+                bill,
+                spec,
                 configuredDevices));
     Optional<Facility> maybe = _repo.findByOrganizationAndFacilityName(org, "Third Floor");
     assertTrue(maybe.isPresent(), "should find the facility");
     Facility found = maybe.get();
     assertEquals(2, found.getDeviceTypes().size());
-    found.addDefaultDeviceSpecimen(billbogies);
+    found.setDefaultDeviceTypeSpecimenType(bill, spec);
     _repo.save(found);
     found = _repo.findById(saved.getInternalId()).get();
     found.removeDeviceType(bill);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -10,12 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.OrderingProviderRequiredException;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
-import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
@@ -81,7 +79,6 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   void createOrganizationAndFacility_success() {
     // GIVEN
-    DeviceSpecimenType dst = getDeviceConfig();
     PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "");
 
     // WHEN
@@ -95,7 +92,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
             testDataFactory.getAddress(),
             "123-456-7890",
             "test@foo.com",
-            List.of(dst.getDeviceType().getInternalId()),
+            List.of(getDeviceConfig().getInternalId()),
             orderingProviderName,
             testDataFactory.getAddress(),
             "123-456-7890",
@@ -120,17 +117,15 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     assertEquals(5, facLink.getLink().length());
   }
 
-  private DeviceSpecimenType getDeviceConfig() {
-    DeviceType device =
-        testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1", "12345-6", "E");
-    SpecimenType specimen = testDataFactory.getGenericSpecimen();
-    return testDataFactory.createDeviceSpecimen(device, specimen);
+  private DeviceType getDeviceConfig() {
+    return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1", "12345-6", "E");
+    //    SpecimenType specimen = testDataFactory.getGenericSpecimen();
+    //    return testDataFactory.createDeviceSpecimen(device, specimen);
   }
 
   @Test
   void createOrganizationAndFacility_orderingProviderRequired_failure() {
     // GIVEN
-    DeviceSpecimenType dst = getDeviceConfig();
     PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
     // THEN
     assertThrows(
@@ -145,7 +140,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
               _dataFactory.getAddress(),
               "123-456-7890",
               "test@foo.com",
-              List.of(dst.getDeviceType().getInternalId()),
+              List.of(getDeviceConfig().getInternalId()),
               orderProviderName,
               _dataFactory.getAddress(),
               null,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -119,8 +119,6 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   private DeviceType getDeviceConfig() {
     return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1", "12345-6", "E");
-    //    SpecimenType specimen = testDataFactory.getGenericSpecimen();
-    //    return testDataFactory.createDeviceSpecimen(device, specimen);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -19,12 +19,13 @@ import gov.cdc.usds.simplereport.api.model.AddTestResultResponse;
 import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentQueueItemException;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
@@ -57,6 +58,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -86,6 +88,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @MockBean TestEventReportingService testEventReportingService;
   @Captor ArgumentCaptor<TestEvent> testEventArgumentCaptor;
 
+  @Autowired private EntityManager entityManager;
+
   private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
   private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
   private static final PersonName CHARLES = new PersonName("Charles", "Mathew", "Albemarle", "Sr.");
@@ -99,15 +103,12 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
   private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
   private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
-
-  private DeviceSpecimenType DEVICE_A = null;
   private Facility _site;
   private Facility _otherSite;
 
   @BeforeEach
   void setupData() {
     initSampleData();
-    DEVICE_A = _dataFactory.getGenericDeviceSpecimen();
   }
 
   @Test
@@ -146,7 +147,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
+
+    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
@@ -154,7 +157,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     // WHEN
     _service.addMultiplexResult(
-        devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+        defaultDeviceType,
+        defaultSpecimenType,
+        positiveCovidOnlyResult,
+        patient.getInternalId(),
+        null);
 
     // THEN
     queue = _service.getQueue(facility.getInternalId());
@@ -206,7 +213,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     _service.addMultiplexResult(
-        _dataFactory.getGenericDeviceSpecimen().getInternalId(),
+        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericSpecimen().getInternalId(),
         positiveCovidOnlyResult,
         p.getInternalId(),
         null);
@@ -221,7 +229,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1866, 12, 25), false);
     _service.addMultiplexResult(
-        _dataFactory.getGenericDeviceSpecimen().getInternalId(),
+        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericSpecimen().getInternalId(),
         positiveCovidOnlyResult,
         p.getInternalId(),
         null);
@@ -363,11 +372,17 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
+
+    // get updated facility
+    facility = _organizationService.getFacilities(org).get(0);
+
+    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
     List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
 
-    _service.addMultiplexResult(devA.getInternalId(), positiveCovidResult, p.getInternalId(), null);
+    _service.addMultiplexResult(
+        defaultDeviceType, defaultSpecimenType, positiveCovidResult, p.getInternalId(), null);
 
     verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
 
@@ -405,12 +420,17 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceSpecimenType devA = facility.getDefaultDeviceSpecimen();
+
+    // get updated facility
+    facility = _organizationService.getFacilities(org).get(0);
+
+    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
 
     _service.addMultiplexResult(
-        devA.getInternalId(), positiveCovidOnlyResult, p.getInternalId(), null);
+        defaultDeviceType, defaultSpecimenType, positiveCovidOnlyResult, p.getInternalId(), null);
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
@@ -488,14 +508,15 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     TestUserIdentities.setFacilityAuthorities();
 
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
+    UUID deviceId = _dataFactory.getGenericDevice().getInternalId();
+    UUID specimenId = _dataFactory.getGenericSpecimen().getInternalId();
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
 
     assertThrows(
         AccessDeniedException.class,
         () ->
             _service.addMultiplexResult(
-                devA.getInternalId(), positiveCovidOnlyResult, p2.getInternalId(), null));
+                deviceId, specimenId, positiveCovidOnlyResult, p2.getInternalId(), null));
 
     // caller has access to the patient (whose facility is null)
     // but cannot modify the test order which was created at a non-accessible facility
@@ -503,14 +524,14 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         AccessDeniedException.class,
         () ->
             _service.addMultiplexResult(
-                devA.getInternalId(), positiveCovidOnlyResult, p1.getInternalId(), null));
+                deviceId, specimenId, positiveCovidOnlyResult, p1.getInternalId(), null));
 
     // make sure the nothing was sent to storage queue
     verifyNoInteractions(testEventReportingService);
 
     TestUserIdentities.setFacilityAuthorities(facility1);
     _service.addMultiplexResult(
-        devA.getInternalId(), positiveCovidOnlyResult, p1.getInternalId(), null);
+        deviceId, specimenId, positiveCovidOnlyResult, p1.getInternalId(), null);
     List<TestOrder> queue = _service.getQueue(facility1.getInternalId());
     assertEquals(1, queue.size());
 
@@ -520,7 +541,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
 
     _service.addMultiplexResult(
-        devA.getInternalId(), negativeCovidResult, p2.getInternalId(), null);
+        deviceId, specimenId, negativeCovidResult, p2.getInternalId(), null);
 
     queue = _service.getQueue(facility1.getInternalId());
     assertEquals(0, queue.size());
@@ -539,11 +560,16 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     _service.addMultiplexResult(
-        devA.getInternalId(), positiveCovidOnlyResult, p.getInternalId(), null);
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidOnlyResult,
+        p.getInternalId(),
+        null);
 
     verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
 
@@ -561,16 +587,26 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    _service.addMultiplexResult(devA.getInternalId(), positiveCovidResult, p.getInternalId(), null);
+    _service.addMultiplexResult(
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidResult,
+        p.getInternalId(),
+        null);
     assertThrows(
         NonexistentQueueItemException.class,
         () ->
             _service.addMultiplexResult(
-                devA.getInternalId(), positiveCovidResult, p.getInternalId(), null));
+                deviceType.getInternalId(),
+                specimenType.getInternalId(),
+                positiveCovidResult,
+                p.getInternalId(),
+                null));
   }
 
   @Test
@@ -581,13 +617,18 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Person p = _dataFactory.createFullPerson(org);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     // Create test event for a later correction
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     _service.addMultiplexResult(
-        devA.getInternalId(), positiveCovidOnlyResult, p.getInternalId(), null);
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidOnlyResult,
+        p.getInternalId(),
+        null);
     List<TestEvent> testEvents =
         _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
     assertEquals(1, testEvents.size());
@@ -600,7 +641,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> negativeCovidOnlyResult = makeCovidOnlyResult(TestResult.NEGATIVE);
     AddTestResultResponse response =
         _service.addMultiplexResult(
-            devA.getInternalId(), negativeCovidOnlyResult, p.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            negativeCovidOnlyResult,
+            p.getInternalId(),
+            null);
 
     TestEvent correctionTestEvent = response.getTestOrder().getTestEvent();
 
@@ -637,8 +682,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
     when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
     when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
 
@@ -646,7 +692,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     assertTrue(res.getDeliverySuccess());
@@ -674,8 +724,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
     when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
@@ -684,7 +735,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
@@ -709,8 +764,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
     when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
@@ -719,7 +775,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     assertTrue(res.getDeliverySuccess());
@@ -747,8 +807,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(false);
     when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(false);
@@ -757,7 +818,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
@@ -782,8 +847,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
     when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
     when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
 
@@ -792,7 +858,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
@@ -818,14 +888,19 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     // WHEN
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     assertTrue(res.getDeliverySuccess());
@@ -848,14 +923,19 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
-    DeviceSpecimenType devA = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(devA);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
     // WHEN
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     AddTestResultResponse res =
         _service.addMultiplexResult(
-            devA.getInternalId(), positiveCovidOnlyResult, patient.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
     // THEN
     List<Result> results = _resultRepository.findAllByTestOrder(res.getTestOrder());
@@ -880,7 +960,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder updatedOrder =
         _service.editQueueItemMultiplexResult(
             order.getInternalId(),
-            DEVICE_A.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
             List.of(covidResult),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
 
@@ -896,7 +977,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder updatedOrder =
         _service.editQueueItemMultiplexResult(
             order.getInternalId(),
-            DEVICE_A.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
             makeMultiplexTestResult(TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
 
@@ -912,7 +994,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder updatedOrder =
         _service.editQueueItemMultiplexResult(
             order.getInternalId(),
-            DEVICE_A.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
             List.of(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
 
@@ -930,7 +1013,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     _service.editQueueItemMultiplexResult(
         order.getInternalId(),
-        DEVICE_A.getInternalId(),
+        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericSpecimen().getInternalId(),
         List.of(covidResult, fluAResult, fluBResult),
         convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
 
@@ -939,7 +1023,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder updatedOrder =
         _service.editQueueItemMultiplexResult(
             order.getInternalId(),
-            DEVICE_A.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
             List.of(updatedCovidResult, fluAResult, fluBResult),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
 
@@ -948,7 +1033,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     AddTestResultResponse response =
         _service.addMultiplexResult(
-            updatedOrder.getDeviceSpecimen().getInternalId(),
+            updatedOrder.getDeviceType().getInternalId(),
+            updatedOrder.getSpecimenType().getInternalId(),
             List.of(updatedCovidResult, fluAResult, fluBResult),
             order.getPatient().getInternalId(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
@@ -962,7 +1048,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder order = addTestToQueue();
     AddTestResultResponse response =
         _service.addMultiplexResult(
-            order.getDeviceSpecimen().getInternalId(),
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
             List.of(new MultiplexResultInput("COVID-19", TestResult.POSITIVE)),
             order.getPatient().getInternalId(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
@@ -973,7 +1060,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     AddTestResultResponse correctedResponse =
         _service.addMultiplexResult(
-            order.getDeviceSpecimen().getInternalId(),
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
             List.of(new MultiplexResultInput("COVID-19", TestResult.NEGATIVE)),
             order.getPatient().getInternalId(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
@@ -997,7 +1085,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder order = addTestToQueue();
     AddTestResultResponse response =
         _service.addMultiplexResult(
-            order.getDeviceSpecimen().getInternalId(),
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
             originalResults,
             order.getPatient().getInternalId(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
@@ -1011,7 +1100,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     AddTestResultResponse correctedResponse =
         _service.addMultiplexResult(
-            order.getDeviceSpecimen().getInternalId(),
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
             correctedResults,
             order.getPatient().getInternalId(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
@@ -1034,7 +1124,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestOrder order = addTestToQueue();
     AddTestResultResponse response =
         _service.addMultiplexResult(
-            order.getDeviceSpecimen().getInternalId(),
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
             originalResults,
             order.getPatient().getInternalId(),
             convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
@@ -1150,7 +1241,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void fetchTestResults_entryOnlyUser_error() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     Person p = _dataFactory.createFullPerson(org);
     _dataFactory.createTestEvent(p, facility);
 
@@ -1166,7 +1258,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void fetchTestEventsResults_getTestEventsResults_NPlusOne() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     Person p = _dataFactory.createFullPerson(org);
 
     // add some initial data
@@ -1199,7 +1292,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void editTestResult_getQueue_NPlusOne() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     UUID facilityId = facility.getInternalId();
 
     Person p1 =
@@ -1273,8 +1367,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void markAsErrorTest() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceSpecimenType device = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(device);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     Person person = _dataFactory.createFullPerson(org);
     TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
 
@@ -1329,8 +1423,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void correctionsTest() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceSpecimenType device = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(device);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     Person p = _dataFactory.createFullPerson(org);
     TestEvent e = _dataFactory.createTestEvent(p, facility);
 
@@ -1361,8 +1455,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void correctTest_backDatedFromCurrentDate() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceSpecimenType device = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(device);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     Person p = _dataFactory.createFullPerson(org);
     TestEvent e = _dataFactory.createTestEvent(p, facility);
 
@@ -1381,8 +1475,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void correctTest_backdatePreserved() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceSpecimenType device = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(device);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     Person p = _dataFactory.createFullPerson(org);
 
     LocalDate localDate = LocalDate.of(2022, 1, 1);
@@ -1400,8 +1494,9 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void removeACorrectedTest_success() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceSpecimenType device = _dataFactory.getGenericDeviceSpecimen();
-    facility.addDefaultDeviceSpecimen(device);
+    DeviceType device = _dataFactory.getGenericDevice();
+    SpecimenType specimen = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
     Person p = _dataFactory.createFullPerson(org);
     TestEvent e = _dataFactory.createTestEvent(p, facility);
 
@@ -1413,7 +1508,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
     AddTestResultResponse response =
         _service.addMultiplexResult(
-            device.getInternalId(), correctedTestResult, p.getInternalId(), null);
+            device.getInternalId(),
+            specimen.getInternalId(),
+            correctedTestResult,
+            p.getInternalId(),
+            null);
     TestEvent correctedEvent = response.getTestOrder().getTestEvent();
 
     assertEquals(
@@ -1915,7 +2014,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             LocalDate.of(2022, 06, 05),
             false);
 
-    facility.addDefaultDeviceSpecimen(DEVICE_A);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
 
     return order;
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -373,9 +373,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
 
-    // get updated facility
-    facility = _organizationService.getFacilities(org).get(0);
-
     UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
     UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
@@ -420,9 +417,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-
-    // get updated facility
-    facility = _organizationService.getFacilities(org).get(0);
 
     UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
     UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -1,8 +1,8 @@
 package gov.cdc.usds.simplereport.test_util;
 
 import gov.cdc.usds.simplereport.api.model.Role;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
@@ -30,7 +30,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationQueueRepository;
@@ -43,7 +43,6 @@ import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.db.repository.ResultRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
-import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
@@ -100,9 +99,35 @@ public class TestDataFactory {
   @Autowired private ResultRepository resultRepository;
   @Autowired private DemoOktaRepository oktaRepository;
   @Autowired private TestResultUploadRepository testResultUploadRepository;
+  @Autowired private DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
 
   @Autowired private ApiUserService apiUserService;
   @Autowired private DiseaseService diseaseService;
+
+  private DeviceType genericDeviceType;
+  private SpecimenType genericSpecimenType;
+
+  public void initGenericDeviceTypeAndSpecimenType() {
+    genericSpecimenType =
+        specimenTypeRepository.findAll().stream()
+            .filter(d -> d.getName().equals(DEFAULT_SPECIMEN_TYPE))
+            .findFirst()
+            .orElseGet(
+                () ->
+                    createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
+
+    genericDeviceType =
+        deviceSpecimenTypeRepository.findAll().stream()
+            .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
+            .findFirst()
+            .orElseGet(
+                () -> createDeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E"));
+
+    deviceSpecimenTypeNewRepository.save(
+        new DeviceTypeSpecimenTypeMapping(
+            genericDeviceType.getInternalId(), genericSpecimenType.getInternalId()));
+  }
+
 
   public Organization saveOrganization(Organization org) {
     Organization savedOrg = organizationRepository.save(org);
@@ -151,10 +176,11 @@ public class TestDataFactory {
   }
 
   public Facility createValidFacility(Organization org, String facilityName) {
-    DeviceSpecimenType dev = getGenericDeviceSpecimen();
+    DeviceType defaultDevice = getGenericDevice();
+    SpecimenType dwfaultSpecimen = getGenericSpecimen();
 
     List<DeviceType> configuredDevices = new ArrayList<>();
-    configuredDevices.add(dev.getDeviceType());
+    configuredDevices.add(defaultDevice);
     Provider doc =
         providerRepository.save(
             new Provider("Doctor", "", "Doom", "", "DOOOOOOM", getAddress(), "800-555-1212"));
@@ -167,7 +193,8 @@ public class TestDataFactory {
             "555-867-5309",
             "facility@test.com",
             doc,
-            dev,
+            defaultDevice,
+            dwfaultSpecimen,
             configuredDevices);
     Facility save = facilityRepository.save(facility);
     oktaRepository.createFacility(save);
@@ -368,7 +395,8 @@ public class TestDataFactory {
   public TestOrder createCompletedTestOrder(Person patient, Facility facility, TestResult result) {
     TestOrder order = new TestOrder(patient, facility);
     order.setAskOnEntrySurvey(savePatientAnswers(createEmptySurvey()));
-    order.setDeviceSpecimen(facility.getDefaultDeviceSpecimen());
+    order.setDeviceTypeAndSpecimenType(
+        facility.getDefaultDeviceType(), facility.getDefaultSpecimenType());
 
     order.markComplete();
     TestOrder savedOrder = testOrderRepository.save(order);
@@ -529,7 +557,8 @@ public class TestDataFactory {
   }
 
   public DeviceType getGenericDevice() {
-    return getGenericDeviceSpecimen().getDeviceType();
+    initGenericDeviceTypeAndSpecimenType();
+    return genericDeviceType;
   }
 
   public SpecimenType createSpecimenType(
@@ -539,30 +568,8 @@ public class TestDataFactory {
   }
 
   public SpecimenType getGenericSpecimen() {
-    return getGenericDeviceSpecimen().getSpecimenType();
-  }
-
-  public DeviceSpecimenType getGenericDeviceSpecimen() {
-    DeviceType dev =
-        deviceTypeRepository.findAll().stream()
-            .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
-            .findFirst()
-            .orElseGet(
-                () -> createDeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E"));
-    SpecimenType specType =
-        specimenTypeRepository.findAll().stream()
-            .filter(d -> d.getName().equals(DEFAULT_SPECIMEN_TYPE))
-            .findFirst()
-            .orElseGet(
-                () ->
-                    createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
-    return deviceSpecimenTypeRepository
-        .find(dev, specType)
-        .orElseGet(() -> createDeviceSpecimen(dev, specType));
-  }
-
-  public DeviceSpecimenType createDeviceSpecimen(DeviceType device, SpecimenType specimen) {
-    return deviceSpecimenTypeRepository.save(new DeviceSpecimenType(device, specimen));
+    initGenericDeviceTypeAndSpecimenType();
+    return genericSpecimenType;
   }
 
   public StreetAddress getAddress() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -94,8 +94,6 @@ public class TestDataFactory {
   @Autowired private PatientLinkRepository patientLinkRepository;
   @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
   @Autowired private SpecimenTypeRepository specimenTypeRepository;
-  @Autowired private DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
-  @Autowired private SupportedDiseaseRepository supportedDiseaseRepository;
   @Autowired private ResultRepository resultRepository;
   @Autowired private DemoOktaRepository oktaRepository;
   @Autowired private TestResultUploadRepository testResultUploadRepository;
@@ -117,7 +115,7 @@ public class TestDataFactory {
                     createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
 
     genericDeviceType =
-        deviceSpecimenTypeRepository.findAll().stream()
+        deviceTypeRepository.findAll().stream()
             .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
             .findFirst()
             .orElseGet(
@@ -127,7 +125,6 @@ public class TestDataFactory {
         new DeviceTypeSpecimenTypeMapping(
             genericDeviceType.getInternalId(), genericSpecimenType.getInternalId()));
   }
-
 
   public Organization saveOrganization(Organization org) {
     Organization savedOrg = organizationRepository.save(org);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352

## Changes Proposed

- Remove DeviceSpecimenType from the backend
- a follow up PR will remove DeviceSpecimenType entity objects and Repo
- a follow up PR will remove extra unused db columns

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

