### PR TITLE
use test performed code in fhir observations

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -378,16 +378,21 @@ public class FhirConverter {
     return results.stream()
         .map(
             result -> {
-              var testPerformedLoincCode =
-                  deviceTestPerformedLoincCode.stream()
-                      .filter(code -> code.getSupportedDisease() == result.getDisease())
-                      .findFirst()
-                      .map(DeviceTestPerformedLoincCode::getTestPerformedLoincCode)
-                      .orElse(result.getTestOrder().getDeviceType().getLoincCode());
+              String testPerformedLoincCode =
+                  getTestPerformedLoincCode(deviceTestPerformedLoincCode, result);
               return convertToObservation(
                   result, testPerformedLoincCode, correctionStatus, correctionReason);
             })
         .collect(Collectors.toList());
+  }
+
+  private static String getTestPerformedLoincCode(
+      List<DeviceTestPerformedLoincCode> deviceTestPerformedLoincCode, Result result) {
+    return deviceTestPerformedLoincCode.stream()
+        .filter(code -> code.getSupportedDisease() == result.getDisease())
+        .findFirst()
+        .map(DeviceTestPerformedLoincCode::getTestPerformedLoincCode)
+        .orElse(result.getTestOrder().getDeviceType().getLoincCode());
   }
 
   public static Observation convertToObservation(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -383,7 +383,7 @@ public class FhirConverter {
                       .filter(code -> code.getSupportedDisease() == result.getDisease())
                       .findFirst()
                       .map(DeviceTestPerformedLoincCode::getTestPerformedLoincCode)
-                      .orElse(result.getDisease().getLoinc());
+                      .orElse(result.getTestOrder().getDeviceType().getLoincCode());
               return convertToObservation(
                   result, testPerformedLoincCode, correctionStatus, correctionReason);
             })

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -572,7 +572,7 @@ public class FhirConverter {
     var deviceFullUrl = ResourceType.Device + "/" + device.getId();
 
     var practitionerRole = createPractitionerRole(organizationFullUrl, practitionerFullUrl);
-    var provenance = createProvenance(organizationFullUrl, deviceFullUrl, dateTested);
+    var provenance = createProvenance(organizationFullUrl, dateTested);
     var provenanceFullUrl = ResourceType.Provenance + "/" + provenance.getId();
     var messageHeader =
         createMessageHeader(organizationFullUrl, diagnosticReportFullUrl, provenanceFullUrl);
@@ -629,8 +629,7 @@ public class FhirConverter {
     return bundle;
   }
 
-  public static Provenance createProvenance(
-      String organizationFullUrl, String deviceFullUrl, Date dateTested) {
+  public static Provenance createProvenance(String organizationFullUrl, Date dateTested) {
     var provenance = new Provenance();
     provenance.setId(UUID.randomUUID().toString());
     provenance
@@ -640,7 +639,6 @@ public class FhirConverter {
         .setCode(EVENT_TYPE_CODE)
         .setDisplay(EVENT_TYPE_DISPLAY);
     provenance.addAgent().setWho(new Reference().setReference(organizationFullUrl));
-    provenance.addTarget(new Reference(deviceFullUrl));
     provenance.setRecorded(dateTested);
     return provenance;
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -939,7 +939,7 @@ class FhirConverterTest {
 
   @Test
   void createProvenance_valid() {
-    var provenance = createProvenance("Organization/org-id", "Device/device-id", new Date());
+    var provenance = createProvenance("Organization/org-id", new Date());
 
     assertThat(provenance.getActivity().getCoding()).hasSize(1);
     assertThat(provenance.getActivity().getCodingFirstRep().getCode()).isEqualTo("R01");
@@ -950,8 +950,6 @@ class FhirConverterTest {
 
     assertThat(provenance.getAgentFirstRep().getWho().getReference())
         .isEqualTo("Organization/org-id");
-
-    assertThat(provenance.getTargetFirstRep().getReference()).isEqualTo("Device/device-id");
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -143,6 +143,12 @@ public class TestDataBuilder {
     return new TestOrder(createPerson(), createFacility());
   }
 
+  public static TestOrder createTestOrderWithDevice() {
+    var testOrder = new TestOrder(createPerson(), createFacility());
+    testOrder.setDeviceTypeAndSpecimenType(createDeviceType(), createSpecimenType());
+    return testOrder;
+  }
+
   public static SupportedDisease createCovidSupportedDisease() {
     return new SupportedDisease("COVID-19", "96741-4");
   }

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -320,12 +320,14 @@
         "resourceType":"Observation",
         "id":"6db25889-09cb-4127-9330-cc7e7459c1cd",
         "status":"final",
-        "code":{
-          "coding":[
+        "code": {
+          "coding": [
             {
-              "system":"http://loinc.org"
+              "system": "http://loinc.org",
+              "code": "444-456"
             }
-          ]
+          ],
+          "text": "FLU B"
         },
         "subject":{
           "reference":"Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
@@ -358,12 +360,14 @@
         "resourceType":"Observation",
         "id":"4163abc1-0a54-4aff-badb-87bb96a89470",
         "status":"final",
-        "code":{
-          "coding":[
+        "code": {
+          "coding": [
             {
-              "system":"http://loinc.org"
+              "system": "http://loinc.org",
+              "code": "333-123"
             }
-          ]
+          ],
+          "text": "COVID-19"
         },
         "subject":{
           "reference":"Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
@@ -396,12 +400,14 @@
         "resourceType":"Observation",
         "id":"f7184a68-c54e-4209-8cc6-5bf5b253e4bd",
         "status":"final",
-        "code":{
-          "coding":[
+        "code": {
+          "coding": [
             {
-              "system":"http://loinc.org"
+              "system": "http://loinc.org",
+              "code": "444-123"
             }
-          ]
+          ],
+          "text": "FLU A"
         },
         "subject":{
           "reference":"Patient/55c53ed2-add5-47fb-884e-b4542ee64589"

--- a/backend/src/test/resources/fhir/observationCorrection.json
+++ b/backend/src/test/resources/fhir/observationCorrection.json
@@ -6,7 +6,7 @@
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "96741-4"
+        "code": "94500-6"
       }
     ],
     "text": "COVID-19"

--- a/backend/src/test/resources/fhir/observationCovid.json
+++ b/backend/src/test/resources/fhir/observationCovid.json
@@ -6,7 +6,7 @@
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "96741-4"
+        "code": "94500-6"
       }
     ],
     "text": "COVID-19"

--- a/backend/src/test/resources/fhir/observationFlu.json
+++ b/backend/src/test/resources/fhir/observationFlu.json
@@ -6,7 +6,7 @@
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "LP14239-5"
+        "code": "85477-8"
       }
     ],
     "text": "FLU A"


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #4943 

## Changes Proposed

- When creating an observation use the information in the DeviceTestPerformedLoincCode table to populate `observation.code`. 

## Additional Information

- Removed `provenance.target` based on this [comment](https://skylight-hq.slack.com/archives/C0411VC78DN/p1674748325373319?thread_ts=1674159747.715449&cid=C0411VC78DN) from Carlos.
- Temporarily, if a test performed code does not exist, use the device loinc code for all observations.

## Testing

- On dev5, use a multiplex device with test performed codes (Like Nabob - Multiplex Device) to submit a test event. Review the bundle published in the queue.

## Example observation

```json
{
      "fullUrl": "Observation/46d98ad3-349d-4eec-9098-5a9ea6cf5952",
      "resource": {
        "resourceType": "Observation",
        "id": "46d98ad3-349d-4eec-9098-5a9ea6cf5952",
        "status": "final",
        "code": {
          "coding": [
            {
              "system": "http://loinc.org",
              "code": "555-123"
            }
          ],
          "text": "Flu A"
        },
        "subject": {
          "reference": "Patient/e47b8fde-000e-43fb-891c-90c647e79646"
        },
        "performer": [
          {
            "reference": "Organization/884859f5-2a00-4259-b361-98adf0716eb4"
          }
        ],
        "valueCodeableConcept": {
          "coding": [
            {
              "system": "http://snomed.info/sct",
              "code": "260373001",
              "display": "POSITIVE"
            }
          ]
        },
        "specimen": {
          "reference": "Specimen/52a582e4-d389-42d0-b738-bee51cf5244d"
        },
        "device": {
          "reference": "Device/b89d2147-55db-4a3d-8b99-a037f95d544e"
        }
      }
    },
    {
      "fullUrl": "Observation/a4a4ea94-87bf-47db-bfe7-07b201961af6",
      "resource": {
        "resourceType": "Observation",
        "id": "a4a4ea94-87bf-47db-bfe7-07b201961af6",
        "status": "final",
        "code": {
          "coding": [
            {
              "system": "http://loinc.org",
              "code": "955-123"
            }
          ],
          "text": "COVID-19"
        },
        "subject": {
          "reference": "Patient/e47b8fde-000e-43fb-891c-90c647e79646"
        },
        "performer": [
          {
            "reference": "Organization/884859f5-2a00-4259-b361-98adf0716eb4"
          }
        ],
        "valueCodeableConcept": {
          "coding": [
            {
              "system": "http://snomed.info/sct",
              "code": "260373001",
              "display": "POSITIVE"
            }
          ]
        },
        "specimen": {
          "reference": "Specimen/52a582e4-d389-42d0-b738-bee51cf5244d"
        },
        "device": {
          "reference": "Device/b89d2147-55db-4a3d-8b99-a037f95d544e"
        }
      }
    },
    {
      "fullUrl": "Observation/aba3017c-2db5-4106-88ab-4d9c33db882b",
      "resource": {
        "resourceType": "Observation",
        "id": "aba3017c-2db5-4106-88ab-4d9c33db882b",
        "status": "final",
        "code": {
          "coding": [
            {
              "system": "http://loinc.org",
              "code": "000-123"
            }
          ],
          "text": "Flu B"
        },
        "subject": {
          "reference": "Patient/e47b8fde-000e-43fb-891c-90c647e79646"
        },
        "performer": [
          {
            "reference": "Organization/884859f5-2a00-4259-b361-98adf0716eb4"
          }
        ],
        "valueCodeableConcept": {
          "coding": [
            {
              "system": "http://snomed.info/sct",
              "code": "260373001",
              "display": "POSITIVE"
            }
          ]
        },
        "specimen": {
          "reference": "Specimen/52a582e4-d389-42d0-b738-bee51cf5244d"
        },
        "device": {
          "reference": "Device/b89d2147-55db-4a3d-8b99-a037f95d544e"
        }
      }
    }
```
