### PR TITLE
Add tooltip aria-label in org sign up

### DIFF
--- a/frontend/src/app/commonComponents/TextWithTooltip.scss
+++ b/frontend/src/app/commonComponents/TextWithTooltip.scss
@@ -1,4 +1,14 @@
 .usa-text-with-tooltip {
+  .usa-button--unstyled {
+    text-decoration: none;
+    color: #1b1b1b;
+
+    &:hover {
+      text-decoration: none;
+      color: #1b1b1b;
+    }
+  }
+
   .usa-tooltip__body {
     white-space: pre-wrap;
     min-width: 300px;
@@ -10,6 +20,7 @@
   }
 
   svg {
+    color: #005ea2;
     display: inline-block !important;
     overflow: visible !important;
     vertical-align: -0.125em !important;

--- a/frontend/src/app/commonComponents/TextWithTooltip.tsx
+++ b/frontend/src/app/commonComponents/TextWithTooltip.tsx
@@ -15,7 +15,7 @@ type CustomButtonProps = React.PropsWithChildren<{
 interface Props {
   tooltip: string;
   position?: "top" | "bottom" | "left" | "right";
-  buttonLabel?: string;
+  hideText?: boolean;
   text?: string;
   className?: string;
 }
@@ -24,7 +24,7 @@ export const TextWithTooltip = ({
   tooltip,
   position,
   text,
-  buttonLabel,
+  hideText,
   className,
 }: Props) => {
   const CustomButton: React.ForwardRefExoticComponent<CustomButtonProps> =
@@ -33,7 +33,7 @@ export const TextWithTooltip = ({
         <button
           className={`usa-button usa-button--unstyled ${className}`}
           ref={ref}
-          aria-label={`${buttonLabel} tooltip`}
+          aria-label={hideText ? `${text} tooltip` : ""}
           {...tooltipProps}
         >
           {children}
@@ -54,7 +54,7 @@ export const TextWithTooltip = ({
       wrapperclasses="usa-text-with-tooltip"
       onClick={preventPageReload}
     >
-      {text}
+      {hideText ? "" : text}
       <FontAwesomeIcon
         alt-text="info"
         className="info-circle-icon"

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -345,11 +345,7 @@ describe("QueueItem", () => {
 
   it("updates the timer when a device is changed", async () => {
     await renderQueueItem();
-
-    await userEvent.type(
-      screen.getAllByLabelText("Device", { exact: false })[1],
-      "lumira"
-    );
+    await userEvent.type(screen.getByTestId("device-type-dropdown"), "lumira");
 
     expect(await screen.findByTestId("timer")).toHaveTextContent("15:00");
   });

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -848,9 +848,8 @@ const QueueItem = ({
                       options={deviceTypeOptions}
                       label={
                         <>
-                          <span>Device</span>
                           <TextWithTooltip
-                            buttonLabel="Device"
+                            text="Device"
                             tooltip="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
                             position="right"
                           />

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -255,16 +255,13 @@ exports[`TestQueue should render the test queue 1`] = `
                         class="usa-label"
                         for="1"
                       >
-                        <span>
-                          Device
-                        </span>
                         <span
                           class="usa-tooltip usa-text-with-tooltip"
                           data-testid="tooltipWrapper"
                         >
                           <button
                             aria-describedby="tooltip-211111"
-                            aria-label="Device tooltip"
+                            aria-label=""
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -272,6 +269,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             title=""
                             wrapperclasses="usa-text-with-tooltip"
                           >
+                            Device
                             <svg
                               alt-text="info"
                               aria-hidden="true"
@@ -672,16 +670,13 @@ exports[`TestQueue should render the test queue 1`] = `
                         class="usa-label"
                         for="4"
                       >
-                        <span>
-                          Device
-                        </span>
                         <span
                           class="usa-tooltip usa-text-with-tooltip"
                           data-testid="tooltipWrapper"
                         >
                           <button
                             aria-describedby="tooltip-211111"
-                            aria-label="Device tooltip"
+                            aria-label=""
                             class="usa-button usa-button--unstyled usa-tooltip__trigger"
                             data-testid="triggerElement"
                             position="right"
@@ -689,6 +684,7 @@ exports[`TestQueue should render the test queue 1`] = `
                             title=""
                             wrapperclasses="usa-text-with-tooltip"
                           >
+                            Device
                             <svg
                               alt-text="info"
                               aria-hidden="true"

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -267,7 +267,8 @@ const MultiplexResultInputForm: React.FC<Props> = ({
         </div>
         <div className="grid-col-auto">
           <TextWithTooltip
-            buttonLabel="Results info"
+            text="Results info"
+            hideText={true}
             tooltip="COVID-19 results are reported to your public health department. Flu results are not reported at this time."
             position={isMobile ? "top" : "left"}
           />


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5129 

## Changes Proposed
Modifies the `<TextWithTooltip>` component to ensure `aria-label`s are set properly and labels are not duplicated using a screen reader like VoiceOver.

## Additional Information
- Slightly modified the appearance of the "Device" label on the "Conduct tests" page since in its current implementation the screen reader was reading that dropdown label as "Device Device tooltip" instead of "Device"
@kenieh would love to know if you see an issue with this! This pattern follows the one in the org sign up flow.

**Before**
<img width="1206" alt="Screen Shot 2023-03-02 at 10 15 43" src="https://user-images.githubusercontent.com/20211771/222504172-027c64fc-fa5a-4e4b-9b61-aa2e62a1c1b4.png">

**After**
<img width="1263" alt="Screen Shot 2023-03-01 at 15 34 33" src="https://user-images.githubusercontent.com/20211771/222504240-352be295-3f72-49b9-ad3c-f7eaeb2aa637.png">

## Testing
Ensure with a screen reader that the tooltip label and label for any inputs make sense.
This component is used in four places (see screenshots below):
- Conduct tests (test card) - Submit button for multiplex results
- Conduct tests (test card) - Device select option
- Org sign up - Organization name
- Org sign up - Organization administrator

## Screenshots / Demos
<img width="709" alt="Screen Shot 2023-03-01 at 15 35 46" src="https://user-images.githubusercontent.com/20211771/222507678-c1d940a1-4eec-453e-bb4c-4b52ff392124.png">

<img width="1263" alt="Screen Shot 2023-03-01 at 15 34 33" src="https://user-images.githubusercontent.com/20211771/222508527-82dd5dde-b9f0-4a9c-914d-e422e1b61ff7.png">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
