### PR TITLE
Add and edit PagerDuty alert for RS uploader errors

### DIFF
--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -291,9 +291,9 @@ requests
   }
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_uploader_400" {
-  name                = "${var.env}-report_stream_uploader_400"
-  description         = "${local.env_title} alert when the publish function results in a 400"
+resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_batched_uploader_400" {
+  name                = "${var.env}-report_stream_batched_uploader_400"
+  description         = "${local.env_title} alert when the batched uploader publish function results in a 400"
   location            = data.azurerm_resource_group.app.location
   resource_group_name = var.rg_name
 
@@ -302,13 +302,42 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_uploader_4
   }
 
   data_source_id = var.app_insights_id
-  enabled        = contains(var.disabled_alerts, "report_stream_uploader_400") ? false : true
+  enabled        = contains(var.disabled_alerts, "report_stream_batched_uploader_400") ? false : true
 
   query = <<-QUERY
 customEvents
 | order by timestamp desc
 | extend httpStatus = toint(customDimensions["status"])
-| where httpStatus == 400 and name == "ReportStream Upload Failed"
+| where httpStatus == 400 and name == "Queue: test-event-publishing. ReportStream Upload Failed"
+  QUERY
+
+  severity    = 1
+  frequency   = 5
+  time_window = 6
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 0
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_fhir_batched_uploader_400" {
+  name                = "${var.env}-report_stream_fhir_batched_uploader_400"
+  description         = "${local.env_title} alert when the fhir batched uploader publish function results in a 400"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+
+  action {
+    action_group = var.action_group_ids
+  }
+
+  data_source_id = var.app_insights_id
+  enabled        = contains(var.disabled_alerts, "report_stream_fhir_batched_uploader_400") ? false : true
+
+  query = <<-QUERY
+customEvents
+| order by timestamp desc
+| extend httpStatus = toint(customDimensions["status"])
+| where httpStatus == 400 and name == "Queue: fhir-data-publishing. ReportStream Upload Failed"
   QUERY
 
   severity    = 1


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

Resolves #5431

## Changes Proposed
This PR accomplishes the following:
- fixes the query for the PagerDuty alert that fires when a 400 error is returned from RS when uploading test events in the `test-event-publishing` queue
- adds a PagerDuty alert for when a 400 error is returned from RS when uploading fhir data in the `fhir-data-publishing` queue

## Additional Information
- It was difficult to test that a PagerDuty alert actually fires since I wasn't sure how to force 400 errors from RS for both queues since once we get the 400 errors from RS that's when we [create a custom event in Azure](https://github.com/CDCgov/prime-simplereport/blob/1496038aa1338c346ccb8c10238676bf732b1522/ops/services/app_functions/report_stream_batched_publisher/functions/common/reportingHandlers.ts#L86) to keep track of these errors

## Testing
- Go to `prime-simple-report-prod-insights`
- Click on "Logs" under the Monitoring section
- Copy the query in the PagerDuty alert
```
customEvents
| order by timestamp desc
| extend httpStatus = toint(customDimensions["status"])
| where httpStatus == 400 and name == "Queue: test-event-publishing. ReportStream Upload Failed"
```
- set the "Time range" to February 20 and February 22
- you should see a custom event being returned
<img width="1306" alt="Screen Shot 2023-03-13 at 11 38 36" src="https://user-images.githubusercontent.com/20211771/224812425-5660b11a-be6e-45a3-aec9-2a0ea6353627.png">

- If you have other ideas to test this please let me know! :) 

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
