### PR TITLE
add semantic form tags to form components

### DIFF
--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
@@ -54,7 +54,7 @@ export const MfaSelect = () => {
 
   return (
     <CardBackground>
-      <Card logo bodyKicker="Set up your account">
+      <Card cardIsForm logo bodyKicker="Set up your account">
         <StepIndicator
           steps={accountCreationSteps}
           currentStepValue={"2"}

--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
@@ -54,7 +54,7 @@ export const MfaSelect = () => {
 
   return (
     <CardBackground>
-      <Card logo bodyKicker="Set up your account">
+      <Card logo cardIsForm bodyKicker="Set up your account">
         <StepIndicator
           steps={accountCreationSteps}
           currentStepValue={"2"}

--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
@@ -54,7 +54,7 @@ export const MfaSelect = () => {
 
   return (
     <CardBackground>
-      <Card cardIsForm logo bodyKicker="Set up your account">
+      <Card logo bodyKicker="Set up your account">
         <StepIndicator
           steps={accountCreationSteps}
           currentStepValue={"2"}
@@ -112,6 +112,7 @@ export const MfaSelect = () => {
           onBlur={validateMfaOption}
           onChange={setMfaOption}
           variant="tile"
+          renderAsForm
         />
         <Button
           className="margin-top-3"

--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.tsx
@@ -54,7 +54,7 @@ export const MfaSelect = () => {
 
   return (
     <CardBackground>
-      <Card logo cardIsForm bodyKicker="Set up your account">
+      <Card logo bodyKicker="Set up your account">
         <StepIndicator
           steps={accountCreationSteps}
           currentStepValue={"2"}

--- a/frontend/src/app/commonComponents/Card/Card.tsx
+++ b/frontend/src/app/commonComponents/Card/Card.tsx
@@ -32,15 +32,10 @@ export const Card: React.FC<CardProps> = ({
       {children}
     </>
   );
-  return (
-    <>
-      {cardIsForm ? (
-        <form className="card">{body}</form>
-      ) : (
-        <div className="card"> {body} </div>
-      )}
-    </>
-  );
+
+  const ContainerEl = cardIsForm ? "form" : "div";
+
+  return <ContainerEl className="card">{body}</ContainerEl>;
 };
 
 export default Card;

--- a/frontend/src/app/commonComponents/Card/Card.tsx
+++ b/frontend/src/app/commonComponents/Card/Card.tsx
@@ -1,10 +1,11 @@
-import siteLogo from "../../../img/simplereport-logo-color.svg";
+import { CardLogoHeader } from "./CardLogoHeader";
 
 export type CardProps = {
   logo?: boolean;
   bodyKicker?: string;
   bodyKickerCentered?: boolean;
   children?: React.ReactNode;
+  cardIsForm?: boolean;
 };
 
 export const Card: React.FC<CardProps> = ({
@@ -12,6 +13,7 @@ export const Card: React.FC<CardProps> = ({
   logo = false,
   bodyKicker = false,
   bodyKickerCentered = false,
+  cardIsForm = false,
 }) => {
   let kicker = null;
   if (bodyKicker && bodyKickerCentered) {
@@ -23,21 +25,21 @@ export const Card: React.FC<CardProps> = ({
   } else if (bodyKicker) {
     kicker = <p className="font-ui-sm text-bold margin-top-3">{bodyKicker}</p>;
   }
-  return (
-    <div className="card">
-      {logo && (
-        <header className="display-flex flex-column">
-          <img
-            className="flex-align-self-center maxw-card-lg width-full"
-            src={siteLogo}
-            alt="SimpleReport logo"
-          />
-          <div className="border-bottom border-base-lighter margin-x-neg-3 margin-top-3"></div>
-        </header>
-      )}
+  const body = (
+    <>
+      {logo && <CardLogoHeader />}
       {kicker}
       {children}
-    </div>
+    </>
+  );
+  return (
+    <>
+      {cardIsForm ? (
+        <form className="card">{body}</form>
+      ) : (
+        <div className="card"> {body} </div>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/app/commonComponents/Card/CardLogoHeader.tsx
+++ b/frontend/src/app/commonComponents/Card/CardLogoHeader.tsx
@@ -1,0 +1,14 @@
+import siteLogo from "../../../img/simplereport-logo-color.svg";
+
+export const CardLogoHeader: React.FC = () => {
+  return (
+    <header className="display-flex flex-column">
+      <img
+        className="flex-align-self-center maxw-card-lg width-full"
+        src={siteLogo}
+        alt="SimpleReport logo"
+      />
+      <div className="border-bottom border-base-lighter margin-x-neg-3 margin-top-3"></div>
+    </header>
+  );
+};

--- a/frontend/src/app/commonComponents/FormGroup.tsx
+++ b/frontend/src/app/commonComponents/FormGroup.tsx
@@ -6,14 +6,14 @@ interface Props {
 }
 
 const FormGroup = (props: Props) => (
-  <div className="prime-formgroup">
+  <form className="prime-formgroup">
     <fieldset className="usa-fieldset">
       <legend className="prime-formgroup-heading usa-legend">
         {props.title}
       </legend>
       {props.children}
     </fieldset>
-  </div>
+  </form>
 );
 
 export default FormGroup;

--- a/frontend/src/app/commonComponents/RadioGroup.tsx
+++ b/frontend/src/app/commonComponents/RadioGroup.tsx
@@ -143,31 +143,17 @@ const RadioGroup = <T extends string>({
     </fieldset>
   );
 
+  const ContainerEl = renderAsForm ? "form" : "div";
   return (
-    <>
-      {renderAsForm ? (
-        <form
-          className={classnames(
-            "usa-form-group",
-            wrapperClassName,
-            validationStatus === "error" && "usa-form-group--error"
-          )}
-        >
-          {body}
-        </form>
-      ) : (
-        <div
-          className={classnames(
-            "usa-form-group",
-            wrapperClassName,
-            validationStatus === "error" && "usa-form-group--error"
-          )}
-        >
-          {" "}
-          {body}{" "}
-        </div>
+    <ContainerEl
+      className={classnames(
+        "usa-form-group",
+        wrapperClassName,
+        validationStatus === "error" && "usa-form-group--error"
       )}
-    </>
+    >
+      {body}
+    </ContainerEl>
   );
 };
 

--- a/frontend/src/app/commonComponents/RadioGroup.tsx
+++ b/frontend/src/app/commonComponents/RadioGroup.tsx
@@ -32,6 +32,7 @@ interface Props<T> {
   onClick?: (value: T) => void;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   inputClassName?: string;
+  renderAsForm?: boolean;
 }
 
 const RadioGroup = <T extends string>({
@@ -52,6 +53,7 @@ const RadioGroup = <T extends string>({
   onClick,
   disabled,
   inputClassName,
+  renderAsForm,
 }: Props<T>): React.ReactElement => {
   const inputClass = classnames(
     "usa-radio__input",
@@ -63,94 +65,101 @@ const RadioGroup = <T extends string>({
     variant === "horizontal" && "prime-radio--horizontal__container"
   );
 
-  return (
-    <form
-      className={classnames(
-        "usa-form-group",
-        wrapperClassName,
-        validationStatus === "error" && "usa-form-group--error"
-      )}
+  const body = (
+    <fieldset
+      className={classnames("usa-fieldset prime-radios", className)}
+      id={name}
     >
-      <fieldset
-        className={classnames("usa-fieldset prime-radios", className)}
-        id={name}
-      >
-        {legend && (
-          <legend
+      {legend && (
+        <legend
+          className={classnames(
+            "usa-legend",
+            legendSrOnly && "usa-sr-only",
+            validationStatus === "error" && "usa-label--error"
+          )}
+        >
+          {required ? <Required label={legend} /> : <Optional label={legend} />}
+        </legend>
+      )}
+      {hintText && <span className="usa-hint">{hintText}</span>}
+      {validationStatus === "error" && (
+        <div className="usa-error-message" role="alert" id={`error_${name}`}>
+          <span className="usa-sr-only">Error: </span>
+          {errorMessage}
+        </div>
+      )}
+      <UIDConsumer>
+        {(_, uid) => (
+          <div
             className={classnames(
-              "usa-legend",
-              legendSrOnly && "usa-sr-only",
-              validationStatus === "error" && "usa-label--error"
+              variant === "horizontal" && "prime-radio--horizontal"
             )}
+            {...(validationStatus === "error"
+              ? { "aria-describedby": `error_${name}`, "aria-invalid": true }
+              : null)}
           >
-            {required ? (
-              <Required label={legend} />
-            ) : (
-              <Optional label={legend} />
-            )}
-          </legend>
-        )}
-        {hintText && <span className="usa-hint">{hintText}</span>}
-        {validationStatus === "error" && (
-          <div className="usa-error-message" role="alert" id={`error_${name}`}>
-            <span className="usa-sr-only">Error: </span>
-            {errorMessage}
+            {buttons.map((c) => {
+              const labelClasses = classnames(
+                "usa-radio__label",
+                (c.disabled || disabled) && "text-base"
+              );
+              const className = classnames(groupClass, c.className);
+              return (
+                <div className={className} key={uid(c.value)}>
+                  <input
+                    type="radio"
+                    id={uid(c.value)}
+                    name={name}
+                    value={c.value}
+                    data-required={required || "false"}
+                    disabled={disabled || c.disabled || false}
+                    className={inputClass}
+                    checked={c.value === selectedRadio}
+                    onClick={onClick ? () => onClick(c.value) : undefined}
+                    onChange={() => onChange(c.value)}
+                    onBlur={onBlur}
+                  />
+                  <label className={labelClasses} htmlFor={uid(c.value)}>
+                    {c.label}
+                    {c.labelDescription && (
+                      <span className="usa-checkbox__label-description text-base-dark">
+                        {c.labelDescription}
+                      </span>
+                    )}
+                    {c.labelTag && (
+                      <div className="display-block margin-top-1">
+                        <span className="usa-tag bg-primary-darker">
+                          {c.labelTag}
+                        </span>
+                      </div>
+                    )}
+                  </label>
+                </div>
+              );
+            })}
           </div>
         )}
-        <UIDConsumer>
-          {(_, uid) => (
-            <div
-              className={classnames(
-                variant === "horizontal" && "prime-radio--horizontal"
-              )}
-              {...(validationStatus === "error"
-                ? { "aria-describedby": `error_${name}`, "aria-invalid": true }
-                : null)}
-            >
-              {buttons.map((c) => {
-                const labelClasses = classnames(
-                  "usa-radio__label",
-                  (c.disabled || disabled) && "text-base"
-                );
-                const className = classnames(groupClass, c.className);
-                return (
-                  <div className={className} key={uid(c.value)}>
-                    <input
-                      type="radio"
-                      id={uid(c.value)}
-                      name={name}
-                      value={c.value}
-                      data-required={required || "false"}
-                      disabled={disabled || c.disabled || false}
-                      className={inputClass}
-                      checked={c.value === selectedRadio}
-                      onClick={onClick ? () => onClick(c.value) : undefined}
-                      onChange={() => onChange(c.value)}
-                      onBlur={onBlur}
-                    />
-                    <label className={labelClasses} htmlFor={uid(c.value)}>
-                      {c.label}
-                      {c.labelDescription && (
-                        <span className="usa-checkbox__label-description text-base-dark">
-                          {c.labelDescription}
-                        </span>
-                      )}
-                      {c.labelTag && (
-                        <div className="display-block margin-top-1">
-                          <span className="usa-tag bg-primary-darker">
-                            {c.labelTag}
-                          </span>
-                        </div>
-                      )}
-                    </label>
-                  </div>
-                );
-              })}
-            </div>
+      </UIDConsumer>
+    </fieldset>
+  );
+
+  return (
+    <>
+      {renderAsForm ? (
+        <form
+          className={classnames(
+            "usa-form-group",
+            wrapperClassName,
+            validationStatus === "error" && "usa-form-group--error"
           )}
-        </UIDConsumer>
-      </fieldset>
-    </form>
+        >
+          {" "}
+          {body}{" "}
+        </form>
+      ) : (
+        <div> {body} </div>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/app/commonComponents/RadioGroup.tsx
+++ b/frontend/src/app/commonComponents/RadioGroup.tsx
@@ -153,11 +153,19 @@ const RadioGroup = <T extends string>({
             validationStatus === "error" && "usa-form-group--error"
           )}
         >
-          {" "}
-          {body}{" "}
+          {body}
         </form>
       ) : (
-        <div> {body} </div>
+        <div
+          className={classnames(
+            "usa-form-group",
+            wrapperClassName,
+            validationStatus === "error" && "usa-form-group--error"
+          )}
+        >
+          {" "}
+          {body}{" "}
+        </div>
       )}
     </>
   );

--- a/frontend/src/app/commonComponents/RadioGroup.tsx
+++ b/frontend/src/app/commonComponents/RadioGroup.tsx
@@ -64,7 +64,7 @@ const RadioGroup = <T extends string>({
   );
 
   return (
-    <div
+    <form
       className={classnames(
         "usa-form-group",
         wrapperClassName,
@@ -150,7 +150,7 @@ const RadioGroup = <T extends string>({
           )}
         </UIDConsumer>
       </fieldset>
-    </div>
+    </form>
   );
 };
 

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -372,6 +372,7 @@ const UploadPatients = () => {
                   selectedRadio={facilityAmount}
                   onChange={setFacilityAmount}
                   variant="horizontal"
+                  renderAsForm
                 />
                 {facilityAmount === "oneFacility" && (
                   <>

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -357,7 +357,6 @@ Object {
                       <div
                         class="usa-form-group"
                       >
-                         
                         <fieldset
                           class="usa-fieldset prime-radios margin-top-3 phoneNumberFormElement"
                           id="phoneType-0"
@@ -416,7 +415,6 @@ Object {
                             </div>
                           </div>
                         </fieldset>
-                         
                       </div>
                     </div>
                     <button
@@ -443,7 +441,6 @@ Object {
                     <div
                       class="usa-form-group"
                     >
-                       
                       <fieldset
                         class="usa-fieldset prime-radios"
                         id="testResultDeliveryText"
@@ -495,7 +492,6 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                       
                     </div>
                   </div>
                   <div
@@ -555,7 +551,6 @@ Object {
                     <div
                       class="usa-form-group"
                     >
-                       
                       <fieldset
                         class="usa-fieldset prime-radios"
                         id="testResultDeliveryEmail"
@@ -607,7 +602,6 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                       
                     </div>
                   </div>
                   <div
@@ -2067,7 +2061,6 @@ Object {
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="race"
@@ -2215,7 +2208,6 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                   <div
                     class="usa-form-group"
@@ -2230,7 +2222,6 @@ Object {
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="ethnicity"
@@ -2306,12 +2297,10 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="gender"
@@ -2410,7 +2399,6 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                 </fieldset>
               </form>
@@ -2428,7 +2416,6 @@ Object {
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="residentCongregateSetting"
@@ -2503,12 +2490,10 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="employedInHealthcare"
@@ -2578,7 +2563,6 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                 </fieldset>
               </form>
@@ -2957,7 +2941,6 @@ Object {
                     <div
                       class="usa-form-group"
                     >
-                       
                       <fieldset
                         class="usa-fieldset prime-radios margin-top-3 phoneNumberFormElement"
                         id="phoneType-0"
@@ -3016,7 +2999,6 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                       
                     </div>
                   </div>
                   <button
@@ -3043,7 +3025,6 @@ Object {
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="testResultDeliveryText"
@@ -3095,7 +3076,6 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                 </div>
                 <div
@@ -3155,7 +3135,6 @@ Object {
                   <div
                     class="usa-form-group"
                   >
-                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="testResultDeliveryEmail"
@@ -3207,7 +3186,6 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                     
                   </div>
                 </div>
                 <div
@@ -4667,7 +4645,6 @@ Object {
                 <div
                   class="usa-form-group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="race"
@@ -4815,7 +4792,6 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
                 <div
                   class="usa-form-group"
@@ -4830,7 +4806,6 @@ Object {
                 <div
                   class="usa-form-group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="ethnicity"
@@ -4906,12 +4881,10 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
                 <div
                   class="usa-form-group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="gender"
@@ -5010,7 +4983,6 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
               </fieldset>
             </form>
@@ -5028,7 +5000,6 @@ Object {
                 <div
                   class="usa-form-group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="residentCongregateSetting"
@@ -5103,12 +5074,10 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
                 <div
                   class="usa-form-group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="employedInHealthcare"
@@ -5178,7 +5147,6 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
               </fieldset>
             </form>

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -354,7 +354,9 @@ Object {
                           />
                         </div>
                       </div>
-                      <div>
+                      <div
+                        class="usa-form-group"
+                      >
                          
                         <fieldset
                           class="usa-fieldset prime-radios margin-top-3 phoneNumberFormElement"
@@ -438,7 +440,9 @@ Object {
                       </svg>
                       Add another number
                     </button>
-                    <div>
+                    <div
+                      class="usa-form-group"
+                    >
                        
                       <fieldset
                         class="usa-fieldset prime-radios"
@@ -548,7 +552,9 @@ Object {
                         Add another email address
                       </button>
                     </div>
-                    <div>
+                    <div
+                      class="usa-form-group"
+                    >
                        
                       <fieldset
                         class="usa-fieldset prime-radios"
@@ -2058,7 +2064,9 @@ Object {
                   >
                     This information is collected as part of public health efforts to recognize and address inequality in health outcomes.
                   </p>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -2219,7 +2227,9 @@ Object {
                       Tribal affiliation
                     </label>
                   </div>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -2298,7 +2308,9 @@ Object {
                     </fieldset>
                      
                   </div>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -2413,7 +2425,9 @@ Object {
                   >
                     Housing and work
                   </legend>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -2491,7 +2505,9 @@ Object {
                     </fieldset>
                      
                   </div>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -2938,7 +2954,9 @@ Object {
                         />
                       </div>
                     </div>
-                    <div>
+                    <div
+                      class="usa-form-group"
+                    >
                        
                       <fieldset
                         class="usa-fieldset prime-radios margin-top-3 phoneNumberFormElement"
@@ -3022,7 +3040,9 @@ Object {
                     </svg>
                     Add another number
                   </button>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -3132,7 +3152,9 @@ Object {
                       Add another email address
                     </button>
                   </div>
-                  <div>
+                  <div
+                    class="usa-form-group"
+                  >
                      
                     <fieldset
                       class="usa-fieldset prime-radios"
@@ -4642,7 +4664,9 @@ Object {
                 >
                   This information is collected as part of public health efforts to recognize and address inequality in health outcomes.
                 </p>
-                <div>
+                <div
+                  class="usa-form-group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"
@@ -4803,7 +4827,9 @@ Object {
                     Tribal affiliation
                   </label>
                 </div>
-                <div>
+                <div
+                  class="usa-form-group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"
@@ -4882,7 +4908,9 @@ Object {
                   </fieldset>
                    
                 </div>
-                <div>
+                <div
+                  class="usa-form-group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"
@@ -4997,7 +5025,9 @@ Object {
                 >
                   Housing and work
                 </legend>
-                <div>
+                <div
+                  class="usa-form-group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"
@@ -5075,7 +5105,9 @@ Object {
                   </fieldset>
                    
                 </div>
-                <div>
+                <div
+                  class="usa-form-group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -75,7 +75,7 @@ Object {
                   </div>
                 </div>
               </div>
-              <div
+              <form
                 class="prime-formgroup"
               >
                 <fieldset
@@ -302,8 +302,8 @@ Object {
                     </div>
                   </div>
                 </fieldset>
-              </div>
-              <div
+              </form>
+              <form
                 class="prime-formgroup"
               >
                 <fieldset
@@ -354,7 +354,7 @@ Object {
                           />
                         </div>
                       </div>
-                      <div
+                      <form
                         class="usa-form-group"
                       >
                         <fieldset
@@ -415,7 +415,7 @@ Object {
                             </div>
                           </div>
                         </fieldset>
-                      </div>
+                      </form>
                     </div>
                     <button
                       class="usa-button usa-button--unstyled margin-top-2"
@@ -438,7 +438,7 @@ Object {
                       </svg>
                       Add another number
                     </button>
-                    <div
+                    <form
                       class="usa-form-group"
                     >
                       <fieldset
@@ -492,7 +492,7 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                    </div>
+                    </form>
                   </div>
                   <div
                     class="usa-form"
@@ -548,7 +548,7 @@ Object {
                         Add another email address
                       </button>
                     </div>
-                    <div
+                    <form
                       class="usa-form-group"
                     >
                       <fieldset
@@ -602,7 +602,7 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                    </div>
+                    </form>
                   </div>
                   <div
                     class="usa-form"
@@ -2041,8 +2041,8 @@ Object {
                     </div>
                   </div>
                 </fieldset>
-              </div>
-              <div
+              </form>
+              <form
                 class="prime-formgroup"
               >
                 <fieldset
@@ -2058,7 +2058,7 @@ Object {
                   >
                     This information is collected as part of public health efforts to recognize and address inequality in health outcomes.
                   </p>
-                  <div
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -2208,7 +2208,7 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
+                  </form>
                   <div
                     class="usa-form-group"
                   >
@@ -2219,7 +2219,7 @@ Object {
                       Tribal affiliation
                     </label>
                   </div>
-                  <div
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -2297,8 +2297,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
-                  <div
+                  </form>
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -2399,10 +2399,10 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
+                  </form>
                 </fieldset>
-              </div>
-              <div
+              </form>
+              <form
                 class="prime-formgroup"
               >
                 <fieldset
@@ -2413,7 +2413,7 @@ Object {
                   >
                     Housing and work
                   </legend>
-                  <div
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -2490,8 +2490,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
-                  <div
+                  </form>
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -2563,9 +2563,9 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
+                  </form>
                 </fieldset>
-              </div>
+              </form>
               <div
                 class="prime-edit-patient-heading"
               >
@@ -2659,7 +2659,7 @@ Object {
                 </div>
               </div>
             </div>
-            <div
+            <form
               class="prime-formgroup"
             >
               <fieldset
@@ -2886,8 +2886,8 @@ Object {
                   </div>
                 </div>
               </fieldset>
-            </div>
-            <div
+            </form>
+            <form
               class="prime-formgroup"
             >
               <fieldset
@@ -2938,7 +2938,7 @@ Object {
                         />
                       </div>
                     </div>
-                    <div
+                    <form
                       class="usa-form-group"
                     >
                       <fieldset
@@ -2999,7 +2999,7 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                    </div>
+                    </form>
                   </div>
                   <button
                     class="usa-button usa-button--unstyled margin-top-2"
@@ -3022,7 +3022,7 @@ Object {
                     </svg>
                     Add another number
                   </button>
-                  <div
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -3076,7 +3076,7 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
+                  </form>
                 </div>
                 <div
                   class="usa-form"
@@ -3132,7 +3132,7 @@ Object {
                       Add another email address
                     </button>
                   </div>
-                  <div
+                  <form
                     class="usa-form-group"
                   >
                     <fieldset
@@ -3186,7 +3186,7 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </div>
+                  </form>
                 </div>
                 <div
                   class="usa-form"
@@ -4625,8 +4625,8 @@ Object {
                   </div>
                 </div>
               </fieldset>
-            </div>
-            <div
+            </form>
+            <form
               class="prime-formgroup"
             >
               <fieldset
@@ -4642,7 +4642,7 @@ Object {
                 >
                   This information is collected as part of public health efforts to recognize and address inequality in health outcomes.
                 </p>
-                <div
+                <form
                   class="usa-form-group"
                 >
                   <fieldset
@@ -4792,7 +4792,7 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </div>
+                </form>
                 <div
                   class="usa-form-group"
                 >
@@ -4803,7 +4803,7 @@ Object {
                     Tribal affiliation
                   </label>
                 </div>
-                <div
+                <form
                   class="usa-form-group"
                 >
                   <fieldset
@@ -4881,8 +4881,8 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </div>
-                <div
+                </form>
+                <form
                   class="usa-form-group"
                 >
                   <fieldset
@@ -4983,10 +4983,10 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </div>
+                </form>
               </fieldset>
-            </div>
-            <div
+            </form>
+            <form
               class="prime-formgroup"
             >
               <fieldset
@@ -4997,7 +4997,7 @@ Object {
                 >
                   Housing and work
                 </legend>
-                <div
+                <form
                   class="usa-form-group"
                 >
                   <fieldset
@@ -5074,8 +5074,8 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </div>
-                <div
+                </form>
+                <form
                   class="usa-form-group"
                 >
                   <fieldset
@@ -5147,9 +5147,9 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </div>
+                </form>
               </fieldset>
-            </div>
+            </form>
             <div
               class="prime-edit-patient-heading"
             >

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -354,9 +354,8 @@ Object {
                           />
                         </div>
                       </div>
-                      <form
-                        class="usa-form-group"
-                      >
+                      <div>
+                         
                         <fieldset
                           class="usa-fieldset prime-radios margin-top-3 phoneNumberFormElement"
                           id="phoneType-0"
@@ -415,7 +414,8 @@ Object {
                             </div>
                           </div>
                         </fieldset>
-                      </form>
+                         
+                      </div>
                     </div>
                     <button
                       class="usa-button usa-button--unstyled margin-top-2"
@@ -438,9 +438,8 @@ Object {
                       </svg>
                       Add another number
                     </button>
-                    <form
-                      class="usa-form-group"
-                    >
+                    <div>
+                       
                       <fieldset
                         class="usa-fieldset prime-radios"
                         id="testResultDeliveryText"
@@ -492,7 +491,8 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                    </form>
+                       
+                    </div>
                   </div>
                   <div
                     class="usa-form"
@@ -548,9 +548,8 @@ Object {
                         Add another email address
                       </button>
                     </div>
-                    <form
-                      class="usa-form-group"
-                    >
+                    <div>
+                       
                       <fieldset
                         class="usa-fieldset prime-radios"
                         id="testResultDeliveryEmail"
@@ -602,7 +601,8 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                    </form>
+                       
+                    </div>
                   </div>
                   <div
                     class="usa-form"
@@ -2058,9 +2058,8 @@ Object {
                   >
                     This information is collected as part of public health efforts to recognize and address inequality in health outcomes.
                   </p>
-                  <form
-                    class="usa-form-group"
-                  >
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="race"
@@ -2208,7 +2207,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
+                     
+                  </div>
                   <div
                     class="usa-form-group"
                   >
@@ -2219,9 +2219,8 @@ Object {
                       Tribal affiliation
                     </label>
                   </div>
-                  <form
-                    class="usa-form-group"
-                  >
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="ethnicity"
@@ -2297,10 +2296,10 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
-                  <form
-                    class="usa-form-group"
-                  >
+                     
+                  </div>
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="gender"
@@ -2399,7 +2398,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
+                     
+                  </div>
                 </fieldset>
               </form>
               <form
@@ -2413,9 +2413,8 @@ Object {
                   >
                     Housing and work
                   </legend>
-                  <form
-                    class="usa-form-group"
-                  >
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="residentCongregateSetting"
@@ -2490,10 +2489,10 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
-                  <form
-                    class="usa-form-group"
-                  >
+                     
+                  </div>
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="employedInHealthcare"
@@ -2563,7 +2562,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
+                     
+                  </div>
                 </fieldset>
               </form>
               <div
@@ -2938,9 +2938,8 @@ Object {
                         />
                       </div>
                     </div>
-                    <form
-                      class="usa-form-group"
-                    >
+                    <div>
+                       
                       <fieldset
                         class="usa-fieldset prime-radios margin-top-3 phoneNumberFormElement"
                         id="phoneType-0"
@@ -2999,7 +2998,8 @@ Object {
                           </div>
                         </div>
                       </fieldset>
-                    </form>
+                       
+                    </div>
                   </div>
                   <button
                     class="usa-button usa-button--unstyled margin-top-2"
@@ -3022,9 +3022,8 @@ Object {
                     </svg>
                     Add another number
                   </button>
-                  <form
-                    class="usa-form-group"
-                  >
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="testResultDeliveryText"
@@ -3076,7 +3075,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
+                     
+                  </div>
                 </div>
                 <div
                   class="usa-form"
@@ -3132,9 +3132,8 @@ Object {
                       Add another email address
                     </button>
                   </div>
-                  <form
-                    class="usa-form-group"
-                  >
+                  <div>
+                     
                     <fieldset
                       class="usa-fieldset prime-radios"
                       id="testResultDeliveryEmail"
@@ -3186,7 +3185,8 @@ Object {
                         </div>
                       </div>
                     </fieldset>
-                  </form>
+                     
+                  </div>
                 </div>
                 <div
                   class="usa-form"
@@ -4642,9 +4642,8 @@ Object {
                 >
                   This information is collected as part of public health efforts to recognize and address inequality in health outcomes.
                 </p>
-                <form
-                  class="usa-form-group"
-                >
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="race"
@@ -4792,7 +4791,8 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </form>
+                   
+                </div>
                 <div
                   class="usa-form-group"
                 >
@@ -4803,9 +4803,8 @@ Object {
                     Tribal affiliation
                   </label>
                 </div>
-                <form
-                  class="usa-form-group"
-                >
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="ethnicity"
@@ -4881,10 +4880,10 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </form>
-                <form
-                  class="usa-form-group"
-                >
+                   
+                </div>
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="gender"
@@ -4983,7 +4982,8 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </form>
+                   
+                </div>
               </fieldset>
             </form>
             <form
@@ -4997,9 +4997,8 @@ Object {
                 >
                   Housing and work
                 </legend>
-                <form
-                  class="usa-form-group"
-                >
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="residentCongregateSetting"
@@ -5074,10 +5073,10 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </form>
-                <form
-                  class="usa-form-group"
-                >
+                   
+                </div>
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="employedInHealthcare"
@@ -5147,7 +5146,8 @@ Object {
                       </div>
                     </div>
                   </fieldset>
-                </form>
+                   
+                </div>
               </fieldset>
             </form>
             <div

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
               >
                 If you plan to test patients at more than one facility, we recommend adding them to all facilities. You can't select multiple facilities individually.
               </p>
-              <div
+              <form
                 class="usa-form-group margin-top-2"
               >
                 <fieldset
@@ -188,7 +188,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
                     </div>
                   </div>
                 </fieldset>
-              </div>
+              </form>
             </div>
           </li>
           <li>

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -138,7 +138,6 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
               <form
                 class="usa-form-group margin-top-2"
               >
-                 
                 <fieldset
                   class="usa-fieldset prime-radios"
                   id="facilitySector"
@@ -189,7 +188,6 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
                     </div>
                   </div>
                 </fieldset>
-                 
               </form>
             </div>
           </li>

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -138,6 +138,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
               <form
                 class="usa-form-group margin-top-2"
               >
+                 
                 <fieldset
                   class="usa-fieldset prime-radios"
                   id="facilitySector"
@@ -188,6 +189,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
                     </div>
                   </div>
                 </fieldset>
+                 
               </form>
             </div>
           </li>

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -212,7 +212,7 @@ const PersonalDetailsForm = ({
 
   return (
     <CardBackground>
-      <Card logo>
+      <Card logo cardIsForm>
         <h1 className="margin-bottom-0 font-ui-xs">Sign up for SimpleReport</h1>
         <StepIndicator
           steps={organizationCreationSteps}

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
@@ -98,7 +98,7 @@ const QuestionsForm: React.FC<Props> = ({
 
   return (
     <CardBackground>
-      <Card logo>
+      <Card logo cardIsForm>
         <div
           className="grid-row prime-test-name usa-card__header"
           id="experian-questions-header"

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -241,7 +241,7 @@ const OrganizationForm = () => {
 
   return (
     <CardBackground>
-      <Card logo>
+      <Card logo cardIsForm>
         <div className="margin-bottom-2 organization-form usa-prose">
           <h4 className="margin-top-2 margin-bottom-0">
             Sign up for SimpleReport

--- a/frontend/src/app/signUp/Organization/SignUpGoals.tsx
+++ b/frontend/src/app/signUp/Organization/SignUpGoals.tsx
@@ -42,7 +42,7 @@ const SignUpGoals = () => {
 
   return (
     <CardBackground>
-      <Card logo>
+      <Card logo cardIsForm>
         <div className="sign-up-goals-card usa-prose margin-bottom-3">
           <h1 className="margin-top-2 font-ui-lg">Sign up for SimpleReport</h1>
           <p className="subheader margin-bottom-0">

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -377,7 +377,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   COVID-19 results
                 </h3>
-                <div
+                <form
                   class="usa-form-group prime-radio__group"
                 >
                   <fieldset
@@ -448,7 +448,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                     </div>
                   </fieldset>
-                </div>
+                </form>
                 <div
                   class="prime-test-result-submit"
                 >
@@ -788,7 +788,7 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   COVID-19 results
                 </h3>
-                <div
+                <form
                   class="usa-form-group prime-radio__group"
                 >
                   <fieldset
@@ -859,7 +859,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                     </div>
                   </fieldset>
-                </div>
+                </form>
                 <div
                   class="prime-test-result-submit"
                 >

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -377,7 +377,9 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   COVID-19 results
                 </h3>
-                <div>
+                <div
+                  class="usa-form-group prime-radio__group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"
@@ -788,7 +790,9 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   COVID-19 results
                 </h3>
-                <div>
+                <div
+                  class="usa-form-group prime-radio__group"
+                >
                    
                   <fieldset
                     class="usa-fieldset prime-radios"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -380,7 +380,6 @@ exports[`TestQueue should render the test queue 1`] = `
                 <div
                   class="usa-form-group prime-radio__group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="covid-test-result-abc"
@@ -449,7 +448,6 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
                 <div
                   class="prime-test-result-submit"
@@ -793,7 +791,6 @@ exports[`TestQueue should render the test queue 1`] = `
                 <div
                   class="usa-form-group prime-radio__group"
                 >
-                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="covid-test-result-def"
@@ -862,7 +859,6 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                     </div>
                   </fieldset>
-                   
                 </div>
                 <div
                   class="prime-test-result-submit"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -377,9 +377,8 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   COVID-19 results
                 </h3>
-                <form
-                  class="usa-form-group prime-radio__group"
-                >
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="covid-test-result-abc"
@@ -448,7 +447,8 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                     </div>
                   </fieldset>
-                </form>
+                   
+                </div>
                 <div
                   class="prime-test-result-submit"
                 >
@@ -788,9 +788,8 @@ exports[`TestQueue should render the test queue 1`] = `
                 >
                   COVID-19 results
                 </h3>
-                <form
-                  class="usa-form-group prime-radio__group"
-                >
+                <div>
+                   
                   <fieldset
                     class="usa-fieldset prime-radios"
                     id="covid-test-result-def"
@@ -859,7 +858,8 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                     </div>
                   </fieldset>
-                </form>
+                   
+                </div>
                 <div
                   class="prime-test-result-submit"
                 >


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #5060  

## Changes Proposed
- Changes some underlying components' markup from `<div>` to `<form>` where appropriate
- Add some props to switch this on or off dependent on the context the component is called in
- Refactors some component code where appropriate to share UI logic

## Additional Information
- Elisa and I ran the axe checker manually in the relevant pages and got passing results. If someone else can verify though that'd be great!

## Testing
Deployed on dev3 for further testing. 

- If you have access to the axe checker, run it in the following places:
    - The edit patients form - `PersonForm` in the ticket
    - The upload patients form - an extension of the `PersonForm` in the ticket
    - [The Experian auth form (all three screens)](https://dev3.simplereport.gov/app/sign-up) - The `QuestionsForm` and `PersonalDetailsForm` components in the ticket

