### PR TITLE
update function_app_memory_alert threshold to be set in bytes

### DIFF
--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -100,5 +100,6 @@ variable "function_id" {
 }
 
 variable "function_memory_threshold" {
-  default = 1200
+  description = "The threshold for the function app memory alert in bytes"
+  default     = 1200000000
 }

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -385,7 +385,7 @@ resource "azurerm_monitor_metric_alert" "function_app_memory_alert" {
   name                = "${var.env}_function_app_batch_publisher_memory_alert"
   resource_group_name = var.rg_name
   scopes              = [var.function_id]
-  description         = "Action will be triggered when memory usage is greater than 1200 mb"
+  description         = "Action will be triggered when memory usage is greater than 1200 mb, threshold is set in bytes"
 
   criteria {
     metric_namespace = "Microsoft.Web/sites"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- function_app_memory_alert was triggered with a value of 191618730 which is about 191mb

## Changes Proposed

- Update threshold to be in bytes

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README