### PR TITLE
Added page titles to settings and dashboard

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.tsx
@@ -7,6 +7,7 @@ import { updateFacility } from "../../store";
 import { showSuccess } from "../../utils/srToast";
 import { getAppInsights } from "../../TelemetryService";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
+import { useDocumentTitle } from "../../utils/hooks";
 
 import FacilityForm from "./FacilityForm";
 
@@ -162,6 +163,7 @@ interface Props {
 }
 
 const FacilityFormContainer: any = (props: Props) => {
+  useDocumentTitle("Add new facility");
   const { facilityId } = useParams();
   const [activeFacility] = useSelectedFacility();
   const { data, loading, error } = useQuery<FacilityData, {}>(

--- a/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilitiesContainer.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 
 import { useGetManagedFacilitiesQuery } from "../../../generated/graphql";
+import { useDocumentTitle } from "../../utils/hooks";
 
 import ManageFacilities from "./ManageFacilities";
 
 const ManageFacilitiesContainer: any = () => {
+  useDocumentTitle("Manage facilities");
+
   const { data, loading, error } = useGetManagedFacilitiesQuery({
     fetchPolicy: "no-cache",
   });

--- a/frontend/src/app/Settings/ManageOrganizationContainer.tsx
+++ b/frontend/src/app/Settings/ManageOrganizationContainer.tsx
@@ -5,6 +5,7 @@ import { gql, useQuery, useMutation } from "@apollo/client";
 import { getAppInsights } from "../TelemetryService";
 import { showError, showSuccess } from "../utils/srToast";
 import { RootState, updateOrganization } from "../store";
+import { useDocumentTitle } from "../utils/hooks";
 
 import ManageOrganization from "./ManageOrganization";
 
@@ -39,6 +40,8 @@ export const SET_ORGANIZATION = gql`
 `;
 
 const ManageOrganizationContainer: any = () => {
+  useDocumentTitle("Manage organization");
+
   const { data, loading, error } = useQuery<Data, {}>(GET_ORGANIZATION, {
     fetchPolicy: "no-cache",
   });

--- a/frontend/src/app/Settings/ManageSelfRegistrationLinksContainer.tsx
+++ b/frontend/src/app/Settings/ManageSelfRegistrationLinksContainer.tsx
@@ -1,6 +1,7 @@
 import { useQuery, gql } from "@apollo/client";
 
 import { getUrl } from "../utils/url";
+import { useDocumentTitle } from "../utils/hooks";
 
 import { ManageSelfRegistrationLinks } from "./ManageSelfRegistrationLinks";
 
@@ -28,6 +29,8 @@ export const REGISTRATION_LINKS_QUERY = gql`
 `;
 
 export const ManageSelfRegistrationLinksContainer = () => {
+  useDocumentTitle("Patient self-registration");
+
   const { data, loading, error } = useQuery<Data, {}>(
     REGISTRATION_LINKS_QUERY,
     {

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -1,7 +1,5 @@
 import { Route, Routes } from "react-router-dom";
 
-import { useDocumentTitle } from "../utils/hooks";
-
 import ManageOrganizationContainer from "./ManageOrganizationContainer";
 import ManageFacilitiesContainer from "./Facility/ManageFacilitiesContainer";
 import FacilityFormContainer from "./Facility/FacilityFormContainer";
@@ -12,8 +10,6 @@ import { ManageSelfRegistrationLinksContainer } from "./ManageSelfRegistrationLi
 import "./Settings.scss";
 
 const Settings = () => {
-  useDocumentTitle("Settings");
-
   return (
     <div className="prime-home flex-1">
       <div className="grid-container">

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import configureStore from "redux-mock-store";
+import { AnyAction, Store } from "redux";
+
+import {
+  GetUserDocument,
+  GetUsersAndStatusDocument,
+} from "../../../generated/graphql";
+
+import ManageUsersContainer from "./ManageUsersContainer";
+
+describe("ManageUsersContainer", () => {
+  const mockStore = configureStore([]);
+  const store = mockStore({
+    organization: {
+      name: "Organization Name",
+    },
+    user: {
+      firstName: "Kim",
+      lastName: "Mendoza",
+    },
+    facilities: [
+      { id: "1", name: "Facility 1" },
+      { id: "2", name: "Facility 2" },
+    ],
+  });
+  const mocks: MockedResponse[] = [
+    {
+      request: {
+        operationName: "GetUsersAndStatus",
+        query: GetUsersAndStatusDocument,
+        variables: {},
+      },
+      result: {
+        data: {
+          usersWithStatus: [
+            {
+              id: "3a4a221d-a8ca-42b3-aa03-37b93266025b",
+              firstName: "Ben",
+              middleName: "Billy",
+              lastName: "Barnes",
+              email: "ben@example.com",
+              status: "ACTIVE",
+              __typename: "ApiUserWithStatus",
+            },
+            {
+              id: "1029653e-24d9-428e-83b0-468319948902",
+              firstName: "Bob",
+              middleName: null,
+              lastName: "Bobberoo",
+              email: "bob@example.com",
+              status: "ACTIVE",
+              __typename: "ApiUserWithStatus",
+            },
+            {
+              id: "60bb9e3a-fe8a-4b81-b894-b01649c95e70",
+              firstName: "Jamar",
+              middleName: "Donald",
+              lastName: "Jackson",
+              email: "jamar@example.com",
+              status: "ACTIVE",
+              __typename: "ApiUserWithStatus",
+            },
+            {
+              id: "0d3fa224-3d56-4382-b89c-9d8e415e59b3",
+              firstName: "Ruby",
+              middleName: "Raven",
+              lastName: "Reynolds",
+              email: "ruby@example.com",
+              status: "ACTIVE",
+              __typename: "ApiUserWithStatus",
+            },
+            {
+              id: "17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a",
+              firstName: "Sarah",
+              middleName: "Sally",
+              lastName: "Samuels",
+              email: "sarah@example.com",
+              status: "ACTIVE",
+              __typename: "ApiUserWithStatus",
+            },
+          ],
+        },
+      },
+    },
+    {
+      request: {
+        operationName: "GetUser",
+        query: GetUserDocument,
+        variables: { id: "3a4a221d-a8ca-42b3-aa03-37b93266025b" },
+      },
+      result: {
+        data: {
+          user: {
+            id: "3a4a221d-a8ca-42b3-aa03-37b93266025b",
+            firstName: "Ben",
+            middleName: "Billy",
+            lastName: "Barnes",
+            roleDescription: "Misconfigured user",
+            role: null,
+            permissions: [],
+            email: "ben@example.com",
+            status: "ACTIVE",
+            organization: {
+              testingFacility: [
+                {
+                  id: "3ea40184-b7d6-4807-b924-747a316a86a6",
+                  name: "Testing Site",
+                  __typename: "Facility",
+                },
+              ],
+              __typename: "Organization",
+            },
+            __typename: "User",
+          },
+        },
+      },
+    },
+  ];
+  const renderComponentWithMocks = (
+    graphqlResponses: MockedResponse[],
+    store: Store<unknown, AnyAction>
+  ) =>
+    render(
+      <MemoryRouter>
+        <MockedProvider mocks={graphqlResponses}>
+          <Provider store={store}>
+            <ManageUsersContainer />
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+  it("loads the component and displays users successfully", async () => {
+    const { container } = renderComponentWithMocks(mocks, store);
+    await waitForElementToBeRemoved(screen.queryByText("Loading..."));
+    await waitForElementToBeRemoved(screen.queryByText("Loading user data"));
+    await screen.findByText(/barnes, ben billy/i);
+    await screen.findByText(/ben@example.com/i);
+    expect(container).toMatchSnapshot();
+    expect(document.title).toEqual("Manage users | SimpleReport");
+  });
+
+  it("loads the component and user not found ", async () => {
+    const notFoundMock = [{ ...mocks[0], result: {} }];
+    renderComponentWithMocks(notFoundMock, store);
+    await screen.findByText(/Error: Users not found/i);
+  });
+});

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -12,6 +12,7 @@ import {
   useResetUserMfaMutation,
   UserPermission,
 } from "../../../generated/graphql";
+import { useDocumentTitle } from "../../utils/hooks";
 
 import ManageUsers from "./ManageUsers";
 
@@ -113,6 +114,8 @@ export interface UserFacilitySetting {
 }
 
 const ManageUsersContainer = () => {
+  useDocumentTitle("Manage users");
+
   const loggedInUser = useSelector<RootState, User>((state) => state.user);
   const allFacilities = useSelector<RootState, UserFacilitySetting[]>(
     (state) => state.facilities

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -66,7 +66,10 @@ const UsersSideNav: React.FC<Props> = ({
                 statusText = "";
             }
             return (
-              <div className="usa-sidenav__item users-sidenav-item">
+              <div
+                className="usa-sidenav__item users-sidenav-item"
+                key={user.id}
+              >
                 <button
                   id={"user-tab-" + user.id}
                   role="tab"

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -1,0 +1,352 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ManageUsersContainer loads the component and displays users successfully 1`] = `
+<div>
+  <div
+    class="prime-container card-container manage-users-card"
+  >
+    <div
+      class="usa-card__header"
+    >
+      <h1>
+        Manage users
+      </h1>
+      <button
+        class="usa-button"
+        type="button"
+      >
+        + Add user
+      </button>
+    </div>
+    <div
+      class="usa-card__body"
+    >
+      <div
+        class="grid-row"
+      >
+        <div
+          class="display-block users-sidenav"
+        >
+          <h2
+            class="users-sidenav-header"
+          >
+            Users
+          </h2>
+          <nav
+            aria-label="Tertiary navigation"
+            class="prime-secondary-nav"
+          >
+            <div
+              aria-owns="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b user-tab-1029653e-24d9-428e-83b0-468319948902 user-tab-60bb9e3a-fe8a-4b81-b894-b01649c95e70 user-tab-0d3fa224-3d56-4382-b89c-9d8e415e59b3 user-tab-17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a"
+              class="usa-sidenav"
+              role="tablist"
+            >
+              <div
+                class="usa-sidenav__item users-sidenav-item"
+              >
+                <button
+                  aria-label="Barnes, Ben Billy"
+                  aria-selected="true"
+                  class="usa-button--unstyled text-ink text-no-underline padding-105 padding-right-2 padding-left-3 usa-current"
+                  id="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b"
+                  role="tab"
+                  style="cursor: pointer;"
+                >
+                  <div
+                    class="sidenav-user-name"
+                  >
+                    Barnes, Ben Billy
+                  </div>
+                  <span
+                    class="sidenav-user-status padding-left-0"
+                  />
+                </button>
+              </div>
+              <div
+                class="usa-sidenav__item users-sidenav-item"
+              >
+                <button
+                  aria-label="Bobberoo, Bob"
+                  aria-selected="false"
+                  class="usa-button--unstyled text-ink text-no-underline padding-105 padding-right-2 padding-left-3"
+                  id="user-tab-1029653e-24d9-428e-83b0-468319948902"
+                  role="tab"
+                  style="cursor: pointer;"
+                >
+                  <div
+                    class="sidenav-user-name"
+                  >
+                    Bobberoo, Bob
+                  </div>
+                  <span
+                    class="sidenav-user-status padding-left-0"
+                  />
+                </button>
+              </div>
+              <div
+                class="usa-sidenav__item users-sidenav-item"
+              >
+                <button
+                  aria-label="Jackson, Jamar Donald"
+                  aria-selected="false"
+                  class="usa-button--unstyled text-ink text-no-underline padding-105 padding-right-2 padding-left-3"
+                  id="user-tab-60bb9e3a-fe8a-4b81-b894-b01649c95e70"
+                  role="tab"
+                  style="cursor: pointer;"
+                >
+                  <div
+                    class="sidenav-user-name"
+                  >
+                    Jackson, Jamar Donald
+                  </div>
+                  <span
+                    class="sidenav-user-status padding-left-0"
+                  />
+                </button>
+              </div>
+              <div
+                class="usa-sidenav__item users-sidenav-item"
+              >
+                <button
+                  aria-label="Reynolds, Ruby Raven"
+                  aria-selected="false"
+                  class="usa-button--unstyled text-ink text-no-underline padding-105 padding-right-2 padding-left-3"
+                  id="user-tab-0d3fa224-3d56-4382-b89c-9d8e415e59b3"
+                  role="tab"
+                  style="cursor: pointer;"
+                >
+                  <div
+                    class="sidenav-user-name"
+                  >
+                    Reynolds, Ruby Raven
+                  </div>
+                  <span
+                    class="sidenav-user-status padding-left-0"
+                  />
+                </button>
+              </div>
+              <div
+                class="usa-sidenav__item users-sidenav-item"
+              >
+                <button
+                  aria-label="Samuels, Sarah Sally"
+                  aria-selected="false"
+                  class="usa-button--unstyled text-ink text-no-underline padding-105 padding-right-2 padding-left-3"
+                  id="user-tab-17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a"
+                  role="tab"
+                  style="cursor: pointer;"
+                >
+                  <div
+                    class="sidenav-user-name"
+                  >
+                    Samuels, Sarah Sally
+                  </div>
+                  <span
+                    class="sidenav-user-status padding-left-0"
+                  />
+                </button>
+              </div>
+            </div>
+          </nav>
+        </div>
+        <div
+          aria-labelledby="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b"
+          class="tablet:grid-col padding-left-3 user-detail-column"
+          role="tabpanel"
+        >
+          <div>
+            <h2
+              class="display-inline-block margin-top-1 margin-bottom-0 user-name-header"
+            >
+              Barnes, Ben Billy
+            </h2>
+            <div
+              class="user-status-subheader"
+            >
+              <span
+                class="top-user-status padding-left-0"
+              />
+            </div>
+          </div>
+          <div
+            class="user-header grid-row flex-row flex-align-center"
+          />
+          <nav
+            aria-label="User action navigation"
+            class="prime-secondary-nav margin-top-4 padding-bottom-0"
+          >
+            <div
+              aria-owns="user-info-tab-id facility-access-tab-id"
+              class="usa-nav__secondary-links prime-nav usa-list"
+              role="tablist"
+            >
+              <div
+                class="usa-nav__secondary-item usa-current"
+              >
+                <button
+                  aria-selected="true"
+                  class="usa-button--unstyled text-ink text-no-underline"
+                  id="user-info-tab-id"
+                  role="tab"
+                >
+                  User information
+                </button>
+              </div>
+              <div
+                class="usa-nav__secondary-item "
+              >
+                <button
+                  aria-selected="false"
+                  class="usa-button--unstyled text-ink text-no-underline"
+                  id="facility-access-tab-id"
+                  role="tab"
+                >
+                  Facility access
+                </button>
+              </div>
+            </div>
+          </nav>
+          <div
+            aria-labelledby="user-info-tab-id"
+            class="padding-left-1"
+            role="tabpanel"
+          >
+            <h3
+              class="basic-info-header"
+            >
+              Basic information
+            </h3>
+            <div
+              class="user-header grid-row flex-row flex-align-center"
+            >
+              <div>
+                <div
+                  class="userinfo-subheader"
+                >
+                  Name
+                </div>
+                <p
+                  class="userinfo-text"
+                >
+                  Ben Billy Barnes
+                </p>
+              </div>
+              <button
+                aria-disabled="false"
+                class="usa-button usa-button--outline margin-left-auto margin-bottom-1"
+                type="button"
+              >
+                Edit name
+              </button>
+            </div>
+            <div
+              class="user-header grid-row flex-row flex-align-center"
+            >
+              <div>
+                <div
+                  class="userinfo-subheader"
+                >
+                  Email
+                </div>
+                <p
+                  class="userinfo-text"
+                >
+                  ben@example.com
+                </p>
+              </div>
+              <button
+                aria-disabled="false"
+                class="usa-button usa-button--outline margin-left-auto margin-bottom-1"
+                type="button"
+              >
+                Edit email
+              </button>
+            </div>
+            <div
+              class="userinfo-divider"
+            />
+            <h3
+              class="user-controls-header"
+            >
+              User controls
+            </h3>
+            <div
+              class="user-header grid-row flex-row flex-align-center"
+            >
+              <div
+                class="grid-col margin-right-8"
+              >
+                <div
+                  class="userinfo-subheader"
+                >
+                  Password
+                </div>
+                <p
+                  class="usercontrols-text"
+                >
+                  Send a link to reset user password. Users must answer a password recovery question to access their account.
+                </p>
+              </div>
+              <button
+                aria-disabled="false"
+                class="usa-button usa-button--outline margin-left-auto margin-bottom-1"
+                type="button"
+              >
+                Send password reset email
+              </button>
+            </div>
+            <div
+              class="user-header grid-row flex-row flex-align-center"
+            >
+              <div
+                class="grid-col"
+              >
+                <div
+                  class="userinfo-subheader"
+                >
+                  Reset multi-factor authentication (MFA)
+                </div>
+                <p
+                  class="usercontrols-text"
+                >
+                  Reset user MFA account access settings
+                </p>
+              </div>
+              <button
+                aria-disabled="false"
+                class="usa-button usa-button--outline margin-left-auto margin-bottom-1"
+                type="button"
+              >
+                Reset MFA
+              </button>
+            </div>
+            <div
+              class="user-header grid-row flex-row flex-align-center"
+            >
+              <div>
+                <div
+                  class="userinfo-subheader"
+                >
+                  Delete user
+                </div>
+                <p
+                  class="usercontrols-text"
+                >
+                  Permanently delete user account and data
+                </p>
+              </div>
+              <button
+                aria-disabled="false"
+                class="usa-button usa-button--outline margin-left-auto margin-bottom-1"
+                type="button"
+              >
+                Delete user
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -8,6 +8,7 @@ import { useGetTopLevelDashboardMetricsNewQuery } from "../../generated/graphql"
 import "./Analytics.scss";
 import { formatDate } from "../utils/date";
 import { PATIENT_TERM_PLURAL } from "../../config/constants";
+import { useDocumentTitle } from "../utils/hooks";
 
 const getDateFromDaysAgo = (daysAgo: number): Date => {
   const date = new Date();
@@ -55,6 +56,8 @@ interface Props {
 }
 
 export const Analytics = (props: Props) => {
+  useDocumentTitle("COVID-19 testing data dashboard");
+
   const organization = useSelector(
     (state) => (state as any).organization as Organization
   );


### PR DESCRIPTION

# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5315 

## Changes Proposed

- Added page titles according to this ticket

  - /app/dashboard | COVID-19 testing data dashboard \| SimpleReport
  - /app/settings | Manage users \| SimpleReport
  - /app/settings/facilities | Manage facilities \| SimpleReport
  - /app/settings/organization | Manage organization \| SimpleReport
  - /app/settings/self-registration | Patient self-registration \| SimpleReport



- Added unit testing for `ManageUserContainer` component

## Additional Information
None

## Testing

_Validated in dev 1 and azure admin_
- Verify that the page titles update accordingly

## Screenshots / Demos
![Screenshot 2023-03-08 at 2 53 25 PM](https://user-images.githubusercontent.com/103958711/223831297-a55dd77e-ae18-440a-90bb-2ba67ae056b3.png)
