### PR TITLE
added new column to report_stream_response table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4472,10 +4472,12 @@ databaseChangeLog:
                   name: latest_recorded_timestamp
                   descending: true
   - changeSet:
-      id: add-queuename-colum-report-stream-response
+      id: add-queuename-column-report-stream-response
       author: tsv7@cdc.gov
       comment: Add column queue name to report stream response table to differentiate the origin of the exception
       changes:
+        - tagDatabase:
+            tag: add-queuename-column-report-stream-response
         - addColumn:
             tableName: report_stream_response
             columns:

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4471,3 +4471,21 @@ databaseChangeLog:
               - column:
                   name: latest_recorded_timestamp
                   descending: true
+  - changeSet:
+      id: add-queuename-colum-report-stream-response
+      author: tsv7@cdc.gov
+      comment: Add column queue name to report stream response table to differentiate the origin of the exception
+      changes:
+        - addColumn:
+            tableName: report_stream_response
+            columns:
+              - column:
+                  name: queue_name
+                  type: text
+                  remarks: Tracks the individual's preference for receiving test results
+      rollback:
+        - dropColumn:
+            tableName: report_stream_response
+            columns:
+              - column:
+                  name: queue_name


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- Pre step to get #5115 report stream exception handling implemented

## Changes Proposed

- Add a new column `queue_name` of type text to the `report_stream_response` table so the origin of the publishing that cause the exception is clear.

## Additional Information

- The new implementation to publish FHIR test events to report stream will be reusing the setup that currently exists to log report stream exceptions into the `report_stream_response` table. This means that the table moving forward will host entries from both flows (covid and fhir multiplex ).

To identify between exceptions thrown by the covid pipeline and the universal pipeline we will be inserting the queue name where the messages that failed to be published were grabbed from.

## Testing

- Verify that the new added column does not disrupt any of the current testing and reporting flows. I have tested this manually in dev4 and all the publishing to `report stream` and logging to our `report stream response table` is working as expected

<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->