### PR TITLE
set processingModeCode=T in staging env

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 public class TestEventExport {
   private static final int FALLBACK_DEFAULT_TEST_MINUTES = 15;
   public static final String USA = "USA";
+  private String processingModeCode = "P";
   private final TestEvent testEvent;
   private final Optional<Person> patient;
   private final Optional<AskOnEntrySurvey> survey;
@@ -60,6 +61,11 @@ public class TestEventExport {
 
     this.deviceType = Optional.ofNullable(testEvent.getDeviceType());
     this.specimenType = Optional.ofNullable(testEvent.getSpecimenType());
+  }
+
+  public TestEventExport(TestEvent testEvent, String processingModeCode) {
+    this(testEvent);
+    this.processingModeCode = processingModeCode;
   }
 
   private String genderUnknown = "U";
@@ -482,9 +488,7 @@ public class TestEventExport {
 
   @JsonProperty("Processing_mode_code")
   public String getFacilityProcessingModeCode() {
-    // todo: this should check a facility attribute to see what mode it's in. (or a separate table
-    // of prod-ready fac)
-    return "P"; // D:Debugging P:Production T:Training
+    return processingModeCode; // D:Debugging P:Production T:Training
   }
 
   @JsonProperty("Ordering_facility_city")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueTestEventReportingService.java
@@ -9,12 +9,17 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 
 @Slf4j
 @RequiredArgsConstructor
 public final class AzureStorageQueueTestEventReportingService implements TestEventReportingService {
+
   private final ObjectMapper mapper;
   private final QueueAsyncClient queueClient;
+
+  @Value("${simple-report.processing-mode-code:P}")
+  private String processingModeCode;
 
   @Override
   public CompletableFuture<Void> reportAsync(TestEvent testEvent) {
@@ -25,7 +30,7 @@ public final class AzureStorageQueueTestEventReportingService implements TestEve
   private String toBuffer(TestEvent testEvent) {
     try {
       return mapper
-          .writeValueAsString(new TestEventExport(testEvent))
+          .writeValueAsString(new TestEventExport(testEvent, processingModeCode))
           .replaceAll("[\u2028\u2029]", "");
     } catch (IOException e) {
       throw new TestEventSerializationFailureException(

--- a/backend/src/main/resources/application-azure-stg.yaml
+++ b/backend/src/main/resources/application-azure-stg.yaml
@@ -1,6 +1,7 @@
 spring:
   profiles.include: okta-stg
 simple-report:
+  processing-mode-code: T
   patient-link-url: https://stg.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://stg.simplereport.gov/api/pxp/callback
   cors:


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #5199

## Changes Proposed

- Sets `ProcessingModeCode = T` for staging env for single entry

## Additional Information

- this is for `non-universal-pipeline` `single-entry` only.
- future PR will add this feature to result bulk uploads
- future PR will add this feature to universal-pipeline (FIHR bundle)

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->