### PR TITLE
Added custom metric for patient upload

### DIFF
--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -3,7 +3,6 @@ import { FormGroup } from "@trussworks/react-uswds";
 import { useSelector } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
-import { useAppInsightsContext } from "@microsoft/applicationinsights-react-js";
 import { useLocation } from "react-router-dom";
 
 import { useDocumentTitle } from "../utils/hooks";
@@ -11,6 +10,7 @@ import Button from "../commonComponents/Button/Button";
 import RadioGroup from "../commonComponents/RadioGroup";
 import Dropdown from "../commonComponents/Dropdown";
 import SingleFileInput from "../commonComponents/SingleFileInput";
+import { getAppInsights } from "../TelemetryService";
 import { Facility, FeedbackMessage } from "../../generated/graphql";
 import { showError } from "../utils/srToast";
 import { FileUploadService } from "../../fileUploadService/FileUploadService";
@@ -41,7 +41,7 @@ const UploadPatients = () => {
     Array<FeedbackMessage | undefined | null>
   >([]);
 
-  const appInsights = useAppInsightsContext();
+  const appInsights = getAppInsights();
 
   const [errorMessage, setErrorMessage] = useState<ErrorMessage>({
     header: "",

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -24,6 +24,17 @@ jest.mock("@microsoft/applicationinsights-react-js", () => {
 
 ReactModal.setAppElement("*"); // suppresses modal-related test warnings.
 
+// Mocking performance API
+Object.defineProperty(global.performance, "mark", { value: jest.fn() });
+Object.defineProperty(global.performance, "measure", { value: jest.fn() });
+Object.defineProperty(global.performance, "clearMarks", { value: jest.fn() });
+Object.defineProperty(global.performance, "clearMeasures", {
+  value: jest.fn(),
+});
+Object.defineProperty(global.performance, "getEntriesByName", {
+  value: jest.fn(),
+});
+
 // Disable moment warnings
 moment.suppressDeprecationWarnings = true;
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

We want to measure how long it takes for a user to complete an upload request with the new patient bulk upload feature

## Changes Proposed

Added logic to create a custom metric in azure. We use the native performance API to make the calculations of how long it takes from the user landing in the page to the point it gets a successful response from the server

## Testing

Test in any dev environment that the metric is successfully sent to azure 

## Screenshots / Demos
<img width="1185" alt="Screenshot 2023-01-23 at 3 59 50 PM" src="https://user-images.githubusercontent.com/103958711/214148916-2ded015a-cc34-406d-adf9-38c7756eee15.png">
<img width="1432" alt="Screenshot 2023-01-23 at 3 50 51 PM" src="https://user-images.githubusercontent.com/103958711/214148960-fce3b6d5-3760-4edc-98b4-7551d7d3d99a.png">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
