### PR TITLE
5007/fhir cleanup

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -29,4 +29,6 @@ public class FhirConstants {
 
   public static final String EVENT_TYPE_DISPLAY =
       "ORU/ACK - Unsolicited transmission of an observation message";
+
+  public static final String DEFAULT_COUNTRY = "USA";
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -148,7 +148,7 @@ public class FhirConverter {
   public static List<ContactPoint> convertEmailsToContactPoint(
       ContactPointUse use, List<String> emails) {
     return emails.stream()
-        .map(s -> convertEmailToContactPoint(use, s))
+        .map(email -> convertEmailToContactPoint(use, email))
         .collect(Collectors.toList());
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.converter;
 
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.DEFAULT_COUNTRY;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ETHNICITY_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ETHNICITY_EXTENSION_URL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EVENT_TYPE_CODE;
@@ -284,7 +285,7 @@ public class FhirConverter {
     var practitioner = new Practitioner();
     practitioner.setId(provider.getInternalId().toString());
     practitioner.addName(convertToHumanName(provider.getNameInfo()));
-    practitioner.addAddress(convertToAddress(provider.getAddress(), "USA"));
+    practitioner.addAddress(convertToAddress(provider.getAddress(), DEFAULT_COUNTRY));
     practitioner.addTelecom(convertToContactPoint(ContactPointUse.WORK, provider.getTelephone()));
     return practitioner;
   }
@@ -295,7 +296,7 @@ public class FhirConverter {
     org.setName(facility.getFacilityName());
     org.addTelecom(convertToContactPoint(ContactPointUse.WORK, facility.getTelephone()));
     org.addTelecom(convertEmailToContactPoint(ContactPointUse.WORK, facility.getEmail()));
-    org.addAddress(convertToAddress(facility.getAddress(), "USA"));
+    org.addAddress(convertToAddress(facility.getAddress(), DEFAULT_COUNTRY));
     return org;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -179,19 +179,30 @@ public class FhirConverter {
     return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
   }
 
-  public static Address convertToAddress(@NotNull StreetAddress address) {
+  public static Address convertToAddress(@NotNull StreetAddress address, String country) {
     return convertToAddress(
         address.getStreet(),
         address.getCity(),
         address.getCounty(),
         address.getState(),
-        address.getPostalCode());
+        address.getPostalCode(),
+        country);
   }
 
   public static Address convertToAddress(
-      List<String> street, String city, String county, String state, String postalCode) {
+      List<String> street,
+      String city,
+      String county,
+      String state,
+      String postalCode,
+      String country) {
     var address =
-        new Address().setCity(city).setDistrict(county).setState(state).setPostalCode(postalCode);
+        new Address()
+            .setCity(city)
+            .setDistrict(county)
+            .setState(state)
+            .setPostalCode(postalCode)
+            .setCountry(country);
     if (street != null) {
       street.forEach(address::addLine);
     }
@@ -279,7 +290,7 @@ public class FhirConverter {
     var practitioner = new Practitioner();
     practitioner.setId(provider.getInternalId().toString());
     practitioner.addName(convertToHumanName(provider.getNameInfo()));
-    practitioner.addAddress(convertToAddress(provider.getAddress()));
+    practitioner.addAddress(convertToAddress(provider.getAddress(), "USA"));
     practitioner.addTelecom(convertToContactPoint(ContactPointUse.WORK, provider.getTelephone()));
     return practitioner;
   }
@@ -290,7 +301,7 @@ public class FhirConverter {
     org.setName(facility.getFacilityName());
     org.addTelecom(convertToContactPoint(ContactPointUse.WORK, facility.getTelephone()));
     org.addTelecom(convertEmailToContactPoint(ContactPointUse.WORK, facility.getEmail()));
-    org.addAddress(convertToAddress(facility.getAddress()));
+    org.addAddress(convertToAddress(facility.getAddress(), "USA"));
     return org;
   }
 
@@ -303,7 +314,7 @@ public class FhirConverter {
         .forEach(patient::addTelecom);
     patient.setGender(convertToAdministrativeGender(person.getGender()));
     patient.setBirthDate(convertToDate(person.getBirthDate()));
-    patient.addAddress(convertToAddress(person.getAddress()));
+    patient.addAddress(convertToAddress(person.getAddress(), "USA"));
     patient.addExtension(convertToRaceExtension(person.getRace()));
     patient.addExtension(convertToEthnicityExtension(person.getEthnicity()));
     patient.addExtension(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -145,14 +145,16 @@ public class FhirConverter {
     return convertToContactPoint(contactPointUse, ContactPointSystem.PHONE, number);
   }
 
-  public static List<ContactPoint> convertEmailsToContactPoint(List<String> emails) {
+  public static List<ContactPoint> convertEmailsToContactPoint(
+      ContactPointUse use, List<String> emails) {
     return emails.stream()
-        .map(FhirConverter::convertEmailToContactPoint)
+        .map(s -> convertEmailToContactPoint(use, s))
         .collect(Collectors.toList());
   }
 
-  public static ContactPoint convertEmailToContactPoint(@NotNull String email) {
-    return convertToContactPoint(null, ContactPointSystem.EMAIL, email);
+  public static ContactPoint convertEmailToContactPoint(
+      ContactPointUse use, @NotNull String email) {
+    return convertToContactPoint(use, ContactPointSystem.EMAIL, email);
   }
 
   public static ContactPoint convertToContactPoint(
@@ -287,7 +289,7 @@ public class FhirConverter {
     org.setId(facility.getInternalId().toString());
     org.setName(facility.getFacilityName());
     org.addTelecom(convertToContactPoint(ContactPointUse.WORK, facility.getTelephone()));
-    org.addTelecom(convertEmailToContactPoint(facility.getEmail()));
+    org.addTelecom(convertEmailToContactPoint(ContactPointUse.WORK, facility.getEmail()));
     org.addAddress(convertToAddress(facility.getAddress()));
     return org;
   }
@@ -297,7 +299,8 @@ public class FhirConverter {
     patient.setId(person.getInternalId().toString());
     patient.addName(convertToHumanName(person.getNameInfo()));
     convertPhoneNumbersToContactPoint(person.getPhoneNumbers()).forEach(patient::addTelecom);
-    convertEmailsToContactPoint(person.getEmails()).forEach(patient::addTelecom);
+    convertEmailsToContactPoint(ContactPointUse.HOME, person.getEmails())
+        .forEach(patient::addTelecom);
     patient.setGender(convertToAdministrativeGender(person.getGender()));
     patient.setBirthDate(convertToDate(person.getBirthDate()));
     patient.addAddress(convertToAddress(person.getAddress()));
@@ -552,7 +555,7 @@ public class FhirConverter {
 
     serviceRequest.setSubject(new Reference(patientFullUrl));
     serviceRequest.addPerformer(new Reference(organizationFullUrl));
-    serviceRequest.setRequester(new Reference(practitionerRoleFullUrl));
+    serviceRequest.setRequester(new Reference(organizationFullUrl));
     diagnosticReport.addBasedOn(new Reference(serviceRequestFullUrl));
     diagnosticReport.setSubject(new Reference(patientFullUrl));
     diagnosticReport.addSpecimen(new Reference(specimenFullUrl));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -384,7 +384,8 @@ public class FhirConverter {
           result.getResultLOINC(),
           correctionStatus,
           correctionReason,
-          result.getInternalId().toString());
+          result.getInternalId().toString(),
+          result.getTestResult().toString());
     }
     return null;
   }
@@ -395,12 +396,13 @@ public class FhirConverter {
       String resultCode,
       TestCorrectionStatus correctionStatus,
       String correctionReason,
-      String id) {
+      String id,
+      String resultDescription) {
     var observation = new Observation();
     observation.setId(id);
     setStatus(observation, correctionStatus);
     addCode(diseaseCode, diseaseName, observation);
-    addValue(resultCode, observation);
+    addValue(resultCode, observation, resultDescription);
     addCorrectionNote(
         correctionStatus != TestCorrectionStatus.ORIGINAL, correctionReason, observation);
     return observation;
@@ -432,11 +434,12 @@ public class FhirConverter {
     }
   }
 
-  private static void addValue(String resultCode, Observation observation) {
+  private static void addValue(String resultCode, Observation observation, String resultDisplay) {
     var valueCodeableConcept = new CodeableConcept();
     var valueCoding = valueCodeableConcept.addCoding();
     valueCoding.setSystem(SNOMED_CODE_SYSTEM);
     valueCoding.setCode(resultCode);
+    valueCoding.setDisplay(resultDisplay);
     observation.setValue(valueCodeableConcept);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -308,7 +308,7 @@ public class FhirConverter {
         .forEach(patient::addTelecom);
     patient.setGender(convertToAdministrativeGender(person.getGender()));
     patient.setBirthDate(convertToDate(person.getBirthDate()));
-    patient.addAddress(convertToAddress(person.getAddress(), "USA"));
+    patient.addAddress(convertToAddress(person.getAddress(), person.getCountry()));
     patient.addExtension(convertToRaceExtension(person.getRace()));
     patient.addExtension(convertToEthnicityExtension(person.getEthnicity()));
     patient.addExtension(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -531,7 +531,8 @@ public class FhirConverter {
             testEvent.getCorrectionStatus(),
             testEvent.getReasonForCorrection()),
         convertToServiceRequest(testEvent.getOrder()),
-        convertToDiagnosticReport(testEvent));
+        convertToDiagnosticReport(testEvent),
+        testEvent.getDateTested());
   }
 
   public static Bundle createFhirBundle(
@@ -542,7 +543,8 @@ public class FhirConverter {
       Specimen specimen,
       List<Observation> observations,
       ServiceRequest serviceRequest,
-      DiagnosticReport diagnosticReport) {
+      DiagnosticReport diagnosticReport,
+      Date dateTested) {
     var patientFullUrl = ResourceType.Patient + "/" + patient.getId();
     var organizationFullUrl = ResourceType.Organization + "/" + organization.getId();
     var practitionerFullUrl = ResourceType.Practitioner + "/" + practitioner.getId();
@@ -552,7 +554,7 @@ public class FhirConverter {
     var deviceFullUrl = ResourceType.Device + "/" + device.getId();
 
     var practitionerRole = createPractitionerRole(organizationFullUrl, practitionerFullUrl);
-    var provenance = createProvenance(organizationFullUrl, deviceFullUrl);
+    var provenance = createProvenance(organizationFullUrl, deviceFullUrl, dateTested);
     var provenanceFullUrl = ResourceType.Provenance + "/" + provenance.getId();
     var messageHeader =
         createMessageHeader(organizationFullUrl, diagnosticReportFullUrl, provenanceFullUrl);
@@ -609,7 +611,8 @@ public class FhirConverter {
     return bundle;
   }
 
-  public static Provenance createProvenance(String organizationFullUrl, String deviceFullUrl) {
+  public static Provenance createProvenance(
+      String organizationFullUrl, String deviceFullUrl, Date dateTested) {
     var provenance = new Provenance();
     provenance.setId(UUID.randomUUID().toString());
     provenance
@@ -620,6 +623,7 @@ public class FhirConverter {
         .setDisplay(EVENT_TYPE_DISPLAY);
     provenance.addAgent().setWho(new Reference().setReference(organizationFullUrl));
     provenance.addTarget(new Reference(deviceFullUrl));
+    provenance.setRecorded(dateTested);
     return provenance;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1022,7 +1022,7 @@ class FhirConverterTest {
 
   @Test
   void createProvenance_valid() {
-    var provenance = createProvenance("Organization/org-id", "Device/device-id");
+    var provenance = createProvenance("Organization/org-id", "Device/device-id", new Date());
 
     assertThat(provenance.getActivity().getCoding()).hasSize(1);
     assertThat(provenance.getActivity().getCodingFirstRep().getCode()).isEqualTo("R01");
@@ -1065,7 +1065,8 @@ class FhirConverterTest {
             specimen,
             List.of(observation),
             serviceRequest,
-            diagnosticReport);
+            diagnosticReport,
+            new Date());
 
     var resourceUrls =
         actual.getEntry().stream()

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -168,7 +168,9 @@ class FhirConverterTest {
 
   @Test
   void convertEmailsToContactPoint_valid() {
-    var actual = convertEmailsToContactPoint(List.of("email1@example.com", "email2@example.com"));
+    var actual =
+        convertEmailsToContactPoint(
+            ContactPointUse.HOME, List.of("email1@example.com", "email2@example.com"));
 
     assertThat(actual).hasSize(2);
     assertThat(
@@ -183,10 +185,11 @@ class FhirConverterTest {
 
   @Test
   void convertEmailToContactPoint_valid() {
-    var actual = FhirConverter.convertEmailToContactPoint("example@example.com");
-    assertThat(actual.getUse()).isNull();
+    var actual =
+        FhirConverter.convertEmailToContactPoint(ContactPointUse.WORK, "example@example.com");
     assertThat(actual.getSystem()).isEqualTo(ContactPointSystem.EMAIL);
     assertThat(actual.getValue()).isEqualTo("example@example.com");
+    assertThat(actual.getUse()).isEqualTo(ContactPointUse.WORK);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -566,7 +566,8 @@ class FhirConverterTest {
             "resultCode",
             TestCorrectionStatus.ORIGINAL,
             null,
-            "id-123");
+            "id-123",
+            TestResult.POSITIVE.toString());
 
     assertThat(actual.getId()).isEqualTo("id-123");
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.FINAL.getDisplay());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -222,7 +222,7 @@ class FhirConverterTest {
     var address =
         new StreetAddress(
             List.of("1234 Main", "Apartment #1"), "MyCity", "MyCounty", "PA", "15025");
-    var actual = convertToAddress(address);
+    var actual = convertToAddress(address, "USA");
     assertThat(actual.getLine().stream().map(PrimitiveType::getValue))
         .containsExactly("1234 Main", "Apartment #1");
     assertThat(actual.getCity()).isEqualTo(address.getCity());
@@ -234,7 +234,8 @@ class FhirConverterTest {
   @Test
   void convertToAddress_Strings_valid() {
     var actual =
-        convertToAddress(List.of("1234 Main", "Apartment #1"), "MyCity", "MyCounty", "PA", "15025");
+        convertToAddress(
+            List.of("1234 Main", "Apartment #1"), "MyCity", "MyCounty", "PA", "15025", "Canada");
     assertThat(actual.getLine().stream().map(PrimitiveType::getValue))
         .containsExactly("1234 Main", "Apartment #1");
     assertThat(actual.getCity()).isEqualTo("MyCity");
@@ -245,7 +246,7 @@ class FhirConverterTest {
 
   @Test
   void convertToAddress_Strings_null() {
-    var actual = convertToAddress(null, null, null, null, null);
+    var actual = convertToAddress(null, null, null, null, null, null);
     assertThat(actual.getLine()).isEmpty();
     assertThat(actual.getCity()).isNull();
     assertThat(actual.getDistrict()).isNull();
@@ -1140,7 +1141,7 @@ class FhirConverterTest {
                 .getReference())
         .isEqualTo("Organization/" + organization.getId());
     assertThat(((ServiceRequest) serviceRequestEntry.getResource()).getRequester().getReference())
-        .contains("PractitionerRole/");
+        .contains("Organization/");
 
     var diagnosticReportEntry =
         actual.getEntry().stream()

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -158,7 +158,8 @@
           },
           {
             "system":"email",
-            "value":"tj@example.com"
+            "value":"tj@example.com",
+            "use": "home"
           }
         ],
         "gender":"male",
@@ -170,7 +171,8 @@
             ],
             "city":"Chicago",
             "state":"IL",
-            "postalCode":"60614"
+            "postalCode":"60614",
+            "country": "USA"
           }
         ],
         "managingOrganization":{
@@ -192,7 +194,8 @@
           },
           {
             "system":"email",
-            "value":"school@example.com"
+            "value":"school@example.com",
+            "use": "work"
           }
         ],
         "address":[
@@ -202,7 +205,8 @@
             ],
             "city":"Chicago",
             "state":"IL",
-            "postalCode":"60614"
+            "postalCode":"60614",
+            "country": "USA"
           }
         ]
       }
@@ -234,7 +238,8 @@
             ],
             "city":"Chicago",
             "state":"IL",
-            "postalCode":"60614"
+            "postalCode":"60614",
+            "country": "USA"
           }
         ]
       }
@@ -277,7 +282,7 @@
           "reference":"Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
         },
         "requester":{
-          "reference":"PractitionerRole/$PRACTITIONER_ROLE_ID"
+          "reference":"Organization/1c3d14b9-e222-4a16-9fb2-d9f173034a6a"
         },
         "performer":[
           {

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -339,7 +339,8 @@
           "coding":[
             {
               "system":"http://snomed.info/sct",
-              "code":"455371000124106"
+              "code":"455371000124106",
+              "display": "UNDETERMINED"
             }
           ]
         },
@@ -376,7 +377,8 @@
           "coding":[
             {
               "system":"http://snomed.info/sct",
-              "code":"260373001"
+              "code":"260373001",
+              "display": "POSITIVE"
             }
           ]
         },
@@ -413,7 +415,8 @@
           "coding":[
             {
               "system":"http://snomed.info/sct",
-              "code":"260415000"
+              "code":"260415000",
+              "display": "NEGATIVE"
             }
           ]
         },

--- a/backend/src/test/resources/fhir/observationCorrection.json
+++ b/backend/src/test/resources/fhir/observationCorrection.json
@@ -15,7 +15,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "260415000"
+        "code": "260415000",
+        "display": "NEGATIVE"
       }
     ]
   },

--- a/backend/src/test/resources/fhir/observationCovid.json
+++ b/backend/src/test/resources/fhir/observationCovid.json
@@ -15,7 +15,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "260373001"
+        "code": "260373001",
+        "display": "POSITIVE"
       }
     ]
   }

--- a/backend/src/test/resources/fhir/observationFlu.json
+++ b/backend/src/test/resources/fhir/observationFlu.json
@@ -15,7 +15,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "260415000"
+        "code": "260415000",
+        "display": "NEGATIVE"
       }
     ]
   }

--- a/backend/src/test/resources/fhir/organization.json
+++ b/backend/src/test/resources/fhir/organization.json
@@ -10,7 +10,8 @@
     },
     {
       "system": "email",
-      "value": "email@example.com"
+      "value": "email@example.com",
+      "use": "work"
     }
   ],
   "address": [
@@ -21,7 +22,8 @@
       ],
       "city": "Lakewood",
       "state": "FL",
-      "postalCode": "21037"
+      "postalCode": "21037",
+      "country": "USA"
     }
   ]
 }

--- a/backend/src/test/resources/fhir/patient.json
+++ b/backend/src/test/resources/fhir/patient.json
@@ -75,11 +75,13 @@
     },
     {
       "system": "email",
-      "value": "email1"
+      "value": "email1",
+      "use": "home"
     },
     {
       "system": "email",
-      "value": "email2"
+      "value": "email2",
+      "use": "home"
     }
   ],
   "gender": "male",
@@ -93,7 +95,8 @@
       "city": "Charleston",
       "district": "Kanawha",
       "state": "WV",
-      "postalCode": "25301"
+      "postalCode": "25301",
+      "country": "USA"
     }
   ]
 }

--- a/backend/src/test/resources/fhir/practitioner.json
+++ b/backend/src/test/resources/fhir/practitioner.json
@@ -14,6 +14,7 @@
     "line" : [ "223 N Terrace St" ],
     "city" : "Atchison",
     "state" : "KS",
-    "postalCode" : "66002"
+    "postalCode" : "66002",
+    "country": "USA"
   } ]
 }

--- a/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
@@ -351,7 +351,7 @@ your local health department.
               <p>
                 Test result printed
                  
-                1/1/2021, 12:00:00 AM
+                1/1/2021, 12:00:00 AM
               </p>
             </footer>
           </div>
@@ -722,7 +722,7 @@ your local health department.
             <p>
               Test result printed
                
-              1/1/2021, 12:00:00 AM
+              1/1/2021, 12:00:00 AM
             </p>
           </footer>
         </div>
@@ -1205,7 +1205,7 @@ Object {
               <p>
                 Test result printed
                  
-                1/1/2021, 12:00:00 AM
+                1/1/2021, 12:00:00 AM
               </p>
             </footer>
           </div>
@@ -1631,7 +1631,7 @@ Object {
             <p>
               Test result printed
                
-              1/1/2021, 12:00:00 AM
+              1/1/2021, 12:00:00 AM
             </p>
           </footer>
         </div>
@@ -2023,7 +2023,7 @@ your local health department.
               <p>
                 Test result printed
                  
-                1/1/2021, 12:00:00 AM
+                1/1/2021, 12:00:00 AM
               </p>
             </footer>
           </div>
@@ -2358,7 +2358,7 @@ your local health department.
             <p>
               Test result printed
                
-              1/1/2021, 12:00:00 AM
+              1/1/2021, 12:00:00 AM
             </p>
           </footer>
         </div>

--- a/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
@@ -351,7 +351,7 @@ your local health department.
               <p>
                 Test result printed
                  
-                1/1/2021, 12:00:00 AM
+                1/1/2021, 12:00:00 AM
               </p>
             </footer>
           </div>
@@ -722,7 +722,7 @@ your local health department.
             <p>
               Test result printed
                
-              1/1/2021, 12:00:00 AM
+              1/1/2021, 12:00:00 AM
             </p>
           </footer>
         </div>
@@ -1205,7 +1205,7 @@ Object {
               <p>
                 Test result printed
                  
-                1/1/2021, 12:00:00 AM
+                1/1/2021, 12:00:00 AM
               </p>
             </footer>
           </div>
@@ -1631,7 +1631,7 @@ Object {
             <p>
               Test result printed
                
-              1/1/2021, 12:00:00 AM
+              1/1/2021, 12:00:00 AM
             </p>
           </footer>
         </div>
@@ -2023,7 +2023,7 @@ your local health department.
               <p>
                 Test result printed
                  
-                1/1/2021, 12:00:00 AM
+                1/1/2021, 12:00:00 AM
               </p>
             </footer>
           </div>
@@ -2358,7 +2358,7 @@ your local health department.
             <p>
               Test result printed
                
-              1/1/2021, 12:00:00 AM
+              1/1/2021, 12:00:00 AM
             </p>
           </footer>
         </div>


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #5007 (feedback from sync with Report Stream engineering) 

## Changes Proposed

- Misc updates and fixes to our fhir mapping

## Additional Information

- Unless I'm missing something we don't have a `country` value for Orgs or Providers, defaulting to "USA"
- Still figuring out how exactly to set the Observation.method with device information.

## Testing

- Existing unit tests + verify that new fields / code have new tests

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->