### PR TITLE
Support valid unknown response for patient demo info

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -277,10 +277,11 @@ public class Translators {
 
   private static final Map<String, Boolean> YES_NO =
       Map.of("y", true, "yes", true, "n", false, "no", false, "true", true, "false", false);
+  private static final Set<String> UNK = Set.of("unk", "unknown");
 
   public static Boolean parseYesNo(String v) {
     String stringValue = parseString(v);
-    if (stringValue == null) {
+    if (stringValue == null || UNK.contains(stringValue.toLowerCase())) {
       return null;
     }
     Boolean boolValue = YES_NO.get(stringValue.toLowerCase());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -279,7 +279,7 @@ public class Translators {
       Map.of("y", true, "yes", true, "n", false, "no", false, "true", true, "false", false);
   private static final Set<String> UNK = Set.of("unk", "unknown");
 
-  public static Boolean parseYesNo(String v) {
+  public static Boolean parseYesNoUnk(String v) {
     String stringValue = parseString(v);
     if (stringValue == null || UNK.contains(stringValue.toLowerCase())) {
       return null;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -3,7 +3,7 @@ package gov.cdc.usds.simplereport.service;
 import static gov.cdc.usds.simplereport.api.Translators.parsePersonRole;
 import static gov.cdc.usds.simplereport.api.Translators.parsePhoneType;
 import static gov.cdc.usds.simplereport.api.Translators.parseUserShortDate;
-import static gov.cdc.usds.simplereport.api.Translators.parseYesNo;
+import static gov.cdc.usds.simplereport.api.Translators.parseYesNoUnk;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.convertEthnicityToDatabaseValue;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.convertRaceToDatabaseValue;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.convertSexToDatabaseValue;
@@ -127,8 +127,8 @@ public class PatientBulkUploadServiceAsync {
                 convertEthnicityToDatabaseValue(extractedData.getEthnicity().getValue()),
                 null, // tribalAffiliation
                 convertSexToDatabaseValue(extractedData.getBiologicalSex().getValue()),
-                parseYesNo(extractedData.getResidentCongregateSetting().getValue()),
-                parseYesNo(extractedData.getEmployedInHealthcare().getValue()),
+                parseYesNoUnk(extractedData.getResidentCongregateSetting().getValue()),
+                parseYesNoUnk(extractedData.getEmployedInHealthcare().getValue()),
                 null, // preferredLanguage
                 null // testResultDeliveryPreference
                 );

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
@@ -11,7 +11,7 @@ import static gov.cdc.usds.simplereport.api.Translators.parseString;
 import static gov.cdc.usds.simplereport.api.Translators.parseTestResult;
 import static gov.cdc.usds.simplereport.api.Translators.parseUUID;
 import static gov.cdc.usds.simplereport.api.Translators.parseUserShortDate;
-import static gov.cdc.usds.simplereport.api.Translators.parseYesNo;
+import static gov.cdc.usds.simplereport.api.Translators.parseYesNoUnk;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -260,29 +260,32 @@ class TranslatorTest {
   }
 
   @Test
-  void testEmptyParseYesNo() {
-    assertNull(parseYesNo(""));
+  void testEmptyParseYesNoUnk() {
+    assertNull(parseYesNoUnk(""));
   }
 
   @Test
-  void testNullParseYesNo() {
-    assertNull(parseYesNo(null));
+  void testNullParseYesNoUnk() {
+    assertNull(parseYesNoUnk(null));
   }
 
   @Test
-  void testValidParseYesNo() {
-    assertEquals(true, parseYesNo("y"));
-    assertEquals(true, parseYesNo("yEs"));
-    assertEquals(false, parseYesNo("n"));
-    assertEquals(false, parseYesNo("nO"));
+  void testValidParseYesNoUnk() {
+    assertEquals(true, parseYesNoUnk("y"));
+    assertEquals(true, parseYesNoUnk("yEs"));
+    assertEquals(false, parseYesNoUnk("n"));
+    assertEquals(false, parseYesNoUnk("nO"));
+    assertNull(parseYesNoUnk("unknown"));
+    assertNull(parseYesNoUnk("unk"));
+    assertNull(parseYesNoUnk("Unknown"));
   }
 
   @Test
-  void testInvalidParseYesNo() {
+  void testInvalidParseYesNoUnk() {
     assertThrows(
         IllegalGraphqlArgumentException.class,
         () -> {
-          parseYesNo("positive");
+          parseYesNoUnk("positive");
         });
   }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
A user's bulk patient upload is failing - giving them a success message but then sending them an email saying their upload failed. Turns out they are passing values of `Unk` in the `resident_congregate_setting` column. This is valid but our Translator does not support it and throws an exception. I can't think of a workaround that would correctly set the values for these patients to null, so I think it's best to fix the method and merge so they can do the upload.

## Changes Proposed
For patient fields that support Unknown, do not throw an exception and instead set the value to null (this is what we do if the user selects Unknown in the add single patient form).

## Additional Information
* renamed the method to more accurately convey the purpose

## Testing
deployed to `dev6`

## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Changes comply with the SimpleReport Style Guide