### PR TITLE
Alert update

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -72,6 +72,11 @@ variable "http_2xx_failure_rate_threshold" {
   default = 1
 }
 
+variable "http_2xx_failed_threshold" {
+  // The resource that uses this value doesn't have a >= check, so we need n - 1 here
+  default = 24
+}
+
 variable "skip_on_weekends" {
   default = false
 }

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -88,9 +88,13 @@ ${local.skip_on_weekends}
 | where toint(resultCode) between (200 .. 299) and timestamp >= ago(5m)
 | sort by timestamp asc
 | summarize alert = iff((todouble(sumif(1, success == false)) * 100 / todouble(count()) >= ${var.http_2xx_failure_rate_threshold} and sumif(1, success == false) > ${var.http_2xx_failed_threshold}), sumif(1, success == false), 0)
+| where alert > 0
+//
+// You can use the following query to see all the requests that triggered this alert.
+// These comments are ignored but the timestamp is updated correctly and should match the timestamp used in the above query.
 //
 // requests
-// | where toint(resultCode) between (200 .. 299) and timestamp >= ago(60m) and success == false
+// | where toint(resultCode) between (200 .. 299) and timestamp >= ago(5m) and success == false
 // | sort by timestamp asc
   QUERY
 

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -87,8 +87,11 @@ requests
 ${local.skip_on_weekends}
 | where toint(resultCode) between (200 .. 299) and timestamp >= ago(5m)
 | sort by timestamp asc
-| summarize alert = iff((todouble(sumif(1, success == false)) * 100 / todouble(count()) >= ${var.http_2xx_failure_rate_threshold}), 1, 0)
-| where alert == 1
+| summarize alert = iff((todouble(sumif(1, success == false)) * 100 / todouble(count()) >= ${var.http_2xx_failure_rate_threshold} and sumif(1, success == false) > ${var.http_2xx_failed_threshold}), sumif(1, success == false), 0)
+//
+// requests
+// | where toint(resultCode) between (200 .. 299) and timestamp >= ago(60m) and success == false
+// | sort by timestamp asc
   QUERY
 
   trigger {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #4615 

## Changes Proposed

- This PR updates our alert to require a minimum threshold (currently 25) of failing requests and a minimum percentage of requests (currently 1 percent) to fail.
- I've included a modified query that returns the requests that triggered the alert. Hopefully, the comments make its purpose and usage clear.
- The number returned from the alert query now represents the number of requests that matched the criteria to trigger the alert, this way, we immediately know that count. 

**- If 14 requests fail and that's under 1 percent of total requests, the query will return 0 and not alert because of both thresholds.**

**- If 14 requests fail and that's over 1 percent of total requests, the query will return 0 and not alert because of our minimum count threshold.**

**- If 27 requests fail and that's under 1 percent of requests, the query will return 0 and not alert because of our percentage-based threshold.**

**- If 27 requests fail and that's over 1 percent of requests, the query will return 27 and alert.**


## Testing

- I've tested this environment in dev6. Feel free to check the non-prod service group in pagerduty to find the alert. Feel free to use the following to see the alert trigger and requests that triggered it.

```
requests
| where true
| where toint(resultCode) between (200 .. 299) and timestamp >= (datetime(2023-01-10T22:32:46.0000000Z) - 5m)
| sort by timestamp asc
| summarize alert = iff((todouble(sumif(1, success == false)) * 100 / todouble(count()) >= 1 and sumif(1, success == false) > 24), sumif(1, success == false), 0)
| where alert > 0
//
// You can use the following query to see all the requests that triggered this alert.
// These comments are ignored but the timestamp is updated correctly and should match the timestamp used in the above query.
//
// requests
// | where toint(resultCode) between (200 .. 299) and timestamp >= (datetime(2023-01-10T22:32:46.0000000Z) - 5m) and success == false
// | sort by timestamp asc
```

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README