### PR TITLE
Add org name to pending org action buttons

### DIFF
--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -209,6 +209,7 @@ const PendingOrganizations = ({
         <td className="verify-button-container">
           <Button
             className="sr-pending-org-edit-verify"
+            ariaLabel={`Edit or verify ${o.name}`}
             onClick={() => {
               setOrgToVerify(o);
             }}
@@ -219,7 +220,7 @@ const PendingOrganizations = ({
         <td>
           <button
             className="sr-pending-org-delete-button"
-            aria-label="delete organization"
+            aria-label={`Delete ${o.name}`}
             data-testid="delete-org-button"
             onClick={() => {
               setOrgToDelete(o);


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5130 

## Changes Proposed
- Adds the pending org's name for the "Edit/Verify" button and the trash icon on the pending organization page (`/admin/pending-organizations`)

## Additional Information
N/A

## Testing
Use VoiceOver or another screen reader to ensure that when navigating to the "Edit/Verify" button and trash icon for the pending organization row that the pending organization's name is given.

## Screenshots / Demos

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
