### PR TITLE
Correct contributor name in gradle backend requests.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,7 @@ updates:
       interval: "weekly"
       day: "sunday"
     reviewers:
-      - "alixmx"
+      - "alismx"
       - "rin-skylight"
       - "cdcgov/simplereport-backendreviews"
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Corrects dependabot review request errors for non-contributors.

## Changes Proposed

- Correct Alis' reviewer handle!
