### PR TITLE
Update ordering provider NPI field label & error message

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/OrderingProvider.tsx
+++ b/frontend/src/app/Settings/Facility/Components/OrderingProvider.tsx
@@ -93,7 +93,7 @@ const OrderingProvider: React.FC<Props> = ({
           onChange={onChange}
         />
         <TextInput
-          label="NPI"
+          label="National Provider Identifier (NPI)"
           hintText={
             <a
               href="https://npiregistry.cms.hhs.gov/"

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -585,7 +585,8 @@ describe("FacilityForm", () => {
         userEvent.clear(npiInput);
         userEvent.tab();
 
-        const expectedError = "Ordering provider NPI is incorrectly formatted";
+        const expectedError =
+          "NPI should be a 10-digit numerical value (##########)";
 
         // The mock function was called at least once
         expect(spy.mock.calls.length).toBeGreaterThan(0);
@@ -620,7 +621,8 @@ describe("FacilityForm", () => {
         userEvent.type(npiInput, "Facility name");
         userEvent.tab();
 
-        const expectedError = "Ordering provider NPI is incorrectly formatted";
+        const expectedError =
+          "NPI should be a 10-digit numerical value (##########)";
         // The mock function was called at least once
         expect(spy.mock.calls.length).toBeGreaterThan(0);
         expect(

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -41,7 +41,9 @@ function isValidNpi(
 type RequiredProviderFields = Nullable<Partial<Provider>>;
 
 const orderingProviderFormatError = (field: string) =>
-  `Ordering provider ${field} is incorrectly formatted`;
+  field === "NPI"
+    ? "NPI should be a 10-digit numerical value (##########)"
+    : `Ordering provider ${field} is incorrectly formatted`;
 
 const providerSchema: yup.SchemaOf<RequiredProviderFields> = yup.object({
   firstName: yup


### PR DESCRIPTION
## Related Issue

- Closes #4545 

## Changes Proposed
- Change ordering provider NPI field label
    - `NPI` -> `National Provider Identifier (NPI)`
- Change ordering provider NPI error message copy
    - `Ordering provider NPI is incorrectly formatted` -> `NPI should be a 10-digit numerical value (##########)`

## Additional Information
- N/A

## Testing
https://user-images.githubusercontent.com/27730981/208714631-06d2387f-9358-4df9-8cf7-675ec316ddc2.mov