### PR TITLE
prevent page reload when the test card tooltip gets clicked

### DIFF
--- a/frontend/src/app/commonComponents/TextWithTooltip.tsx
+++ b/frontend/src/app/commonComponents/TextWithTooltip.tsx
@@ -38,7 +38,9 @@ export const TextWithTooltip = ({
         </button>
       )
     );
-
+  function preventPageReload(e: React.MouseEvent) {
+    e.preventDefault();
+  }
   CustomButton.displayName = "custom button";
 
   return (
@@ -48,6 +50,7 @@ export const TextWithTooltip = ({
       position={position || "top"}
       className={className}
       wrapperclasses="usa-text-with-tooltip"
+      onClick={(e) => preventPageReload(e)}
     >
       {text}
       <FontAwesomeIcon

--- a/frontend/src/app/commonComponents/TextWithTooltip.tsx
+++ b/frontend/src/app/commonComponents/TextWithTooltip.tsx
@@ -50,7 +50,7 @@ export const TextWithTooltip = ({
       position={position || "top"}
       className={className}
       wrapperclasses="usa-text-with-tooltip"
-      onClick={(e) => preventPageReload(e)}
+      onClick={preventPageReload}
     >
       {text}
       <FontAwesomeIcon

--- a/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
@@ -353,4 +353,40 @@ describe("TestResultInputForm", () => {
     expect(preventDefaultSpy).toHaveBeenCalled();
     expect(onSubmitFn).toHaveBeenCalled();
   });
+  it("makes sure that clicking the tooltip doesn't reload the page", () => {
+    render(
+      <MultiplexResultInputForm
+        queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
+        testResults={[
+          {
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
+        ]}
+        onChange={onChangeFn}
+        onSubmit={onSubmitFn}
+      />
+    );
+
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    const preventDefaultSpy = spyOn(clickEvent, "preventDefault");
+    fireEvent(
+      screen.getByRole("button", { name: /Results info tooltip/i }),
+      clickEvent
+    );
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    jest.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #4909 

## Changes Proposed

- Adds a prevent default handler to prevent the page reloading on click of the tooltip

## Testing

- Deployed to [dev3](https://dev3.simplereport.gov/app/queue?facility=d6bc6687-74f3-4b51-bc6e-44ee89d8ecbf) for testing

## Screenshots / Demos

https://user-images.githubusercontent.com/29645040/211610344-8e511c9f-d98f-4331-8b99-9fa20872872c.mov