### PR TITLE
Johanna/5504 add order control to bundle

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -48,4 +48,11 @@ public class FhirConstants {
           "D", "Debugging",
           "P", "Production",
           "T", "Training");
+
+  public static final String ORDER_CONTROL_EXTENSION_URL =
+      "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control";
+  public static final String ORDER_CONTROL_CODE_OBSERVATIONS = "RE";
+
+  public static final String ORDER_CONTROL_CODE_SYSTEM =
+      "http://terminology.hl7.org/CodeSystem/v2-0119";
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -650,16 +650,14 @@ public class FhirConverter {
       serviceRequest.getCode().addCoding().setSystem(LOINC_CODE_SYSTEM).setCode(requestedCode);
     }
 
-    serviceRequest.addExtension(
-        new Extension()
-            .setUrl(ORDER_CONTROL_EXTENSION_URL)
-            .setValue(
-                new CodeableConcept()
-                    .addCoding(
-                        new Coding()
-                            .setSystem(ORDER_CONTROL_CODE_SYSTEM)
-                            .setCode(ORDER_CONTROL_CODE_OBSERVATIONS))));
-
+    serviceRequest
+        .addExtension()
+        .setUrl(ORDER_CONTROL_EXTENSION_URL)
+        .setValue(
+            new CodeableConcept()
+                .getCodingFirstRep()
+                .setSystem(ORDER_CONTROL_CODE_SYSTEM)
+                .setCode(ORDER_CONTROL_CODE_OBSERVATIONS));
     return serviceRequest;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -655,9 +655,10 @@ public class FhirConverter {
         .setUrl(ORDER_CONTROL_EXTENSION_URL)
         .setValue(
             new CodeableConcept()
-                .getCodingFirstRep()
-                .setSystem(ORDER_CONTROL_CODE_SYSTEM)
-                .setCode(ORDER_CONTROL_CODE_OBSERVATIONS));
+                .addCoding(
+                    new Coding()
+                        .setSystem(ORDER_CONTROL_CODE_SYSTEM)
+                        .setCode(ORDER_CONTROL_CODE_OBSERVATIONS)));
     return serviceRequest;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -12,6 +12,9 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_SY
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_SYMPTOM_ONSET;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NULL_CODE_SYSTEM;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ORDER_CONTROL_CODE_OBSERVATIONS;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ORDER_CONTROL_CODE_SYSTEM;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ORDER_CONTROL_EXTENSION_URL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.PROCESSING_ID_DISPLAY;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.PROCESSING_ID_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.RACE_CODING_SYSTEM;
@@ -492,6 +495,7 @@ public class FhirConverter {
             new Extension()
                 .setUrl(EQUIPMENT_UID_EXTENSION_URL)
                 .setValue(new CodeableConcept().addCoding().setCode(equipmentUid)));
+
     addCorrectionNote(
         correctionStatus != TestCorrectionStatus.ORIGINAL, correctionReason, observation);
     return observation;
@@ -640,9 +644,20 @@ public class FhirConverter {
     serviceRequest.setId(id);
     serviceRequest.setIntent(ServiceRequestIntent.ORDER);
     serviceRequest.setStatus(status);
+
     if (StringUtils.isNotBlank(requestedCode)) {
       serviceRequest.getCode().addCoding().setSystem(LOINC_CODE_SYSTEM).setCode(requestedCode);
     }
+
+    serviceRequest.addExtension(
+        new Extension()
+            .setUrl(ORDER_CONTROL_EXTENSION_URL)
+            .setValue(
+                new CodeableConcept()
+                    .addCoding()
+                    .setSystem(ORDER_CONTROL_CODE_SYSTEM)
+                    .setCode(ORDER_CONTROL_CODE_OBSERVATIONS)));
+
     return serviceRequest;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -67,6 +67,7 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem;
 import org.hl7.fhir.r4.model.ContactPoint.ContactPointUse;
@@ -654,9 +655,10 @@ public class FhirConverter {
             .setUrl(ORDER_CONTROL_EXTENSION_URL)
             .setValue(
                 new CodeableConcept()
-                    .addCoding()
-                    .setSystem(ORDER_CONTROL_CODE_SYSTEM)
-                    .setCode(ORDER_CONTROL_CODE_OBSERVATIONS)));
+                    .addCoding(
+                        new Coding()
+                            .setSystem(ORDER_CONTROL_CODE_SYSTEM)
+                            .setCode(ORDER_CONTROL_CODE_OBSERVATIONS))));
 
     return serviceRequest;
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -965,7 +965,7 @@ class FhirConverterTest {
     assertThat(actual.getCode().getCoding()).hasSize(1);
     assertThat(actual.getCode().getCodingFirstRep().getSystem()).isEqualTo("http://loinc.org");
     assertThat(actual.getCode().getCodingFirstRep().getCode()).isEqualTo("95422-2");
-    assertThat(actual.getExtension().size()).isEqualTo(1);
+    assertThat(actual.getExtension()).hasSize(1);
     assertThat(
             actual
                 .castToCodeableConcept(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -966,24 +966,28 @@ class FhirConverterTest {
     assertThat(actual.getCode().getCodingFirstRep().getSystem()).isEqualTo("http://loinc.org");
     assertThat(actual.getCode().getCodingFirstRep().getCode()).isEqualTo("95422-2");
     assertThat(actual.getExtension().size()).isEqualTo(1);
-    // ToDo fix this URL
-    System.out.println("what does this have?");
-    actual.getExtensionByUrl("https://reportstream.cdc.gov/fhir/StructureDefinition/order-control");
-    System.out.println(
-        actual
-            .getExtensionByUrl(
-                "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control")
-            .getValue()
-            .getClass()
-            .getName());
-    /* assertThat(
-        actual
-            .castToCodeableConcept(
-                actual
-                    .getExtensionByUrl(
-                        "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control")
-                    .getValue()).getCoding().get(0).getCode())
-    .isEqualTo("RE");*/
+    assertThat(
+            actual
+                .castToCodeableConcept(
+                    actual
+                        .getExtensionByUrl(
+                            "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control")
+                        .getValue())
+                .getCoding()
+                .get(0)
+                .getCode())
+        .isEqualTo("RE");
+    assertThat(
+            actual
+                .castToCodeableConcept(
+                    actual
+                        .getExtensionByUrl(
+                            "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control")
+                        .getValue())
+                .getCoding()
+                .get(0)
+                .getSystem())
+        .isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0119");
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -965,6 +965,25 @@ class FhirConverterTest {
     assertThat(actual.getCode().getCoding()).hasSize(1);
     assertThat(actual.getCode().getCodingFirstRep().getSystem()).isEqualTo("http://loinc.org");
     assertThat(actual.getCode().getCodingFirstRep().getCode()).isEqualTo("95422-2");
+    assertThat(actual.getExtension().size()).isEqualTo(1);
+    // ToDo fix this URL
+    System.out.println("what does this have?");
+    actual.getExtensionByUrl("https://reportstream.cdc.gov/fhir/StructureDefinition/order-control");
+    System.out.println(
+        actual
+            .getExtensionByUrl(
+                "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control")
+            .getValue()
+            .getClass()
+            .getName());
+    /* assertThat(
+        actual
+            .castToCodeableConcept(
+                actual
+                    .getExtensionByUrl(
+                        "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control")
+                    .getValue()).getCoding().get(0).getCode())
+    .isEqualTo("RE");*/
   }
 
   @Test

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -313,6 +313,19 @@
       "resource":{
         "resourceType":"ServiceRequest",
         "id":"cae01b8c-37dc-4c09-a6d4-ae7bcafc9720",
+        "extension": [
+          {
+            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0119",
+                  "code": "RE"
+                }
+              ]
+            }
+          }
+        ],
         "status":"active",
         "intent":"order",
         "code":{

--- a/backend/src/test/resources/fhir/serviceRequest.json
+++ b/backend/src/test/resources/fhir/serviceRequest.json
@@ -2,6 +2,19 @@
   "resourceType": "ServiceRequest",
   "id": "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29",
   "status": "completed",
+  "extension": [
+    {
+      "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0119",
+            "code": "RE"
+          }
+        ]
+      }
+    }
+  ],
   "intent": "order",
   "code": {
     "coding": [

--- a/cypress/integration/09-multiplex_testing_spec.js
+++ b/cypress/integration/09-multiplex_testing_spec.js
@@ -59,10 +59,10 @@ describe("Testing with multiplex devices", () => {
       cy.visit("/admin/create-device-type");
       cy.wait("@gqlgetSpecimenTypesQuery");
       cy.wait("@gqlgetSupportedDiseasesQuery");
-
+      cy.contains("Device type");
+      cy.contains("Save changes").should("be.not.enabled");
       cy.injectAxe();
       cy.checkA11y();
-      cy.contains("Save changes").should("be.not.enabled");
       cy.get('input[name="name"]').type(deviceName);
       cy.get('input[name="model"]').type("1RX");
       cy.get('input[name="manufacturer"]').type("acme");


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5504 

## Changes Proposed

- Create constants with the extension url, the system and the code value for the order control.
- Add the extension to the ServiceRequest instance.
- Update all unit test to validate that the extension is present in ServiceRequest pair.

## Additional Information

Added code to fix the spec 09 failing due to checking a11y when the UI was not done rendering.

## Testing

_Validated in dev7_

- Check that when the FHIR bundle gets created the extension with the order control data is present in the bundle.
- You can check the changes in bundle.json to see an example of how this data looks like. 

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->


