### PR TITLE
Drop data_hub_upload table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4333,3 +4333,12 @@ databaseChangeLog:
               - column:
                   name: test_performed_code
                   type: text
+  - changeSet:
+      id: drop-data_hub_upload-table
+      author: merethe@skylight.digital
+      comment: remove unused table formerly used for tracking uploads to ReportStream via deprecated implementation
+      changes:
+        - tagDatabase:
+            tag: drop-data_hub_upload-table
+        - dropTable:
+            tableName: data_hub_upload

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4404,3 +4404,70 @@ databaseChangeLog:
             tag: drop-data_hub_upload-table
         - dropTable:
             tableName: data_hub_upload
+        - sql:
+            sql: |
+              DROP TYPE ${database.defaultSchemaName}.DATA_HUB_UPLOAD_STATUS;
+      rollback:
+        - sql:
+            remarks: Create the enumerations needed for DataHubUpload.
+            sql: |
+              CREATE TYPE ${database.defaultSchemaName}.DATA_HUB_UPLOAD_STATUS as ENUM('IN_PROGRESS', 'SUCCESS', 'FAIL');
+        - createTable:
+            tableName: data_hub_upload
+            remarks: Track uploads and results of test_events to the data-hub.
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: job_status
+                  type: ${database.defaultSchemaName}.DATA_HUB_UPLOAD_STATUS
+                  remarks: State of this upload. Enumerated value.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  remarks: The creation timestamp for this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  remarks: The timestamp for the most recent update of this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: records_processed
+                  type: int
+                  remarks: Number of rows sent to the server.
+              - column:
+                  name: error_message
+                  type: text
+                  remarks: Set if an exception happens.
+              - column:
+                  name: response_data
+                  type: jsonb
+                  remarks: Response json from data-hub.
+              - column:
+                  name: earliest_recorded_timestamp
+                  type: DATETIME
+                  remarks: Lowerbound timestamp used to collect test_events. Entities with created_by > this value are sent.
+              - column:
+                  name: latest_recorded_timestamp
+                  type: DATETIME
+                  remarks: Upperbounds timestamp used to collect test_event. Entities with created_by <= this value are sent.
+        - createIndex:
+            indexName: uk__data_hub_upload__job_status__latest_recorded_timestamp
+            tableName: data_hub_upload
+            clustered: true
+            columns:
+              - column:
+                  name: job_status
+              - column:
+                  name: latest_recorded_timestamp
+                  descending: true


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

removing an unused table as followup to this commit: https://github.com/CDCgov/prime-simplereport/commit/1d646e9d9d9ad84de090bf478e7d4397dfaaf03d

## Changes Proposed

see PR #5105 for more info. this table hasn't been used since 2021 and we are no longer storing this kind of upload data in this way (can be found in Azure function app logs) so it's not entirely relevant to keep

## Additional Information

open to discussion on whether we should keep this in case we ever have need for it

## Testing

I'll deploy to a lower and we can check out metabase

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment