### PR TITLE
Enable metabase routing without trailing slash.

### DIFF
--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -326,7 +326,7 @@ resource "azurerm_application_gateway" "load_balancer" {
       condition {
         ignore_case = true
         negate      = false
-        pattern     = ".*metabase/(.*)"
+        pattern     = ".*/metabase(.*)"
         variable    = "var_uri_path"
       }
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #5198.

## Changes Proposed

- Correct regex that triggers metabase rewrite rule.

## Testing

This can be tested with the following set of steps:
- Deploy to an environment with metabase
- Navigate to the metabase instance without the use of the forward slash.
- Smoketest metabase and its expected functionality to ensure that nothing has been compromised with this changeset.

This item has already been tested on the `test` environment via direct edits within the Azure UI. 

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
