### PR TITLE
make extra fields in device_specimen_type optional

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4180,3 +4180,61 @@ databaseChangeLog:
         - addNotNullConstraint:
             tableName: test_order
             columnName: device_specimen_type_id
+  - changeSet:
+      id: drop-primary-key-device_specimen_type
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: drop-primary-key-device_specimen_type
+        - dropPrimaryKey:
+            tableName: device_specimen_type
+            constraintName: device_specimen_type_pkey
+            dropIndex: true
+      rollback:
+        - addPrimaryKey:
+            tableName: device_specimen_type
+            constraintName: device_specimen_type_pkey
+            columnNames: internal_id
+  - changeSet:
+      id: drop-not-null-constraints-device_specimen_type
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: drop-not-null-constraints-device_specimen_type
+        - dropNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: internal_id
+        - dropNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: created_at
+        - dropNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: created_by
+        - dropNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: updated_at
+        - dropNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: updated_by
+        - dropNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: is_deleted
+      rollback:
+        - addNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: internal_id
+        - addNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: created_at
+        - addNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: created_by
+        - addNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: updated_at
+        - addNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: updated_by
+        - addNotNullConstraint:
+            tableName: device_specimen_type
+            columnName: is_deleted


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352

## Changes Proposed

 `device_specimen_type` is a join table and should only have two columns, `deviceTypeId` and `SpecimenTypeId`
- Drop primary key constraint on the `device_specimen_type` table
- Make the following fields in the join table `device_specimen_type` optional
  - internal_id
  - created_at
  - created_by
  - updated_at
  - updated_by
  - is_deleted

This will enable the code to stop writing to these fields

## Testing

- How should reviewers verify this PR? deployed on dev7

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

