### PR TITLE
Johanna/fixes apollo client upgrade

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "node": "18"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.2",
+    "@apollo/client": "^3.7.9",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.test.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.test.tsx
@@ -1,13 +1,66 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import ReactDOM from "react-dom";
+
+import {
+  GetFacilityResultsForCsvWithCountDocument,
+} from "../../generated/graphql";
 
 import { DownloadResultsCsvModal } from "./DownloadResultsCsvModal";
 
 const mockFacilityID = "b0d2041f-93c9-4192-b19a-dd99c0044a7e";
+const graphqlMocks = [
+  {
+    request: {
+      variables: {
+        facilityId: "b0d2041f-93c9-4192-b19a-dd99c0044a7e",
+        pageNumber: 0,
+        pageSize: 1,
+      },
+      query: GetFacilityResultsForCsvWithCountDocument,
+      fetchPolicy: "no-cache",
+    },
+    result: {
+      data: {
+        testResultsPage: {
+          content: [
+            {
+              facility: {
+                name: "1677594642-Russel - Mann",
+                isDeleted: null,
+                __typename: "Facility",
+              },
+              dateTested: "2023-02-28T14:35:13.975Z",
+              dateUpdated: "2023-02-28T14:35:13.975Z",
+              results: [
+                {
+                  disease: { name: "COVID-19", __typename: "SupportedDisease" },
+                  testResult: "UNDETERMINED",
+                  __typename: "MultiplexResult",
+                },
+              ],
+              correctionStatus: "ORIGINAL",
+              reasonForCorrection: null,
+              deviceType: {
+                name: "Abbott IDNow",
+                manufacturer: "Abbott",
+                model: "ID Now",
+                swabType: "445297001",
+                __typename: "DeviceType",
+              },
+            },
+          ],
+          totalElements: 1,
+        },
+      },
+    },
+  },
+];
 
 describe("DownloadResultsCsvModal with no filters and under 20k results", () => {
   let component: any;
+
+  const closeModalMock = jest.fn();
 
   beforeEach(() => {
     ReactDOM.createPortal = jest.fn((element, _node) => {
@@ -15,11 +68,11 @@ describe("DownloadResultsCsvModal with no filters and under 20k results", () => 
     }) as any;
 
     component = render(
-      <MockedProvider mocks={[]}>
+      <MockedProvider mocks={graphqlMocks}>
         <DownloadResultsCsvModal
           filterParams={{}}
           modalIsOpen={true}
-          closeModal={() => {}}
+          closeModal={closeModalMock}
           totalEntries={1}
           activeFacilityId={mockFacilityID}
         />
@@ -46,6 +99,9 @@ describe("DownloadResultsCsvModal with no filters and under 20k results", () => 
     expect(
       await screen.findByLabelText("Download test results")
     ).toHaveTextContent("The CSV file will include 1 row");
+
+    fireEvent.click(screen.getByRole("button", { name: /download results/i }));
+    expect(closeModalMock).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.test.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.test.tsx
@@ -2,9 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import ReactDOM from "react-dom";
 
-import {
-  GetFacilityResultsForCsvWithCountDocument,
-} from "../../generated/graphql";
+import { GetFacilityResultsForCsvWithCountDocument } from "../../generated/graphql";
 
 import { DownloadResultsCsvModal } from "./DownloadResultsCsvModal";
 

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -32,7 +32,6 @@ export const DownloadResultsCsvModal = ({
   activeFacilityId,
 }: DownloadResultsCsvModalProps) => {
   const rowsMaxLimit = 20000;
-  const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<any[]>([]);
   const csvLink = useRef<
     CSVLink & HTMLAnchorElement & { link: HTMLAnchorElement }
@@ -60,7 +59,7 @@ export const DownloadResultsCsvModal = ({
     ...filterParams,
   };
 
-  const [downloadTestResultsQuery] =
+  const [downloadTestResultsQuery, { loading }] =
     useGetFacilityResultsForCsvWithCountLazyQuery({
       variables,
       fetchPolicy: "no-cache",
@@ -76,16 +75,13 @@ export const DownloadResultsCsvModal = ({
         multiplexEnabled
       );
       setResults(csvResults);
-      setLoading(false);
     } else {
       showError("Unknown error downloading results");
-      setLoading(false);
     }
   };
 
   const handleError = (error: ApolloError) => {
     showError("Error downloading results", error.message);
-    setLoading(false);
   };
 
   // triggers the download of the file only after the csv data has been properly set
@@ -165,10 +161,7 @@ export const DownloadResultsCsvModal = ({
               label={disableDownload ? "Go back" : "No, go back"}
             />
             <Button
-              onClick={async () => {
-                setLoading(true);
-                await downloadTestResultsQuery();
-              }}
+              onClick={() => downloadTestResultsQuery()}
               disabled={disableDownload}
               icon={faDownload}
               label={loading ? "Loading..." : "Download results"}

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -92,7 +92,7 @@ export const DownloadResultsCsvModal = ({
   useEffect(() => {
     csvLink?.current?.link.click();
     closeModal();
-  }, [results]);
+  }, [results]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const pluralizeRows = (entriesCount: number) => {
     return entriesCount > 1 ? "s" : "";

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -1,16 +1,16 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Modal from "react-modal";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CSVLink } from "react-csv";
 import { useFeature } from "flagged";
+import { ApolloError } from "@apollo/client";
 
 import { showError } from "../utils/srToast";
-import { useImperativeQuery } from "../utils/hooks";
 import { parseDataForCSV } from "../utils/testResultCSV";
 import Button from "../commonComponents/Button/Button";
 import {
-  GetFacilityResultsForCsvWithCountDocument,
+  useGetFacilityResultsForCsvWithCountLazyQuery,
   GetFacilityResultsForCsvWithCountQuery,
 } from "../../generated/graphql";
 
@@ -60,32 +60,39 @@ export const DownloadResultsCsvModal = ({
     ...filterParams,
   };
 
-  const getResults = useImperativeQuery<GetFacilityResultsForCsvWithCountQuery>(
-    GetFacilityResultsForCsvWithCountDocument,
-    {
+  const [downloadTestResultsQuery] =
+    useGetFacilityResultsForCsvWithCountLazyQuery({
+      variables,
       fetchPolicy: "no-cache",
-    }
-  );
+      onCompleted: (data: GetFacilityResultsForCsvWithCountQuery) =>
+        handleComplete(data),
+      onError: (error: ApolloError) => handleError(error),
+    });
 
-  const downloadResults = async () => {
-    const { data, error } = await getResults(variables);
-    if (error) {
-      showError("Error downloading results", error.message);
-      setLoading(false);
-    } else if (data.testResultsPage && data.testResultsPage.content) {
+  const handleComplete = (data: GetFacilityResultsForCsvWithCountQuery) => {
+    if (data.testResultsPage && data.testResultsPage.content) {
       const csvResults = parseDataForCSV(
         data.testResultsPage.content,
         multiplexEnabled
       );
       setResults(csvResults);
       setLoading(false);
-      csvLink?.current?.link.click();
-      closeModal();
     } else {
       showError("Unknown error downloading results");
       setLoading(false);
     }
   };
+
+  const handleError = (error: ApolloError) => {
+    showError("Error downloading results", error.message);
+    setLoading(false);
+  };
+
+  // triggers the download of the file only after the csv data has been properly set
+  useEffect(() => {
+    csvLink?.current?.link.click();
+    closeModal();
+  }, [results]);
 
   const pluralizeRows = (entriesCount: number) => {
     return entriesCount > 1 ? "s" : "";
@@ -160,7 +167,7 @@ export const DownloadResultsCsvModal = ({
             <Button
               onClick={async () => {
                 setLoading(true);
-                downloadResults();
+                await downloadTestResultsQuery();
               }}
               disabled={disableDownload}
               icon={faDownload}

--- a/frontend/src/app/utils/hooks.tsx
+++ b/frontend/src/app/utils/hooks.tsx
@@ -1,10 +1,3 @@
-import {
-  DocumentNode,
-  OperationVariables,
-  QueryHookOptions,
-  QueryResult,
-  useQuery,
-} from "@apollo/client";
 import React, { useEffect, useRef } from "react";
 
 const useOutsideClick = (
@@ -46,31 +39,4 @@ const useDocumentTitle = (title: string, retainOnUnmount = false) => {
   }, [retainOnUnmount, title]);
 };
 
-/**
- * Small wrapper around `useQuery` so that we can use it imperatively.
- *
- * @see Credit: https://github.com/apollographql/react-apollo/issues/3499#issuecomment-610649667
- *
- * @example
- * const callQuery = useImperativeQuery(query, options)
- * const handleClick = async () => {
- *   const{ data, error } = await callQuery()
- * }
- */
-function useImperativeQuery<TData = any, TVariables = OperationVariables>(
-  query: DocumentNode,
-  options: QueryHookOptions<TData, TVariables> = {}
-): QueryResult<TData, TVariables>["refetch"] {
-  const { refetch } = useQuery<TData, TVariables>(query, {
-    ...options,
-    skip: true,
-  });
-
-  const imperativelyCallQuery = (queryVariables: TVariables) => {
-    return refetch(queryVariables);
-  };
-
-  return imperativelyCallQuery;
-}
-
-export { useOutsideClick, useDocumentTitle, useImperativeQuery };
+export { useOutsideClick, useDocumentTitle };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2103,10 +2103,15 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
-"@graphql-typed-document-node/core@3.1.1", "@graphql-typed-document-node/core@^3.1.1":
+"@graphql-typed-document-node/core@3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.2.tgz#6fc464307cbe3c8ca5064549b806360d84457b04"
+  integrity sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -18518,10 +18523,15 @@ tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.4.1, tslib@~2.4.0:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.4.1, tslib@~2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@^2.1.0, tslib@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@~2.0.1:
   version "2.0.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -24,10 +24,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apollo/client@^3.7.0", "@apollo/client@^3.7.2":
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.3.tgz#ab3fe31046e74bc1a3762363a185ba5bcfffc58b"
-  integrity sha512-nzZ6d6a4flLpm3pZOGpuAUxLlp9heob7QcCkyIqZlCLvciUibgufRfYTwfkWCc4NaGHGSZyodzvfr79H6oUwGQ==
+"@apollo/client@^3.7.0", "@apollo/client@^3.7.9":
+  version "3.7.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.9.tgz#459454dc4a7c81adaa66e13e626ce41f633dc862"
+  integrity sha512-YnJvrJOVWrp4y/zdNvUaM8q4GuSHCEIecsRDTJhK/veT33P/B7lfqGJ24NeLdKMj8tDEuXYF7V0t+th4+rgC+Q==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.7.0"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves a dependabot upgrade that needed code changes and fixes some weird behavior in the csv download logic

## Changes Proposed

- Upgrade `apollo-client` dependency
- Refactor logic in the csv download to not depend on a custom wrapper to trigger lazy queries and use the `lazyQuery` method in apollo client and `useEffect` combo instead
- Remove the `useImperativeQuery` wrapper that had typescript issues with the latest apollo client version and that was not strictly necessary for the csv download logic

## Additional Information
All axe checks are passing

## Testing
_I have manually tested this in Dev5_

- Verify that the csv file downloads correctly with and without filter params

