### PR TITLE
Change from debug to info in patient bulk upload service log

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadService.java
@@ -49,7 +49,7 @@ public class PatientBulkUploadService {
     if (!errors.isEmpty()) {
       result.setStatus(UploadStatus.FAILURE);
       result.setErrors(errors.toArray(FeedbackMessage[]::new));
-      log.debug("CSV patient bulk upload rejected with the following errors: {}", errors);
+      log.info("CSV patient bulk upload rejected with the following errors: {}", errors);
       return result;
     }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- I added logging for failed validation on patient bulk upload, but set the log level to `debug` instead of `info`, so it's not recording anything in production 🤦 

## Changes Proposed

- Change logs to `info` so we get them in prod
