### PR TITLE
fix inaccurate "no results" state on conduct test page search

### DIFF
--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -150,10 +150,13 @@ const AddToQueueSearchBox = ({
     runIf: (q) => q.length >= MIN_SEARCH_CHARACTER_COUNT,
   });
 
-  const [queryPatients, { data, error }] = useLazyQuery(QUERY_PATIENT, {
-    fetchPolicy: "no-cache",
-    variables: { facilityId, namePrefixMatch: queryString },
-  });
+  const [queryPatients, { data, error, loading }] = useLazyQuery(
+    QUERY_PATIENT,
+    {
+      fetchPolicy: "no-cache",
+      variables: { facilityId, namePrefixMatch: queryString },
+    }
+  );
 
   const [mutationError, updateMutationError] = useState(null);
   const [showSuggestion, setShowSuggestion] = useState(true);
@@ -272,7 +275,7 @@ const AddToQueueSearchBox = ({
         onAddToQueue={onAddToQueue}
         patientsInQueue={patientsInQueue}
         shouldShowSuggestions={showDropdown}
-        loading={debounced !== queryString}
+        loading={debounced !== queryString || loading}
         dropDownRef={dropDownRef}
       />
     </React.Fragment>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #4426 by adding the appropriate loading state var from the GQL hook to the UI

## Testing

- Live on dev5 for testing. Recommend throttling the network connection via browser dev tools and trying the search to notice that the modal repopulates appropriately.

## Screenshots / Demos

https://user-images.githubusercontent.com/29645040/213528202-9b3354bb-dbe3-4345-b581-d65cafbe14f5.mp4
