### PR TITLE
4552/org state error messaging

### DIFF
--- a/frontend/src/app/commonComponents/Checkboxes.tsx
+++ b/frontend/src/app/commonComponents/Checkboxes.tsx
@@ -9,7 +9,7 @@ import Optional from "../commonComponents/Optional";
 // DOM properties such as `disabled`, `readonly`, `aria-xxx` etc.
 export type CheckboxProps = {
   value: string;
-  label: string;
+  label: string | JSX.Element;
 };
 type InputProps = JSX.IntrinsicElements["input"];
 type Checkbox = CheckboxProps & InputProps;

--- a/frontend/src/app/commonComponents/Modal.tsx
+++ b/frontend/src/app/commonComponents/Modal.tsx
@@ -37,10 +37,11 @@ const Header: React.FC<HeaderProps> = ({ children, styleClassNames }) => (
 
 type FooterProps = {
   children?: React.ReactNode;
+  styleClassNames?: string;
 };
 
-const Footer: React.FC<FooterProps> = ({ children }) => (
-  <div className="modal__footer">{children}</div>
+const Footer: React.FC<FooterProps> = ({ children, styleClassNames }) => (
+  <div className={"modal__footer " + styleClassNames}>{children}</div>
 );
 
 const Modal = ({

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import OrganizationForm, {
@@ -87,16 +87,13 @@ describe("OrganizationForm", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText("SimpleReport isn't available yet in your state.", {
-        exact: false,
-      })
+      screen.getByText(
+        "U.S. Virgin Islands isn't connected to SimpleReport yet.",
+        {
+          exact: false,
+        }
+      )
     ).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(
-        screen.getByRole("textbox", { name: "Organization name required" })
-      ).toHaveFocus()
-    );
   });
 
   it("redirects to identity verification when submitting valid input", async () => {

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -55,7 +55,6 @@ const OrganizationForm = () => {
     initOrg()
   );
   const [stateModalOpen, setStateModalOpen] = useState(false);
-  const [selectedState, setSelectedState] = useState("");
   const [errors, setErrors] = useState<OrganizationFormErrors>(initOrgErrors());
   const focusOnce = useRef(false);
   const [backendError, setBackendError] = useState<ReactElement>();
@@ -70,9 +69,6 @@ const OrganizationForm = () => {
     (value: OrganizationCreateRequest[typeof field]) => {
       setFormChanged(true);
       setOrganization({ ...organization, [field]: value });
-      if (field === "state") {
-        setSelectedState(value!);
-      }
     };
 
   const validateField = async (field: keyof OrganizationCreateRequest) => {
@@ -140,10 +136,13 @@ const OrganizationForm = () => {
   ]);
 
   useEffect(() => {
-    if (selectedState! && !liveJurisdictions.includes(selectedState)) {
+    if (
+      organization.state! &&
+      !liveJurisdictions.includes(organization.state)
+    ) {
       setStateModalOpen(true);
     }
-  }, [selectedState]);
+  }, [organization.state]);
 
   if (orgExternalId) {
     return (
@@ -329,10 +328,13 @@ const OrganizationForm = () => {
       </Card>
       <UnsupportedStateModal
         showModal={stateModalOpen}
-        onClose={() => {
+        state={organization.state}
+        onClose={(clearField: boolean) => {
+          if (clearField) {
+            setOrganization({ ...organization, "state": "" });
+          }
           setStateModalOpen(false);
         }}
-        state={selectedState}
       />
     </CardBackground>
   );

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useRef, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router-dom";
 
 import { Card } from "../../commonComponents/Card/Card";
@@ -19,6 +19,7 @@ import { SignUpApi } from "../SignUpApi";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
 import { PersonalDetailsFormProps } from "../IdentityVerification/PersonalDetailsForm";
 import StepIndicator from "../../commonComponents/StepIndicator";
+import { liveJurisdictions } from "../../../config/constants";
 
 import {
   initOrg,
@@ -30,6 +31,7 @@ import {
 } from "./utils";
 
 import "./OrganizationForm.scss";
+import { UnsupportedStateModal } from "./UnsupportedStateModal";
 
 export interface OrganizationCreateRequest {
   name: string;
@@ -52,6 +54,8 @@ const OrganizationForm = () => {
   const [organization, setOrganization] = useState<OrganizationCreateRequest>(
     initOrg()
   );
+  const [stateModalOpen, setStateModalOpen] = useState(false);
+  const [selectedState, setSelectedState] = useState("");
   const [errors, setErrors] = useState<OrganizationFormErrors>(initOrgErrors());
   const focusOnce = useRef(false);
   const [backendError, setBackendError] = useState<ReactElement>();
@@ -66,6 +70,9 @@ const OrganizationForm = () => {
     (value: OrganizationCreateRequest[typeof field]) => {
       setFormChanged(true);
       setOrganization({ ...organization, [field]: value });
+      if (field === "state") {
+        setSelectedState(value!);
+      }
     };
 
   const validateField = async (field: keyof OrganizationCreateRequest) => {
@@ -131,6 +138,12 @@ const OrganizationForm = () => {
     errors.email,
     errors.workPhoneNumber,
   ]);
+
+  useEffect(() => {
+    if (selectedState! && !liveJurisdictions.includes(selectedState)) {
+      setStateModalOpen(true);
+    }
+  }, [selectedState]);
 
   if (orgExternalId) {
     return (
@@ -314,6 +327,13 @@ const OrganizationForm = () => {
           label={"Continue"}
         />
       </Card>
+      <UnsupportedStateModal
+        showModal={stateModalOpen}
+        onClose={() => {
+          setStateModalOpen(false);
+        }}
+        state={selectedState}
+      />
     </CardBackground>
   );
 };

--- a/frontend/src/app/signUp/Organization/UnsupportedStateModal.test.tsx
+++ b/frontend/src/app/signUp/Organization/UnsupportedStateModal.test.tsx
@@ -1,0 +1,39 @@
+import { render, RenderResult, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { UnsupportedStateModal } from "./UnsupportedStateModal";
+
+describe("UnsupportedStateModal", () => {
+  let mockOnClose = jest.fn();
+  let component: RenderResult;
+
+  beforeEach(() => {
+    component = render(
+      <UnsupportedStateModal
+        showModal={true}
+        onClose={mockOnClose}
+        state={"MI"}
+      />
+    );
+  });
+  it("renders", () => {
+    expect(component).toMatchSnapshot();
+  });
+
+  it("closes on continue", () => {
+    const continueButton = screen.getByText("Continue sign up");
+    expect(continueButton).toBeDisabled();
+
+    screen.getByLabelText("acknowledged").click();
+    expect(continueButton).toBeEnabled();
+    continueButton.click();
+
+    expect(mockOnClose).toBeCalledWith(false);
+  });
+
+  it("closes on esc key", async () => {
+    expect(mockOnClose).not.toHaveBeenCalled();
+    await userEvent.keyboard("{Escape}");
+    expect(mockOnClose).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
+++ b/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from "react";
+
+import Button from "../../commonComponents/Button/Button";
+import Modal from "../../commonComponents/Modal";
+import Checkboxes from "../../commonComponents/Checkboxes";
+
+const noop = () => {
+  /**
+   * The `onClose` callback is technically optional in this component but not
+   * in the child `Modal` component. Pass a no-op callback to the inner
+   * component to satisfy the prop type requirement
+   */
+};
+
+export type UnsupportedStateModalProps = {
+  showModal: boolean;
+  onClose?: () => void;
+  state: string;
+};
+
+export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
+  showModal,
+  onClose,
+  state,
+}) => {
+  const [checkboxState, setCheckboxState] = useState(false);
+
+  return (
+    <Modal
+      onClose={onClose || noop}
+      showModal={showModal}
+      showClose={true}
+      variant="warning"
+      contentLabel={"Unsupported State"}
+    >
+      <Modal.Header
+        styleClassNames={"margin-0 font-sans-lg line-height-sans-2"}
+      ></Modal.Header>
+      <p>
+        {state} isn't connected to SimpleReport yet.
+        <br />
+        <br />
+        You can join the waitlist to be notified when SimpleReport is available
+        in your state, or if your organization is reporting to a SimpleReport
+        state, you can continue.
+      </p>
+      <Checkboxes
+        name="acknowledge"
+        legend=""
+        onChange={(e) => {
+          setCheckboxState(!checkboxState);
+        }}
+        boxes={[
+          {
+            value: "acknowledged",
+            label: (
+              <>
+                My organization is submitting test results to a{" "}
+                <a
+                  href="https://simplereport.gov/using-simplereport/manage-facility-info/find-supported-jurisdictions"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  state that is connected to SimpleReport
+                </a>
+                .
+              </>
+            ),
+            checked: checkboxState,
+          },
+        ]}
+      />
+      <Modal.Footer styleClassNames={"prime-right-align"}>
+        <a
+          href={"https://simplereport.gov/waitlist"}
+          target={"_blank"}
+          rel="noopener noreferrer"
+        >
+          <Button>Join waitlist</Button>
+        </a>
+        {onClose && (
+          <Button
+            onClick={() => {
+              onClose();
+              setCheckboxState(false);
+            }}
+            disabled={!checkboxState}
+          >
+            Continue sign up
+          </Button>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
+++ b/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
@@ -5,14 +5,6 @@ import Modal from "../../commonComponents/Modal";
 import Checkboxes from "../../commonComponents/Checkboxes";
 import { getStateNameFromCode } from "../../utils/state";
 
-const noop = () => {
-  /**
-   * The `onClose` callback is technically optional in this component but not
-   * in the child `Modal` component. Pass a no-op callback to the inner
-   * component to satisfy the prop type requirement
-   */
-};
-
 export type UnsupportedStateModalProps = {
   showModal: boolean;
   onClose: (clearField: boolean) => void;
@@ -47,7 +39,7 @@ export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
       <Checkboxes
         name="acknowledge"
         legend=""
-        onChange={(e) => {
+        onChange={() => {
           setCheckboxState(!checkboxState);
         }}
         boxes={[
@@ -67,17 +59,17 @@ export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
               </>
             ),
             checked: checkboxState,
+            "aria-label": "acknowledged",
           },
         ]}
       />
       <Modal.Footer styleClassNames={"prime-right-align"}>
-        <a
-          href={"https://simplereport.gov/waitlist"}
-          target={"_blank"}
-          rel="noopener noreferrer"
+        <Button
+          variant="outline"
+          onClick={() => window.open("https://simplereport.gov/waitlist")}
         >
-          <Button variant="outline">Join waitlist</Button>
-        </a>
+          Join waitlist
+        </Button>
         {onClose && (
           <Button
             onClick={() => {

--- a/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
+++ b/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
@@ -14,7 +14,7 @@ const noop = () => {
 
 export type UnsupportedStateModalProps = {
   showModal: boolean;
-  onClose?: () => void;
+  onClose: (clearField: boolean) => void;
   state: string;
 };
 
@@ -27,11 +27,12 @@ export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
 
   return (
     <Modal
-      onClose={onClose || noop}
+      onClose={() => onClose(true)}
       showModal={showModal}
       showClose={true}
       variant="warning"
       contentLabel={"Unsupported State"}
+      containerClassName={"unsupported-state-modal"}
     >
       <Modal.Header
         styleClassNames={"margin-0 font-sans-lg line-height-sans-2"}
@@ -81,7 +82,7 @@ export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
         {onClose && (
           <Button
             onClick={() => {
-              onClose();
+              onClose(false);
               setCheckboxState(false);
             }}
             disabled={!checkboxState}

--- a/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
+++ b/frontend/src/app/signUp/Organization/UnsupportedStateModal.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Button from "../../commonComponents/Button/Button";
 import Modal from "../../commonComponents/Modal";
 import Checkboxes from "../../commonComponents/Checkboxes";
+import { getStateNameFromCode } from "../../utils/state";
 
 const noop = () => {
   /**
@@ -30,17 +31,15 @@ export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
       onClose={() => onClose(true)}
       showModal={showModal}
       showClose={true}
-      variant="warning"
       contentLabel={"Unsupported State"}
       containerClassName={"unsupported-state-modal"}
     >
       <Modal.Header
         styleClassNames={"margin-0 font-sans-lg line-height-sans-2"}
-      ></Modal.Header>
+      >
+        {getStateNameFromCode(state)} isn't connected to SimpleReport yet.
+      </Modal.Header>
       <p>
-        {state} isn't connected to SimpleReport yet.
-        <br />
-        <br />
         You can join the waitlist to be notified when SimpleReport is available
         in your state, or if your organization is reporting to a SimpleReport
         state, you can continue.
@@ -77,7 +76,7 @@ export const UnsupportedStateModal: React.FC<UnsupportedStateModalProps> = ({
           target={"_blank"}
           rel="noopener noreferrer"
         >
-          <Button>Join waitlist</Button>
+          <Button variant="outline">Join waitlist</Button>
         </a>
         {onClose && (
           <Button

--- a/frontend/src/app/signUp/Organization/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/frontend/src/app/signUp/Organization/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -1,0 +1,184 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnsupportedStateModal renders 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body
+    class="ReactModal__Body--open"
+  >
+    <div
+      data-react-modal-body-trap=""
+      style="position: absolute; opacity: 0;"
+      tabindex="0"
+    />
+    <div />
+    <div
+      data-react-modal-body-trap=""
+      style="position: absolute; opacity: 0;"
+      tabindex="0"
+    />
+    <div
+      class="modal--basic"
+    >
+      <div
+        class="ReactModal__Overlay prime-modal-overlay display-flex flex-align-center flex-justify-center"
+      >
+        <div
+          aria-label="Unsupported State"
+          aria-modal="true"
+          class="ReactModal__Content"
+          role="dialog"
+          style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 20px;"
+          tabindex="-1"
+        >
+          <div
+            class="unsupported-state-modal modal__container"
+          >
+            <button
+              class="modal__close-button"
+              style="cursor: pointer;"
+            >
+              <img
+                alt="Close"
+                class="modal__close-img"
+                src="close.svg"
+              />
+            </button>
+            <main>
+              <div
+                class="modal__content grid-row"
+              >
+                <div
+                  class="grid-col"
+                >
+                  <h1
+                    class="modal__heading margin-0 font-sans-lg line-height-sans-2"
+                  >
+                    Michigan
+                     isn't connected to SimpleReport yet.
+                  </h1>
+                  <p>
+                    You can join the waitlist to be notified when SimpleReport is available in your state, or if your organization is reporting to a SimpleReport state, you can continue.
+                  </p>
+                  <div
+                    class="usa-form-group"
+                  >
+                    <fieldset
+                      class="usa-fieldset prime-checkboxes"
+                    >
+                      <legend
+                        class="usa-legend"
+                      />
+                      <div
+                        class="checkboxes"
+                      >
+                        <div
+                          class="usa-checkbox"
+                        >
+                          <input
+                            aria-label="acknowledged"
+                            class="usa-checkbox__input"
+                            id="1-val-0"
+                            name="acknowledge"
+                            type="checkbox"
+                            value="acknowledged"
+                          />
+                          <label
+                            class="usa-checkbox__label"
+                            for="1-val-0"
+                          >
+                            My organization is submitting test results to a
+                             
+                            <a
+                              href="https://simplereport.gov/using-simplereport/manage-facility-info/find-supported-jurisdictions"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              state that is connected to SimpleReport
+                            </a>
+                            .
+                          </label>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="modal__footer prime-right-align"
+                  >
+                    <button
+                      class="usa-button usa-button--outline"
+                      type="button"
+                    >
+                      Join waitlist
+                    </button>
+                    <button
+                      aria-disabled="true"
+                      class="usa-button usa-button-disabled"
+                      disabled=""
+                      type="button"
+                    >
+                      Continue sign up
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div />,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -3,7 +3,6 @@ import { ReactElement } from "react";
 
 import { TextWithTooltip } from "../../commonComponents/TextWithTooltip";
 import { phoneNumberIsValid } from "../../patients/personSchema";
-import { liveJurisdictions } from "../../../config/constants";
 import Alert from "../../commonComponents/Alert";
 
 import { OrganizationCreateRequest } from "./OrganizationForm";
@@ -125,10 +124,7 @@ export const organizationSchema: yup.SchemaOf<OrganizationCreateRequest> = yup
       .mixed()
       .oneOf(Object.keys(OrganizationTypeEnum), "Organization type is required")
       .required(),
-    state: yup
-      .mixed()
-      .oneOf(liveJurisdictions, getStateErrorMessage)
-      .required(),
+    state: yup.string().required(),
     firstName: yup.string().required("First name is required"),
     middleName: yup.string().nullable(),
     lastName: yup.string().required("Last name is required"),


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #4552 Updating validation and error messaging to account for orgs operating in states SimpleReport doesn't support, but are reporting to states that we do.

## Changes Proposed

- Updated existing validation to only check that a state is required
- New modal pops when an unsupported state is selected in the dropdown

## Testing

- How should reviewers verify this PR?

## Screenshots / Demos

https://user-images.githubusercontent.com/7085658/215580131-7fbb6d7e-ed2b-4d4c-8508-0ebee85f5ab1.mov



<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
