### PR TITLE
upgrade okta and pagerduty providers

### DIFF
--- a/ops/demo/persistent/_config.tf
+++ b/ops/demo/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev/persistent/_config.tf
+++ b/ops/dev/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev2/persistent/_config.tf
+++ b/ops/dev2/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev3/persistent/_config.tf
+++ b/ops/dev3/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev4/persistent/_config.tf
+++ b/ops/dev4/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev5/persistent/_config.tf
+++ b/ops/dev5/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev6/persistent/_config.tf
+++ b/ops/dev6/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/dev7/persistent/_config.tf
+++ b/ops/dev7/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/global/_config.tf
+++ b/ops/global/_config.tf
@@ -12,11 +12,11 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "~> 2.1"
+      version = "~> 2.11"
     }
   }
   required_version = "~> 1.3.3"

--- a/ops/pentest/persistent/_config.tf
+++ b/ops/pentest/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/prod/persistent/_config.tf
+++ b/ops/prod/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/services/okta-app/_config.tf
+++ b/ops/services/okta-app/_config.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     okta = {
-      source = "okta/okta"
+      source  = "okta/okta"
+      version = "~> 3.42"
     }
   }
   required_version = "~> 1.3.3"

--- a/ops/services/okta-global/_config.tf
+++ b/ops/services/okta-global/_config.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     okta = {
-      source = "okta/okta"
+      source  = "okta/okta"
+      version = "~> 3.42"
     }
   }
   required_version = "~> 1.3.3"

--- a/ops/services/okta-global/main.tf
+++ b/ops/services/okta-global/main.tf
@@ -42,6 +42,7 @@ resource "okta_policy_signon" "mfa_require" {
 }
 
 # We recieve an error when attempting to import this resource.
+# This may get deleted in the future.
 resource "okta_policy_rule_signon" "app_mfa" {
   policy_id          = okta_policy_signon.mfa_require.id
   name               = "simple-report-mfa-require"

--- a/ops/services/pagerduty/_config.tf
+++ b/ops/services/pagerduty/_config.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     pagerduty = {
-      source = "pagerduty/pagerduty"
+      source  = "pagerduty/pagerduty"
+      version = "~> 2.11"
     }
   }
   required_version = "~> 1.3.3"

--- a/ops/stg/persistent/_config.tf
+++ b/ops/stg/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/test/persistent/_config.tf
+++ b/ops/test/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"

--- a/ops/training/persistent/_config.tf
+++ b/ops/training/persistent/_config.tf
@@ -12,7 +12,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = "~> 3.39"
+      version = "~> 3.42"
     }
     random = {
       version = "~> 3.4"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #5330
- resolves #5331

## Changes Proposed

- Sets the version for Okta at 3.42
- Sets the version for Pagerduty at 2.11

## Additional Information

## Testing

- Check the tf plan. :smile: 

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
