### PR TITLE
stop building image for e2e tests

### DIFF
--- a/.github/workflows/e2eLocal.yml
+++ b/.github/workflows/e2eLocal.yml
@@ -85,7 +85,8 @@ jobs:
       run: |
         echo "::group::Run Cypress locally"
         docker compose pull
-        docker-compose -f docker-compose.yml -f docker-compose.cypress.yml build
+#        Uncomment to build a new image
+#        docker-compose -f docker-compose.yml -f docker-compose.cypress.yml build
         docker-compose -f docker-compose.yml -f docker-compose.cypress.yml up --abort-on-container-exit --exit-code-from cypress
         echo "::endgroup::"
     

--- a/.github/workflows/e2eLocal.yml
+++ b/.github/workflows/e2eLocal.yml
@@ -82,11 +82,11 @@ jobs:
         REACT_APP_OKTA_ENABLED: "true"
         REACT_APP_DISABLE_MAINTENANCE_BANNER: "true"
       shell: bash
+      # To build a new image add this before docker-compose up
+      # docker-compose -f docker-compose.yml -f docker-compose.cypress.yml build
       run: |
         echo "::group::Run Cypress locally"
         docker compose pull
-#        Uncomment to build a new image
-#        docker-compose -f docker-compose.yml -f docker-compose.cypress.yml build
         docker-compose -f docker-compose.yml -f docker-compose.cypress.yml up --abort-on-container-exit --exit-code-from cypress
         echo "::endgroup::"
     

--- a/lighthouse.sh
+++ b/lighthouse.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 docker compose pull
-docker-compose -f docker-compose.yml -f docker-compose.ci.yml build
+#Uncomment to build a new image
+#docker-compose -f docker-compose.yml -f docker-compose.ci.yml build
 docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 
 echo "Waiting for backend to start at https://localhost.simplereport.gov/api/health"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #4641 

## Changes Proposed

- Remove the command used to build the image for e2e tests in order to speed up e2e tests.

## Additional Information


## Testing

- E2E tests still work