### PR TITLE
dynamically set the start and expiry on azurerm_storage_account_sas

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/infra/_data.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/_data.tf
@@ -38,8 +38,8 @@ data "azurerm_storage_account" "app" {
 data "azurerm_storage_account_sas" "sas" {
   connection_string = data.azurerm_storage_account.app.primary_connection_string
   https_only        = true
-  start             = "2023-01-01"
-  expiry            = "2023-12-31"
+  start             = formatdate("YYYY-MM-DD", timeadd(timestamp(), "-24"))
+  expiry            = formatdate("YYYY-MM-DD", timeadd(timestamp(), "2880h"))
   resource_types {
     object    = true
     container = false


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #4935 
- This will update the azurerm_storage_account_sas expiry to 120 days on every deployment.

## Changes Proposed

- Dynamically set the azurerm_storage_account_sas start and expiry.

## Testing

- Check the azurerm_storage_account_sas resource changes in the `terraform_checks` workflow.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README