### PR TITLE
Create TestDataBuilder class

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -275,7 +275,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
     TestUserIdentities.withUser(
         TestUserIdentities.SITE_ADMIN_USER,
         () -> {
-          Organization org = _dataFactory.createUnverifiedOrg();
+          Organization org = _dataFactory.saveUnverifiedOrganization();
 
           useSuperUser();
 
@@ -1193,7 +1193,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         TestUserIdentities.SITE_ADMIN_USER,
         () -> {
           useSuperUser();
-          _dataFactory.createValidOrg("The Mall", "k12", "dc-with-trailing-space ", true);
+          _dataFactory.saveOrganization("The Mall", "k12", "dc-with-trailing-space ", true);
 
           Map<String, Object> variables =
               Map.of(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingTest.java
@@ -151,7 +151,7 @@ class AuditLoggingTest extends BaseGraphqlTest {
     MutableObject<PatientLink> linkHolder = new MutableObject<>();
     TestUserIdentities.withStandardUser(
         () -> {
-          Organization org = _dataFactory.createValidOrg();
+          Organization org = _dataFactory.saveValidOrganization();
           Facility site = _dataFactory.createValidFacility(org);
           Person person = _dataFactory.createFullPerson(org);
           TestEvent testEvent = _dataFactory.createTestEvent(person, site);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -123,7 +123,7 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
     TestUserIdentities.withUser(
         TestUserIdentities.SITE_ADMIN_USER,
         () -> {
-          Organization org = _dataFactory.createValidOrg();
+          Organization org = _dataFactory.saveValidOrganization();
           useSuperUser();
           Map<String, Object> variables =
               Map.of("externalId", org.getExternalId(), "verified", false);
@@ -142,7 +142,7 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
     TestUserIdentities.withUser(
         TestUserIdentities.SITE_ADMIN_USER,
         () -> {
-          OrganizationQueueItem orgQueueItem = _dataFactory.createOrganizationQueueItem();
+          OrganizationQueueItem orgQueueItem = _dataFactory.saveOrganizationQueueItem();
           useSuperUser();
           Map<String, Object> variables =
               Map.of("externalId", orgQueueItem.getExternalId(), "verified", true);
@@ -156,8 +156,8 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
     TestUserIdentities.withUser(
         TestUserIdentities.SITE_ADMIN_USER,
         () -> {
-          _dataFactory.createUnverifiedOrg();
-          OrganizationQueueItem orgQueueItem = _dataFactory.createOrganizationQueueItem();
+          _dataFactory.saveUnverifiedOrganization();
+          OrganizationQueueItem orgQueueItem = _dataFactory.saveOrganizationQueueItem();
           useSuperUser();
 
           // Get all queue items

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
@@ -21,14 +21,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class TestEventExportTest extends BaseRepositoryTest {
-  @Autowired protected TestDataFactory _dataFactory;
+  @Autowired protected TestDataFactory dataFactory;
 
   @Test
   void json_property_gender_mapping() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     assertEquals("male", p.getGender());
 
@@ -38,10 +38,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void json_property_preferredLang_mapping() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPersonWithPreferredLanguage(o, "will-be-default-value");
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPersonWithPreferredLanguage(o, "will-be-default-value");
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     TestEventExport sut = new TestEventExport(te);
     assertEquals("will-be-default-value", sut.getPatientPreferredLanguage());
@@ -49,10 +49,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void json_property_ethnicity_mapping() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     assertEquals("not_hispanic", p.getEthnicity());
 
@@ -63,10 +63,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void json_property_test_result_mapping() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     assertEquals(TestResult.NEGATIVE, te.getCovidTestResult().get());
 
@@ -77,10 +77,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void json_property_race_mapping() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     assertEquals("white", p.getRace());
 
@@ -91,10 +91,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void json_property_site_of_care_reporting() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     TestEventExport sut = new TestEventExport(te);
 
@@ -103,10 +103,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void certainDateFieldsIncludeTime() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f);
 
     TestEventExport sut = new TestEventExport(te);
 
@@ -121,10 +121,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void determinesFirstTestFromTestEvent_hasPriorTest_false() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f, TestResult.NEGATIVE, false);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f, TestResult.NEGATIVE, false);
 
     TestEventExport sut = new TestEventExport(te);
 
@@ -133,10 +133,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void determinesFirstTestFromTestEvent_hasPriorTest_true() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f, TestResult.NEGATIVE, true);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f, TestResult.NEGATIVE, true);
 
     TestEventExport sut = new TestEventExport(te);
 
@@ -145,10 +145,10 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void determinesFirstTestFromTestEvent_hasPriorTest_null() {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
-    TestEvent te = _dataFactory.createTestEvent(p, f, TestResult.NEGATIVE, null);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
+    TestEvent te = dataFactory.createTestEvent(p, f, TestResult.NEGATIVE, null);
 
     TestEventExport sut = new TestEventExport(te);
 
@@ -157,12 +157,12 @@ class TestEventExportTest extends BaseRepositoryTest {
 
   @Test
   void specimenCollectionSubtractsDeviceOffset() throws ParseException {
-    Organization o = _dataFactory.createValidOrg();
-    Facility f = _dataFactory.createValidFacility(o);
-    Person p = _dataFactory.createFullPerson(o);
+    Organization o = dataFactory.saveValidOrganization();
+    Facility f = dataFactory.createValidFacility(o);
+    Person p = dataFactory.createFullPerson(o);
 
     TestEvent te =
-        _dataFactory.createTestEvent(
+        dataFactory.createTestEvent(
             p,
             f,
             AskOnEntrySurvey.builder().symptoms(Collections.emptyMap()).build(),
@@ -177,17 +177,17 @@ class TestEventExportTest extends BaseRepositoryTest {
   @Test
   void sendCorrectionReason() {
     // GIVEN
-    Organization org = _dataFactory.createValidOrg();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person person = _dataFactory.createFullPerson(org);
+    Organization org = dataFactory.saveValidOrganization();
+    Facility facility = dataFactory.createValidFacility(org);
+    Person person = dataFactory.createFullPerson(org);
 
     LocalDate localDate = LocalDate.of(2020, 7, 23);
     Date backTestedDate = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     TestEvent originalTestEvent =
-        _dataFactory.createTestEvent(person, facility, null, TestResult.NEGATIVE, backTestedDate);
+        dataFactory.createTestEvent(person, facility, null, TestResult.NEGATIVE, backTestedDate);
     String originalEventId = originalTestEvent.getInternalId().toString();
     TestEvent testEvent =
-        _dataFactory.createTestEventCorrection(originalTestEvent, TestCorrectionStatus.REMOVED);
+        dataFactory.createTestEventCorrection(originalTestEvent, TestCorrectionStatus.REMOVED);
 
     // WHEN
     TestEventExport exportedEvent = new TestEventExport(testEvent);
@@ -201,11 +201,10 @@ class TestEventExportTest extends BaseRepositoryTest {
   @Test
   void sendPatientInfo() {
     // GIVEN
-    Organization org = _dataFactory.createValidOrg();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person person = _dataFactory.createFullPerson(org);
-    TestEvent testEvent =
-        _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE, false);
+    Organization org = dataFactory.saveValidOrganization();
+    Facility facility = dataFactory.createValidFacility(org);
+    Person person = dataFactory.createFullPerson(org);
+    TestEvent testEvent = dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE, false);
 
     // WHEN
     TestEventExport exportedEvent = new TestEventExport(testEvent);
@@ -227,11 +226,10 @@ class TestEventExportTest extends BaseRepositoryTest {
   @Test
   void sendPatientInfoWithCountryNull() {
     // GIVEN
-    Organization org = _dataFactory.createValidOrg();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person person = _dataFactory.createFullPersonWithSpecificCountry(org, null);
-    TestEvent testEvent =
-        _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE, false);
+    Organization org = dataFactory.saveValidOrganization();
+    Facility facility = dataFactory.createValidFacility(org);
+    Person person = dataFactory.createFullPersonWithSpecificCountry(org, null);
+    TestEvent testEvent = dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE, false);
 
     // WHEN
     TestEventExport exportedEvent = new TestEventExport(testEvent);
@@ -243,11 +241,10 @@ class TestEventExportTest extends BaseRepositoryTest {
   @Test
   void sendPatientInfoWithNonUSACountry() {
     // GIVEN
-    Organization org = _dataFactory.createValidOrg();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person person = _dataFactory.createFullPersonWithSpecificCountry(org, "CAN");
-    TestEvent testEvent =
-        _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE, false);
+    Organization org = dataFactory.saveValidOrganization();
+    Facility facility = dataFactory.createValidFacility(org);
+    Person person = dataFactory.createFullPersonWithSpecificCountry(org, "CAN");
+    TestEvent testEvent = dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE, false);
 
     // WHEN
     TestEventExport exportedEvent = new TestEventExport(testEvent);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
@@ -59,10 +59,10 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
 
   @BeforeEach
   void setup() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     organization = org;
     facility = _dataFactory.createValidFacility(org);
-    pendingOrg = _dataFactory.createOrganizationQueueItem();
+    pendingOrg = _dataFactory.saveOrganizationQueueItem();
     address = facility.getAddress();
     orgUserInfo = _dataFactory.createValidApiUser("demo@example.com", org);
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientResolverTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.PersonService;
+import gov.cdc.usds.simplereport.test_util.TestDataBuilder;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -20,7 +21,7 @@ class PatientResolverTest extends BaseServiceTest<PersonService> {
   void patientExists_hasFacilityId_callsServiceWithFacility() {
     var personService = mock(PersonService.class);
     var orgService = mock(OrganizationService.class);
-    var org = _dataFactory.createValidOrg();
+    var org = _dataFactory.saveValidOrganization();
     var facility = _dataFactory.createValidFacility(org);
 
     when(orgService.getCurrentOrganization()).thenReturn(org);
@@ -40,7 +41,7 @@ class PatientResolverTest extends BaseServiceTest<PersonService> {
   void patientExists_hasNoFacilityId_callsServiceWithNoFacility() {
     var personService = mock(PersonService.class);
     var orgService = mock(OrganizationService.class);
-    var org = _dataFactory.createValidOrg();
+    var org = TestDataBuilder.createValidOrganization();
 
     when(orgService.getCurrentOrganization()).thenReturn(org);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -59,7 +59,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
     truncateDb();
     TestUserIdentities.withStandardUser(
         () -> {
-          org = _dataFactory.createValidOrg();
+          org = _dataFactory.saveValidOrganization();
           facility = _dataFactory.createValidFacility(org);
           person = _dataFactory.createFullPerson(org);
           testEvent = _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientSelfRegistrationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientSelfRegistrationControllerTest.java
@@ -39,7 +39,7 @@ class PatientSelfRegistrationControllerTest extends BaseFullStackTest {
     truncateDb();
     TestUserIdentities.withStandardUser(
         () -> {
-          _org = _dataFactory.createValidOrg();
+          _org = _dataFactory.saveValidOrganization();
           _site = _dataFactory.createValidFacility(_org);
           _orgRegistrationLink = _dataFactory.createPatientRegistrationLink(_org);
           _facilityRegistrationLink = _dataFactory.createPatientRegistrationLink(_site);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/SmsCallbackControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/SmsCallbackControllerTest.java
@@ -111,7 +111,7 @@ class SmsCallbackControllerTest extends BaseFullStackTest {
     String messageId = "some-message-id";
     String messageStatus = "delivered";
 
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility f = _dataFactory.createValidFacility(org);
     Person p = _dataFactory.createFullPerson(org);
     TestOrder to = _dataFactory.createTestOrder(p, f);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/reportstream/ReportStreamCallbackControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/reportstream/ReportStreamCallbackControllerTest.java
@@ -35,7 +35,7 @@ class ReportStreamCallbackControllerTest extends BaseFullStackTest {
     truncateDb();
     TestUserIdentities.withStandardUser(
         () -> {
-          org = _dataFactory.createValidOrg();
+          org = _dataFactory.saveValidOrganization();
           site = _dataFactory.createValidFacility(org);
           person = _dataFactory.createFullPerson(org);
           testEvent = _dataFactory.createTestEvent(person, site);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepositoryTest.java
@@ -33,7 +33,7 @@ class PatientLinkRepositoryTest extends BaseRepositoryTest {
   void findMostRecentByTestOrderIdInTest() {
     // GIVEN
     mockCreationTime("2020-01-01 00:00");
-    Organization org = testDataFactory.createValidOrg();
+    Organization org = testDataFactory.saveValidOrganization();
     Facility facility = testDataFactory.createValidFacility(org, "PatientLinkTest Facility");
     Person patient = testDataFactory.createFullPerson(org);
     Person patient2 = testDataFactory.createFullPerson(org);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepositoryTest.java
@@ -19,7 +19,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void testFindFacilityByLink() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility fac = _dataFactory.createValidFacility(org, "Foo Facility");
     Facility otherFac = _dataFactory.createValidFacility(org, "Bar Facility");
 
@@ -34,7 +34,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void testFindOrganizationByLink() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility fac = _dataFactory.createValidFacility(org, "Foo Facility");
 
     _repo.save(new PatientSelfRegistrationLink(fac, "foo-facility"));
@@ -48,7 +48,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void testBadLink() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility fac = _dataFactory.createValidFacility(org, "Foo Facility");
 
     _repo.save(new PatientSelfRegistrationLink(org, "happy-org"));
@@ -61,7 +61,7 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void testUniqueLinks() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility fac = _dataFactory.createValidFacility(org, "Foo Facility");
     _repo.save(new PatientSelfRegistrationLink(fac, "the-link"));
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/ResultRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/ResultRepositoryTest.java
@@ -31,7 +31,7 @@ class ResultRepositoryTest extends BaseRepositoryTest {
   // creating auditable entities like org and facility.
   @BeforeEach
   void setUp() {
-    ORG = _factory.createValidOrg();
+    ORG = _factory.saveValidOrganization();
     FACILITY = _factory.createValidFacility(ORG);
     PATIENT = _factory.createFullPerson(ORG);
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -71,7 +71,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void testFindByPatient() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility place = _dataFactory.createValidFacility(org);
     Person patient = _dataFactory.createMinimalPerson(org);
     TestOrder order = _dataFactory.createTestOrder(patient, place);
@@ -98,7 +98,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
         new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
     List<TestEvent> foundTestReports1 =
         _repo.queryMatchAllBetweenDates(d1, DATE_1MIN_FUTURE, PageRequest.of(0, 100));
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility place = _dataFactory.createValidFacility(org);
     Person patient = _dataFactory.createMinimalPerson(org);
 
@@ -131,7 +131,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void fetchResults_multipleEntries_sortedLifo() throws InterruptedException {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Person adam = _dataFactory.createMinimalPerson(org, null, "Adam", "A.", "Astaire", "Jr.");
     Person brad = _dataFactory.createMinimalPerson(org, null, "Bradley", "B.", "Bones", null);
     Person charlie =
@@ -173,7 +173,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
     final Date DATE_1MIN_FUTURE =
         new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility place = createTestEventsForMetricsTests(org);
 
     List<TestResultWithCount> results =
@@ -195,7 +195,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
     final Date DATE_1MIN_FUTURE =
         new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility place = createTestEventsForMetricsTests(org);
 
     List<TestResultWithCount> results =
@@ -217,7 +217,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
     final Date DATE_1MIN_FUTURE =
         new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility place = createTestEventsForMetricsTests(org);
     var p = _dataFactory.createMinimalPerson(org);
     _dataFactory.createMultiplexTestEvent(
@@ -243,7 +243,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Date d1 = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
     final Date DATE_1MIN_FUTURE =
         new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     createTestEventsForMetricsTests(org);
 
     Set<UUID> facilityIds =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -37,8 +37,9 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void runChanges() {
-    Organization gwu = _dataFactory.createValidOrg("George Washington", "university", "gwu", true);
-    Organization gtown = _dataFactory.createValidOrg("Georgetown", "university", "gt", true);
+    Organization gwu =
+        _dataFactory.saveOrganization("George Washington", "university", "gwu", true);
+    Organization gtown = _dataFactory.saveOrganization("Georgetown", "university", "gt", true);
     Facility site = _dataFactory.createValidFacility(gtown);
     Facility otherSite = _dataFactory.createValidFacility(gwu);
     Person hoya =
@@ -84,7 +85,7 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void testLifeCycle() {
-    Organization gtown = _dataFactory.createValidOrg("Georgetown", "university", "gt", true);
+    Organization gtown = _dataFactory.saveOrganization("Georgetown", "university", "gt", true);
     Person hoya =
         _personRepo.save(
             new Person(
@@ -137,7 +138,7 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void createOrder_duplicatesFound_error() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Person patient0 = _dataFactory.createMinimalPerson(org);
     Facility site = _dataFactory.createValidFacility(org);
     TestOrder order1 = new TestOrder(patient0, site);
@@ -156,7 +157,7 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void createOrder_duplicateCanceled_ok() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Person patient0 = _dataFactory.createMinimalPerson(org);
     Facility site = _dataFactory.createValidFacility(org);
     TestOrder order1 = new TestOrder(patient0, site);
@@ -178,7 +179,7 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void createOrder_duplicateSubmitted_ok() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Person patient0 = _dataFactory.createMinimalPerson(org);
     Facility site = _dataFactory.createValidFacility(org);
     TestOrder order1 = new TestOrder(patient0, site);
@@ -204,7 +205,7 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void fetchQueue_multipleEntries_sortedFifo() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Person adam = _dataFactory.createMinimalPerson(org, null, "Adam", "A.", "Astaire", "Jr.");
     Person brad = _dataFactory.createMinimalPerson(org, null, "Bradley", "B.", "Bones", null);
     Person charlie =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TextMessageSentRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TextMessageSentRepositoryTest.java
@@ -26,7 +26,7 @@ class TextMessageSentRepositoryTest extends BaseRepositoryTest {
 
   @BeforeEach
   public void init() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Person p1 = _dataFactory.createFullPerson(org);
     Person p2 = _dataFactory.createFullPerson(org);
     Facility f = _dataFactory.createValidFacility(org);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -217,13 +217,14 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
   @Test
   @WithSimpleReportSiteAdminUser
   void getAllUsersByOrganization_success() {
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     _dataFactory.createValidApiUser("allfacilities@example.com", org);
     _dataFactory.createValidApiUser("nofacilities@example.com", org);
     UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
     _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
 
-    Organization differentOrg = _dataFactory.createValidOrg("other org", "k12", "OTHER_ORG", true);
+    Organization differentOrg =
+        _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
     _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
 
     List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingServiceTest.java
@@ -176,7 +176,7 @@ class AzureStorageQueueTestEventReportingServiceTest
   }
 
   private Set<TestEvent> createTestEvents(int count) {
-    var org = _dataFactory.createValidOrg();
+    var org = _dataFactory.saveValidOrganization();
     var facility = _dataFactory.createValidFacility(org);
     var patient = _dataFactory.createFullPerson(org);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
@@ -48,7 +48,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void getUnverifiedQueuedOrganizationByExternalId_newOrg_success() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
 
     Optional<OrganizationQueueItem> optFetchedQueueItem =
         _service.getUnverifiedQueuedOrganizationByExternalId(createdQueueItem.getExternalId());
@@ -60,7 +60,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void editQueueItem_newOrgName_success() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
 
     OrganizationQueueItem editedItem =
         _service.editQueueItem(
@@ -81,7 +81,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void editQueueItem_newAdminName_success() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
 
     _service.editQueueItem(
         createdQueueItem.getExternalId(),
@@ -100,7 +100,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void editQueueItem_newContactInfo_success() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
 
     _service.editQueueItem(
         createdQueueItem.getExternalId(),
@@ -137,7 +137,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void getUnverifiedQueuedOrganizations_success() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
 
     List<OrganizationQueueItem> unverifiedOrgs = _service.getUnverifiedQueuedOrganizations();
 
@@ -147,7 +147,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void createAndActivateQueuedOrganization_newOrg_success() {
-    OrganizationQueueItem queueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem queueItem = _dataFactory.saveOrganizationQueueItem();
 
     String activationToken = _service.createAndActivateQueuedOrganization(queueItem);
     assertTrue(activationToken.length() > 0);
@@ -167,7 +167,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void deleteQueuedOrg_sucessful() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
     OrganizationQueueItem deletedQueueItem =
         _service.markPendingOrganizationAsDeleted(createdQueueItem.getExternalId(), true);
 
@@ -176,7 +176,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void undeletionQueuedOrg_sucessful() {
-    OrganizationQueueItem createdQueueItem = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem createdQueueItem = _dataFactory.saveOrganizationQueueItem();
     createdQueueItem.setIsDeleted(true);
     assertThat(createdQueueItem.isDeleted()).isTrue();
     OrganizationQueueItem undeletedItem =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -62,7 +62,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   void getOrganizationById_success() {
-    Organization createdOrg = _dataFactory.createValidOrg();
+    Organization createdOrg = _dataFactory.saveValidOrganization();
     Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
     assertNotNull(foundOrg);
     assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
@@ -157,8 +157,8 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @WithSimpleReportSiteAdminUser
   void getOrganizationsAndFacility_filterByIdentityVerified_success() {
     // GIVEN
-    Organization verifiedOrg = testDataFactory.createValidOrg();
-    Organization unverifiedOrg = testDataFactory.createUnverifiedOrg();
+    Organization verifiedOrg = testDataFactory.saveValidOrganization();
+    Organization unverifiedOrg = testDataFactory.saveUnverifiedOrganization();
 
     // WHEN
     List<Organization> allOrgs = _service.getOrganizations(null);
@@ -188,7 +188,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   @WithSimpleReportSiteAdminUser
   void getFacilitiesIncludeArchived_includeArchived_success() {
-    Organization org = testDataFactory.createValidOrg();
+    Organization org = testDataFactory.saveValidOrganization();
     Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
     testDataFactory.createValidFacility(org, "Not deleted");
 
@@ -203,7 +203,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   @WithSimpleReportSiteAdminUser
   void getFacilitiesIncludeArchived_excludeArchived_success() {
-    Organization org = testDataFactory.createValidOrg();
+    Organization org = testDataFactory.saveValidOrganization();
     testDataFactory.createArchivedFacility(org, "Delete me");
     Facility activeFacility = testDataFactory.createValidFacility(org, "Not deleted");
 
@@ -218,7 +218,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   @WithSimpleReportOrgAdminUser
   void viewArchivedFacilities_success() {
-    Organization org = testDataFactory.createValidOrg();
+    Organization org = testDataFactory.saveValidOrganization();
     Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
 
     Set<Facility> archivedFacilities = _service.getArchivedFacilities(org);
@@ -231,7 +231,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   @WithSimpleReportStandardUser
   void viewArchivedFacilities_standardUser_failure() {
-    Organization org = testDataFactory.createValidOrg();
+    Organization org = testDataFactory.saveValidOrganization();
     Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
 
     assertThrows(AccessDeniedException.class, () -> _service.getArchivedFacilities());
@@ -242,7 +242,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @WithSimpleReportSiteAdminUser
   void deleteFacilityTest_successful() {
     // GIVEN
-    Organization verifiedOrg = testDataFactory.createValidOrg();
+    Organization verifiedOrg = testDataFactory.saveValidOrganization();
     Facility mistakeFacility =
         testDataFactory.createValidFacility(verifiedOrg, "This facility is a mistake");
     // WHEN
@@ -269,7 +269,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @WithSimpleReportSiteAdminUser
   void deleteOrganizationTest_successful() {
     // GIVEN
-    Organization verifiedOrg = testDataFactory.createValidOrg();
+    Organization verifiedOrg = testDataFactory.saveValidOrganization();
     // WHEN
     Organization deletedOrganization =
         _service.markOrganizationAsDeleted(verifiedOrg.getInternalId(), true);
@@ -300,7 +300,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   void verifyOrganizationNoPermissions_noUser_success() {
-    Organization org = testDataFactory.createUnverifiedOrg();
+    Organization org = testDataFactory.saveUnverifiedOrganization();
     _service.verifyOrganizationNoPermissions(org.getExternalId());
 
     org = _service.getOrganization(org.getExternalId());
@@ -309,7 +309,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
-    Organization org = testDataFactory.createValidOrg();
+    Organization org = testDataFactory.saveValidOrganization();
     String orgExternalId = org.getExternalId();
     IllegalStateException e =
         assertThrows(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientSelfRegistrationLinkServiceTest.java
@@ -42,9 +42,9 @@ class PatientSelfRegistrationLinkServiceTest
 
   @BeforeEach
   void setupData() {
-    _org = _dataFactory.createValidOrg();
+    _org = _dataFactory.saveValidOrganization();
     _fac = _dataFactory.createValidFacility(_org);
-    _unverifiedOrg = _dataFactory.createUnverifiedOrg();
+    _unverifiedOrg = _dataFactory.saveUnverifiedOrganization();
     _unverifiedFac = _dataFactory.createValidFacility(_unverifiedOrg);
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ReminderServiceTest.java
@@ -35,12 +35,12 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
   void sendAccountReminderEmails_sendEmails_success() throws SQLException {
     String email = "fake@example.org";
     OrganizationQueueItem unverifiedQueuedOrg =
-        _dataFactory.createOrganizationQueueItem("New Org Name", "NEW_ORG_NAME", email);
+        _dataFactory.saveOrganizationQueueItem("New Org Name", "NEW_ORG_NAME", email);
     initAndBackdateUnverifiedQueuedOrg(unverifiedQueuedOrg);
 
     // person submitted a second time (still only 1 email sent)
     OrganizationQueueItem unverifiedQueuedOrg2 =
-        _dataFactory.createOrganizationQueueItem("New Org Name", "NEW_ORG_NAME_AGAIN", email);
+        _dataFactory.saveOrganizationQueueItem("New Org Name", "NEW_ORG_NAME_AGAIN", email);
     backdateQueuedOrgCreatedAt(unverifiedQueuedOrg2);
 
     Map<String, OrganizationQueueItem> orgEmailsSentMap = _service.sendAccountReminderEmails();
@@ -56,7 +56,7 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
   @Test
   void sendAccountReminderEmails_concurrencyLock_success()
       throws InterruptedException, ExecutionException, SQLException {
-    OrganizationQueueItem unverifiedQueuedOrg = _dataFactory.createOrganizationQueueItem();
+    OrganizationQueueItem unverifiedQueuedOrg = _dataFactory.saveOrganizationQueueItem();
     initAndBackdateUnverifiedQueuedOrg(unverifiedQueuedOrg);
 
     int n = 3;
@@ -101,7 +101,7 @@ class ReminderServiceTest extends BaseServiceTest<ReminderService> {
     backdateQueuedOrgCreatedAt(unverifiedQueuedOrg);
 
     // another unverified org, too new to be reminded
-    _dataFactory.createOrganizationQueueItem(
+    _dataFactory.saveOrganizationQueueItem(
         "Second Org Name", "SECOND_ORG_NAME", "second.org.email@example.com");
     // verified org should not be reminded
     _dataFactory.createVerifiedOrganizationQueueItem(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TenantDataAccessServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TenantDataAccessServiceTest.java
@@ -22,7 +22,7 @@ class TenantDataAccessServiceTest extends BaseServiceTest<TenantDataAccessServic
   @Test
   void addTenantDataAccess_success() {
     ApiUser apiUser = _userService.getCurrentApiUserInContainedTransaction();
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     String justification = "Test justification";
 
     Optional<OrganizationRoleClaims> claimsOpt =
@@ -38,7 +38,7 @@ class TenantDataAccessServiceTest extends BaseServiceTest<TenantDataAccessServic
   @Test
   void addAndRemoveDataAccess_success() {
     ApiUser apiUser = _userService.getCurrentApiUserInContainedTransaction();
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     String justification = "Test justification";
 
     // set access for a user to an org

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
@@ -238,7 +238,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
 
     // GIVEN
     when(csvFileValidatorMock.validate(any())).thenReturn(Collections.emptyList());
-    when(orgServiceMock.getCurrentOrganization()).thenReturn(factory.createValidOrg());
+    when(orgServiceMock.getCurrentOrganization()).thenReturn(factory.saveValidOrganization());
     var testResultUpload =
         factory.createTestResultUpload(
             reportId, UploadStatus.PENDING, orgServiceMock.getCurrentOrganization());
@@ -281,7 +281,7 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
     InputStream invalidInput = new ByteArrayInputStream("invalid".getBytes());
     when(csvFileValidatorMock.validate(any()))
         .thenReturn(List.of(new FeedbackMessage("error", "my lovely error message")));
-    when(orgServiceMock.getCurrentOrganization()).thenReturn(factory.createValidOrg());
+    when(orgServiceMock.getCurrentOrganization()).thenReturn(factory.saveValidOrganization());
 
     // WHEN
     TestResultUpload result = sut.processResultCSV(invalidInput);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/sms/TextMessageStatusServiceTest.java
@@ -67,7 +67,7 @@ class TextMessageStatusServiceTest extends BaseServiceTest<TextMessageStatusServ
     String messageId = "some-message-id";
     String messageStatus = "delivered";
 
-    Organization org = _dataFactory.createValidOrg();
+    Organization org = _dataFactory.saveValidOrganization();
     Facility f = _dataFactory.createValidFacility(org);
     Person p = _dataFactory.createFullPerson(org);
     TestOrder to = _dataFactory.createTestOrder(p, f);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -1,3 +1,40 @@
 package gov.cdc.usds.simplereport.test_util;
 
-public class TestDataBuilder {}
+import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
+
+public class TestDataBuilder {
+
+  public static final String DEFAULT_ORG_ID = "MALLRAT";
+  public static final String ALT_ORG_ID = "PLAZARAT";
+
+  public static Organization buildOrg(
+      String name, String type, String externalId, boolean identityVerified) {
+    return new Organization(name, type, externalId, identityVerified);
+  }
+
+  public static Organization createValidOrganization() {
+    return buildOrg("The Mall", "k12", DEFAULT_ORG_ID, true);
+  }
+
+  public static Organization createUnverifiedOrganization() {
+    return buildOrg("The Plaza", "k12", ALT_ORG_ID, false);
+  }
+
+  public static OrganizationAccountRequest createOrganizationAccountRequest(String adminEmail) {
+    return new OrganizationAccountRequest(
+        "First", "Last", adminEmail, "800-555-1212", "CA", null, null);
+  }
+
+  public static OrganizationQueueItem buildOrganizationQueueItem(
+      String orgName, String orgExternalId, String adminEmail) {
+    return new OrganizationQueueItem(
+        orgName, orgExternalId, createOrganizationAccountRequest(adminEmail));
+  }
+
+  public static OrganizationQueueItem createOrganizationQueueItem() {
+    return buildOrganizationQueueItem(
+        "New Org Queue Name", "CA-New-Org-Queue-Name-12345", "org.queue.admin@example.com");
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -1,0 +1,3 @@
+package gov.cdc.usds.simplereport.test_util;
+
+public class TestDataBuilder {}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -1,7 +1,6 @@
 package gov.cdc.usds.simplereport.test_util;
 
 import gov.cdc.usds.simplereport.api.model.Role;
-import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
@@ -105,20 +104,25 @@ public class TestDataFactory {
   @Autowired private ApiUserService apiUserService;
   @Autowired private DiseaseService diseaseService;
 
-  public Organization createValidOrg(
+  //  @Autowired private TestDataBuilder dataBuilder;
+
+  public Organization saveOrganization(Organization org) {
+    Organization savedOrg = organizationRepository.save(org);
+    oktaRepository.createOrganization(savedOrg);
+    return savedOrg;
+  }
+
+  public Organization saveOrganization(
       String name, String type, String externalId, boolean identityVerified) {
-    Organization org =
-        organizationRepository.save(new Organization(name, type, externalId, identityVerified));
-    oktaRepository.createOrganization(org);
-    return org;
+    return saveOrganization(TestDataBuilder.buildOrg(name, type, externalId, identityVerified));
   }
 
-  public Organization createValidOrg() {
-    return createValidOrg("The Mall", "k12", DEFAULT_ORG_ID, true);
+  public Organization saveValidOrganization() {
+    return saveOrganization(TestDataBuilder.createValidOrganization());
   }
 
-  public Organization createUnverifiedOrg() {
-    return createValidOrg("The Plaza", "k12", ALT_ORG_ID, false);
+  public Organization saveUnverifiedOrganization() {
+    return saveOrganization(TestDataBuilder.createUnverifiedOrganization());
   }
 
   public UserInfo createValidApiUser(String username, Organization org) {
@@ -126,30 +130,20 @@ public class TestDataFactory {
     return apiUserService.createUser(username, name, org.getExternalId(), Role.USER);
   }
 
-  public OrganizationQueueItem createOrganizationQueueItem(
+  public OrganizationQueueItem saveOrganizationQueueItem(
       String orgName, String orgExternalId, String adminEmail) {
     return organizationQueueRepository.save(
-        new OrganizationQueueItem(
-            orgName,
-            orgExternalId,
-            new OrganizationAccountRequest(
-                "First", "Last", adminEmail, "800-555-1212", "CA", null, null)));
+        TestDataBuilder.buildOrganizationQueueItem(orgName, orgExternalId, adminEmail));
   }
 
-  public OrganizationQueueItem createOrganizationQueueItem() {
-    return createOrganizationQueueItem(
-        "New Org Queue Name", "CA-New-Org-Queue-Name-12345", "org.queue.admin@example.com");
+  public OrganizationQueueItem saveOrganizationQueueItem() {
+    return organizationQueueRepository.save(TestDataBuilder.createOrganizationQueueItem());
   }
 
   public OrganizationQueueItem createVerifiedOrganizationQueueItem(
       String orgName, String orgExternalId, String adminEmail) {
-    Organization org = createValidOrg(orgName, "k12", orgExternalId, true);
-    OrganizationQueueItem queueItem =
-        new OrganizationQueueItem(
-            orgName,
-            orgExternalId,
-            new OrganizationAccountRequest(
-                "First", "Last", adminEmail, "800-555-1212", "CA", null, null));
+    Organization org = saveOrganization(orgName, "k12", orgExternalId, true);
+    OrganizationQueueItem queueItem = saveOrganizationQueueItem(orgName, orgExternalId, adminEmail);
     queueItem.setVerifiedOrganization(org);
     return organizationQueueRepository.save(queueItem);
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -83,32 +83,33 @@ public class TestDataFactory {
   private static final String DEFAULT_DEVICE_TYPE = "Acme SuperFine";
   private static final String DEFAULT_SPECIMEN_TYPE = "Nasal swab";
 
-  @Autowired private OrganizationRepository _orgRepo;
-  @Autowired private OrganizationQueueRepository _orgQueueRepo;
-  @Autowired private FacilityRepository _facilityRepo;
-  @Autowired private PersonRepository _personRepo;
-  @Autowired private ProviderRepository _providerRepo;
-  @Autowired private DeviceTypeRepository _deviceRepo;
-  @Autowired private TestOrderRepository _testOrderRepo;
-  @Autowired private TestEventRepository _testEventRepo;
-  @Autowired private PatientAnswersRepository _patientAnswerRepo;
-  @Autowired private PhoneNumberRepository _phoneNumberRepo;
-  @Autowired private PatientLinkRepository _patientLinkRepository;
-  @Autowired private PatientRegistrationLinkRepository _patientRegistrationLinkRepository;
-  @Autowired private SpecimenTypeRepository _specimenRepo;
-  @Autowired private DeviceSpecimenTypeRepository _deviceSpecimenRepo;
-  @Autowired private SupportedDiseaseRepository _supportedDiseaseRepo;
-  @Autowired private ResultRepository _resultRepository;
-  @Autowired private DemoOktaRepository _oktaRepo;
-  @Autowired private TestResultUploadRepository _testResultUploadRepo;
+  @Autowired private OrganizationRepository organizationRepository;
+  @Autowired private OrganizationQueueRepository organizationQueueRepository;
+  @Autowired private FacilityRepository facilityRepository;
+  @Autowired private PersonRepository personRepository;
+  @Autowired private ProviderRepository providerRepository;
+  @Autowired private DeviceTypeRepository deviceTypeRepository;
+  @Autowired private TestOrderRepository testOrderRepository;
+  @Autowired private TestEventRepository testEventRepository;
+  @Autowired private PatientAnswersRepository patientAnswersRepository;
+  @Autowired private PhoneNumberRepository phoneNumberRepository;
+  @Autowired private PatientLinkRepository patientLinkRepository;
+  @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
+  @Autowired private SpecimenTypeRepository specimenTypeRepository;
+  @Autowired private DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
+  @Autowired private SupportedDiseaseRepository supportedDiseaseRepository;
+  @Autowired private ResultRepository resultRepository;
+  @Autowired private DemoOktaRepository oktaRepository;
+  @Autowired private TestResultUploadRepository testResultUploadRepository;
 
-  @Autowired private ApiUserService _apiUserService;
-  @Autowired private DiseaseService _diseaseService;
+  @Autowired private ApiUserService apiUserService;
+  @Autowired private DiseaseService diseaseService;
 
   public Organization createValidOrg(
       String name, String type, String externalId, boolean identityVerified) {
-    Organization org = _orgRepo.save(new Organization(name, type, externalId, identityVerified));
-    _oktaRepo.createOrganization(org);
+    Organization org =
+        organizationRepository.save(new Organization(name, type, externalId, identityVerified));
+    oktaRepository.createOrganization(org);
     return org;
   }
 
@@ -122,12 +123,12 @@ public class TestDataFactory {
 
   public UserInfo createValidApiUser(String username, Organization org) {
     PersonName name = new PersonName("John", null, "June", null);
-    return _apiUserService.createUser(username, name, org.getExternalId(), Role.USER);
+    return apiUserService.createUser(username, name, org.getExternalId(), Role.USER);
   }
 
   public OrganizationQueueItem createOrganizationQueueItem(
       String orgName, String orgExternalId, String adminEmail) {
-    return _orgQueueRepo.save(
+    return organizationQueueRepository.save(
         new OrganizationQueueItem(
             orgName,
             orgExternalId,
@@ -150,7 +151,7 @@ public class TestDataFactory {
             new OrganizationAccountRequest(
                 "First", "Last", adminEmail, "800-555-1212", "CA", null, null));
     queueItem.setVerifiedOrganization(org);
-    return _orgQueueRepo.save(queueItem);
+    return organizationQueueRepository.save(queueItem);
   }
 
   public Facility createValidFacility(Organization org) {
@@ -163,7 +164,7 @@ public class TestDataFactory {
     List<DeviceType> configuredDevices = new ArrayList<>();
     configuredDevices.add(dev.getDeviceType());
     Provider doc =
-        _providerRepo.save(
+        providerRepository.save(
             new Provider("Doctor", "", "Doom", "", "DOOOOOOM", getAddress(), "800-555-1212"));
     Facility facility =
         new Facility(
@@ -176,15 +177,15 @@ public class TestDataFactory {
             doc,
             dev,
             configuredDevices);
-    Facility save = _facilityRepo.save(facility);
-    _oktaRepo.createFacility(save);
+    Facility save = facilityRepository.save(facility);
+    oktaRepository.createFacility(save);
     return save;
   }
 
   public Facility createArchivedFacility(Organization org, String facilityName) {
     Facility facility = createValidFacility(org, facilityName);
     facility.setIsDeleted(true);
-    return _facilityRepo.save(facility);
+    return facilityRepository.save(facility);
   }
 
   @Transactional
@@ -218,11 +219,11 @@ public class TestDataFactory {
   public Person createMinimalPerson(
       Organization org, Facility fac, PersonName names, PersonRole role) {
     Person p = new Person(names, org, fac, role);
-    _personRepo.save(p);
+    personRepository.save(p);
     PhoneNumber pn = new PhoneNumber(p, PhoneType.MOBILE, "503-867-5309");
-    _phoneNumberRepo.save(pn);
+    phoneNumberRepository.save(pn);
     p.setPrimaryPhone(pn);
-    return _personRepo.save(p);
+    return personRepository.save(p);
   }
 
   @Transactional
@@ -255,11 +256,11 @@ public class TestDataFactory {
             false,
             language,
             TestResultDeliveryPreference.SMS);
-    _personRepo.save(p);
+    personRepository.save(p);
     PhoneNumber pn = new PhoneNumber(p, PhoneType.MOBILE, "216-555-1234");
-    _phoneNumberRepo.save(pn);
+    phoneNumberRepository.save(pn);
     p.setPrimaryPhone(pn);
-    return _personRepo.save(p);
+    return personRepository.save(p);
   }
 
   @Transactional
@@ -287,11 +288,11 @@ public class TestDataFactory {
             false,
             "English",
             TestResultDeliveryPreference.SMS);
-    _personRepo.save(p);
+    personRepository.save(p);
     PhoneNumber pn = new PhoneNumber(p, PhoneType.MOBILE, telephone);
-    _phoneNumberRepo.save(pn);
+    phoneNumberRepository.save(pn);
     p.setPrimaryPhone(pn);
-    return _personRepo.save(p);
+    return personRepository.save(p);
   }
 
   @Transactional
@@ -319,7 +320,7 @@ public class TestDataFactory {
             false,
             "English",
             TestResultDeliveryPreference.SMS);
-    return _personRepo.save(p);
+    return personRepository.save(p);
   }
 
   private Specification<Person> personFilter(PersonName n) {
@@ -331,7 +332,7 @@ public class TestDataFactory {
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public Person getPersonByName(PersonName n) {
-    List<Person> perple = _personRepo.findAll(personFilter(n), PageRequest.of(0, 10));
+    List<Person> perple = personRepository.findAll(personFilter(n), PageRequest.of(0, 10));
     if (perple.size() != 1) {
       throw new RuntimeException(
           String.format(
@@ -343,7 +344,7 @@ public class TestDataFactory {
 
   public PhoneNumber addPhoneNumberToPerson(Person p, PhoneNumber pn) {
     pn.setPerson(p);
-    return _phoneNumberRepo.save(pn);
+    return phoneNumberRepository.save(pn);
   }
 
   public TestResultUpload createTestResultUpload(
@@ -351,7 +352,7 @@ public class TestDataFactory {
     var warnings = (FeedbackMessage[]) Array.newInstance(FeedbackMessage.class, 0);
     var errors = (FeedbackMessage[]) Array.newInstance(FeedbackMessage.class, 0);
     var upload = new TestResultUpload(reportId, status, 0, organization, warnings, errors);
-    var saved = _testResultUploadRepo.save(upload);
+    var saved = testResultUploadRepository.save(upload);
     return saved;
   }
 
@@ -362,14 +363,14 @@ public class TestDataFactory {
   public TestOrder createTestOrder(Person p, Facility f, AskOnEntrySurvey s) {
     TestOrder o = new TestOrder(p, f);
     o.setAskOnEntrySurvey(savePatientAnswers(s));
-    var savedOrder = _testOrderRepo.save(o);
-    _patientLinkRepository.save(new PatientLink(savedOrder));
+    var savedOrder = testOrderRepository.save(o);
+    patientLinkRepository.save(new PatientLink(savedOrder));
     return savedOrder;
   }
 
   public TestOrder createTestOrderNoPatientLink(Person p, Facility f) {
     TestOrder o = new TestOrder(p, f);
-    return _testOrderRepo.save(o);
+    return testOrderRepository.save(o);
   }
 
   public TestOrder createCompletedTestOrder(Person patient, Facility facility, TestResult result) {
@@ -378,12 +379,12 @@ public class TestDataFactory {
     order.setDeviceSpecimen(facility.getDefaultDeviceSpecimen());
 
     order.markComplete();
-    TestOrder savedOrder = _testOrderRepo.save(order);
+    TestOrder savedOrder = testOrderRepository.save(order);
 
-    Result resultEntity = new Result(order, _diseaseService.covid(), result);
+    Result resultEntity = new Result(order, diseaseService.covid(), result);
     order.addResult(resultEntity);
-    _resultRepository.save(resultEntity);
-    _patientLinkRepository.save(new PatientLink(savedOrder));
+    resultRepository.save(resultEntity);
+    patientLinkRepository.save(new PatientLink(savedOrder));
     return order;
   }
 
@@ -393,7 +394,7 @@ public class TestDataFactory {
 
   private PatientAnswers savePatientAnswers(AskOnEntrySurvey survey) {
     PatientAnswers answers = new PatientAnswers(survey);
-    _patientAnswerRepo.save(answers);
+    patientAnswersRepository.save(answers);
     return answers;
   }
 
@@ -404,14 +405,14 @@ public class TestDataFactory {
   public TestEvent createTestEvent(Person p, Facility f, AskOnEntrySurvey s, TestResult r, Date d) {
     TestOrder o = createTestOrder(p, f, s);
     o.setDateTestedBackdate(d);
-    Result result = new Result(o, _diseaseService.covid(), r);
-    TestEvent e = _testEventRepo.save(new TestEvent(o, false, Set.of(result)));
+    Result result = new Result(o, diseaseService.covid(), r);
+    TestEvent e = testEventRepository.save(new TestEvent(o, false, Set.of(result)));
     o.setTestEventRef(e);
     o.markComplete();
 
     result.setTestEvent(e);
-    _resultRepository.save(result);
-    _testOrderRepo.save(o);
+    resultRepository.save(result);
+    testOrderRepository.save(o);
     return e;
   }
 
@@ -421,17 +422,17 @@ public class TestDataFactory {
 
   public TestEvent createTestEvent(Person p, Facility f, TestResult r, Boolean hasPriorTests) {
     TestOrder o = createTestOrder(p, f);
-    Result result = new Result(o, _diseaseService.covid(), r);
-    _resultRepository.save(result);
-    o = _testOrderRepo.save(o);
+    Result result = new Result(o, diseaseService.covid(), r);
+    resultRepository.save(result);
+    o = testOrderRepository.save(o);
 
     TestEvent e = new TestEvent(o, hasPriorTests, Set.of(result));
-    _testEventRepo.save(e);
+    testEventRepository.save(e);
     result.setTestEvent(e);
-    _resultRepository.save(result);
+    resultRepository.save(result);
     o.setTestEventRef(e);
     o.markComplete();
-    _testOrderRepo.save(o);
+    testOrderRepository.save(o);
     return e;
   }
 
@@ -443,26 +444,26 @@ public class TestDataFactory {
       TestResult fluBResult,
       Boolean hasPriorTests) {
     TestOrder order = createTestOrder(person, facility);
-    Result covid = new Result(order, _diseaseService.covid(), covidResult);
-    _resultRepository.save(covid);
-    Result fluA = new Result(order, _diseaseService.fluA(), fluAResult);
-    _resultRepository.save(fluA);
-    Result fluB = new Result(order, _diseaseService.fluB(), fluBResult);
-    _resultRepository.save(fluB);
-    order = _testOrderRepo.save(order);
+    Result covid = new Result(order, diseaseService.covid(), covidResult);
+    resultRepository.save(covid);
+    Result fluA = new Result(order, diseaseService.fluA(), fluAResult);
+    resultRepository.save(fluA);
+    Result fluB = new Result(order, diseaseService.fluB(), fluBResult);
+    resultRepository.save(fluB);
+    order = testOrderRepository.save(order);
 
     TestEvent event = new TestEvent(order, hasPriorTests, Set.of(covid, fluA, fluB));
-    _testEventRepo.save(event);
+    testEventRepository.save(event);
     covid.setTestEvent(event);
-    _resultRepository.save(covid);
+    resultRepository.save(covid);
     fluA.setTestEvent(event);
-    _resultRepository.save(fluA);
+    resultRepository.save(fluA);
     fluB.setTestEvent(event);
-    _resultRepository.save(fluB);
+    resultRepository.save(fluB);
 
     order.setTestEventRef(event);
     order.markComplete();
-    _testOrderRepo.save(order);
+    testOrderRepository.save(order);
 
     return event;
   }
@@ -475,7 +476,7 @@ public class TestDataFactory {
     order.setReasonForCorrection("Cold feet");
     order.setCorrectionStatus(correctionStatus);
 
-    List<Result> originalResults = _resultRepository.findAllByTestOrder(order);
+    List<Result> originalResults = resultRepository.findAllByTestOrder(order);
     Set<Result> copiedResults =
         originalResults.stream().map(Result::new).collect(Collectors.toSet());
 
@@ -484,54 +485,55 @@ public class TestDataFactory {
     copiedResults.forEach(result -> result.setTestEvent(newRemoveEvent));
 
     order.setTestEventRef(newRemoveEvent);
-    _testEventRepo.save(newRemoveEvent);
-    _testOrderRepo.save(order);
-    _resultRepository.saveAll(copiedResults);
+    testEventRepository.save(newRemoveEvent);
+    testOrderRepository.save(order);
+    resultRepository.saveAll(copiedResults);
 
     Hibernate.initialize(newRemoveEvent.getOrganization());
     return newRemoveEvent;
   }
 
   public TestEvent doTest(TestOrder order, TestResult result) {
-    TestEvent event = _testEventRepo.save(new TestEvent(order));
-    Result resultEntity = new Result(event, order, _diseaseService.covid(), result);
-    _resultRepository.save(resultEntity);
+    TestEvent event = testEventRepository.save(new TestEvent(order));
+    Result resultEntity = new Result(event, order, diseaseService.covid(), result);
+    resultRepository.save(resultEntity);
     order.setTestEventRef(event);
     order.markComplete();
-    _testOrderRepo.save(order);
+    testOrderRepository.save(order);
     return event;
   }
 
   @Transactional
   public PatientLink createPatientLink(TestOrder order) {
-    TestOrder to = _testOrderRepo.findById(order.getInternalId()).orElseThrow();
+    TestOrder to = testOrderRepository.findById(order.getInternalId()).orElseThrow();
     PatientLink pl = new PatientLink(to);
-    return _patientLinkRepository.save(pl);
+    return patientLinkRepository.save(pl);
   }
 
   @Transactional
   public PatientLink expirePatientLink(PatientLink pl) {
     pl.expire();
-    return _patientLinkRepository.save(pl);
+    return patientLinkRepository.save(pl);
   }
 
   @Transactional
   public PatientSelfRegistrationLink createPatientRegistrationLink(Organization org) {
     String link = UUID.randomUUID().toString();
     PatientSelfRegistrationLink prl = new PatientSelfRegistrationLink(org, link);
-    return _patientRegistrationLinkRepository.save(prl);
+    return patientRegistrationLinkRepository.save(prl);
   }
 
   @Transactional
   public PatientSelfRegistrationLink createPatientRegistrationLink(Facility fac) {
     String link = UUID.randomUUID().toString();
     PatientSelfRegistrationLink prl = new PatientSelfRegistrationLink(fac, link);
-    return _patientRegistrationLinkRepository.save(prl);
+    return patientRegistrationLinkRepository.save(prl);
   }
 
   public DeviceType createDeviceType(
       String name, String manufacturer, String model, String loincCode, String swabType) {
-    return _deviceRepo.save(new DeviceType(name, manufacturer, model, loincCode, swabType, 15));
+    return deviceTypeRepository.save(
+        new DeviceType(name, manufacturer, model, loincCode, swabType, 15));
   }
 
   public DeviceType getGenericDevice() {
@@ -540,7 +542,7 @@ public class TestDataFactory {
 
   public SpecimenType createSpecimenType(
       String name, String typeCode, String collectionLocationName, String collectionLocationCode) {
-    return _specimenRepo.save(
+    return specimenTypeRepository.save(
         new SpecimenType(name, typeCode, collectionLocationName, collectionLocationCode));
   }
 
@@ -550,25 +552,25 @@ public class TestDataFactory {
 
   public DeviceSpecimenType getGenericDeviceSpecimen() {
     DeviceType dev =
-        _deviceRepo.findAll().stream()
+        deviceTypeRepository.findAll().stream()
             .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
             .findFirst()
             .orElseGet(
                 () -> createDeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E"));
     SpecimenType specType =
-        _specimenRepo.findAll().stream()
+        specimenTypeRepository.findAll().stream()
             .filter(d -> d.getName().equals(DEFAULT_SPECIMEN_TYPE))
             .findFirst()
             .orElseGet(
                 () ->
                     createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
-    return _deviceSpecimenRepo
+    return deviceSpecimenTypeRepository
         .find(dev, specType)
         .orElseGet(() -> createDeviceSpecimen(dev, specType));
   }
 
   public DeviceSpecimenType createDeviceSpecimen(DeviceType device, SpecimenType specimen) {
-    return _deviceSpecimenRepo.save(new DeviceSpecimenType(device, specimen));
+    return deviceSpecimenTypeRepository.save(new DeviceSpecimenType(device, specimen));
   }
 
   public StreetAddress getAddress() {
@@ -591,6 +593,6 @@ public class TestDataFactory {
   public void createResult(
       TestEvent testEvent, TestOrder testOrder, SupportedDisease disease, TestResult testResult) {
     var res = new Result(testEvent, testOrder, disease, testResult);
-    _resultRepository.save(res);
+    resultRepository.save(res);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -104,8 +104,6 @@ public class TestDataFactory {
   @Autowired private ApiUserService apiUserService;
   @Autowired private DiseaseService diseaseService;
 
-  //  @Autowired private TestDataBuilder dataBuilder;
-
   public Organization saveOrganization(Organization org) {
     Organization savedOrg = organizationRepository.save(org);
     oktaRepository.createOrganization(savedOrg);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part one to #4462 

## Changes Proposed

- Creates a new class, TestDataBuilder
- Existing organization-related TestDataFactory methods were refactored to take advantage of this Builder
- Starting small here - rather than reconfigure the entire TestDataFactory in a single PR, just changing a few methods at a time. As we move forward and write more tests, we can continue to migrate the creation of some objects to the TestDataBuilder, especially in any tests that don't require a backing database.

## Additional information

Open to feedback on what would be most useful to tackle next with this refactor - my guess would be device and facility creation, but are there any particular tests that would benefit from this reworking? I'd rather start with the affected tests and move back towards the refactor.

## Testing

- All tests pass

## Checklist for Primary Reviewer
- [x] Changes comply with the SimpleReport Style Guide