### PR TITLE
Update logs in async service to include patient count

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -73,6 +73,7 @@ public class PatientBulkUploadServiceAsync {
     List<PhoneNumber> phoneNumbersList = new ArrayList<>();
 
     Set<Person> allPatients = new HashSet<>();
+    int totalPatientCount = 0;
 
     final MappingIterator<Map<String, String>> valueIterator =
         CsvValidatorUtils.getIteratorForCsv(new ByteArrayInputStream(content));
@@ -147,6 +148,7 @@ public class PatientBulkUploadServiceAsync {
 
           patientsList.add(newPatient);
           allPatients.add(newPatient);
+          totalPatientCount += 1;
         }
 
         if (patientsList.size() >= batchSize) {
@@ -184,7 +186,10 @@ public class PatientBulkUploadServiceAsync {
       throw new IllegalArgumentException(errorMessage);
     }
 
-    log.info("CSV patient upload completed for {}", currentOrganization.getOrganizationName());
+    log.info(
+        "CSV patient upload completed for {}. {} total patients uploaded",
+        currentOrganization.getOrganizationName(),
+        totalPatientCount);
 
     sendEmail(
         uploaderEmail,


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Async service logs do not include the total number of patients saved; we need this for our metrics

## Changes Proposed

- Add patient count to internal logs

## Testing

- Tests pass
