### PR TITLE
Add aria-label attribute to button on device code lookup search

### DIFF
--- a/frontend/src/app/commonComponents/Button/Button.test.tsx
+++ b/frontend/src/app/commonComponents/Button/Button.test.tsx
@@ -120,4 +120,17 @@ describe("button", () => {
       expect(counter).toEqual(1);
     });
   });
+  describe("ariaLabel", () => {
+    it("should set aria-label", () => {
+      render(<Button ariaLabel={"some aria label"} />);
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "aria-label",
+        "some aria label"
+      );
+    });
+    it("should not have aria-label", () => {
+      render(<Button />);
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-label");
+    });
+  });
 });

--- a/frontend/src/app/commonComponents/Button/Button.tsx
+++ b/frontend/src/app/commonComponents/Button/Button.tsx
@@ -23,6 +23,7 @@ interface Props {
   id?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   ariaHidden?: boolean;
+  ariaLabel?: string;
 }
 
 const Button = ({
@@ -37,6 +38,7 @@ const Button = ({
   onClick,
   id,
   ariaHidden,
+  ariaLabel,
 }: Props) => (
   <button
     type={type}
@@ -52,6 +54,7 @@ const Button = ({
     id={id}
     onClick={onClick}
     aria-describedby={ariaDescribedBy || undefined}
+    aria-label={ariaLabel}
   >
     {icon && <FontAwesomeIcon icon={icon} className="margin-right-1" />}
     {label || children}

--- a/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
@@ -66,6 +66,7 @@ const DeviceSearchResults = (props: SearchResultsProps) => {
                 {
                   <Button
                     label={"Select"}
+                    ariaLabel={`Select ${d.manufacturer} ${d.model}`}
                     onClick={() => {
                       setSelectedDevice(d);
                     }}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5133 

## Changes Proposed
- Adds `aria-label` attribute to the `<Button>` component
- Adds the device's manufacturer and model name to the "Select" button's `aria-label` so it 

## Additional Information

## Testing
Go to `/results/upload/submit/code-lookup`
Check that when searching for a device the "Select" button has an `aria-label` with the device's manufacturer and model name

## Screenshots / Demos
<img width="917" alt="Screen Shot 2023-02-08 at 20 38 51" src="https://user-images.githubusercontent.com/20211771/217705028-fdcf91b9-f7e4-4208-ac36-c8405ea1b70d.png">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
