### PR TITLE
Add additional logging about patient bulk upload errors

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
@@ -49,6 +49,7 @@ public class PatientBulkUploadService {
     if (!errors.isEmpty()) {
       result.setStatus(UploadStatus.FAILURE);
       result.setErrors(errors.toArray(FeedbackMessage[]::new));
+      log.debug("CSV patient bulk upload rejected with the following errors: {}", errors);
       return result;
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/reportstream/FeedbackMessage.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/reportstream/FeedbackMessage.java
@@ -4,9 +4,11 @@ import java.io.Serializable;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
+@ToString
 public class FeedbackMessage implements Serializable {
   private String scope;
   private String message;


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Checking in on patient bulk upload usage this morning, I noticed that we don't log anything for a failed validation. It'd be helpful to see the kinds of errors users are generating, so we can better understand their expectations or formatting issues.

## Changes Proposed

- Add logging for errors caught in the patient bulk upload validation process.

## Additional Information

- I don't _think_ this should result in PII exposure in the logs, but I'm definitely open to suggestions on how we can make sure the logs are as innocuous as possible.
