### PR TITLE
explicitly set the role of the file input

### DIFF
--- a/frontend/src/app/commonComponents/SingleFileInput.tsx
+++ b/frontend/src/app/commonComponents/SingleFileInput.tsx
@@ -63,7 +63,7 @@ const SingleFileInput = ({
         className="usa-file-input"
         aria-describedby="file-input-specific-hint"
         accept={accept}
-        role={"button"}
+        role={"textbox"}
       />
       <span id="file-input-specific-hint">{getHint(fileState)}</span>
     </div>

--- a/frontend/src/app/commonComponents/SingleFileInput.tsx
+++ b/frontend/src/app/commonComponents/SingleFileInput.tsx
@@ -51,7 +51,10 @@ const SingleFileInput = ({
   }
 
   return (
-    <div className={classnames(["sr-single-file-input", fileState])}>
+    <div
+      className={classnames(["sr-single-file-input", fileState])}
+      role={"button"}
+    >
       <input
         type="file"
         id={id}

--- a/frontend/src/app/commonComponents/SingleFileInput.tsx
+++ b/frontend/src/app/commonComponents/SingleFileInput.tsx
@@ -51,10 +51,7 @@ const SingleFileInput = ({
   }
 
   return (
-    <div
-      className={classnames(["sr-single-file-input", fileState])}
-      role={"button"}
-    >
+    <div className={classnames(["sr-single-file-input", fileState])}>
       <input
         type="file"
         id={id}
@@ -66,6 +63,7 @@ const SingleFileInput = ({
         className="usa-file-input"
         aria-describedby="file-input-specific-hint"
         accept={accept}
+        role={"button"}
       />
       <span id="file-input-specific-hint">{getHint(fileState)}</span>
     </div>

--- a/frontend/src/app/commonComponents/__snapshots__/SingleFileInput.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/SingleFileInput.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`Single File Input checks component with initial state 1`] = `
 <div>
   <div
     class="sr-single-file-input blank"
-    role="button"
   >
     <input
       aria-describedby="file-input-specific-hint"
@@ -13,6 +12,7 @@ exports[`Single File Input checks component with initial state 1`] = `
       data-testid="testId"
       id="testId"
       name="testId"
+      role="textbox"
       type="file"
     />
     <span

--- a/frontend/src/app/commonComponents/__snapshots__/SingleFileInput.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/SingleFileInput.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Single File Input checks component with initial state 1`] = `
 <div>
   <div
     class="sr-single-file-input blank"
+    role="button"
   >
     <input
       aria-describedby="file-input-specific-hint"

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -212,7 +212,6 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
               >
                 <div
                   class="sr-single-file-input blank"
-                  role="button"
                 >
                   <input
                     accept="text/csv, .csv"
@@ -223,6 +222,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
                     id="upload-patients-file-input"
                     name="upload-patients-file-input"
                     required=""
+                    role="textbox"
                     type="file"
                   />
                   <span

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -212,6 +212,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
               >
                 <div
                   class="sr-single-file-input blank"
+                  role="button"
                 >
                   <input
                     accept="text/csv, .csv"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5136

## Changes Proposed

- Set the role of the div of the input to "button"

## Additional Information

## Testing

- The correct role shows up

## Screenshots / Demos

- 

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
