### PR TITLE
change disabled color

### DIFF
--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -229,7 +229,7 @@
     }
 
     .disabled-dark * {
-      color: #adadad !important;
+      color: #6e6e6e !important;
     }
 
     .userrole-subtext {

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -229,7 +229,7 @@
     }
 
     .disabled-dark * {
-      color: #6e6e6e !important;
+      color: #757575 !important;
     }
 
     .userrole-subtext {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5116 

## Changes Proposed

- Change the color of the disabled text to `6e6e6e`

## Additional Information

- [Sign off from Kenny](https://github.com/CDCgov/prime-simplereport/issues/5116#issuecomment-1431829768)

## Testing


## Screenshots / Demos

Original:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/10108172/218851987-5d122208-c6eb-4e2c-84fa-118f01435033.png">
Example with OK contrast: 
<img width="875" alt="image" src="https://user-images.githubusercontent.com/10108172/219685435-3970cd80-fc45-4cfe-8e08-48e710c96e93.png">

