### PR TITLE
Added logic to the dropdown component so aria-selected gets set in option elements

### DIFF
--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -138,7 +138,7 @@ export const Analytics = (props: Props) => {
           <div id="analytics-page">
             <div className="prime-container padding-3">
               <div className="grid-row grid-gap">
-                <div className="grid-col-4">
+                <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
                   <Dropdown
                     label="Testing facility"
                     options={[
@@ -156,7 +156,7 @@ export const Analytics = (props: Props) => {
                   />
                 </div>
                 {/* TODO: filter by patient role */}
-                <div className="grid-col-4">
+                <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
                   <Dropdown
                     label="Date range"
                     options={[
@@ -184,7 +184,7 @@ export const Analytics = (props: Props) => {
               </div>
               {dateRange === "custom" && (
                 <div className="grid-row grid-gap margin-top-2">
-                  <div className="grid-col-4">
+                  <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
                     <label className={classNames("usa-label")}>Begin</label>
                     <input
                       id={"startDate"}
@@ -205,7 +205,7 @@ export const Analytics = (props: Props) => {
                       defaultValue={formatDate(new Date(startDate))}
                     />{" "}
                   </div>
-                  <div className="grid-col-4">
+                  <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
                     <label className={classNames("usa-label")}>End</label>
                     <input
                       id={"endDate"}
@@ -239,7 +239,7 @@ export const Analytics = (props: Props) => {
                   </p>
                   <p className="padding-top-1">{`${startDate} \u2013 ${endDate}`}</p>
                   <div className="grid-row grid-gap">
-                    <div className="grid-col-3">
+                    <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-row">
                         <h2>Tests conducted</h2>
                         <span className="font-sans-3xl text-bold margin-y-auto">
@@ -248,7 +248,7 @@ export const Analytics = (props: Props) => {
                         <p></p>
                       </div>
                     </div>
-                    <div className="grid-col-3">
+                    <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-align-center">
                         <h2>Positive tests</h2>
                         <span className="font-sans-3xl text-bold margin-y-auto">
@@ -261,7 +261,7 @@ export const Analytics = (props: Props) => {
                         </p>
                       </div>
                     </div>
-                    <div className="grid-col-3">
+                    <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-align-center">
                         <h2>Negative tests</h2>
                         <span className="font-sans-3xl text-bold margin-y-auto">
@@ -270,7 +270,7 @@ export const Analytics = (props: Props) => {
                         <p></p>
                       </div>
                     </div>
-                    <div className="grid-col-3">
+                    <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-align-center">
                         <h2>Positivity rate</h2>
                         <span className="font-sans-3xl text-bold margin-y-auto">

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -99,7 +99,12 @@ const Dropdown: React.FC<Props & SelectProps> = ({
           >
             {defaultSelect && <option value="">{defaultOption}</option>}
             {options.map(({ value, label, disabled }) => (
-              <option key={value} value={value} disabled={disabled}>
+              <option
+                key={value}
+                value={value}
+                disabled={disabled}
+                aria-selected={selectedValue === value}
+              >
                 {label}
               </option>
             ))}

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -198,21 +198,25 @@ Object {
                           - Select -
                         </option>
                         <option
+                          aria-selected="false"
                           value="STAFF"
                         >
                           Staff
                         </option>
                         <option
+                          aria-selected="false"
                           value="RESIDENT"
                         >
                           Resident
                         </option>
                         <option
+                          aria-selected="false"
                           value="STUDENT"
                         >
                           Student
                         </option>
                         <option
+                          aria-selected="false"
                           value="VISITOR"
                         >
                           Visitor
@@ -247,11 +251,13 @@ Object {
                           - Select -
                         </option>
                         <option
+                          aria-selected="true"
                           value="~~ALL-FACILITIES~~"
                         >
                           All facilities
                         </option>
                         <option
+                          aria-selected="false"
                           value="b0d2041f-93c9-4192-b19a-dd99c0044a7e"
                         >
                           123
@@ -630,1311 +636,1573 @@ Object {
                         name="country"
                       >
                         <option
+                          aria-selected="false"
                           value="AFG"
                         >
                           Afghanistan
                         </option>
                         <option
+                          aria-selected="false"
                           value="XQZ"
                         >
                           Akrotiri
                         </option>
                         <option
+                          aria-selected="false"
                           value="ALB"
                         >
                           Albania
                         </option>
                         <option
+                          aria-selected="false"
                           value="DZA"
                         >
                           Algeria
                         </option>
                         <option
+                          aria-selected="false"
                           value="ASM"
                         >
                           American Samoa
                         </option>
                         <option
+                          aria-selected="false"
                           value="AND"
                         >
                           Andorra
                         </option>
                         <option
+                          aria-selected="false"
                           value="AGO"
                         >
                           Angola
                         </option>
                         <option
+                          aria-selected="false"
                           value="AIA"
                         >
                           Anguilla
                         </option>
                         <option
+                          aria-selected="false"
                           value="ATA"
                         >
                           Antarctica
                         </option>
                         <option
+                          aria-selected="false"
                           value="ATG"
                         >
                           Antigua
                         </option>
                         <option
+                          aria-selected="false"
                           value="ARG"
                         >
                           Argentina
                         </option>
                         <option
+                          aria-selected="false"
                           value="ARM"
                         >
                           Armenia
                         </option>
                         <option
+                          aria-selected="false"
                           value="ABW"
                         >
                           Aruba
                         </option>
                         <option
+                          aria-selected="false"
                           value="XAC"
                         >
                           Ashmore and Cartier Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="AUS"
                         >
                           Australia
                         </option>
                         <option
+                          aria-selected="false"
                           value="AUT"
                         >
                           Austria
                         </option>
                         <option
+                          aria-selected="false"
                           value="AZE"
                         >
                           Azerbaijan
                         </option>
                         <option
+                          aria-selected="false"
                           value="BHS"
                         >
                           Bahamas, The
                         </option>
                         <option
+                          aria-selected="false"
                           value="BHR"
                         >
                           Bahrain
                         </option>
                         <option
+                          aria-selected="false"
                           value="XBK"
                         >
                           Baker Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="BGD"
                         >
                           Bangladesh
                         </option>
                         <option
+                          aria-selected="false"
                           value="BRB"
                         >
                           Barbados
                         </option>
                         <option
+                          aria-selected="false"
                           value="BLR"
                         >
                           Belarus
                         </option>
                         <option
+                          aria-selected="false"
                           value="BEL"
                         >
                           Belgium
                         </option>
                         <option
+                          aria-selected="false"
                           value="BLZ"
                         >
                           Belize
                         </option>
                         <option
+                          aria-selected="false"
                           value="BEN"
                         >
                           Benin
                         </option>
                         <option
+                          aria-selected="false"
                           value="BMU"
                         >
                           Bermuda
                         </option>
                         <option
+                          aria-selected="false"
                           value="BTN"
                         >
                           Bhutan
                         </option>
                         <option
+                          aria-selected="false"
                           value="BOL"
                         >
                           Bolivia
                         </option>
                         <option
+                          aria-selected="false"
                           value="BIH"
                         >
                           Bosnia and Herzegovina
                         </option>
                         <option
+                          aria-selected="false"
                           value="BWA"
                         >
                           Botswana
                         </option>
                         <option
+                          aria-selected="false"
                           value="BVT"
                         >
                           Bouvet Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="BRA"
                         >
                           Brazil
                         </option>
                         <option
+                          aria-selected="false"
                           value="IOT"
                         >
                           British Indian Ocean Territory
                         </option>
                         <option
+                          aria-selected="false"
                           value="BRN"
                         >
                           Brunei
                         </option>
                         <option
+                          aria-selected="false"
                           value="BGR"
                         >
                           Bulgaria
                         </option>
                         <option
+                          aria-selected="false"
                           value="BFA"
                         >
                           Burkina Faso
                         </option>
                         <option
+                          aria-selected="false"
                           value="MMR"
                         >
                           Burma
                         </option>
                         <option
+                          aria-selected="false"
                           value="BDI"
                         >
                           Burundi
                         </option>
                         <option
+                          aria-selected="false"
                           value="CPV"
                         >
                           Cabo Verde
                         </option>
                         <option
+                          aria-selected="false"
                           value="KHM"
                         >
                           Cambodia
                         </option>
                         <option
+                          aria-selected="false"
                           value="CMR"
                         >
                           Cameroon
                         </option>
                         <option
+                          aria-selected="false"
                           value="CAN"
                         >
                           Canada
                         </option>
                         <option
+                          aria-selected="false"
                           value="CYM"
                         >
                           Cayman Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="CAF"
                         >
                           Central African Republic
                         </option>
                         <option
+                          aria-selected="false"
                           value="TCD"
                         >
                           Chad
                         </option>
                         <option
+                          aria-selected="false"
                           value="CHL"
                         >
                           Chile
                         </option>
                         <option
+                          aria-selected="false"
                           value="CHN"
                         >
                           China
                         </option>
                         <option
+                          aria-selected="false"
                           value="CXR"
                         >
                           Christmas Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="CPT"
                         >
                           Clipperton Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="CCK"
                         >
                           Cocos (Keeling) Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="COL"
                         >
                           Colombia
                         </option>
                         <option
+                          aria-selected="false"
                           value="COM"
                         >
                           Comoros
                         </option>
                         <option
+                          aria-selected="false"
                           value="COK"
                         >
                           Cook Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="XCS"
                         >
                           Coral Sea Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="CRI"
                         >
                           Costa Rica
                         </option>
                         <option
+                          aria-selected="false"
                           value="CIV"
                         >
                           Côte d’Ivoire
                         </option>
                         <option
+                          aria-selected="false"
                           value="HRV"
                         >
                           Croatia
                         </option>
                         <option
+                          aria-selected="false"
                           value="CUB"
                         >
                           Cuba
                         </option>
                         <option
+                          aria-selected="false"
                           value="CUW"
                         >
                           Curaçao
                         </option>
                         <option
+                          aria-selected="false"
                           value="CYP"
                         >
                           Cyprus
                         </option>
                         <option
+                          aria-selected="false"
                           value="CZE"
                         >
                           Czechia
                         </option>
                         <option
+                          aria-selected="false"
                           value="COD"
                         >
                           Democratic Republic of the Congo
                         </option>
                         <option
+                          aria-selected="false"
                           value="DNK"
                         >
                           Denmark
                         </option>
                         <option
+                          aria-selected="false"
                           value="XXD"
                         >
                           Dhekelia
                         </option>
                         <option
+                          aria-selected="false"
                           value="DJI"
                         >
                           Djibouti
                         </option>
                         <option
+                          aria-selected="false"
                           value="DMA"
                         >
                           Dominica
                         </option>
                         <option
+                          aria-selected="false"
                           value="DOM"
                         >
                           Dominican Republic
                         </option>
                         <option
+                          aria-selected="false"
                           value="ECU"
                         >
                           Ecuador
                         </option>
                         <option
+                          aria-selected="false"
                           value="EGY"
                         >
                           Egypt
                         </option>
                         <option
+                          aria-selected="false"
                           value="SLV"
                         >
                           El Salvador
                         </option>
                         <option
+                          aria-selected="false"
                           value="GNQ"
                         >
                           Equatorial Guinea
                         </option>
                         <option
+                          aria-selected="false"
                           value="ERI"
                         >
                           Eritrea
                         </option>
                         <option
+                          aria-selected="false"
                           value="EST"
                         >
                           Estonia
                         </option>
                         <option
+                          aria-selected="false"
                           value="SWZ"
                         >
                           Eswatini
                         </option>
                         <option
+                          aria-selected="false"
                           value="ETH"
                         >
                           Ethiopia
                         </option>
                         <option
+                          aria-selected="false"
                           value="FLK"
                         >
                           Falkland Islands (Islas Malvinas)
                         </option>
                         <option
+                          aria-selected="false"
                           value="FRO"
                         >
                           Faroe Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="FJI"
                         >
                           Fiji
                         </option>
                         <option
+                          aria-selected="false"
                           value="FIN"
                         >
                           Finland
                         </option>
                         <option
+                          aria-selected="false"
                           value="FRA"
                         >
                           France
                         </option>
                         <option
+                          aria-selected="false"
                           value="GUF"
                         >
                           French Guiana
                         </option>
                         <option
+                          aria-selected="false"
                           value="PYF"
                         >
                           French Polynesia
                         </option>
                         <option
+                          aria-selected="false"
                           value="ATF"
                         >
                           French Southern and Antarctic Lands
                         </option>
                         <option
+                          aria-selected="false"
                           value="GAB"
                         >
                           Gabon
                         </option>
                         <option
+                          aria-selected="false"
                           value="GMB"
                         >
                           Gambia, The
                         </option>
                         <option
+                          aria-selected="false"
                           value="GEO"
                         >
                           Georgia
                         </option>
                         <option
+                          aria-selected="false"
                           value="DEU"
                         >
                           Germany
                         </option>
                         <option
+                          aria-selected="false"
                           value="GHA"
                         >
                           Ghana
                         </option>
                         <option
+                          aria-selected="false"
                           value="GIB"
                         >
                           Gibraltar
                         </option>
                         <option
+                          aria-selected="false"
                           value="GRC"
                         >
                           Greece
                         </option>
                         <option
+                          aria-selected="false"
                           value="GRL"
                         >
                           Greenland
                         </option>
                         <option
+                          aria-selected="false"
                           value="GRD"
                         >
                           Grenada
                         </option>
                         <option
+                          aria-selected="false"
                           value="GLP"
                         >
                           Guadeloupe
                         </option>
                         <option
+                          aria-selected="false"
                           value="GUM"
                         >
                           Guam
                         </option>
                         <option
+                          aria-selected="false"
                           value="GTM"
                         >
                           Guatemala
                         </option>
                         <option
+                          aria-selected="false"
                           value="GGY"
                         >
                           Guernsey
                         </option>
                         <option
+                          aria-selected="false"
                           value="GIN"
                         >
                           Guinea
                         </option>
                         <option
+                          aria-selected="false"
                           value="GNB"
                         >
                           Guinea-Bissau
                         </option>
                         <option
+                          aria-selected="false"
                           value="GUY"
                         >
                           Guyana
                         </option>
                         <option
+                          aria-selected="false"
                           value="HTI"
                         >
                           Haiti
                         </option>
                         <option
+                          aria-selected="false"
                           value="HMD"
                         >
                           Heard Island and McDonald Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="VAT"
                         >
                           Holy See
                         </option>
                         <option
+                          aria-selected="false"
                           value="HND"
                         >
                           Honduras
                         </option>
                         <option
+                          aria-selected="false"
                           value="HKG"
                         >
                           Hong Kong
                         </option>
                         <option
+                          aria-selected="false"
                           value="XHO"
                         >
                           Howland Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="HUN"
                         >
                           Hungary
                         </option>
                         <option
+                          aria-selected="false"
                           value="ISL"
                         >
                           Iceland
                         </option>
                         <option
+                          aria-selected="false"
                           value="IND"
                         >
                           India
                         </option>
                         <option
+                          aria-selected="false"
                           value="IDN"
                         >
                           Indonesia
                         </option>
                         <option
+                          aria-selected="false"
                           value="IRN"
                         >
                           Iran
                         </option>
                         <option
+                          aria-selected="false"
                           value="IRQ"
                         >
                           Iraq
                         </option>
                         <option
+                          aria-selected="false"
                           value="IRL"
                         >
                           Ireland
                         </option>
                         <option
+                          aria-selected="false"
                           value="IMN"
                         >
                           Isle of Man
                         </option>
                         <option
+                          aria-selected="false"
                           value="ISR"
                         >
                           Israel
                         </option>
                         <option
+                          aria-selected="false"
                           value="ITA"
                         >
                           Italy
                         </option>
                         <option
+                          aria-selected="false"
                           value="JAM"
                         >
                           Jamaica
                         </option>
                         <option
+                          aria-selected="false"
                           value="XJM"
                         >
                           Jan Mayen
                         </option>
                         <option
+                          aria-selected="false"
                           value="JPN"
                         >
                           Japan
                         </option>
                         <option
+                          aria-selected="false"
                           value="XJV"
                         >
                           Jarvis Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="JEY"
                         >
                           Jersey
                         </option>
                         <option
+                          aria-selected="false"
                           value="XJA"
                         >
                           Johnston Atoll
                         </option>
                         <option
+                          aria-selected="false"
                           value="JOR"
                         >
                           Jordan
                         </option>
                         <option
+                          aria-selected="false"
                           value="KAZ"
                         >
                           Kazakhstan
                         </option>
                         <option
+                          aria-selected="false"
                           value="KEN"
                         >
                           Kenya
                         </option>
                         <option
+                          aria-selected="false"
                           value="XKR"
                         >
                           Kingman Reef
                         </option>
                         <option
+                          aria-selected="false"
                           value="KIR"
                         >
                           Kiribati
                         </option>
                         <option
+                          aria-selected="false"
                           value="PRK"
                         >
                           Korea, North
                         </option>
                         <option
+                          aria-selected="false"
                           value="KOR"
                         >
                           Korea, South
                         </option>
                         <option
+                          aria-selected="false"
                           value="XKS"
                         >
                           Kosovo
                         </option>
                         <option
+                          aria-selected="false"
                           value="KWT"
                         >
                           Kuwait
                         </option>
                         <option
+                          aria-selected="false"
                           value="KGZ"
                         >
                           Kyrgyzstan
                         </option>
                         <option
+                          aria-selected="false"
                           value="LAO"
                         >
                           Laos
                         </option>
                         <option
+                          aria-selected="false"
                           value="LVA"
                         >
                           Latvia
                         </option>
                         <option
+                          aria-selected="false"
                           value="LBN"
                         >
                           Lebanon
                         </option>
                         <option
+                          aria-selected="false"
                           value="LSO"
                         >
                           Lesotho
                         </option>
                         <option
+                          aria-selected="false"
                           value="LBR"
                         >
                           Liberia
                         </option>
                         <option
+                          aria-selected="false"
                           value="LBY"
                         >
                           Libya
                         </option>
                         <option
+                          aria-selected="false"
                           value="LIE"
                         >
                           Liechtenstein
                         </option>
                         <option
+                          aria-selected="false"
                           value="LTU"
                         >
                           Lithuania
                         </option>
                         <option
+                          aria-selected="false"
                           value="LUX"
                         >
                           Luxembourg
                         </option>
                         <option
+                          aria-selected="false"
                           value="MAC"
                         >
                           Macau
                         </option>
                         <option
+                          aria-selected="false"
                           value="MDG"
                         >
                           Madagascar
                         </option>
                         <option
+                          aria-selected="false"
                           value="MWI"
                         >
                           Malawi
                         </option>
                         <option
+                          aria-selected="false"
                           value="MYS"
                         >
                           Malaysia
                         </option>
                         <option
+                          aria-selected="false"
                           value="MDV"
                         >
                           Maldives
                         </option>
                         <option
+                          aria-selected="false"
                           value="MLI"
                         >
                           Mali
                         </option>
                         <option
+                          aria-selected="false"
                           value="MLT"
                         >
                           Malta
                         </option>
                         <option
+                          aria-selected="false"
                           value="MHL"
                         >
                           Marshall Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="MTQ"
                         >
                           Martinique
                         </option>
                         <option
+                          aria-selected="false"
                           value="MRT"
                         >
                           Mauritania
                         </option>
                         <option
+                          aria-selected="false"
                           value="MUS"
                         >
                           Mauritius
                         </option>
                         <option
+                          aria-selected="false"
                           value="MYT"
                         >
                           Mayotte
                         </option>
                         <option
+                          aria-selected="false"
                           value="MEX"
                         >
                           Mexico
                         </option>
                         <option
+                          aria-selected="false"
                           value="FSM"
                         >
                           Micronesia, Federated States of
                         </option>
                         <option
+                          aria-selected="false"
                           value="XMW"
                         >
                           Midway Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="MDA"
                         >
                           Moldova
                         </option>
                         <option
+                          aria-selected="false"
                           value="MCO"
                         >
                           Monaco
                         </option>
                         <option
+                          aria-selected="false"
                           value="MNG"
                         >
                           Mongolia
                         </option>
                         <option
+                          aria-selected="false"
                           value="MNE"
                         >
                           Montenegro
                         </option>
                         <option
+                          aria-selected="false"
                           value="MSR"
                         >
                           Montserrat
                         </option>
                         <option
+                          aria-selected="false"
                           value="MAR"
                         >
                           Morocco
                         </option>
                         <option
+                          aria-selected="false"
                           value="MOZ"
                         >
                           Mozambique
                         </option>
                         <option
+                          aria-selected="false"
                           value="NAM"
                         >
                           Namibia
                         </option>
                         <option
+                          aria-selected="false"
                           value="NRU"
                         >
                           Nauru
                         </option>
                         <option
+                          aria-selected="false"
                           value="XNV"
                         >
                           Navassa Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="NPL"
                         >
                           Nepal
                         </option>
                         <option
+                          aria-selected="false"
                           value="NLD"
                         >
                           Netherlands
                         </option>
                         <option
+                          aria-selected="false"
                           value="NCL"
                         >
                           New Caledonia
                         </option>
                         <option
+                          aria-selected="false"
                           value="NZL"
                         >
                           New Zealand
                         </option>
                         <option
+                          aria-selected="false"
                           value="NIC"
                         >
                           Nicaragua
                         </option>
                         <option
+                          aria-selected="false"
                           value="NER"
                         >
                           Niger
                         </option>
                         <option
+                          aria-selected="false"
                           value="NGA"
                         >
                           Nigeria
                         </option>
                         <option
+                          aria-selected="false"
                           value="NIU"
                         >
                           Niue
                         </option>
                         <option
+                          aria-selected="false"
                           value="NFK"
                         >
                           Norfolk Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="MKD"
                         >
                           North Macedonia
                         </option>
                         <option
+                          aria-selected="false"
                           value="MNP"
                         >
                           Northern Mariana Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="NOR"
                         >
                           Norway
                         </option>
                         <option
+                          aria-selected="false"
                           value="OMN"
                         >
                           Oman
                         </option>
                         <option
+                          aria-selected="false"
                           value="PAK"
                         >
                           Pakistan
                         </option>
                         <option
+                          aria-selected="false"
                           value="PLW"
                         >
                           Palau
                         </option>
                         <option
+                          aria-selected="false"
                           value="XPL"
                         >
                           Palmyra Atoll
                         </option>
                         <option
+                          aria-selected="false"
                           value="PAN"
                         >
                           Panama
                         </option>
                         <option
+                          aria-selected="false"
                           value="PNG"
                         >
                           Papua New Guinea
                         </option>
                         <option
+                          aria-selected="false"
                           value="XPR"
                         >
                           Paracel Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="PRY"
                         >
                           Paraguay
                         </option>
                         <option
+                          aria-selected="false"
                           value="PER"
                         >
                           Peru
                         </option>
                         <option
+                          aria-selected="false"
                           value="PHL"
                         >
                           Philippines
                         </option>
                         <option
+                          aria-selected="false"
                           value="PCN"
                         >
                           Pitcairn Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="POL"
                         >
                           Poland
                         </option>
                         <option
+                          aria-selected="false"
                           value="PRT"
                         >
                           Portugal
                         </option>
                         <option
+                          aria-selected="false"
                           value="PRI"
                         >
                           Puerto Rico
                         </option>
                         <option
+                          aria-selected="false"
                           value="QAT"
                         >
                           Qatar
                         </option>
                         <option
+                          aria-selected="false"
                           value="COG"
                         >
                           Republic of the Congo
                         </option>
                         <option
+                          aria-selected="false"
                           value="REU"
                         >
                           Reunion
                         </option>
                         <option
+                          aria-selected="false"
                           value="ROU"
                         >
                           Romania
                         </option>
                         <option
+                          aria-selected="false"
                           value="RUS"
                         >
                           Russia
                         </option>
                         <option
+                          aria-selected="false"
                           value="RWA"
                         >
                           Rwanda
                         </option>
                         <option
+                          aria-selected="false"
                           value="BLM"
                         >
                           Saint Barthelemy
                         </option>
                         <option
+                          aria-selected="false"
                           value="SHN"
                         >
                           Saint Helena, Ascension, and Tristan da Cunha
                         </option>
                         <option
+                          aria-selected="false"
                           value="KNA"
                         >
                           Saint Kitts and Nevis
                         </option>
                         <option
+                          aria-selected="false"
                           value="LCA"
                         >
                           Saint Lucia
                         </option>
                         <option
+                          aria-selected="false"
                           value="MAF"
                         >
                           Saint Martin
                         </option>
                         <option
+                          aria-selected="false"
                           value="SPM"
                         >
                           Saint Pierre and Miquelon
                         </option>
                         <option
+                          aria-selected="false"
                           value="VCT"
                         >
                           Saint Vincent and the Grenadines
                         </option>
                         <option
+                          aria-selected="false"
                           value="WSM"
                         >
                           Samoa
                         </option>
                         <option
+                          aria-selected="false"
                           value="SMR"
                         >
                           San Marino
                         </option>
                         <option
+                          aria-selected="false"
                           value="STP"
                         >
                           Sao Tome and Principe
                         </option>
                         <option
+                          aria-selected="false"
                           value="SAU"
                         >
                           Saudi Arabia
                         </option>
                         <option
+                          aria-selected="false"
                           value="SEN"
                         >
                           Senegal
                         </option>
                         <option
+                          aria-selected="false"
                           value="SRB"
                         >
                           Serbia
                         </option>
                         <option
+                          aria-selected="false"
                           value="SYC"
                         >
                           Seychelles
                         </option>
                         <option
+                          aria-selected="false"
                           value="SLE"
                         >
                           Sierra Leone
                         </option>
                         <option
+                          aria-selected="false"
                           value="SGP"
                         >
                           Singapore
                         </option>
                         <option
+                          aria-selected="false"
                           value="SXM"
                         >
                           Sint Maarten
                         </option>
                         <option
+                          aria-selected="false"
                           value="SVK"
                         >
                           Slovakia
                         </option>
                         <option
+                          aria-selected="false"
                           value="SVN"
                         >
                           Slovenia
                         </option>
                         <option
+                          aria-selected="false"
                           value="SLB"
                         >
                           Solomon Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="SOM"
                         >
                           Somalia
                         </option>
                         <option
+                          aria-selected="false"
                           value="ZAF"
                         >
                           South Africa
                         </option>
                         <option
+                          aria-selected="false"
                           value="SGS"
                         >
                           South Georgia and the South Sandwich Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="SSD"
                         >
                           South Sudan
                         </option>
                         <option
+                          aria-selected="false"
                           value="ESP"
                         >
                           Spain
                         </option>
                         <option
+                          aria-selected="false"
                           value="XSP"
                         >
                           Spratly Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="LKA"
                         >
                           Sri Lanka
                         </option>
                         <option
+                          aria-selected="false"
                           value="SDN"
                         >
                           Sudan
                         </option>
                         <option
+                          aria-selected="false"
                           value="SUR"
                         >
                           Suriname
                         </option>
                         <option
+                          aria-selected="false"
                           value="XSV"
                         >
                           Svalbard
                         </option>
                         <option
+                          aria-selected="false"
                           value="SWE"
                         >
                           Sweden
                         </option>
                         <option
+                          aria-selected="false"
                           value="CHE"
                         >
                           Switzerland
                         </option>
                         <option
+                          aria-selected="false"
                           value="SYR"
                         >
                           Syria
                         </option>
                         <option
+                          aria-selected="false"
                           value="TWN"
                         >
                           Taiwan
                         </option>
                         <option
+                          aria-selected="false"
                           value="TJK"
                         >
                           Tajikistan
                         </option>
                         <option
+                          aria-selected="false"
                           value="TZA"
                         >
                           Tanzania
                         </option>
                         <option
+                          aria-selected="false"
                           value="THA"
                         >
                           Thailand
                         </option>
                         <option
+                          aria-selected="false"
                           value="TLS"
                         >
                           Timor-Leste
                         </option>
                         <option
+                          aria-selected="false"
                           value="TGO"
                         >
                           Togo
                         </option>
                         <option
+                          aria-selected="false"
                           value="TKL"
                         >
                           Tokelau
                         </option>
                         <option
+                          aria-selected="false"
                           value="TON"
                         >
                           Tonga
                         </option>
                         <option
+                          aria-selected="false"
                           value="TTO"
                         >
                           Trinidad and Tobago
                         </option>
                         <option
+                          aria-selected="false"
                           value="TUN"
                         >
                           Tunisia
                         </option>
                         <option
+                          aria-selected="false"
                           value="TUR"
                         >
                           Turkey
                         </option>
                         <option
+                          aria-selected="false"
                           value="TKM"
                         >
                           Turkmenistan
                         </option>
                         <option
+                          aria-selected="false"
                           value="TCA"
                         >
                           Turks and Caicos Islands
                         </option>
                         <option
+                          aria-selected="false"
                           value="TUV"
                         >
                           Tuvalu
                         </option>
                         <option
+                          aria-selected="false"
                           value="UGA"
                         >
                           Uganda
                         </option>
                         <option
+                          aria-selected="false"
                           value="UKR"
                         >
                           Ukraine
                         </option>
                         <option
+                          aria-selected="false"
                           value="ARE"
                         >
                           United Arab Emirates
                         </option>
                         <option
+                          aria-selected="false"
                           value="GBR"
                         >
                           United Kingdom
                         </option>
                         <option
+                          aria-selected="true"
                           value="USA"
                         >
                           United States
                         </option>
                         <option
+                          aria-selected="false"
                           value="URY"
                         >
                           Uruguay
                         </option>
                         <option
+                          aria-selected="false"
                           value="UZB"
                         >
                           Uzbekistan
                         </option>
                         <option
+                          aria-selected="false"
                           value="VUT"
                         >
                           Vanuatu
                         </option>
                         <option
+                          aria-selected="false"
                           value="VEN"
                         >
                           Venezuela
                         </option>
                         <option
+                          aria-selected="false"
                           value="VNM"
                         >
                           Vietnam
                         </option>
                         <option
+                          aria-selected="false"
                           value="VGB"
                         >
                           Virgin Islands, British
                         </option>
                         <option
+                          aria-selected="false"
                           value="VIR"
                         >
                           Virgin Islands, U.S.
                         </option>
                         <option
+                          aria-selected="false"
                           value="XWK"
                         >
                           Wake Island
                         </option>
                         <option
+                          aria-selected="false"
                           value="WLF"
                         >
                           Wallis and Futuna
                         </option>
                         <option
+                          aria-selected="false"
                           value="YEM"
                         >
                           Yemen
                         </option>
                         <option
+                          aria-selected="false"
                           value="ZMB"
                         >
                           Zambia
                         </option>
                         <option
+                          aria-selected="false"
                           value="ZWE"
                         >
                           Zimbabwe
@@ -2782,21 +3050,25 @@ Object {
                         - Select -
                       </option>
                       <option
+                        aria-selected="false"
                         value="STAFF"
                       >
                         Staff
                       </option>
                       <option
+                        aria-selected="false"
                         value="RESIDENT"
                       >
                         Resident
                       </option>
                       <option
+                        aria-selected="false"
                         value="STUDENT"
                       >
                         Student
                       </option>
                       <option
+                        aria-selected="false"
                         value="VISITOR"
                       >
                         Visitor
@@ -2831,11 +3103,13 @@ Object {
                         - Select -
                       </option>
                       <option
+                        aria-selected="true"
                         value="~~ALL-FACILITIES~~"
                       >
                         All facilities
                       </option>
                       <option
+                        aria-selected="false"
                         value="b0d2041f-93c9-4192-b19a-dd99c0044a7e"
                       >
                         123
@@ -3214,1311 +3488,1573 @@ Object {
                       name="country"
                     >
                       <option
+                        aria-selected="false"
                         value="AFG"
                       >
                         Afghanistan
                       </option>
                       <option
+                        aria-selected="false"
                         value="XQZ"
                       >
                         Akrotiri
                       </option>
                       <option
+                        aria-selected="false"
                         value="ALB"
                       >
                         Albania
                       </option>
                       <option
+                        aria-selected="false"
                         value="DZA"
                       >
                         Algeria
                       </option>
                       <option
+                        aria-selected="false"
                         value="ASM"
                       >
                         American Samoa
                       </option>
                       <option
+                        aria-selected="false"
                         value="AND"
                       >
                         Andorra
                       </option>
                       <option
+                        aria-selected="false"
                         value="AGO"
                       >
                         Angola
                       </option>
                       <option
+                        aria-selected="false"
                         value="AIA"
                       >
                         Anguilla
                       </option>
                       <option
+                        aria-selected="false"
                         value="ATA"
                       >
                         Antarctica
                       </option>
                       <option
+                        aria-selected="false"
                         value="ATG"
                       >
                         Antigua
                       </option>
                       <option
+                        aria-selected="false"
                         value="ARG"
                       >
                         Argentina
                       </option>
                       <option
+                        aria-selected="false"
                         value="ARM"
                       >
                         Armenia
                       </option>
                       <option
+                        aria-selected="false"
                         value="ABW"
                       >
                         Aruba
                       </option>
                       <option
+                        aria-selected="false"
                         value="XAC"
                       >
                         Ashmore and Cartier Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="AUS"
                       >
                         Australia
                       </option>
                       <option
+                        aria-selected="false"
                         value="AUT"
                       >
                         Austria
                       </option>
                       <option
+                        aria-selected="false"
                         value="AZE"
                       >
                         Azerbaijan
                       </option>
                       <option
+                        aria-selected="false"
                         value="BHS"
                       >
                         Bahamas, The
                       </option>
                       <option
+                        aria-selected="false"
                         value="BHR"
                       >
                         Bahrain
                       </option>
                       <option
+                        aria-selected="false"
                         value="XBK"
                       >
                         Baker Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="BGD"
                       >
                         Bangladesh
                       </option>
                       <option
+                        aria-selected="false"
                         value="BRB"
                       >
                         Barbados
                       </option>
                       <option
+                        aria-selected="false"
                         value="BLR"
                       >
                         Belarus
                       </option>
                       <option
+                        aria-selected="false"
                         value="BEL"
                       >
                         Belgium
                       </option>
                       <option
+                        aria-selected="false"
                         value="BLZ"
                       >
                         Belize
                       </option>
                       <option
+                        aria-selected="false"
                         value="BEN"
                       >
                         Benin
                       </option>
                       <option
+                        aria-selected="false"
                         value="BMU"
                       >
                         Bermuda
                       </option>
                       <option
+                        aria-selected="false"
                         value="BTN"
                       >
                         Bhutan
                       </option>
                       <option
+                        aria-selected="false"
                         value="BOL"
                       >
                         Bolivia
                       </option>
                       <option
+                        aria-selected="false"
                         value="BIH"
                       >
                         Bosnia and Herzegovina
                       </option>
                       <option
+                        aria-selected="false"
                         value="BWA"
                       >
                         Botswana
                       </option>
                       <option
+                        aria-selected="false"
                         value="BVT"
                       >
                         Bouvet Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="BRA"
                       >
                         Brazil
                       </option>
                       <option
+                        aria-selected="false"
                         value="IOT"
                       >
                         British Indian Ocean Territory
                       </option>
                       <option
+                        aria-selected="false"
                         value="BRN"
                       >
                         Brunei
                       </option>
                       <option
+                        aria-selected="false"
                         value="BGR"
                       >
                         Bulgaria
                       </option>
                       <option
+                        aria-selected="false"
                         value="BFA"
                       >
                         Burkina Faso
                       </option>
                       <option
+                        aria-selected="false"
                         value="MMR"
                       >
                         Burma
                       </option>
                       <option
+                        aria-selected="false"
                         value="BDI"
                       >
                         Burundi
                       </option>
                       <option
+                        aria-selected="false"
                         value="CPV"
                       >
                         Cabo Verde
                       </option>
                       <option
+                        aria-selected="false"
                         value="KHM"
                       >
                         Cambodia
                       </option>
                       <option
+                        aria-selected="false"
                         value="CMR"
                       >
                         Cameroon
                       </option>
                       <option
+                        aria-selected="false"
                         value="CAN"
                       >
                         Canada
                       </option>
                       <option
+                        aria-selected="false"
                         value="CYM"
                       >
                         Cayman Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="CAF"
                       >
                         Central African Republic
                       </option>
                       <option
+                        aria-selected="false"
                         value="TCD"
                       >
                         Chad
                       </option>
                       <option
+                        aria-selected="false"
                         value="CHL"
                       >
                         Chile
                       </option>
                       <option
+                        aria-selected="false"
                         value="CHN"
                       >
                         China
                       </option>
                       <option
+                        aria-selected="false"
                         value="CXR"
                       >
                         Christmas Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="CPT"
                       >
                         Clipperton Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="CCK"
                       >
                         Cocos (Keeling) Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="COL"
                       >
                         Colombia
                       </option>
                       <option
+                        aria-selected="false"
                         value="COM"
                       >
                         Comoros
                       </option>
                       <option
+                        aria-selected="false"
                         value="COK"
                       >
                         Cook Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="XCS"
                       >
                         Coral Sea Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="CRI"
                       >
                         Costa Rica
                       </option>
                       <option
+                        aria-selected="false"
                         value="CIV"
                       >
                         Côte d’Ivoire
                       </option>
                       <option
+                        aria-selected="false"
                         value="HRV"
                       >
                         Croatia
                       </option>
                       <option
+                        aria-selected="false"
                         value="CUB"
                       >
                         Cuba
                       </option>
                       <option
+                        aria-selected="false"
                         value="CUW"
                       >
                         Curaçao
                       </option>
                       <option
+                        aria-selected="false"
                         value="CYP"
                       >
                         Cyprus
                       </option>
                       <option
+                        aria-selected="false"
                         value="CZE"
                       >
                         Czechia
                       </option>
                       <option
+                        aria-selected="false"
                         value="COD"
                       >
                         Democratic Republic of the Congo
                       </option>
                       <option
+                        aria-selected="false"
                         value="DNK"
                       >
                         Denmark
                       </option>
                       <option
+                        aria-selected="false"
                         value="XXD"
                       >
                         Dhekelia
                       </option>
                       <option
+                        aria-selected="false"
                         value="DJI"
                       >
                         Djibouti
                       </option>
                       <option
+                        aria-selected="false"
                         value="DMA"
                       >
                         Dominica
                       </option>
                       <option
+                        aria-selected="false"
                         value="DOM"
                       >
                         Dominican Republic
                       </option>
                       <option
+                        aria-selected="false"
                         value="ECU"
                       >
                         Ecuador
                       </option>
                       <option
+                        aria-selected="false"
                         value="EGY"
                       >
                         Egypt
                       </option>
                       <option
+                        aria-selected="false"
                         value="SLV"
                       >
                         El Salvador
                       </option>
                       <option
+                        aria-selected="false"
                         value="GNQ"
                       >
                         Equatorial Guinea
                       </option>
                       <option
+                        aria-selected="false"
                         value="ERI"
                       >
                         Eritrea
                       </option>
                       <option
+                        aria-selected="false"
                         value="EST"
                       >
                         Estonia
                       </option>
                       <option
+                        aria-selected="false"
                         value="SWZ"
                       >
                         Eswatini
                       </option>
                       <option
+                        aria-selected="false"
                         value="ETH"
                       >
                         Ethiopia
                       </option>
                       <option
+                        aria-selected="false"
                         value="FLK"
                       >
                         Falkland Islands (Islas Malvinas)
                       </option>
                       <option
+                        aria-selected="false"
                         value="FRO"
                       >
                         Faroe Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="FJI"
                       >
                         Fiji
                       </option>
                       <option
+                        aria-selected="false"
                         value="FIN"
                       >
                         Finland
                       </option>
                       <option
+                        aria-selected="false"
                         value="FRA"
                       >
                         France
                       </option>
                       <option
+                        aria-selected="false"
                         value="GUF"
                       >
                         French Guiana
                       </option>
                       <option
+                        aria-selected="false"
                         value="PYF"
                       >
                         French Polynesia
                       </option>
                       <option
+                        aria-selected="false"
                         value="ATF"
                       >
                         French Southern and Antarctic Lands
                       </option>
                       <option
+                        aria-selected="false"
                         value="GAB"
                       >
                         Gabon
                       </option>
                       <option
+                        aria-selected="false"
                         value="GMB"
                       >
                         Gambia, The
                       </option>
                       <option
+                        aria-selected="false"
                         value="GEO"
                       >
                         Georgia
                       </option>
                       <option
+                        aria-selected="false"
                         value="DEU"
                       >
                         Germany
                       </option>
                       <option
+                        aria-selected="false"
                         value="GHA"
                       >
                         Ghana
                       </option>
                       <option
+                        aria-selected="false"
                         value="GIB"
                       >
                         Gibraltar
                       </option>
                       <option
+                        aria-selected="false"
                         value="GRC"
                       >
                         Greece
                       </option>
                       <option
+                        aria-selected="false"
                         value="GRL"
                       >
                         Greenland
                       </option>
                       <option
+                        aria-selected="false"
                         value="GRD"
                       >
                         Grenada
                       </option>
                       <option
+                        aria-selected="false"
                         value="GLP"
                       >
                         Guadeloupe
                       </option>
                       <option
+                        aria-selected="false"
                         value="GUM"
                       >
                         Guam
                       </option>
                       <option
+                        aria-selected="false"
                         value="GTM"
                       >
                         Guatemala
                       </option>
                       <option
+                        aria-selected="false"
                         value="GGY"
                       >
                         Guernsey
                       </option>
                       <option
+                        aria-selected="false"
                         value="GIN"
                       >
                         Guinea
                       </option>
                       <option
+                        aria-selected="false"
                         value="GNB"
                       >
                         Guinea-Bissau
                       </option>
                       <option
+                        aria-selected="false"
                         value="GUY"
                       >
                         Guyana
                       </option>
                       <option
+                        aria-selected="false"
                         value="HTI"
                       >
                         Haiti
                       </option>
                       <option
+                        aria-selected="false"
                         value="HMD"
                       >
                         Heard Island and McDonald Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="VAT"
                       >
                         Holy See
                       </option>
                       <option
+                        aria-selected="false"
                         value="HND"
                       >
                         Honduras
                       </option>
                       <option
+                        aria-selected="false"
                         value="HKG"
                       >
                         Hong Kong
                       </option>
                       <option
+                        aria-selected="false"
                         value="XHO"
                       >
                         Howland Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="HUN"
                       >
                         Hungary
                       </option>
                       <option
+                        aria-selected="false"
                         value="ISL"
                       >
                         Iceland
                       </option>
                       <option
+                        aria-selected="false"
                         value="IND"
                       >
                         India
                       </option>
                       <option
+                        aria-selected="false"
                         value="IDN"
                       >
                         Indonesia
                       </option>
                       <option
+                        aria-selected="false"
                         value="IRN"
                       >
                         Iran
                       </option>
                       <option
+                        aria-selected="false"
                         value="IRQ"
                       >
                         Iraq
                       </option>
                       <option
+                        aria-selected="false"
                         value="IRL"
                       >
                         Ireland
                       </option>
                       <option
+                        aria-selected="false"
                         value="IMN"
                       >
                         Isle of Man
                       </option>
                       <option
+                        aria-selected="false"
                         value="ISR"
                       >
                         Israel
                       </option>
                       <option
+                        aria-selected="false"
                         value="ITA"
                       >
                         Italy
                       </option>
                       <option
+                        aria-selected="false"
                         value="JAM"
                       >
                         Jamaica
                       </option>
                       <option
+                        aria-selected="false"
                         value="XJM"
                       >
                         Jan Mayen
                       </option>
                       <option
+                        aria-selected="false"
                         value="JPN"
                       >
                         Japan
                       </option>
                       <option
+                        aria-selected="false"
                         value="XJV"
                       >
                         Jarvis Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="JEY"
                       >
                         Jersey
                       </option>
                       <option
+                        aria-selected="false"
                         value="XJA"
                       >
                         Johnston Atoll
                       </option>
                       <option
+                        aria-selected="false"
                         value="JOR"
                       >
                         Jordan
                       </option>
                       <option
+                        aria-selected="false"
                         value="KAZ"
                       >
                         Kazakhstan
                       </option>
                       <option
+                        aria-selected="false"
                         value="KEN"
                       >
                         Kenya
                       </option>
                       <option
+                        aria-selected="false"
                         value="XKR"
                       >
                         Kingman Reef
                       </option>
                       <option
+                        aria-selected="false"
                         value="KIR"
                       >
                         Kiribati
                       </option>
                       <option
+                        aria-selected="false"
                         value="PRK"
                       >
                         Korea, North
                       </option>
                       <option
+                        aria-selected="false"
                         value="KOR"
                       >
                         Korea, South
                       </option>
                       <option
+                        aria-selected="false"
                         value="XKS"
                       >
                         Kosovo
                       </option>
                       <option
+                        aria-selected="false"
                         value="KWT"
                       >
                         Kuwait
                       </option>
                       <option
+                        aria-selected="false"
                         value="KGZ"
                       >
                         Kyrgyzstan
                       </option>
                       <option
+                        aria-selected="false"
                         value="LAO"
                       >
                         Laos
                       </option>
                       <option
+                        aria-selected="false"
                         value="LVA"
                       >
                         Latvia
                       </option>
                       <option
+                        aria-selected="false"
                         value="LBN"
                       >
                         Lebanon
                       </option>
                       <option
+                        aria-selected="false"
                         value="LSO"
                       >
                         Lesotho
                       </option>
                       <option
+                        aria-selected="false"
                         value="LBR"
                       >
                         Liberia
                       </option>
                       <option
+                        aria-selected="false"
                         value="LBY"
                       >
                         Libya
                       </option>
                       <option
+                        aria-selected="false"
                         value="LIE"
                       >
                         Liechtenstein
                       </option>
                       <option
+                        aria-selected="false"
                         value="LTU"
                       >
                         Lithuania
                       </option>
                       <option
+                        aria-selected="false"
                         value="LUX"
                       >
                         Luxembourg
                       </option>
                       <option
+                        aria-selected="false"
                         value="MAC"
                       >
                         Macau
                       </option>
                       <option
+                        aria-selected="false"
                         value="MDG"
                       >
                         Madagascar
                       </option>
                       <option
+                        aria-selected="false"
                         value="MWI"
                       >
                         Malawi
                       </option>
                       <option
+                        aria-selected="false"
                         value="MYS"
                       >
                         Malaysia
                       </option>
                       <option
+                        aria-selected="false"
                         value="MDV"
                       >
                         Maldives
                       </option>
                       <option
+                        aria-selected="false"
                         value="MLI"
                       >
                         Mali
                       </option>
                       <option
+                        aria-selected="false"
                         value="MLT"
                       >
                         Malta
                       </option>
                       <option
+                        aria-selected="false"
                         value="MHL"
                       >
                         Marshall Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="MTQ"
                       >
                         Martinique
                       </option>
                       <option
+                        aria-selected="false"
                         value="MRT"
                       >
                         Mauritania
                       </option>
                       <option
+                        aria-selected="false"
                         value="MUS"
                       >
                         Mauritius
                       </option>
                       <option
+                        aria-selected="false"
                         value="MYT"
                       >
                         Mayotte
                       </option>
                       <option
+                        aria-selected="false"
                         value="MEX"
                       >
                         Mexico
                       </option>
                       <option
+                        aria-selected="false"
                         value="FSM"
                       >
                         Micronesia, Federated States of
                       </option>
                       <option
+                        aria-selected="false"
                         value="XMW"
                       >
                         Midway Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="MDA"
                       >
                         Moldova
                       </option>
                       <option
+                        aria-selected="false"
                         value="MCO"
                       >
                         Monaco
                       </option>
                       <option
+                        aria-selected="false"
                         value="MNG"
                       >
                         Mongolia
                       </option>
                       <option
+                        aria-selected="false"
                         value="MNE"
                       >
                         Montenegro
                       </option>
                       <option
+                        aria-selected="false"
                         value="MSR"
                       >
                         Montserrat
                       </option>
                       <option
+                        aria-selected="false"
                         value="MAR"
                       >
                         Morocco
                       </option>
                       <option
+                        aria-selected="false"
                         value="MOZ"
                       >
                         Mozambique
                       </option>
                       <option
+                        aria-selected="false"
                         value="NAM"
                       >
                         Namibia
                       </option>
                       <option
+                        aria-selected="false"
                         value="NRU"
                       >
                         Nauru
                       </option>
                       <option
+                        aria-selected="false"
                         value="XNV"
                       >
                         Navassa Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="NPL"
                       >
                         Nepal
                       </option>
                       <option
+                        aria-selected="false"
                         value="NLD"
                       >
                         Netherlands
                       </option>
                       <option
+                        aria-selected="false"
                         value="NCL"
                       >
                         New Caledonia
                       </option>
                       <option
+                        aria-selected="false"
                         value="NZL"
                       >
                         New Zealand
                       </option>
                       <option
+                        aria-selected="false"
                         value="NIC"
                       >
                         Nicaragua
                       </option>
                       <option
+                        aria-selected="false"
                         value="NER"
                       >
                         Niger
                       </option>
                       <option
+                        aria-selected="false"
                         value="NGA"
                       >
                         Nigeria
                       </option>
                       <option
+                        aria-selected="false"
                         value="NIU"
                       >
                         Niue
                       </option>
                       <option
+                        aria-selected="false"
                         value="NFK"
                       >
                         Norfolk Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="MKD"
                       >
                         North Macedonia
                       </option>
                       <option
+                        aria-selected="false"
                         value="MNP"
                       >
                         Northern Mariana Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="NOR"
                       >
                         Norway
                       </option>
                       <option
+                        aria-selected="false"
                         value="OMN"
                       >
                         Oman
                       </option>
                       <option
+                        aria-selected="false"
                         value="PAK"
                       >
                         Pakistan
                       </option>
                       <option
+                        aria-selected="false"
                         value="PLW"
                       >
                         Palau
                       </option>
                       <option
+                        aria-selected="false"
                         value="XPL"
                       >
                         Palmyra Atoll
                       </option>
                       <option
+                        aria-selected="false"
                         value="PAN"
                       >
                         Panama
                       </option>
                       <option
+                        aria-selected="false"
                         value="PNG"
                       >
                         Papua New Guinea
                       </option>
                       <option
+                        aria-selected="false"
                         value="XPR"
                       >
                         Paracel Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="PRY"
                       >
                         Paraguay
                       </option>
                       <option
+                        aria-selected="false"
                         value="PER"
                       >
                         Peru
                       </option>
                       <option
+                        aria-selected="false"
                         value="PHL"
                       >
                         Philippines
                       </option>
                       <option
+                        aria-selected="false"
                         value="PCN"
                       >
                         Pitcairn Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="POL"
                       >
                         Poland
                       </option>
                       <option
+                        aria-selected="false"
                         value="PRT"
                       >
                         Portugal
                       </option>
                       <option
+                        aria-selected="false"
                         value="PRI"
                       >
                         Puerto Rico
                       </option>
                       <option
+                        aria-selected="false"
                         value="QAT"
                       >
                         Qatar
                       </option>
                       <option
+                        aria-selected="false"
                         value="COG"
                       >
                         Republic of the Congo
                       </option>
                       <option
+                        aria-selected="false"
                         value="REU"
                       >
                         Reunion
                       </option>
                       <option
+                        aria-selected="false"
                         value="ROU"
                       >
                         Romania
                       </option>
                       <option
+                        aria-selected="false"
                         value="RUS"
                       >
                         Russia
                       </option>
                       <option
+                        aria-selected="false"
                         value="RWA"
                       >
                         Rwanda
                       </option>
                       <option
+                        aria-selected="false"
                         value="BLM"
                       >
                         Saint Barthelemy
                       </option>
                       <option
+                        aria-selected="false"
                         value="SHN"
                       >
                         Saint Helena, Ascension, and Tristan da Cunha
                       </option>
                       <option
+                        aria-selected="false"
                         value="KNA"
                       >
                         Saint Kitts and Nevis
                       </option>
                       <option
+                        aria-selected="false"
                         value="LCA"
                       >
                         Saint Lucia
                       </option>
                       <option
+                        aria-selected="false"
                         value="MAF"
                       >
                         Saint Martin
                       </option>
                       <option
+                        aria-selected="false"
                         value="SPM"
                       >
                         Saint Pierre and Miquelon
                       </option>
                       <option
+                        aria-selected="false"
                         value="VCT"
                       >
                         Saint Vincent and the Grenadines
                       </option>
                       <option
+                        aria-selected="false"
                         value="WSM"
                       >
                         Samoa
                       </option>
                       <option
+                        aria-selected="false"
                         value="SMR"
                       >
                         San Marino
                       </option>
                       <option
+                        aria-selected="false"
                         value="STP"
                       >
                         Sao Tome and Principe
                       </option>
                       <option
+                        aria-selected="false"
                         value="SAU"
                       >
                         Saudi Arabia
                       </option>
                       <option
+                        aria-selected="false"
                         value="SEN"
                       >
                         Senegal
                       </option>
                       <option
+                        aria-selected="false"
                         value="SRB"
                       >
                         Serbia
                       </option>
                       <option
+                        aria-selected="false"
                         value="SYC"
                       >
                         Seychelles
                       </option>
                       <option
+                        aria-selected="false"
                         value="SLE"
                       >
                         Sierra Leone
                       </option>
                       <option
+                        aria-selected="false"
                         value="SGP"
                       >
                         Singapore
                       </option>
                       <option
+                        aria-selected="false"
                         value="SXM"
                       >
                         Sint Maarten
                       </option>
                       <option
+                        aria-selected="false"
                         value="SVK"
                       >
                         Slovakia
                       </option>
                       <option
+                        aria-selected="false"
                         value="SVN"
                       >
                         Slovenia
                       </option>
                       <option
+                        aria-selected="false"
                         value="SLB"
                       >
                         Solomon Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="SOM"
                       >
                         Somalia
                       </option>
                       <option
+                        aria-selected="false"
                         value="ZAF"
                       >
                         South Africa
                       </option>
                       <option
+                        aria-selected="false"
                         value="SGS"
                       >
                         South Georgia and the South Sandwich Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="SSD"
                       >
                         South Sudan
                       </option>
                       <option
+                        aria-selected="false"
                         value="ESP"
                       >
                         Spain
                       </option>
                       <option
+                        aria-selected="false"
                         value="XSP"
                       >
                         Spratly Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="LKA"
                       >
                         Sri Lanka
                       </option>
                       <option
+                        aria-selected="false"
                         value="SDN"
                       >
                         Sudan
                       </option>
                       <option
+                        aria-selected="false"
                         value="SUR"
                       >
                         Suriname
                       </option>
                       <option
+                        aria-selected="false"
                         value="XSV"
                       >
                         Svalbard
                       </option>
                       <option
+                        aria-selected="false"
                         value="SWE"
                       >
                         Sweden
                       </option>
                       <option
+                        aria-selected="false"
                         value="CHE"
                       >
                         Switzerland
                       </option>
                       <option
+                        aria-selected="false"
                         value="SYR"
                       >
                         Syria
                       </option>
                       <option
+                        aria-selected="false"
                         value="TWN"
                       >
                         Taiwan
                       </option>
                       <option
+                        aria-selected="false"
                         value="TJK"
                       >
                         Tajikistan
                       </option>
                       <option
+                        aria-selected="false"
                         value="TZA"
                       >
                         Tanzania
                       </option>
                       <option
+                        aria-selected="false"
                         value="THA"
                       >
                         Thailand
                       </option>
                       <option
+                        aria-selected="false"
                         value="TLS"
                       >
                         Timor-Leste
                       </option>
                       <option
+                        aria-selected="false"
                         value="TGO"
                       >
                         Togo
                       </option>
                       <option
+                        aria-selected="false"
                         value="TKL"
                       >
                         Tokelau
                       </option>
                       <option
+                        aria-selected="false"
                         value="TON"
                       >
                         Tonga
                       </option>
                       <option
+                        aria-selected="false"
                         value="TTO"
                       >
                         Trinidad and Tobago
                       </option>
                       <option
+                        aria-selected="false"
                         value="TUN"
                       >
                         Tunisia
                       </option>
                       <option
+                        aria-selected="false"
                         value="TUR"
                       >
                         Turkey
                       </option>
                       <option
+                        aria-selected="false"
                         value="TKM"
                       >
                         Turkmenistan
                       </option>
                       <option
+                        aria-selected="false"
                         value="TCA"
                       >
                         Turks and Caicos Islands
                       </option>
                       <option
+                        aria-selected="false"
                         value="TUV"
                       >
                         Tuvalu
                       </option>
                       <option
+                        aria-selected="false"
                         value="UGA"
                       >
                         Uganda
                       </option>
                       <option
+                        aria-selected="false"
                         value="UKR"
                       >
                         Ukraine
                       </option>
                       <option
+                        aria-selected="false"
                         value="ARE"
                       >
                         United Arab Emirates
                       </option>
                       <option
+                        aria-selected="false"
                         value="GBR"
                       >
                         United Kingdom
                       </option>
                       <option
+                        aria-selected="true"
                         value="USA"
                       >
                         United States
                       </option>
                       <option
+                        aria-selected="false"
                         value="URY"
                       >
                         Uruguay
                       </option>
                       <option
+                        aria-selected="false"
                         value="UZB"
                       >
                         Uzbekistan
                       </option>
                       <option
+                        aria-selected="false"
                         value="VUT"
                       >
                         Vanuatu
                       </option>
                       <option
+                        aria-selected="false"
                         value="VEN"
                       >
                         Venezuela
                       </option>
                       <option
+                        aria-selected="false"
                         value="VNM"
                       >
                         Vietnam
                       </option>
                       <option
+                        aria-selected="false"
                         value="VGB"
                       >
                         Virgin Islands, British
                       </option>
                       <option
+                        aria-selected="false"
                         value="VIR"
                       >
                         Virgin Islands, U.S.
                       </option>
                       <option
+                        aria-selected="false"
                         value="XWK"
                       >
                         Wake Island
                       </option>
                       <option
+                        aria-selected="false"
                         value="WLF"
                       >
                         Wallis and Futuna
                       </option>
                       <option
+                        aria-selected="false"
                         value="YEM"
                       >
                         Yemen
                       </option>
                       <option
+                        aria-selected="false"
                         value="ZMB"
                       >
                         Zambia
                       </option>
                       <option
+                        aria-selected="false"
                         value="ZWE"
                       >
                         Zimbabwe

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -358,6 +358,7 @@ Object {
                             value=""
                           />
                           <option
+                            aria-selected="false"
                             value="294729"
                           >
                             COVID-19
@@ -861,6 +862,7 @@ Object {
                           value=""
                         />
                         <option
+                          aria-selected="false"
                           value="294729"
                         >
                           COVID-19

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -309,21 +309,25 @@ exports[`TestQueue should render the test queue 1`] = `
                         name="testDevice"
                       >
                         <option
+                          aria-selected="false"
                           value="5c711888-ba37-4b2e-b347-311ca364efdb"
                         >
                           Abbott BinaxNow
                         </option>
                         <option
+                          aria-selected="false"
                           value="32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10"
                         >
                           BD Veritor
                         </option>
                         <option
+                          aria-selected="true"
                           value="ee4f40b7-ac32-4709-be0a-56dd77bb9609"
                         >
                           LumiraDX
                         </option>
                         <option
+                          aria-selected="false"
                           value="67109f6f-eaee-49d3-b8ff-c61b79a9da8e"
                         >
                           Multiplex
@@ -351,11 +355,13 @@ exports[`TestQueue should render the test queue 1`] = `
                         name="swabType"
                       >
                         <option
+                          aria-selected="false"
                           value="f127ef55-4133-4556-9bca-33615d071e8d"
                         >
                           Nasopharyngeal swab
                         </option>
                         <option
+                          aria-selected="true"
                           value="8596682d-6053-4720-8a39-1f5d19ff4ed9"
                         >
                           Swab of internal nose
@@ -720,21 +726,25 @@ exports[`TestQueue should render the test queue 1`] = `
                         name="testDevice"
                       >
                         <option
+                          aria-selected="false"
                           value="5c711888-ba37-4b2e-b347-311ca364efdb"
                         >
                           Abbott BinaxNow
                         </option>
                         <option
+                          aria-selected="false"
                           value="32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10"
                         >
                           BD Veritor
                         </option>
                         <option
+                          aria-selected="true"
                           value="ee4f40b7-ac32-4709-be0a-56dd77bb9609"
                         >
                           LumiraDX
                         </option>
                         <option
+                          aria-selected="false"
                           value="67109f6f-eaee-49d3-b8ff-c61b79a9da8e"
                         >
                           Multiplex
@@ -762,11 +772,13 @@ exports[`TestQueue should render the test queue 1`] = `
                         name="swabType"
                       >
                         <option
+                          aria-selected="false"
                           value="f127ef55-4133-4556-9bca-33615d071e8d"
                         >
                           Nasopharyngeal swab
                         </option>
                         <option
+                          aria-selected="true"
                           value="8596682d-6053-4720-8a39-1f5d19ff4ed9"
                         >
                           Swab of internal nose

--- a/frontend/src/app/testResults/__snapshots__/TestResultCorrectionModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultCorrectionModal.test.tsx.snap
@@ -46,21 +46,25 @@ Object {
               name="correctionReason"
             >
               <option
+                aria-selected="true"
                 value="DUPLICATE_TEST"
               >
                 Duplicate test
               </option>
               <option
+                aria-selected="false"
                 value="INCORRECT_RESULT"
               >
                 Incorrect test result
               </option>
               <option
+                aria-selected="false"
                 value="INCORRECT_TEST_DATE"
               >
                 Incorrect test date
               </option>
               <option
+                aria-selected="false"
                 value="OTHER"
               >
                 Reason not listed
@@ -131,21 +135,25 @@ Object {
             name="correctionReason"
           >
             <option
+              aria-selected="true"
               value="DUPLICATE_TEST"
             >
               Duplicate test
             </option>
             <option
+              aria-selected="false"
               value="INCORRECT_RESULT"
             >
               Incorrect test result
             </option>
             <option
+              aria-selected="false"
               value="INCORRECT_TEST_DATE"
             >
               Incorrect test date
             </option>
             <option
+              aria-selected="false"
               value="OTHER"
             >
               Reason not listed

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -181,16 +181,19 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   - Select -
                 </option>
                 <option
+                  aria-selected="false"
                   value="POSITIVE"
                 >
                   Positive
                 </option>
                 <option
+                  aria-selected="false"
                   value="NEGATIVE"
                 >
                   Negative
                 </option>
                 <option
+                  aria-selected="false"
                   value="UNDETERMINED"
                 >
                   Inconclusive
@@ -218,21 +221,25 @@ exports[`TestResultsList should render a list of tests 1`] = `
                   - Select -
                 </option>
                 <option
+                  aria-selected="false"
                   value="STAFF"
                 >
                   Staff
                 </option>
                 <option
+                  aria-selected="false"
                   value="RESIDENT"
                 >
                   Resident
                 </option>
                 <option
+                  aria-selected="false"
                   value="STUDENT"
                 >
                   Student
                 </option>
                 <option
+                  aria-selected="false"
                   value="VISITOR"
                 >
                   Visitor
@@ -255,21 +262,25 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 name="facility"
               >
                 <option
+                  aria-selected="false"
                   value="all"
                 >
                   All facilities
                 </option>
                 <option
+                  aria-selected="true"
                   value="1"
                 >
                   Facility 1
                 </option>
                 <option
+                  aria-selected="false"
                   value="2"
                 >
                   Facility 2
                 </option>
                 <option
+                  aria-selected="false"
                   value="3"
                 >
                   Facility 3 (Archived)


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Resolves #5126 

## Changes Proposed
- Set the aria-selected attribute in the dropdown component

## Additional Information
- Because the dropdown component is a shared component multiple snapshots had to be updated for this implementation
- I took this ticket as an opportunity to fix the tablet and mobile view of this page

## Testing
- The dashboard page should pass axe scanning.
- Verify that this attribute updates as user changes the selected option.

<img width="474" alt="Screenshot 2023-03-01 at 10 03 29 AM" src="https://user-images.githubusercontent.com/103958711/222270685-5a241d54-fd36-48b7-b8fa-14f2af971f4d.png">
