### PR TITLE
set observation.method.display to device.model

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -250,7 +250,8 @@ public class BulkUploadResultsToFhir {
                 UUID.randomUUID().toString(),
                 getDescriptionValue(row.getTestResult().value),
                 testKitNameId,
-                equipmentUid));
+                equipmentUid,
+                row.getEquipmentModelName().value));
 
     var serviceRequest =
         FhirConverter.convertToServiceRequest(

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -431,6 +431,11 @@
           }
         ],
         "method":{
+          "coding": [
+            {
+              "display": "model"
+            }
+          ],
           "extension":[
             {
               "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
@@ -498,6 +503,11 @@
           }
         ],
         "method":{
+          "coding": [
+            {
+              "display": "model"
+            }
+          ],
           "extension":[
             {
               "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
@@ -565,6 +575,11 @@
           }
         ],
         "method":{
+          "coding": [
+            {
+              "display": "model"
+            }
+          ],
           "extension":[
             {
               "url":"https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",

--- a/backend/src/test/resources/fhir/observationCovid.json
+++ b/backend/src/test/resources/fhir/observationCovid.json
@@ -32,6 +32,11 @@
     }
   ],
   "method": {
+    "coding": [
+      {
+        "display": "deviceModel"
+      }
+    ],
     "extension": [
       {
         "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",

--- a/backend/src/test/resources/fhir/observationFlu.json
+++ b/backend/src/test/resources/fhir/observationFlu.json
@@ -32,6 +32,11 @@
     }
   ],
   "method": {
+    "coding": [
+      {
+        "display": "deviceModel"
+      }
+    ],
     "extension": [
       {
         "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5532 

## Changes Proposed

- Change the convertToObservation method to accept a device or device model.

## Additional Information


## Testing
- Available on DEV2

