### PR TITLE
Remove facilities on org deletion

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -207,13 +207,13 @@ public class DemoOktaRepository implements OktaRepository {
     }
   }
 
+  // returns ALL users including inactive ones
   public Set<String> getAllUsersForOrganization(Organization org) {
     if (!orgUsernamesMap.containsKey(org.getExternalId())) {
       throw new IllegalGraphqlArgumentException(
           "Cannot get Okta users from nonexistent organization.");
     }
     return orgUsernamesMap.get(org.getExternalId()).stream()
-        .filter(u -> !inactiveUsernames.contains(u))
         .collect(Collectors.toUnmodifiableSet());
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -604,6 +604,14 @@ public class ApiUserService {
     return new UserInfo(apiUser, orgRoles, isAdmin);
   }
 
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public List<ApiUser> getAllUsersByOrganization(Organization organization) {
+    Set<String> usernames = _oktaRepo.getAllUsersForOrganization(organization);
+    return usernames.stream()
+        .map(username -> _apiUserRepo.findByLoginEmailIncludeArchived(username).orElse(null))
+        .collect(Collectors.toList());
+  }
+
   private UserInfo cancelCurrentUserTenantDataAccess() {
     ApiUser apiUser = getCurrentApiUser();
     _tenantService.removeAllTenantDataAccess(apiUser);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -609,6 +610,7 @@ public class ApiUserService {
     Set<String> usernames = _oktaRepo.getAllUsersForOrganization(organization);
     return usernames.stream()
         .map(username -> _apiUserRepo.findByLoginEmailIncludeArchived(username).orElse(null))
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -121,6 +121,14 @@ public class OrganizationService {
                 "An organization with external_id=" + externalId + " does not exist"));
   }
 
+  public Organization getOrganizationById(UUID internalId) {
+    Optional<Organization> found = organizationRepository.findById(internalId);
+    return found.orElseThrow(
+        () ->
+            new IllegalGraphqlArgumentException(
+                "An organization with internal_id=" + internalId + " does not exist"));
+  }
+
   public List<Organization> getOrganizationsByName(String name) {
     return organizationRepository.findAllByName(name);
   }
@@ -144,6 +152,11 @@ public class OrganizationService {
 
   public List<Facility> getFacilities(Organization org) {
     return facilityRepository.findByOrganizationOrderByFacilityName(org);
+  }
+
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public Set<Facility> getFacilitiesIncludeArchived(Organization org, Boolean includeArchived) {
+    return facilityRepository.findAllByOrganizationAndDeleted(org, includeArchived);
   }
 
   public Set<Facility> getFacilities(Organization org, Collection<UUID> facilityIds) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -1,12 +1,14 @@
 package gov.cdc.usds.simplereport.idp.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.okta.sdk.resource.user.UserStatus;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
@@ -336,9 +338,11 @@ class DemoOktaRepositoryTest {
         Set.of(OrganizationRole.ENTRY_ONLY, OrganizationRole.ALL_FACILITIES),
         true);
     _repo.setUserIsActive(AMOS.getUsername(), false);
-
-    assertTrue(_repo.getAllUsersForOrganization(ABC).contains(BRAD.getUsername()));
-    assertFalse(_repo.getAllUsersForOrganization(ABC).contains(AMOS.getUsername()));
+    assertEquals(
+        _repo.getAllUsersWithStatusForOrganization(ABC).get(AMOS.getUsername()),
+        UserStatus.DEPROVISIONED);
+    assertEquals(
+        _repo.getAllUsersWithStatusForOrganization(ABC).get(BRAD.getUsername()), UserStatus.ACTIVE);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -339,10 +339,10 @@ class DemoOktaRepositoryTest {
         true);
     _repo.setUserIsActive(AMOS.getUsername(), false);
     assertEquals(
-        _repo.getAllUsersWithStatusForOrganization(ABC).get(AMOS.getUsername()),
-        UserStatus.DEPROVISIONED);
+        UserStatus.DEPROVISIONED,
+        _repo.getAllUsersWithStatusForOrganization(ABC).get(AMOS.getUsername()));
     assertEquals(
-        _repo.getAllUsersWithStatusForOrganization(ABC).get(BRAD.getUsername()), UserStatus.ACTIVE);
+        UserStatus.ACTIVE, _repo.getAllUsersWithStatusForOrganization(ABC).get(BRAD.getUsername()));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -238,7 +237,6 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
         activeUserEmails,
         List.of(
             "allfacilities@example.com", "nofacilities@example.com", "somefacilities@example.com"));
-    assertThat(activeUserEmails.contains("otherorgfacilities@example.com")).isFalse();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -216,26 +217,28 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Test
   @WithSimpleReportSiteAdminUser
-  void getAllActiveUsersByOrganization_success() {
+  void getAllUsersByOrganization_success() {
     Organization org = _dataFactory.createValidOrg();
     _dataFactory.createValidApiUser("allfacilities@example.com", org);
     _dataFactory.createValidApiUser("nofacilities@example.com", org);
     UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
-    // delete a user
     _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
-    // create another org with a user
+
     Organization differentOrg = _dataFactory.createValidOrg("other org", "k12", "OTHER_ORG", true);
     _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
 
     List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
-    assertEquals(2, activeUsers.size());
+    assertEquals(3, activeUsers.size());
     List<String> activeUserEmails =
         activeUsers.stream()
             .map(activeUser -> activeUser.getLoginEmail())
             .sorted()
             .collect(Collectors.toList());
     assertEquals(
-        activeUserEmails, List.of("allfacilities@example.com", "nofacilities@example.com"));
+        activeUserEmails,
+        List.of(
+            "allfacilities@example.com", "nofacilities@example.com", "somefacilities@example.com"));
+    assertThat(activeUserEmails.contains("otherorgfacilities@example.com")).isFalse();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -9,15 +9,18 @@ import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import gov.cdc.usds.simplereport.service.model.UserInfo;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
@@ -28,6 +31,9 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Autowired ApiUserRepository _apiUserRepo;
   @Autowired OktaRepository _oktaRepo;
+
+  @Autowired OrganizationService _organizationService;
+  @Autowired private TestDataFactory _dataFactory;
 
   // The next several retrieval tests expect the demo users as they are defined in the
   // no-security and no-okta-mgmt profiles
@@ -206,6 +212,30 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
             () -> _service.createUserInCurrentOrg("captain@pirate.com", personName, Role.USER));
 
     assertEquals("Unable to add user.", caught.getMessage());
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getAllActiveUsersByOrganization_success() {
+    Organization org = _dataFactory.createValidOrg();
+    _dataFactory.createValidApiUser("allfacilities@example.com", org);
+    _dataFactory.createValidApiUser("nofacilities@example.com", org);
+    UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
+    // delete a user
+    _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
+    // create another org with a user
+    Organization differentOrg = _dataFactory.createValidOrg("other org", "k12", "OTHER_ORG", true);
+    _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
+
+    List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
+    assertEquals(2, activeUsers.size());
+    List<String> activeUserEmails =
+        activeUsers.stream()
+            .map(activeUser -> activeUser.getLoginEmail())
+            .sorted()
+            .collect(Collectors.toList());
+    assertEquals(
+        activeUserEmails, List.of("allfacilities@example.com", "nofacilities@example.com"));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -194,6 +194,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
     Set<Facility> archivedFacilities = _service.getFacilitiesIncludeArchived(org, true);
 
+    assertEquals(1, archivedFacilities.size());
     assertTrue(
         archivedFacilities.stream()
             .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.test_util;
 
+import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
@@ -48,7 +49,9 @@ import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
 import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
+import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.DiseaseService;
+import gov.cdc.usds.simplereport.service.model.UserInfo;
 import gov.cdc.usds.simplereport.service.model.reportstream.FeedbackMessage;
 import java.lang.reflect.Array;
 import java.time.LocalDate;
@@ -98,6 +101,8 @@ public class TestDataFactory {
   @Autowired private ResultRepository _resultRepository;
   @Autowired private DemoOktaRepository _oktaRepo;
   @Autowired private TestResultUploadRepository _testResultUploadRepo;
+
+  @Autowired private ApiUserService _apiUserService;
   @Autowired private DiseaseService _diseaseService;
 
   public Organization createValidOrg(
@@ -113,6 +118,11 @@ public class TestDataFactory {
 
   public Organization createUnverifiedOrg() {
     return createValidOrg("The Plaza", "k12", ALT_ORG_ID, false);
+  }
+
+  public UserInfo createValidApiUser(String username, Organization org) {
+    PersonName name = new PersonName("John", null, "June", null);
+    return _apiUserService.createUser(username, name, org.getExternalId(), Role.USER);
   }
 
   public OrganizationQueueItem createOrganizationQueueItem(


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Resolves #3725 

## Changes Proposed

This PR removes the following manual steps that folks responding to support requests to delete organizations had to after running the `markOrganizationAsDeleted` mutation:
- deleting facilities associated with the deleted organization
- deleting users associated with the deleted organization

## Additional Information
- Will be updating the support docs once this goes in: https://github.com/cdcent/simplereport_docs/wiki/Support-requests

## Testing
- This code has been deployed to dev4 to test
- Have an undeleted verified org with facilities and users
- [Have an API testing tool setup](https://github.com/CDCgov/prime-simplereport/wiki/API-Testing-with-Insomnia)
- Easiest way to get the organization id for an org you want to delete is 
```
query {
	whoami {
		organization {
			id 
			name
		}
	}
}
```
- replace [ORGANIZATION_ID] with the org you want to delete
```
mutation {
	markOrganizationAsDeleted(
			organizationId: [ORGANIZATION_ID],
			deleted: false)
}
```
- Ensure you can delete and undelete the orgs and its associated facilities and users

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
