### PR TITLE
Fix patient bulk upload for non-Okta environments

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.support.ScopeNotActiveException;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
@@ -38,6 +39,9 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class DemoOktaRepository implements OktaRepository {
+
+  @Value("${simple-report.authorization.environment-name:DEV}")
+  private String environment;
 
   private final OrganizationExtractor organizationExtractor;
   private final CurrentTenantDataAccessContextHolder tenantDataContextHolder;
@@ -320,7 +324,9 @@ public class DemoOktaRepository implements OktaRepository {
       }
       return Optional.ofNullable(usernameOrgRolesMap.get(username));
     } catch (ScopeNotActiveException e) {
-      if (usernameOrgRolesMap.containsKey(username)) {
+      // Tests are set up with a full SecurityContextHolder and should not rely on
+      // usernameOrgRolesMap as the source of truth.
+      if (!environment.equals("UNITTEST") && usernameOrgRolesMap.containsKey(username)) {
         return Optional.of(usernameOrgRolesMap.get(username));
       }
       Set<String> authorities =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -320,7 +320,7 @@ public class DemoOktaRepository implements OktaRepository {
       }
       return Optional.ofNullable(usernameOrgRolesMap.get(username));
     } catch (ScopeNotActiveException e) {
-      if (usernameOrgRolesMap.get(username) != null) {
+      if (usernameOrgRolesMap.containsKey(username)) {
         return Optional.of(usernameOrgRolesMap.get(username));
       }
       Set<String> authorities =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -326,7 +326,7 @@ public class DemoOktaRepository implements OktaRepository {
     } catch (ScopeNotActiveException e) {
       // Tests are set up with a full SecurityContextHolder and should not rely on
       // usernameOrgRolesMap as the source of truth.
-      if (!environment.equals("UNITTEST") && usernameOrgRolesMap.containsKey(username)) {
+      if (!("UNITTEST".equals(environment)) && usernameOrgRolesMap.containsKey(username)) {
         return Optional.of(usernameOrgRolesMap.get(username));
       }
       Set<String> authorities =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -320,6 +320,9 @@ public class DemoOktaRepository implements OktaRepository {
       }
       return Optional.ofNullable(usernameOrgRolesMap.get(username));
     } catch (ScopeNotActiveException e) {
+      if (usernameOrgRolesMap.get(username) != null) {
+        return Optional.of(usernameOrgRolesMap.get(username));
+      }
       Set<String> authorities =
           SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
               .map(GrantedAuthority::getAuthority)


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixes #4900 

## Changes Proposed

- Update the logic in DemoOktaRepository to correctly check user permissions in non-Okta environments

## Additional Information

- DemoOktaRepository originally had to change because the TenantDataContextHolder is no longer active in asynchronous threads
- However, it was checking for a real security context instead of the authentication held in the demo environment
- This worked fine for tests, but broke if running Okta locally - patients just wouldn't upload, because the user authentication  couldn't be determined
- This change fixes Okta local for asynchronous threads (specifically, patient bulk upload)

## Testing

- You're able to upload patients in a non-Okta local environment
- It's not possible to test this outside of running locally, since all our upper environments are behind Okta security