### PR TITLE
style override to remove hover state

### DIFF
--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -454,7 +454,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   <button
                     aria-disabled="true"
-                    class="usa-button usa-button--outline usa-button-disabled"
+                    class="usa-button usa-button--outline usa-button-disabled no-hover-state-when-disabled"
                     disabled=""
                     type="submit"
                   >
@@ -865,7 +865,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   <button
                     aria-disabled="true"
-                    class="usa-button usa-button--outline usa-button-disabled"
+                    class="usa-button usa-button--outline usa-button-disabled no-hover-state-when-disabled"
                     disabled=""
                     type="submit"
                   >

--- a/frontend/src/app/testResults/CovidResultInputForm.tsx
+++ b/frontend/src/app/testResults/CovidResultInputForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 
 import RadioGroup from "../commonComponents/RadioGroup";
 import Button from "../commonComponents/Button/Button";
@@ -97,6 +98,9 @@ const CovidResultInputForm: React.FC<Props> = ({
       />
       <div className="prime-test-result-submit">
         <Button
+          className={classNames({
+            "no-hover-state-when-disabled": !allowSubmit,
+          })}
           onClick={onResultSubmit}
           type="submit"
           disabled={!allowSubmit}

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 
 import RadioGroup from "../commonComponents/RadioGroup";
 import Button from "../commonComponents/Button/Button";
@@ -272,7 +273,9 @@ const MultiplexResultInputForm: React.FC<Props> = ({
           />
         </div>
         <Button
-          className="grid-col-auto prime-multiplex-btn"
+          className={classNames("grid-col-auto", "prime-multiplex-btn", {
+            "no-hover-state-when-disabled": !validateForm() || isSubmitDisabled,
+          })}
           onClick={onResultSubmit}
           type="submit"
           disabled={!validateForm() || isSubmitDisabled}

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -1167,3 +1167,7 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+.no-hover-state-when-disabled:hover {
+  box-shadow: inset 0 0 0 2px #c9c9c9 !important;
+}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #3841 by disabling the hover state on the multiplex and COVID test cards that shouldn't be there

## Testing

- Included screen recording below and deployed to dev3 if anyone wants to smoke it in a real env.

## Screenshots / Demos

Multiplex card
https://user-images.githubusercontent.com/29645040/211085248-850ad888-2fbc-4ed4-bfd1-fbe1f8450a87.mov

COVID card
https://user-images.githubusercontent.com/29645040/211102161-8a4efe4f-7bf9-4cc6-80fb-294d9e2e4715.mov

