### PR TITLE
Shorten function app prefix.

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/_var.tf
@@ -1,6 +1,6 @@
 variable "prefix" {
   type    = string
-  default = "reportstream-batched-publisher"
+  default = "rs-batch-publisher"
 }
 
 variable "location" {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #4936.

## Changes Proposed

- Shortens the resource prefix used for function apps, which clears the name issue.

## Testing

**This code has been successfully tested on `dev7`.**

- Deploy this code to an environment of your choosing.
- Verify that the name length error disappears. (Screenshots contained within the issue denote the location of this error.)
- Verify that the function still properly dequeues and processes messages to send to ReportStream. (Creating at least one test should allow this process to correctly fire.)


## Checklist for Primary Reviewer
### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification