### PR TITLE
4867 Row errors extend off page boundary (patient bulk upload)

### DIFF
--- a/frontend/src/app/patients/UploadPatients.test.tsx
+++ b/frontend/src/app/patients/UploadPatients.test.tsx
@@ -88,9 +88,13 @@ describe("Upload Patient", () => {
       userEvent.click(screen.getByText("One facility"));
 
       expect(await screen.findByText("Which facility?")).toBeInTheDocument();
+      await userEvent.selectOptions(
+        screen.getByRole("combobox", { name: /select facility/i }),
+        "2"
+      );
       expect(
         await screen.findByText(
-          "3. Upload your spreadsheet for Lincoln Middle School."
+          "3. Upload your spreadsheet for Rosa Parks High School."
         )
       );
     });
@@ -185,6 +189,26 @@ describe("Upload Patient", () => {
     let mockResponse = new Response(null, {
       status: 500,
     });
+    const uploadFile = file("someText");
+
+    const uploadSpy = submitCSVFile(mockResponse, uploadFile);
+
+    expect(uploadSpy).toHaveBeenCalledWith(uploadFile, "");
+    expect(
+      await screen.findByText("Error: File not accepted")
+    ).toBeInTheDocument();
+  });
+  it("should show error message if 200 but is a failure with no message", async () => {
+    renderUploadPatients();
+
+    let mockResponse = new Response(
+      JSON.stringify({
+        status: "FAILURE",
+      }),
+      {
+        status: 200,
+      }
+    );
     const uploadFile = file("someText");
 
     const uploadSpy = submitCSVFile(mockResponse, uploadFile);

--- a/frontend/src/app/patients/UploadPatients.test.tsx
+++ b/frontend/src/app/patients/UploadPatients.test.tsx
@@ -184,6 +184,44 @@ describe("Upload Patient", () => {
     expect(await screen.findByText("bad zipcode")).toBeInTheDocument();
     expect(await screen.findByText("Row(s): 0, 1, 2")).toBeInTheDocument();
   });
+
+  it("should show error message and list errors even if error info is incomplete", async () => {
+    const incompleteResponseBody = {
+      status: "FAILURE",
+      errors: [
+        { indices: [0, 1, 2], message: "properly formed error" },
+        { indices: [0, 1, 2, 3] },
+        { message: "error with no indices" },
+        {},
+      ],
+    };
+
+    renderUploadPatients();
+
+    let mockResponse = new Response(JSON.stringify(incompleteResponseBody), {
+      status: 200,
+    });
+
+    submitCSVFile(mockResponse);
+
+    expect(
+      await screen.findByText("Error: File not accepted")
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(
+        "Please resolve the errors below and upload your edited file."
+      )
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("properly formed error")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("error with no indices")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Row(s): 0, 1, 2")).toBeInTheDocument();
+    expect(await screen.findByText("Row(s): 0, 1, 2, 3")).toBeInTheDocument();
+  });
   it("should show error message if 500 is returned", async () => {
     renderUploadPatients();
     let mockResponse = new Response(null, {

--- a/frontend/src/app/patients/UploadPatients.test.tsx
+++ b/frontend/src/app/patients/UploadPatients.test.tsx
@@ -44,7 +44,7 @@ const uploadPatientsSpy = (response: Response) =>
   });
 const errorResponseBody = {
   status: "FAILURE",
-  errors: [{ indices: [0], message: "bad zipcode" }],
+  errors: [{ indices: [0, 1, 2], message: "bad zipcode" }],
 };
 
 const successResponseBody = {
@@ -178,7 +178,7 @@ describe("Upload Patient", () => {
       )
     ).toBeInTheDocument();
     expect(await screen.findByText("bad zipcode")).toBeInTheDocument();
-    expect(await screen.findByText("Row(s): 0")).toBeInTheDocument();
+    expect(await screen.findByText("Row(s): 0, 1, 2")).toBeInTheDocument();
   });
   it("should show error message if 500 is returned", async () => {
     renderUploadPatients();

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -135,9 +135,11 @@ const UploadPatients = ({ isAdmin }: { isAdmin: boolean }) => {
         <div className={"card padding-top-5 padding-bottom-7"}>
           <ol className={"prime-ul margin-0"}>
             <li>
-              <span className={"font-sans-lg text-light line-height-225"}>
+              <h2
+                className={"margin-0 font-sans-lg text-light line-height-225"}
+              >
                 1. Setup your spreadsheet
-              </span>
+              </h2>
               <div className={"margin-left-3"}>
                 <div
                   className={
@@ -168,20 +170,20 @@ const UploadPatients = ({ isAdmin }: { isAdmin: boolean }) => {
             </li>
 
             <li>
-              <div
+              <h2
                 className={
                   "margin-top-7 margin-bottom-1 font-sans-lg text-light line-height-225"
                 }
               >
                 2. Would you like to import these patients to one facility OR
                 all facilities?
-              </div>
+              </h2>
               <div className={"margin-left-3"}>
-                <div className={"maxw-710 line-height-sans-4"}>
+                <p className={"maxw-710 line-height-sans-4"}>
                   If you plan to test patients at more than one facility, we
                   recommend adding them to all facilities. You can't select
                   multiple facilities individually.
-                </div>
+                </p>
                 <RadioGroup
                   wrapperClassName="margin-top-2"
                   inputClassName={"usa-radio__input--tile"}
@@ -203,8 +205,8 @@ const UploadPatients = ({ isAdmin }: { isAdmin: boolean }) => {
                   variant="horizontal"
                 />
                 {facilityAmount === "oneFacility" && (
-                  <div className={"margin-top-205"}>
-                    <div>Which facility?</div>
+                  <>
+                    <div className={"margin-top-205"}>Which facility?</div>
                     <Dropdown
                       aria-label={"Select facility"}
                       selectedValue={facility.id}
@@ -215,146 +217,138 @@ const UploadPatients = ({ isAdmin }: { isAdmin: boolean }) => {
                         value: id,
                       }))}
                     />
-                  </div>
+                  </>
                 )}
               </div>
             </li>
             <li>
-              <div
+              <h2
                 className={
                   "margin-top-7 margin-bottom-1 font-sans-lg text-light line-height-225"
                 }
               >
                 3. Upload your spreadsheet
                 {facilityAmount === "oneFacility" && " for " + facility.name}.
-              </div>
+              </h2>
               <div className={"margin-left-3"}>
-                <div className={"maxw-710 line-height-sans-4"}>
+                <p className={"maxw-710 line-height-sans-4"}>
                   The spreadsheet may take 10 or more minutes to upload. You do
                   not need to stay on this page. We'll email you if you need to
                   fix any errors or when the upload is complete.
-                </div>
-                <div>
-                  {status === "success" && (
-                    <div className="usa-alert usa-alert--success maxw-560 margin-top-3 outline-0">
-                      <div className="usa-alert__body">
-                        <span className="usa-alert__heading text-bold">
-                          Success: File Accepted
-                        </span>
-                        <button
-                          className="Toastify__close-button Toastify__close-button--default position-absolute top-0 right-0"
-                          type="button"
-                          aria-label="close"
-                          onClick={() => setStatus("")}
-                        >
-                          <FontAwesomeIcon icon={faXmark} />
-                        </button>
-                        <p className="usa-alert__text">
-                          Patients in your file have been successfully uploaded.
-                        </p>
-                      </div>
+                </p>
+                {status === "success" && (
+                  <div className="usa-alert usa-alert--success maxw-560 margin-top-3 outline-0">
+                    <div className="usa-alert__body">
+                      <span className="usa-alert__heading text-bold">
+                        Success: File Accepted
+                      </span>
+                      <button
+                        className="Toastify__close-button Toastify__close-button--default position-absolute top-0 right-0"
+                        type="button"
+                        aria-label="close"
+                        onClick={() => setStatus("")}
+                      >
+                        <FontAwesomeIcon icon={faXmark} />
+                      </button>
+                      <p className="usa-alert__text">
+                        Patients in your file have been successfully uploaded.
+                      </p>
                     </div>
-                  )}
-                  {status === "fail" && (
-                    <div className={"margin-top-3"}>
-                      {errorMessageText && (
-                        <div className="usa-alert usa-alert--error maxw-560">
-                          <div className="usa-alert__body">
-                            <span className="usa-alert__heading text-bold">
-                              Error: File not accepted
-                            </span>
-                            <button
-                              className="Toastify__close-button Toastify__close-button--default position-absolute top-0 right-0"
-                              type="button"
-                              aria-label="close"
-                              onClick={() => {
-                                setErrorMessageText("");
-                                setErrors([]);
-                              }}
-                            >
-                              <FontAwesomeIcon icon={faXmark} />
-                            </button>
-                            <p className="usa-alert__text">
-                              {errorMessageText}
-                            </p>
-                          </div>
-                        </div>
-                      )}
-                      {errors.length > 0 && (
-                        <table className="usa-table usa-table--borderless">
-                          <thead>
-                            <tr>
-                              <th
-                                className={"thick-bottom-border padding-left-0"}
-                              >
-                                Edits needed
-                              </th>
-                              <th
-                                className={"thick-bottom-border padding-left-0"}
-                              >
-                                Areas requiring edits
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {errors.map((e) => {
-                              return (
-                                <tr
-                                  key={(e?.message || "") + (e?.indices || "")}
-                                >
-                                  <td className={"border-bottom-0"}>
-                                    {e?.["message"]}{" "}
-                                  </td>
-                                  <td className={"border-bottom-0"}>
-                                    {e?.["indices"] &&
-                                      "Row(s): " + e?.["indices"]}
-                                  </td>
-                                </tr>
-                              );
-                            })}
-                          </tbody>
-                        </table>
-                      )}
-                    </div>
-                  )}
-                  <FormGroup className="margin-bottom-3">
-                    {status === "submitting" ? (
-                      <div className={"usa-file-input"}>
-                        <div className={"usa-file-input__target"}>
-                          <div className={"margin-top-1"}>
-                            <span className="usa-file-input__drag-text font-sans-xs text-bold">
-                              Uploading patient information...
-                            </span>
-                            <div className={"margin-top-1"}>
-                              <img
-                                src={iconLoader}
-                                alt="submitting"
-                                className={"square-5"}
-                              />
-                            </div>
-                          </div>
+                  </div>
+                )}
+                {status === "fail" && (
+                  <div className={"margin-top-3"}>
+                    {errorMessageText && (
+                      <div className="usa-alert usa-alert--error maxw-560">
+                        <div className="usa-alert__body">
+                          <span className="usa-alert__heading text-bold">
+                            Error: File not accepted
+                          </span>
+                          <button
+                            className="Toastify__close-button Toastify__close-button--default position-absolute top-0 right-0"
+                            type="button"
+                            aria-label="close"
+                            onClick={() => {
+                              setErrorMessageText("");
+                              setErrors([]);
+                            }}
+                          >
+                            <FontAwesomeIcon icon={faXmark} />
+                          </button>
+                          <p className="usa-alert__text">{errorMessageText}</p>
                         </div>
                       </div>
-                    ) : (
-                      <FileInput
-                        id="upload-csv-input"
-                        name="upload-csv-input"
-                        aria-label="Choose CSV file"
-                        accept="text/csv, .csv"
-                        onChange={handleFileChange()}
-                        required
-                      />
                     )}
-                  </FormGroup>
-                </div>
-                <div>
-                  <Button
-                    disabled={buttonIsDisabled || facilityAmount === undefined}
-                    onClick={handleSubmit()}
-                  >
-                    Upload CSV file
-                  </Button>
-                </div>
+                    {errors.length > 0 && (
+                      <table className="usa-table usa-table--borderless">
+                        <thead>
+                          <tr>
+                            <th
+                              className={"thick-bottom-border padding-left-0"}
+                            >
+                              Edits needed
+                            </th>
+                            <th
+                              className={"thick-bottom-border padding-left-0"}
+                            >
+                              Areas requiring edits
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {errors.map((e) => {
+                            return (
+                              <tr key={(e?.message || "") + (e?.indices || "")}>
+                                <td className={"border-bottom-0"}>
+                                  {e?.["message"]}{" "}
+                                </td>
+                                <td className={"border-bottom-0"}>
+                                  {e?.["indices"] &&
+                                    "Row(s): " + e?.["indices"]?.join(", ")}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                )}
+                <FormGroup className="margin-bottom-3">
+                  {status === "submitting" ? (
+                    <div className={"usa-file-input"}>
+                      <div className={"usa-file-input__target"}>
+                        <div className={"margin-top-1"}>
+                          <span className="usa-file-input__drag-text font-sans-xs text-bold">
+                            Uploading patient information...
+                          </span>
+                          <div className={"margin-top-1"}>
+                            <img
+                              src={iconLoader}
+                              alt="submitting"
+                              className={"square-5"}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <FileInput
+                      id="upload-csv-input"
+                      name="upload-csv-input"
+                      aria-label="Choose CSV file"
+                      accept="text/csv, .csv"
+                      onChange={handleFileChange()}
+                      required
+                    />
+                  )}
+                </FormGroup>
+                <Button
+                  disabled={buttonIsDisabled || facilityAmount === undefined}
+                  onClick={handleSubmit()}
+                >
+                  Upload CSV file
+                </Button>
               </div>
             </li>
           </ol>

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -85,11 +85,11 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
           class="prime-ul margin-0"
         >
           <li>
-            <span
-              class="font-sans-lg text-light line-height-225"
+            <h2
+              class="margin-0 font-sans-lg text-light line-height-225"
             >
               1. Setup your spreadsheet
-            </span>
+            </h2>
             <div
               class="margin-left-3"
             >
@@ -130,19 +130,19 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
             </div>
           </li>
           <li>
-            <div
+            <h2
               class="margin-top-7 margin-bottom-1 font-sans-lg text-light line-height-225"
             >
               2. Would you like to import these patients to one facility OR all facilities?
-            </div>
+            </h2>
             <div
               class="margin-left-3"
             >
-              <div
+              <p
                 class="maxw-710 line-height-sans-4"
               >
                 If you plan to test patients at more than one facility, we recommend adding them to all facilities. You can't select multiple facilities individually.
-              </div>
+              </p>
               <div
                 class="usa-form-group margin-top-2"
               >
@@ -200,77 +200,73 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
             </div>
           </li>
           <li>
-            <div
+            <h2
               class="margin-top-7 margin-bottom-1 font-sans-lg text-light line-height-225"
             >
               3. Upload your spreadsheet
               .
-            </div>
+            </h2>
             <div
               class="margin-left-3"
             >
-              <div
+              <p
                 class="maxw-710 line-height-sans-4"
               >
                 The spreadsheet may take 10 or more minutes to upload. You do not need to stay on this page. We'll email you if you need to fix any errors or when the upload is complete.
-              </div>
-              <div>
+              </p>
+              <div
+                class="usa-form-group margin-bottom-3"
+                data-testid="formGroup"
+              >
                 <div
-                  class="usa-form-group margin-bottom-3"
-                  data-testid="formGroup"
+                  class="usa-file-input"
+                  data-testid="file-input"
                 >
                   <div
-                    class="usa-file-input"
-                    data-testid="file-input"
+                    class="usa-file-input__target"
+                    data-testid="file-input-droptarget"
                   >
                     <div
-                      class="usa-file-input__target"
-                      data-testid="file-input-droptarget"
+                      aria-hidden="true"
+                      class="usa-file-input__instructions"
+                      data-testid="file-input-instructions"
                     >
-                      <div
-                        aria-hidden="true"
-                        class="usa-file-input__instructions"
-                        data-testid="file-input-instructions"
+                      <span
+                        class="usa-file-input__drag-text"
                       >
-                        <span
-                          class="usa-file-input__drag-text"
-                        >
-                          Drag file here or 
-                        </span>
-                        <span
-                          class="usa-file-input__choose"
-                        >
-                          choose from folder
-                        </span>
-                      </div>
-                      <div
-                        class="usa-file-input__box"
-                        data-testid="file-input-box"
-                      />
-                      <input
-                        accept="text/csv, .csv"
-                        aria-label="Choose CSV file"
-                        class="usa-file-input__input"
-                        data-testid="file-input-input"
-                        id="upload-csv-input"
-                        name="upload-csv-input"
-                        required=""
-                        type="file"
-                      />
+                        Drag file here or 
+                      </span>
+                      <span
+                        class="usa-file-input__choose"
+                      >
+                        choose from folder
+                      </span>
                     </div>
+                    <div
+                      class="usa-file-input__box"
+                      data-testid="file-input-box"
+                    />
+                    <input
+                      accept="text/csv, .csv"
+                      aria-label="Choose CSV file"
+                      class="usa-file-input__input"
+                      data-testid="file-input-input"
+                      id="upload-csv-input"
+                      name="upload-csv-input"
+                      required=""
+                      type="file"
+                    />
                   </div>
                 </div>
               </div>
-              <div>
-                <button
-                  aria-disabled="true"
-                  class="usa-button usa-button-disabled"
-                  disabled=""
-                  type="button"
-                >
-                  Upload CSV file
-                </button>
-              </div>
+              <button
+                aria-disabled="true"
+                class="usa-button usa-button-disabled"
+                disabled=""
+                type="button"
+              >
+                Upload CSV file
+              </button>
             </div>
           </li>
         </ol>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #4867 

## Changes Proposed

Root cause of table not being responsive to page width was that the cell content was being constructed as a whole word so browser was not able to adjust the table (browsers do not break out words unless explicitly told). I added a space after the commas that separate the indices to present the cell content as multiple words.

## Additional Information

I also took the chance to clean up the html structure a little. Some of the changes I made were replacing divs for more semantic elements like headings and paragraphs and removed nested divs that were not necessary.

## Testing
Load a csv file that causes many errors in the patient bulk upload flow and verify that the table adjusts properly the content.

## Screenshots / Demos
![patientBulkUploadErrorTable](https://user-images.githubusercontent.com/103958711/210839309-c1acc122-b08d-43ee-8c44-e0fa7195a7b9.png)

## Checklist for Author and Reviewer
### Accessibility
- [X] Any large changes have been run through Deque manual testing
- [X] All changes have run through the Deque automated testing
