### PR TITLE
Add page titles to test results bulk upload

### DIFF
--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
@@ -8,6 +8,7 @@ import { getAppInsights } from "../../TelemetryService";
 import CsvSchemaDocumentation, {
   CsvSchemaDocumentationItem,
   CsvSchemaItem,
+  getPageTitle,
 } from "./CsvSchemaDocumentation";
 
 jest.mock("../../TelemetryService", () => ({
@@ -174,6 +175,28 @@ describe("CsvSchemaDocumentation tests", () => {
       expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
         name: "Download spreadsheet template",
       });
+    });
+  });
+
+  describe("getPageTitle", () => {
+    it("returns the default bulk results upload guide page title", () => {
+      const currentUrl = "/app/results/upload/submit/guide";
+      expect(getPageTitle(currentUrl)).toBe(
+        "Bulk results upload guide | SimpleReport"
+      );
+    });
+    it("returns 'formatting guidelines' in the page title when on guidelines section", () => {
+      const currentUrl =
+        "/app/results/upload/submit/guide#formatting-guidelines";
+      expect(getPageTitle(currentUrl)).toBe(
+        "Bulk results upload guide - formatting guidelines | SimpleReport"
+      );
+    });
+    it("returns 'preparing upload' in the page title when on preparing upload section", () => {
+      const currentUrl = "/app/results/upload/submit/guide#preparing-upload";
+      expect(getPageTitle(currentUrl)).toBe(
+        "Bulk results upload guide - preparing upload | SimpleReport"
+      );
     });
   });
 });

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
@@ -180,21 +180,20 @@ describe("CsvSchemaDocumentation tests", () => {
 
   describe("getPageTitle", () => {
     it("returns the default bulk results upload guide page title", () => {
-      const currentUrl = "/app/results/upload/submit/guide";
-      expect(getPageTitle(currentUrl)).toBe(
+      const hash = "";
+      expect(getPageTitle(hash)).toBe(
         "Bulk results upload guide | SimpleReport"
       );
     });
     it("returns 'formatting guidelines' in the page title when on guidelines section", () => {
-      const currentUrl =
-        "/app/results/upload/submit/guide#formatting-guidelines";
-      expect(getPageTitle(currentUrl)).toBe(
+      const hash = "#formatting-guidelines";
+      expect(getPageTitle(hash)).toBe(
         "Bulk results upload guide - formatting guidelines | SimpleReport"
       );
     });
     it("returns 'preparing upload' in the page title when on preparing upload section", () => {
-      const currentUrl = "/app/results/upload/submit/guide#preparing-upload";
-      expect(getPageTitle(currentUrl)).toBe(
+      const hash = "#preparing-upload";
+      expect(getPageTitle(hash)).toBe(
         "Bulk results upload guide - preparing upload | SimpleReport"
       );
     });

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -1,5 +1,6 @@
+import { useEffect } from "react";
+
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
-import { useDocumentTitle } from "../../utils/hooks";
 import iconSprite from "../../../../node_modules/uswds/dist/img/sprite.svg";
 import "./CsvSchemaDocumentation.scss";
 import { getAppInsights } from "../../TelemetryService";
@@ -136,9 +137,24 @@ export const CsvSchemaDocumentationItem: React.FC<CsvSchemaItemProps> = ({
   );
 };
 
+export function getPageTitle(currentUrl: string) {
+  let srPageTitle = " | SimpleReport";
+  let bulkResultsPageTitle = "Bulk results upload guide";
+  if (currentUrl.includes("#formatting-guidelines")) {
+    return bulkResultsPageTitle + " - formatting guidelines" + srPageTitle;
+  } else if (currentUrl.includes("#preparing-upload")) {
+    return bulkResultsPageTitle + " - preparing upload" + srPageTitle;
+  } else {
+    return bulkResultsPageTitle + srPageTitle;
+  }
+}
+
 /* eslint-disable jsx-a11y/anchor-has-content */
 const CsvSchemaDocumentation = () => {
-  useDocumentTitle("Bulk results upload guide");
+  useEffect(() => {
+    let currentUrl = window.location.href;
+    document.title = getPageTitle(currentUrl);
+  });
 
   const appInsights = getAppInsights();
 

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -151,10 +151,11 @@ export function getPageTitle(currentUrl: string) {
 
 /* eslint-disable jsx-a11y/anchor-has-content */
 const CsvSchemaDocumentation = () => {
+  let currentUrl = window.location.href;
+  let pageTitle = getPageTitle(currentUrl);
   useEffect(() => {
-    let currentUrl = window.location.href;
-    document.title = getPageTitle(currentUrl);
-  }, [window.location.href, getPageTitle]);
+    document.title = pageTitle;
+  }, [pageTitle]);
 
   const appInsights = getAppInsights();
 

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -154,7 +154,7 @@ const CsvSchemaDocumentation = () => {
   useEffect(() => {
     let currentUrl = window.location.href;
     document.title = getPageTitle(currentUrl);
-  });
+  }, [window.location.href, getPageTitle]);
 
   const appInsights = getAppInsights();
 

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
 import iconSprite from "../../../../node_modules/uswds/dist/img/sprite.svg";
@@ -137,13 +138,13 @@ export const CsvSchemaDocumentationItem: React.FC<CsvSchemaItemProps> = ({
   );
 };
 
-export function getPageTitle(currentUrl: string) {
+export function getPageTitle(hash: string) {
   let srPageTitle = " | SimpleReport";
   let bulkResultsPageTitle = "Bulk results upload guide";
-  if (currentUrl.includes("#formatting-guidelines")) {
-    return bulkResultsPageTitle + " - formatting guidelines" + srPageTitle;
-  } else if (currentUrl.includes("#preparing-upload")) {
+  if (hash === "#preparing-upload") {
     return bulkResultsPageTitle + " - preparing upload" + srPageTitle;
+  } else if (hash === "#formatting-guidelines") {
+    return bulkResultsPageTitle + " - formatting guidelines" + srPageTitle;
   } else {
     return bulkResultsPageTitle + srPageTitle;
   }
@@ -151,11 +152,12 @@ export function getPageTitle(currentUrl: string) {
 
 /* eslint-disable jsx-a11y/anchor-has-content */
 const CsvSchemaDocumentation = () => {
-  let currentUrl = window.location.href;
-  let pageTitle = getPageTitle(currentUrl);
+  let location = useLocation();
+  let locationHash = location.hash;
+  let pageTitle = getPageTitle(locationHash);
   useEffect(() => {
     document.title = pageTitle;
-  }, [pageTitle]);
+  }, [location, pageTitle]);
 
   const appInsights = getAppInsights();
 

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookupContainer.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookupContainer.tsx
@@ -3,10 +3,12 @@ import {
   useGetDeviceTypesForLookupQuery,
 } from "../../../generated/graphql";
 import { LoadingCard } from "../../commonComponents/LoadingCard/LoadingCard";
+import { useDocumentTitle } from "../../utils/hooks";
 
 import DeviceLookup from "./DeviceLookup";
 
 const DeviceLookupContainer = () => {
+  useDocumentTitle("Device code lookup");
   const { data: deviceTypeResults } = useGetDeviceTypesForLookupQuery({
     fetchPolicy: "no-cache",
   });


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5132 

## Changes Proposed
This PR updates the test result bulk upload guide page titles

path | new title
-- | --
/app/results/upload/submit/guide | Bulk results upload guide \| SimpleReport
/app/results/upload/submit/guide#formatting-guidelines | Bulk results upload guide - formatting guidelines \| SimpleReport
/app/results/upload/submit/guide#preparing-upload | Bulk results upload guide - preparing upload \| SimpleReport
/app/results/submit/code-lookup | Device code lookup \| SimpleReport

## Additional Information
This wasn't explicitly stated in the ticket but for the `/app/results/upload/submit/guide` url, I set the page title to "Bulk results upload guide | SimpleReport" as the default option

## Testing
Deployed to dev5
Check the above URLs that they have the correct page titles

## Screenshots / Demos


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
