### PR TITLE
Throw helpful err msg when creating user w/ existing email

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlConfig.java
@@ -2,7 +2,6 @@ package gov.cdc.usds.simplereport.config;
 
 import static java.util.Collections.singletonList;
 
-import com.okta.sdk.resource.ResourceException;
 import gov.cdc.usds.simplereport.api.DefaultArgumentValidation;
 import gov.cdc.usds.simplereport.api.directives.RequiredPermissionsDirectiveWiring;
 import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
@@ -35,14 +34,6 @@ public class GraphQlConfig {
   public static final String REQUIRED_PERMISSIONS_DIRECTIVE_NAME = "requiredPermissions";
   public static final int MAXIMUM_SIZE = 256;
   private static final String defaultErrorBody = "body: Please check for errors and try again";
-
-  private Mono setOktaDuplicateUserMessage(String errorPath) {
-    String errorBody =
-        "A user with this email already exists in our system. Please contact SimpleReport support for help.";
-    String errorMessage = String.format("header: Can't add user; body: %s", errorBody);
-    return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
-  }
-
   // mask all exception by default
   // to customize errors returned, you have to manually throw it here
   @Bean
@@ -52,12 +43,11 @@ public class GraphQlConfig {
 
       log.error("Will replace the following exception with a GenericGraphqlException: ", exception);
 
-      if (exception instanceof ResourceException) {
-        return setOktaDuplicateUserMessage(errorPath);
-      }
-
       if (exception instanceof ConflictingUserException) {
-        return setOktaDuplicateUserMessage(errorPath);
+        String errorBody =
+            "A user with this email already exists in our system. Please contact SimpleReport support for help.";
+        String errorMessage = String.format("header: Can't add user; body: %s", errorBody);
+        return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
       }
 
       if (exception instanceof AccessDeniedException) {
@@ -71,14 +61,9 @@ public class GraphQlConfig {
       }
 
       if (exception instanceof IllegalGraphqlArgumentException) {
-        if ("addUserToCurrentOrg".equals(errorPath)
-            && exception.getMessage().contains("Cannot reprovision user in unsupported state")) {
-          return setOktaDuplicateUserMessage(errorPath);
-        } else {
-          String errorMessage =
-              String.format("header: %s; %s", exception.getMessage(), defaultErrorBody);
-          return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
-        }
+        String errorMessage =
+            String.format("header: %s; %s", exception.getMessage(), defaultErrorBody);
+        return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
       }
 
       if (exception instanceof IllegalGraphqlFieldAccessException) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -16,6 +16,7 @@ import com.okta.sdk.resource.user.UserProfile;
 import com.okta.sdk.resource.user.UserStatus;
 import com.okta.spring.boot.sdk.config.OktaClientProperties;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
+import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
 import gov.cdc.usds.simplereport.config.BeanProfiles;
@@ -274,8 +275,7 @@ public class LiveOktaRepository implements OktaRepository {
 
     // any org user "deleted" through our api will be in SUSPENDED state
     if (userStatus != UserStatus.SUSPENDED) {
-      throw new IllegalGraphqlArgumentException(
-          "Cannot reprovision user in unsupported state: " + userStatus);
+      throw new ConflictingUserException();
     }
 
     updateUser(user, userIdentity);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -469,7 +469,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
         "add-user-to-current-org",
         "addUserToCurrentOrgNovel",
         variables,
-        "A user with this email address already exists.");
+        "A user with this email already exists in our system. Please contact SimpleReport support for help.");
   }
 
   @Test

--- a/frontend/src/app/Settings/Users/CreateUserForm.tsx
+++ b/frontend/src/app/Settings/Users/CreateUserForm.tsx
@@ -80,6 +80,7 @@ const CreateUserForm: React.FC<Props> = ({ onClose, onSubmit, isUpdating }) => {
     if (validation.valid) {
       setErrors(initCreateUserErrors());
       onSubmit(newUser);
+      setSaving(false);
       return;
     }
     setErrors(validation.errors);

--- a/frontend/src/app/utils/__snapshots__/srGraphQLErrorMessage.test.tsx.snap
+++ b/frontend/src/app/utils/__snapshots__/srGraphQLErrorMessage.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getBody adds mailto anchor tag if there is support@simplereport.gov email in the body 1`] = `
+exports[`getBody adds link to contact us page if there is 'SimpleReport support' in the body 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -10,13 +10,15 @@ Object {
         <span>
            
           <a
-            href="mailto:support@simplereport.gov"
+            href="/contact-us"
+            target="_blank"
           >
-            support@simplereport.gov
+            SimpleReport
+             
+            support
           </a>
            
         </span>
-        for more information
       </span>
     </div>
   </body>,
@@ -26,13 +28,15 @@ Object {
       <span>
          
         <a
-          href="mailto:support@simplereport.gov"
+          href="/contact-us"
+          target="_blank"
         >
-          support@simplereport.gov
+          SimpleReport
+           
+          support
         </a>
          
       </span>
-      for more information
     </span>
   </div>,
   "debug": [Function],
@@ -89,35 +93,45 @@ Object {
 }
 `;
 
-exports[`getBody adds mailto anchor tag if there is support@simplereport.gov email in the body 2`] = `
+exports[`getBody adds link to contact us page if there is 'SimpleReport support' in the body 2`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
       <span>
-        Contact
+        A user with this email already exists in our system. Please contact
         <span>
            
           <a
-            href="mailto:support@simplereport.gov"
+            href="/contact-us"
+            target="_blank"
           >
-            support@simplereport.gov
+            SimpleReport
+             
+            support
           </a>
+           
         </span>
+        for help.
       </span>
     </div>
   </body>,
   "container": <div>
     <span>
-      Contact
+      A user with this email already exists in our system. Please contact
       <span>
          
         <a
-          href="mailto:support@simplereport.gov"
+          href="/contact-us"
+          target="_blank"
         >
-          support@simplereport.gov
+          SimpleReport
+           
+          support
         </a>
+         
       </span>
+      for help.
     </span>
   </div>,
   "debug": [Function],

--- a/frontend/src/app/utils/__snapshots__/srGraphQLErrorMessage.test.tsx.snap
+++ b/frontend/src/app/utils/__snapshots__/srGraphQLErrorMessage.test.tsx.snap
@@ -10,7 +10,8 @@ Object {
         <span>
            
           <a
-            href="/contact-us"
+            href="https://www.simplereport.gov/contact-us"
+            rel="noopener noreferrer"
             target="_blank"
           >
             SimpleReport
@@ -28,7 +29,8 @@ Object {
       <span>
          
         <a
-          href="/contact-us"
+          href="https://www.simplereport.gov/contact-us"
+          rel="noopener noreferrer"
           target="_blank"
         >
           SimpleReport
@@ -103,7 +105,8 @@ Object {
         <span>
            
           <a
-            href="/contact-us"
+            href="https://www.simplereport.gov/contact-us"
+            rel="noopener noreferrer"
             target="_blank"
           >
             SimpleReport
@@ -122,7 +125,8 @@ Object {
       <span>
          
         <a
-          href="/contact-us"
+          href="https://www.simplereport.gov/contact-us"
+          rel="noopener noreferrer"
           target="_blank"
         >
           SimpleReport
@@ -132,6 +136,180 @@ Object {
          
       </span>
       for help.
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`getBody adds mailto link if there is 'support@simplereport.gov' in the body 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span>
+        Contact
+        <span>
+           
+          <a
+            href="mailto:support@simplereport.gov"
+          >
+            support@simplereport.gov
+          </a>
+           
+        </span>
+        for more information
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span>
+      Contact
+      <span>
+         
+        <a
+          href="mailto:support@simplereport.gov"
+        >
+          support@simplereport.gov
+        </a>
+         
+      </span>
+      for more information
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`getBody adds mailto link if there is 'support@simplereport.gov' in the body 2`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span>
+        Contact
+        <span>
+           
+          <a
+            href="mailto:support@simplereport.gov"
+          >
+            support@simplereport.gov
+          </a>
+        </span>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span>
+      Contact
+      <span>
+         
+        <a
+          href="mailto:support@simplereport.gov"
+        >
+          support@simplereport.gov
+        </a>
+      </span>
     </span>
   </div>,
   "debug": [Function],

--- a/frontend/src/app/utils/srGraphQLErrorMessage.test.tsx
+++ b/frontend/src/app/utils/srGraphQLErrorMessage.test.tsx
@@ -34,14 +34,23 @@ describe("getBody", () => {
     render(getBody(message));
     expect(screen.getByText("try again")).toBeInTheDocument();
   });
-  test("adds mailto anchor tag if there is support@simplereport.gov email in the body", () => {
+  test("adds mailto link if there is 'support@simplereport.gov' in the body", () => {
     const message =
       "header: check the logs, body: Contact support@simplereport.gov for more information";
     expect(render(getBody(message))).toMatchSnapshot();
   });
-  test("adds mailto anchor tag if there is support@simplereport.gov email in the body", () => {
+  test("adds mailto link if there is 'support@simplereport.gov' in the body", () => {
     const message =
       "body: Contact support@simplereport.gov; reason: did not work";
+    expect(render(getBody(message))).toMatchSnapshot();
+  });
+  test("adds link to contact us page if there is 'SimpleReport support' in the body", () => {
+    const message = "body: Contact SimpleReport support; reason: did not work";
+    expect(render(getBody(message))).toMatchSnapshot();
+  });
+  test("adds link to contact us page if there is 'SimpleReport support' in the body", () => {
+    const message =
+      "header: Can't add user; body: A user with this email already exists in our system. Please contact SimpleReport support for help.";
     expect(render(getBody(message))).toMatchSnapshot();
   });
 });

--- a/frontend/src/app/utils/srGraphQLErrorMessage.tsx
+++ b/frontend/src/app/utils/srGraphQLErrorMessage.tsx
@@ -50,7 +50,11 @@ function createContactUsLink(
   return (
     <span key={index}>
       {" "}
-      <a target="_blank" href="/contact-us">
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://www.simplereport.gov/contact-us"
+      >
         {msg} {nextMsg}
       </a>
       {addEndWhiteSpace ? " " : ""}

--- a/frontend/src/app/utils/srGraphQLErrorMessage.tsx
+++ b/frontend/src/app/utils/srGraphQLErrorMessage.tsx
@@ -23,21 +23,59 @@ export function getHeader(message: string): string {
   return getErrorText(message, "header");
 }
 
+function addEndWhiteSpace(errorArrayLength: number, index: number) {
+  return index !== errorArrayLength - 1;
+}
+
+function createSupportMailToLink(
+  msg: string,
+  index: number,
+  addEndWhiteSpace: boolean
+) {
+  return (
+    <span key={index}>
+      {" "}
+      <a href="mailto:support@simplereport.gov">{msg}</a>
+      {addEndWhiteSpace ? " " : ""}
+    </span>
+  );
+}
+
+function createContactUsLink(
+  msg: string,
+  nextMsg: string,
+  index: number,
+  addEndWhiteSpace: boolean
+) {
+  return (
+    <span key={index}>
+      {" "}
+      <a target="_blank" href="/contact-us">
+        {msg} {nextMsg}
+      </a>
+      {addEndWhiteSpace ? " " : ""}
+    </span>
+  );
+}
+
 export function getBody(message: string): JSX.Element {
   let errorText = getErrorText(message, "body");
   let errorTextArray = errorText.split(" ");
   let errorElementArray: any = [];
   let addNewValue = true;
   errorTextArray.forEach((msg, index) => {
+    let addWhiteSpace = addEndWhiteSpace(errorTextArray.length, index);
+    let nextMsg = errorTextArray[index + 1];
     if (msg.includes("support@simplereport.gov")) {
-      let addEndWhitespace = index !== errorTextArray.length - 1;
       errorElementArray.push(
-        <span key={index}>
-          {" "}
-          <a href="mailto:support@simplereport.gov">{msg}</a>
-          {addEndWhitespace ? " " : ""}
-        </span>
+        createSupportMailToLink(msg, index, addWhiteSpace)
       );
+      addNewValue = true;
+    } else if (msg.includes("SimpleReport") && nextMsg.includes("support")) {
+      errorElementArray.push(
+        createContactUsLink(msg, nextMsg, index, addWhiteSpace)
+      );
+      errorTextArray.splice(index + 1, 1);
       addNewValue = true;
     } else {
       if (addNewValue) {


### PR DESCRIPTION
# BACKEND & FRONTEND PULL REQUEST

## Related Issue
Resolves #5075

## Changes Proposed
- Throw a more helpful error message when attempting to create users that have emails that already exist in Okta

## Additional Information


## Testing
This has been deployed to `dev5` for testing purposes.
Each of the following scenarios should result in the new error message (see laura's comment in #5075:

> Can't add user
> A user with this email already exists in our system. Please contact SimpleReport support for help.

- Create a user with an email that already exists in that org or a different org 
- Create a user with an email for a user that has been deleted (e.g. `testUserSimpleReport2@yopmail.com`)
- Edit a current user's email with an email that already exists in that org or a different org
- Edit a current user's email with an email for a user that has been deleted (e.g. `testUserSimpleReport2@yopmail.com`)


## Screenshots / Demos
<img width="1193" alt="Screen Shot 2023-02-01 at 09 34 00" src="https://user-images.githubusercontent.com/20211771/216142658-510d210e-2c5c-423a-b208-ccda2a6d2233.png">

<img width="1133" alt="Screen Shot 2023-02-01 at 09 34 19" src="https://user-images.githubusercontent.com/20211771/216142678-62f51b67-0848-451c-9212-cb4e09abedbf.png">

