### PR TITLE
Find Okta users by unique login instead of email

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -393,7 +393,8 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public UserStatus getUserStatus(String username) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot retrieve Okta user's status with unrecognized username");
     User user = users.single();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -530,13 +530,14 @@ public class LiveOktaRepository implements OktaRepository {
   public Optional<OrganizationRoleClaims> getOrganizationRoleClaimsForUser(String username) {
     // When a site admin is using tenant data access, bypass okta and get org from the altered
     // authorities.  If the site admin is getting the claims for another site admin who also has
-    // active tenant data access, the reflect what is in Okta, not the temporary claims.
+    // active tenant data access, then reflect what is in Okta, not the temporary claims.
     if (_tenantDataContextHolder.hasBeenPopulated()
         && username.equals(_tenantDataContextHolder.getUsername())) {
       return getOrganizationRoleClaimsFromAuthorities(_tenantDataContextHolder.getAuthorities());
     }
 
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot get org external ID for nonexistent user");
     User user = users.single();
     return getOrganizationRoleClaimsForUser(user);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -204,7 +204,7 @@ public class LiveOktaRepository implements OktaRepository {
     Group orgDefaultOktaGroup = getDefaultOktaGroup(org);
 
     return orgDefaultOktaGroup.listUsers().stream()
-        .map(u -> u.getProfile().getEmail())
+        .map(u -> u.getProfile().getLogin())
         .collect(Collectors.toUnmodifiableSet());
   }
 
@@ -212,7 +212,7 @@ public class LiveOktaRepository implements OktaRepository {
     Group orgDefaultOktaGroup = getDefaultOktaGroup(org);
 
     return orgDefaultOktaGroup.listUsers().stream()
-        .collect(Collectors.toMap(u -> u.getProfile().getEmail(), User::getStatus));
+        .collect(Collectors.toMap(u -> u.getProfile().getLogin(), User::getStatus));
   }
 
   private Group getDefaultOktaGroup(Organization org) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -227,7 +227,8 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public Optional<OrganizationRoleClaims> updateUser(IdentityAttributes userIdentity) {
-    UserList users = _client.listUsers(userIdentity.getUsername(), null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + userIdentity.getUsername() + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot update Okta user with unrecognized username");
     User user = users.single();
     updateUser(user, userIdentity);
@@ -247,7 +248,8 @@ public class LiveOktaRepository implements OktaRepository {
 
   public Optional<OrganizationRoleClaims> updateUserEmail(
       IdentityAttributes userIdentity, String email) {
-    UserList users = _client.listUsers(userIdentity.getUsername(), null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + userIdentity.getUsername() + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot update email of Okta user with unrecognized username");
     User user = users.single();
@@ -261,7 +263,8 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void reprovisionUser(IdentityAttributes userIdentity) {
-    UserList users = _client.listUsers(userIdentity.getUsername(), null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + userIdentity.getUsername() + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reprovision Okta user with unrecognized username");
     User user = users.single();
     UserStatus userStatus = user.getStatus();
@@ -287,7 +290,8 @@ public class LiveOktaRepository implements OktaRepository {
 
   public Optional<OrganizationRoleClaims> updateUserPrivileges(
       String username, Organization org, Set<Facility> facilities, Set<OrganizationRole> roles) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot update role of Okta user with unrecognized username");
     User user = users.single();
 
@@ -365,7 +369,8 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void resetUserPassword(String username) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot reset password for Okta user with unrecognized username");
     User user = users.single();
@@ -373,14 +378,16 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void resetUserMfa(String username) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reset MFA for Okta user with unrecognized username");
     User user = users.single();
     user.resetFactors();
   }
 
   public void setUserIsActive(String username, Boolean active) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot update active status of Okta user with unrecognized username");
     User user = users.single();
@@ -402,14 +409,16 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void reactivateUser(String username) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reactivate Okta user with unrecognized username");
     User user = users.single();
     user.unsuspend();
   }
 
   public void resendActivationEmail(String username) {
-    UserList users = _client.listUsers(username, null, null, null, null);
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
+    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reactivate Okta user with unrecognized username");
     User user = users.single();
     if (user.getStatus() == UserStatus.PROVISIONED) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -227,8 +227,9 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public Optional<OrganizationRoleClaims> updateUser(IdentityAttributes userIdentity) {
-    String loginSearchTerm = "profile.login eq \"" + userIdentity.getUsername() + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users =
+        _client.listUsers(
+            null, null, generateLoginSearchTerm(userIdentity.getUsername()), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot update Okta user with unrecognized username");
     User user = users.single();
     updateUser(user, userIdentity);
@@ -248,8 +249,9 @@ public class LiveOktaRepository implements OktaRepository {
 
   public Optional<OrganizationRoleClaims> updateUserEmail(
       IdentityAttributes userIdentity, String email) {
-    String loginSearchTerm = "profile.login eq \"" + userIdentity.getUsername() + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users =
+        _client.listUsers(
+            null, null, generateLoginSearchTerm(userIdentity.getUsername()), null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot update email of Okta user with unrecognized username");
     User user = users.single();
@@ -263,8 +265,9 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void reprovisionUser(IdentityAttributes userIdentity) {
-    String loginSearchTerm = "profile.login eq \"" + userIdentity.getUsername() + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users =
+        _client.listUsers(
+            null, null, generateLoginSearchTerm(userIdentity.getUsername()), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reprovision Okta user with unrecognized username");
     User user = users.single();
     UserStatus userStatus = user.getStatus();
@@ -290,8 +293,7 @@ public class LiveOktaRepository implements OktaRepository {
 
   public Optional<OrganizationRoleClaims> updateUserPrivileges(
       String username, Organization org, Set<Facility> facilities, Set<OrganizationRole> roles) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot update role of Okta user with unrecognized username");
     User user = users.single();
 
@@ -369,8 +371,7 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void resetUserPassword(String username) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot reset password for Okta user with unrecognized username");
     User user = users.single();
@@ -378,16 +379,14 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void resetUserMfa(String username) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reset MFA for Okta user with unrecognized username");
     User user = users.single();
     user.resetFactors();
   }
 
   public void setUserIsActive(String username, Boolean active) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot update active status of Okta user with unrecognized username");
     User user = users.single();
@@ -400,8 +399,7 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public UserStatus getUserStatus(String username) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot retrieve Okta user's status with unrecognized username");
     User user = users.single();
@@ -409,16 +407,14 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public void reactivateUser(String username) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reactivate Okta user with unrecognized username");
     User user = users.single();
     user.unsuspend();
   }
 
   public void resendActivationEmail(String username) {
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot reactivate Okta user with unrecognized username");
     User user = users.single();
     if (user.getStatus() == UserStatus.PROVISIONED) {
@@ -545,8 +541,7 @@ public class LiveOktaRepository implements OktaRepository {
       return getOrganizationRoleClaimsFromAuthorities(_tenantDataContextHolder.getAuthorities());
     }
 
-    String loginSearchTerm = "profile.login eq \"" + username + "\"";
-    UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
+    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
     throwErrorIfEmpty(users.stream(), "Cannot get org external ID for nonexistent user");
     User user = users.single();
     return getOrganizationRoleClaimsForUser(user);
@@ -605,6 +600,10 @@ public class LiveOktaRepository implements OktaRepository {
 
   private String generateFacilitySuffix(String facilityId) {
     return ":" + OrganizationExtractor.FACILITY_ACCESS_MARKER + ":" + facilityId;
+  }
+
+  private String generateLoginSearchTerm(String username) {
+    return "profile.login eq \"" + username + "\"";
   }
 
   private void throwErrorIfEmpty(Stream<?> stream, String errorMessage) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -393,7 +393,7 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   public UserStatus getUserStatus(String username) {
-    String loginSearchTerm = "login eq \"" + username + "\"";
+    String loginSearchTerm = "profile.login eq \"" + username + "\"";
     UserList users = _client.listUsers(null, null, loginSearchTerm, null, null);
     throwErrorIfEmpty(
         users.stream(), "Cannot retrieve Okta user's status with unrecognized username");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -85,7 +85,7 @@ class LiveOktaRepositoryTest {
     GroupProfile groupProfile3 = mock(GroupProfile.class);
     GroupProfile groupProfile4 = mock(GroupProfile.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(null, null, "profile.login eq \"" + username + "\"", null, null)).thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.listGroups()).thenReturn(groupList);
@@ -153,7 +153,8 @@ class LiveOktaRepositoryTest {
     Group group1 = mock(Group.class);
     GroupProfile groupProfile1 = mock(GroupProfile.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getProfile()).thenReturn(userProfile);
@@ -186,7 +187,8 @@ class LiveOktaRepositoryTest {
     Group group1 = mock(Group.class);
     GroupProfile groupProfile1 = mock(GroupProfile.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getProfile()).thenReturn(userProfile);
@@ -210,7 +212,8 @@ class LiveOktaRepositoryTest {
 
     UserList userList = mock(UserList.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of());
 
     Throwable caught =
@@ -227,7 +230,8 @@ class LiveOktaRepositoryTest {
 
     UserList userList = mock(UserList.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of());
 
     Throwable caught =
@@ -247,7 +251,8 @@ class LiveOktaRepositoryTest {
     User user = mock(User.class);
     UserProfile userProfile = mock(UserProfile.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getStatus()).thenReturn(UserStatus.SUSPENDED);
@@ -270,7 +275,8 @@ class LiveOktaRepositoryTest {
     UserList userList = mock(UserList.class);
     User user = mock(User.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -290,7 +296,8 @@ class LiveOktaRepositoryTest {
 
     UserList userList = mock(UserList.class);
 
-    when(_client.listUsers(username, null, null, null, null)).thenReturn(userList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of());
 
     IdentityAttributes identityAttributes = new IdentityAttributes(username, personName);
@@ -446,7 +453,7 @@ class LiveOktaRepositoryTest {
     when(mockGroup.listUsers()).thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUser.getProfile()).thenReturn(mockUserProfile);
-    when(mockUserProfile.getEmail()).thenReturn("email@example.com");
+    when(mockUserProfile.getLogin()).thenReturn("email@example.com");
 
     var actual = _repo.getAllUsersForOrganization(org);
     assertEquals(Set.of("email@example.com"), actual);
@@ -486,7 +493,7 @@ class LiveOktaRepositoryTest {
     when(mockGroup.listUsers()).thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUser.getProfile()).thenReturn(mockUserProfile);
-    when(mockUserProfile.getEmail()).thenReturn("email@example.com");
+    when(mockUserProfile.getLogin()).thenReturn("email@example.com");
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
 
     var actual = _repo.getAllUsersWithStatusForOrganization(org);
@@ -508,8 +515,8 @@ class LiveOktaRepositoryTest {
     var mockFullGroupList = mock(GroupList.class);
     var mockAdminGroup = mock(Group.class);
     var mockAdminGroupProfile = mock(GroupProfile.class);
-    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.listGroups()).thenReturn(mockGroupList);
@@ -539,8 +546,8 @@ class LiveOktaRepositoryTest {
     var org = new Organization("orgName", "orgType", "1", true);
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -560,7 +567,7 @@ class LiveOktaRepositoryTest {
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
     var mockGroupProfile = mock(GroupProfile.class);
-    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
@@ -593,8 +600,8 @@ class LiveOktaRepositoryTest {
     var mockGroupProfile = mock(GroupProfile.class);
     var mockEmptyGroupList = mock(GroupList.class);
 
-    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.listGroups()).thenReturn(mockGroupList);
@@ -629,8 +636,8 @@ class LiveOktaRepositoryTest {
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
     var mockGroupProfile = mock(GroupProfile.class);
-    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.listGroups()).thenReturn(mockGroupList);
@@ -648,8 +655,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
 
@@ -662,8 +669,8 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -679,8 +686,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
 
@@ -693,8 +700,8 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -708,8 +715,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -725,8 +732,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.SUSPENDED);
@@ -742,8 +749,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -758,8 +765,8 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -775,8 +782,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -789,8 +796,8 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -805,8 +812,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
 
@@ -819,8 +826,8 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -834,8 +841,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.PROVISIONED);
@@ -850,8 +857,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.STAGED);
@@ -865,8 +872,8 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -882,8 +889,8 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(eq(username), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockUserList);
+    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+            .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -85,7 +85,8 @@ class LiveOktaRepositoryTest {
     GroupProfile groupProfile3 = mock(GroupProfile.class);
     GroupProfile groupProfile4 = mock(GroupProfile.class);
 
-    when(_client.listUsers(null, null, "profile.login eq \"" + username + "\"", null, null)).thenReturn(userList);
+    when(_client.listUsers(null, null, "profile.login eq \"" + username + "\"", null, null))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.listGroups()).thenReturn(groupList);
@@ -153,8 +154,9 @@ class LiveOktaRepositoryTest {
     Group group1 = mock(Group.class);
     GroupProfile groupProfile1 = mock(GroupProfile.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getProfile()).thenReturn(userProfile);
@@ -187,8 +189,9 @@ class LiveOktaRepositoryTest {
     Group group1 = mock(Group.class);
     GroupProfile groupProfile1 = mock(GroupProfile.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getProfile()).thenReturn(userProfile);
@@ -212,8 +215,9 @@ class LiveOktaRepositoryTest {
 
     UserList userList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of());
 
     Throwable caught =
@@ -230,8 +234,9 @@ class LiveOktaRepositoryTest {
 
     UserList userList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of());
 
     Throwable caught =
@@ -251,8 +256,9 @@ class LiveOktaRepositoryTest {
     User user = mock(User.class);
     UserProfile userProfile = mock(UserProfile.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getStatus()).thenReturn(UserStatus.SUSPENDED);
@@ -275,8 +281,9 @@ class LiveOktaRepositoryTest {
     UserList userList = mock(UserList.class);
     User user = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of(user));
     when(userList.single()).thenReturn(user);
     when(user.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -296,8 +303,9 @@ class LiveOktaRepositoryTest {
 
     UserList userList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(userList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(userList);
     when(userList.stream()).thenReturn(Stream.of());
 
     IdentityAttributes identityAttributes = new IdentityAttributes(username, personName);
@@ -515,8 +523,9 @@ class LiveOktaRepositoryTest {
     var mockFullGroupList = mock(GroupList.class);
     var mockAdminGroup = mock(Group.class);
     var mockAdminGroupProfile = mock(GroupProfile.class);
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.listGroups()).thenReturn(mockGroupList);
@@ -546,8 +555,9 @@ class LiveOktaRepositoryTest {
     var org = new Organization("orgName", "orgType", "1", true);
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -567,7 +577,8 @@ class LiveOktaRepositoryTest {
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
     var mockGroupProfile = mock(GroupProfile.class);
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
@@ -600,8 +611,9 @@ class LiveOktaRepositoryTest {
     var mockGroupProfile = mock(GroupProfile.class);
     var mockEmptyGroupList = mock(GroupList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.listGroups()).thenReturn(mockGroupList);
@@ -636,8 +648,9 @@ class LiveOktaRepositoryTest {
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
     var mockGroupProfile = mock(GroupProfile.class);
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.listGroups()).thenReturn(mockGroupList);
@@ -655,8 +668,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
 
@@ -669,8 +683,9 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -686,8 +701,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
 
@@ -700,8 +716,9 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -715,8 +732,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -732,8 +750,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.SUSPENDED);
@@ -749,8 +768,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -765,8 +785,9 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -782,8 +803,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
@@ -796,8 +818,9 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -812,8 +835,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
 
@@ -826,8 +850,9 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -841,8 +866,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.PROVISIONED);
@@ -857,8 +883,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.STAGED);
@@ -872,8 +899,9 @@ class LiveOktaRepositoryTest {
     var username = "fraud@example.com";
     var mockUserList = mock(UserList.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
     Throwable caught =
@@ -889,8 +917,9 @@ class LiveOktaRepositoryTest {
     var mockUserList = mock(UserList.class);
     var mockUser = mock(User.class);
 
-    when(_client.listUsers(isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
-            .thenReturn(mockUserList);
+    when(_client.listUsers(
+            isNull(), isNull(), eq("profile.login eq \"" + username + "\""), isNull(), isNull()))
+        .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUserList.single()).thenReturn(mockUser);
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Support reported an issue where user would get the default error page when they tried to view the settings page. It turns out the user had created a new account with a login username and primary email equal to the primary email on another account. When two users in the same org have the same primary email, our users with status query will fail because we assume primary emails are unique when this is not enforced. When a user's login username and primary email don't match, many of our user-related queries/mutations fail because we assume login username and email are equivalent and so we query Okta for users with emails matching their username from the ApiUsers table.

## Changes Proposed

* when getting Okta users matching a username, use search against `login` (Username) field instead of `email`
* when getting API Users matching an Okta user, look for matches in our table based on Okta `login` field instead of `email`

## Additional Information

* list users request parameters: https://developer.okta.com/docs/reference/api/users/#request-parameters-3
* primary emails can be changed in the Okta UI and do not need to be unique. the login field is unique and this is enforced in the Okta UI

## Testing
deployed to `dev3`
Update a user's primary email in Okta to equal the primary email of another user, then view the Manage users page and click on both users to view their info. Update their permissions or other info and verify the mutations succeed.
Update a user in Okta to have a different primary email from their login email. Verify you can still successfully run user queries and mutations.

## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Changes comply with the SimpleReport Style Guide