### PR TITLE
Make DemoOktaRepository::DuplicateUserError a static class (per Fortify)

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -328,7 +328,7 @@ public class DemoOktaRepository implements OktaRepository {
 
   // Dummy error for duplicate users.
   // Status, code, and message taken from a real Okta exception.
-  private class DuplicateUserError implements Error {
+  private static class DuplicateUserError implements Error {
 
     public int getStatus() {
       return HttpStatus.BAD_REQUEST.value();


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
-  Closes #3376 

## Changes Proposed
- Make DemoOktaRepository::DuplicateUserError a static class

## Additional Information
- Really gonna have to hang on to your hats for this one, people.

## Testing
- Just click the Approve button, you know you want to.