### PR TITLE
Exclude MSDB from email field. (They are a valid user!)

### DIFF
--- a/ops/services/web_application_firewall/main.tf
+++ b/ops/services/web_application_firewall/main.tf
@@ -160,6 +160,12 @@ resource "azurerm_web_application_firewall_policy" "sr_waf_policy" {
       selector_match_operator = "Contains"
     }
 
+    exclusion {
+      match_variable          = "RequestArgNames"
+      selector                = "variables.email"
+      selector_match_operator = "Contains"
+    }
+
     managed_rule_set {
       type    = "OWASP"
       version = "3.2"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Addresses a support request from the Montana School for the Deaf and Blind (MSDB).

## Changes Proposed

- Exclude WAF enforcement of the email field.

## Additional Information

- MSDB shares an email domain with a common database provider denotation. This causes the WAF to panic, thinking that there is an ongoing attack. Short of asking the requester to change their email domain, excluding this field from WAF evaluation is the least impactful change to our security stance.

## Testing

- Emails with the MSDB domain should be able to process normally.


## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed