### PR TITLE
a11y: Fixed headings in the terms of service page

### DIFF
--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -73,8 +73,11 @@ const PatientApp = () => {
       children={
         <PatientLinkURL404Wrapper plid={plid}>
           <Routes>
-            <Route path="/" element={<TermsOfService />} />
-            <Route path="terms-of-service" element={<TermsOfService />} />
+            <Route path="/" element={<TermsOfService asPage={true} />} />
+            <Route
+              path="terms-of-service"
+              element={<TermsOfService asPage={true} />}
+            />
             <Route path="birth-date-confirmation" element={<DOB />} />
             <Route
               path="test-result"

--- a/frontend/src/patientApp/timeOfTest/TermsOfService.test.tsx
+++ b/frontend/src/patientApp/timeOfTest/TermsOfService.test.tsx
@@ -10,10 +10,11 @@ import "../../i18n";
 const mockStore = configureStore([]);
 
 describe("TermsOfService", () => {
+  const store = mockStore({
+    plid: "foo",
+  });
+
   it("renders", () => {
-    const store = mockStore({
-      plid: "foo",
-    });
     render(
       <Provider store={store}>
         <MockedProvider mocks={[]} addTypename={false}>
@@ -23,5 +24,19 @@ describe("TermsOfService", () => {
     );
 
     expect(screen.getByText("Terms of service")).toBeInTheDocument();
+  });
+
+  it("renders as page", () => {
+    render(
+      <Provider store={store}>
+        <MockedProvider mocks={[]} addTypename={false}>
+          <TermsOfService asPage={true} />
+        </MockedProvider>
+      </Provider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /terms of service/i })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
+++ b/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
@@ -43,9 +43,9 @@ const TermsOfService: React.FunctionComponent<Props> = ({
       )}
     >
       <form className="grid-container maxw-tablet usa-prose">
-        <h1 className="font-heading-lg margin-top-3">
+        <h2 className="font-heading-lg margin-top-3">
           {t("testResult.tos.header")}
-        </h1>
+        </h2>
         <Trans
           t={t}
           parent="p"

--- a/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
+++ b/frontend/src/patientApp/timeOfTest/TermsOfService.tsx
@@ -12,11 +12,13 @@ import ToS from "./ToS";
 interface Props {
   className?: string;
   onAgree?: () => void;
+  asPage?: boolean;
 }
 
 const TermsOfService: React.FunctionComponent<Props> = ({
   className,
   onAgree,
+  asPage = false,
 }) => {
   const [nextPage, setNextPage] = useState(false);
   const plid = useSelector((state: any) => state.plid);
@@ -43,9 +45,15 @@ const TermsOfService: React.FunctionComponent<Props> = ({
       )}
     >
       <form className="grid-container maxw-tablet usa-prose">
-        <h2 className="font-heading-lg margin-top-3">
-          {t("testResult.tos.header")}
-        </h2>
+        {asPage ? (
+          <h1 className="font-heading-lg margin-top-3">
+            {t("testResult.tos.header")}
+          </h1>
+        ) : (
+          <h2 className="font-heading-lg margin-top-3">
+            {t("testResult.tos.header")}
+          </h2>
+        )}
         <Trans
           t={t}
           parent="p"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Implements #5077 

## Changes Proposed

Changed heading to h2.

## Testing

Verify the terms of service page the axe scan.

## Screenshots / Demos
![Screenshot 2023-02-10 at 10 29 54 AM](https://user-images.githubusercontent.com/103958711/218135414-4592b51e-053c-41ae-b775-cceb85d18247.png)
![Screenshot 2023-02-10 at 10 30 00 AM](https://user-images.githubusercontent.com/103958711/218135415-190328c0-e833-4586-a327-83f43559b086.png)


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
