### PR TITLE
include equipment uid in fhir

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -428,7 +428,6 @@ public class FhirConverter {
               deviceTypeDiseases.stream()
                   .filter(code -> code.getSupportedDisease() == result.getDisease())
                   .findFirst();
-
           String testPerformedLoincCode = getTestPerformedLoincCode(deviceTypeDisease, result);
           String testkitNameId = getTestkitNameId(deviceTypeDisease);
           Observation observation =
@@ -438,12 +437,14 @@ public class FhirConverter {
                   correctionStatus,
                   correctionReason,
                   testkitNameId);
+          if (observation != null) {
+            Device device = convertToDevice(deviceType, deviceTypeDisease);
+            String deviceFullUrl =
+                ResourceType.Device + "/" + device.getId() + "/" + result.getInternalId();
+            observation.setDevice(new Reference(deviceFullUrl));
 
-          Device device = convertToDevice(deviceType, deviceTypeDisease);
-          String deviceFullUrl = ResourceType.Device + "/" + device.getId();
-          observation.setDevice(new Reference(deviceFullUrl));
-
-          observations.add(new ObservationDevicePair(observation, device));
+            observations.add(new ObservationDevicePair(observation, device));
+          }
         });
 
     return observations;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -366,9 +366,11 @@ public class FhirConverter {
   }
 
   public static Device convertToDevice(
-      @NotNull DeviceType deviceType, DeviceTypeDisease deviceTypeDisease) {
+      @NotNull DeviceType deviceType, Optional<DeviceTypeDisease> deviceTypeDisease) {
     Device device = convertToDevice(deviceType);
-    device.addIdentifier(new Identifier().setValue(deviceTypeDisease.getEquipmentUid()));
+    device.addIdentifier(
+        new Identifier()
+            .setValue(deviceTypeDisease.map(DeviceTypeDisease::getEquipmentUid).orElse(null)));
     return device;
   }
 
@@ -422,11 +424,10 @@ public class FhirConverter {
 
     results.forEach(
         result -> {
-          DeviceTypeDisease deviceTypeDisease =
+          Optional<DeviceTypeDisease> deviceTypeDisease =
               deviceTypeDiseases.stream()
                   .filter(code -> code.getSupportedDisease() == result.getDisease())
-                  .findFirst()
-                  .orElse(null);
+                  .findFirst();
 
           String testPerformedLoincCode = getTestPerformedLoincCode(deviceTypeDisease, result);
           String testkitNameId = getTestkitNameId(deviceTypeDisease);
@@ -448,15 +449,13 @@ public class FhirConverter {
     return observations;
   }
 
-  private static String getTestkitNameId(DeviceTypeDisease deviceTypeDisease) {
-    return Optional.ofNullable(deviceTypeDisease)
-        .map(DeviceTypeDisease::getTestkitNameId)
-        .orElse(null);
+  private static String getTestkitNameId(Optional<DeviceTypeDisease> deviceTypeDisease) {
+    return deviceTypeDisease.map(DeviceTypeDisease::getTestkitNameId).orElse(null);
   }
 
   private static String getTestPerformedLoincCode(
-      DeviceTypeDisease deviceTypeDisease, Result result) {
-    return Optional.ofNullable(deviceTypeDisease)
+      Optional<DeviceTypeDisease> deviceTypeDisease, Result result) {
+    return deviceTypeDisease
         .map(DeviceTypeDisease::getTestPerformedLoincCode)
         .orElse(result.getTestOrder().getDeviceType().getLoincCode());
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
@@ -78,7 +78,6 @@ public class DeviceType extends EternalAuditedEntity {
     this.testLength = testLength;
   }
 
-  @Builder
   public DeviceType(
       String name,
       String manufacturer,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -88,6 +88,7 @@ import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.PractitionerRole;
 import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.ServiceRequest.ServiceRequestIntent;
 import org.hl7.fhir.r4.model.ServiceRequest.ServiceRequestStatus;
@@ -738,6 +739,7 @@ class FhirConverterTest {
   void convertToObservation_Result_matchesJson() throws IOException {
     var covidId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
     var fluId = "302a7919-b699-4e0d-95ca-5fd2e3fcaf7a";
+    var deviceTypeId = "d0d3344d-a747-4100-905a-5a8d7da1e442";
     var covidDisease = new SupportedDisease("COVID-19", "96741-4");
     var fluDisease = new SupportedDisease("FLU A", "LP14239-5");
     var testOrder = TestDataBuilder.createTestOrderWithDevice();
@@ -747,12 +749,21 @@ class FhirConverterTest {
     ReflectionTestUtils.setField(fluResult, "internalId", UUID.fromString(fluId));
     var covidDiseaseTestPerformedCode =
         new DeviceTypeDisease(
-            null, covidDisease, "94500-6", "covidEquipmentUID", "covidTestkitNameId", "94500-0");
+            UUID.fromString(deviceTypeId),
+            covidDisease,
+            "94500-6",
+            "covidEquipmentUID",
+            "covidTestkitNameId",
+            "94500-0");
     var fluDiseaseTestPerformedCode =
         new DeviceTypeDisease(
-            null, fluDisease, "85477-8", "fluEquipmentUID", "fluTestkitNameId", "85477-0");
+            UUID.fromString(deviceTypeId),
+            fluDisease,
+            "85477-8",
+            "fluEquipmentUID",
+            "fluTestkitNameId",
+            "85477-0");
 
-    var deviceTypeId = "d0d3344d-a747-4100-905a-5a8d7da1e442";
     DeviceType deviceType =
         DeviceType.builder()
             .name("device")
@@ -1157,6 +1168,7 @@ class FhirConverterTest {
     device.setId(UUID.randomUUID().toString());
     specimen.setId(UUID.randomUUID().toString());
     observation.setId(UUID.randomUUID().toString());
+    observation.setDevice(new Reference(ResourceType.Device + "/" + device.getId()));
     aoeobservation1.setId(UUID.randomUUID().toString());
     aoeobservation2.setId(UUID.randomUUID().toString());
     serviceRequest.setId(UUID.randomUUID().toString());

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -342,10 +342,53 @@
       }
     },
     {
-      "fullUrl":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4",
+      "fullUrl":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4/6db25889-09cb-4127-9330-cc7e7459c1cd",
       "resource":{
         "resourceType":"Device",
         "id":"48aabd5f-a591-4e0e-9fa2-301d3d5a6df4",
+        "identifier":[
+          {
+            "value":"equipmentUID3"
+          }
+        ],
+        "manufacturer":"manufacturer",
+        "deviceName":[
+          {
+            "name":"model",
+            "type":"model-name"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4/4163abc1-0a54-4aff-badb-87bb96a89470",
+      "resource":{
+        "resourceType":"Device",
+        "id":"48aabd5f-a591-4e0e-9fa2-301d3d5a6df4",
+        "identifier":[
+          {
+            "value":"equipmentUID1"
+          }
+        ],
+        "manufacturer":"manufacturer",
+        "deviceName":[
+          {
+            "name":"model",
+            "type":"model-name"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4/f7184a68-c54e-4209-8cc6-5bf5b253e4bd",
+      "resource":{
+        "resourceType":"Device",
+        "id":"48aabd5f-a591-4e0e-9fa2-301d3d5a6df4",
+        "identifier":[
+          {
+            "value":"equipmentUID2"
+          }
+        ],
         "manufacturer":"manufacturer",
         "deviceName":[
           {
@@ -404,7 +447,7 @@
           "reference":"Specimen/725252ea-50ef-46bd-ae79-c70e1d04b949"
         },
         "device":{
-          "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
+          "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4/6db25889-09cb-4127-9330-cc7e7459c1cd"
         },
         "method": {
           "coding": [
@@ -451,7 +494,7 @@
           "reference":"Specimen/725252ea-50ef-46bd-ae79-c70e1d04b949"
         },
         "device":{
-          "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
+          "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4/4163abc1-0a54-4aff-badb-87bb96a89470"
         },
         "method": {
           "coding": [
@@ -498,7 +541,7 @@
           "reference":"Specimen/725252ea-50ef-46bd-ae79-c70e1d04b949"
         },
         "device":{
-          "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
+          "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4/f7184a68-c54e-4209-8cc6-5bf5b253e4bd"
         },
         "method": {
           "coding": [

--- a/backend/src/test/resources/fhir/observationCorrection.json
+++ b/backend/src/test/resources/fhir/observationCorrection.json
@@ -27,6 +27,9 @@
       }
     ]
   },
+  "device": {
+    "reference": "Device/d0d3344d-a747-4100-905a-5a8d7da1e442/3c9c7370-e2e3-49ad-bb7a-f6005f41cf29"
+  },
   "note": [
     {
       "text": "Corrected Result: woops"

--- a/backend/src/test/resources/fhir/observationCovid.json
+++ b/backend/src/test/resources/fhir/observationCovid.json
@@ -26,5 +26,8 @@
         "code": "covidTestkitNameId"
       }
     ]
+  },
+  "device": {
+    "reference": "Device/d0d3344d-a747-4100-905a-5a8d7da1e442/3c9c7370-e2e3-49ad-bb7a-f6005f41cf29"
   }
 }

--- a/backend/src/test/resources/fhir/observationFlu.json
+++ b/backend/src/test/resources/fhir/observationFlu.json
@@ -26,5 +26,8 @@
         "code": "fluTestkitNameId"
       }
     ]
+  },
+  "device": {
+    "reference": "Device/d0d3344d-a747-4100-905a-5a8d7da1e442/302a7919-b699-4e0d-95ca-5fd2e3fcaf7a"
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- resolves #4898

## Changes Proposed

- Include equipment UID to the device
- create a different device block per result

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
