### PR TITLE
add testkit/equipment id to single-entry covid pipeline

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -4,6 +4,7 @@ import static java.lang.Boolean.TRUE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.cdc.usds.simplereport.api.MappingConstants;
+import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -25,6 +26,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -173,6 +175,13 @@ public class TestEventExport {
           .put("Singhalese", "sin")
           .put("Taiwanese", "oan")
           .build();
+
+  private static Optional<? extends DeviceTestPerformedLoincCode> getCovidDiseaseInfo(
+      List<DeviceTestPerformedLoincCode> deviceTestPerformedLoincCodes) {
+    return deviceTestPerformedLoincCodes.stream()
+        .filter(s -> "COVID-19".equals(s.getSupportedDisease().getName()))
+        .findFirst();
+  }
 
   private String boolToYesNoUnk(Boolean value) {
     if (value == null) {
@@ -609,6 +618,24 @@ public class TestEventExport {
   @JsonProperty("Device_ID")
   public String getDeviceID() {
     return deviceType.map(DeviceType::getModel).orElse(null);
+  }
+
+  @JsonProperty("Test_Kit_Name_ID")
+  public String getTestKitNameId() {
+    return deviceType
+        .map(DeviceType::getSupportedDiseaseTestPerformed)
+        .flatMap(TestEventExport::getCovidDiseaseInfo)
+        .map(DeviceTestPerformedLoincCode::getTestkitNameId)
+        .orElse(null);
+  }
+
+  @JsonProperty("Equipment_Model_ID")
+  public String getEquipmentModelId() {
+    return deviceType
+        .map(DeviceType::getSupportedDiseaseTestPerformed)
+        .flatMap(TestEventExport::getCovidDiseaseInfo)
+        .map(DeviceTestPerformedLoincCode::getEquipmentUid)
+        .orElse(null);
   }
 
   @JsonProperty("Test_date")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -248,21 +248,24 @@ public class OrganizationInitializingService {
       }
     }
 
-    Map<String, DeviceTestPerformedLoincCode> deviceExtraInfoByLoinc =
+    Map<String, DeviceTestPerformedLoincCode> deviceExtraInfoByLoincTestkitEquipmentId =
         deviceTestPerformedLoincCodeRepository.findAll().stream()
-            .collect(
-                Collectors.toMap(DeviceTestPerformedLoincCode::getTestPerformedLoincCode, d -> d));
+            .collect(Collectors.toMap(d -> deviceExtraInfoKey(d), d -> d));
     for (DeviceTestPerformedLoincCode d : getDeviceTestPerformedLoincCode(deviceTypesByName)) {
-      if (!deviceExtraInfoByLoinc.containsKey(d.getTestPerformedLoincCode())) {
+      if (!deviceExtraInfoByLoincTestkitEquipmentId.containsKey(deviceExtraInfoKey(d))) {
         log.info("Creating device test performed loinc code {}", d.getTestPerformedLoincCode());
         DeviceTestPerformedLoincCode deviceTestPerformedLoincCode =
             deviceTestPerformedLoincCodeRepository.save(d);
-        deviceExtraInfoByLoinc.put(
+        deviceExtraInfoByLoincTestkitEquipmentId.put(
             deviceTestPerformedLoincCode.getTestPerformedLoincCode(), deviceTestPerformedLoincCode);
       }
     }
 
     return new ArrayList<>(deviceTypesByName.values());
+  }
+
+  private static String deviceExtraInfoKey(DeviceTestPerformedLoincCode d) {
+    return d.getTestPerformedLoincCode() + d.getTestkitNameId() + d.getEquipmentUid();
   }
 
   private List<DeviceType> getDeviceTypes(Map<String, SpecimenType> specimenTypesByCode) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportIntegrationTest.java
@@ -140,6 +140,10 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + "\"Ordered_test_code\":\"95209-3\","
             + "\"Specimen_source_site_code\":\"71836000\","
             + "\"Specimen_type_code\":\"445297001\","
+            + "\"Observation_result_status\":\"F\","
+            + "\"Order_result_status\":\"F\","
+            + "\"Test_Kit_Name_ID\":\"LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd.\","
+            + "\"Equipment_Model_ID\":\"LumiraDx Platform_LumiraDx\","
             + "\"Instrument_ID\":"
             + testEventExport.getInstrumentID()
             + ","
@@ -156,7 +160,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + "\"Site_of_care\":\"university\""
             + "}",
         objectMapper.writeValueAsString(testEventExport),
-        false);
+        true);
   }
 
   @Test
@@ -242,6 +246,9 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + "\"Ordered_test_code\":\"95209-3\","
             + "\"Specimen_source_site_code\":\"71836000\","
             + "\"Specimen_type_code\":\"445297001\","
+            + "\"Test_result_status\":\"C\","
+            + "\"Test_Kit_Name_ID\":\"LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd.\","
+            + "\"Equipment_Model_ID\":\"LumiraDx Platform_LumiraDx\","
             + "\"Instrument_ID\":"
             + correctedTestEventExport.getInstrumentID()
             + ","
@@ -258,7 +265,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + "\"Site_of_care\":\"university\""
             + "}",
         actualStr,
-        false);
+        true);
   }
 
   @Test
@@ -344,6 +351,9 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + "\"Ordered_test_code\":\"95209-3\","
             + "\"Specimen_source_site_code\":\"71836000\","
             + "\"Specimen_type_code\":\"445297001\","
+            + "\"Test_result_status\":\"W\","
+            + "\"Test_Kit_Name_ID\":\"LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd.\","
+            + "\"Equipment_Model_ID\":\"LumiraDx Platform_LumiraDx\","
             + "\"Instrument_ID\":"
             + correctedTestEventExport.getInstrumentID()
             + ","
@@ -360,7 +370,7 @@ class TestEventExportIntegrationTest extends BaseGraphqlTest {
             + "\"Site_of_care\":\"university\""
             + "}",
         actualStr,
-        false);
+        true);
   }
 
   private JsonNode submitTestResult(Map<String, Object> variables, Optional<String> expectedError) {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- part of #4898

## Changes Proposed

- Adds `Test_Kit_Name_ID` and `Equipment_Model_ID` to covid single-entry export
- Fixes bug in init device service where it didn't handle different devices with the same loinc code
- A follow up PR will add those two fields to the FHIR pipeline

## Testing

- How should reviewers verify this PR? deployed on dev6

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
