### PR TITLE
add new device fields to frontend

### DIFF
--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -58,6 +58,16 @@ describe("create new device", () => {
         screen.getByLabelText("Test performed code *"),
         "1920-12"
       );
+
+      await userEvent.type(
+        screen.getByLabelText("Testkit Name Id *"),
+        "testkitNameId123"
+      );
+
+      await userEvent.type(
+        screen.getByLabelText("Equipment Uid *"),
+        "equipmentUid321"
+      );
     });
 
     it("enables the save button", async () => {
@@ -81,6 +91,8 @@ describe("create new device", () => {
             {
               supportedDisease: "3821904728",
               testPerformedLoincCode: "1920-12",
+              testkitNameId: "testkitNameId123",
+              equipmentUid: "equipmentUid321",
             },
           ],
         });
@@ -167,6 +179,8 @@ describe("update existing devices", () => {
                   name: "COVID-19",
                 },
                 testPerformedLoincCode: "1234-1",
+                equipmentUid: "equipmentUid123",
+                testkitNameId: "testkitNameId123",
               },
               {
                 supportedDisease: {
@@ -175,6 +189,8 @@ describe("update existing devices", () => {
                   name: "Flu A",
                 },
                 testPerformedLoincCode: "Test123",
+                equipmentUid: "equipmentUid321",
+                testkitNameId: "testkitNameId321",
               },
               {
                 supportedDisease: {
@@ -183,6 +199,8 @@ describe("update existing devices", () => {
                   name: "Flu B",
                 },
                 testPerformedLoincCode: "Test345",
+                equipmentUid: "equipmentUid345",
+                testkitNameId: "testkitNameId345",
               },
             ],
           },
@@ -246,6 +264,8 @@ describe("update existing devices", () => {
       const pillContainer = screen.getAllByTestId("pill-container")[0];
       const supportedDisease = screen.getAllByLabelText("Supported disease *");
       const testPerformed = screen.getAllByLabelText("Test performed code *");
+      const testkitNameId = screen.getAllByLabelText("Testkit Name Id *");
+      const equipmentUid = screen.getAllByLabelText("Equipment Uid *");
 
       expect(manufacturerInput).toBeEnabled();
       expect(modelInput).toBeEnabled();
@@ -264,6 +284,14 @@ describe("update existing devices", () => {
       expect(
         testPerformed.map((code) => (code as HTMLInputElement).value)
       ).toEqual(["1234-1", "Test123", "Test345"]);
+
+      expect(
+        testkitNameId.map((code) => (code as HTMLInputElement).value)
+      ).toEqual(["testkitNameId123", "testkitNameId321", "testkitNameId345"]);
+
+      expect(
+        equipmentUid.map((code) => (code as HTMLInputElement).value)
+      ).toEqual(["equipmentUid123", "equipmentUid321", "equipmentUid345"]);
     });
     it("maps supported diseases to supported disease and empty test performed", async () => {
       await userEvent.click(screen.getByTestId("combo-box-select"));
@@ -358,6 +386,15 @@ describe("update existing devices", () => {
           screen.getAllByLabelText("Test performed code *")[1],
           "LP 123"
         );
+        await userEvent.type(
+          screen.getAllByLabelText("Testkit Name Id *")[1],
+          "testkitNameId123"
+        );
+
+        await userEvent.type(
+          screen.getAllByLabelText("Equipment Uid *")[1],
+          "equipmentUid321"
+        );
 
         await userEvent.click(screen.getByText("Save changes"));
 
@@ -372,7 +409,12 @@ describe("update existing devices", () => {
           testLength: 15,
           supportedDiseaseTestPerformed: [
             { supportedDisease: "123", testPerformedLoincCode: "1234-1" },
-            { supportedDisease: "456", testPerformedLoincCode: "LP 123" },
+            {
+              supportedDisease: "456",
+              testPerformedLoincCode: "LP 123",
+              equipmentUid: "equipmentUid321",
+              testkitNameId: "testkitNameId123",
+            },
           ],
         });
         expect(saveDeviceType).toBeCalledTimes(1);

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -411,7 +411,12 @@ const DeviceForm = (props: Props) => {
                         );
                       } else {
                         updateDeviceAttribute("supportedDiseaseTestPerformed", [
-                          { supportedDisease: "", testPerformedLoincCode: "" },
+                          {
+                            supportedDisease: "",
+                            testPerformedLoincCode: "",
+                            equipmentUid: "",
+                            testkitNameId: "",
+                          },
                         ]);
                       }
                     }}

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -72,6 +72,8 @@ const DeviceForm = (props: Props) => {
         (diseaseTestPerformed) => ({
           supportedDisease: diseaseTestPerformed.supportedDisease.internalId,
           testPerformedLoincCode: diseaseTestPerformed.testPerformedLoincCode,
+          testkitNameId: diseaseTestPerformed.testkitNameId,
+          equipmentUid: diseaseTestPerformed.equipmentUid,
         })
       );
     } else if (device?.supportedDiseases?.length) {
@@ -117,98 +119,144 @@ const DeviceForm = (props: Props) => {
 
   const createSupportedDiseaseRow = (index: number) => {
     return (
-      <fieldset className={"usa-fieldset margin-top-205"}>
-        <legend>Disease Information</legend>
-        <div className="grid-row grid-gap">
-          <div className="tablet:grid-col">
-            <Select
-              label={"Supported disease"}
-              options={props.supportedDiseaseOptions}
-              value={
-                device?.supportedDiseaseTestPerformed?.[index]
-                  ?.supportedDisease || ""
+      <div className="grid-row grid-gap" key={index}>
+        <div className="tablet:grid-col">
+          <Select
+            label={"Supported disease"}
+            options={props.supportedDiseaseOptions}
+            value={
+              device?.supportedDiseaseTestPerformed?.[index]
+                ?.supportedDisease || ""
+            }
+            onChange={(val) => {
+              if (device?.supportedDiseaseTestPerformed) {
+                let newSupportedDisease = [
+                  ...device?.supportedDiseaseTestPerformed,
+                ];
+                newSupportedDisease[index].supportedDisease = val;
+                updateDevice({
+                  ...device,
+                  supportedDiseaseTestPerformed: newSupportedDisease,
+                });
               }
-              onChange={(val) => {
-                if (device?.supportedDiseaseTestPerformed) {
-                  let newSupportedDisease = [
-                    ...device?.supportedDiseaseTestPerformed,
-                  ];
-                  newSupportedDisease[index].supportedDisease = val;
-                  updateDevice({
-                    ...device,
-                    supportedDiseaseTestPerformed: newSupportedDisease,
-                  });
+            }}
+            required={true}
+            disabled={!device}
+            defaultOption={""}
+            defaultSelect={true}
+            name={`selectSupportedDisease${index}`}
+            className={"margin-top-1"}
+          />
+        </div>
+        <div className="tablet:grid-col">
+          <TextInput
+            label="Test performed code"
+            name={`testPerformedCode${index}`}
+            value={
+              device?.supportedDiseaseTestPerformed?.[index]
+                ?.testPerformedLoincCode
+            }
+            onChange={(event) => {
+              if (device?.supportedDiseaseTestPerformed) {
+                let newSupportedDisease = [
+                  ...device?.supportedDiseaseTestPerformed,
+                ];
+                newSupportedDisease[index].testPerformedLoincCode =
+                  event.target.value;
+                updateDeviceAttribute(
+                  "supportedDiseaseTestPerformed",
+                  newSupportedDisease
+                );
+                const covidId = props.supportedDiseaseOptions.find(
+                  (d) => d.label === "COVID-19"
+                )?.value;
+                if (
+                  device?.supportedDiseaseTestPerformed?.[index]
+                    ?.supportedDisease === covidId
+                ) {
+                  updateDeviceAttribute("loincCode", event.target.value);
                 }
-              }}
-              required={true}
-              disabled={!device}
-              defaultOption={""}
-              defaultSelect={true}
-              name={`selectSupportedDisease${index}`}
-              className={"margin-top-1"}
-            />
-          </div>
-          <div className="tablet:grid-col">
-            <TextInput
-              label="Test performed code"
-              name={`testPerformedCode${index}`}
-              value={
-                device?.supportedDiseaseTestPerformed?.[index]
-                  ?.testPerformedLoincCode
               }
-              onChange={(event) => {
+            }}
+            disabled={!device}
+            required
+            className={"margin-top-1"}
+          />
+        </div>
+        <div className="tablet:grid-col">
+          <TextInput
+            label="Testkit Name Id"
+            name={`testkitNameId${index}`}
+            value={
+              device?.supportedDiseaseTestPerformed?.[index]?.testkitNameId ||
+              ""
+            }
+            onChange={(event) => {
+              if (device?.supportedDiseaseTestPerformed) {
+                let newSupportedDisease = [
+                  ...device?.supportedDiseaseTestPerformed,
+                ];
+                newSupportedDisease[index].testkitNameId = event.target.value;
+                updateDeviceAttribute(
+                  "supportedDiseaseTestPerformed",
+                  newSupportedDisease
+                );
+              }
+            }}
+            disabled={!device}
+            required
+            className={"margin-top-1"}
+          />
+        </div>
+        <div className="tablet:grid-col">
+          <TextInput
+            label="Equipment Uid"
+            name={`equipmentUid${index}`}
+            value={
+              device?.supportedDiseaseTestPerformed?.[index]?.equipmentUid || ""
+            }
+            onChange={(event) => {
+              if (device?.supportedDiseaseTestPerformed) {
+                let newSupportedDisease = [
+                  ...device?.supportedDiseaseTestPerformed,
+                ];
+                newSupportedDisease[index].equipmentUid = event.target.value;
+                updateDeviceAttribute(
+                  "supportedDiseaseTestPerformed",
+                  newSupportedDisease
+                );
+              }
+            }}
+            disabled={!device}
+            required
+            className={"margin-top-1"}
+          />
+        </div>
+        <div className="flex-align-self-end">
+          {index > 0 ? (
+            <button
+              className="usa-button--unstyled padding-105 height-5 cursor-pointer"
+              onClick={() => {
                 if (device?.supportedDiseaseTestPerformed) {
                   let newSupportedDisease = [
                     ...device?.supportedDiseaseTestPerformed,
                   ];
-                  newSupportedDisease[index].testPerformedLoincCode =
-                    event.target.value;
+                  newSupportedDisease.splice(index, 1);
                   updateDeviceAttribute(
                     "supportedDiseaseTestPerformed",
                     newSupportedDisease
                   );
-                  const covidId = props.supportedDiseaseOptions.find(
-                    (d) => d.label === "COVID-19"
-                  )?.value;
-                  if (
-                    device?.supportedDiseaseTestPerformed?.[index]
-                      ?.supportedDisease === covidId
-                  ) {
-                    updateDeviceAttribute("loincCode", event.target.value);
-                  }
                 }
               }}
-              disabled={!device}
-              required
-              className={"margin-top-1"}
-            />
-          </div>
-          <div className="flex-align-self-end">
-            {index > 0 ? (
-              <button
-                className="usa-button--unstyled padding-105 height-5 cursor-pointer"
-                onClick={() => {
-                  if (device?.supportedDiseaseTestPerformed) {
-                    let newSupportedDisease = [
-                      ...device?.supportedDiseaseTestPerformed,
-                    ];
-                    newSupportedDisease.splice(index, 1);
-                    updateDeviceAttribute(
-                      "supportedDiseaseTestPerformed",
-                      newSupportedDisease
-                    );
-                  }
-                }}
-                aria-label={`Delete disease`}
-              >
-                <FontAwesomeIcon icon={"trash"} className={"text-error"} />
-              </button>
-            ) : (
-              <div className={"padding-205 height-5"}> </div>
-            )}
-          </div>
+              aria-label={`Delete disease`}
+            >
+              <FontAwesomeIcon icon={"trash"} className={"text-error"} />
+            </button>
+          ) : (
+            <div className={"padding-205 height-5"}> </div>
+          )}
         </div>
-      </fieldset>
+      </div>
     );
   };
 
@@ -333,9 +381,12 @@ const DeviceForm = (props: Props) => {
                   />
                 </div>
               </div>
-              {device?.supportedDiseaseTestPerformed?.map((disease, index) =>
-                createSupportedDiseaseRow(index)
-              )}
+              <fieldset className={"usa-fieldset margin-top-205"}>
+                <legend>Disease Information</legend>
+                {device?.supportedDiseaseTestPerformed?.map((disease, index) =>
+                  createSupportedDiseaseRow(index)
+                )}
+              </fieldset>
               <div className="grid-row grid-gap">
                 <div
                   className="tablet:grid-col"
@@ -351,6 +402,8 @@ const DeviceForm = (props: Props) => {
                         newSupportedDisease.push({
                           supportedDisease: "",
                           testPerformedLoincCode: "",
+                          equipmentUid: "",
+                          testkitNameId: "",
                         });
                         updateDeviceAttribute(
                           "supportedDiseaseTestPerformed",

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -293,7 +293,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="20"
+                        for="24"
                       >
                         Device name
                         <abbr
@@ -309,7 +309,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="20"
+                        id="24"
                         name="name"
                         type="text"
                         value=""
@@ -328,7 +328,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="21"
+                        for="25"
                       >
                         Model
                         <abbr
@@ -344,7 +344,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="21"
+                        id="25"
                         name="model"
                         type="text"
                         value=""
@@ -363,7 +363,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="22"
+                        for="26"
                       >
                         Manufacturer
                         <abbr
@@ -379,7 +379,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="22"
+                        id="26"
                         name="manufacturer"
                         type="text"
                         value=""
@@ -398,7 +398,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="23"
+                        for="27"
                       >
                         Test length (minutes)
                         <abbr
@@ -414,7 +414,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="23"
+                        id="27"
                         max="999"
                         min="0"
                         name="testLength"
@@ -435,8 +435,8 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="24"
-                        id="label-for-24"
+                        for="28"
+                        id="label-for-28"
                       >
                         SNOMED code for swab type(s)
                         <abbr
@@ -450,12 +450,12 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="24"
+                        id="28"
                       >
                         <input
                           aria-expanded="false"
                           aria-invalid="false"
-                          aria-labelledby="label-for-24"
+                          aria-labelledby="label-for-28"
                           aria-owns="multi-select-swabTypes-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -552,6 +552,13 @@ Object {
                     </div>
                   </div>
                 </div>
+                <fieldset
+                  class="usa-fieldset margin-top-205"
+                >
+                  <legend>
+                    Disease Information
+                  </legend>
+                </fieldset>
                 <div
                   class="grid-row grid-gap"
                 >
@@ -880,7 +887,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="20"
+                      for="24"
                     >
                       Device name
                       <abbr
@@ -896,7 +903,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="20"
+                      id="24"
                       name="name"
                       type="text"
                       value=""
@@ -915,7 +922,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="21"
+                      for="25"
                     >
                       Model
                       <abbr
@@ -931,7 +938,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="21"
+                      id="25"
                       name="model"
                       type="text"
                       value=""
@@ -950,7 +957,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="22"
+                      for="26"
                     >
                       Manufacturer
                       <abbr
@@ -966,7 +973,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="22"
+                      id="26"
                       name="manufacturer"
                       type="text"
                       value=""
@@ -985,7 +992,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="23"
+                      for="27"
                     >
                       Test length (minutes)
                       <abbr
@@ -1001,7 +1008,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="23"
+                      id="27"
                       max="999"
                       min="0"
                       name="testLength"
@@ -1022,8 +1029,8 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="24"
-                      id="label-for-24"
+                      for="28"
+                      id="label-for-28"
                     >
                       SNOMED code for swab type(s)
                       <abbr
@@ -1037,12 +1044,12 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="24"
+                      id="28"
                     >
                       <input
                         aria-expanded="false"
                         aria-invalid="false"
-                        aria-labelledby="label-for-24"
+                        aria-labelledby="label-for-28"
                         aria-owns="multi-select-swabTypes-list"
                         autocapitalize="off"
                         autocomplete="off"
@@ -1139,6 +1146,13 @@ Object {
                   </div>
                 </div>
               </div>
+              <fieldset
+                class="usa-fieldset margin-top-205"
+              >
+                <legend>
+                  Disease Information
+                </legend>
+              </fieldset>
               <div
                 class="grid-row grid-gap"
               >

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -293,7 +293,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="24"
+                        for="1"
                       >
                         Device name
                         <abbr
@@ -309,7 +309,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="24"
+                        id="1"
                         name="name"
                         type="text"
                         value=""
@@ -328,7 +328,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="25"
+                        for="2"
                       >
                         Model
                         <abbr
@@ -344,7 +344,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="25"
+                        id="2"
                         name="model"
                         type="text"
                         value=""
@@ -363,7 +363,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="26"
+                        for="3"
                       >
                         Manufacturer
                         <abbr
@@ -379,7 +379,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="26"
+                        id="3"
                         name="manufacturer"
                         type="text"
                         value=""
@@ -398,7 +398,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="27"
+                        for="4"
                       >
                         Test length (minutes)
                         <abbr
@@ -414,7 +414,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="27"
+                        id="4"
                         max="999"
                         min="0"
                         name="testLength"
@@ -435,8 +435,8 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="28"
-                        id="label-for-28"
+                        for="5"
+                        id="label-for-5"
                       >
                         SNOMED code for swab type(s)
                         <abbr
@@ -450,12 +450,12 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="28"
+                        id="5"
                       >
                         <input
                           aria-expanded="false"
                           aria-invalid="false"
-                          aria-labelledby="label-for-28"
+                          aria-labelledby="label-for-5"
                           aria-owns="multi-select-swabTypes-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -887,7 +887,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="24"
+                      for="1"
                     >
                       Device name
                       <abbr
@@ -903,7 +903,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="24"
+                      id="1"
                       name="name"
                       type="text"
                       value=""
@@ -922,7 +922,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="25"
+                      for="2"
                     >
                       Model
                       <abbr
@@ -938,7 +938,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="25"
+                      id="2"
                       name="model"
                       type="text"
                       value=""
@@ -957,7 +957,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="26"
+                      for="3"
                     >
                       Manufacturer
                       <abbr
@@ -973,7 +973,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="26"
+                      id="3"
                       name="manufacturer"
                       type="text"
                       value=""
@@ -992,7 +992,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="27"
+                      for="4"
                     >
                       Test length (minutes)
                       <abbr
@@ -1008,7 +1008,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="27"
+                      id="4"
                       max="999"
                       min="0"
                       name="testLength"
@@ -1029,8 +1029,8 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="28"
-                      id="label-for-28"
+                      for="5"
+                      id="label-for-5"
                     >
                       SNOMED code for swab type(s)
                       <abbr
@@ -1044,12 +1044,12 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="28"
+                      id="5"
                     >
                       <input
                         aria-expanded="false"
                         aria-invalid="false"
-                        aria-labelledby="label-for-28"
+                        aria-labelledby="label-for-5"
                         aria-owns="multi-select-swabTypes-list"
                         autocapitalize="off"
                         autocomplete="off"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -293,7 +293,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="1"
+                        for="24"
                       >
                         Device name
                         <abbr
@@ -309,7 +309,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="1"
+                        id="24"
                         name="name"
                         type="text"
                         value=""
@@ -328,7 +328,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="2"
+                        for="25"
                       >
                         Model
                         <abbr
@@ -344,7 +344,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="2"
+                        id="25"
                         name="model"
                         type="text"
                         value=""
@@ -363,7 +363,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="3"
+                        for="26"
                       >
                         Manufacturer
                         <abbr
@@ -379,7 +379,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="3"
+                        id="26"
                         name="manufacturer"
                         type="text"
                         value=""
@@ -398,7 +398,7 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="4"
+                        for="27"
                       >
                         Test length (minutes)
                         <abbr
@@ -414,7 +414,7 @@ Object {
                         aria-required="true"
                         class="usa-input"
                         disabled=""
-                        id="4"
+                        id="27"
                         max="999"
                         min="0"
                         name="testLength"
@@ -435,8 +435,8 @@ Object {
                     >
                       <label
                         class="usa-label"
-                        for="5"
-                        id="label-for-5"
+                        for="28"
+                        id="label-for-28"
                       >
                         SNOMED code for swab type(s)
                         <abbr
@@ -450,12 +450,12 @@ Object {
                       <div
                         class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                         data-testid="multi-select"
-                        id="5"
+                        id="28"
                       >
                         <input
                           aria-expanded="false"
                           aria-invalid="false"
-                          aria-labelledby="label-for-5"
+                          aria-labelledby="label-for-28"
                           aria-owns="multi-select-swabTypes-list"
                           autocapitalize="off"
                           autocomplete="off"
@@ -887,7 +887,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="1"
+                      for="24"
                     >
                       Device name
                       <abbr
@@ -903,7 +903,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="1"
+                      id="24"
                       name="name"
                       type="text"
                       value=""
@@ -922,7 +922,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="2"
+                      for="25"
                     >
                       Model
                       <abbr
@@ -938,7 +938,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="2"
+                      id="25"
                       name="model"
                       type="text"
                       value=""
@@ -957,7 +957,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="3"
+                      for="26"
                     >
                       Manufacturer
                       <abbr
@@ -973,7 +973,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="3"
+                      id="26"
                       name="manufacturer"
                       type="text"
                       value=""
@@ -992,7 +992,7 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="4"
+                      for="27"
                     >
                       Test length (minutes)
                       <abbr
@@ -1008,7 +1008,7 @@ Object {
                       aria-required="true"
                       class="usa-input"
                       disabled=""
-                      id="4"
+                      id="27"
                       max="999"
                       min="0"
                       name="testLength"
@@ -1029,8 +1029,8 @@ Object {
                   >
                     <label
                       class="usa-label"
-                      for="5"
-                      id="label-for-5"
+                      for="28"
+                      id="label-for-28"
                     >
                       SNOMED code for swab type(s)
                       <abbr
@@ -1044,12 +1044,12 @@ Object {
                     <div
                       class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                       data-testid="multi-select"
-                      id="5"
+                      id="28"
                     >
                       <input
                         aria-expanded="false"
                         aria-invalid="false"
-                        aria-labelledby="label-for-5"
+                        aria-labelledby="label-for-28"
                         aria-owns="multi-select-swabTypes-list"
                         autocapitalize="off"
                         autocomplete="off"

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -396,6 +396,66 @@ Object {
                       </div>
                     </div>
                     <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="8"
+                        >
+                          Testkit Name Id
+                          <abbr
+                            class="usa-hint usa-hint--required"
+                            title="required"
+                          >
+                             
+                            *
+                          </abbr>
+                        </label>
+                        <input
+                          aria-disabled="false"
+                          aria-required="true"
+                          class="usa-input"
+                          id="8"
+                          name="testkitNameId0"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="9"
+                        >
+                          Equipment Uid
+                          <abbr
+                            class="usa-hint usa-hint--required"
+                            title="required"
+                          >
+                             
+                            *
+                          </abbr>
+                        </label>
+                        <input
+                          aria-disabled="false"
+                          aria-required="true"
+                          class="usa-input"
+                          id="9"
+                          name="equipmentUid0"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
                       class="flex-align-self-end"
                     >
                       <div
@@ -833,6 +893,66 @@ Object {
                         class="usa-input"
                         id="7"
                         name="testPerformedCode0"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="tablet:grid-col"
+                  >
+                    <div
+                      class="usa-form-group margin-top-1"
+                    >
+                      <label
+                        class="usa-label"
+                        for="8"
+                      >
+                        Testkit Name Id
+                        <abbr
+                          class="usa-hint usa-hint--required"
+                          title="required"
+                        >
+                           
+                          *
+                        </abbr>
+                      </label>
+                      <input
+                        aria-disabled="false"
+                        aria-required="true"
+                        class="usa-input"
+                        id="8"
+                        name="testkitNameId0"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="tablet:grid-col"
+                  >
+                    <div
+                      class="usa-form-group margin-top-1"
+                    >
+                      <label
+                        class="usa-label"
+                        for="9"
+                      >
+                        Equipment Uid
+                        <abbr
+                          class="usa-hint usa-hint--required"
+                          title="required"
+                        >
+                           
+                          *
+                        </abbr>
+                      </label>
+                      <input
+                        aria-disabled="false"
+                        aria-required="true"
+                        class="usa-input"
+                        id="9"
+                        name="equipmentUid0"
                         type="text"
                         value=""
                       />

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -514,6 +514,13 @@ Object {
                     </div>
                   </div>
                 </div>
+                <fieldset
+                  class="usa-fieldset margin-top-205"
+                >
+                  <legend>
+                    Disease Information
+                  </legend>
+                </fieldset>
                 <div
                   class="grid-row grid-gap"
                 >
@@ -1066,6 +1073,13 @@ Object {
                   </div>
                 </div>
               </div>
+              <fieldset
+                class="usa-fieldset margin-top-205"
+              >
+                <legend>
+                  Disease Information
+                </legend>
+              </fieldset>
               <div
                 class="grid-row grid-gap"
               >

--- a/frontend/src/app/supportAdmin/DeviceType/operations.graphql
+++ b/frontend/src/app/supportAdmin/DeviceType/operations.graphql
@@ -74,6 +74,8 @@ query getDeviceTypeList{
         name
       }
       testPerformedLoincCode
+      testkitNameId
+      equipmentUid
     }
     testLength
   }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1785,6 +1785,8 @@ export type GetDeviceTypeListQuery = {
       | Array<{
           __typename?: "SupportedDiseaseTestPerformed";
           testPerformedLoincCode: string;
+          testkitNameId?: string | null | undefined;
+          equipmentUid?: string | null | undefined;
           supportedDisease: {
             __typename?: "SupportedDisease";
             internalId: string;
@@ -5066,6 +5068,8 @@ export const GetDeviceTypeListDocument = gql`
           name
         }
         testPerformedLoincCode
+        testkitNameId
+        equipmentUid
       }
       testLength
     }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolves #4831 

## Changes Proposed

- Add `Testkit Name Id` and `Equipment Uid` to device create/edit screens


## Testing

- How should reviewers verify this PR? deployed to dev3

## Screenshots / Demos
![image](https://user-images.githubusercontent.com/4952042/218566555-19a087e8-064d-4ae9-a69b-46d52c352eec.png)


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
