### PR TITLE
Johanna/5505 add adnormal flags to bundle

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -399,7 +399,7 @@ public class Translators {
           Map.entry("other", "Other"));
   private static final Set<String> ORGANIZATION_TYPE_KEYS = ORGANIZATION_TYPES.keySet();
 
-  private static final SnomedConceptRecord DETECTED_SNOMED_CONCEPT =
+  public static final SnomedConceptRecord DETECTED_SNOMED_CONCEPT =
       new SnomedConceptRecord("Detected", "260373001", TestResult.POSITIVE);
   private static final SnomedConceptRecord NOT_DETECTED_SNOMED_CONCEPT =
       new SnomedConceptRecord("Not detected", "260415000", TestResult.NEGATIVE);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -59,15 +59,11 @@ public class FhirConstants {
 
   public static final String ABNORMAL_FLAGS_CODE_SYSTEM =
       "http://terminology.hl7.org/CodeSystem/v2-0078";
-<<<<<<< HEAD
 
   public static final Map<String, String> ABNORMAL_FLAGS =
       Map.of(
           "N", "Normal",
           "A", "Abnormal");
-
-=======
   public static final CodingRecord ABNORMAL_FLAG_NORMAL = new CodingRecord("N", "Normal");
   public static final CodingRecord ABNORMAL_FLAG_ABNORMAL = new CodingRecord("A", "Abnormal");
->>>>>>> 71d70702a (Updated unit testing)
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -55,4 +55,13 @@ public class FhirConstants {
 
   public static final String ORDER_CONTROL_CODE_SYSTEM =
       "http://terminology.hl7.org/CodeSystem/v2-0119";
+
+  public static final String ABNORMAL_FLAGS_CODE_SYSTEM =
+      "http://terminology.hl7.org/CodeSystem/v2-0078";
+
+  public static final Map<String, String> ABNORMAL_FLAGS =
+      Map.of(
+          "N", "Normal",
+          "A", "Abnormal");
+
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.converter;
 
+import gov.cdc.usds.simplereport.db.model.auxiliary.CodingRecord;
 import java.util.Map;
 
 public class FhirConstants {
@@ -58,10 +59,15 @@ public class FhirConstants {
 
   public static final String ABNORMAL_FLAGS_CODE_SYSTEM =
       "http://terminology.hl7.org/CodeSystem/v2-0078";
+<<<<<<< HEAD
 
   public static final Map<String, String> ABNORMAL_FLAGS =
       Map.of(
           "N", "Normal",
           "A", "Abnormal");
 
+=======
+  public static final CodingRecord ABNORMAL_FLAG_NORMAL = new CodingRecord("N", "Normal");
+  public static final CodingRecord ABNORMAL_FLAG_ABNORMAL = new CodingRecord("A", "Abnormal");
+>>>>>>> 71d70702a (Updated unit testing)
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -59,11 +59,6 @@ public class FhirConstants {
 
   public static final String ABNORMAL_FLAGS_CODE_SYSTEM =
       "http://terminology.hl7.org/CodeSystem/v2-0078";
-
-  public static final Map<String, String> ABNORMAL_FLAGS =
-      Map.of(
-          "N", "Normal",
-          "A", "Abnormal");
   public static final CodingRecord ABNORMAL_FLAG_NORMAL = new CodingRecord("N", "Normal");
   public static final CodingRecord ABNORMAL_FLAG_ABNORMAL = new CodingRecord("A", "Abnormal");
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1,5 +1,9 @@
 package gov.cdc.usds.simplereport.api.converter;
 
+import static gov.cdc.usds.simplereport.api.Translators.DETECTED_SNOMED_CONCEPT;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAGS_CODE_SYSTEM;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAG_ABNORMAL;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAG_NORMAL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.DEFAULT_COUNTRY;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EQUIPMENT_UID_EXTENSION_URL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ETHNICITY_CODE_SYSTEM;
@@ -564,10 +568,25 @@ public class FhirConverter {
     addCorrectionNote(
         correctionStatus != TestCorrectionStatus.ORIGINAL, correctionReason, observation);
 
-    // ToDo implement the logic to add the abnormal flags
-    // observation.addInterpretation().getCodingFirstRep().setSystem((resultCode.equals())?
-    // :).getCode()
+    observation.addInterpretation().addCoding(convertToAbnormalFlagInterpretation(resultCode));
+
     return observation;
+  }
+
+  private static Coding convertToAbnormalFlagInterpretation(String resultCode) {
+    Coding abnormalFlag = new Coding();
+
+    abnormalFlag.setSystem(ABNORMAL_FLAGS_CODE_SYSTEM);
+
+    if (resultCode.equals(DETECTED_SNOMED_CONCEPT.code())) {
+      abnormalFlag.setCode(ABNORMAL_FLAG_ABNORMAL.code());
+      abnormalFlag.setDisplay(ABNORMAL_FLAG_ABNORMAL.displayName());
+    } else {
+      abnormalFlag.setCode(ABNORMAL_FLAG_NORMAL.code());
+      abnormalFlag.setDisplay(ABNORMAL_FLAG_NORMAL.displayName());
+    }
+
+    return abnormalFlag;
   }
 
   private static void setStatus(Observation observation, TestCorrectionStatus correctionStatus) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -563,6 +563,10 @@ public class FhirConverter {
 
     addCorrectionNote(
         correctionStatus != TestCorrectionStatus.ORIGINAL, correctionReason, observation);
+
+    // ToDo implement the logic to add the abnormal flags
+    // observation.addInterpretation().getCodingFirstRep().setSystem((resultCode.equals())?
+    // :).getCode()
     return observation;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/CodingRecord.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/CodingRecord.java
@@ -1,0 +1,3 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+public record CodingRecord(String code, String displayName) {}

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -419,6 +419,17 @@
         "device":{
           "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
         },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+                "code": "N",
+                "display": "Normal"
+              }
+            ]
+          }
+        ],
         "method":{
           "extension":[
             {
@@ -475,6 +486,17 @@
         "device":{
           "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
         },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+                "code": "A",
+                "display": "Abnormal"
+              }
+            ]
+          }
+        ],
         "method":{
           "extension":[
             {
@@ -531,6 +553,17 @@
         "device":{
           "reference":"Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
         },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+                "code": "N",
+                "display": "Normal"
+              }
+            ]
+          }
+        ],
         "method":{
           "extension":[
             {

--- a/backend/src/test/resources/fhir/observationCorrection.json
+++ b/backend/src/test/resources/fhir/observationCorrection.json
@@ -20,6 +20,17 @@
       }
     ]
   },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+          "code": "N",
+          "display": "Normal"
+        }
+      ]
+    }
+  ],
   "method": {
     "extension": [
       {

--- a/backend/src/test/resources/fhir/observationCovid.json
+++ b/backend/src/test/resources/fhir/observationCovid.json
@@ -20,6 +20,17 @@
       }
     ]
   },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+          "code": "A",
+          "display": "Abnormal"
+        }
+      ]
+    }
+  ],
   "method": {
     "extension": [
       {

--- a/backend/src/test/resources/fhir/observationFlu.json
+++ b/backend/src/test/resources/fhir/observationFlu.json
@@ -20,6 +20,17 @@
       }
     ]
   },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+          "code": "N",
+          "display": "Normal"
+        }
+      ]
+    }
+  ],
   "method": {
     "extension": [
       {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5505 

## Changes Proposed

- Adds a interpretation to the observation object.
- Creates a codingRecord class to keep the static values related.
- Add an utility method to set the correct values in the coding depending on the test result.
- Updates unit testing.

## Additional Information

None

## Testing

_Tested in dev 7_
- Perform a test(s) with the values positive, negative, inconclusive and verify the bundle has the correct interpretation code.
```
Normal (N) -> Negative, Inconclusive
Abnormal (A) -> Positive
 
```
<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->


