### PR TITLE
Removed simple report redundant text from sign up page titles

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/Consent.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Consent.tsx
@@ -15,7 +15,7 @@ const Consent = () => {
   const { orgExternalId, firstName, middleName, lastName } =
     (useLocation().state as PersonalDetailsFormProps) || {};
   const [submitted, setSubmitted] = useState(false);
-  useDocumentTitle("Sign up - identity verification consent | SimpleReport");
+  useDocumentTitle("Sign up - identity verification consent");
 
   if (!orgExternalId || !firstName || !lastName) {
     return <Navigate to="/sign-up" />;

--- a/frontend/src/app/signUp/IdentityVerification/NextSteps.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/NextSteps.tsx
@@ -3,7 +3,7 @@ import { CardBackground } from "../../commonComponents/CardBackground/CardBackgr
 import { useDocumentTitle } from "../../utils/hooks";
 
 const NextSteps = () => {
-  useDocumentTitle("Sign up - schedule call | SimpleReport");
+  useDocumentTitle("Sign up - schedule call");
 
   return (
     <CardBackground>

--- a/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/PersonalDetailsForm.tsx
@@ -53,7 +53,7 @@ const PersonalDetailsForm = ({
   const [saving, setSaving] = useState(false);
   const [formChanged, setFormChanged] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  useDocumentTitle("Sign up - personal details | SimpleReport");
+  useDocumentTitle("Sign up - personal details");
 
   const onDetailChange =
     (field: keyof IdentityVerificationRequest) =>

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsForm.tsx
@@ -38,7 +38,7 @@ const QuestionsForm: React.FC<Props> = ({
   timeToComplete,
   disableTimer,
 }) => {
-  useDocumentTitle("Sign up - identity verification | SimpleReport");
+  useDocumentTitle("Sign up - identity verification");
   const [answers, setAnswers] = useState<Nullable<Answers>>(
     initAnswers(questionSet)
   );

--- a/frontend/src/app/signUp/IdentityVerification/Success.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/Success.tsx
@@ -12,7 +12,7 @@ const Success: React.FC<Props> = ({ email, activationToken }) => {
   const activationLink = activationToken
     ? `${process.env.PUBLIC_URL}/uac/?activationToken=${activationToken}`
     : null;
-  useDocumentTitle("Sign up - success | SimpleReport");
+  useDocumentTitle("Sign up - success");
 
   return (
     <CardBackground>

--- a/frontend/src/app/signUp/Organization/OrganizationForm.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.tsx
@@ -59,7 +59,7 @@ const OrganizationForm = () => {
   const [loading, setLoading] = useState(false);
   const [formChanged, setFormChanged] = useState(false);
   const [orgExternalId, setOrgExternalId] = useState("");
-  useDocumentTitle("Sign up - organization information | SimpleReport");
+  useDocumentTitle("Sign up - organization information");
 
   const onDetailChange =
     (field: keyof OrganizationCreateRequest) =>

--- a/frontend/src/app/signUp/Organization/RequestAccess.tsx
+++ b/frontend/src/app/signUp/Organization/RequestAccess.tsx
@@ -3,7 +3,7 @@ import { CardBackground } from "../../commonComponents/CardBackground/CardBackgr
 import { useDocumentTitle } from "../../utils/hooks";
 
 const RequestAccess = () => {
-  useDocumentTitle("Request access | SimpleReport");
+  useDocumentTitle("Request access");
 
   return (
     <CardBackground>

--- a/frontend/src/app/signUp/Organization/RequestTestResult.tsx
+++ b/frontend/src/app/signUp/Organization/RequestTestResult.tsx
@@ -3,7 +3,7 @@ import { CardBackground } from "../../commonComponents/CardBackground/CardBackgr
 import { useDocumentTitle } from "../../utils/hooks";
 
 const RequestTestResult = () => {
-  useDocumentTitle("Get COVID-19 test results | SimpleReport");
+  useDocumentTitle("Get COVID-19 test results");
 
   return (
     <CardBackground>

--- a/frontend/src/app/signUp/Organization/SignUpGoals.tsx
+++ b/frontend/src/app/signUp/Organization/SignUpGoals.tsx
@@ -16,7 +16,7 @@ const SignUpGoals = () => {
   const [submitted, setSubmitted] = useState(false);
   const [signUpGoal, setSignUpGoal] = useState("");
   const [signUpGoalError, setSignUpGoalError] = useState("");
-  useDocumentTitle("Sign up - select status | SimpleReport");
+  useDocumentTitle("Sign up - select status");
 
   if (submitted) {
     switch (signUpGoal) {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5056 

## Changes Proposed

- Remove text `| Simple Report` from the titles of all pages used in the sign up flows

## Testing

- Verify that the page titles for all 4 pages in the sign up flow do not display the `| Simple Report` test twice.

