### PR TITLE
remove the facility_device_specimen_type table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4132,3 +4132,32 @@ databaseChangeLog:
       rollback:
         - dropIndex:
             indexName: ix__patient_link__created_at
+  - changeSet:
+      id: drop-facility_device_specimen_type-table
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: drop-facility_device_specimen_type-table
+        - dropTable:
+            tableName: facility_device_specimen_type
+      rollback:
+        - createTable:
+            tableName: facility_device_specimen_type
+            remarks: Many-to-many table for device/specimen configuration at a facility.
+            columns:
+              - column:
+                  name: facility_id
+                  remarks: A facility at which this device/specimen combination is used.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_specimen_type__facility
+                    references: facility
+              - column:
+                  name: device_specimen_type_id
+                  remarks: A device/specimen combination that is allowed to be used at the facility.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_specimen_type__device_specimen_type
+                    references: device_specimen_type


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352 

## Changes Proposed

- Remove unused facility_device_specimen_type table

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
