### PR TITLE
rollback without throwing error due to permissions issue

### DIFF
--- a/.github/actions/set-swap-space/action.yml
+++ b/.github/actions/set-swap-space/action.yml
@@ -19,13 +19,13 @@ runs:
     - name: Set Swap
       shell: bash
       run: |
-          export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
-          sudo swapoff $SWAP_FILE
-          sudo rm $SWAP_FILE
-          sudo fallocate -l ${{ inputs.swap-size-gb }}G $SWAP_FILE
-          sudo chmod 600 $SWAP_FILE
-          sudo mkswap $SWAP_FILE
-          sudo swapon $SWAP_FILE
+        export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
+        sudo swapoff $SWAP_FILE
+        sudo rm $SWAP_FILE
+        sudo fallocate -l ${{ inputs.swap-size-gb }}G $SWAP_FILE
+        sudo chmod 600 $SWAP_FILE
+        sudo mkswap $SWAP_FILE
+        sudo swapon $SWAP_FILE
     - name: Swap space report after modification
       shell: bash
       run: |

--- a/.github/workflows/rollbackDB.yml
+++ b/.github/workflows/rollbackDB.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Display logs
         if: always()
         run: |
+          echo "::group::Set resource group, run rollback"
           RESOURCE_GROUP=$DEPLOY_ENV
           if [[ "$DEPLOY_ENV" == *"dev"* ]]; then RESOURCE_GROUP="dev"; fi;
+          echo "Resource Group: $RESOURCE_GROUP"
           az container logs --follow -g prime-simple-report-$RESOURCE_GROUP --name simple-report-$DEPLOY_ENV-db-rollback
+          echo "::endgroup::"

--- a/backend/Dockerfile.db-rollback
+++ b/backend/Dockerfile.db-rollback
@@ -1,16 +1,18 @@
 FROM gradle:7.6.0-jdk11 AS build
 
-USER gradle
-
 WORKDIR /home/gradle/graphql-api
 COPY ./.git ./.git
 
 WORKDIR /home/gradle/graphql-api/backend
-COPY backend/gradle ./gradle
-COPY backend/*.gradle ./
+COPY ./backend/gradle ./gradle
+COPY ./backend/*.gradle ./
 COPY ./backend/config ./config
 COPY ./backend/src ./src
 COPY ./backend/gradle.properties gradle.properties
 COPY ./backend/db_rollback_to_tag.sh ./db_rollback_to_tag.sh
+
+RUN chown -R gradle:gradle .
+
+USER gradle
 
 ENTRYPOINT ["./db_rollback_to_tag.sh"]

--- a/backend/build_and_push.sh
+++ b/backend/build_and_push.sh
@@ -13,7 +13,7 @@ if docker manifest inspect $ACR_TAG > /dev/null 2>&1; then
 fi
 
 echo "Building backend images"
-docker-compose -f ${DOCKER_COMPOSE_FILE:-docker-compose.prod.yml} build
+docker compose -f ${DOCKER_COMPOSE_FILE:-docker-compose.prod.yml} build
 
 docker tag "simple-report-api-build:latest" $ACR_TAG
 echo "Tagged $ACR_TAG"


### PR DESCRIPTION
# DEVOPS/DATABASE PULL REQUEST

## Related Issue

- Fix database rollbacks #5110 

## Changes Proposed

- adjust indentation on github action to match usage in other parts of the file.
- add some output to the rollback job with helpful info
- update dockerfile to ensure proper user permissions
- update docker-compose usage to docker compose

## Testing

- [failed rollback](https://github.com/CDCgov/prime-simplereport/actions/runs/3944240823/jobs/6749948755) - check "Display logs"
- [passing rollback](https://github.com/CDCgov/prime-simplereport/actions/runs/3991006557/jobs/6845904653) - check "Display logs" 
- [docker compose usage works](https://github.com/CDCgov/prime-simplereport/actions/runs/3991006557/jobs/6845885802) - check "Build and push Docker images"

## Checklist for Primary Reviewer

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification