### PR TITLE
Update SSL bindings in Terraform.

### DIFF
--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -27,7 +27,7 @@ data "azurerm_subnet" "app_gateways" {
 
 data "azurerm_key_vault_certificate" "wildcard_simplereport_gov" {
   key_vault_id = data.azurerm_key_vault.global.id
-  name         = "wildcard-simplereport-gov"
+  name         = "new-sr-wildcard"
 }
 
 data "azurerm_key_vault_certificate" "simplereport_cdc_gov" {

--- a/ops/services/app_gateway/_data.tf
+++ b/ops/services/app_gateway/_data.tf
@@ -1,4 +1,4 @@
 data "azurerm_key_vault_certificate" "wildcard_simplereport_gov" {
   key_vault_id = var.key_vault_id
-  name         = "wildcard-simplereport-gov"
+  name         = "new-sr-wildcard"
 }

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -175,7 +175,7 @@ resource "azurerm_app_service_slot_virtual_network_swift_connection" "staging" {
 
   WHAT'S HAPPENING HERE:
 
-  1) The wildcard-simplereport-gov cert is being imported from Key Vault into the App Service
+  1) The new-sr-wildcard cert is being imported from Key Vault into the App Service
     [NOTE: This only takes place if this is the first environment being created in this environment level. Cert ownership is bound to the index-less environment!]
   2) That cert is being bound to the custom domain created above, enabling HTTPS
 */


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves SSL renewal issues with Akamai.

## Changes Proposed

- Points existing environments to newly-created SSL certificate containing full trust chain.

## Additional Information

- For the curious, the cause of the current issue is that Entrust, our Certificate Authority, issued us a bundle of certificates, including the leaf and intermediate trust chain. Azure only accepts a single leaf certificate upon renewal without a private key. Conveniently, Azure also obfuscates this private key, which makes it nearly impossible to actually get it back...and that private key is essential for securely joining the certificates in the bundle together for upload. Because of this process, we've lost the intermediate part of the chain bundle in this new certificate.
- To create a fix, we were able to extract the private key from the incomplete certificate chain, reconstitute the chain in the proper order, re-sign the certificate with the existing private key, and push it to a new certificate in Azure. The old certificate exists as a backup, and can be switched back to on a revert if this version fails during the merge process.

## Testing

- Unfortunately, there is no verification to be done unless you claim `dev5`, `dev6`, or `dev7`. I have tested this on `dev3` and `dev4`, and have confirmed fixes there, but, with this being an infrastructure change, there is very little we can do to verify further.