### PR TITLE
Change test results upload instruction <h2>s to <p>s

### DIFF
--- a/frontend/src/app/testResults/uploads/Uploads.scss
+++ b/frontend/src/app/testResults/uploads/Uploads.scss
@@ -1,0 +1,5 @@
+.sr-test-results-uploads {
+  .usa-process-list__heading {
+    font-size: 1.17rem;
+  }
+}

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -7,6 +7,7 @@ import { FeedbackMessage } from "../../../generated/graphql";
 import { useDocumentTitle } from "../../utils/hooks";
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
 import { FileUploadService } from "../../../fileUploadService/FileUploadService";
+import "./Uploads.scss";
 import "../HeaderSizeFix.scss";
 import { getAppInsights } from "../../TelemetryService";
 import { RootState } from "../../store";
@@ -178,7 +179,7 @@ const Uploads = () => {
   };
 
   return (
-    <div className="grid-row header-size-fix">
+    <div className="grid-row header-size-fix sr-test-results-uploads">
       <div className="prime-container card-container">
         <div className="usa-card__header">
           <h1>Upload your results</h1>
@@ -217,15 +218,15 @@ const Uploads = () => {
           <section>
             <ol className="usa-process-list">
               <li className="usa-process-list__item margin-bottom-1em">
-                <h2 className="usa-process-list__heading">
+                <p className="usa-process-list__heading">
                   Visit the{" "}
                   <LinkWithQuery to="/results/upload/submit/guide">
                     <strong>spreadsheet upload guide</strong>
                   </LinkWithQuery>
-                </h2>
+                </p>
               </li>
               <li className="usa-process-list__item margin-bottom-1em">
-                <h2 className="usa-process-list__heading">
+                <p className="usa-process-list__heading">
                   Download the{" "}
                   <a
                     href="/assets/resources/test_results_example_10-3-2022.csv"
@@ -237,24 +238,24 @@ const Uploads = () => {
                   >
                     spreadsheet template
                   </a>
-                </h2>
+                </p>
               </li>
               <li className="usa-process-list__item margin-bottom-1em">
-                <h2 className="usa-process-list__heading">
+                <p className="usa-process-list__heading">
                   Following the guide and template, format your data to match
                   SimpleReport requirements
-                </h2>
+                </p>
               </li>
               <li className="usa-process-list__item margin-bottom-1em">
-                <h2 className="usa-process-list__heading">
+                <p className="usa-process-list__heading">
                   Save your spreadsheet in a CSV format (file size limit is 50
                   MB or 10,000 rows)
-                </h2>
+                </p>
               </li>
               <li className="usa-process-list__item margin-bottom-1em">
-                <h2 className="usa-process-list__heading">
+                <p className="usa-process-list__heading">
                   Submit your CSV to the uploader below
-                </h2>
+                </p>
               </li>
             </ol>
           </section>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #5135 

## Changes Proposed
Changes the `<h2>`s for test results upload instructions to `<p>`s because the text is not actually a heading. (see: https://cdc-devtools.dequecloud.com/rule-help/en/semantic-heading-misused)

## Additional Information
Checked via the axe dev tool's "Intelligent Guided Tests" structure test that all looked good. ✅ 

## Testing
Ensure the styling remains the same and ensures no more headings are present for the test result upload instructions.

## Screenshots / Demos
**Before**
<img width="634" alt="Screen Shot 2023-02-08 at 19 40 04" src="https://user-images.githubusercontent.com/20211771/217693276-0ecbcb71-48a0-4a3d-b593-f80fefb31ff9.png">

**After**
<img width="626" alt="test copy" src="https://user-images.githubusercontent.com/20211771/217693153-0b1f4ad6-4b14-42a1-b344-7f35604c6fdb.png">


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
