### PR TITLE
allow null email in patient bulk upload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -22,6 +22,7 @@ import gov.cdc.usds.simplereport.validators.CsvValidatorUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +123,9 @@ public class PatientBulkUploadServiceAsync {
                 address,
                 country,
                 parsePersonRole(extractedData.getRole().getValue(), false),
-                List.of(extractedData.getEmail().getValue()),
+                extractedData.getEmail().getValue() == null
+                    ? Collections.emptyList()
+                    : List.of(extractedData.getEmail().getValue()),
                 convertRaceToDatabaseValue(extractedData.getRace().getValue()),
                 convertEthnicityToDatabaseValue(extractedData.getEthnicity().getValue()),
                 null, // tribalAffiliation

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -164,7 +164,7 @@ public class PatientBulkUploadServiceAsync {
             EmailProviderTemplate.SIMPLE_REPORT_PATIENT_UPLOAD_ERROR,
             Map.of("simplereport_url", simplereportUrl));
 
-        String errorMessage = "Error uploading patient roster";
+        String errorMessage = "Error uploading patient roster " + e;
         logProcessingFailure(errorMessage, currentOrganization.getExternalId(), facilityId);
 
         throw new IllegalArgumentException(errorMessage);

--- a/backend/src/test/resources/patientBulkUpload/validEmptyOptionalValues.csv
+++ b/backend/src/test/resources/patientBulkUpload/validEmptyOptionalValues.csv
@@ -1,0 +1,2 @@
+last_name,first_name,middle_name,suffix,race,date_of_birth,biological_sex,ethnicity,street,street_2,city,county,state,zip_code,phone_number,phone_number_type,employed_in_healthcare,resident_congregate_setting,role,email
+Kuphal,Lucienne,,,black or african american,3/12/86,female,hispanic or latino,5945 Rath Manors,,,,AK,99501,410-675-4559,Mobile,No,No,,

--- a/backend/src/test/resources/patientBulkUpload/validRequiredOnly.csv
+++ b/backend/src/test/resources/patientBulkUpload/validRequiredOnly.csv
@@ -1,0 +1,2 @@
+last_name,first_name,race,date_of_birth,biological_sex,ethnicity,street,state,zip_code,phone_number,phone_number_type,employed_in_healthcare,resident_congregate_setting
+Doe,Jane,black or african american,01/01/90,female,Not Hispanic or Latino,1 main st,AK,99551,410-867-5309,mobile,Y,n


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5455 

## Changes Proposed

- Add a check to see if email is null

## Additional Information

- add additional logging about the error message

## Testing

- Do a bulk upload without email on [dev1](https://dev.simplereport.gov/app/upload-patients?facility=1e37071a-51ec-4a42-9a52-7d03613e5d78)

