### PR TITLE
Added logic to infer multiplex testOrderedLoinc

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -42,6 +42,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
+import gov.cdc.usds.simplereport.utils.MultiplexUtils;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -587,8 +588,11 @@ public class FhirConverter {
     }
 
     String deviceLoincCode = null;
-    if (order.getDeviceType() != null) {
-      deviceLoincCode = order.getDeviceType().getLoincCode();
+    if (order.getDeviceType() != null
+        && order.getDeviceType().getSupportedDiseaseTestPerformed().size() > 0) {
+      deviceLoincCode =
+          MultiplexUtils.inferMultiplexTestOrderLoinc(
+              order.getDeviceType().getSupportedDiseaseTestPerformed());
     }
     return convertToServiceRequest(
         serviceRequestStatus, deviceLoincCode, Objects.toString(order.getInternalId(), ""));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/MultiplexUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/MultiplexUtils.java
@@ -1,0 +1,55 @@
+package gov.cdc.usds.simplereport.utils;
+
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class MultiplexUtils {
+  public static <K, V extends Comparable<V>> TreeMap<K, V> sort_by_values(final Map<K, V> map) {
+    Comparator<K> valueComparator =
+        new Comparator<K>() {
+          public int compare(K k1, K k2) {
+            // comparing on the basis of values
+            int comp = map.get(k1).compareTo(map.get(k2));
+            if (comp == 0) {
+              String x1 = (String) k1;
+              String x2 = (String) k2;
+              return Integer.compare(x1.length(), x2.length());
+            }
+            return comp;
+          }
+          ;
+        };
+
+    // SortedMap created using the comparator
+    TreeMap<K, V> sorted = new TreeMap<K, V>(valueComparator);
+    sorted.putAll(map);
+
+    return sorted;
+  }
+
+  public static String inferMultiplexTestOrderLoinc(List<DeviceTypeDisease> deviceTypeDiseases) {
+    if (deviceTypeDiseases.size() <= 0) {
+      return null;
+    }
+
+    // track testOrderLoinc repeats
+    HashMap<String, Integer> testOrdersLoincs = new HashMap<>();
+    deviceTypeDiseases.forEach(
+        deviceTypeDisease -> {
+          if (testOrdersLoincs.containsKey(deviceTypeDisease.getTestOrderedLoincCode())) {
+            Integer results = testOrdersLoincs.get(deviceTypeDisease.getTestOrderedLoincCode());
+            testOrdersLoincs.put(deviceTypeDisease.getTestOrderedLoincCode(), results + 1);
+          } else {
+            testOrdersLoincs.put(deviceTypeDisease.getTestOrderedLoincCode(), 1);
+          }
+        });
+
+    // Convert to arrayList and sort
+    TreeMap<String, Integer> sortedMap = sort_by_values(testOrdersLoincs);
+    return sortedMap.lastKey();
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/MultiplexUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/MultiplexUtilsTest.java
@@ -1,0 +1,41 @@
+package gov.cdc.usds.simplereport.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class MultiplexUtilsTest {
+  @Test
+  void inferMultiplexTestOrderLoinc_getsCalledWithEmptySupportedDiseaseTestPerformed() {
+    assertEquals(null, MultiplexUtils.inferMultiplexTestOrderLoinc(new ArrayList<>()));
+  }
+
+  @Test
+  void inferMultiplexTestOrderLoinc_findsTestOrderedLoincThatRepeats() {
+    List<DeviceTypeDisease> supportedDiseaseTestsOrders =
+        List.of(
+            DeviceTypeDisease.builder()
+                .testPerformedLoincCode("loincFluA")
+                .equipmentUid("equipmentUid2")
+                .testkitNameId("testkitNameId2")
+                .testOrderedLoincCode("loincMultiplex")
+                .build(),
+            DeviceTypeDisease.builder()
+                .testPerformedLoincCode("loincFluB")
+                .equipmentUid("equipmentUid2")
+                .testkitNameId("testkitNameId2")
+                .testOrderedLoincCode("loincMultiplex")
+                .build(),
+            DeviceTypeDisease.builder()
+                .testPerformedLoincCode("loincCovid")
+                .equipmentUid("equipmentUid2")
+                .testkitNameId("testkitNameId2")
+                .testOrderedLoincCode("loincNotMultiplex")
+                .build());
+    assertEquals(
+        "loincMultiplex", MultiplexUtils.inferMultiplexTestOrderLoinc(supportedDiseaseTestsOrders));
+  }
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---

# DATABASE PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->

---

# DEVOPS PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---

# FRONTEND PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
