### PR TITLE
Don't cancel ongoing test jobs, to prevent loss of TF lock control.

### DIFF
--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -7,7 +7,6 @@ on:
 
 concurrency:
   group: test-deploy
-  cancel-in-progress: false
 env:
   DEPLOY_ENV: test
   NODE_VERSION: 18

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: test-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 env:
   DEPLOY_ENV: test
   NODE_VERSION: 18


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- TF can maintain a perpetual state lock if an ongoing job is not allowed to gracefully terminate. This requires DevOps intervention to fix.
- GitHub should not be allowed to cancel an in-progress TF action.

## Changes Proposed

- Set `cancel-in-progress` flag in `deployTest.yml` to `false`.
