### PR TITLE
Enable Utah in SimpleReport

### DIFF
--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -38,6 +38,7 @@ export const liveJurisdictions = [
   "RI",
   "TN",
   "TX",
+  "UT",
   "VT",
   "WA",
   "WI",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Utah was turned on in production by ReportStream on Friday!

## Changes Proposed

- Enable facilities from Utah to sign up for SimpleReport

## Additional Information

- Corresponding PR coming to the static site to update map and list
