### PR TITLE
handle null device specimen type

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -4,13 +4,13 @@ import static java.lang.Boolean.TRUE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.cdc.usds.simplereport.api.MappingConstants;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.PersonUtils;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -47,7 +47,8 @@ public class TestEventExport {
   private final Optional<Provider> provider;
   private final Optional<Facility> facility;
   private final Optional<Organization> organization;
-  private final Optional<DeviceSpecimenType> deviceSpecimenType;
+  private final Optional<DeviceType> deviceType;
+  private final Optional<SpecimenType> specimenType;
 
   public TestEventExport(TestEvent testEvent) {
     this.testEvent = testEvent;
@@ -57,7 +58,8 @@ public class TestEventExport {
     this.facility = Optional.ofNullable(testEvent.getFacility());
     this.organization = Optional.ofNullable(testEvent.getOrganization());
 
-    this.deviceSpecimenType = Optional.ofNullable(testEvent.getDeviceSpecimen());
+    this.deviceType = Optional.ofNullable(testEvent.getDeviceType());
+    this.specimenType = Optional.ofNullable(testEvent.getSpecimenType());
   }
 
   private String genderUnknown = "U";
@@ -65,7 +67,7 @@ public class TestEventExport {
   // "Internal nose structure"
   // values pulled from
   // https://github.com/CDCgov/prime-data-hub/blob/master/prime-router/metadata/valuesets/common.valuesets
-  private Map<String, String> genderMap =
+  private final Map<String, String> genderMap =
       Map.of(
           "male", "M",
           "female", "F",
@@ -76,13 +78,13 @@ public class TestEventExport {
           "refused", genderUnknown,
           "notapplicable", "N");
 
-  private Map<String, String> ethnicityMap =
+  private final Map<String, String> ethnicityMap =
       Map.of(
           "hispanic", "H",
           "not_hispanic", "N",
           "refused", "U");
 
-  private Map<TestResult, String> testResultMap =
+  private final Map<TestResult, String> testResultMap =
       Map.of(
           TestResult.POSITIVE, "260373001",
           TestResult.NEGATIVE, "260415000",
@@ -406,10 +408,7 @@ public class TestEventExport {
   @JsonProperty("Specimen_collection_date_time")
   public String getSpecimenCollectionDateTime() {
     var testDuration =
-        deviceSpecimenType
-            .map(DeviceSpecimenType::getDeviceType)
-            .map(DeviceType::getTestLength)
-            .orElse(FALLBACK_DEFAULT_TEST_MINUTES);
+        deviceType.map(DeviceType::getTestLength).orElse(FALLBACK_DEFAULT_TEST_MINUTES);
     return dateToHealthCareString(
         convertToLocalDateTime(
             Date.from(
@@ -585,32 +584,27 @@ public class TestEventExport {
 
   @JsonProperty("Ordered_test_code")
   public String getOrderedTestCode() {
-    return deviceSpecimenType.map(dst -> dst.getDeviceType().getLoincCode()).orElse(null);
+    return deviceType.map(DeviceType::getLoincCode).orElse(null);
   }
 
   @JsonProperty("Specimen_source_site_code")
   public String getSpecimenSourceSiteCode() {
-    return deviceSpecimenType
-        .map(dst -> dst.getSpecimenType().getCollectionLocationCode())
-        .orElse(DEFAULT_LOCATION_CODE);
+    return specimenType.map(SpecimenType::getCollectionLocationCode).orElse(DEFAULT_LOCATION_CODE);
   }
 
   @JsonProperty("Specimen_type_code")
   public String getSpecimenTypeCode() {
-    return deviceSpecimenType.map(dst -> dst.getSpecimenType().getTypeCode()).orElse(null);
+    return specimenType.map(SpecimenType::getTypeCode).orElse(null);
   }
 
   @JsonProperty("Instrument_ID")
   public String getInstrumentID() {
-    return deviceSpecimenType
-        .map(dst -> dst.getDeviceType().getInternalId())
-        .map(UUID::toString)
-        .orElse(null);
+    return deviceType.map(d -> d.getInternalId().toString()).orElse(null);
   }
 
   @JsonProperty("Device_ID")
   public String getDeviceID() {
-    return deviceSpecimenType.map(dst -> dst.getDeviceType().getModel()).orElse(null);
+    return deviceType.map(DeviceType::getModel).orElse(null);
   }
 
   @JsonProperty("Test_date")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -60,7 +60,12 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
   }
 
   protected BaseTestInfo(BaseTestInfo orig) {
-    this(orig.getPatient(), orig.getFacility(), orig.getDeviceSpecimen());
+    this(orig.getPatient(), orig.getFacility());
+    if (orig.getDeviceSpecimen() != null) {
+      this.setDeviceSpecimen(orig.getDeviceSpecimen());
+    } else {
+      this.setDeviceTypeAndSpecimenType(orig.getDeviceType(), orig.getSpecimenType());
+    }
   }
 
   protected BaseTestInfo(Person patient, Facility facility, DeviceSpecimenType deviceSpecimen) {
@@ -126,6 +131,11 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     this.deviceSpecimen = deviceSpecimen;
     this.deviceType = deviceSpecimen.getDeviceType();
     this.specimenType = deviceSpecimen.getSpecimenType();
+  }
+
+  protected void setDeviceTypeAndSpecimenType(DeviceType device, SpecimenType specimen) {
+    this.deviceType = device;
+    this.specimenType = specimen;
   }
 
   public TestCorrectionStatus getCorrectionStatus() {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352


## Changes Proposed

- this will enable the backend to handle `device_specimen_type` being null
- use `deviceType` and `specimentType` when exporting the `TestEvent`, instead of `device_specimen_type`
- this will be merged before we stop writing that field for `testevent` and `testorders`, in order to be able to rollback safely if we needed to 
- to be merged before https://github.com/CDCgov/prime-simplereport/pull/5012
- test coverage will remain low.

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

