### PR TITLE
add fields to device_test_performed_loinc_code backend changes

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
@@ -9,4 +9,6 @@ import lombok.Getter;
 public class SupportedDiseaseTestPerformedInput {
   UUID supportedDisease;
   String testPerformedLoincCode;
+  String equipmentUid;
+  String testkitNameId;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTestPerformedLoincCode.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTestPerformedLoincCode.java
@@ -6,12 +6,14 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Getter
 public class DeviceTestPerformedLoincCode extends IdentifiedEntity {
 
@@ -23,4 +25,6 @@ public class DeviceTestPerformedLoincCode extends IdentifiedEntity {
   private SupportedDisease supportedDisease;
 
   @Column private String testPerformedLoincCode;
+  @Column private String equipmentUid;
+  @Column private String testkitNameId;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -199,8 +199,13 @@ public class DeviceTypeService {
           supportedDisease.ifPresent(
               disease ->
                   deviceTestPerformedLoincCodeList.add(
-                      new DeviceTestPerformedLoincCode(
-                          device.getInternalId(), disease, input.getTestPerformedLoincCode())));
+                      DeviceTestPerformedLoincCode.builder()
+                          .deviceTypeId(device.getInternalId())
+                          .supportedDisease(disease)
+                          .testPerformedLoincCode(input.getTestPerformedLoincCode())
+                          .equipmentUid(input.getEquipmentUid())
+                          .testkitNameId(input.getTestkitNameId())
+                          .build()));
         });
     return deviceTestPerformedLoincCodeList;
   }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -78,6 +78,8 @@ input UpdateDeviceType {
 input SupportedDiseaseTestPerformedInput {
   supportedDisease: ID!
   testPerformedLoincCode: String!
+  equipmentUid: String
+  testkitNameId: String
 }
 
 type DeviceType {

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -98,6 +98,8 @@ type DeviceType {
 type SupportedDiseaseTestPerformed {
   supportedDisease: SupportedDisease!
   testPerformedLoincCode: String!
+  equipmentUid: String
+  testkitNameId: String
 }
 
 type SupportedDisease {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -124,11 +124,29 @@ class DeviceTypeDataLoaderHelperTest {
     var deviceIdSet = Set.of(device1Id, device2Id, device3Id);
 
     var deviceTestPerformedLoincCode1 =
-        new DeviceTestPerformedLoincCode(device1Id, new SupportedDisease(), "123");
+        DeviceTestPerformedLoincCode.builder()
+            .deviceTypeId(device1Id)
+            .testPerformedLoincCode("123")
+            .supportedDisease(new SupportedDisease())
+            .equipmentUid("111")
+            .testkitNameId("222")
+            .build();
     var deviceTestPerformedLoincCode2 =
-        new DeviceTestPerformedLoincCode(device1Id, new SupportedDisease(), "456");
+        DeviceTestPerformedLoincCode.builder()
+            .deviceTypeId(device1Id)
+            .testPerformedLoincCode("456")
+            .supportedDisease(new SupportedDisease())
+            .equipmentUid("333")
+            .testkitNameId("444")
+            .build();
     var deviceTestPerformedLoincCode3 =
-        new DeviceTestPerformedLoincCode(device2Id, new SupportedDisease(), "123");
+        DeviceTestPerformedLoincCode.builder()
+            .deviceTypeId(device2Id)
+            .testPerformedLoincCode("123")
+            .supportedDisease(new SupportedDisease())
+            .equipmentUid("555")
+            .testkitNameId("666")
+            .build();
 
     when(deviceTestPerformedLoincCodeRepository.findAllByDeviceTypeIdIn(deviceIdSet))
         .thenReturn(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -178,6 +178,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease1.getInternalId())
                             .testPerformedLoincCode("loinc1")
+                            .equipmentUid("equipmentUid1")
+                            .testkitNameId("testkitNameId1")
                             .build()))
                 .testLength(1)
                 .build());
@@ -194,6 +196,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease2.getInternalId())
                             .testPerformedLoincCode("loinc2")
+                            .equipmentUid("equipmentUid2")
+                            .testkitNameId("testkitNameId2")
                             .build()))
                 .testLength(2)
                 .build());
@@ -226,6 +230,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
             .findFirst();
     assertThat(disease1TestPerformed).isPresent();
     assertThat(disease1TestPerformed.get().getTestPerformedLoincCode()).isEqualTo("loinc1");
+    assertThat(disease1TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid1");
+    assertThat(disease1TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId1");
 
     devB = _deviceTypeRepo.findById(devB.getInternalId()).get();
     assertNotNull(devB);
@@ -308,6 +314,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease1.getInternalId())
                             .testPerformedLoincCode("loinc1")
+                            .equipmentUid("equipmentUid1")
+                            .testkitNameId("testkitNameId1")
                             .build()))
                 .testLength(10)
                 .build());
@@ -322,10 +330,14 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease1.getInternalId())
                             .testPerformedLoincCode("loinc2")
+                            .equipmentUid("equipmentUid2")
+                            .testkitNameId("testkitNameId2")
                             .build(),
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease2.getInternalId())
                             .testPerformedLoincCode("loinc3")
+                            .equipmentUid("equipmentUid3")
+                            .testkitNameId("testkitNameId3")
                             .build()))
                 .build());
 
@@ -345,6 +357,9 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
             .findFirst();
     assertThat(disease1TestPerformed).isPresent();
     assertThat(disease1TestPerformed.get().getTestPerformedLoincCode()).isEqualTo("loinc2");
+    assertThat(disease1TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid2");
+    assertThat(disease1TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId2");
+
     var disease2TestPerformed =
         updatedDevice.getSupportedDiseaseTestPerformed().stream()
             .filter(
@@ -356,6 +371,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
             .findFirst();
     assertThat(disease2TestPerformed).isPresent();
     assertThat(disease2TestPerformed.get().getTestPerformedLoincCode()).isEqualTo("loinc3");
+    assertThat(disease2TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid3");
+    assertThat(disease2TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId3");
 
     var deviceTestPerformedLoincCodeRepositoryAll =
         deviceTestPerformedLoincCodeRepository.findAll();
@@ -391,6 +408,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease1.getInternalId())
                             .testPerformedLoincCode("loinc1")
+                            .equipmentUid("equipmentUid1")
+                            .testkitNameId("testkitNameId1")
                             .build()))
                 .build());
 
@@ -401,6 +420,10 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(updatedDevice.getSupportedDiseaseTestPerformed()).hasSize(1);
     assertThat(updatedDevice.getSupportedDiseaseTestPerformed().get(0).getTestPerformedLoincCode())
         .isEqualTo("loinc1");
+    assertThat(updatedDevice.getSupportedDiseaseTestPerformed().get(0).getEquipmentUid())
+        .isEqualTo("equipmentUid1");
+    assertThat(updatedDevice.getSupportedDiseaseTestPerformed().get(0).getTestkitNameId())
+        .isEqualTo("testkitNameId1");
     assertThat(
             updatedDevice
                 .getSupportedDiseaseTestPerformed()

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -933,8 +933,10 @@ export type SupportedDiseaseTestPerformed = {
 };
 
 export type SupportedDiseaseTestPerformedInput = {
+  equipmentUid?: InputMaybe<Scalars["String"]>;
   supportedDisease: Scalars["ID"];
   testPerformedLoincCode: Scalars["String"];
+  testkitNameId?: InputMaybe<Scalars["String"]>;
 };
 
 export enum TestCorrectionStatus {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -928,8 +928,10 @@ export type SupportedDisease = {
 
 export type SupportedDiseaseTestPerformed = {
   __typename?: "SupportedDiseaseTestPerformed";
+  equipmentUid?: Maybe<Scalars["String"]>;
   supportedDisease: SupportedDisease;
   testPerformedLoincCode: Scalars["String"];
+  testkitNameId?: Maybe<Scalars["String"]>;
 };
 
 export type SupportedDiseaseTestPerformedInput = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #4831 

## Changes Proposed

- db changes here https://github.com/CDCgov/prime-simplereport/pull/5233
- add `equipmentUid` and `testkitNameId` to DeviceTestPerformedLoincCode


## Testing

- How should reviewers verify this PR? dev3

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
