### PR TITLE
Remove pagination without results upload history

### DIFF
--- a/frontend/src/app/testResults/submissions/Submissions.test.tsx
+++ b/frontend/src/app/testResults/submissions/Submissions.test.tsx
@@ -132,7 +132,7 @@ const getMocks = () => [
 ];
 
 describe("Submissions", () => {
-  it("should render no results and pagination", async () => {
+  it("should render no results and no pagination", async () => {
     render(
       <MockedProvider mocks={getNoResultsMocks()}>
         <Provider store={store}>

--- a/frontend/src/app/testResults/submissions/Submissions.test.tsx
+++ b/frontend/src/app/testResults/submissions/Submissions.test.tsx
@@ -132,7 +132,7 @@ const getMocks = () => [
 ];
 
 describe("Submissions", () => {
-  it("should render no results", async () => {
+  it("should render no results and pagination", async () => {
     render(
       <MockedProvider mocks={getNoResultsMocks()}>
         <Provider store={store}>
@@ -144,9 +144,10 @@ describe("Submissions", () => {
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(await screen.findByText("No results"));
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
   });
 
-  it("should render submission results", async () => {
+  it("should render submission results and pagination", async () => {
     render(
       <MockedProvider mocks={getMocks()}>
         <Provider store={store}>
@@ -161,6 +162,10 @@ describe("Submissions", () => {
     expect(await screen.findByText("reportId_1"));
     expect(await screen.findByText("reportId_2"));
     expect(await screen.findByText("reportId_3"));
+    expect(screen.queryByRole("navigation")).toHaveAttribute(
+      "aria-label",
+      "Pagination"
+    );
   });
 
   it("should filter results when start date specified", async () => {

--- a/frontend/src/app/testResults/submissions/Submissions.tsx
+++ b/frontend/src/app/testResults/submissions/Submissions.tsx
@@ -56,7 +56,7 @@ const Submissions = () => {
       submissionsResult.uploadSubmissions.totalElements === 0
     ) {
       return (
-        <tr>
+        <tr className="border-bottom">
           <td>No results</td>
         </tr>
       );
@@ -163,14 +163,17 @@ const Submissions = () => {
         </div>
 
         {/*pagination*/}
-        <div className="usa-card__footer">
-          <Pagination
-            baseRoute="/results/upload/submissions"
-            currentPage={pageNumber}
-            entriesPerPage={pageSize}
-            totalEntries={submissions?.uploadSubmissions.totalElements || 0}
-          />
-        </div>
+        {submissions !== undefined &&
+          submissions.uploadSubmissions.totalElements > 0 && (
+            <div className="usa-card__footer">
+              <Pagination
+                baseRoute="/results/upload/submissions"
+                currentPage={pageNumber}
+                entriesPerPage={pageSize}
+                totalEntries={submissions?.uploadSubmissions.totalElements || 0}
+              />
+            </div>
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5131 

## Changes Proposed
- Hides pagination when there is no history of bulk test results upload
- Extends the border for "No results" to the entire width of the table (see screenshots below)

## Additional Information

## Testing
- on dev2 for testing
- Check that pagination appears if you have at least 1 result
- Check that empty pagination is not there if you have no results
- Passes axe tests

## Screenshots / Demos
**Before**
<img width="1191" alt="Screen Shot 2023-02-10 at 14 32 23" src="https://user-images.githubusercontent.com/20211771/218192143-07d03c67-7396-4d66-9b2e-a7c1ffce3b64.png">

**After**

No results
<img width="1264" alt="Screen Shot 2023-02-10 at 13 12 37" src="https://user-images.githubusercontent.com/20211771/218192218-b5b70a1c-6d04-4468-8d7f-651e38436115.png">

Results
<img width="1165" alt="Screen Shot 2023-02-21 at 11 44 30" src="https://user-images.githubusercontent.com/20211771/220421076-53d8e9ae-269b-4dc8-b47d-294a0b79b2b9.png">


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
