### PR TITLE
stop reading/writing to unused swabtype field on deviceType

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -97,7 +97,6 @@ public class InitialSetupProperties {
                     d.getManufacturer(),
                     d.getModel(),
                     d.getLoincCode(),
-                    d.getSwabType(),
                     d.getTestLength() > 0 ? d.getTestLength() : determineTestLength(d.getName())))
         .collect(Collectors.toList());
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
@@ -14,6 +14,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 /** The durable (and non-deletable) representation of a POC test device model. */
 @Entity
 @Getter
+@Setter
 public class DeviceType extends EternalAuditedEntity {
 
   @Column(nullable = false)
@@ -55,66 +56,12 @@ public class DeviceType extends EternalAuditedEntity {
 
   @ConstructorBinding
   public DeviceType(
-      String name,
-      String manufacturer,
-      String model,
-      String loincCode,
-      String swabType,
-      int testLength) {
+      String name, String manufacturer, String model, String loincCode, int testLength) {
     super();
     this.name = name;
     this.manufacturer = manufacturer;
     this.model = model;
     this.loincCode = loincCode;
-    this.swabType = swabType;
-    this.testLength = testLength;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getManufacturer() {
-    return manufacturer;
-  }
-
-  public void setManufacturer(String manufacturer) {
-    this.manufacturer = manufacturer;
-  }
-
-  public String getModel() {
-    return model;
-  }
-
-  public void setModel(String model) {
-    this.model = model;
-  }
-
-  public String getLoincCode() {
-    return loincCode;
-  }
-
-  public void setLoincCode(String loincCode) {
-    this.loincCode = loincCode;
-  }
-
-  public String getSwabType() {
-    return swabType;
-  }
-
-  public void setSwabType(String swabType) {
-    this.swabType = swabType;
-  }
-
-  public int getTestLength() {
-    return this.testLength;
-  }
-
-  public void setTestLength(int testLength) {
     this.testLength = testLength;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -154,7 +154,6 @@ public class DeviceTypeService {
                 createDevice.getManufacturer(),
                 createDevice.getModel(),
                 createDevice.getLoincCode(),
-                null,
                 createDevice.getTestLength()));
 
     specimenTypes.stream()

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -440,7 +440,7 @@ class FhirConverterTest {
   @Test
   void convertToDevice_DeviceType_valid() {
     var internalId = UUID.randomUUID();
-    var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", "swab type", 15);
+    var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", 15);
     ReflectionTestUtils.setField(deviceType, "internalId", internalId);
 
     var actual = convertToDevice(deviceType);
@@ -457,12 +457,7 @@ class FhirConverterTest {
     var internalId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
     DeviceType deviceType =
         new DeviceType(
-            "name",
-            "BioFire Diagnostics",
-            "BioFire Respiratory Panel 2.1 (RP2.1)*@",
-            "loinc",
-            "swab type",
-            15);
+            "name", "BioFire Diagnostics", "BioFire Respiratory Panel 2.1 (RP2.1)*@", "loinc", 15);
     ReflectionTestUtils.setField(deviceType, "internalId", UUID.fromString(internalId));
 
     var actual = convertToDevice(deviceType);
@@ -1060,7 +1055,7 @@ class FhirConverterTest {
   @Test
   void createFhirBundle_TestEvent_matchesJson() throws IOException {
     var address = new StreetAddress(List.of("1 Main St"), "Chicago", "IL", "60614", "");
-    var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", "nasal", 0);
+    var deviceType = new DeviceType("name", "manufacturer", "model", "loinc", 0);
     var specimenType = new SpecimenType("name", "typeCode");
     var provider =
         new Provider(new PersonName("Michaela", null, "Quinn", ""), "1", address, "7735551235");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -75,7 +75,7 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
     Organization fakeOrg = new Organization("ABC", "university", "123", true);
     Person p = makeSerializablePerson(fakeOrg);
     Provider mccoy = new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222");
-    DeviceType device = new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15);
+    DeviceType device = new DeviceType("Bill", "Weasleys", "1", "12345-6", 15);
     SpecimenType specimenType = new SpecimenType();
     StreetAddress addy =
         new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -28,8 +28,8 @@ class FacilityRepositoryTest extends BaseRepositoryTest {
   @Test
   void smokeTestDeviceOperations() {
     List<DeviceType> configuredDevices = new ArrayList<>();
-    DeviceType bill = _devices.save(new DeviceType("Bill", "Weasleys", "1", "12345-6", "E", 15));
-    DeviceType percy = _devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", "E", 15));
+    DeviceType bill = _devices.save(new DeviceType("Bill", "Weasleys", "1", "12345-6", 15));
+    DeviceType percy = _devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7", 15));
     SpecimenType spec = _specimens.save(new SpecimenType("Troll Bogies", "0001111234"));
     Provider mccoy =
         _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -57,7 +57,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
   @Test
   void fetchDeviceTypes() {
-    _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE, STANDARD_TEST_LENGTH));
+    _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", STANDARD_TEST_LENGTH));
 
     DeviceType deviceType = _service.fetchDeviceTypes().get(0);
 
@@ -88,8 +88,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
   @Test
   void updateDeviceType_baseUser_error() {
     DeviceType deviceType =
-        _deviceTypeRepo.save(
-            new DeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE, STANDARD_TEST_LENGTH));
+        _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", STANDARD_TEST_LENGTH));
     assertSecurityError(
         () ->
             _service.updateDeviceType(
@@ -99,8 +98,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
   @Test
   void removeDeviceType_baseUser_error() {
     DeviceType deviceType =
-        _deviceTypeRepo.save(
-            new DeviceType("A", "B", "C", "D", FAKE_SWAB_TYPE, STANDARD_TEST_LENGTH));
+        _deviceTypeRepo.save(new DeviceType("A", "B", "C", "D", STANDARD_TEST_LENGTH));
     assertSecurityError(() -> _service.removeDeviceType(deviceType));
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -68,7 +68,7 @@ public class TestDataBuilder {
   }
 
   public static DeviceType createEmptyDeviceWithLoinc() {
-    return new DeviceType(null, null, null, "95422-2", null, 0);
+    return new DeviceType(null, null, null, "95422-2", 0);
   }
 
   public static TestOrder createEmptyTestOrder() {
@@ -110,7 +110,7 @@ public class TestDataBuilder {
   }
 
   public static DeviceType createDeviceType() {
-    return new DeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", "E", 15);
+    return new DeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM", 15);
   }
 
   public static SpecimenType createSpecimenType() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -551,8 +551,7 @@ public class TestDataFactory {
 
   public DeviceType createDeviceType(
       String name, String manufacturer, String model, String loincCode, String swabType) {
-    return deviceTypeRepository.save(
-        new DeviceType(name, manufacturer, model, loincCode, swabType, 15));
+    return deviceTypeRepository.save(new DeviceType(name, manufacturer, model, loincCode, 15));
   }
 
   public DeviceType getGenericDevice() {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #4831 (breaking the changes to multiple easy to review PRs)

## Changes Proposed

- stop reading/writing to unused swabtype field on deviceType
- removed duplicated getters
- replaced setters with @setter

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
