### PR TITLE
make device_specimen_type nullable for testevent and testorder

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4161,3 +4161,22 @@ databaseChangeLog:
                     nullable: false
                     foreignKeyName: fk__facility_device_specimen_type__device_specimen_type
                     references: device_specimen_type
+  - changeSet:
+      id: drop-not-null-constraints_device_specimen_type_id
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: drop-not-null-constraints_device_specimen_type_id
+        - dropNotNullConstraint:
+            tableName: test_event
+            columnName: device_specimen_type_id
+        - dropNotNullConstraint:
+            tableName: test_order
+            columnName: device_specimen_type_id
+      rollback:
+        - addNotNullConstraint:
+            tableName: test_event
+            columnName: device_specimen_type_id
+        - addNotNullConstraint:
+            tableName: test_order
+            columnName: device_specimen_type_id


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352

## Changes Proposed

- Make device_specimen_type nullable in preparation for the code to stop writing them


## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

