### PR TITLE
Strip invalid whitespace characters from patient/facility data fields

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
@@ -79,7 +79,7 @@ public final class AzureStorageQueueTestEventReportingService implements TestEve
 
   private String toBuffer(TestEvent testEvent) {
     try {
-      return mapper.writeValueAsString(new TestEventExport(testEvent));
+      return mapper.writeValueAsString(new TestEventExport(testEvent)).replaceAll("\\p{Z}", "");
     } catch (IOException e) {
       throw new TestEventSerializationFailureException(
           testEvent.getInternalId(), e.getCause().getMessage());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
@@ -81,7 +81,7 @@ public final class AzureStorageQueueTestEventReportingService implements TestEve
     try {
       return mapper
           .writeValueAsString(new TestEventExport(testEvent))
-          .replaceAll("\\p{Zl}|\\p{Zp}", "");
+          .replaceAll("[\u2028\u2029]", "");
     } catch (IOException e) {
       throw new TestEventSerializationFailureException(
           testEvent.getInternalId(), e.getCause().getMessage());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
@@ -79,7 +79,9 @@ public final class AzureStorageQueueTestEventReportingService implements TestEve
 
   private String toBuffer(TestEvent testEvent) {
     try {
-      return mapper.writeValueAsString(new TestEventExport(testEvent)).replaceAll("\\p{Z}", "");
+      return mapper
+          .writeValueAsString(new TestEventExport(testEvent))
+          .replaceAll("\\p{Zl}|\\p{Zp}", "");
     } catch (IOException e) {
       throw new TestEventSerializationFailureException(
           testEvent.getInternalId(), e.getCause().getMessage());


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Closes #4296 

## Changes Proposed
- Certain whitespace characters (namely, `line separator` and `paragraph separator`) could exist in patient or facility data fields
    - Proliferated by copy + paste, either via the UI or directly in a patient upload CSV
- The presence of these characters would lead to failures when submitting test results to ReportStream
- We had hoped that Jackson would provide an easy way to account for these characters through some configuration option for JSON serialization
    - This doesn't seem to be the case: see this [open issue](https://github.com/FasterXML/jackson-core/issues/473) in the `jackson-core` repository
- Instead, we'll do this the dumb way: simple perform a string replacement operation on the serialized JSON string

## Testing
- The tester identified an existing item in the `dev3` `error-queue`
- This event has been unable to be reported due to the aforementioned problematic whitespace characters
- This branch was deployed to `dev3`
- With these changes present, another test result was submitted via the UI using the data from the event in the `error-queue`
- Logs confirmed that this event was successfully reported:
- <img width="623" alt="Screen Shot 2022-12-15 at 12 37 05 PM" src="https://user-images.githubusercontent.com/27730981/207940071-41e290bb-bfd2-4807-848c-f3e671e9b78f.png">

## Feedback requested
- The chosen method of basic string replacement feels inelegant, but does anyone have an concrete concerns about this approach?
- Are there any other characters, whitespace or otherwise, we would like to account for in this manner?