### PR TITLE
Close orphaned connection in ReminderServiceTest.

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -119,5 +119,6 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
     PreparedStatement statement = conn.prepareStatement(query);
     statement.setObject(1, queuedOrg.getInternalId());
     statement.execute();
+    conn.close();
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Found during debugging for #4662.

## Changes Proposed

- Close a connection that is triggering a leak by adding an explicit `close` call.

## Additional Information

- During a debugging session, with Hikari leak detection active, the associated method was found to be leaking connections. Although the method is transactional, it deals with manual JPA manipulations, so we are responsible for closing things when complete.

## Testing

- Passing unit tests should take care of the testing effort. No additional effort is needed. For those who are curious, however, leak detection can be turned on, `TRACE`-level debugging in Hikari can be activated, and the associated logs for ReminderServiceTest can be analyzed.
