### PR TITLE
Elisa/5321 remove supported disease frontend

### DIFF
--- a/frontend/src/app/ReportingApp.test.tsx
+++ b/frontend/src/app/ReportingApp.test.tsx
@@ -27,6 +27,8 @@ import {
   getStartDateFromDaysAgo,
 } from "./analytics/Analytics";
 import { getAppInsights } from "./TelemetryService";
+import mockSupportedDiseaseMultiplex from "./testQueue/mocks/mockSupportedDiseaseMultiplex";
+import mockSupportedDiseaseCovid from "./testQueue/mocks/mockSupportedDiseaseCovid";
 
 const mockDispatch = jest.fn();
 
@@ -157,14 +159,14 @@ const facilityQueryMock = {
             internalId: "d70bb3b8-96bd-40d9-a3ce-b266a7edb91d",
             name: "Quidel Sofia 2",
             testLength: 15,
-            supportedDiseases: [],
+            supportedDiseaseTestPerformed: mockSupportedDiseaseMultiplex,
             swabTypes: [],
           },
           {
             internalId: "5e44dcef-8cc6-44f4-a200-a5b8169ab60a",
             name: "LumiraDX",
             testLength: 15,
-            supportedDiseases: [],
+            supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
             swabTypes: [],
           },
         ],

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
@@ -13,21 +13,18 @@ import ManageDevices from "./ManageDevices";
 const deviceA = {
   internalId: "device-a",
   name: "Device A",
-  supportedDiseases: [],
 };
 const deviceB = {
   internalId: "device-b",
   name: "Device B",
-  supportedDiseases: [],
 };
 const deviceC = {
   internalId: "device-c",
   name: "Device C",
-  supportedDiseases: [],
 };
 
 const devices: DeviceType[] = [deviceA, deviceB, deviceC];
-const selectedDevices: DeviceType[] = [deviceA, deviceB];
+const selectedDevices: FacilityFormDeviceType[] = [deviceA, deviceB];
 
 function ManageDevicesContainer(props: { selectedDevices: DeviceType[] }) {
   const [selectedDevices, updateSelectedDevices] = useState<DeviceType[]>(

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -4,9 +4,9 @@ import { FacilityErrors } from "../facilitySchema";
 import MultiSelect from "../../../commonComponents/MultiSelect/MultiSelect";
 
 interface Props {
-  deviceTypes: DeviceType[];
-  selectedDevices: DeviceType[];
-  updateSelectedDevices: (deviceTypes: DeviceType[]) => void;
+  deviceTypes: FacilityFormDeviceType[];
+  selectedDevices: FacilityFormDeviceType[];
+  updateSelectedDevices: (deviceTypes: FacilityFormDeviceType[]) => void;
   errors: FacilityErrors;
   clearError: (field: keyof FacilityErrors) => void;
   newOrg?: boolean;

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -23,12 +23,10 @@ const devices: DeviceType[] = [
   {
     internalId: "device-1",
     name: "Device 1",
-    supportedDiseases: [],
   },
   {
     internalId: "device-2",
     name: "Device 2",
-    supportedDiseases: [],
   },
 ];
 

--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -143,7 +143,7 @@ type AddressOptions = "facility" | "provider";
 
 export interface Props {
   facility: Facility;
-  deviceTypes: DeviceType[];
+  deviceTypes: FacilityFormDeviceType[];
   saveFacility: (facility: Facility) => void;
   newOrg?: boolean;
 }

--- a/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityFormContainer.test.tsx
@@ -17,16 +17,14 @@ import FacilityFormContainer, {
   UPDATE_FACILITY_MUTATION,
 } from "./FacilityFormContainer";
 
-export const deviceTypes: DeviceType[] = [
+export const deviceTypes: FacilityFormDeviceType[] = [
   {
     internalId: "bc0536ea-4564-4291-bbf3-0e7b0731f6e8",
     name: "Fake Device 1",
-    supportedDiseases: [],
   },
   {
     internalId: "ee85bdfb-b6c9-4951-ae30-6c025be4580e",
     name: "Fake Device 2",
-    supportedDiseases: [],
   },
 ];
 

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -83,11 +83,10 @@ const providerSchema: yup.SchemaOf<RequiredProviderFields> = yup.object({
   zipCode: yup.string().nullable(),
 });
 
-const deviceTypeSchema: yup.SchemaOf<DeviceType> = yup.object({
+const deviceTypeSchema: yup.SchemaOf<FacilityFormDeviceType> = yup.object({
   internalId: yup.string().required(),
   name: yup.string().required(),
   testLength: yup.number().optional(),
-  supportedDiseases: yup.array().of(yup.string()).optional(),
 });
 
 export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({

--- a/frontend/src/app/Settings/types.d.ts
+++ b/frontend/src/app/Settings/types.d.ts
@@ -9,8 +9,7 @@ type RequiredExceptFor<T, TOptional extends keyof T> = Pick<
 > &
   Partial<T>;
 
-interface DeviceType {
-  supportedDiseases: { internalId: string; name: string }[];
+interface FacilityFormDeviceType {
   internalId: string;
   name: string;
   testLength?: number | undefined;
@@ -39,7 +38,7 @@ interface Facility extends Address {
   name: string;
   phone: string;
   email: string | null;
-  deviceTypes: DeviceType[];
+  deviceTypes: FacilityFormDeviceType[];
   orderingProvider: Provider;
 }
 
@@ -108,18 +107,7 @@ interface FacilityData {
         zipCode: string;
         phone: string;
         email: string;
-        deviceTypes: [
-          {
-            name: string;
-            internalId: string;
-            supportedDiseases: [
-              {
-                internalId: string;
-                name: string;
-              }
-            ];
-          }
-        ];
+        deviceTypes: FacilityFormDeviceType[];
         orderingProvider: {
           firstName: string;
           middleName: string;
@@ -137,7 +125,7 @@ interface FacilityData {
       }
     ];
   };
-  deviceTypes: DeviceType[];
+  deviceTypes: FacilityFormDeviceType[];
 }
 
 type TestCorrectionStatus = "ORIGINAL" | "CORRECTED" | "REMOVED";

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -1,11 +1,20 @@
 import React from "react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { cloneDeep } from "lodash";
 
 import DeviceForm from "./DeviceForm";
+import mockSupportedDiseaseTestPerformedCovid from "./mocks/mockSupportedDiseaseTestPerformedCovid";
+import mockSupportedDiseaseTestPerformedMultiplex from "./mocks/mockSupportedDiseaseTestPerformedMultiplex";
 
 const addValue = async (name: string, value: string) => {
   await userEvent.type(screen.getByLabelText(name, { exact: false }), value);
+};
+
+const clearAndEnterInput = async (fieldToEdit: string, newValue: string) => {
+  const label = screen.getAllByLabelText(fieldToEdit)[0];
+  await userEvent.clear(label);
+  await userEvent.type(label, newValue);
 };
 
 describe("create new device", () => {
@@ -99,7 +108,6 @@ describe("create new device", () => {
           name: "Accula",
           testLength: 10,
           swabTypes: ["445297001"],
-          supportedDiseases: ["3821904728"],
           supportedDiseaseTestPerformed: [
             {
               supportedDisease: "3821904728",
@@ -120,6 +128,11 @@ describe("update existing devices", () => {
   let container: any;
   beforeEach(() => {
     saveDeviceType = jest.fn();
+    let supportedDiseaseWithoutTestPerformedLoinc = cloneDeep(
+      mockSupportedDiseaseTestPerformedMultiplex
+    );
+    supportedDiseaseWithoutTestPerformedLoinc[1].testPerformedLoincCode = "";
+    supportedDiseaseWithoutTestPerformedLoinc[2].testPerformedLoincCode = "";
     container = render(
       <DeviceForm
         formTitle="Manage devices"
@@ -129,11 +142,14 @@ describe("update existing devices", () => {
           { label: "eye", value: "456" },
           { label: "mouth", value: "789" },
         ]}
-        supportedDiseaseOptions={[
-          { label: "COVID-19", value: "123" },
-          { label: "Flu A", value: "456" },
-          { label: "Flu B", value: "789" },
-        ]}
+        supportedDiseaseOptions={mockSupportedDiseaseTestPerformedMultiplex.map(
+          (sd) => {
+            return {
+              label: sd.supportedDisease.name,
+              value: sd.supportedDisease.internalId,
+            };
+          }
+        )}
         deviceOptions={[
           {
             internalId: "abc1",
@@ -142,22 +158,9 @@ describe("update existing devices", () => {
             manufacturer: "Celoxitin",
             testLength: 15,
             swabTypes: [{ internalId: "123", name: "nose", typeCode: "n123" }],
-            supportedDiseases: [
-              { internalId: "123", name: "COVID-19", loinc: "1234-1" },
-            ],
-            supportedDiseaseTestPerformed: [
-              {
-                supportedDisease: {
-                  internalId: "123",
-                  loinc: "1234-3",
-                  name: "COVID-19",
-                },
-                testPerformedLoincCode: "1234-1",
-                equipmentUid: "equipmentUid123",
-                testkitNameId: "testkitNameId123",
-                testOrderedLoincCode: "1432-1",
-              },
-            ],
+            supportedDiseases: [], // Remove in #5322
+            supportedDiseaseTestPerformed:
+              mockSupportedDiseaseTestPerformedCovid,
           },
           {
             internalId: "abc2",
@@ -166,46 +169,9 @@ describe("update existing devices", () => {
             manufacturer: "Curentz",
             testLength: 15,
             swabTypes: [{ internalId: "456", name: "eye", typeCode: "e456" }],
-            supportedDiseases: [
-              { internalId: "123", name: "COVID-19", loinc: "1234-1" },
-              { internalId: "456", name: "Flu A", loinc: "LP123" },
-              { internalId: "789", name: "Flu B", loinc: "LP345" },
-            ],
-            supportedDiseaseTestPerformed: [
-              {
-                supportedDisease: {
-                  internalId: "123",
-                  loinc: "1234-3",
-                  name: "COVID-19",
-                },
-                testPerformedLoincCode: "1234-1",
-                equipmentUid: "equipmentUid123",
-                testkitNameId: "testkitNameId123",
-                testOrderedLoincCode: "1432-1",
-              },
-              {
-                supportedDisease: {
-                  internalId: "456",
-                  loinc: "LP123",
-                  name: "Flu A",
-                },
-                testPerformedLoincCode: "Test123",
-                equipmentUid: "equipmentUid321",
-                testkitNameId: "testkitNameId321",
-                testOrderedLoincCode: "321Tset",
-              },
-              {
-                supportedDisease: {
-                  internalId: "789",
-                  loinc: "LP456",
-                  name: "Flu B",
-                },
-                testPerformedLoincCode: "Test345",
-                equipmentUid: "equipmentUid345",
-                testkitNameId: "testkitNameId345",
-                testOrderedLoincCode: "543Tset",
-              },
-            ],
+            supportedDiseases: [], // Remove in #5322
+            supportedDiseaseTestPerformed:
+              supportedDiseaseWithoutTestPerformedLoinc,
           },
           {
             internalId: "abc3",
@@ -214,22 +180,9 @@ describe("update existing devices", () => {
             manufacturer: "Vitamin Tox",
             testLength: 15,
             swabTypes: [{ internalId: "789", name: "mouth", typeCode: "m789" }],
-            supportedDiseases: [
-              { internalId: "123", name: "COVID-19", loinc: "1234-1" },
-            ],
-            supportedDiseaseTestPerformed: [
-              {
-                supportedDisease: {
-                  internalId: "123",
-                  loinc: "1234-3",
-                  name: "COVID-19",
-                },
-                testPerformedLoincCode: "1234-1",
-                equipmentUid: "equipmentUid123",
-                testkitNameId: "testkitNameId123",
-                testOrderedLoincCode: "1432-1",
-              },
-            ],
+            supportedDiseases: [], // Remove in #5322
+            supportedDiseaseTestPerformed:
+              mockSupportedDiseaseTestPerformedCovid,
           },
           {
             internalId: "abc4",
@@ -238,44 +191,9 @@ describe("update existing devices", () => {
             manufacturer: "Local",
             testLength: 15,
             swabTypes: [{ internalId: "789", name: "mouth", typeCode: "m789" }],
-            supportedDiseases: [
-              { internalId: "123", name: "COVID-19", loinc: "1234-1" },
-            ],
-            supportedDiseaseTestPerformed: [
-              {
-                supportedDisease: {
-                  internalId: "123",
-                  loinc: "1234-3",
-                  name: "COVID-19",
-                },
-                testPerformedLoincCode: "1234-1",
-                equipmentUid: "equipmentUid123",
-                testkitNameId: "testkitNameId123",
-                testOrderedLoincCode: "1432-1",
-              },
-              {
-                supportedDisease: {
-                  internalId: "456",
-                  loinc: "LP123",
-                  name: "Flu A",
-                },
-                testPerformedLoincCode: "Test123",
-                equipmentUid: "equipmentUid321",
-                testkitNameId: "testkitNameId321",
-                testOrderedLoincCode: "321Tset",
-              },
-              {
-                supportedDisease: {
-                  internalId: "789",
-                  loinc: "LP456",
-                  name: "Flu B",
-                },
-                testPerformedLoincCode: "Test345",
-                equipmentUid: "equipmentUid345",
-                testkitNameId: "testkitNameId345",
-                testOrderedLoincCode: "543Tset",
-              },
-            ],
+            supportedDiseases: [], // Remove in #5322
+            supportedDiseaseTestPerformed:
+              mockSupportedDiseaseTestPerformedMultiplex,
           },
           {
             internalId: "abc5",
@@ -284,8 +202,9 @@ describe("update existing devices", () => {
             manufacturer: "Brand",
             testLength: 15,
             swabTypes: [{ internalId: "789", name: "mouth", typeCode: "m789" }],
-            supportedDiseases: [],
-            supportedDiseaseTestPerformed: [],
+            supportedDiseases: [], // Remove in #5322
+            supportedDiseaseTestPerformed:
+              mockSupportedDiseaseTestPerformedCovid,
           },
         ]}
       />
@@ -352,21 +271,33 @@ describe("update existing devices", () => {
         supportedDisease.map(
           (diseaseInput) => (diseaseInput as HTMLSelectElement).value
         )
-      ).toEqual(["123", "456", "789"]);
+      ).toEqual([
+        "177cfdfa-1ce5-404f-bd39-5492f87868f4",
+        "e286f2a8-38e2-445b-80a5-c16507a96b66",
+        "14924488-268f-47db-bea6-aa706971a098",
+      ]);
       expect(testPerformed).toHaveLength(3);
       expect(
         testPerformed.map((code) => (code as HTMLInputElement).value)
-      ).toEqual(["1234-1", "Test123", "Test345"]);
+      ).toEqual(["1234-1", "LP14239-3", "LP14240-1"]);
       expect(
         testOrdered.map((code) => (code as HTMLInputElement).value)
-      ).toEqual(["1432-1", "321Tset", "543Tset"]);
+      ).toEqual(["1432-1", "LP14239-6", "LP14240-5"]);
       expect(
         testkitNameId.map((code) => (code as HTMLInputElement).value)
-      ).toEqual(["testkitNameId123", "testkitNameId321", "testkitNameId345"]);
+      ).toEqual([
+        "testkitNameId123",
+        "FluATestkitNameId123",
+        "FluBTestkitNameId123",
+      ]);
 
       expect(
         equipmentUid.map((code) => (code as HTMLInputElement).value)
-      ).toEqual(["equipmentUid123", "equipmentUid321", "equipmentUid345"]);
+      ).toEqual([
+        "equipmentUid123",
+        "FluAEquipmentUid123",
+        "FluBEquipmentUid123",
+      ]);
     });
 
     it("maps supported diseases to supported disease and empty test performed", async () => {
@@ -382,10 +313,15 @@ describe("update existing devices", () => {
         supportedDisease.map(
           (diseaseInput) => (diseaseInput as HTMLSelectElement).value
         )
-      ).toEqual(["123", "456", "789"]);
+      ).toEqual([
+        "177cfdfa-1ce5-404f-bd39-5492f87868f4",
+        "e286f2a8-38e2-445b-80a5-c16507a96b66",
+        "14924488-268f-47db-bea6-aa706971a098",
+      ]);
+
       expect(
         testPerformed.map((code) => (code as HTMLInputElement).value)
-      ).toEqual(["1234-1", "Test123", "Test345"]);
+      ).toEqual(["1234-1", "", ""]);
     });
 
     it("displays a list of available snomeds", () => {
@@ -404,13 +340,20 @@ describe("update existing devices", () => {
         screen
           .getAllByLabelText("Supported disease *")
           .map((disease) => (disease as HTMLInputElement).value)
-      ).toEqual(["123", "456", "789"]);
+      ).toEqual([
+        "177cfdfa-1ce5-404f-bd39-5492f87868f4",
+        "e286f2a8-38e2-445b-80a5-c16507a96b66",
+        "14924488-268f-47db-bea6-aa706971a098",
+      ]);
       await userEvent.click(screen.getAllByLabelText("Delete disease")[0]);
       expect(
         screen
           .getAllByLabelText("Supported disease *")
           .map((disease) => (disease as HTMLInputElement).value)
-      ).toEqual(["123", "789"]);
+      ).toEqual([
+        "177cfdfa-1ce5-404f-bd39-5492f87868f4",
+        "14924488-268f-47db-bea6-aa706971a098",
+      ]);
     });
 
     describe("selecting another device", () => {
@@ -444,31 +387,19 @@ describe("update existing devices", () => {
         await addValue("Model", "X");
         await userEvent.click(snomedInput);
         await userEvent.click(within(snomedList).getByText("eye"));
+        await clearAndEnterInput("Test ordered code *", "LP 321");
         await userEvent.click(screen.getByText("Add another disease"));
         await userEvent.selectOptions(
           screen.getAllByLabelText("Supported disease *")[1],
           "Flu A"
         );
-        await userEvent.clear(
-          screen.getAllByLabelText("Test performed code *")[1]
-        );
         await userEvent.type(
           screen.getAllByLabelText("Test performed code *")[1],
           "LP 123"
         );
-        await userEvent.clear(
-          screen.getAllByLabelText("Test ordered code *")[0]
-        );
-        await userEvent.type(
-          screen.getAllByLabelText("Test ordered code *")[0],
-          "LP 321"
-        );
-        await userEvent.clear(
-          screen.getAllByLabelText("Test ordered code *")[1]
-        );
         await userEvent.type(
           screen.getAllByLabelText("Test ordered code *")[1],
-          "LP 321"
+          "LP 444"
         );
         await userEvent.type(
           screen.getAllByLabelText("Testkit Name Id")[1],
@@ -488,20 +419,19 @@ describe("update existing devices", () => {
             model: "Model AX",
             manufacturer: "Celoxitin LLC",
             swabTypes: ["123", "456"],
-            supportedDiseases: ["123", "456"],
             testLength: 15,
             supportedDiseaseTestPerformed: [
               {
-                supportedDisease: "123",
                 testPerformedLoincCode: "1234-1",
+                supportedDisease: "177cfdfa-1ce5-404f-bd39-5492f87868f4",
                 testOrderedLoincCode: "LP 321",
                 equipmentUid: "equipmentUid123",
                 testkitNameId: "testkitNameId123",
               },
               {
-                supportedDisease: "456",
+                supportedDisease: "e286f2a8-38e2-445b-80a5-c16507a96b66",
                 testPerformedLoincCode: "LP 123",
-                testOrderedLoincCode: "LP 321",
+                testOrderedLoincCode: "LP 444",
                 equipmentUid: "equipmentUid321",
                 testkitNameId: "testkitNameId123",
               },
@@ -512,22 +442,8 @@ describe("update existing devices", () => {
       it("sets loinc code to the test performed code for covid", async () => {
         await userEvent.click(screen.getByTestId("combo-box-select"));
         await userEvent.click(screen.getAllByText("Tesla Emitter")[1]);
-        await userEvent.clear(
-          screen.getAllByLabelText("Test performed code *")[0]
-        );
-
-        await userEvent.type(
-          screen.getAllByLabelText("Test performed code *")[0],
-          "950-9501"
-        );
-        await userEvent.clear(
-          screen.getAllByLabelText("Test ordered code *")[0]
-        );
-        await userEvent.type(
-          screen.getAllByLabelText("Test ordered code *")[0],
-          "1059-059"
-        );
-
+        await clearAndEnterInput("Test performed code *", "950-9501");
+        await clearAndEnterInput("Test ordered code *", "1059-059");
         await userEvent.click(screen.getByText("Save changes"));
 
         await waitFor(() =>
@@ -537,14 +453,13 @@ describe("update existing devices", () => {
             model: "Model A",
             manufacturer: "Celoxitin",
             swabTypes: ["123"],
-            supportedDiseases: ["123"],
             testLength: 15,
             supportedDiseaseTestPerformed: [
               {
-                supportedDisease: "123",
+                equipmentUid: "equipmentUid123",
+                supportedDisease: "177cfdfa-1ce5-404f-bd39-5492f87868f4",
                 testPerformedLoincCode: "950-9501",
                 testOrderedLoincCode: "1059-059",
-                equipmentUid: "equipmentUid123",
                 testkitNameId: "testkitNameId123",
               },
             ],

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -77,11 +77,7 @@ const DeviceForm = (props: Props) => {
       manufacturer: deviceData.manufacturer,
       model: deviceData.model,
       name: deviceData.name,
-      supportedDiseases: deviceData.supportedDiseases.map(
-        (supportedDisease: SupportedDiseasesFormData) =>
-          supportedDisease.supportedDisease
-      ),
-      supportedDiseaseTestPerformed: deviceData.supportedDiseases?.map(
+      supportedDiseaseTestPerformed: deviceData.supportedDiseases.map(
         (supportedDisease: SupportedDiseasesFormData) => {
           const convertedSupportedDisease = {
             supportedDisease: supportedDisease.supportedDisease,
@@ -155,9 +151,6 @@ const DeviceForm = (props: Props) => {
           manufacturer: device.manufacturer,
           model: device.model,
           swabTypes: device.swabTypes?.map((swab) => swab.internalId),
-          supportedDiseases:
-            device.supportedDiseases?.map((disease) => disease.internalId) ||
-            [],
           testLength: device.testLength ? device.testLength : 15,
           supportedDiseaseTestPerformed:
             device.supportedDiseaseTestPerformed?.map(

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceTypeFormContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceTypeFormContainer.test.tsx
@@ -119,7 +119,6 @@ describe("DeviceTypeFormContainer", () => {
           model: "Accula SARS-Cov-2 Test*",
           name: "Accula",
           swabTypes: ["887799"],
-          supportedDiseases: ["294729"],
           testLength: 15,
           supportedDiseaseTestPerformed: [
             {

--- a/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.test.tsx
@@ -5,6 +5,7 @@ import { DeviceType, SpecimenType } from "../../../generated/graphql";
 import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import ManageDeviceTypeFormContainer from "./ManageDeviceTypeFormContainer";
+import mockSupportedDiseaseTestPerformedCovid from "./mocks/mockSupportedDiseaseTestPerformedCovid";
 
 const mockUpdateDeviceType = jest.fn();
 
@@ -73,9 +74,9 @@ jest.mock("../../../generated/graphql", () => {
               swabTypes: [
                 { internalId: "123", name: "nose", typeCode: "n123" },
               ],
-              supportedDiseases: [
-                { internalId: "294729", name: "COVID-19", loinc: "4829" },
-              ],
+              supportedDiseaseTestPerformed:
+                mockSupportedDiseaseTestPerformedCovid,
+              testLength: 15,
             },
             {
               internalId: "abc2",
@@ -84,9 +85,9 @@ jest.mock("../../../generated/graphql", () => {
               manufacturer: "Curentz",
               loincCode: "1234-2",
               swabTypes: [{ internalId: "456", name: "eye", typeCode: "e456" }],
-              supportedDiseases: [
-                { internalId: "294729", name: "COVID-19", loinc: "4829" },
-              ],
+              supportedDiseaseTestPerformed:
+                mockSupportedDiseaseTestPerformedCovid,
+              testLength: 15,
             },
             {
               internalId: "abc3",
@@ -97,9 +98,9 @@ jest.mock("../../../generated/graphql", () => {
               swabTypes: [
                 { internalId: "789", name: "mouth", typeCode: "m789" },
               ],
-              supportedDiseases: [
-                { internalId: "294729", name: "COVID-19", loinc: "4829" },
-              ],
+              supportedDiseaseTestPerformed:
+                mockSupportedDiseaseTestPerformedCovid,
+              testLength: 15,
             },
           ] as DeviceType[],
         },
@@ -161,11 +162,12 @@ describe("ManageDeviceTypeFormContainer", () => {
       "COVID-19"
     );
     await userEvent.clear(screen.getByLabelText("Test performed code *"));
-
     await userEvent.type(
       screen.getByLabelText("Test performed code *"),
       "LP 123"
     );
+
+    await userEvent.clear(screen.getByLabelText("Test ordered code *"));
     await userEvent.type(
       screen.getByLabelText("Test ordered code *"),
       "LP 321"
@@ -181,13 +183,14 @@ describe("ManageDeviceTypeFormContainer", () => {
           manufacturer: "Vitamin Tox LLC",
           model: "Model CD",
           swabTypes: ["789"],
-          supportedDiseases: ["294729"],
           testLength: 15,
           supportedDiseaseTestPerformed: [
             {
               supportedDisease: "294729",
               testPerformedLoincCode: "LP 123",
               testOrderedLoincCode: "LP 321",
+              testkitNameId: "testkitNameId123",
+              equipmentUid: "equipmentUid123",
             },
           ],
         },

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -589,19 +589,19 @@ Object {
                               />
                               <option
                                 aria-selected="false"
-                                value="123"
+                                value="177cfdfa-1ce5-404f-bd39-5492f87868f4"
                               >
                                 COVID-19
                               </option>
                               <option
                                 aria-selected="false"
-                                value="456"
+                                value="e286f2a8-38e2-445b-80a5-c16507a96b66"
                               >
                                 Flu A
                               </option>
                               <option
                                 aria-selected="false"
-                                value="789"
+                                value="14924488-268f-47db-bea6-aa706971a098"
                               >
                                 Flu B
                               </option>
@@ -1353,19 +1353,19 @@ Object {
                             />
                             <option
                               aria-selected="false"
-                              value="123"
+                              value="177cfdfa-1ce5-404f-bd39-5492f87868f4"
                             >
                               COVID-19
                             </option>
                             <option
                               aria-selected="false"
-                              value="456"
+                              value="e286f2a8-38e2-445b-80a5-c16507a96b66"
                             >
                               Flu A
                             </option>
                             <option
                               aria-selected="false"
-                              value="789"
+                              value="14924488-268f-47db-bea6-aa706971a098"
                             >
                               Flu B
                             </option>

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid.ts
@@ -1,0 +1,15 @@
+const mockSupportedDiseaseTestPerformedCovid = [
+  {
+    supportedDisease: {
+      internalId: "177cfdfa-1ce5-404f-bd39-5492f87868f4",
+      loinc: "96741-4",
+      name: "COVID-19",
+    },
+    testPerformedLoincCode: "1234-1",
+    equipmentUid: "equipmentUid123",
+    testkitNameId: "testkitNameId123",
+    testOrderedLoincCode: "1432-1",
+  },
+];
+
+export default mockSupportedDiseaseTestPerformedCovid;

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedMultiplex.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedMultiplex.ts
@@ -1,0 +1,33 @@
+import mockSupportedDiseaseTestPerformedCovid from "./mockSupportedDiseaseTestPerformedCovid";
+
+let mockSupportedDiseaseTestPerformedFlu = [
+  {
+    supportedDisease: {
+      internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
+      loinc: "LP14239-5",
+      name: "Flu A",
+    },
+    testPerformedLoincCode: "LP14239-3",
+    equipmentUid: "FluAEquipmentUid123",
+    testkitNameId: "FluATestkitNameId123",
+    testOrderedLoincCode: "LP14239-6",
+  },
+  {
+    supportedDisease: {
+      internalId: "14924488-268f-47db-bea6-aa706971a098",
+      loinc: "LP14240-3",
+      name: "Flu B",
+    },
+    testPerformedLoincCode: "LP14240-1",
+    equipmentUid: "FluBEquipmentUid123",
+    testkitNameId: "FluBTestkitNameId123",
+    testOrderedLoincCode: "LP14240-5",
+  },
+];
+
+const mockSupportedDiseaseTestPerformedMultiplex = [
+  ...mockSupportedDiseaseTestPerformedCovid,
+  ...mockSupportedDiseaseTestPerformedFlu,
+];
+
+export default mockSupportedDiseaseTestPerformedMultiplex;

--- a/frontend/src/app/supportAdmin/DeviceType/operations.graphql
+++ b/frontend/src/app/supportAdmin/DeviceType/operations.graphql
@@ -3,7 +3,6 @@ mutation createDeviceType(
   $manufacturer: String!
   $model: String!
   $swabTypes: [ID!]!
-  $supportedDiseases: [ID!]!
   $supportedDiseaseTestPerformed: [SupportedDiseaseTestPerformedInput!]!
   $testLength: Int!
 ) {
@@ -13,7 +12,6 @@ mutation createDeviceType(
       manufacturer: $manufacturer
       model: $model
       swabTypes: $swabTypes
-      supportedDiseases: $supportedDiseases
       supportedDiseaseTestPerformed: $supportedDiseaseTestPerformed
       testLength: $testLength
     }
@@ -28,7 +26,6 @@ mutation updateDeviceType(
   $manufacturer: String!
   $model: String!
   $swabTypes: [ID!]!
-  $supportedDiseases: [ID!]
   $supportedDiseaseTestPerformed: [SupportedDiseaseTestPerformedInput!]!
   $testLength: Int!
 ) {
@@ -39,7 +36,6 @@ mutation updateDeviceType(
       manufacturer: $manufacturer
       model: $model
       swabTypes: $swabTypes
-      supportedDiseases: $supportedDiseases
       supportedDiseaseTestPerformed: $supportedDiseaseTestPerformed
       testLength: $testLength
     }
@@ -56,10 +52,6 @@ query getDeviceTypeList{
     model,
     testLength,
     swabTypes {
-      internalId,
-      name
-    }
-    supportedDiseases {
       internalId,
       name
     }

--- a/frontend/src/app/supportAdmin/DeviceType/types.d.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/types.d.ts
@@ -1,0 +1,16 @@
+interface DeviceType {
+  internalId: string;
+  name: string;
+  testLength?: number | undefined;
+  supportedDiseaseTestPerformed?: {
+    supportedDisease: {
+      internalId: string;
+      loinc: string;
+      name: string;
+    };
+    testPerformedLoincCode: string;
+    testkitNameId?: string;
+    equipmentUid?: string;
+    testOrderedLoincCode: string;
+  };
+}

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -32,6 +32,8 @@ import QueueItem, {
   QueriedTestOrder,
   QueueItemProps,
 } from "./QueueItem";
+import mockSupportedDiseaseCovid from "./mocks/mockSupportedDiseaseCovid";
+import mockSupportedDiseaseMultiplex from "./mocks/mockSupportedDiseaseMultiplex";
 
 jest.mock("../TelemetryService", () => ({
   getAppInsights: jest.fn(),
@@ -142,13 +144,7 @@ describe("QueueItem", () => {
         internalId: device1Id,
         name: device1Name,
         testLength: 15,
-        supportedDiseases: [
-          {
-            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-            loinc: "96741-4",
-            name: "COVID-19",
-          },
-        ],
+        supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
         swabTypes: [
           {
             name: specimen1Name,
@@ -166,13 +162,7 @@ describe("QueueItem", () => {
         internalId: device2Id,
         name: device2Name,
         testLength: 15,
-        supportedDiseases: [
-          {
-            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-            loinc: "96741-4",
-            name: "COVID-19",
-          },
-        ],
+        supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
         swabTypes: [
           {
             name: specimen1Name,
@@ -185,13 +175,7 @@ describe("QueueItem", () => {
         internalId: device3Id,
         name: device3Name,
         testLength: 15,
-        supportedDiseases: [
-          {
-            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-            loinc: "96741-4",
-            name: "COVID-19",
-          },
-        ],
+        supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
         swabTypes: [
           {
             name: specimen1Name,
@@ -209,23 +193,7 @@ describe("QueueItem", () => {
         internalId: device4Id,
         name: device4Name,
         testLength: 15,
-        supportedDiseases: [
-          {
-            internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-            loinc: "96741-4",
-            name: "COVID-19",
-          },
-          {
-            internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
-            loinc: "LP14239-5",
-            name: "Flu A",
-          },
-          {
-            internalId: "14924488-268f-47db-bea6-aa706971a098",
-            loinc: "LP14240-3",
-            name: "Flu B",
-          },
-        ],
+        supportedDiseaseTestPerformed: mockSupportedDiseaseMultiplex,
         swabTypes: [
           {
             name: specimen1Name,
@@ -472,13 +440,7 @@ describe("QueueItem", () => {
           name: deletedDeviceName,
           model: "test",
           testLength: 12,
-          supportedDiseases: [
-            {
-              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-              loinc: "96741-4",
-              name: "COVID-19",
-            },
-          ],
+          supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
         },
         correctionStatus: "CORRECTED",
         reasonForCorrection: TestCorrectionReason.INCORRECT_RESULT,

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -14,6 +14,7 @@ import {
   useEditQueueItemMutation,
   useSubmitQueueItemMutation,
   GetFacilityQueueQuery,
+  SupportedDisease,
 } from "../../generated/graphql";
 import Button from "../commonComponents/Button/Button";
 import Dropdown from "../commonComponents/Dropdown";
@@ -101,7 +102,6 @@ export type QueriedDeviceType = NonNullable<
   GetFacilityQueueQuery["facility"]
 >["deviceTypes"][number];
 export type QueriedFacility = GetFacilityQueueQuery["facility"];
-type QueriedSupportedDiseases = QueriedDeviceType["supportedDiseases"][number];
 
 const convertFromMultiplexResponse = (
   responseResult: QueriedTestOrder["results"]
@@ -236,7 +236,7 @@ const QueueItem = ({
   };
 
   const updateDeviceMultiplexSupport = (
-    supportedDiseases: QueriedSupportedDiseases[]
+    supportedDiseases: SupportedDisease[]
   ) => {
     const updatedDiseaseSupport =
       supportedDiseases.filter((d: any) => d.name !== "COVID-19").length > 0;
@@ -285,7 +285,12 @@ const QueueItem = ({
 
   useEffect(() => {
     if (devicesMap.has(deviceId)) {
-      updateDeviceMultiplexSupport(devicesMap.get(deviceId)!.supportedDiseases);
+      let supportedDiseases = devicesMap
+        .get(deviceId)!
+        .supportedDiseaseTestPerformed.map((supportedDisease) => {
+          return supportedDisease.supportedDisease;
+        });
+      updateDeviceMultiplexSupport(supportedDiseases);
     }
     // eslint-disable-next-line
   }, [deviceId]);

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -20,6 +20,8 @@ import { PATIENT_TERM } from "../../config/constants";
 
 import TestQueue from "./TestQueue";
 import { QUERY_PATIENT } from "./addToQueue/AddToQueueSearch";
+import mockSupportedDiseaseCovid from "./mocks/mockSupportedDiseaseCovid";
+import mockSupportedDiseaseMultiplex from "./mocks/mockSupportedDiseaseMultiplex";
 
 jest.mock("@microsoft/applicationinsights-react-js", () => {
   return {
@@ -298,7 +300,7 @@ const createPatient = ({
     name: "LumiraDX",
     model: "LumiraDx SARS-CoV-2 Ag Test*",
     testLength: 15,
-    supportedDiseases: [],
+    supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
   },
   specimenType: {
     internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",
@@ -336,13 +338,7 @@ const result = {
           internalId: "ee4f40b7-ac32-4709-be0a-56dd77bb9609",
           name: "LumiraDX",
           testLength: 15,
-          supportedDiseases: [
-            {
-              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-              loinc: "96741-4",
-              name: "COVID-19",
-            },
-          ],
+          supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
           swabTypes: [
             {
               name: "Swab of internal nose",
@@ -360,13 +356,7 @@ const result = {
           internalId: "5c711888-ba37-4b2e-b347-311ca364efdb",
           name: "Abbott BinaxNow",
           testLength: 15,
-          supportedDiseases: [
-            {
-              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-              loinc: "96741-4",
-              name: "COVID-19",
-            },
-          ],
+          supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
           swabTypes: [
             {
               name: "Swab of internal nose",
@@ -379,13 +369,7 @@ const result = {
           internalId: "32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10",
           name: "BD Veritor",
           testLength: 15,
-          supportedDiseases: [
-            {
-              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-              loinc: "96741-4",
-              name: "COVID-19",
-            },
-          ],
+          supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
           swabTypes: [
             {
               name: "Swab of internal nose",
@@ -403,23 +387,7 @@ const result = {
           internalId: "67109f6f-eaee-49d3-b8ff-c61b79a9da8e",
           name: "Multiplex",
           testLength: 15,
-          supportedDiseases: [
-            {
-              internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-              loinc: "96741-4",
-              name: "COVID-19",
-            },
-            {
-              internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
-              loinc: "LP14239-5",
-              name: "Flu A",
-            },
-            {
-              internalId: "14924488-268f-47db-bea6-aa706971a098",
-              loinc: "LP14240-3",
-              name: "Flu B",
-            },
-          ],
+          supportedDiseaseTestPerformed: mockSupportedDiseaseMultiplex,
           swabTypes: [
             {
               name: "Swab of internal nose",

--- a/frontend/src/app/testQueue/mocks/mockSupportedDiseaseCovid.ts
+++ b/frontend/src/app/testQueue/mocks/mockSupportedDiseaseCovid.ts
@@ -1,0 +1,10 @@
+import mockSupportedDiseaseTestPerformedCovid from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
+
+const mockSupportedDiseaseCovid = [
+  {
+    supportedDisease:
+      mockSupportedDiseaseTestPerformedCovid[0].supportedDisease,
+  },
+];
+
+export default mockSupportedDiseaseCovid;

--- a/frontend/src/app/testQueue/mocks/mockSupportedDiseaseMultiplex.ts
+++ b/frontend/src/app/testQueue/mocks/mockSupportedDiseaseMultiplex.ts
@@ -1,0 +1,21 @@
+import mockSupportedDiseaseTestPerformedMultiplex from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedMultiplex";
+
+import mockSupportedDiseaseCovid from "./mockSupportedDiseaseCovid";
+
+let mockSupportedDiseaseFlu = [
+  {
+    supportedDisease:
+      mockSupportedDiseaseTestPerformedMultiplex[1].supportedDisease,
+  },
+  {
+    supportedDisease:
+      mockSupportedDiseaseTestPerformedMultiplex[2].supportedDisease,
+  },
+];
+
+const mockSupportedDiseaseMultiplex = [
+  ...mockSupportedDiseaseCovid,
+  ...mockSupportedDiseaseFlu,
+];
+
+export default mockSupportedDiseaseMultiplex;

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -105,10 +105,12 @@ query GetFacilityQueue($facilityId: ID!) {
       internalId
       name
       testLength
-      supportedDiseases {
-        internalId
-        name
-        loinc
+      supportedDiseaseTestPerformed {
+        supportedDisease {
+          internalId
+          name
+          loinc
+        }
       }
       swabTypes {
         internalId

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookup.test.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookup.test.tsx
@@ -8,6 +8,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
+import mockSupportedDiseaseTestPerformedCovid from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
+
 import DeviceLookup from "./DeviceLookup";
 
 window.scrollTo = jest.fn();
@@ -20,33 +22,19 @@ const devices = [
     manufacturer: "Celoxitin",
     testLength: 15,
     swabTypes: [{ internalId: "123", name: "nose", typeCode: "n123" }],
-    supportedDiseases: [
-      { internalId: "123", name: "COVID-19", loinc: "1234-1" },
-    ],
-    supportedDiseaseTestPerformed: [
-      {
-        supportedDisease: {
-          internalId: "123",
-          name: "COVID-19",
-          loinc: "1234-1",
-        },
-        testPerformedLoincCode: "1234-1",
-        equipmentUid: "equipmentUid123",
-        testkitNameId: "testkitNameId123",
-        testOrderedLoincCode: "1432-1",
-      },
-    ],
+    supportedDiseases: [], // Remove in #5322
+    supportedDiseaseTestPerformed: mockSupportedDiseaseTestPerformedCovid,
   },
   {
     internalId: "some-guid",
     name: "covid-mctester",
     model: "Giselle",
-    manufacturer: "yo-mama",
+    manufacturer: "mctester manufacturer",
     loincCode: "8675309",
     testLength: 15,
     swabTypes: [{ internalId: "123", name: "nose", typeCode: "nose-code" }],
-    supportedDiseases: [],
-    supportedDiseaseTestPerformed: [],
+    supportedDiseases: [], // Remove in #5322
+    supportedDiseaseTestPerformed: mockSupportedDiseaseTestPerformedCovid,
   },
 ];
 

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookupContainer.test.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookupContainer.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import SRToastContainer from "../../commonComponents/SRToastContainer";
+import mockSupportedDiseaseTestPerformedCovid from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
 
 import DeviceLookupContainer from "./DeviceLookupContainer";
 
@@ -18,6 +19,8 @@ jest.mock("../../../generated/graphql", () => {
               loincCode: "loinc-1",
               manufacturer: "Abbott",
               model: "A",
+              supportedDiseaseTestPerformed:
+                mockSupportedDiseaseTestPerformedCovid,
               swabTypes: [
                 {
                   internalId: "1234",

--- a/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
@@ -60,7 +60,9 @@ const DeviceSearchResults = (props: SearchResultsProps) => {
               <td id={`device-${idx}`}>{d.manufacturer}</td>
               <td id={`model-name-${idx}`}>{d.model}</td>
               <td id={`test-type-${idx}`}>
-                {d.supportedDiseases?.map((sd) => sd.name).join(", ")}
+                {d.supportedDiseaseTestPerformed
+                  ?.map((sd) => sd.supportedDisease.name)
+                  .join(", ")}
               </td>
               <td id={`view-${idx}`}>
                 {

--- a/frontend/src/app/uploads/DeviceLookup/operations.graphql
+++ b/frontend/src/app/uploads/DeviceLookup/operations.graphql
@@ -9,8 +9,12 @@ query getDeviceTypesForLookup {
             name
             typeCode
         }
-        supportedDiseases {
-            name
+        supportedDiseaseTestPerformed {
+            supportedDisease {
+                internalId
+                name
+                loinc
+            }
         }
         supportedDiseaseTestPerformed {
             supportedDisease {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1717,7 +1717,6 @@ export type CreateDeviceTypeMutationVariables = Exact<{
   manufacturer: Scalars["String"];
   model: Scalars["String"];
   swabTypes: Array<Scalars["ID"]> | Scalars["ID"];
-  supportedDiseases: Array<Scalars["ID"]> | Scalars["ID"];
   supportedDiseaseTestPerformed:
     | Array<SupportedDiseaseTestPerformedInput>
     | SupportedDiseaseTestPerformedInput;
@@ -1738,7 +1737,6 @@ export type UpdateDeviceTypeMutationVariables = Exact<{
   manufacturer: Scalars["String"];
   model: Scalars["String"];
   swabTypes: Array<Scalars["ID"]> | Scalars["ID"];
-  supportedDiseases?: InputMaybe<Array<Scalars["ID"]> | Scalars["ID"]>;
   supportedDiseaseTestPerformed:
     | Array<SupportedDiseaseTestPerformedInput>
     | SupportedDiseaseTestPerformedInput;
@@ -1766,11 +1764,6 @@ export type GetDeviceTypeListQuery = {
     testLength: number;
     swabTypes: Array<{
       __typename?: "SpecimenType";
-      internalId: string;
-      name: string;
-    }>;
-    supportedDiseases: Array<{
-      __typename?: "SupportedDisease";
       internalId: string;
       name: string;
     }>;
@@ -2162,11 +2155,14 @@ export type GetFacilityQueueQuery = {
           internalId: string;
           name: string;
           testLength: number;
-          supportedDiseases: Array<{
-            __typename?: "SupportedDisease";
-            internalId: string;
-            name: string;
-            loinc: string;
+          supportedDiseaseTestPerformed: Array<{
+            __typename?: "SupportedDiseaseTestPerformed";
+            supportedDisease: {
+              __typename?: "SupportedDisease";
+              internalId: string;
+              name: string;
+              loinc: string;
+            };
           }>;
           swabTypes: Array<{
             __typename?: "SpecimenType";
@@ -2837,7 +2833,6 @@ export type GetDeviceTypesForLookupQuery = {
       name: string;
       typeCode: string;
     }>;
-    supportedDiseases: Array<{ __typename?: "SupportedDisease"; name: string }>;
     supportedDiseaseTestPerformed: Array<{
       __typename?: "SupportedDiseaseTestPerformed";
       testPerformedLoincCode: string;
@@ -2848,6 +2843,7 @@ export type GetDeviceTypesForLookupQuery = {
         __typename?: "SupportedDisease";
         internalId: string;
         name: string;
+        loinc: string;
       };
     }>;
   }>;
@@ -4900,7 +4896,6 @@ export const CreateDeviceTypeDocument = gql`
     $manufacturer: String!
     $model: String!
     $swabTypes: [ID!]!
-    $supportedDiseases: [ID!]!
     $supportedDiseaseTestPerformed: [SupportedDiseaseTestPerformedInput!]!
     $testLength: Int!
   ) {
@@ -4910,7 +4905,6 @@ export const CreateDeviceTypeDocument = gql`
         manufacturer: $manufacturer
         model: $model
         swabTypes: $swabTypes
-        supportedDiseases: $supportedDiseases
         supportedDiseaseTestPerformed: $supportedDiseaseTestPerformed
         testLength: $testLength
       }
@@ -4941,7 +4935,6 @@ export type CreateDeviceTypeMutationFn = Apollo.MutationFunction<
  *      manufacturer: // value for 'manufacturer'
  *      model: // value for 'model'
  *      swabTypes: // value for 'swabTypes'
- *      supportedDiseases: // value for 'supportedDiseases'
  *      supportedDiseaseTestPerformed: // value for 'supportedDiseaseTestPerformed'
  *      testLength: // value for 'testLength'
  *   },
@@ -4975,7 +4968,6 @@ export const UpdateDeviceTypeDocument = gql`
     $manufacturer: String!
     $model: String!
     $swabTypes: [ID!]!
-    $supportedDiseases: [ID!]
     $supportedDiseaseTestPerformed: [SupportedDiseaseTestPerformedInput!]!
     $testLength: Int!
   ) {
@@ -4986,7 +4978,6 @@ export const UpdateDeviceTypeDocument = gql`
         manufacturer: $manufacturer
         model: $model
         swabTypes: $swabTypes
-        supportedDiseases: $supportedDiseases
         supportedDiseaseTestPerformed: $supportedDiseaseTestPerformed
         testLength: $testLength
       }
@@ -5018,7 +5009,6 @@ export type UpdateDeviceTypeMutationFn = Apollo.MutationFunction<
  *      manufacturer: // value for 'manufacturer'
  *      model: // value for 'model'
  *      swabTypes: // value for 'swabTypes'
- *      supportedDiseases: // value for 'supportedDiseases'
  *      supportedDiseaseTestPerformed: // value for 'supportedDiseaseTestPerformed'
  *      testLength: // value for 'testLength'
  *   },
@@ -5054,10 +5044,6 @@ export const GetDeviceTypeListDocument = gql`
       model
       testLength
       swabTypes {
-        internalId
-        name
-      }
-      supportedDiseases {
         internalId
         name
       }
@@ -6143,10 +6129,12 @@ export const GetFacilityQueueDocument = gql`
         internalId
         name
         testLength
-        supportedDiseases {
-          internalId
-          name
-          loinc
+        supportedDiseaseTestPerformed {
+          supportedDisease {
+            internalId
+            name
+            loinc
+          }
         }
         swabTypes {
           internalId
@@ -7353,8 +7341,12 @@ export const GetDeviceTypesForLookupDocument = gql`
         name
         typeCode
       }
-      supportedDiseases {
-        name
+      supportedDiseaseTestPerformed {
+        supportedDisease {
+          internalId
+          name
+          loinc
+        }
       }
       supportedDiseaseTestPerformed {
         supportedDisease {

--- a/frontend/src/stories/testQueue/QueueItem.stories.tsx
+++ b/frontend/src/stories/testQueue/QueueItem.stories.tsx
@@ -9,6 +9,8 @@ import QueueItem, {
 } from "../../app/testQueue/QueueItem";
 import { PhoneType } from "../../generated/graphql";
 import { getMocks, StoryGraphQLProvider } from "../storyMocks";
+import mockSupportedDiseaseMultiplex from "../../app/testQueue/mocks/mockSupportedDiseaseMultiplex";
+import mockSupportedDiseaseCovid from "../../app/testQueue/mocks/mockSupportedDiseaseCovid";
 
 const mockStore = createMockStore([]);
 
@@ -57,13 +59,7 @@ const facilityInfo = {
       internalId: "ee4f40b7-ac32-4709-be0a-56dd77bb9609",
       name: "LumiraDX",
       testLength: 15,
-      supportedDiseases: [
-        {
-          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-          loinc: "96741-4",
-          name: "COVID-19",
-        },
-      ],
+      supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
       swabTypes: [
         {
           name: "Swab of internal nose",
@@ -81,13 +77,7 @@ const facilityInfo = {
       internalId: "5c711888-ba37-4b2e-b347-311ca364efdb",
       name: "Abbott BinaxNow",
       testLength: 15,
-      supportedDiseases: [
-        {
-          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-          loinc: "96741-4",
-          name: "COVID-19",
-        },
-      ],
+      supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
       swabTypes: [
         {
           name: "Swab of internal nose",
@@ -100,13 +90,7 @@ const facilityInfo = {
       internalId: "32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10",
       name: "BD Veritor",
       testLength: 15,
-      supportedDiseases: [
-        {
-          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-          loinc: "96741-4",
-          name: "COVID-19",
-        },
-      ],
+      supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
       swabTypes: [
         {
           name: "Swab of internal nose",
@@ -124,23 +108,7 @@ const facilityInfo = {
       internalId: "67109f6f-eaee-49d3-b8ff-c61b79a9da8e",
       name: "Multiplex",
       testLength: 15,
-      supportedDiseases: [
-        {
-          internalId: "6e67ea1c-f9e8-4b3f-8183-b65383ac1283",
-          loinc: "96741-4",
-          name: "COVID-19",
-        },
-        {
-          internalId: "e286f2a8-38e2-445b-80a5-c16507a96b66",
-          loinc: "LP14239-5",
-          name: "Flu A",
-        },
-        {
-          internalId: "14924488-268f-47db-bea6-aa706971a098",
-          loinc: "LP14240-3",
-          name: "Flu B",
-        },
-      ],
+      supportedDiseaseTestPerformed: mockSupportedDiseaseMultiplex,
       swabTypes: [
         {
           name: "Swab of internal nose",
@@ -173,7 +141,7 @@ const queueItemInfo = {
     name: "LumiraDX",
     model: "LumiraDx SARS-CoV-2 Ag Test*",
     testLength: 15,
-    supportedDiseases: [],
+    supportedDiseaseTestPerformed: mockSupportedDiseaseCovid,
   },
   specimenType: {
     internalId: "8596682d-6053-4720-8a39-1f5d19ff4ed9",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Resolves #5321 

## Changes Proposed
- Removes usages of `DeviceType.SupportedDiseases` from the frontend
- Adds mocks of `supportedDiseaseTestPerformed` to be reused in tests
- Updates storybook

## Additional Information

## Testing
Deployed on `dev2` for testing!
Please ensure the following continue to work as intended:

**Support Admin**
- Create a new device
- Edit a new device

**Facility Settings**
- Add/Remove device to facility

**Test Queue**
- Add a test to the queue and change between a multiplex and covid test
- Ensure timer on test queue continues to work
(Note switching between devices with different time lengths doesn't update the time on the test queue without a refresh -- this seems to be a current bug and not one introduced in this PR -- will create ticket for this)

**Device Code Lookup**
- searching for a device shows the supported disease in the search bar

**storybook**
- ensure storybook for "QueueItem" works as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
