### PR TITLE
add specimen_type_id and device_type_id to test_event_no_phi_view

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4305,3 +4305,14 @@ databaseChangeLog:
             selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, patient_id, organization_id, result, facility_id, specimen_type_id, device_type_id, survey_data, date_tested_backdate, test_order_id, correction_status, prior_corrected_test_event_id, reason_for_correction FROM ${database.defaultSchemaName}.test_event
         - sql:
             sql: GRANT SELECT ON ${database.defaultSchemaName}.test_event_no_phi_view TO ${noPhiUsername};
+      rollback:
+        - dropView:
+            viewName: test_event_no_phi_view
+        - createView:
+            viewName: test_event_no_phi_view
+            remarks: A subset of the test_event table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT device_specimen_type_id, created_at, created_by, updated_at, updated_by, patient_id, organization_id, result, facility_id, survey_data, date_tested_backdate, test_order_id, correction_status, prior_corrected_test_event_id, internal_id, reason_for_correction FROM ${database.defaultSchemaName}.test_event
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.test_event_no_phi_view TO ${noPhiUsername};

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4289,3 +4289,19 @@ databaseChangeLog:
       rollback:
         dropTable:
           tableName: shedlock
+  - changeSet:
+      id: update-test_event_no_phi_view
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: update-test_event_no_phi_view
+        - dropView:
+            viewName: test_event_no_phi_view
+        - createView:
+            viewName: test_event_no_phi_view
+            remarks: A subset of the test_event table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, patient_id, organization_id, result, facility_id, specimen_type_id, device_type_id, survey_data, date_tested_backdate, test_order_id, correction_status, prior_corrected_test_event_id, reason_for_correction FROM ${database.defaultSchemaName}.test_event
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.test_event_no_phi_view TO ${noPhiUsername};


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- part of #3352 

## Changes Proposed

- add `specimen_type_id` and `device_type_id` to `test_event_no_phi_view`


## Testing

- How should reviewers verify this PR?
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->

Original select query
https://github.com/CDCgov/prime-simplereport/blob/66ede3bc4dc291e54854192be5e4052bb7c4c456/backend/src/main/resources/db/changelog/db.changelog-master.yaml#L2100

new select query
https://github.com/CDCgov/prime-simplereport/blob/34c25c066a9df1d25cebaa4a84eb0ef7054e4861/backend/src/main/resources/db/changelog/db.changelog-master.yaml#L4305


diff

![image](https://user-images.githubusercontent.com/4952042/213509343-17a4b3cb-d3d4-46ed-b592-5be87ad671f9.png)

reordered `internal_id` to be first (if you know, you know :D)