### PR TITLE
Deprecated tag cleanup

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -22,21 +22,9 @@ import org.springframework.data.jpa.repository.Query;
  */
 public interface TestEventRepository
     extends AuditedEntityRepository<TestEvent>, JpaSpecificationExecutor<TestEvent> {
-  @Deprecated
-  /** @deprecated (for sonar) */
   @Query("FROM #{#entityName} e WHERE e.patient = :p and e.facility in :facilities")
   List<TestEvent> findAllByPatientAndFacilities(Person p, Collection<Facility> facilities);
 
-  @Deprecated
-  /** @deprecated (for sonar) */
-  List<TestEvent> findAllByOrganizationOrderByCreatedAtDesc(Organization o);
-
-  @Deprecated
-  /** @deprecated (for sonar) */
-  List<TestEvent> findAllByOrganizationAndFacility(Organization o, Facility f);
-
-  @Deprecated
-  /** @deprecated (for sonar) */
   TestEvent findFirst1ByPatientOrderByCreatedAtDesc(Person p);
 
   @Query(
@@ -47,13 +35,18 @@ public interface TestEventRepository
       nativeQuery = true)
   List<TestEvent> findLastTestsByPatient(Collection<UUID> patientIds);
 
-  @Deprecated
-  /** @deprecated (for sonar) */
   @EntityGraph(attributePaths = {"patient", "order"})
   TestEvent findByOrganizationAndInternalId(Organization o, UUID id);
 
-  @Deprecated
-  /** @deprecated (for sonar) */
+  /**
+   * This query seems to only be used it unit tests - and based on comments we should not use it
+   * outside of that context
+   *
+   * @param begin
+   * @param end
+   * @param p
+   * @return TestEvents
+   */
   // Need to control how this query is built. "between" is too vague.
   // This is across all Orgs/facilities because datahub uploader users
   @Query(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestEventService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestEventService.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.service;
 
-import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
@@ -18,10 +17,5 @@ public class TestEventService {
 
   public TestEvent getLastTestResultsForPatient(Person patient) {
     return _terepo.findFirst1ByPatientOrderByCreatedAtDesc(patient);
-  }
-
-  @AuthorizationConfiguration.RequirePermissionStartTestForPatient
-  public TestEvent getLastTestResultsForPatientPermRestricted(Person patient) {
-    return getLastTestResultsForPatient(patient);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
#3385 

A number of functions were marked as deprecated incorrectly.  Others were unused and were removed.

## Changes Proposed

- Remove incorrect deprecation tags and remove unused code

## Additional Information

- deployed on dev3

## Testing

- regression test

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
