### PR TITLE
add gradle locks script to intellij

### DIFF
--- a/.run/write gradle locks.run.xml
+++ b/.run/write gradle locks.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="write gradle locks" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="cd backend &amp;&amp; ./gradlew dependencies --write-locks" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- I constantly find myself either looking in gradle docs or our docs for this command.

## Changes Proposed

- Add `gradle dependencies --write-locks` to intellij scripts
- https://docs.gradle.org/current/userguide/dependency_locking.html#:~:text=gradle%20dependencies%20%2D%2Dwrite%2Dlocks

