### PR TITLE
Removed babel unused dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -180,7 +180,6 @@
     ]
   },
   "devDependencies": {
-    "@babel/helper-plugin-utils": "^7.20.2",
     "@graphql-codegen/cli": "2.13.7",
     "@graphql-codegen/typescript": "2.4.2",
     "@graphql-codegen/typescript-operations": "2.2.2",
@@ -211,9 +210,6 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.46.1",
-    "babel-loader": "8.1.0",
-    "babel-plugin-named-exports-order": "^0.0.2",
-    "babel-preset-react-app": "^10.0.1",
     "chromatic": "^6.10.2",
     "dayjs": "^1.10.7",
     "depcheck": "^1.4.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6157,17 +6157,6 @@ babel-jest@^29.3.1:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-loader@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
-  integrity sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
-  dependencies:
-    find-cache-dir "^2.1.0"
-    loader-utils "^1.4.0"
-    mkdirp "^0.5.3"
-    pify "^4.0.1"
-    schema-utils "^2.6.5"
-
 babel-loader@^8.0.0, babel-loader@^8.2.3:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.3.0.tgz#124936e841ba4fe8176786d6ff28add1f134d6a8"
@@ -12758,7 +12747,7 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
-loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.2.3:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
   integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Dependabot opened a dependecy upgrade PR for the direct dependency babel-loader which opened the question of whether or not we are using this package as a direct dependency. 

## Changes Proposed
Remove babel-loader and other babel related packages as a direct dependencies 

## Additional Information
After checking the project it is concluded that babel-loader is being used in our project but not as a peerDependency or direct dependency. Below is a list of the packages that currently use it in the project but these packages take care of installing it themselves.
![Screenshot 2023-01-20 at 8 50 02 AM](https://user-images.githubusercontent.com/103958711/213712845-16c097e2-a336-483a-a830-211ad4926859.png)

## Testing

Run yarn build in local and check that no issues are raised. 
Run the app in local and check that all the normal JS bundles are there and the app works as expected.
This has been tested in Dev4 as well
