### PR TITLE
set processingId on FHIR

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.api.converter;
 
+import java.util.Map;
+
 public class FhirConstants {
   private FhirConstants() {
     throw new IllegalStateException("Utility class");
@@ -10,6 +12,8 @@ public class FhirConstants {
   public static final String RACE_EXTENSION_URL =
       "http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd";
   public static final String RACE_CODING_SYSTEM = "http://terminology.hl7.org/CodeSystem/v3-Race";
+  public static final String PROCESSING_ID_SYSTEM =
+      "http://terminology.hl7.org/CodeSystem/v3-ProcessingID";
   public static final String ETHNICITY_EXTENSION_URL =
       "https://reportstream.cdc.gov/fhir/StructureDefinition/ethnic-group";
   public static final String ETHNICITY_CODE_SYSTEM =
@@ -28,4 +32,10 @@ public class FhirConstants {
       "ORU/ACK - Unsolicited transmission of an observation message";
   public static final String DEFAULT_COUNTRY = "USA";
   public static final String UNIVERSAL_ID_SYSTEM = "http://terminology.hl7.org/CodeSystem/v2-0301";
+
+  public static final Map<String, String> PROCESSING_ID_DISPLAY =
+      Map.of(
+          "D", "Debugging",
+          "P", "Production",
+          "T", "Training");
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -70,7 +70,6 @@ import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Identifier.IdentifierUse;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.MessageHeader;
-import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 import org.hl7.fhir.r4.model.Organization;
@@ -669,9 +668,9 @@ public class FhirConverter {
                     .setFullUrl(pair.getFirst())
                     .setResource(pair.getSecond())));
 
-    bundle.setMeta(
-        new Meta()
-            .addTag(PROCESSING_ID_SYSTEM, processingId, PROCESSING_ID_DISPLAY.get(processingId)));
+    bundle
+        .getMeta()
+        .addTag(PROCESSING_ID_SYSTEM, processingId, PROCESSING_ID_DISPLAY.get(processingId));
     return bundle;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -8,6 +8,8 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EVENT_TYPE_C
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EVENT_TYPE_DISPLAY;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NULL_CODE_SYSTEM;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.PROCESSING_ID_DISPLAY;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.PROCESSING_ID_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.RACE_CODING_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.RACE_EXTENSION_URL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.SNOMED_CODE_SYSTEM;
@@ -68,6 +70,7 @@ import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Identifier.IdentifierUse;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 import org.hl7.fhir.r4.model.Organization;
@@ -562,7 +565,10 @@ public class FhirConverter {
   }
 
   public static Bundle createFhirBundle(
-      @NotNull TestEvent testEvent, GitProperties gitProperties, Date currentDate) {
+      @NotNull TestEvent testEvent,
+      GitProperties gitProperties,
+      Date currentDate,
+      String processingId) {
     return createFhirBundle(
         convertToPatient(testEvent.getPatient()),
         convertToOrganization(testEvent.getFacility()),
@@ -578,7 +584,8 @@ public class FhirConverter {
         convertToDiagnosticReport(testEvent),
         testEvent.getDateTested(),
         currentDate,
-        gitProperties);
+        gitProperties,
+        processingId);
   }
 
   public static Bundle createFhirBundle(
@@ -592,7 +599,8 @@ public class FhirConverter {
       DiagnosticReport diagnosticReport,
       Date dateTested,
       Date currentDate,
-      GitProperties gitProperties) {
+      GitProperties gitProperties,
+      String processingId) {
     var patientFullUrl = ResourceType.Patient + "/" + patient.getId();
     var organizationFullUrl = ResourceType.Organization + "/" + organization.getId();
     var practitionerFullUrl = ResourceType.Practitioner + "/" + practitioner.getId();
@@ -661,6 +669,9 @@ public class FhirConverter {
                     .setFullUrl(pair.getFirst())
                     .setResource(pair.getSecond())));
 
+    bundle.setMeta(
+        new Meta()
+            .addTag(PROCESSING_ID_SYSTEM, processingId, PROCESSING_ID_DISPLAY.get(processingId)));
     return bundle;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueFhirReportingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueFhirReportingService.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.GitProperties;
 
 @Slf4j
@@ -20,6 +21,9 @@ public final class AzureStorageQueueFhirReportingService implements TestEventRep
   private final QueueAsyncClient queueClient;
   private final GitProperties gitProperties;
 
+  @Value("${simple-report.processing-mode-code:P}")
+  private String processingModeCode = "P";
+
   @Override
   public CompletableFuture<Void> reportAsync(TestEvent testEvent) {
     if (testEvent.getResults().stream()
@@ -28,7 +32,8 @@ public final class AzureStorageQueueFhirReportingService implements TestEventRep
       var parser = context.newJsonParser();
       return queueClient
           .sendMessage(
-              parser.encodeResourceToString(createFhirBundle(testEvent, gitProperties, new Date())))
+              parser.encodeResourceToString(
+                  createFhirBundle(testEvent, gitProperties, new Date(), processingModeCode)))
           .toFuture()
           .thenApply(result -> null);
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -93,6 +93,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -1276,6 +1277,6 @@ class FhirConverterTest {
             "$BUNDLE_TIMESTAMP",
             OffsetDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault())
                 .format(DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSxxx")));
-    JSONAssert.assertEquals(expectedSerialized, actualSerialized, false);
+    JSONAssert.assertEquals(expectedSerialized, actualSerialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1053,7 +1053,8 @@ class FhirConverterTest {
             diagnosticReport,
             new Date(),
             date,
-            gitProperties);
+            gitProperties,
+            "P");
 
     var resourceUrls =
         actual.getEntry().stream()
@@ -1244,7 +1245,7 @@ class FhirConverterTest {
     ReflectionTestUtils.setField(
         person, "phoneNumbers", List.of(new PhoneNumber(PhoneType.LANDLINE, "7735551234")));
 
-    var actual = createFhirBundle(testEvent, gitProperties, date);
+    var actual = createFhirBundle(testEvent, gitProperties, date, "P");
 
     String actualSerialized = parser.encodeResourceToString(actual);
 

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -1,6 +1,15 @@
 {
   "resourceType":"Bundle",
   "type":"message",
+  "meta": {
+    "tag": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ProcessingID",
+        "code": "P",
+        "display": "Production"
+      }
+    ]
+  },
   "identifier": {
     "value": "45e9539f-c9a4-4c86-b79d-4ba2c43f9ee0"
   },


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #5199

## Changes Proposed

- Sets `ProcessingModeCode = T` for staging env for FHIR
- ProcessingModeCode corresponds to processingId in FHIR

## Additional Information

- https://github.com/CDCgov/prime-simplereport/pull/5275 for `non-universal-pipeline` `single-entry` only.
- https://github.com/CDCgov/prime-simplereport/pull/5285 will add this feature to result bulk uploads
- **THIS** PR will add this feature to universal-pipeline (FIHR bundle)

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->