### PR TITLE
remove device specimen type from TestOrder/TestEvent/Facility

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -1,7 +1,6 @@
 package gov.cdc.usds.simplereport.api.model;
 
 import gov.cdc.usds.simplereport.api.model.facets.LocatedWrapper;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
@@ -36,14 +35,6 @@ public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapp
 
   public List<DeviceType> getDeviceTypes() {
     return getWrapped().getDeviceTypes();
-  }
-
-  public DeviceType getDefaultDeviceType() {
-    return getWrapped().getDefaultDeviceType();
-  }
-
-  public DeviceSpecimenType getDefaultDeviceSpecimen() {
-    return getWrapped().getDefaultDeviceSpecimen();
   }
 
   public ApiProvider getOrderingProvider() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.api.model;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.service.model.WrappedEntity;
@@ -30,9 +29,5 @@ public class ApiTestOrder extends WrappedEntity<TestOrder> {
 
   public String getReasonForCorrection() {
     return wrapped.getReasonForCorrection();
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType() {
-    return wrapped.getDeviceSpecimen();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -62,7 +62,7 @@ public class TestEventExport {
     this.specimenType = Optional.ofNullable(testEvent.getSpecimenType());
   }
 
-  private static final String genderUnknown = "U";
+  private String genderUnknown = "U";
   private static final String DEFAULT_LOCATION_CODE = "53342003"; // http://snomed.info/id/53342003
   // "Internal nose structure"
   // values pulled from

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -62,7 +62,7 @@ public class TestEventExport {
     this.specimenType = Optional.ofNullable(testEvent.getSpecimenType());
   }
 
-  private String genderUnknown = "U";
+  private static final String genderUnknown = "U";
   private static final String DEFAULT_LOCATION_CODE = "53342003"; // http://snomed.info/id/53342003
   // "Internal nose structure"
   // values pulled from

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -7,7 +7,6 @@ import gov.cdc.usds.simplereport.api.model.ApiTestOrder;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.MultiplexResultInput;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
-import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import java.time.LocalDate;
@@ -28,7 +27,6 @@ public class QueueMutationResolver {
 
   private final TestOrderService testOrderService;
   private final PersonService personService;
-  private final DeviceTypeService deviceTypeService;
 
   @MutationMapping
   public AddTestResultResponse submitQueueItem(
@@ -37,11 +35,8 @@ public class QueueMutationResolver {
       @Argument List<MultiplexResultInput> results,
       @Argument UUID patientId,
       @Argument Date dateTested) {
-    UUID deviceSpecimenTypeId =
-        deviceTypeService.getDeviceSpecimenType(deviceTypeId, specimenTypeId).getInternalId();
-
     return testOrderService.addMultiplexResult(
-        deviceSpecimenTypeId, results, patientId, dateTested);
+        deviceTypeId, specimenTypeId, results, patientId, dateTested);
   }
 
   @MutationMapping
@@ -51,12 +46,9 @@ public class QueueMutationResolver {
       @Argument UUID specimenTypeId,
       @Argument List<MultiplexResultInput> results,
       @Argument Date dateTested) {
-    UUID deviceSpecimenTypeId =
-        deviceTypeService.getDeviceSpecimenType(deviceTypeId, specimenTypeId).getInternalId();
-
     return new ApiTestOrder(
         testOrderService.editQueueItemMultiplexResult(
-            id, deviceSpecimenTypeId, results, dateTested));
+            id, deviceTypeId, specimenTypeId, results, dateTested));
   }
 
   @MutationMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -2,7 +2,6 @@ package gov.cdc.usds.simplereport.config;
 
 import static gov.cdc.usds.simplereport.utils.DeviceTestLengthConverter.determineTestLength;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -134,10 +133,20 @@ public class InitialSetupProperties {
     public Facility makeRealFacility(
         Organization org,
         Provider p,
-        DeviceSpecimenType defaultDeviceSpec,
+        DeviceType defaultDeviceType,
+        SpecimenType defaultSpecimenType,
         List<DeviceType> configured) {
       return new Facility(
-          org, name, cliaNumber, address, telephone, email, p, defaultDeviceSpec, configured);
+          org,
+          name,
+          cliaNumber,
+          address,
+          telephone,
+          email,
+          p,
+          defaultDeviceType,
+          defaultSpecimenType,
+          configured);
     }
 
     public String getName() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -28,10 +28,6 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   private Facility facility;
 
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  @JoinColumn(name = "device_specimen_type_id")
-  private DeviceSpecimenType deviceSpecimen;
-
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "device_type_id")
   private DeviceType deviceType;
 
@@ -61,26 +57,16 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
 
   protected BaseTestInfo(BaseTestInfo orig) {
     this(orig.getPatient(), orig.getFacility());
-    if (orig.getDeviceSpecimen() != null) {
-      this.setDeviceSpecimen(orig.getDeviceSpecimen());
-    } else {
-      this.setDeviceTypeAndSpecimenType(orig.getDeviceType(), orig.getSpecimenType());
-    }
   }
 
-  protected BaseTestInfo(Person patient, Facility facility, DeviceSpecimenType deviceSpecimen) {
+  protected BaseTestInfo(Person patient, Facility facility) {
     super();
     this.patient = patient;
     this.facility = facility;
     this.organization = facility.getOrganization();
-    this.deviceSpecimen = deviceSpecimen;
-    this.deviceType = deviceSpecimen.getDeviceType();
-    this.specimenType = deviceSpecimen.getSpecimenType();
+    this.deviceType = facility.getDefaultDeviceType();
+    this.specimenType = facility.getDefaultSpecimenType();
     this.correctionStatus = TestCorrectionStatus.ORIGINAL;
-  }
-
-  protected BaseTestInfo(Person patient, Facility facility) {
-    this(patient, facility, facility.getDefaultDeviceSpecimen());
   }
 
   protected BaseTestInfo(
@@ -111,10 +97,6 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     return specimenType;
   }
 
-  public DeviceSpecimenType getDeviceSpecimen() {
-    return deviceSpecimen;
-  }
-
   // FYI Setters shouldn't be allowed in TestEvent, so they are always *protected*
   // in this base class
   // and exposed only in TestOrder.
@@ -125,12 +107,6 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
 
   protected void setDateTestedBackdate(Date dateTestedBackdate) {
     this.dateTestedBackdate = dateTestedBackdate;
-  }
-
-  protected void setDeviceSpecimen(DeviceSpecimenType deviceSpecimen) {
-    this.deviceSpecimen = deviceSpecimen;
-    this.deviceType = deviceSpecimen.getDeviceType();
-    this.specimenType = deviceSpecimen.getSpecimenType();
   }
 
   protected void setDeviceTypeAndSpecimenType(DeviceType device, SpecimenType specimen) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -60,12 +60,17 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   }
 
   protected BaseTestInfo(Person patient, Facility facility) {
+    this(patient, facility, facility.getDefaultDeviceType(), facility.getDefaultSpecimenType());
+  }
+
+  protected BaseTestInfo(
+      Person patient, Facility facility, DeviceType deviceType, SpecimenType specimenType) {
     super();
     this.patient = patient;
     this.facility = facility;
     this.organization = facility.getOrganization();
-    this.deviceType = facility.getDefaultDeviceType();
-    this.specimenType = facility.getDefaultSpecimenType();
+    this.deviceType = deviceType;
+    this.specimenType = specimenType;
     this.correctionStatus = TestCorrectionStatus.ORIGINAL;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -4,7 +4,6 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -34,10 +33,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
   private Provider orderingProvider;
 
   @ManyToOne(optional = true, fetch = FetchType.EAGER)
-  @JoinColumn(name = "default_device_specimen_type_id")
-  private DeviceSpecimenType defaultDeviceSpecimen;
-
-  @ManyToOne(optional = true, fetch = FetchType.EAGER)
   @JoinColumn(name = "default_device_type_id")
   private DeviceType defaultDeviceType;
 
@@ -63,7 +58,8 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
       String phone,
       String email,
       Provider orderingProvider,
-      DeviceSpecimenType defaultDeviceSpecimen,
+      DeviceType defaultDeviceType,
+      SpecimenType defaultSpecimenType,
       List<DeviceType> configuredDevices) {
     this(
         org,
@@ -74,7 +70,7 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
         email,
         orderingProvider,
         configuredDevices);
-    this.addDefaultDeviceSpecimen(defaultDeviceSpecimen);
+    this.setDefaultDeviceTypeSpecimenType(defaultDeviceType, defaultSpecimenType);
   }
 
   public Facility(
@@ -105,7 +101,20 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
   }
 
   public DeviceType getDefaultDeviceType() {
-    return this.defaultDeviceSpecimen == null ? null : this.defaultDeviceSpecimen.getDeviceType();
+    return this.defaultDeviceType;
+  }
+
+  public void setDefaultDeviceTypeSpecimenType(DeviceType deviceType, SpecimenType specimenType) {
+    if (deviceType != null) {
+      configuredDeviceTypes.add(deviceType);
+    }
+
+    this.defaultDeviceType = deviceType;
+    this.defaultSpecimenType = specimenType;
+  }
+
+  public void removeDefaultDeviceTypeSpecimenType() {
+    this.setDefaultDeviceTypeSpecimenType(null, null);
   }
 
   public SpecimenType getDefaultSpecimenType() {
@@ -120,34 +129,14 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
     return configuredDeviceTypes.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
   }
 
-  public DeviceSpecimenType getDefaultDeviceSpecimen() {
-    return defaultDeviceSpecimen;
-  }
-
-  public void addDefaultDeviceSpecimen(DeviceSpecimenType newDefault) {
-    if (newDefault != null) {
-      configuredDeviceTypes.add(newDefault.getDeviceType());
-      this.defaultDeviceType = newDefault.getDeviceType();
-      this.defaultSpecimenType = newDefault.getSpecimenType();
-    }
-
-    defaultDeviceSpecimen = newDefault;
-  }
-
-  public void removeDefaultDeviceSpecimen() {
-    defaultDeviceSpecimen = null;
-  }
-
   public void removeDeviceType(DeviceType deletedDevice) {
     this.configuredDeviceTypes.remove(deletedDevice);
 
     // If the corresponding device to a facility's default device swab type is removed,
     // set default to null
-    if (this.getDefaultDeviceSpecimen() != null) {
-      UUID defaultDeviceTypeId = this.defaultDeviceSpecimen.getDeviceType().getInternalId();
-      if (defaultDeviceTypeId.equals(deletedDevice.getInternalId())) {
-        this.addDefaultDeviceSpecimen(null);
-      }
+    if (this.getDefaultDeviceType() != null
+        && this.getDefaultDeviceType().getInternalId().equals(deletedDevice.getInternalId())) {
+      this.removeDefaultDeviceTypeSpecimenType();
     }
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -70,7 +70,7 @@ public class TestEvent extends BaseTestInfo {
   }
 
   private TestEvent(TestOrder order, Boolean hasPriorTests) {
-    super(order.getPatient(), order.getFacility());
+    super(order.getPatient(), order.getFacility(), order.getDeviceType(), order.getSpecimenType());
     // store a link, and *also* store the object as JSON
     // force load the lazy-loaded phone numbers so values are available to the object mapper
     // when serializing `patientData` (phoneNumbers is default lazy-loaded because of `OneToMany`)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -70,7 +70,7 @@ public class TestEvent extends BaseTestInfo {
   }
 
   private TestEvent(TestOrder order, Boolean hasPriorTests) {
-    super(order.getPatient(), order.getFacility(), order.getDeviceSpecimen());
+    super(order.getPatient(), order.getFacility());
     // store a link, and *also* store the object as JSON
     // force load the lazy-loaded phone numbers so values are available to the object mapper
     // when serializing `patientData` (phoneNumbers is default lazy-loaded because of `OneToMany`)
@@ -162,10 +162,6 @@ public class TestEvent extends BaseTestInfo {
 
   public UUID getPriorCorrectedTestEventId() {
     return priorCorrectedTestEventId;
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType() {
-    return order.getDeviceSpecimen();
   }
 
   public Optional<TestResult> getCovidTestResult() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -78,8 +78,8 @@ public class TestOrder extends BaseTestInfo {
   }
 
   @Override
-  public void setDeviceSpecimen(DeviceSpecimenType ds) {
-    super.setDeviceSpecimen(ds);
+  public void setDeviceTypeAndSpecimenType(DeviceType device, SpecimenType specimen) {
+    super.setDeviceTypeAndSpecimenType(device, specimen);
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeRepository.java
@@ -5,7 +5,6 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
@@ -20,13 +19,6 @@ public interface DeviceSpecimenTypeRepository
   @EntityGraph(attributePaths = {"deviceType", "specimenType"})
   @Query(BASE_QUERY + " and e.deviceType = :deviceType and e.specimenType = :specimenType")
   Optional<DeviceSpecimenType> find(DeviceType deviceType, SpecimenType specimenType);
-
-  @EntityGraph(attributePaths = {"deviceType", "specimenType"})
-  Optional<DeviceSpecimenType> findFirstByDeviceTypeInternalIdOrderByCreatedAt(UUID deviceTypeId);
-
-  @EntityGraph(attributePaths = {"deviceType", "specimenType"})
-  Optional<DeviceSpecimenType> findByDeviceTypeInternalIdAndSpecimenTypeInternalIdOrderByCreatedAt(
-      UUID deviceTypeId, UUID specimenTypeId);
 
   List<DeviceSpecimenType> findAllByDeviceType(DeviceType deviceType);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.db.repository;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import java.util.Collection;
@@ -43,6 +42,4 @@ public interface FacilityRepository extends EternalAuditedEntityRepository<Facil
       EternalAuditedEntityRepository.BASE_QUERY
           + " and e.organization = :org order by e.facilityName")
   List<Facility> findByOrganizationOrderByFacilityName(Organization org);
-
-  List<Facility> findAllByDefaultDeviceSpecimenIn(List<DeviceSpecimenType> dsts);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -26,8 +26,7 @@ public interface TestOrderRepository
   String RESULT_RECENT_ORDER = " order by q.updatedAt desc ";
 
   @Query(FACILITY_QUERY + IS_PENDING + ORDER_CREATION_ORDER)
-  @EntityGraph(
-      attributePaths = {"patient", "deviceType", "specimenType", "results", "deviceSpecimen"})
+  @EntityGraph(attributePaths = {"patient", "deviceType", "specimenType", "results"})
   List<TestOrder> fetchQueue(Organization org, Facility facility);
 
   @Query(BASE_ORG_QUERY + IS_PENDING + " and q.patient = :patient")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -104,16 +104,6 @@ public class DeviceTypeService {
       ArrayList<DeviceSpecimenType> toBeDeletedDeviceSpecimenTypes =
           new ArrayList<>(exitingDeviceSpecimenTypes);
       toBeDeletedDeviceSpecimenTypes.removeAll(newDeviceSpecimenTypes);
-
-      /* todo deal with this case
-      // Null out facilities' default device specimen if it was deleted
-      List<Facility> facilitiesToRemoveDefaultDeviceSpecimen =
-          facilityRepository.findAllByDefaultDeviceSpecimenIn(toBeDeletedDeviceSpecimenTypes);
-
-      facilitiesToRemoveDefaultDeviceSpecimen.forEach(
-          Facility::removeDefaultDeviceTypeSpecimenType);
-      */
-
       deviceSpecimenTypeRepository.deleteAll(toBeDeletedDeviceSpecimenTypes);
 
       // create new ones

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -6,12 +6,10 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import java.util.ArrayList;
@@ -19,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,76 +26,35 @@ import org.springframework.transaction.annotation.Transactional;
  * specific facility or organization).
  */
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DeviceTypeService {
 
   public static final String SWAB_TYPE_DELETED_MESSAGE =
       "swab type has been deleted and cannot be used";
-  private DeviceTypeRepository _repo;
-  private DeviceSpecimenTypeRepository _deviceSpecimenRepo;
-  private SpecimenTypeRepository _specimenTypeRepo;
-  private FacilityRepository _facilityRepo;
-  private SupportedDiseaseRepository _supportedDiseaseRepo;
-
-  public DeviceTypeService(
-      DeviceTypeRepository repo,
-      DeviceSpecimenTypeRepository deviceSpecimenRepo,
-      SpecimenTypeRepository specimenTypeRepo,
-      FacilityRepository facilityRepo,
-      SupportedDiseaseRepository supportedDiseaseRepo) {
-    _repo = repo;
-    _deviceSpecimenRepo = deviceSpecimenRepo;
-    _specimenTypeRepo = specimenTypeRepo;
-    _facilityRepo = facilityRepo;
-    _supportedDiseaseRepo = supportedDiseaseRepo;
-  }
+  private final DeviceTypeRepository deviceTypeRepository;
+  private final DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
+  private final SpecimenTypeRepository specimenTypeRepository;
+  private final SupportedDiseaseRepository supportedDiseaseRepository;
 
   @Transactional(readOnly = false)
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public void removeDeviceType(DeviceType d) {
-    _repo.delete(d);
+    deviceTypeRepository.delete(d);
   }
 
   public List<DeviceType> fetchDeviceTypes() {
-    return _repo.findAll();
+    return deviceTypeRepository.findAll();
   }
 
   public DeviceType getDeviceType(UUID internalId) {
-    return _repo
+    return deviceTypeRepository
         .findById(internalId)
         .orElseThrow(() -> new IllegalGraphqlArgumentException("invalid device type ID"));
   }
 
   public DeviceType getDeviceType(String name) {
-    return _repo.findDeviceTypeByName(name);
-  }
-
-  public List<DeviceSpecimenType> getDeviceSpecimenTypes() {
-    return _deviceSpecimenRepo.findAll();
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType(UUID deviceSpecimenTypeId) {
-    return _deviceSpecimenRepo
-        .findById(deviceSpecimenTypeId)
-        .orElseThrow(() -> new IllegalGraphqlArgumentException("invalid device specimen type ID"));
-  }
-
-  public DeviceSpecimenType getFirstDeviceSpecimenTypeForDeviceTypeId(UUID deviceId) {
-    return _deviceSpecimenRepo
-        .findFirstByDeviceTypeInternalIdOrderByCreatedAt(deviceId)
-        .orElseThrow(
-            () ->
-                new IllegalGraphqlArgumentException(
-                    "Device is not configured with a specimen type"));
-  }
-
-  public DeviceSpecimenType getDeviceSpecimenType(UUID deviceTypeId, UUID specimenTypeId) {
-    return _deviceSpecimenRepo
-        .findByDeviceTypeInternalIdAndSpecimenTypeInternalIdOrderByCreatedAt(
-            deviceTypeId, specimenTypeId)
-        .orElseThrow(
-            () ->
-                new IllegalGraphqlArgumentException("Not a valid device and specimen combination"));
+    return deviceTypeRepository.findDeviceTypeByName(name);
   }
 
   @Transactional(readOnly = false)
@@ -122,7 +80,7 @@ public class DeviceTypeService {
     if (updateDevice.getSwabTypes() != null) {
       List<SpecimenType> updatedSpecimenTypes =
           updateDevice.getSwabTypes().stream()
-              .map(uuid -> _specimenTypeRepo.findById(uuid))
+              .map(specimenTypeRepository::findById)
               .filter(Optional::isPresent)
               .map(Optional::get)
               .collect(Collectors.toList());
@@ -140,37 +98,40 @@ public class DeviceTypeService {
               .collect(Collectors.toList());
 
       List<DeviceSpecimenType> exitingDeviceSpecimenTypes =
-          _deviceSpecimenRepo.findAllByDeviceType(device);
+          deviceSpecimenTypeRepository.findAllByDeviceType(device);
 
       // delete old ones
       ArrayList<DeviceSpecimenType> toBeDeletedDeviceSpecimenTypes =
           new ArrayList<>(exitingDeviceSpecimenTypes);
       toBeDeletedDeviceSpecimenTypes.removeAll(newDeviceSpecimenTypes);
 
+      /* todo deal with this case
       // Null out facilities' default device specimen if it was deleted
       List<Facility> facilitiesToRemoveDefaultDeviceSpecimen =
-          _facilityRepo.findAllByDefaultDeviceSpecimenIn(toBeDeletedDeviceSpecimenTypes);
+          facilityRepository.findAllByDefaultDeviceSpecimenIn(toBeDeletedDeviceSpecimenTypes);
 
-      facilitiesToRemoveDefaultDeviceSpecimen.forEach(Facility::removeDefaultDeviceSpecimen);
+      facilitiesToRemoveDefaultDeviceSpecimen.forEach(
+          Facility::removeDefaultDeviceTypeSpecimenType);
+      */
 
-      _deviceSpecimenRepo.deleteAll(toBeDeletedDeviceSpecimenTypes);
+      deviceSpecimenTypeRepository.deleteAll(toBeDeletedDeviceSpecimenTypes);
 
       // create new ones
       ArrayList<DeviceSpecimenType> toBeAddedDeviceSpecimenTypes =
           new ArrayList<>(newDeviceSpecimenTypes);
       toBeAddedDeviceSpecimenTypes.removeAll(exitingDeviceSpecimenTypes);
-      _deviceSpecimenRepo.saveAll(toBeAddedDeviceSpecimenTypes);
+      deviceSpecimenTypeRepository.saveAll(toBeAddedDeviceSpecimenTypes);
     }
     if (updateDevice.getSupportedDiseases() != null) {
       List<SupportedDisease> supportedDiseases =
           updateDevice.getSupportedDiseases().stream()
-              .map(uuid -> _supportedDiseaseRepo.findById(uuid))
+              .map(supportedDiseaseRepository::findById)
               .filter(Optional::isPresent)
               .map(Optional::get)
               .collect(Collectors.toList());
       device.setSupportedDiseases(supportedDiseases);
     }
-    return _repo.save(device);
+    return deviceTypeRepository.save(device);
   }
 
   @Transactional(readOnly = false)
@@ -179,7 +140,7 @@ public class DeviceTypeService {
 
     List<SpecimenType> specimenTypes =
         createDevice.getSwabTypes().stream()
-            .map(uuid -> _specimenTypeRepo.findById(uuid).get())
+            .map(uuid -> specimenTypeRepository.findById(uuid).get())
             .collect(Collectors.toList());
 
     specimenTypes.forEach(
@@ -191,13 +152,13 @@ public class DeviceTypeService {
 
     List<SupportedDisease> supportedDiseases =
         createDevice.getSupportedDiseases().stream()
-            .map(uuid -> _supportedDiseaseRepo.findById(uuid))
+            .map(supportedDiseaseRepository::findById)
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());
 
     DeviceType dt =
-        _repo.save(
+        deviceTypeRepository.save(
             new DeviceType(
                 createDevice.getName(),
                 createDevice.getManufacturer(),
@@ -208,10 +169,10 @@ public class DeviceTypeService {
 
     specimenTypes.stream()
         .map(specimenType -> new DeviceSpecimenType(dt, specimenType))
-        .forEach(_deviceSpecimenRepo::save);
+        .forEach(deviceSpecimenTypeRepository::save);
 
     dt.setSupportedDiseases(supportedDiseases);
-    _repo.save(dt);
+    deviceTypeRepository.save(dt);
 
     return dt;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -72,7 +72,8 @@ public class OrganizationInitializingService {
         _props.getConfiguredDeviceTypeNames().stream()
             .map(dsByDeviceName::get)
             .collect(Collectors.toList());
-    DeviceSpecimenType defaultDeviceSpecimen = configuredDs.get(0);
+    DeviceType defaultDeviceType = configuredDs.get(0).getDeviceType();
+    SpecimenType defaultSpecimenType = configuredDs.get(0).getSpecimenType();
 
     List<Organization> emptyOrgs = _props.getOrganizations();
     Map<String, Organization> orgsByExternalId =
@@ -107,7 +108,8 @@ public class OrganizationInitializingService {
                         : f.makeRealFacility(
                             orgsByExternalId.get(f.getOrganizationExternalId()),
                             savedProvider,
-                            defaultDeviceSpecimen,
+                            defaultDeviceType,
+                            defaultSpecimenType,
                             configuredDs.stream()
                                 .map(DeviceSpecimenType::getDeviceType)
                                 .collect(Collectors.toList())))

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -439,7 +439,7 @@ public class TestOrderService {
               + "are incompatible with facility of queue");
     }
 
-    // if test facility doesnt have defaults, grab the first device on that facility
+    // if test facility doesn't have defaults, grab the first device on that facility
     if (testFacility.getDefaultDeviceType() == null
         || testFacility.getDefaultSpecimenType() == null) {
       testFacility.setDefaultDeviceTypeSpecimenType(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -8,7 +8,7 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.AuditedEntity_;
 import gov.cdc.usds.simplereport.db.model.BaseTestInfo_;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
@@ -17,6 +17,7 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Person_;
 import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.Result_;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestEvent_;
@@ -252,24 +253,29 @@ public class TestOrderService {
   @AuthorizationConfiguration.RequirePermissionUpdateTestForTestOrder
   public TestOrder editQueueItemMultiplexResult(
       UUID testOrderId,
-      UUID deviceSpecimenTypeId,
+      UUID deviceTypeId,
+      UUID specimenTypeId,
       List<MultiplexResultInput> results,
       Date dateTested) {
-    lockOrder(testOrderId);
     try {
+      DeviceType deviceType = _deviceTypeService.getDeviceType(deviceTypeId);
+      SpecimenType specimenType =
+          deviceType.getSwabTypes().stream()
+              .filter(swab -> swab.getInternalId().equals(specimenTypeId))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalGraphqlArgumentException(
+                          "invalid device type and specimen type combination"));
+
+      lockOrder(testOrderId);
       TestOrder order = this.getTestOrder(testOrderId);
 
-      if (deviceSpecimenTypeId != null) {
-        DeviceSpecimenType deviceSpecimenType =
-            _deviceTypeService.getDeviceSpecimenType(deviceSpecimenTypeId);
+      order.setDeviceTypeAndSpecimenType(deviceType, specimenType);
+      // Set the most-recently configured device specimen for a facility's
+      // test as facility default
+      order.getFacility().setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
-        if (deviceSpecimenType != null) {
-          order.setDeviceSpecimen(deviceSpecimenType);
-          // Set the most-recently configured device specimen for a facility's
-          // test as facility default
-          order.getFacility().addDefaultDeviceSpecimen(deviceSpecimenType);
-        }
-      }
       if (!results.isEmpty()) {
         editMultiplexResult(order, results);
       }
@@ -282,7 +288,8 @@ public class TestOrderService {
 
   @AuthorizationConfiguration.RequirePermissionSubmitTestForPatient
   public AddTestResultResponse addMultiplexResult(
-      UUID deviceSpecimenTypeId,
+      UUID deviceTypeId,
+      UUID specimenTypeId,
       List<MultiplexResultInput> results,
       UUID patientId,
       Date dateTested) {
@@ -291,15 +298,21 @@ public class TestOrderService {
     TestOrder order =
         _testOrderRepo.fetchQueueItem(org, person).orElseThrow(TestOrderService::noSuchOrderFound);
 
-    DeviceSpecimenType deviceSpecimenType =
-        _deviceTypeService.getDeviceSpecimenType(deviceSpecimenTypeId);
+    DeviceType deviceType = _deviceTypeService.getDeviceType(deviceTypeId);
+    SpecimenType specimenType =
+        deviceType.getSwabTypes().stream()
+            .filter(swab -> swab.getInternalId().equals(specimenTypeId))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalGraphqlArgumentException(
+                        "invalid device type and specimen type combination"));
 
     lockOrder(order.getInternalId());
-
     TestOrder savedOrder = null;
 
     try {
-      order.setDeviceSpecimen(deviceSpecimenType);
+      order.setDeviceTypeAndSpecimenType(deviceType, specimenType);
       var resultSet = editMultiplexResult(order, results);
       order.setDateTestedBackdate(dateTested);
       order.markComplete();
@@ -426,10 +439,12 @@ public class TestOrderService {
               + "are incompatible with facility of queue");
     }
 
-    if (testFacility.getDefaultDeviceSpecimen() == null) {
-      testFacility.addDefaultDeviceSpecimen(
-          _deviceTypeService.getFirstDeviceSpecimenTypeForDeviceTypeId(
-              testFacility.getDeviceTypes().get(0).getInternalId()));
+    // if test facility doesnt have defaults, grab the first device on that facility
+    if (testFacility.getDefaultDeviceType() == null
+        || testFacility.getDefaultSpecimenType() == null) {
+      testFacility.setDefaultDeviceTypeSpecimenType(
+          testFacility.getDeviceTypes().get(0),
+          testFacility.getDeviceTypes().get(0).getSwabTypes().get(0));
     }
 
     TestOrder newOrder = new TestOrder(patient, testFacility);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -862,8 +862,7 @@ class FhirConverterTest {
     var internalId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
     var testOrder = TestDataBuilder.createEmptyTestOrder();
     testOrder.markComplete();
-    testOrder.setDeviceTypeAndSpecimenType(
-        TestDataBuilder.createEmptyDeviceWithLoinc(), null);
+    testOrder.setDeviceTypeAndSpecimenType(TestDataBuilder.createEmptyDeviceWithLoinc(), null);
     ReflectionTestUtils.setField(testOrder, "internalId", UUID.fromString(internalId));
 
     var actual = convertToServiceRequest(testOrder);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -863,8 +862,7 @@ class FhirConverterTest {
     var internalId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
     var testOrder = TestDataBuilder.createEmptyTestOrder();
     testOrder.markComplete();
-    testOrder.setDeviceSpecimen(
-        new DeviceSpecimenType(TestDataBuilder.createEmptyDeviceWithLoinc(), null));
+    testOrder.setDeviceTypeAndSpecimenType(TestDataBuilder.createEmptyDeviceWithLoinc(), null);
     ReflectionTestUtils.setField(testOrder, "internalId", UUID.fromString(internalId));
 
     var actual = convertToServiceRequest(testOrder);
@@ -1063,9 +1061,7 @@ class FhirConverterTest {
   void createFhirBundle_TestEvent_matchesJson() throws IOException {
     var address = new StreetAddress(List.of("1 Main St"), "Chicago", "IL", "60614", "");
     var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", "nasal", 0);
-    var specimenType = new SpecimenType("name", "typeCode");
-    var deviceSpecimenType = new DeviceSpecimenType(deviceType, specimenType);
-    var provider =
+    var specimenType = new SpecimenType("name", "typeCode");var provider =
         new Provider(new PersonName("Michaela", null, "Quinn", ""), "1", address, "7735551235");
     var organization = new Organization("District", "school", "1", true);
     var facility =
@@ -1077,7 +1073,8 @@ class FhirConverterTest {
             "7735551234",
             "school@example.com",
             provider,
-            deviceSpecimenType,
+            deviceType,
+            specimenType,
             Collections.emptyList());
     var person =
         new Person(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -862,7 +862,8 @@ class FhirConverterTest {
     var internalId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
     var testOrder = TestDataBuilder.createEmptyTestOrder();
     testOrder.markComplete();
-    testOrder.setDeviceTypeAndSpecimenType(TestDataBuilder.createEmptyDeviceWithLoinc(), null);
+    testOrder.setDeviceTypeAndSpecimenType(
+        TestDataBuilder.createEmptyDeviceWithLoinc(), null);
     ReflectionTestUtils.setField(testOrder, "internalId", UUID.fromString(internalId));
 
     var actual = convertToServiceRequest(testOrder);
@@ -1061,7 +1062,8 @@ class FhirConverterTest {
   void createFhirBundle_TestEvent_matchesJson() throws IOException {
     var address = new StreetAddress(List.of("1 Main St"), "Chicago", "IL", "60614", "");
     var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", "nasal", 0);
-    var specimenType = new SpecimenType("name", "typeCode");var provider =
+    var specimenType = new SpecimenType("name", "typeCode");
+    var provider =
         new Provider(new PersonName("Michaela", null, "Quinn", ""), "1", address, "7735551235");
     var organization = new Organization("District", "school", "1", true);
     var facility =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/AuditLoggingFailuresTest.java
@@ -82,7 +82,8 @@ class AuditLoggingFailuresTest extends BaseGraphqlTest {
         () -> {
           Organization org = _orgService.getCurrentOrganizationNoCache();
           facility = _orgService.getFacilities(org).get(0);
-          facility.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+          facility.setDefaultDeviceTypeSpecimenType(
+              _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
           patient = _dataFactory.createFullPerson(org);
           TestOrder order = _dataFactory.createTestOrder(patient, facility);
           patientLink = _dataFactory.createPatientLink(order);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
@@ -25,7 +24,6 @@ import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -185,18 +183,7 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
 
   private HashMap<String, Object> getDeviceArgs() {
     String someDeviceType = _deviceService.fetchDeviceTypes().get(0).getInternalId().toString();
-    List<UUID> someDeviceSpecimenTypes =
-        List.of(_deviceService.getDeviceSpecimenTypes().get(0).getInternalId());
-
-    final ObjectMapper mapper = new ObjectMapper();
-
-    Map<String, Object> variables =
-        Map.of(
-            "deviceId",
-            someDeviceType,
-            "deviceSpecimenTypes",
-            mapper.convertValue(someDeviceSpecimenTypes, JsonNode.class));
-
+    Map<String, Object> variables = Map.of("deviceId", someDeviceType);
     return new HashMap<>(variables);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -55,7 +55,8 @@ class QueueManagementTest extends BaseGraphqlTest {
   public void init() {
     _org = _orgService.getCurrentOrganizationNoCache();
     _site = _orgService.getFacilities(_org).get(0);
-    _site.addDefaultDeviceSpecimen(_dataFactory.getGenericDeviceSpecimen());
+    _site.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
     positiveCovidResult =
         List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -75,8 +75,8 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
     Organization fakeOrg = new Organization("ABC", "university", "123", true);
     Person p = makeSerializablePerson(fakeOrg);
     Provider mccoy = new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222");
-    DeviceType d = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15);
-    DeviceSpecimenType dst = new DeviceSpecimenType(d, new SpecimenType());
+    DeviceType device = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15);
+    SpecimenType specimenType = new SpecimenType();
     StreetAddress addy =
         new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
     p.setFacility(
@@ -88,8 +88,9 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
             "555-867-5309",
             "facility@test.com",
             mccoy,
-            dst,
-            List.of(d)));
+            device,
+            specimenType,
+            List.of(device)));
     JsonContent<Person> serialized = _tester.write(p);
     assertThat(serialized)
         .extractingJsonPathStringValue("lastName")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -32,7 +31,6 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
     DeviceType bill = _devices.save(new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15));
     DeviceType percy = _devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", "E", 15));
     SpecimenType spec = _specimens.save(new SpecimenType("Troll Bogies", "0001111234"));
-    DeviceSpecimenType billbogies = _deviceSpecimens.save(new DeviceSpecimenType(bill, spec));
     Provider mccoy =
         _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
     configuredDevices.add(bill);
@@ -48,13 +46,14 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
                 "555-867-5309",
                 "facility@test.com",
                 mccoy,
-                billbogies,
+                bill,
+                spec,
                 configuredDevices));
     Optional<Facility> maybe = _repo.findByOrganizationAndFacilityName(org, "Third Floor");
     assertTrue(maybe.isPresent(), "should find the facility");
     Facility found = maybe.get();
     assertEquals(2, found.getDeviceTypes().size());
-    found.addDefaultDeviceSpecimen(billbogies);
+    found.setDefaultDeviceTypeSpecimenType(bill, spec);
     _repo.save(found);
     found = _repo.findById(saved.getInternalId()).get();
     found.removeDeviceType(bill);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -1,16 +1,19 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Facility_;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.Result_;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestEvent_;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
@@ -264,6 +267,34 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     assertEquals(2L, resultMap.get(TestResult.POSITIVE));
     assertEquals(1L, resultMap.get(TestResult.NEGATIVE));
     assertEquals(1L, resultMap.get(TestResult.UNDETERMINED));
+  }
+
+  @Test
+  void testEventFromTestOrder_copies_deviceAndSpecimen() {
+    // GIVEN
+    DeviceType facilityDevice = _dataFactory.getGenericDevice();
+    SpecimenType facilitySpecimen = _dataFactory.getGenericSpecimen();
+
+    DeviceType newDevice = _dataFactory.createDeviceType("new device", "llc", "t", "123", "swab");
+    SpecimenType newSpecimen =
+        _dataFactory.createSpecimenType("new specimen", "123456", "321", "123456");
+
+    Organization org = _dataFactory.saveValidOrganization();
+    Facility facility = _dataFactory.createValidFacility(org);
+    facility.setDefaultDeviceTypeSpecimenType(facilityDevice, facilitySpecimen);
+    Person patient = _dataFactory.createMinimalPerson(org);
+
+    TestOrder order = _dataFactory.createTestOrder(patient, facility);
+    order.setDeviceTypeAndSpecimenType(newDevice, newSpecimen);
+
+    // WHEN
+    TestEvent testEvent = new TestEvent(order);
+
+    // THEN
+    assertEquals(testEvent.getDeviceType(), newDevice);
+    assertEquals(testEvent.getSpecimenType(), newSpecimen);
+    assertNotEquals(testEvent.getDeviceType(), facilityDevice);
+    assertNotEquals(testEvent.getSpecimenType(), facilitySpecimen);
   }
 
   private Facility createTestEventsForMetricsTests(Organization org) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -17,7 +17,6 @@ import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
@@ -53,7 +52,6 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
             _deviceTypeRepoMock,
             mock(DeviceSpecimenTypeRepository.class),
             mock(SpecimenTypeRepository.class),
-            mock(FacilityRepository.class),
             mock(SupportedDiseaseRepository.class));
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -120,8 +120,6 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   private DeviceType getDeviceConfig() {
     return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1", "12345-6", "E");
-    //    SpecimenType specimen = testDataFactory.getGenericSpecimen();
-    //    return testDataFactory.createDeviceSpecimen(device, specimen);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -11,12 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.OrderingProviderRequiredException;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
-import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
@@ -82,7 +80,6 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Test
   void createOrganizationAndFacility_success() {
     // GIVEN
-    DeviceSpecimenType dst = getDeviceConfig();
     PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "");
 
     // WHEN
@@ -96,7 +93,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
             getAddress(),
             "123-456-7890",
             "test@foo.com",
-            List.of(dst.getDeviceType().getInternalId()),
+            List.of(getDeviceConfig().getInternalId()),
             orderingProviderName,
             getAddress(),
             "123-456-7890",
@@ -121,17 +118,15 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     assertEquals(5, facLink.getLink().length());
   }
 
-  private DeviceSpecimenType getDeviceConfig() {
-    DeviceType device =
-        testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1", "12345-6", "E");
-    SpecimenType specimen = testDataFactory.getGenericSpecimen();
-    return testDataFactory.createDeviceSpecimen(device, specimen);
+  private DeviceType getDeviceConfig() {
+    return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1", "12345-6", "E");
+    //    SpecimenType specimen = testDataFactory.getGenericSpecimen();
+    //    return testDataFactory.createDeviceSpecimen(device, specimen);
   }
 
   @Test
   void createOrganizationAndFacility_orderingProviderRequired_failure() {
     // GIVEN
-    DeviceSpecimenType dst = getDeviceConfig();
     PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
     // THEN
     assertThrows(
@@ -146,7 +141,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
                 getAddress(),
                 "123-456-7890",
                 "test@foo.com",
-                List.of(dst.getDeviceType().getInternalId()),
+                List.of(getDeviceConfig().getInternalId()),
                 orderProviderName,
                 getAddress(),
                 null,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -382,9 +382,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
 
-    // get updated facility
-    facility = _organizationService.getFacilities(org).get(0);
-
     UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
     UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
@@ -430,9 +427,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null);
     _service.addPatientToQueue(
         facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-
-    // get updated facility
-    facility = _organizationService.getFacilities(org).get(0);
 
     UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
     UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -4,7 +4,6 @@ import static gov.cdc.usds.simplereport.db.model.Facility_.DEFAULT_DEVICE_TYPE;
 import static gov.cdc.usds.simplereport.db.model.Facility_.DEFAULT_SPECIMEN_TYPE;
 
 import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -66,16 +65,7 @@ public class TestDataBuilder {
   public static Facility createEmptyFacility(boolean includeValidDevice) {
     DeviceType device = includeValidDevice ? createEmptyDeviceWithLoinc() : null;
     return new Facility(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        device,
-        null,
-        Collections.emptyList());
+        null, null, null, null, null, null, null, device, null, Collections.emptyList());
   }
 
   public static DeviceType createEmptyDeviceWithLoinc() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -18,7 +18,6 @@ import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -118,14 +117,9 @@ public class TestDataBuilder {
     return new SpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321");
   }
 
-  public static DeviceSpecimenType createDeviceSpecimenType() {
-    return new DeviceSpecimenType(createDeviceType(), createSpecimenType());
-  }
-
   public static Facility createFacility() {
-    var dev = createDeviceSpecimenType();
-    List<DeviceType> configuredDevices = new ArrayList<>();
-    configuredDevices.add(dev.getDeviceType());
+    DeviceType deviceType = createDeviceType();
+    SpecimenType specimenType = createSpecimenType();
     Provider doc = new Provider("Doctor", "", "Doom", "", "DOOOOOOM", getAddress(), "800-555-1212");
 
     return new Facility(
@@ -136,8 +130,9 @@ public class TestDataBuilder {
         "555-867-5309",
         "facility@test.com",
         doc,
-        dev,
-        configuredDevices);
+        deviceType,
+        specimenType,
+        List.of(deviceType));
   }
 
   public static StreetAddress getAddress() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -73,7 +73,8 @@ public class TestDataBuilder {
         null,
         null,
         null,
-        new DeviceSpecimenType(device, null),
+        device,
+        null,
         Collections.emptyList());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -3,8 +3,8 @@ package gov.cdc.usds.simplereport.test_util;
 import static gov.cdc.usds.simplereport.test_util.TestDataBuilder.getAddress;
 
 import gov.cdc.usds.simplereport.api.model.Role;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.OrganizationQueueItem;
@@ -32,7 +32,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationQueueRepository;
@@ -45,7 +45,6 @@ import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.db.repository.ResultRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
-import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
@@ -102,9 +101,35 @@ public class TestDataFactory {
   @Autowired private ResultRepository resultRepository;
   @Autowired private DemoOktaRepository oktaRepository;
   @Autowired private TestResultUploadRepository testResultUploadRepository;
+  @Autowired private DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
 
   @Autowired private ApiUserService apiUserService;
   @Autowired private DiseaseService diseaseService;
+
+  private DeviceType genericDeviceType;
+  private SpecimenType genericSpecimenType;
+
+  public void initGenericDeviceTypeAndSpecimenType() {
+    genericSpecimenType =
+        specimenTypeRepository.findAll().stream()
+            .filter(d -> d.getName().equals(DEFAULT_SPECIMEN_TYPE))
+            .findFirst()
+            .orElseGet(
+                () ->
+                    createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
+
+    genericDeviceType =
+        deviceSpecimenTypeRepository.findAll().stream()
+            .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
+            .findFirst()
+            .orElseGet(
+                () -> createDeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E"));
+
+    deviceSpecimenTypeNewRepository.save(
+        new DeviceTypeSpecimenTypeMapping(
+            genericDeviceType.getInternalId(), genericSpecimenType.getInternalId()));
+  }
+
 
   public Organization saveOrganization(Organization org) {
     Organization savedOrg = organizationRepository.save(org);
@@ -153,10 +178,11 @@ public class TestDataFactory {
   }
 
   public Facility createValidFacility(Organization org, String facilityName) {
-    DeviceSpecimenType dev = getGenericDeviceSpecimen();
+    DeviceType defaultDevice = getGenericDevice();
+    SpecimenType dwfaultSpecimen = getGenericSpecimen();
 
     List<DeviceType> configuredDevices = new ArrayList<>();
-    configuredDevices.add(dev.getDeviceType());
+    configuredDevices.add(defaultDevice);
     Provider doc =
         providerRepository.save(
             new Provider("Doctor", "", "Doom", "", "DOOOOOOM", getAddress(), "800-555-1212"));
@@ -169,7 +195,8 @@ public class TestDataFactory {
             "555-867-5309",
             "facility@test.com",
             doc,
-            dev,
+            defaultDevice,
+            dwfaultSpecimen,
             configuredDevices);
     Facility save = facilityRepository.save(facility);
     oktaRepository.createFacility(save);
@@ -370,7 +397,8 @@ public class TestDataFactory {
   public TestOrder createCompletedTestOrder(Person patient, Facility facility, TestResult result) {
     TestOrder order = new TestOrder(patient, facility);
     order.setAskOnEntrySurvey(savePatientAnswers(createEmptySurvey()));
-    order.setDeviceSpecimen(facility.getDefaultDeviceSpecimen());
+    order.setDeviceTypeAndSpecimenType(
+        facility.getDefaultDeviceType(), facility.getDefaultSpecimenType());
 
     order.markComplete();
     TestOrder savedOrder = testOrderRepository.save(order);
@@ -531,7 +559,8 @@ public class TestDataFactory {
   }
 
   public DeviceType getGenericDevice() {
-    return getGenericDeviceSpecimen().getDeviceType();
+    initGenericDeviceTypeAndSpecimenType();
+    return genericDeviceType;
   }
 
   public SpecimenType createSpecimenType(
@@ -541,30 +570,8 @@ public class TestDataFactory {
   }
 
   public SpecimenType getGenericSpecimen() {
-    return getGenericDeviceSpecimen().getSpecimenType();
-  }
-
-  public DeviceSpecimenType getGenericDeviceSpecimen() {
-    DeviceType dev =
-        deviceTypeRepository.findAll().stream()
-            .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
-            .findFirst()
-            .orElseGet(
-                () -> createDeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E"));
-    SpecimenType specType =
-        specimenTypeRepository.findAll().stream()
-            .filter(d -> d.getName().equals(DEFAULT_SPECIMEN_TYPE))
-            .findFirst()
-            .orElseGet(
-                () ->
-                    createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
-    return deviceSpecimenTypeRepository
-        .find(dev, specType)
-        .orElseGet(() -> createDeviceSpecimen(dev, specType));
-  }
-
-  public DeviceSpecimenType createDeviceSpecimen(DeviceType device, SpecimenType specimen) {
-    return deviceSpecimenTypeRepository.save(new DeviceSpecimenType(device, specimen));
+    initGenericDeviceTypeAndSpecimenType();
+    return genericSpecimenType;
   }
 
   public StreetAddress getFullAddress() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -96,8 +96,6 @@ public class TestDataFactory {
   @Autowired private PatientLinkRepository patientLinkRepository;
   @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
   @Autowired private SpecimenTypeRepository specimenTypeRepository;
-  @Autowired private DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
-  @Autowired private SupportedDiseaseRepository supportedDiseaseRepository;
   @Autowired private ResultRepository resultRepository;
   @Autowired private DemoOktaRepository oktaRepository;
   @Autowired private TestResultUploadRepository testResultUploadRepository;
@@ -119,7 +117,7 @@ public class TestDataFactory {
                     createSpecimenType(DEFAULT_SPECIMEN_TYPE, "000111222", "Da Nose", "986543321"));
 
     genericDeviceType =
-        deviceSpecimenTypeRepository.findAll().stream()
+        deviceTypeRepository.findAll().stream()
             .filter(d -> d.getName().equals(DEFAULT_DEVICE_TYPE))
             .findFirst()
             .orElseGet(
@@ -129,7 +127,6 @@ public class TestDataFactory {
         new DeviceTypeSpecimenTypeMapping(
             genericDeviceType.getInternalId(), genericSpecimenType.getInternalId()));
   }
-
 
   public Organization saveOrganization(Organization org) {
     Organization savedOrg = organizationRepository.save(org);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -176,7 +176,7 @@ public class TestDataFactory {
 
   public Facility createValidFacility(Organization org, String facilityName) {
     DeviceType defaultDevice = getGenericDevice();
-    SpecimenType dwfaultSpecimen = getGenericSpecimen();
+    SpecimenType defaultSpecimen = getGenericSpecimen();
 
     List<DeviceType> configuredDevices = new ArrayList<>();
     configuredDevices.add(defaultDevice);
@@ -193,7 +193,7 @@ public class TestDataFactory {
             "facility@test.com",
             doc,
             defaultDevice,
-            dwfaultSpecimen,
+            defaultSpecimen,
             configuredDevices);
     Facility save = facilityRepository.save(facility);
     oktaRepository.createFacility(save);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352

## Changes Proposed
 Remove `DeviceSpecimenType` from `TestOrder/TestEvent/Facility`
- remove `device_specimen_type_id` from `BaseTestInfo.java` (`TestOrder` and `TestEvent`)
- remove `default_device_specimen_type_id` from `Facility.java`
- a follow up PR will remove `DeviceSpecimenType` entity objects and Repo
- a follow up PR will remove extra unused db columns
- improve performance by removing a join when loading a `TestEvent/TestOrder/Facility` to the `device_specimen_type` table.

## Testing

- How should reviewers verify this PR? deployed on dev3

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

