### PR TITLE
remove DeviceSpecimenType from DeviceTypeService

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeNewRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceSpecimenTypeNewRepository.java
@@ -9,4 +9,6 @@ public interface DeviceSpecimenTypeNewRepository
     extends CrudRepository<DeviceTypeSpecimenTypeMapping, UUID> {
 
   List<DeviceTypeSpecimenTypeMapping> findAllByDeviceTypeIdIn(Iterable<UUID> uuids);
+
+  List<DeviceTypeSpecimenTypeMapping> findAllByDeviceTypeId(UUID uuid);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -5,12 +5,12 @@ import gov.cdc.usds.simplereport.api.model.SupportedDiseaseTestPerformedInput;
 import gov.cdc.usds.simplereport.api.model.UpdateDeviceType;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
-import gov.cdc.usds.simplereport.db.model.DeviceSpecimenType;
 import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
@@ -35,7 +35,7 @@ public class DeviceTypeService {
   public static final String SWAB_TYPE_DELETED_MESSAGE =
       "swab type has been deleted and cannot be used";
   private final DeviceTypeRepository deviceTypeRepository;
-  private final DeviceSpecimenTypeRepository deviceSpecimenTypeRepository;
+  private final DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
   private final SpecimenTypeRepository specimenTypeRepository;
   private final SupportedDiseaseRepository supportedDiseaseRepository;
 
@@ -94,25 +94,28 @@ public class DeviceTypeService {
             }
           });
 
-      List<DeviceSpecimenType> newDeviceSpecimenTypes =
+      List<DeviceTypeSpecimenTypeMapping> newDeviceSpecimenTypes =
           updatedSpecimenTypes.stream()
-              .map(specimenType -> new DeviceSpecimenType(device, specimenType))
+              .map(
+                  specimenType ->
+                      new DeviceTypeSpecimenTypeMapping(
+                          device.getInternalId(), specimenType.getInternalId()))
               .collect(Collectors.toList());
 
-      List<DeviceSpecimenType> exitingDeviceSpecimenTypes =
-          deviceSpecimenTypeRepository.findAllByDeviceType(device);
+      List<DeviceTypeSpecimenTypeMapping> exitingDeviceSpecimenTypes =
+          deviceSpecimenTypeNewRepository.findAllByDeviceTypeId(device.getInternalId());
 
       // delete old ones
-      ArrayList<DeviceSpecimenType> toBeDeletedDeviceSpecimenTypes =
+      ArrayList<DeviceTypeSpecimenTypeMapping> toBeDeletedDeviceSpecimenTypes =
           new ArrayList<>(exitingDeviceSpecimenTypes);
       toBeDeletedDeviceSpecimenTypes.removeAll(newDeviceSpecimenTypes);
-      deviceSpecimenTypeRepository.deleteAll(toBeDeletedDeviceSpecimenTypes);
+      deviceSpecimenTypeNewRepository.deleteAll(toBeDeletedDeviceSpecimenTypes);
 
       // create new ones
-      ArrayList<DeviceSpecimenType> toBeAddedDeviceSpecimenTypes =
+      ArrayList<DeviceTypeSpecimenTypeMapping> toBeAddedDeviceSpecimenTypes =
           new ArrayList<>(newDeviceSpecimenTypes);
       toBeAddedDeviceSpecimenTypes.removeAll(exitingDeviceSpecimenTypes);
-      deviceSpecimenTypeRepository.saveAll(toBeAddedDeviceSpecimenTypes);
+      deviceSpecimenTypeNewRepository.saveAll(toBeAddedDeviceSpecimenTypes);
     }
     if (updateDevice.getSupportedDiseaseTestPerformed() != null) {
       var deviceTestPerformedLoincCodeList =
@@ -163,8 +166,10 @@ public class DeviceTypeService {
                 createDevice.getTestLength()));
 
     specimenTypes.stream()
-        .map(specimenType -> new DeviceSpecimenType(dt, specimenType))
-        .forEach(deviceSpecimenTypeRepository::save);
+        .map(
+            specimenType ->
+                new DeviceTypeSpecimenTypeMapping(dt.getInternalId(), specimenType.getInternalId()))
+        .forEach(deviceSpecimenTypeNewRepository::save);
 
     if (createDevice.getSupportedDiseaseTestPerformed() != null) {
       var deviceTestPerformedLoincCodeList =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 class FacilityRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private DeviceTypeRepository _devices;
-  @Autowired private DeviceSpecimenTypeRepository _deviceSpecimens;
   @Autowired private SpecimenTypeRepository _specimens;
   @Autowired private ProviderRepository _providers;
   @Autowired private OrganizationRepository _orgs;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -16,7 +16,7 @@ import gov.cdc.usds.simplereport.api.model.UpdateDeviceType;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
-import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTestPerformedLoincCodeRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
@@ -53,7 +53,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     this.deviceTypeServiceWithMock =
         new DeviceTypeService(
             _deviceTypeRepoMock,
-            mock(DeviceSpecimenTypeRepository.class),
+            mock(DeviceSpecimenTypeNewRepository.class),
             mock(SpecimenTypeRepository.class),
             mock(SupportedDiseaseRepository.class));
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #3352

## Changes Proposed

- Replace `DeviceSpecimenType` with `DeviceTypeSpecimenTypeMapping` in `DeviceTypeService`
- Replace `DeviceSpecimenTypeRepository` with `DeviceSpecimenTypeNewRepository` in `DeviceTypeService`

## Additional Information

- `DeviceSpecimenType` represents a join table, and incorrectly labeled as auditable/soft deleteable

## Testing

- How should reviewers verify this PR? deployed on dev6

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->