### PR TITLE
check dev* container logs in prime-simple-report-dev resource group

### DIFF
--- a/.github/workflows/rollbackDB.yml
+++ b/.github/workflows/rollbackDB.yml
@@ -63,4 +63,7 @@ jobs:
         run: terraform -chdir=$DEPLOY_ENV apply -var acr_image_tag=dummy -var liquibase_rollback_tag=$LIQUIBASE_ROLLBACK_TAG -target module.db_rollback[0] --auto-approve
       - name: Display logs
         if: always()
-        run: az container logs --follow -g prime-simple-report-$DEPLOY_ENV --name simple-report-$DEPLOY_ENV-db-rollback
+        run: |
+          RESOURCE_GROUP=$DEPLOY_ENV
+          if [[ "$DEPLOY_ENV" == *"dev"* ]]; then RESOURCE_GROUP="dev"; fi;
+          az container logs --follow -g prime-simple-report-$RESOURCE_GROUP --name simple-report-$DEPLOY_ENV-db-rollback


### PR DESCRIPTION
# DEVOPS/DATABASE PULL REQUEST

## Related Issue

- resolves #4872 

## Changes Proposed

- This checks the environment we're rolling back; if it's a dev environment, check the logs from the dev resource group because that's where all dev* azure resources are. 

## Testing

- Feel free to run a rollback, [this is the rollback that I ran](https://github.com/CDCgov/prime-simplereport/actions/runs/3895313129). I pulled the tag from the failed job that attempted to roll back dev6. Unfortunately, the build failed; I'm not sure if that's because of my branch or something else but the changes I made allowed us to see those logs.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README