### PR TITLE
add test ordered loinc to backend

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -22,8 +22,8 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
 import gov.cdc.usds.simplereport.api.MappingConstants;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.PersonUtils;
@@ -394,14 +394,13 @@ public class FhirConverter {
 
   public static List<Observation> convertToObservation(
       Set<Result> results,
-      List<DeviceTestPerformedLoincCode> deviceTestPerformedLoincCode,
+      List<DeviceTypeDisease> deviceTypeDisease,
       TestCorrectionStatus correctionStatus,
       String correctionReason) {
     return results.stream()
         .map(
             result -> {
-              String testPerformedLoincCode =
-                  getTestPerformedLoincCode(deviceTestPerformedLoincCode, result);
+              String testPerformedLoincCode = getTestPerformedLoincCode(deviceTypeDisease, result);
               return convertToObservation(
                   result, testPerformedLoincCode, correctionStatus, correctionReason);
             })
@@ -409,11 +408,11 @@ public class FhirConverter {
   }
 
   private static String getTestPerformedLoincCode(
-      List<DeviceTestPerformedLoincCode> deviceTestPerformedLoincCode, Result result) {
-    return deviceTestPerformedLoincCode.stream()
+      List<DeviceTypeDisease> deviceTypeDisease, Result result) {
+    return deviceTypeDisease.stream()
         .filter(code -> code.getSupportedDisease() == result.getDisease())
         .findFirst()
-        .map(DeviceTestPerformedLoincCode::getTestPerformedLoincCode)
+        .map(DeviceTypeDisease::getTestPerformedLoincCode)
         .orElse(result.getTestOrder().getDeviceType().getLoincCode());
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
@@ -9,7 +9,7 @@ import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceSupportedDiseaseRepository;
-import gov.cdc.usds.simplereport.db.repository.DeviceTestPerformedLoincCodeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ public class DeviceTypeDataLoaderService {
   final DiseaseService diseaseService;
   final DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
   final SpecimenTypeRepository specimenTypeRepository;
-  final DeviceTestPerformedLoincCodeRepository deviceTestPerformedLoincCodeRepository;
+  final DeviceTypeDiseaseRepository deviceTypeDiseaseRepository;
 
   Map<UUID, List<SupportedDisease>> getSupportedDiseases(Set<UUID> deviceTypeIds) {
     // load cached supportedDisease
@@ -106,7 +106,7 @@ public class DeviceTypeDataLoaderService {
   Map<UUID, List<DeviceTypeDisease>> getDeviceTestPerformedLoincCode(Set<UUID> deviceTypeIds) {
     var found = new HashMap<UUID, List<DeviceTypeDisease>>();
     deviceTypeIds.forEach(id -> found.put(id, new ArrayList<>()));
-    deviceTestPerformedLoincCodeRepository
+    deviceTypeDiseaseRepository
         .findAllByDeviceTypeIdIn(deviceTypeIds)
         .forEach(
             deviceTestPerformedLoincCode ->

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
@@ -103,16 +103,14 @@ public class DeviceTypeDataLoaderService {
     return found;
   }
 
-  Map<UUID, List<DeviceTypeDisease>> getDeviceTestPerformedLoincCode(Set<UUID> deviceTypeIds) {
+  Map<UUID, List<DeviceTypeDisease>> getDeviceTypeDisease(Set<UUID> deviceTypeIds) {
     var found = new HashMap<UUID, List<DeviceTypeDisease>>();
     deviceTypeIds.forEach(id -> found.put(id, new ArrayList<>()));
     deviceTypeDiseaseRepository
         .findAllByDeviceTypeIdIn(deviceTypeIds)
         .forEach(
-            deviceTestPerformedLoincCode ->
-                found
-                    .get(deviceTestPerformedLoincCode.getDeviceTypeId())
-                    .add(deviceTestPerformedLoincCode));
+            deviceTypeDisease ->
+                found.get(deviceTypeDisease.getDeviceTypeId()).add(deviceTypeDisease));
     return found;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderService.java
@@ -3,7 +3,7 @@ package gov.cdc.usds.simplereport.api.devicetype;
 import static java.util.Collections.emptyList;
 
 import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
@@ -103,9 +103,8 @@ public class DeviceTypeDataLoaderService {
     return found;
   }
 
-  Map<UUID, List<DeviceTestPerformedLoincCode>> getDeviceTestPerformedLoincCode(
-      Set<UUID> deviceTypeIds) {
-    var found = new HashMap<UUID, List<DeviceTestPerformedLoincCode>>();
+  Map<UUID, List<DeviceTypeDisease>> getDeviceTestPerformedLoincCode(Set<UUID> deviceTypeIds) {
+    var found = new HashMap<UUID, List<DeviceTypeDisease>>();
     deviceTypeIds.forEach(id -> found.put(id, new ArrayList<>()));
     deviceTestPerformedLoincCodeRepository
         .findAllByDeviceTypeIdIn(deviceTypeIds)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
@@ -35,14 +35,13 @@ public class DeviceTypeDataResolver {
             (deviceTypeIds, batchLoaderEnvironment) ->
                 Mono.just(deviceTypeDataLoaderService.getSpecimenTypes(deviceTypeIds)));
 
-    Class<List<DeviceTypeDisease>> deviceTestPerformedLoincCodeClazz = (Class) List.class;
+    Class<List<DeviceTypeDisease>> deviceTypeDiseaseCodeClazz = (Class) List.class;
     registry
-        .forTypePair(UUID.class, deviceTestPerformedLoincCodeClazz)
-        .withName("deviceTestPerformedLoincDataloader")
+        .forTypePair(UUID.class, deviceTypeDiseaseCodeClazz)
+        .withName("deviceTypeDiseaseDataloader")
         .registerMappedBatchLoader(
             (deviceTypeIds, batchLoaderEnvironment) ->
-                Mono.just(
-                    deviceTypeDataLoaderService.getDeviceTestPerformedLoincCode(deviceTypeIds)));
+                Mono.just(deviceTypeDataLoaderService.getDeviceTypeDisease(deviceTypeIds)));
   }
 
   @SchemaMapping(typeName = "DeviceType", field = "supportedDiseases")
@@ -61,7 +60,7 @@ public class DeviceTypeDataResolver {
   @SchemaMapping(typeName = "DeviceType", field = "supportedDiseaseTestPerformed")
   public CompletableFuture<List<DeviceTypeDisease>> supportedDiseaseTestPerformed(
       DeviceType deviceType,
-      DataLoader<UUID, List<DeviceTypeDisease>> deviceTestPerformedLoincDataloader) {
-    return deviceTestPerformedLoincDataloader.load(deviceType.getInternalId());
+      DataLoader<UUID, List<DeviceTypeDisease>> deviceTypeDiseaseDataloader) {
+    return deviceTypeDiseaseDataloader.load(deviceType.getInternalId());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataResolver.java
@@ -1,7 +1,7 @@
 package gov.cdc.usds.simplereport.api.devicetype;
 
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import java.util.List;
@@ -35,8 +35,7 @@ public class DeviceTypeDataResolver {
             (deviceTypeIds, batchLoaderEnvironment) ->
                 Mono.just(deviceTypeDataLoaderService.getSpecimenTypes(deviceTypeIds)));
 
-    Class<List<DeviceTestPerformedLoincCode>> deviceTestPerformedLoincCodeClazz =
-        (Class) List.class;
+    Class<List<DeviceTypeDisease>> deviceTestPerformedLoincCodeClazz = (Class) List.class;
     registry
         .forTypePair(UUID.class, deviceTestPerformedLoincCodeClazz)
         .withName("deviceTestPerformedLoincDataloader")
@@ -60,9 +59,9 @@ public class DeviceTypeDataResolver {
   }
 
   @SchemaMapping(typeName = "DeviceType", field = "supportedDiseaseTestPerformed")
-  public CompletableFuture<List<DeviceTestPerformedLoincCode>> supportedDiseaseTestPerformed(
+  public CompletableFuture<List<DeviceTypeDisease>> supportedDiseaseTestPerformed(
       DeviceType deviceType,
-      DataLoader<UUID, List<DeviceTestPerformedLoincCode>> deviceTestPerformedLoincDataloader) {
+      DataLoader<UUID, List<DeviceTypeDisease>> deviceTestPerformedLoincDataloader) {
     return deviceTestPerformedLoincDataloader.load(deviceType.getInternalId());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
@@ -11,4 +11,5 @@ public class SupportedDiseaseTestPerformedInput {
   String testPerformedLoincCode;
   String equipmentUid;
   String testkitNameId;
+  String testOrderedLoincCode;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -4,8 +4,8 @@ import static java.lang.Boolean.TRUE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.cdc.usds.simplereport.api.MappingConstants;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
@@ -176,9 +176,9 @@ public class TestEventExport {
           .put("Taiwanese", "oan")
           .build();
 
-  private static Optional<? extends DeviceTestPerformedLoincCode> getCovidDiseaseInfo(
-      List<DeviceTestPerformedLoincCode> deviceTestPerformedLoincCodes) {
-    return deviceTestPerformedLoincCodes.stream()
+  private static Optional<? extends DeviceTypeDisease> getCovidDiseaseInfo(
+      List<DeviceTypeDisease> deviceTypeDiseases) {
+    return deviceTypeDiseases.stream()
         .filter(s -> "COVID-19".equals(s.getSupportedDisease().getName()))
         .findFirst();
   }
@@ -625,7 +625,7 @@ public class TestEventExport {
     return deviceType
         .map(DeviceType::getSupportedDiseaseTestPerformed)
         .flatMap(TestEventExport::getCovidDiseaseInfo)
-        .map(DeviceTestPerformedLoincCode::getTestkitNameId)
+        .map(DeviceTypeDisease::getTestkitNameId)
         .orElse(null);
   }
 
@@ -634,7 +634,7 @@ public class TestEventExport {
     return deviceType
         .map(DeviceType::getSupportedDiseaseTestPerformed)
         .flatMap(TestEventExport::getCovidDiseaseInfo)
-        .map(DeviceTestPerformedLoincCode::getEquipmentUid)
+        .map(DeviceTypeDisease::getEquipmentUid)
         .orElse(null);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -125,5 +125,6 @@ public class InitialSetupProperties {
     String supportedDisease;
     String equipmentUid;
     String testkitNameId;
+    String testOrderedLoincCode;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
@@ -55,7 +55,7 @@ public class DeviceType extends EternalAuditedEntity {
 
   @JsonIgnore
   @OneToMany(mappedBy = "deviceTypeId", cascade = CascadeType.ALL, orphanRemoval = true)
-  List<DeviceTestPerformedLoincCode> supportedDiseaseTestPerformed = new ArrayList<>();
+  List<DeviceTypeDisease> supportedDiseaseTestPerformed = new ArrayList<>();
 
   protected DeviceType() {
     /* no-op for hibernate */

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class DeviceTestPerformedLoincCode extends IdentifiedEntity {
+public class DeviceTypeDisease extends IdentifiedEntity {
 
   @Column(name = "device_type_id")
   private UUID deviceTypeId;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -27,4 +27,5 @@ public class DeviceTypeDisease extends IdentifiedEntity {
   @Column private String testPerformedLoincCode;
   @Column private String equipmentUid;
   @Column private String testkitNameId;
+  @Column private String testOrderedLoincCode;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SupportedDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SupportedDisease.java
@@ -38,7 +38,7 @@ public class SupportedDisease extends IdentifiedEntity {
 
   @JsonIgnore
   @OneToMany(mappedBy = "supportedDisease")
-  private List<DeviceTestPerformedLoincCode> supportedDiseaseTestPerformed = new ArrayList<>();
+  private List<DeviceTypeDisease> supportedDiseaseTestPerformed = new ArrayList<>();
 
   @ConstructorBinding
   public SupportedDisease(String name, String loinc) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceTestPerformedLoincCodeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceTestPerformedLoincCodeRepository.java
@@ -1,15 +1,15 @@
 package gov.cdc.usds.simplereport.db.repository;
 
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface DeviceTestPerformedLoincCodeRepository
-    extends CrudRepository<DeviceTestPerformedLoincCode, UUID> {
+    extends CrudRepository<DeviceTypeDisease, UUID> {
   @Override
-  List<DeviceTestPerformedLoincCode> findAll();
+  List<DeviceTypeDisease> findAll();
 
-  List<DeviceTestPerformedLoincCode> findAllByDeviceTypeIdIn(Set<UUID> deviceTypeInternalIds);
+  List<DeviceTypeDisease> findAllByDeviceTypeIdIn(Set<UUID> deviceTypeInternalIds);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceTypeDiseaseRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeviceTypeDiseaseRepository.java
@@ -6,8 +6,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
-public interface DeviceTestPerformedLoincCodeRepository
-    extends CrudRepository<DeviceTypeDisease, UUID> {
+public interface DeviceTypeDiseaseRepository extends CrudRepository<DeviceTypeDisease, UUID> {
   @Override
   List<DeviceTypeDisease> findAll();
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -5,8 +5,8 @@ import gov.cdc.usds.simplereport.api.model.SupportedDiseaseTestPerformedInput;
 import gov.cdc.usds.simplereport.api.model.UpdateDeviceType;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
@@ -123,7 +123,7 @@ public class DeviceTypeService {
               updateDevice.getSupportedDiseaseTestPerformed(), device);
       device.setSupportedDiseases(
           deviceTestPerformedLoincCodeList.stream()
-              .map(DeviceTestPerformedLoincCode::getSupportedDisease)
+              .map(DeviceTypeDisease::getSupportedDisease)
               .collect(Collectors.toList()));
       device.getSupportedDiseaseTestPerformed().clear();
       device.getSupportedDiseaseTestPerformed().addAll(deviceTestPerformedLoincCodeList);
@@ -177,7 +177,7 @@ public class DeviceTypeService {
               createDevice.getSupportedDiseaseTestPerformed(), dt);
       dt.setSupportedDiseases(
           deviceTestPerformedLoincCodeList.stream()
-              .map(DeviceTestPerformedLoincCode::getSupportedDisease)
+              .map(DeviceTypeDisease::getSupportedDisease)
               .collect(Collectors.toList()));
       dt.getSupportedDiseaseTestPerformed().addAll(deviceTestPerformedLoincCodeList);
     } else {
@@ -194,17 +194,17 @@ public class DeviceTypeService {
     return dt;
   }
 
-  private ArrayList<DeviceTestPerformedLoincCode> createDeviceTestPerformedLoincCodeList(
+  private ArrayList<DeviceTypeDisease> createDeviceTestPerformedLoincCodeList(
       List<SupportedDiseaseTestPerformedInput> supportedDiseaseTestPerformedInput,
       DeviceType device) {
-    var deviceTestPerformedLoincCodeList = new ArrayList<DeviceTestPerformedLoincCode>();
+    var deviceTestPerformedLoincCodeList = new ArrayList<DeviceTypeDisease>();
     supportedDiseaseTestPerformedInput.forEach(
         input -> {
           var supportedDisease = supportedDiseaseRepository.findById(input.getSupportedDisease());
           supportedDisease.ifPresent(
               disease ->
                   deviceTestPerformedLoincCodeList.add(
-                      DeviceTestPerformedLoincCode.builder()
+                      DeviceTypeDisease.builder()
                           .deviceTypeId(device.getInternalId())
                           .supportedDisease(disease)
                           .testPerformedLoincCode(input.getTestPerformedLoincCode())

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -118,15 +118,14 @@ public class DeviceTypeService {
       deviceSpecimenTypeNewRepository.saveAll(toBeAddedDeviceSpecimenTypes);
     }
     if (updateDevice.getSupportedDiseaseTestPerformed() != null) {
-      var deviceTestPerformedLoincCodeList =
-          createDeviceTestPerformedLoincCodeList(
-              updateDevice.getSupportedDiseaseTestPerformed(), device);
+      var deviceTypeDiseaseList =
+          createDeviceTypeDiseaseList(updateDevice.getSupportedDiseaseTestPerformed(), device);
       device.setSupportedDiseases(
-          deviceTestPerformedLoincCodeList.stream()
+          deviceTypeDiseaseList.stream()
               .map(DeviceTypeDisease::getSupportedDisease)
               .collect(Collectors.toList()));
       device.getSupportedDiseaseTestPerformed().clear();
-      device.getSupportedDiseaseTestPerformed().addAll(deviceTestPerformedLoincCodeList);
+      device.getSupportedDiseaseTestPerformed().addAll(deviceTypeDiseaseList);
     } else if (updateDevice.getSupportedDiseases() != null) {
       List<SupportedDisease> supportedDiseases =
           updateDevice.getSupportedDiseases().stream()
@@ -172,14 +171,13 @@ public class DeviceTypeService {
         .forEach(deviceSpecimenTypeNewRepository::save);
 
     if (createDevice.getSupportedDiseaseTestPerformed() != null) {
-      var deviceTestPerformedLoincCodeList =
-          createDeviceTestPerformedLoincCodeList(
-              createDevice.getSupportedDiseaseTestPerformed(), dt);
+      var deviceTypeDiseaseList =
+          createDeviceTypeDiseaseList(createDevice.getSupportedDiseaseTestPerformed(), dt);
       dt.setSupportedDiseases(
-          deviceTestPerformedLoincCodeList.stream()
+          deviceTypeDiseaseList.stream()
               .map(DeviceTypeDisease::getSupportedDisease)
               .collect(Collectors.toList()));
-      dt.getSupportedDiseaseTestPerformed().addAll(deviceTestPerformedLoincCodeList);
+      dt.getSupportedDiseaseTestPerformed().addAll(deviceTypeDiseaseList);
     } else {
       List<SupportedDisease> supportedDiseases =
           createDevice.getSupportedDiseases().stream()
@@ -194,16 +192,16 @@ public class DeviceTypeService {
     return dt;
   }
 
-  private ArrayList<DeviceTypeDisease> createDeviceTestPerformedLoincCodeList(
+  private ArrayList<DeviceTypeDisease> createDeviceTypeDiseaseList(
       List<SupportedDiseaseTestPerformedInput> supportedDiseaseTestPerformedInput,
       DeviceType device) {
-    var deviceTestPerformedLoincCodeList = new ArrayList<DeviceTypeDisease>();
+    var deviceTypeDiseaseList = new ArrayList<DeviceTypeDisease>();
     supportedDiseaseTestPerformedInput.forEach(
         input -> {
           var supportedDisease = supportedDiseaseRepository.findById(input.getSupportedDisease());
           supportedDisease.ifPresent(
               disease ->
-                  deviceTestPerformedLoincCodeList.add(
+                  deviceTypeDiseaseList.add(
                       DeviceTypeDisease.builder()
                           .deviceTypeId(device.getInternalId())
                           .supportedDisease(disease)
@@ -212,6 +210,6 @@ public class DeviceTypeService {
                           .testkitNameId(input.getTestkitNameId())
                           .build()));
         });
-    return deviceTestPerformedLoincCodeList;
+    return deviceTypeDiseaseList;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -208,6 +208,7 @@ public class DeviceTypeService {
                           .testPerformedLoincCode(input.getTestPerformedLoincCode())
                           .equipmentUid(input.getEquipmentUid())
                           .testkitNameId(input.getTestkitNameId())
+                          .testOrderedLoincCode(input.getTestOrderedLoincCode())
                           .build()));
         });
     return deviceTypeDiseaseList;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -251,7 +251,7 @@ public class OrganizationInitializingService {
     Map<String, DeviceTypeDisease> deviceExtraInfoByLoincTestkitEquipmentId =
         deviceTypeDiseaseRepository.findAll().stream()
             .collect(Collectors.toMap(d -> deviceExtraInfoKey(d), d -> d));
-    for (DeviceTypeDisease d : getdeviceTypeDiseaseCode(deviceTypesByName)) {
+    for (DeviceTypeDisease d : getDeviceTypeDiseaseCode(deviceTypesByName)) {
       if (!deviceExtraInfoByLoincTestkitEquipmentId.containsKey(deviceExtraInfoKey(d))) {
         log.info("Creating device test performed loinc code {}", d.getTestPerformedLoincCode());
         DeviceTypeDisease deviceTypeDisease = deviceTypeDiseaseRepository.save(d);
@@ -292,7 +292,7 @@ public class OrganizationInitializingService {
         .collect(Collectors.toList());
   }
 
-  private List<DeviceTypeDisease> getdeviceTypeDiseaseCode(
+  private List<DeviceTypeDisease> getDeviceTypeDiseaseCode(
       Map<String, DeviceType> deviceTypesByName) {
     List<List<DeviceTypeDisease>> collect =
         _props.getDeviceTypes().stream()
@@ -309,6 +309,7 @@ public class OrganizationInitializingService {
                                     .testPerformedLoincCode(c.getTestPerformedLoincCode())
                                     .supportedDisease(
                                         diseaseService.getDiseaseByName(c.getSupportedDisease()))
+                                    .testOrderedLoincCode(c.getTestOrderedLoincCode())
                                     .build())
                         .collect(Collectors.toList()))
             .collect(Collectors.toList());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -251,7 +251,7 @@ public class OrganizationInitializingService {
     Map<String, DeviceTypeDisease> deviceExtraInfoByLoincTestkitEquipmentId =
         deviceTypeDiseaseRepository.findAll().stream()
             .collect(Collectors.toMap(d -> deviceExtraInfoKey(d), d -> d));
-    for (DeviceTypeDisease d : getDeviceTestPerformedLoincCode(deviceTypesByName)) {
+    for (DeviceTypeDisease d : getdeviceTypeDiseaseCode(deviceTypesByName)) {
       if (!deviceExtraInfoByLoincTestkitEquipmentId.containsKey(deviceExtraInfoKey(d))) {
         log.info("Creating device test performed loinc code {}", d.getTestPerformedLoincCode());
         DeviceTypeDisease deviceTypeDisease = deviceTypeDiseaseRepository.save(d);
@@ -292,7 +292,7 @@ public class OrganizationInitializingService {
         .collect(Collectors.toList());
   }
 
-  private List<DeviceTypeDisease> getDeviceTestPerformedLoincCode(
+  private List<DeviceTypeDisease> getdeviceTypeDiseaseCode(
       Map<String, DeviceType> deviceTypesByName) {
     List<List<DeviceTypeDisease>> collect =
         _props.getDeviceTypes().stream()

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -10,8 +10,8 @@ import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration.DemoAuthorization;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration.DemoUser;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
@@ -248,23 +248,22 @@ public class OrganizationInitializingService {
       }
     }
 
-    Map<String, DeviceTestPerformedLoincCode> deviceExtraInfoByLoincTestkitEquipmentId =
+    Map<String, DeviceTypeDisease> deviceExtraInfoByLoincTestkitEquipmentId =
         deviceTestPerformedLoincCodeRepository.findAll().stream()
             .collect(Collectors.toMap(d -> deviceExtraInfoKey(d), d -> d));
-    for (DeviceTestPerformedLoincCode d : getDeviceTestPerformedLoincCode(deviceTypesByName)) {
+    for (DeviceTypeDisease d : getDeviceTestPerformedLoincCode(deviceTypesByName)) {
       if (!deviceExtraInfoByLoincTestkitEquipmentId.containsKey(deviceExtraInfoKey(d))) {
         log.info("Creating device test performed loinc code {}", d.getTestPerformedLoincCode());
-        DeviceTestPerformedLoincCode deviceTestPerformedLoincCode =
-            deviceTestPerformedLoincCodeRepository.save(d);
+        DeviceTypeDisease deviceTypeDisease = deviceTestPerformedLoincCodeRepository.save(d);
         deviceExtraInfoByLoincTestkitEquipmentId.put(
-            deviceTestPerformedLoincCode.getTestPerformedLoincCode(), deviceTestPerformedLoincCode);
+            deviceTypeDisease.getTestPerformedLoincCode(), deviceTypeDisease);
       }
     }
 
     return new ArrayList<>(deviceTypesByName.values());
   }
 
-  private static String deviceExtraInfoKey(DeviceTestPerformedLoincCode d) {
+  private static String deviceExtraInfoKey(DeviceTypeDisease d) {
     return d.getTestPerformedLoincCode() + d.getTestkitNameId() + d.getEquipmentUid();
   }
 
@@ -293,16 +292,16 @@ public class OrganizationInitializingService {
         .collect(Collectors.toList());
   }
 
-  private List<DeviceTestPerformedLoincCode> getDeviceTestPerformedLoincCode(
+  private List<DeviceTypeDisease> getDeviceTestPerformedLoincCode(
       Map<String, DeviceType> deviceTypesByName) {
-    List<List<DeviceTestPerformedLoincCode>> collect =
+    List<List<DeviceTypeDisease>> collect =
         _props.getDeviceTypes().stream()
             .map(
                 device ->
                     device.getTestPerformedLoincs().stream()
                         .map(
                             c ->
-                                DeviceTestPerformedLoincCode.builder()
+                                DeviceTypeDisease.builder()
                                     .deviceTypeId(
                                         deviceTypesByName.get(device.getName()).getInternalId())
                                     .equipmentUid(c.getEquipmentUid())

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -18,7 +18,7 @@ import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
-import gov.cdc.usds.simplereport.db.repository.DeviceTestPerformedLoincCodeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
@@ -50,7 +50,7 @@ public class OrganizationInitializingService {
   private final ProviderRepository _providerRepo;
   private final DeviceTypeRepository _deviceTypeRepo;
   private final SpecimenTypeRepository _specimenTypeRepo;
-  private final DeviceTestPerformedLoincCodeRepository deviceTestPerformedLoincCodeRepository;
+  private final DeviceTypeDiseaseRepository deviceTypeDiseaseRepository;
   private final FacilityRepository _facilityRepo;
   private final ApiUserRepository _apiUserRepo;
   private final OktaRepository _oktaRepo;
@@ -249,12 +249,12 @@ public class OrganizationInitializingService {
     }
 
     Map<String, DeviceTypeDisease> deviceExtraInfoByLoincTestkitEquipmentId =
-        deviceTestPerformedLoincCodeRepository.findAll().stream()
+        deviceTypeDiseaseRepository.findAll().stream()
             .collect(Collectors.toMap(d -> deviceExtraInfoKey(d), d -> d));
     for (DeviceTypeDisease d : getDeviceTestPerformedLoincCode(deviceTypesByName)) {
       if (!deviceExtraInfoByLoincTestkitEquipmentId.containsKey(deviceExtraInfoKey(d))) {
         log.info("Creating device test performed loinc code {}", d.getTestPerformedLoincCode());
-        DeviceTypeDisease deviceTypeDisease = deviceTestPerformedLoincCodeRepository.save(d);
+        DeviceTypeDisease deviceTypeDisease = deviceTypeDiseaseRepository.save(d);
         deviceExtraInfoByLoincTestkitEquipmentId.put(
             deviceTypeDisease.getTestPerformedLoincCode(), deviceTypeDisease);
       }

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -81,14 +81,17 @@ simple-report-initialization:
           supported-disease: "Flu A"
           equipment-uid: "00884999048034"
           testkit-name-id: "Alinity m Resp-4-Plex_Abbott Molecular Inc."
+          test-ordered-loinc-code: "95941-1"
         - test-performed-loinc-code: "94500-6"
           supported-disease: "COVID-19"
           equipment-uid: "00884999048034"
           testkit-name-id: "Alinity m Resp-4-Plex_Abbott Molecular Inc."
+          test-ordered-loinc-code: "95941-1"
         - test-performed-loinc-code: "85478-6"
           supported-disease: "Flu B"
           equipment-uid: "00884999048034"
           testkit-name-id: "Alinity m Resp-4-Plex_Abbott Molecular Inc."
+          test-ordered-loinc-code: "95941-1"
     - name: Abbott IDNow
       manufacturer: Abbott
       model: ID Now
@@ -99,6 +102,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: 00811877010616
           testkit-name-id: 10811877011269
+          test-ordered-loinc-code: "94534-5"
     - name: Abbott BinaxNow
       manufacturer: Abbott
       model: BinaxNOW COVID-19 Ag Card
@@ -109,6 +113,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: 10811877011290
+          test-ordered-loinc-code: "94558-4"
     - name: Quidel Sofia 2
       manufacturer: Quidel
       model: Sofia 2 SARS Antigen FIA
@@ -119,6 +124,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "Sofia Instrument_Quidel"
           testkit-name-id: "Sofia SARS Antigen FIA_Quidel Corporation"
+          test-ordered-loinc-code: "95209-3"
     - name: BD Veritor
       manufacturer: Becton, Dickinson and Company (BD)
       model: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
@@ -129,6 +135,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "BD Veritor Plus System_Becton Dickinson"
           testkit-name-id: "BD Veritor System for Rapid Detection of SARS-CoV-2_Becton, Dickinson and Company (BD)"
+          test-ordered-loinc-code: "94558-4"
     - name: LumiraDX
       manufacturer: LumiraDx UK Ltd.
       model: LumiraDx SARS-CoV-2 Ag Test*
@@ -139,6 +146,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "LumiraDx Platform_LumiraDx"
           testkit-name-id: "LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd."
+          test-ordered-loinc-code: "95209-3"
     - name: Access Bio CareStart
       manufacturer: Access Bio, Inc.
       model: CareStart COVID-19 Antigen test*
@@ -149,6 +157,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: "CareStart COVID-19 Antigen test_Access Bio, Inc."
+          test-ordered-loinc-code: "94558-4"
   patient-registration-links:
     - link: dis-org
       organization-external-id: DIS_ORG

--- a/backend/src/main/resources/application-e2e.yaml
+++ b/backend/src/main/resources/application-e2e.yaml
@@ -58,6 +58,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: 00811877010616
           testkit-name-id: 10811877011269
+          test-ordered-loinc-code: "94534-5"
     - name: Abbott BinaxNow
       manufacturer: Abbott
       model: BinaxNOW COVID-19 Ag Card
@@ -68,6 +69,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: 10811877011290
+          test-ordered-loinc-code: "94558-4"
     - name: Quidel Sofia 2
       manufacturer: Quidel
       model: Sofia 2 SARS Antigen FIA
@@ -78,6 +80,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "Sofia Instrument_Quidel"
           testkit-name-id: "Sofia SARS Antigen FIA_Quidel Corporation"
+          test-ordered-loinc-code: "95209-3"
     - name: BD Veritor
       manufacturer: Becton, Dickinson and Company (BD)
       model: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
@@ -88,6 +91,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "BD Veritor Plus System_Becton Dickinson"
           testkit-name-id: "BD Veritor System for Rapid Detection of SARS-CoV-2_Becton, Dickinson and Company (BD)"
+          test-ordered-loinc-code: "94558-4"
     - name: LumiraDX
       manufacturer: LumiraDx UK Ltd.
       model: LumiraDx SARS-CoV-2 Ag Test*
@@ -98,6 +102,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "LumiraDx Platform_LumiraDx"
           testkit-name-id: "LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd."
+          test-ordered-loinc-code: "95209-3"
     - name: Access Bio CareStart
       manufacturer: Access Bio, Inc.
       model: CareStart COVID-19 Antigen test*
@@ -108,6 +113,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: "CareStart COVID-19 Antigen test_Access Bio, Inc."
+          test-ordered-loinc-code: "94558-4"
 datahub:
   url: "http://invalidhost:8080"
   api-key: "placeholder"

--- a/backend/src/main/resources/application-okta-local.yaml
+++ b/backend/src/main/resources/application-okta-local.yaml
@@ -34,14 +34,17 @@ simple-report-initialization:
           supported-disease: "Flu A"
           equipment-uid: "00884999048034"
           testkit-name-id: "Alinity m Resp-4-Plex_Abbott Molecular Inc."
+          test-ordered-loinc-code: "95941-1"
         - test-performed-loinc-code: "94500-6"
           supported-disease: "COVID-19"
           equipment-uid: "00884999048034"
           testkit-name-id: "Alinity m Resp-4-Plex_Abbott Molecular Inc."
+          test-ordered-loinc-code: "95941-1"
         - test-performed-loinc-code: "85478-6"
           supported-disease: "Flu B"
           equipment-uid: "00884999048034"
           testkit-name-id: "Alinity m Resp-4-Plex_Abbott Molecular Inc."
+          test-ordered-loinc-code: "95941-1"
     - name: Abbott IDNow
       manufacturer: Abbott
       model: ID Now
@@ -52,6 +55,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: 00811877010616
           testkit-name-id: 10811877011269
+          test-ordered-loinc-code: "94534-5"
     - name: Abbott BinaxNow
       manufacturer: Abbott
       model: BinaxNOW COVID-19 Ag Card
@@ -62,6 +66,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: 10811877011290
+          test-ordered-loinc-code: "94558-4"
     - name: Quidel Sofia 2
       manufacturer: Quidel
       model: Sofia 2 SARS Antigen FIA
@@ -72,6 +77,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "Sofia Instrument_Quidel"
           testkit-name-id: "Sofia SARS Antigen FIA_Quidel Corporation"
+          test-ordered-loinc-code: "95209-3"
     - name: BD Veritor
       manufacturer: Becton, Dickinson and Company (BD)
       model: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
@@ -82,6 +88,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "BD Veritor Plus System_Becton Dickinson"
           testkit-name-id: "BD Veritor System for Rapid Detection of SARS-CoV-2_Becton, Dickinson and Company (BD)"
+          test-ordered-loinc-code: "94558-4"
     - name: LumiraDX
       manufacturer: LumiraDx UK Ltd.
       model: LumiraDx SARS-CoV-2 Ag Test*
@@ -92,6 +99,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "LumiraDx Platform_LumiraDx"
           testkit-name-id: "LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd."
+          test-ordered-loinc-code: "95209-3"
     - name: Access Bio CareStart
       manufacturer: Access Bio, Inc.
       model: CareStart COVID-19 Antigen test*
@@ -102,3 +110,4 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: "CareStart COVID-19 Antigen test_Access Bio, Inc."
+          test-ordered-loinc-code: "94558-4"

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -80,6 +80,7 @@ input SupportedDiseaseTestPerformedInput {
   testPerformedLoincCode: String!
   equipmentUid: String
   testkitNameId: String
+  testOrderedLoincCode: String
 }
 
 type DeviceType {
@@ -100,6 +101,7 @@ type SupportedDiseaseTestPerformed {
   testPerformedLoincCode: String!
   equipmentUid: String
   testkitNameId: String
+  testOrderedLoincCode: String
 }
 
 type SupportedDisease {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -723,9 +723,9 @@ class FhirConverterTest {
     ReflectionTestUtils.setField(covidResult, "internalId", UUID.fromString(covidId));
     ReflectionTestUtils.setField(fluResult, "internalId", UUID.fromString(fluId));
     var covidDiseaseTestPerformedCode =
-        new DeviceTypeDisease(null, covidDisease, "94500-6", null, null);
+        new DeviceTypeDisease(null, covidDisease, "94500-6", null, null, null);
     var fluDiseaseTestPerformedCode =
-        new DeviceTypeDisease(null, fluDisease, "85477-8", null, null);
+        new DeviceTypeDisease(null, fluDisease, "85477-8", null, null, null);
 
     var actual =
         convertToObservation(
@@ -772,7 +772,7 @@ class FhirConverterTest {
     var testOrder = TestDataBuilder.createTestOrderWithDevice();
     var result = new Result(testOrder, covidDisease, TestResult.NEGATIVE);
     var covidDiseaseTestPerformedCode =
-        new DeviceTypeDisease(null, covidDisease, "94500-6", null, null);
+        new DeviceTypeDisease(null, covidDisease, "94500-6", null, null, null);
 
     ReflectionTestUtils.setField(result, "internalId", UUID.fromString(id));
 
@@ -1232,9 +1232,9 @@ class FhirConverterTest {
     var testEventId = UUID.fromString("45e9539f-c9a4-4c86-b79d-4ba2c43f9ee0");
     var testPerformedCodesList =
         List.of(
-            new DeviceTypeDisease(deviceTypeId, covidDisease, "333-123", null, null),
-            new DeviceTypeDisease(deviceTypeId, fluADisease, "444-123", null, null),
-            new DeviceTypeDisease(deviceTypeId, fluBDisease, "444-456", null, null));
+            new DeviceTypeDisease(deviceTypeId, covidDisease, "333-123", null, null, null),
+            new DeviceTypeDisease(deviceTypeId, fluADisease, "444-123", null, null, null),
+            new DeviceTypeDisease(deviceTypeId, fluBDisease, "444-456", null, null, null));
     var date = new Date();
     ReflectionTestUtils.setField(provider, "internalId", providerId);
     ReflectionTestUtils.setField(facility, "internalId", facilityId);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.when;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
@@ -723,9 +723,9 @@ class FhirConverterTest {
     ReflectionTestUtils.setField(covidResult, "internalId", UUID.fromString(covidId));
     ReflectionTestUtils.setField(fluResult, "internalId", UUID.fromString(fluId));
     var covidDiseaseTestPerformedCode =
-        new DeviceTestPerformedLoincCode(null, covidDisease, "94500-6", null, null);
+        new DeviceTypeDisease(null, covidDisease, "94500-6", null, null);
     var fluDiseaseTestPerformedCode =
-        new DeviceTestPerformedLoincCode(null, fluDisease, "85477-8", null, null);
+        new DeviceTypeDisease(null, fluDisease, "85477-8", null, null);
 
     var actual =
         convertToObservation(
@@ -772,7 +772,7 @@ class FhirConverterTest {
     var testOrder = TestDataBuilder.createTestOrderWithDevice();
     var result = new Result(testOrder, covidDisease, TestResult.NEGATIVE);
     var covidDiseaseTestPerformedCode =
-        new DeviceTestPerformedLoincCode(null, covidDisease, "94500-6", null, null);
+        new DeviceTypeDisease(null, covidDisease, "94500-6", null, null);
 
     ReflectionTestUtils.setField(result, "internalId", UUID.fromString(id));
 
@@ -1232,9 +1232,9 @@ class FhirConverterTest {
     var testEventId = UUID.fromString("45e9539f-c9a4-4c86-b79d-4ba2c43f9ee0");
     var testPerformedCodesList =
         List.of(
-            new DeviceTestPerformedLoincCode(deviceTypeId, covidDisease, "333-123", null, null),
-            new DeviceTestPerformedLoincCode(deviceTypeId, fluADisease, "444-123", null, null),
-            new DeviceTestPerformedLoincCode(deviceTypeId, fluBDisease, "444-456", null, null));
+            new DeviceTypeDisease(deviceTypeId, covidDisease, "333-123", null, null),
+            new DeviceTypeDisease(deviceTypeId, fluADisease, "444-123", null, null),
+            new DeviceTypeDisease(deviceTypeId, fluBDisease, "444-456", null, null));
     var date = new Date();
     ReflectionTestUtils.setField(provider, "internalId", providerId);
     ReflectionTestUtils.setField(facility, "internalId", facilityId);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -12,7 +12,7 @@ import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceSupportedDiseaseRepository;
-import gov.cdc.usds.simplereport.db.repository.DeviceTestPerformedLoincCodeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import java.util.List;
@@ -32,7 +32,7 @@ class DeviceTypeDataLoaderHelperTest {
   @Mock DiseaseService diseaseService;
   @Mock DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
   @Mock SpecimenTypeRepository specimenTypeRepository;
-  @Mock DeviceTestPerformedLoincCodeRepository deviceTestPerformedLoincCodeRepository;
+  @Mock DeviceTypeDiseaseRepository deviceTypeDiseaseRepository;
 
   @InjectMocks private DeviceTypeDataLoaderService deviceTypeDataLoaderService;
 
@@ -148,7 +148,7 @@ class DeviceTypeDataLoaderHelperTest {
             .testkitNameId("666")
             .build();
 
-    when(deviceTestPerformedLoincCodeRepository.findAllByDeviceTypeIdIn(deviceIdSet))
+    when(deviceTypeDiseaseRepository.findAllByDeviceTypeIdIn(deviceIdSet))
         .thenReturn(
             List.of(
                 deviceTestPerformedLoincCode1,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -130,6 +130,7 @@ class DeviceTypeDataLoaderHelperTest {
             .supportedDisease(new SupportedDisease())
             .equipmentUid("111")
             .testkitNameId("222")
+            .testOrderedLoincCode("234")
             .build();
     var deviceTypeDisease2 =
         DeviceTypeDisease.builder()
@@ -138,6 +139,7 @@ class DeviceTypeDataLoaderHelperTest {
             .supportedDisease(new SupportedDisease())
             .equipmentUid("333")
             .testkitNameId("444")
+            .testOrderedLoincCode("345")
             .build();
     var deviceTypeDisease3 =
         DeviceTypeDisease.builder()
@@ -146,6 +148,7 @@ class DeviceTypeDataLoaderHelperTest {
             .supportedDisease(new SupportedDisease())
             .equipmentUid("555")
             .testkitNameId("666")
+            .testOrderedLoincCode("244")
             .build();
 
     when(deviceTypeDiseaseRepository.findAllByDeviceTypeIdIn(deviceIdSet))

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -117,13 +117,13 @@ class DeviceTypeDataLoaderHelperTest {
   }
 
   @Test
-  void getDeviceTestPerformedLoincCode() {
+  void getDeviceTypeDisease() {
     var device1Id = UUID.randomUUID();
     var device2Id = UUID.randomUUID();
     var device3Id = UUID.randomUUID();
     var deviceIdSet = Set.of(device1Id, device2Id, device3Id);
 
-    var deviceTestPerformedLoincCode1 =
+    var deviceTypeDisease1 =
         DeviceTypeDisease.builder()
             .deviceTypeId(device1Id)
             .testPerformedLoincCode("123")
@@ -131,7 +131,7 @@ class DeviceTypeDataLoaderHelperTest {
             .equipmentUid("111")
             .testkitNameId("222")
             .build();
-    var deviceTestPerformedLoincCode2 =
+    var deviceTypeDisease2 =
         DeviceTypeDisease.builder()
             .deviceTypeId(device1Id)
             .testPerformedLoincCode("456")
@@ -139,7 +139,7 @@ class DeviceTypeDataLoaderHelperTest {
             .equipmentUid("333")
             .testkitNameId("444")
             .build();
-    var deviceTestPerformedLoincCode3 =
+    var deviceTypeDisease3 =
         DeviceTypeDisease.builder()
             .deviceTypeId(device2Id)
             .testPerformedLoincCode("123")
@@ -149,19 +149,14 @@ class DeviceTypeDataLoaderHelperTest {
             .build();
 
     when(deviceTypeDiseaseRepository.findAllByDeviceTypeIdIn(deviceIdSet))
-        .thenReturn(
-            List.of(
-                deviceTestPerformedLoincCode1,
-                deviceTestPerformedLoincCode2,
-                deviceTestPerformedLoincCode3));
+        .thenReturn(List.of(deviceTypeDisease1, deviceTypeDisease2, deviceTypeDisease3));
 
-    var actual = deviceTypeDataLoaderService.getDeviceTestPerformedLoincCode(deviceIdSet);
+    var actual = deviceTypeDataLoaderService.getDeviceTypeDisease(deviceIdSet);
 
     assertThat(actual)
         .hasSize(3)
-        .containsEntry(
-            device1Id, List.of(deviceTestPerformedLoincCode1, deviceTestPerformedLoincCode2))
-        .containsEntry(device2Id, List.of(deviceTestPerformedLoincCode3))
+        .containsEntry(device1Id, List.of(deviceTypeDisease1, deviceTypeDisease2))
+        .containsEntry(device2Id, List.of(deviceTypeDisease3))
         .containsEntry(device3Id, emptyList());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.db.model.DeviceSupportedDisease;
-import gov.cdc.usds.simplereport.db.model.DeviceTestPerformedLoincCode;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
@@ -124,7 +124,7 @@ class DeviceTypeDataLoaderHelperTest {
     var deviceIdSet = Set.of(device1Id, device2Id, device3Id);
 
     var deviceTestPerformedLoincCode1 =
-        DeviceTestPerformedLoincCode.builder()
+        DeviceTypeDisease.builder()
             .deviceTypeId(device1Id)
             .testPerformedLoincCode("123")
             .supportedDisease(new SupportedDisease())
@@ -132,7 +132,7 @@ class DeviceTypeDataLoaderHelperTest {
             .testkitNameId("222")
             .build();
     var deviceTestPerformedLoincCode2 =
-        DeviceTestPerformedLoincCode.builder()
+        DeviceTypeDisease.builder()
             .deviceTypeId(device1Id)
             .testPerformedLoincCode("456")
             .supportedDisease(new SupportedDisease())
@@ -140,7 +140,7 @@ class DeviceTypeDataLoaderHelperTest {
             .testkitNameId("444")
             .build();
     var deviceTestPerformedLoincCode3 =
-        DeviceTestPerformedLoincCode.builder()
+        DeviceTypeDisease.builder()
             .deviceTypeId(device2Id)
             .testPerformedLoincCode("123")
             .supportedDisease(new SupportedDisease())

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -17,7 +17,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
-import gov.cdc.usds.simplereport.db.repository.DeviceTestPerformedLoincCodeRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
@@ -42,7 +42,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
   private static final int STANDARD_TEST_LENGTH = 15;
   @Autowired private DeviceTypeRepository _deviceTypeRepo;
   @Autowired private SpecimenTypeRepository specimenTypeRepository;
-  @Autowired private DeviceTestPerformedLoincCodeRepository deviceTestPerformedLoincCodeRepository;
+  @Autowired private DeviceTypeDiseaseRepository deviceTypeDiseaseRepository;
 
   @Mock private DeviceTypeRepository _deviceTypeRepoMock;
 
@@ -374,9 +374,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(disease2TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid3");
     assertThat(disease2TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId3");
 
-    var deviceTestPerformedLoincCodeRepositoryAll =
-        deviceTestPerformedLoincCodeRepository.findAll();
-    assertThat(deviceTestPerformedLoincCodeRepositoryAll).hasSize(2);
+    var deviceTypeDiseaseRepositoryAll = deviceTypeDiseaseRepository.findAll();
+    assertThat(deviceTypeDiseaseRepositoryAll).hasSize(2);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -180,6 +180,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                             .testPerformedLoincCode("loinc1")
                             .equipmentUid("equipmentUid1")
                             .testkitNameId("testkitNameId1")
+                            .testOrderedLoincCode("loinc3")
                             .build()))
                 .testLength(1)
                 .build());
@@ -198,6 +199,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                             .testPerformedLoincCode("loinc2")
                             .equipmentUid("equipmentUid2")
                             .testkitNameId("testkitNameId2")
+                            .testOrderedLoincCode("loinc3")
                             .build()))
                 .testLength(2)
                 .build());
@@ -232,6 +234,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(disease1TestPerformed.get().getTestPerformedLoincCode()).isEqualTo("loinc1");
     assertThat(disease1TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid1");
     assertThat(disease1TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId1");
+    assertThat(disease1TestPerformed.get().getTestOrderedLoincCode()).isEqualTo("loinc3");
 
     devB = _deviceTypeRepo.findById(devB.getInternalId()).get();
     assertNotNull(devB);
@@ -316,6 +319,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                             .testPerformedLoincCode("loinc1")
                             .equipmentUid("equipmentUid1")
                             .testkitNameId("testkitNameId1")
+                            .testOrderedLoincCode("loinc3")
                             .build()))
                 .testLength(10)
                 .build());
@@ -332,12 +336,14 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                             .testPerformedLoincCode("loinc2")
                             .equipmentUid("equipmentUid2")
                             .testkitNameId("testkitNameId2")
+                            .testOrderedLoincCode("loinc3")
                             .build(),
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease2.getInternalId())
                             .testPerformedLoincCode("loinc3")
                             .equipmentUid("equipmentUid3")
                             .testkitNameId("testkitNameId3")
+                            .testOrderedLoincCode("loinc4")
                             .build()))
                 .build());
 
@@ -359,6 +365,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(disease1TestPerformed.get().getTestPerformedLoincCode()).isEqualTo("loinc2");
     assertThat(disease1TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid2");
     assertThat(disease1TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId2");
+    assertThat(disease1TestPerformed.get().getTestOrderedLoincCode()).isEqualTo("loinc3");
 
     var disease2TestPerformed =
         updatedDevice.getSupportedDiseaseTestPerformed().stream()
@@ -373,6 +380,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(disease2TestPerformed.get().getTestPerformedLoincCode()).isEqualTo("loinc3");
     assertThat(disease2TestPerformed.get().getEquipmentUid()).isEqualTo("equipmentUid3");
     assertThat(disease2TestPerformed.get().getTestkitNameId()).isEqualTo("testkitNameId3");
+    assertThat(disease2TestPerformed.get().getTestOrderedLoincCode()).isEqualTo("loinc4");
 
     var deviceTypeDiseaseRepositoryAll = deviceTypeDiseaseRepository.findAll();
     assertThat(deviceTypeDiseaseRepositoryAll).hasSize(2);
@@ -409,6 +417,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
                             .testPerformedLoincCode("loinc1")
                             .equipmentUid("equipmentUid1")
                             .testkitNameId("testkitNameId1")
+                            .testOrderedLoincCode("loinc3")
                             .build()))
                 .build());
 
@@ -423,6 +432,8 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
         .isEqualTo("equipmentUid1");
     assertThat(updatedDevice.getSupportedDiseaseTestPerformed().get(0).getTestkitNameId())
         .isEqualTo("testkitNameId1");
+    assertThat(updatedDevice.getSupportedDiseaseTestPerformed().get(0).getTestOrderedLoincCode())
+        .isEqualTo("loinc3");
     assertThat(
             updatedDevice
                 .getSupportedDiseaseTestPerformed()

--- a/backend/src/test/resources/application-default.yaml
+++ b/backend/src/test/resources/application-default.yaml
@@ -213,6 +213,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: 00811877010616
           testkit-name-id: 10811877011269
+          test-ordered-loinc-code: "94534-5"
     - name: Abbott BinaxNow
       manufacturer: Abbott
       model: BinaxNOW COVID-19 Ag Card
@@ -223,6 +224,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "No Equipment"
           testkit-name-id: 10811877011290
+          test-ordered-loinc-code: "94558-4"
     - name: Quidel Sofia 2
       manufacturer: Quidel
       model: Sofia 2 SARS Antigen FIA
@@ -233,6 +235,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "Sofia Instrument_Quidel"
           testkit-name-id: "Sofia SARS Antigen FIA_Quidel Corporation"
+          test-ordered-loinc-code: "95209-3"
     - name: BD Veritor
       manufacturer: Becton, Dickinson and Company (BD)
       model: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
@@ -243,6 +246,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "BD Veritor Plus System_Becton Dickinson"
           testkit-name-id: "BD Veritor System for Rapid Detection of SARS-CoV-2_Becton, Dickinson and Company (BD)"
+          test-ordered-loinc-code: "94558-4"
     - name: LumiraDX
       manufacturer: LumiraDx UK Ltd.
       model: LumiraDx SARS-CoV-2 Ag Test*
@@ -253,6 +257,7 @@ simple-report-initialization:
           supported-disease: "COVID-19"
           equipment-uid: "LumiraDx Platform_LumiraDx"
           testkit-name-id: "LumiraDx SARS-CoV-2 Ag Test_LumiraDx UK Ltd."
+          test-ordered-loinc-code: "95209-3"
   patient-registration-links:
     - link: dis-org
       organization-external-id: DIS_ORG

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -930,6 +930,7 @@ export type SupportedDiseaseTestPerformed = {
   __typename?: "SupportedDiseaseTestPerformed";
   equipmentUid?: Maybe<Scalars["String"]>;
   supportedDisease: SupportedDisease;
+  testOrderedLoincCode?: Maybe<Scalars["String"]>;
   testPerformedLoincCode: Scalars["String"];
   testkitNameId?: Maybe<Scalars["String"]>;
 };
@@ -937,6 +938,7 @@ export type SupportedDiseaseTestPerformed = {
 export type SupportedDiseaseTestPerformedInput = {
   equipmentUid?: InputMaybe<Scalars["String"]>;
   supportedDisease: Scalars["ID"];
+  testOrderedLoincCode?: InputMaybe<Scalars["String"]>;
   testPerformedLoincCode: Scalars["String"];
   testkitNameId?: InputMaybe<Scalars["String"]>;
 };


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of #5383
- To support FHIR, we need to send ReportStream the test ordered loinc code.

## Changes Proposed

- Add test ordered loinc code to the graphql input and mutation
- Rename the class and variables from DeviceTestPerformedLoincCode to DeviceTypeDisease to match the new table.

## Additional Information

## Testing

- Test the CreateDevice and UpdateDevice mutations in graphql to make sure that test ordered loinc can be created
- Example curl for my local, supported disease id 
```curl
curl --location 'http://localhost:8080/graphql' \
--header 'x-ms-session-id;' \
--header 'Authorization: Bearer SR-DEMO-LOGIN bob@example.com' \
--header 'Content-Type: application/json' \
--header 'Cookie: SESSION=OGQzMzFmNmMtYjZlZS00YzRkLWFiYjEtN2QzZjYzNDBmN2Nl; userId=00u42i8xnpPMNBCoZ1d7' \
--data '{"query":"mutation createDeviceType {\n  createDeviceType(\n    input: {\n        name: \"test - Charity\",\n        manufacturer: \"Isacshire\", \n        model: \"grey\",\n        loincCode: \"1009-1\",\n        swabTypes:  [\n            \"393ebdfd-9778-42aa-bc72-33202ca459d8\"\n            ],\n        supportedDiseases:  [\n            \"e88bfd39-5c82-4958-9706-6802789552c6\"\n            ],\n        supportedDiseaseTestPerformed: [\n            {\n                supportedDisease: \"e88bfd39-5c82-4958-9706-6802789552c6\",\n                testPerformedLoincCode: \"blah\",\n                equipmentUid: \"haha\",\n                testkitNameId:\"ahaha\",\n                testOrderedLoincCode: \"hleb\"\n            }\n        ]\n        testLength: 15\n        }\n  ) {\n    internalId\n    supportedDiseaseTestPerformed{\n        supportedDisease{\n            internalId\n        }\n        testPerformedLoincCode\n        testOrderedLoincCode\n        equipmentUid\n        testkitNameId\n    }\n  }\n}","variables":{}}'
```
```curl
curl --location 'http://localhost:8080/graphql' \
--header 'x-ms-session-id;' \
--header 'Authorization: Bearer SR-DEMO-LOGIN bob@example.com' \
--header 'Content-Type: application/json' \
--header 'Cookie: SESSION=OGQzMzFmNmMtYjZlZS00YzRkLWFiYjEtN2QzZjYzNDBmN2Nl; userId=00u42i8xnpPMNBCoZ1d7' \
--data '{"query":"mutation updateDevice {\n  updateDeviceType(\n    input: {\n        internalId:\"d7b2ba43-92ba-4a57-ae18-cc7b42766eb8\"\n        name: \"Adalberto\",\n        manufacturer: \"Port Helenaborough\", \n        model: \"ivory\",\n        loincCode: \"1009-1\",\n        swabTypes:  [\n            \"1886abc0-c18e-435c-ab01-ede79fb4a02d\"\n            ],\n        supportedDiseases:  [\n            \"8f9e3746-465c-4e59-8151-8e4f5f7cf7db\"\n            ],\n        supportedDiseaseTestPerformed: [\n            {\n                supportedDisease: \"a55570d3-35b9-460e-9947-b9e7fa4496e0\",\n                testPerformedLoincCode: \"z\"\n            },\n            {\n                supportedDisease: \"f995184f-9359-43b5-aefb-afdeff8b8e57\",\n                testPerformedLoincCode: \"clack\"\n            },\n            {\n                supportedDisease: \"e88bfd39-5c82-4958-9706-6802789552c6\",\n                testPerformedLoincCode: \"ah\",\n                testkitNameId:\" alskjdfklajsd\",\n                equipmentUid: \"aksfdljksd\",\n                testOrderedLoincCode: \"1234\"\n            }\n        ]\n        testLength: 15\n        }\n  ) {\n    internalId\n    supportedDiseaseTestPerformed{\n        equipmentUid\n        testkitNameId\n    }\n  }\n}","variables":{}}'
```
- Test the DeviceType mutation in graphql to make sure that test ordered loinc can be viewed.
```curl
curl --location 'http://localhost:8080/graphql' \
--header 'x-ms-session-id;' \
--header 'Authorization: Bearer SR-DEMO-LOGIN bob@example.com' \
--header 'Content-Type: application/json' \
--header 'Cookie: SESSION=NTE2ZjgyYzQtYjYxMC00MmZmLWFkZWQtZjhkODgwNTk2NDQ1; userId=00u42i8xnpPMNBCoZ1d7' \
--data '{"query":"query getDevice {\n  deviceTypes {\n    internalId\n    supportedDiseaseTestPerformed{\n        supportedDisease{\n            internalId\n            name\n        }\n        testPerformedLoincCode\n        testOrderedLoincCode\n    }\n  }\n}","variables":{}}'
```
