### PR TITLE
create new device_disease_loinc_code table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4536,14 +4536,14 @@ databaseChangeLog:
                   type: text
                   remarks: represents the data from "Testkit Name ID" column in the LIVD
   - changeSet:
-      id: create-device-disease-table-table
+      id: create-device-disease-table
       author: boban@skylight.digital
       comment: creates a new table to store the relationship between device and disease
       changes:
         - tagDatabase:
-            tag: create-device_disease_loinc_code-table
+            tag: create-device_type_disease-table
         - createTable:
-            tableName: device_disease_loinc_code
+            tableName: device_type_disease
             columns:
               - column:
                   name: internal_id
@@ -4587,9 +4587,9 @@ databaseChangeLog:
                   remarks: The code that identifies which disease was tested.
                   type: text
         - sql:
-            sql: GRANT SELECT ON ${database.defaultSchemaName}.device_disease_loinc_code TO ${noPhiUsername};
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.device_type_disease TO ${noPhiUsername};
         - sql:
-            sql: INSERT INTO ${database.defaultSchemaName}.device_disease_loinc_code SELECT * FROM ${database.defaultSchemaName}.device_test_performed_loinc_code
+            sql: INSERT INTO ${database.defaultSchemaName}.device_type_disease SELECT * FROM ${database.defaultSchemaName}.device_test_performed_loinc_code
       rollback:
         - dropTable:
-            tableName: device_disease_loinc_code
+            tableName: device_type_disease

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4590,3 +4590,6 @@ databaseChangeLog:
             sql: GRANT SELECT ON ${database.defaultSchemaName}.device_disease_loinc_code TO ${noPhiUsername};
         - sql:
             sql: INSERT INTO ${database.defaultSchemaName}.device_disease_loinc_code SELECT * FROM ${database.defaultSchemaName}.device_test_performed_loinc_code
+      rollback:
+        - dropTable:
+            tableName: device_disease_loinc_code

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4535,3 +4535,58 @@ databaseChangeLog:
                   name: testkit_name_id
                   type: text
                   remarks: represents the data from "Testkit Name ID" column in the LIVD
+  - changeSet:
+      id: create-device-disease-table-table
+      author: boban@skylight.digital
+      comment: creates a new table to store the relationship between device and disease
+      changes:
+        - tagDatabase:
+            tag: create-device_disease_loinc_code-table
+        - createTable:
+            tableName: device_disease_loinc_code
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: device_type_id
+                  remarks: The reference to the device type.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_supported_disease__device_type
+                    references: device_type
+              - column:
+                  name: supported_disease_id
+                  remarks: The reference to the supported disease.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_supported_disease__supported_disease_type
+                    references: supported_disease
+              - column:
+                  name: test_performed_loinc_code
+                  remarks: The code that identifies which disease was tested.
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: equipment_uid
+                  remarks: represents the data from "Equipment UID" column in the LIVD
+                  type: text
+              - column:
+                  name: testkit_name_id
+                  remarks: represents the data from "Testkit Name ID" column in the LIVD
+                  type: text
+              - column:
+                  name: test_ordered_loinc_code
+                  remarks: The code that identifies which disease was tested.
+                  type: text
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.device_disease_loinc_code TO ${noPhiUsername};
+        - sql:
+            sql: INSERT INTO ${database.defaultSchemaName}.device_disease_loinc_code SELECT * FROM ${database.defaultSchemaName}.device_test_performed_loinc_code


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Related to #5383 

## Changes Proposed

- Create a new table called `device_type_disease` that has all of the same fields as `device_test_performed_loinc_code` and  a new field`test_ordered_loinc_code`
- Copy data from old table

## Additional Information

- Follow up work will be done to remove the old table, 

