### PR TITLE
move meta to message header

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -613,7 +613,11 @@ public class FhirConverter {
     var provenanceFullUrl = ResourceType.Provenance + "/" + provenance.getId();
     var messageHeader =
         createMessageHeader(
-            organizationFullUrl, diagnosticReportFullUrl, provenanceFullUrl, gitProperties);
+            organizationFullUrl,
+            diagnosticReportFullUrl,
+            provenanceFullUrl,
+            gitProperties,
+            processingId);
     var practitionerRoleFullUrl = ResourceType.PractitionerRole + "/" + practitionerRole.getId();
     var messageHeaderFullUrl = ResourceType.MessageHeader + "/" + messageHeader.getId();
 
@@ -668,9 +672,6 @@ public class FhirConverter {
                     .setFullUrl(pair.getFirst())
                     .setResource(pair.getSecond())));
 
-    bundle
-        .getMeta()
-        .addTag(PROCESSING_ID_SYSTEM, processingId, PROCESSING_ID_DISPLAY.get(processingId));
     return bundle;
   }
 
@@ -702,7 +703,8 @@ public class FhirConverter {
       String organizationUrl,
       String mainResourceUrl,
       String provenanceFullUrl,
-      GitProperties gitProperties) {
+      GitProperties gitProperties,
+      String processingId) {
     var messageHeader = new MessageHeader();
     messageHeader.setId(UUID.randomUUID().toString());
     messageHeader
@@ -737,6 +739,9 @@ public class FhirConverter {
         .addExtension()
         .setUrl("https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org")
         .setValue(new Reference(ResourceType.Organization + "/" + SIMPLE_REPORT_ORG_ID));
+    messageHeader
+        .getMeta()
+        .addTag(PROCESSING_ID_SYSTEM, processingId, PROCESSING_ID_DISPLAY.get(processingId));
     return messageHeader;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -626,7 +626,7 @@ public class FhirConverter {
 
     serviceRequest.setSubject(new Reference(patientFullUrl));
     serviceRequest.addPerformer(new Reference(organizationFullUrl));
-    serviceRequest.setRequester(new Reference(organizationFullUrl));
+    serviceRequest.setRequester(new Reference(practitionerRoleFullUrl));
     diagnosticReport.addBasedOn(new Reference(serviceRequestFullUrl));
     diagnosticReport.setSubject(new Reference(patientFullUrl));
     diagnosticReport.addSpecimen(new Reference(specimenFullUrl));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1140,7 +1140,7 @@ class FhirConverterTest {
                 .getReference())
         .isEqualTo("Organization/" + organization.getId());
     assertThat(((ServiceRequest) serviceRequestEntry.getResource()).getRequester().getReference())
-        .contains("Organization/");
+        .contains("PractitionerRole/");
 
     var diagnosticReportEntry =
         actual.getEntry().stream()

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -964,7 +964,8 @@ class FhirConverterTest {
   @Test
   void createMessageHeader_valid() {
     var messageHeader =
-        createMessageHeader("Organization/org-id", "mainResource", "provenance", gitProperties);
+        createMessageHeader(
+            "Organization/org-id", "mainResource", "provenance", gitProperties, "P");
 
     assertThat(messageHeader.getEventCoding().getSystem())
         .isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0003");
@@ -1004,6 +1005,11 @@ class FhirConverterTest {
                 .getValueAsPrimitive()
                 .getValueAsString())
         .isEqualTo("FRIDAY");
+    assertThat(messageHeader.getMeta().getTag()).hasSize(1);
+    assertThat(messageHeader.getMeta().getTag().get(0).getCode()).isEqualTo("P");
+    assertThat(messageHeader.getMeta().getTag().get(0).getDisplay()).isEqualTo("Production");
+    assertThat(messageHeader.getMeta().getTag().get(0).getSystem())
+        .isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0103");
   }
 
   @Test

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -316,7 +316,7 @@
           "reference":"Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
         },
         "requester":{
-          "reference":"Organization/1c3d14b9-e222-4a16-9fb2-d9f173034a6a"
+          "reference":"PractitionerRole/$PRACTITIONER_ROLE_ID"
         },
         "performer":[
           {

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -1,15 +1,6 @@
 {
   "resourceType":"Bundle",
   "type":"message",
-  "meta": {
-    "tag": [
-      {
-        "system": "http://terminology.hl7.org/CodeSystem/v2-0103",
-        "code": "P",
-        "display": "Production"
-      }
-    ]
-  },
   "identifier": {
     "value": "45e9539f-c9a4-4c86-b79d-4ba2c43f9ee0"
   },
@@ -58,7 +49,16 @@
           {
             "reference":"DiagnosticReport/45e9539f-c9a4-4c86-b79d-4ba2c43f9ee0"
           }
-        ]
+        ],
+        "meta": {
+          "tag": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0103",
+              "code": "P",
+              "display": "Production"
+            }
+          ]
+        }
       }
     },
     {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Processing information is currently in the bundle, but RS is expecting it in the MessageHeader.
- `ServiceRequest.requester` is pointing to `Organization`, but RS is expecting it to point to `PractitionerRole`

## Changes Proposed

- Move the meta section to MessageHeader
- Change the reference in `ServiceRequest.requester` from `Organization` to `PractitionerRole`

## Additional Information

