### PR TITLE
add equipment_uid and testkit_name_id to device_type table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4333,3 +4333,21 @@ databaseChangeLog:
               - column:
                   name: test_performed_code
                   type: text
+  - changeSet:
+      id: add-equipment_uid-testkit_name_id-to-device_type
+      author: zedd@skylight.digital
+      comment: Add equipment_uid and testkit_name_id columns to device_type table
+      changes:
+        - tagDatabase:
+            tag: add-equipment_uid-testkit_name_id-to-device_type
+        - addColumn:
+            tableName: device_type
+            columns:
+              - column:
+                  name: equipment_uid
+                  type: text
+                  remarks: represents the data from "Equipment UID" column in the LIVD
+              - column:
+                  name: testkit_name_id
+                  type: text
+                  remarks: represents the data from "Testkit Name ID" column in the LIVD


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- part of #4831

## Changes Proposed

- add `equipment_uid` and `testkit_name_id` to `device_type` table

## Additional Information

- AddColumn [supports](https://docs.liquibase.com/change-types/add-column.html#:~:text=PostgreSQL,Yes) auto rollback for postgres

## Testing

- How should reviewers verify this PR?
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->


