### PR TITLE
Apply nowrap only to test queue radio buttons

### DIFF
--- a/frontend/src/app/testQueue/TestQueue.scss
+++ b/frontend/src/app/testQueue/TestQueue.scss
@@ -2,6 +2,8 @@
   max-width: 1200px;
 }
 
-.usa-radio {
-  white-space: nowrap;
+.prime-test-result {
+  .usa-radio {
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

@emmastephenson  [reported the issue here](https://skylight-hq.slack.com/archives/C03KQ79EB16/p1673546662821889) with text not wrapping on sign up page
Thank you @johanna-skylight for the quick debugging 😭 🙌 

## Changes Proposed
- Isolate the nowrap on radio buttons to the ones on the test queue cards

## Additional Information
N/A

## Testing
- Check Safari to ensure multiplex cards' radio button text do not wrap strangely
- Check the /sign-up page to ensure the radio button text is wrapped correctly

## Screenshots / Demos
After fix - sign up page 😅 
<img width="791" alt="Screen Shot 2023-01-12 at 12 17 52" src="https://user-images.githubusercontent.com/20211771/212148124-32ee5919-5543-4e8c-bb3b-3b00f28a9c4a.png">

After fix - safari multiplex card
<img width="1483" alt="Screen Shot 2023-01-12 at 12 17 39" src="https://user-images.githubusercontent.com/20211771/212148157-683a5f6f-66de-465c-88e8-ccf9808c7c9e.png">


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
