### PR TITLE
Undelete archived users with active Okta profiles

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -481,11 +481,18 @@ public class ApiUserService {
   }
 
   private ApiUser getCurrentApiUserFromIdentity(IdentityAttributes userIdentity) {
-    Optional<ApiUser> found = _apiUserRepo.findByLoginEmail(userIdentity.getUsername());
+    Optional<ApiUser> found =
+        _apiUserRepo.findByLoginEmailIncludeArchived(userIdentity.getUsername());
     if (found.isPresent()) {
       log.debug("User has logged in before: retrieving user record.");
       ApiUser user = found.get();
       user.updateLastSeen();
+      if (user.isDeleted()) {
+        log.info("Login for user with deleted account; undeleting user record");
+        // if a user has an active Okta account, their user record should be active as well
+        user.setIsDeleted(false);
+        log.info("User with id={} undeleted", user.getInternalId());
+      }
       user = _apiUserRepo.save(user);
       return user;
     } else {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

There is an issue in our code that led to a couple support requests where a user that had previously been deleted was trying to log back in from an active Okta account. They can complete the Okta log in but then see a Server connection error. In the case where a user has an active Okta account but no api user record, we create a record for them on initial login. If they were previously deleted, however, there is already a record in the table for that login email and we throw an exception for violating a constraint on a unique column.

## Changes Proposed

 If they were previously deleted, we undelete their existing record instead of trying to create a new one.

## Additional Information

Any security concerns on undeleting a user? It seems like if they have an active Okta account, it's valid for them to have an entry in the user table as well. We control permissions via the Okta account groups, so undeleting a user doesn't expose anything they wouldn't already have had access to. And a deleted user will have their Okta account suspended, and they can't reactivate themselves.

## Testing

will deploy in a lower and replicate and update here with findings

## Checklist for Primary Reviewer
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)