### PR TITLE
add DB fields to device_test_performed_loinc_code

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4491,3 +4491,47 @@ databaseChangeLog:
             columns:
               - column:
                   name: queue_name
+  - changeSet:
+      id: add-equipment_uid-testkit_name_id-to-device_test_performed_loinc_code
+      author: zedd@skylight.digital
+      comment: Add equipment_uid and testkit_name_id columns to device_test_performed_loinc_code table
+      changes:
+        - tagDatabase:
+            tag: add-equipment_uid-testkit_name_id-to-device_test_performed_loinc_code
+        - addColumn:
+            tableName: device_test_performed_loinc_code
+            columns:
+              - column:
+                  name: equipment_uid
+                  type: text
+                  remarks: represents the data from "Equipment UID" column in the LIVD
+              - column:
+                  name: testkit_name_id
+                  type: text
+                  remarks: represents the data from "Testkit Name ID" column in the LIVD
+  - changeSet:
+      id: remove-equipment_uid-testkit_name_id-from-device_type
+      author: zedd@skylight.digital
+      comment: remove equipment_uid and testkit_name_id columns from device_type table
+      changes:
+        - tagDatabase:
+            tag: remove-equipment_uid-testkit_name_id-from-device_type
+        - dropColumn:
+            tableName: device_type
+            columns:
+              - column:
+                  name: equipment_uid
+              - column:
+                  name: testkit_name_id
+      rollback:
+        - addColumn:
+            tableName: device_type
+            columns:
+              - column:
+                  name: equipment_uid
+                  type: text
+                  remarks: represents the data from "Equipment UID" column in the LIVD
+              - column:
+                  name: testkit_name_id
+                  type: text
+                  remarks: represents the data from "Testkit Name ID" column in the LIVD


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- part of #4831 

## Changes Proposed

- add `equipment_uid` and `testkit_name_id` to `device_test_performed_loinc_code` table
- remove `equipment_uid` and `testkit_name_id` from `device_type` table

## Additional Information

After analyzing the LIVD table, it shows that there are some devices that have the same
`Model+Manufacturer`, multiple LOINCs and within that different `equipmentUid/testkitNameId`
for example, if we pick the first `equipmentUid` for a device `Model+Manufacturer` regardless of the `LOINC`, that could be an _invalid_ combination.
So the correct way to address this situation is to also store the `equipmentUid/testkitNameId` inside the `DeviceTestPerformedLoincCode` sub-table. In order to accommodate that different `Model+Manufacturer+LOINC` combos can have different `equipmentUid/testkitNameId`

## Testing

- How should reviewers verify this PR?
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->


