### PR TITLE
EquipmentUid and TestkitNameId to fhir extensions

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -15,6 +15,11 @@ public class FhirConstants {
   public static final String PROCESSING_ID_SYSTEM = "http://terminology.hl7.org/CodeSystem/v2-0103";
   public static final String ETHNICITY_EXTENSION_URL =
       "https://reportstream.cdc.gov/fhir/StructureDefinition/ethnic-group";
+  public static final String TESTKIT_NAME_ID_EXTENSION_URL =
+      "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id";
+
+  public static final String EQUIPMENT_UID_EXTENSION_URL =
+      "https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid";
   public static final String ETHNICITY_CODE_SYSTEM =
       "http://terminology.hl7.org/CodeSystem/v2-0189";
   public static final String TRIBAL_AFFILIATION_EXTENSION_URL =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -611,7 +611,8 @@ class FhirConverterTest {
             null,
             "id-123",
             TestResult.POSITIVE.toString(),
-            "testKitName");
+            "testKitName",
+            null);
 
     assertThat(actual.getId()).isEqualTo("id-123");
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.FINAL.getDisplay());
@@ -637,7 +638,8 @@ class FhirConverterTest {
     ReflectionTestUtils.setField(result, "internalId", internalId);
 
     var actual =
-        convertToObservation(result, "loinc", TestCorrectionStatus.ORIGINAL, null, "testkitName");
+        convertToObservation(
+            result, "loinc", TestCorrectionStatus.ORIGINAL, null, "testkitName", null);
 
     assertThat(actual.getId()).isEqualTo(internalId.toString());
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.FINAL.getDisplay());
@@ -662,7 +664,7 @@ class FhirConverterTest {
 
     var actual =
         convertToObservation(
-            result, "loinc", TestCorrectionStatus.CORRECTED, "Oopsy Daisy", "testkitName");
+            result, "loinc", TestCorrectionStatus.CORRECTED, "Oopsy Daisy", "testkitName", null);
 
     assertThat(actual.getId()).isEqualTo(internalId.toString());
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.CORRECTED.getDisplay());
@@ -678,7 +680,8 @@ class FhirConverterTest {
     ReflectionTestUtils.setField(result, "internalId", internalId);
 
     var actual =
-        convertToObservation(result, "loinc", TestCorrectionStatus.REMOVED, null, "testkitName");
+        convertToObservation(
+            result, "loinc", TestCorrectionStatus.REMOVED, null, "testkitName", null);
 
     assertThat(actual.getId()).isEqualTo(internalId.toString());
     assertThat(actual.getStatus().getDisplay())
@@ -689,7 +692,8 @@ class FhirConverterTest {
 
   @Test
   void convertToObservation_Result_null() {
-    var actual = convertToObservation(null, "", TestCorrectionStatus.ORIGINAL, null, "testkitName");
+    var actual =
+        convertToObservation(null, "", TestCorrectionStatus.ORIGINAL, null, "testkitName", null);
 
     assertThat(actual).isNull();
   }
@@ -702,7 +706,8 @@ class FhirConverterTest {
             "",
             TestCorrectionStatus.ORIGINAL,
             null,
-            "testkitName");
+            "testkitName",
+            null);
 
     assertThat(actual).isNull();
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -612,7 +612,7 @@ class FhirConverterTest {
             "id-123",
             TestResult.POSITIVE.toString(),
             "testKitName",
-            null);
+            "equipmentUid");
 
     assertThat(actual.getId()).isEqualTo("id-123");
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.FINAL.getDisplay());
@@ -620,8 +620,7 @@ class FhirConverterTest {
     assertThat(actual.getCode().getCoding()).hasSize(1);
     assertThat(actual.getCode().getCodingFirstRep().getSystem()).isEqualTo("http://loinc.org");
     assertThat(actual.getCode().getCodingFirstRep().getCode()).isEqualTo("diseaseCode");
-    assertThat(actual.getMethod().getCoding()).hasSize(1);
-    assertThat(actual.getMethod().getCoding().get(0).getCode()).isEqualTo("testKitName");
+    assertThat(actual.getMethod().getExtension()).hasSize(2);
     assertThat(actual.getValueCodeableConcept().getCoding()).hasSize(1);
     assertThat(actual.getValueCodeableConcept().getCodingFirstRep().getSystem())
         .isEqualTo("http://snomed.info/sct");
@@ -639,7 +638,7 @@ class FhirConverterTest {
 
     var actual =
         convertToObservation(
-            result, "loinc", TestCorrectionStatus.ORIGINAL, null, "testkitName", null);
+            result, "loinc", TestCorrectionStatus.ORIGINAL, null, "testkitName", "equipmentUid");
 
     assertThat(actual.getId()).isEqualTo(internalId.toString());
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.FINAL.getDisplay());
@@ -664,7 +663,12 @@ class FhirConverterTest {
 
     var actual =
         convertToObservation(
-            result, "loinc", TestCorrectionStatus.CORRECTED, "Oopsy Daisy", "testkitName", null);
+            result,
+            "loinc",
+            TestCorrectionStatus.CORRECTED,
+            "Oopsy Daisy",
+            "testkitName",
+            "equipmentUid");
 
     assertThat(actual.getId()).isEqualTo(internalId.toString());
     assertThat(actual.getStatus().getDisplay()).isEqualTo(ObservationStatus.CORRECTED.getDisplay());
@@ -681,7 +685,7 @@ class FhirConverterTest {
 
     var actual =
         convertToObservation(
-            result, "loinc", TestCorrectionStatus.REMOVED, null, "testkitName", null);
+            result, "loinc", TestCorrectionStatus.REMOVED, null, "testkitName", "equipmentUid");
 
     assertThat(actual.getId()).isEqualTo(internalId.toString());
     assertThat(actual.getStatus().getDisplay())
@@ -693,7 +697,8 @@ class FhirConverterTest {
   @Test
   void convertToObservation_Result_null() {
     var actual =
-        convertToObservation(null, "", TestCorrectionStatus.ORIGINAL, null, "testkitName", null);
+        convertToObservation(
+            null, "", TestCorrectionStatus.ORIGINAL, null, "testkitName", "equipmentUid");
 
     assertThat(actual).isNull();
   }
@@ -707,7 +712,7 @@ class FhirConverterTest {
             TestCorrectionStatus.ORIGINAL,
             null,
             "testkitName",
-            null);
+            "equipmentUid");
 
     assertThat(actual).isNull();
   }

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -406,10 +406,19 @@
         "device":{
           "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
         },
-        "method": {
-          "coding": [
+        "method":{
+          "extension":[
             {
-              "code": "testkitNameId3"
+              "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+              "valueCoding":{
+                "code":"testkitNameId3"
+              }
+            },
+            {
+              "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid",
+              "valueCoding":{
+                "code":"equipmentUID3"
+              }
             }
           ]
         }
@@ -453,10 +462,19 @@
         "device":{
           "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
         },
-        "method": {
-          "coding": [
+        "method":{
+          "extension":[
             {
-              "code": "testkitNameId1"
+              "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+              "valueCoding":{
+                "code":"testkitNameId1"
+              }
+            },
+            {
+              "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid",
+              "valueCoding":{
+                "code":"equipmentUID1"
+              }
             }
           ]
         }
@@ -500,10 +518,19 @@
         "device":{
           "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
         },
-        "method": {
-          "coding": [
+        "method":{
+          "extension":[
             {
-              "code": "testkitNameId2"
+              "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+              "valueCoding":{
+                "code":"testkitNameId2"
+              }
+            },
+            {
+              "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid",
+              "valueCoding":{
+                "code":"equipmentUID2"
+              }
             }
           ]
         }

--- a/backend/src/test/resources/fhir/observationCorrection.json
+++ b/backend/src/test/resources/fhir/observationCorrection.json
@@ -21,9 +21,18 @@
     ]
   },
   "method": {
-    "coding": [
+    "extension": [
       {
-        "code": "covidTestkitNameId"
+        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+        "valueCoding": {
+          "code": "covidTestkitNameId"
+        }
+      },
+      {
+        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid",
+        "valueCoding": {
+          "code": "covidEquipmentUID"
+        }
       }
     ]
   },

--- a/backend/src/test/resources/fhir/observationCovid.json
+++ b/backend/src/test/resources/fhir/observationCovid.json
@@ -21,9 +21,18 @@
     ]
   },
   "method": {
-    "coding": [
+    "extension": [
       {
-        "code": "covidTestkitNameId"
+        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+        "valueCoding": {
+          "code": "covidTestkitNameId"
+        }
+      },
+      {
+        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid",
+        "valueCoding": {
+          "code": "covidEquipmentUID"
+        }
       }
     ]
   }

--- a/backend/src/test/resources/fhir/observationFlu.json
+++ b/backend/src/test/resources/fhir/observationFlu.json
@@ -21,9 +21,18 @@
     ]
   },
   "method": {
-    "coding": [
+    "extension": [
       {
-        "code": "fluTestkitNameId"
+        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+        "valueCoding": {
+          "code": "fluTestkitNameId"
+        }
+      },
+      {
+        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/equipment-uid",
+        "valueCoding": {
+          "code": "fluEquipmentUID"
+        }
       }
     ]
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- resolves #4898

## Changes Proposed

- Include equipment UID + testkitNameId to the observation extension

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
