### PR TITLE
Track user id or patient link id in Azure

### DIFF
--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -82,11 +82,7 @@ const App = () => {
   useEffect(() => {
     if (!data) return;
 
-    appInsights?.setAuthenticatedUserContext(
-      data.whoami.id,
-      data.whoami.organization?.name,
-      false
-    );
+    appInsights?.setAuthenticatedUserContext(data.whoami.id, "", false);
 
     dispatch(
       setInitialState({

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -82,6 +82,12 @@ const App = () => {
   useEffect(() => {
     if (!data) return;
 
+    appInsights?.setAuthenticatedUserContext(
+      data.whoami.id,
+      data.whoami.organization?.name,
+      false
+    );
+
     dispatch(
       setInitialState({
         dataLoaded: true,

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -82,7 +82,7 @@ const App = () => {
   useEffect(() => {
     if (!data) return;
 
-    appInsights?.setAuthenticatedUserContext(data.whoami.id, "", false);
+    appInsights?.setAuthenticatedUserContext(data.whoami.id, undefined, false);
 
     dispatch(
       setInitialState({

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -105,7 +105,7 @@ const App = () => {
         },
       })
     );
-  }, [data, dispatch]);
+  }, [data, dispatch, appInsights]);
 
   if (loading) {
     return <p>Loading account information...</p>;

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -34,14 +34,24 @@ const createTelemetryService = () => {
     });
 
     appInsights.addTelemetryInitializer(function (envelope) {
-      if (envelope.name === "Ms.Web.PageView") {
-        // @ts-ignore
-        envelope["data"]["baseData"][
-          "url"
-        ] = `${window.location.origin}${window.location.pathname}`;
+      try {
+        const regex = new RegExp("Microsoft.ApplicationInsights.(.*).Pageview");
+
+        if (
+          regex.test(envelope.name) ||
+          // @ts-ignore access to fields
+          envelope["data"]["baseType"] === "PageViewData"
+        ) {
+          // @ts-ignore access to fields
+          envelope["data"]["baseData"][
+            "url"
+          ] = `${window.location.origin}${window.location.pathname}`;
+        }
+      } catch (e) {
+        /* do nothing and don't disrupt logging*/
       }
     });
-    // end of insertion
+
     appInsights.loadAppInsights();
   };
 

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -36,7 +36,9 @@ const createTelemetryService = () => {
     appInsights.addTelemetryInitializer(function (envelope) {
       if (envelope.name === "Ms.Web.PageView") {
         // @ts-ignore
-        envelope?.data.baseData.url = `${window.location.origin}${window.location.pathname}`;
+        envelope["data"]["baseData"][
+          "url"
+        ] = `${window.location.origin}${window.location.pathname}`;
       }
     });
     // end of insertion

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -33,25 +33,6 @@ const createTelemetryService = () => {
       },
     });
 
-    appInsights.addTelemetryInitializer(function (envelope) {
-      try {
-        const regex = new RegExp("Microsoft.ApplicationInsights.(.*).Pageview");
-
-        if (
-          regex.test(envelope.name) ||
-          // @ts-ignore access to fields
-          envelope["data"]["baseType"] === "PageViewData"
-        ) {
-          // @ts-ignore access to fields
-          envelope["data"]["baseData"][
-            "url"
-          ] = `${window.location.origin}${window.location.pathname}`;
-        }
-      } catch (e) {
-        /* do nothing and don't disrupt logging*/
-      }
-    });
-
     appInsights.loadAppInsights();
   };
 

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -50,17 +50,16 @@ const createTelemetryService = () => {
 
         if (
           regexRemoteDependency.test(envelope.name) &&
-          staticFilesToIgnore.includes((envelope as any).data.baseData.name)
+          staticFilesToIgnore.includes((envelope as any).baseData.name)
         ) {
           return false;
         } else if (
           regexPageView.test(envelope.name) ||
-          (envelope as any).data.baseType === "PageViewData"
+          (envelope as any).baseType === "PageViewData"
         ) {
-          console.log("page view envelope:", envelope);
           (
             envelope as any
-          ).data.baseData.url = `${window.location.origin}${window.location.pathname}`;
+          ).baseData.uri = `${window.location.origin}${window.location.pathname}`;
         }
       } catch (e) {
         /* do nothing and don't disrupt logging*/

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -33,6 +33,13 @@ const createTelemetryService = () => {
       },
     });
 
+    appInsights.addTelemetryInitializer(function (envelope) {
+      if (envelope.name === "Ms.Web.PageView") {
+        // @ts-ignore
+        envelope?.data.baseData.url = `${window.location.origin}${window.location.pathname}`;
+      }
+    });
+    // end of insertion
     appInsights.loadAppInsights();
   };
 

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -35,35 +35,7 @@ const createTelemetryService = () => {
     });
 
     appInsights.addTelemetryInitializer(function (envelope: ITelemetryItem) {
-      try {
-        const regexPageView = new RegExp(
-          "Microsoft.ApplicationInsights.(.*).Pageview"
-        );
-        const regexRemoteDependency = new RegExp(
-          "Microsoft.ApplicationInsights.(.*).RemoteDependency"
-        );
-
-        const staticFilesToIgnore = [
-          "GET /maintenance.json",
-          "GET /app/static/commit.txt",
-        ];
-
-        if (
-          regexRemoteDependency.test(envelope.name) &&
-          staticFilesToIgnore.includes((envelope as any).baseData.name)
-        ) {
-          return false;
-        } else if (
-          regexPageView.test(envelope.name) ||
-          (envelope as any).baseType === "PageViewData"
-        ) {
-          (
-            envelope as any
-          ).baseData.uri = `${window.location.origin}${window.location.pathname}`;
-        }
-      } catch (e) {
-        /* do nothing and don't disrupt logging*/
-      }
+      filterStaticFiles(envelope);
     });
 
     appInsights.loadAppInsights();
@@ -74,6 +46,27 @@ const createTelemetryService = () => {
 
 export const ai = createTelemetryService();
 export const getAppInsights = () => appInsights;
+
+export function filterStaticFiles(envelope: ITelemetryItem) {
+  try {
+    const regexRemoteDependency =
+      /Microsoft.ApplicationInsights.(.*).RemoteDependency/;
+
+    const staticFilesToIgnore = [
+      "GET /maintenance.json",
+      "GET /app/static/commit.txt",
+    ];
+
+    if (
+      regexRemoteDependency.test(envelope.name) &&
+      staticFilesToIgnore.includes((envelope as any).baseData.name)
+    ) {
+      return false;
+    }
+  } catch (e) {
+    /* do nothing and don't disrupt logging*/
+  }
+}
 
 const logSeverityMap = {
   log: SeverityLevel.Information,

--- a/frontend/src/app/telemetry.test.tsx
+++ b/frontend/src/app/telemetry.test.tsx
@@ -1,6 +1,14 @@
-import { SeverityLevel } from "@microsoft/applicationinsights-web";
+import {
+  ITelemetryItem,
+  SeverityLevel,
+} from "@microsoft/applicationinsights-web";
 
-import { ai, getAppInsights, withInsights } from "./TelemetryService";
+import {
+  ai,
+  filterStaticFiles,
+  getAppInsights,
+  withInsights,
+} from "./TelemetryService";
 
 jest.mock("@microsoft/applicationinsights-web", () => {
   return {
@@ -10,6 +18,7 @@ jest.mock("@microsoft/applicationinsights-web", () => {
         loadAppInsights() {},
         trackEvent: jest.fn(),
         trackException: jest.fn(),
+        addTelemetryInitializer: jest.fn(),
       };
     },
   };
@@ -84,5 +93,15 @@ describe("telemetry", () => {
         additionalInformation: undefined,
       },
     });
+  });
+
+  it("ignores static files", () => {
+    const item = {
+      name: "Microsoft.ApplicationInsights.mock.RemoteDependency",
+      baseData: {
+        name: "GET /maintenance.json",
+      },
+    } as ITelemetryItem;
+    expect(filterStaticFiles(item)).toEqual(false);
   });
 });

--- a/frontend/src/patientApp/PatientApp.test.tsx
+++ b/frontend/src/patientApp/PatientApp.test.tsx
@@ -1,0 +1,77 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+
+import { getAppInsights } from "../app/TelemetryService";
+
+import PatientApp from "./PatientApp";
+
+jest.mock("../app/TelemetryService", () => ({
+  getAppInsights: jest.fn(),
+  getAppInsightsHeaders: jest.fn(),
+}));
+
+describe("PatientApp", () => {
+  let mockStore: any;
+  let store: any;
+  let setAuthenticatedUserContextMock: any;
+  let clearAuthenticatedUserContextMock: any;
+
+  beforeEach(() => {
+    mockStore = configureStore([]);
+  });
+
+  describe("telemetry", () => {
+    it("does not set the authenticated user context when not given the plid", () => {
+      setAuthenticatedUserContextMock = jest.fn();
+      clearAuthenticatedUserContextMock = jest.fn();
+
+      store = mockStore({
+        testResult: {
+          testEventId: "fake-test-event-id",
+        },
+      });
+      (getAppInsights as jest.Mock).mockImplementation(() => ({
+        setAuthenticatedUserContext: setAuthenticatedUserContextMock,
+        clearAuthenticatedUserContext: clearAuthenticatedUserContextMock,
+      }));
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <PatientApp />
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(clearAuthenticatedUserContextMock).toHaveBeenCalledTimes(0);
+      expect(setAuthenticatedUserContextMock).toHaveBeenCalledTimes(0);
+    });
+
+    it("sets the authenticated user context as the plid when given the plid", () => {
+      setAuthenticatedUserContextMock = jest.fn();
+      store = mockStore({
+        plid: "fake-plid",
+        testResult: {
+          testEventId: "fake-test-event-id",
+        },
+      });
+      (getAppInsights as jest.Mock).mockImplementation(() => ({
+        setAuthenticatedUserContext: setAuthenticatedUserContextMock,
+        clearAuthenticatedUserContext: clearAuthenticatedUserContextMock,
+      }));
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <PatientApp />
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(clearAuthenticatedUserContextMock).toHaveBeenCalledTimes(1);
+      expect(setAuthenticatedUserContextMock).toHaveBeenCalledWith(
+        "fake-plid",
+        undefined,
+        true
+      );
+    });
+  });
+});

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -72,8 +72,6 @@ const PatientApp = () => {
         isPatientApp={true}
       />
     );
-  } else {
-    appInsights?.trackEvent({ name: "PXP page loaded" });
   }
 
   return (

--- a/frontend/src/patientApp/PatientApp.tsx
+++ b/frontend/src/patientApp/PatientApp.tsx
@@ -9,6 +9,7 @@ import { setInitialState } from "../app/store";
 import PageNotFound from "../app/commonComponents/PageNotFound";
 import Alert from "../app/commonComponents/Alert";
 import { getPatientLinkIdFromUrl } from "../app/utils/url";
+import { getAppInsights } from "../app/TelemetryService";
 
 import PatientHeader from "./PatientHeader";
 import TermsOfService from "./timeOfTest/TermsOfService";
@@ -35,18 +36,24 @@ const PatientLinkURL404Wrapper: FunctionComponent<WrapperProps> = ({
 
 const PatientApp = () => {
   const { t } = useTranslation();
+  const appInsights = getAppInsights();
   const dispatch = useDispatch();
   const plid = useSelector((state: any) => state.plid);
   const testResult = useSelector((state: any) => state.testResult);
   const auth = !!testResult.testEventId;
 
   useEffect(() => {
+    if (typeof plid === "string") {
+      appInsights?.clearAuthenticatedUserContext();
+      appInsights?.setAuthenticatedUserContext(plid, undefined, true);
+    }
+
     dispatch(
       setInitialState({
         plid: getPatientLinkIdFromUrl(),
       })
     );
-  });
+  }, [plid, dispatch, appInsights]);
 
   if (!isValidUUID(plid)) {
     return (
@@ -65,6 +72,8 @@ const PatientApp = () => {
         isPatientApp={true}
       />
     );
+  } else {
+    appInsights?.trackEvent({ name: "PXP page loaded" });
   }
 
   return (


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5125 
Co-authored by @johanna-skylight 

## Changes Proposed
In a field called `userAuthenticatedId` in Azure, we will now be able to store a `api_user`'s `internal_id` (if using the SimpleReport app) or the `patient_link`'s `internal_id` (if using the patient experience app).

## Additional Information
- For testing purposes, I have deployed [commit 705a29b1](https://github.com/CDCgov/prime-simplereport/pull/5324/commits/705a29b163181a6831e040e3d451d9439ec9ce63) 
- But for the sake of the PR, I have [removed the PXP tracking event](https://github.com/CDCgov/prime-simplereport/pull/5324/commits/42e1b32bbce9c11154cf5b23cd446e29a9842269) until we know exactly what events we want to track
- Thank you, Johanna, for the big lift on this and doing all the initial research and implementation to get this going 🙌 😸 

## Testing
Please test on dev2
**In app**
- Make sure to not have any ad blockers enabled or anything of that sort for testing 😅 
- Get a link to a patient's test result and visit their pxp page.
- Perform an action in-app that results in tracking (e.g. starting the timer on the test queue card, clicking "What's new", etc...)

**Azure**
1. Go to ["Logs" tab for dev2's application insights](https://portal.azure.com/#@cdc.onmicrosoft.com/resource/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-dev/providers/Microsoft.Insights/components/prime-simple-report-dev2-insights/logs)
2. Run the following query for pxp tracking event:
`customEvents
| where name has "Pxp page loaded"`
3. Ensure when you expand the result (it may take a couple minutes to register) you see a field called `user_AuthenticatedId` with the correct `plid`
4. Try steps 2-3 with a different query and check the `user_AuthenticatedId` matches with your user id

## Screenshots / Demos
<img width="1114" alt="Screen Shot 2023-02-23 at 16 42 31" src="https://user-images.githubusercontent.com/20211771/221050169-17da29c4-4a6b-4a7a-b5dd-8d4a22a0de63.png">

<img width="723" alt="Screen Shot 2023-02-23 at 17 00 16" src="https://user-images.githubusercontent.com/20211771/221050212-46055d64-bb45-4fa1-8bc9-00cd6b7db3fa.png">


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
