### PR TITLE
fix regex in app insights obfuscation

### DIFF
--- a/frontend/src/app/PrimeErrorBoundary.tsx
+++ b/frontend/src/app/PrimeErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { ErrorInfo } from "react";
 
 import ErrorPage from "./commonComponents/ErrorPage";
 import { getAppInsights } from "./TelemetryService";
-import { getUrl, stripIdTokenFromOktaRedirectUri } from "./utils/url";
+import { getUrl } from "./utils/url";
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -53,10 +53,7 @@ export default class PrimeErrorBoundary extends React.Component<
     if (this.state.redirectToOkta) {
       const url = `${process.env.REACT_APP_OKTA_URL}/oauth2/default/v1/authorize`;
       const clientId = `?client_id=${process.env.REACT_APP_OKTA_CLIENT_ID}`;
-      const sanitizedRedirectUri = stripIdTokenFromOktaRedirectUri(getUrl());
-      const redirectUri = `&redirect_uri=${encodeURIComponent(
-        sanitizedRedirectUri
-      )}`;
+      const redirectUri = `&redirect_uri=${encodeURIComponent(getUrl())}`;
       const responseType = `&response_type=${encodeURIComponent(
         "token id_token"
       )}`;

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -5,10 +5,7 @@ import {
 } from "@microsoft/applicationinsights-web";
 import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
 
-import {
-  stripIdTokenFromOktaRedirectUri,
-  stripIdTokenFromOperationName,
-} from "./utils/url";
+import { stripIdTokenFromString } from "./utils/url";
 
 let reactPlugin: ReactPlugin | null = null;
 let appInsights: ApplicationInsights | null = null;
@@ -92,15 +89,11 @@ export function sanitizeOktaToken(envelope: ITelemetryItem): void {
       envelope?.ext?.trace.name
     ) {
       // possible properties that need replacing
-      const urlWithoutIdToken = stripIdTokenFromOktaRedirectUri(
-        telemetryItem.uri
-      );
+      const urlWithoutIdToken = stripIdTokenFromString(telemetryItem.uri);
       telemetryItem.uri = urlWithoutIdToken;
       telemetryItem.refUri = urlWithoutIdToken;
 
-      envelope.ext.trace.name = stripIdTokenFromOperationName(
-        envelope.ext.trace.name
-      );
+      envelope.ext.trace.name = stripIdTokenFromString(envelope.ext.trace.name);
     }
   } catch (e) {
     /* do nothing and don't disrupt logging*/
@@ -134,7 +127,7 @@ export function withInsights(console: Console) {
           if (typeof message === "string") {
             const messageNeedsSanitation = message.includes("#id_token");
             if (messageNeedsSanitation) {
-              message = stripIdTokenFromOktaRedirectUri(message);
+              message = stripIdTokenFromString(message);
             }
           }
           if (exception) {

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -5,7 +5,10 @@ import {
 } from "@microsoft/applicationinsights-web";
 import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
 
-import { stripIdTokenFromString } from "./utils/url";
+import {
+  stripIdTokenFromOktaRedirectUri,
+  stripIdTokenFromOperationName,
+} from "./utils/url";
 
 let reactPlugin: ReactPlugin | null = null;
 let appInsights: ApplicationInsights | null = null;
@@ -89,11 +92,15 @@ export function sanitizeOktaToken(envelope: ITelemetryItem): void {
       envelope?.ext?.trace.name
     ) {
       // possible properties that need replacing
-      const urlWithoutIdToken = stripIdTokenFromString(telemetryItem.uri);
+      const urlWithoutIdToken = stripIdTokenFromOktaRedirectUri(
+        telemetryItem.uri
+      );
       telemetryItem.uri = urlWithoutIdToken;
       telemetryItem.refUri = urlWithoutIdToken;
 
-      envelope.ext.trace.name = stripIdTokenFromString(envelope.ext.trace.name);
+      envelope.ext.trace.name = stripIdTokenFromOperationName(
+        envelope.ext.trace.name
+      );
     }
   } catch (e) {
     /* do nothing and don't disrupt logging*/
@@ -127,7 +134,7 @@ export function withInsights(console: Console) {
           if (typeof message === "string") {
             const messageNeedsSanitation = message.includes("#id_token");
             if (messageNeedsSanitation) {
-              message = stripIdTokenFromString(message);
+              message = stripIdTokenFromOktaRedirectUri(message);
             }
           }
           if (exception) {

--- a/frontend/src/app/TelemetryService.ts
+++ b/frontend/src/app/TelemetryService.ts
@@ -7,7 +7,7 @@ import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
 
 import {
   stripIdTokenFromOktaRedirectUri,
-  stripIdTokenFromOperationName,
+  stripIdTokenFromMatchUntilEndOfString,
 } from "./utils/url";
 
 let reactPlugin: ReactPlugin | null = null;
@@ -92,14 +92,15 @@ export function sanitizeOktaToken(envelope: ITelemetryItem): void {
       envelope?.ext?.trace.name
     ) {
       // possible properties that need replacing
-      const urlWithoutIdToken = stripIdTokenFromOktaRedirectUri(
-        telemetryItem.uri
+      telemetryItem.refUri = stripIdTokenFromOktaRedirectUri(
+        telemetryItem.refUri
       );
-      telemetryItem.uri = urlWithoutIdToken;
-      telemetryItem.refUri = urlWithoutIdToken;
 
-      envelope.ext.trace.name = stripIdTokenFromOperationName(
+      envelope.ext.trace.name = stripIdTokenFromMatchUntilEndOfString(
         envelope.ext.trace.name
+      );
+      telemetryItem.uri = stripIdTokenFromMatchUntilEndOfString(
+        telemetryItem.uri
       );
     }
   } catch (e) {

--- a/frontend/src/app/telemetry.test.tsx
+++ b/frontend/src/app/telemetry.test.tsx
@@ -154,12 +154,14 @@ describe("filter events on okta redirect", () => {
     expect(sanitizeOktaToken(item)).toBe(undefined);
   });
   it("scrubs values with id token", () => {
-    const urlWithToken = "localhost/#id_token=blahblahblah&token_type=test";
-    const urlWithoutToken = stripIdTokenFromOktaRedirectUri(urlWithToken);
+    const urlWithToken = "localhost/#id_token=blahblahblahtoken_type=test";
+    const urlWithOtherParamsWithoutToken =
+      stripIdTokenFromOktaRedirectUri(urlWithToken);
 
     const operationWithToken = "#id_token=blahblahblah&token_type=test";
     const operationWithoutToken =
       stripIdTokenFromMatchUntilEndOfString(operationWithToken);
+    const urlWithoutToken = stripIdTokenFromMatchUntilEndOfString(urlWithToken);
 
     const item = {
       name: "Microsoft.ApplicationInsights.mock.Pageview",
@@ -177,6 +179,6 @@ describe("filter events on okta redirect", () => {
     sanitizeOktaToken(item);
     expect(item?.ext?.trace?.name).toEqual(operationWithoutToken);
     expect(item?.baseData?.uri).toEqual(urlWithoutToken);
-    expect(item?.baseData?.refUri).toEqual(urlWithoutToken);
+    expect(item?.baseData?.refUri).toEqual(urlWithOtherParamsWithoutToken);
   });
 });

--- a/frontend/src/app/telemetry.test.tsx
+++ b/frontend/src/app/telemetry.test.tsx
@@ -10,10 +10,7 @@ import {
   sanitizeOktaToken,
   withInsights,
 } from "./TelemetryService";
-import {
-  stripIdTokenFromOktaRedirectUri,
-  stripIdTokenFromOperationName,
-} from "./utils/url";
+import { stripIdTokenFromString } from "./utils/url";
 
 jest.mock("@microsoft/applicationinsights-web", () => {
   return {
@@ -119,7 +116,7 @@ describe("telemetry", () => {
 
     const nonErrorErrorWithToken =
       "something something #id_token=blahblahblah&token_type=test";
-    const errorStringWithoutToken = stripIdTokenFromOktaRedirectUri(
+    const errorStringWithoutToken = stripIdTokenFromString(
       nonErrorErrorWithToken
     );
     console.error(nonErrorErrorWithToken);
@@ -154,12 +151,11 @@ describe("filter events on okta redirect", () => {
     expect(sanitizeOktaToken(item)).toBe(undefined);
   });
   it("scrubs values with id token", () => {
-    const urlWithToken = "localhost/#id_token=blahblahblah&token_type=test";
-    const urlWithoutToken = stripIdTokenFromOktaRedirectUri(urlWithToken);
+    const urlWithToken = "localhost/#id_token=blahblahblah";
+    const urlWithoutToken = stripIdTokenFromString(urlWithToken);
 
-    const operationWithToken = "#id_token=blahblahblah&token_type=test";
-    const operationWithoutToken =
-      stripIdTokenFromOperationName(operationWithToken);
+    const operationWithToken = "#id_token=blahblahblah";
+    const operationWithoutToken = stripIdTokenFromString(operationWithToken);
 
     const item = {
       name: "Microsoft.ApplicationInsights.mock.Pageview",

--- a/frontend/src/app/telemetry.test.tsx
+++ b/frontend/src/app/telemetry.test.tsx
@@ -12,7 +12,7 @@ import {
 } from "./TelemetryService";
 import {
   stripIdTokenFromOktaRedirectUri,
-  stripIdTokenFromOperationName,
+  stripIdTokenFromMatchUntilEndOfString,
 } from "./utils/url";
 
 jest.mock("@microsoft/applicationinsights-web", () => {
@@ -159,7 +159,7 @@ describe("filter events on okta redirect", () => {
 
     const operationWithToken = "#id_token=blahblahblah&token_type=test";
     const operationWithoutToken =
-      stripIdTokenFromOperationName(operationWithToken);
+      stripIdTokenFromMatchUntilEndOfString(operationWithToken);
 
     const item = {
       name: "Microsoft.ApplicationInsights.mock.Pageview",

--- a/frontend/src/app/telemetry.test.tsx
+++ b/frontend/src/app/telemetry.test.tsx
@@ -10,7 +10,10 @@ import {
   sanitizeOktaToken,
   withInsights,
 } from "./TelemetryService";
-import { stripIdTokenFromString } from "./utils/url";
+import {
+  stripIdTokenFromOktaRedirectUri,
+  stripIdTokenFromOperationName,
+} from "./utils/url";
 
 jest.mock("@microsoft/applicationinsights-web", () => {
   return {
@@ -116,7 +119,7 @@ describe("telemetry", () => {
 
     const nonErrorErrorWithToken =
       "something something #id_token=blahblahblah&token_type=test";
-    const errorStringWithoutToken = stripIdTokenFromString(
+    const errorStringWithoutToken = stripIdTokenFromOktaRedirectUri(
       nonErrorErrorWithToken
     );
     console.error(nonErrorErrorWithToken);
@@ -151,11 +154,12 @@ describe("filter events on okta redirect", () => {
     expect(sanitizeOktaToken(item)).toBe(undefined);
   });
   it("scrubs values with id token", () => {
-    const urlWithToken = "localhost/#id_token=blahblahblah";
-    const urlWithoutToken = stripIdTokenFromString(urlWithToken);
+    const urlWithToken = "localhost/#id_token=blahblahblah&token_type=test";
+    const urlWithoutToken = stripIdTokenFromOktaRedirectUri(urlWithToken);
 
-    const operationWithToken = "#id_token=blahblahblah";
-    const operationWithoutToken = stripIdTokenFromString(operationWithToken);
+    const operationWithToken = "#id_token=blahblahblah&token_type=test";
+    const operationWithoutToken =
+      stripIdTokenFromOperationName(operationWithToken);
 
     const item = {
       name: "Microsoft.ApplicationInsights.mock.Pageview",

--- a/frontend/src/app/utils/url.test.ts
+++ b/frontend/src/app/utils/url.test.ts
@@ -1,20 +1,17 @@
-import {
-  stripIdTokenFromOktaRedirectUri,
-  stripIdTokenFromOperationName,
-} from "./url";
+import { stripIdTokenFromString } from "./url";
 
 describe("stripIdTokenFromOktaRedirectUri", () => {
   it("empty text", () => {
     const text = "";
-    expect(stripIdTokenFromOktaRedirectUri(text)).toBe("");
+    expect(stripIdTokenFromString(text)).toBe("");
   });
   it("with no match", () => {
     const text = "localhost:3000/token_type=test";
-    expect(stripIdTokenFromOktaRedirectUri(text)).toBe(text);
+    expect(stripIdTokenFromString(text)).toBe(text);
   });
   it("with url", () => {
     const text = "localhost:3000/#id_token=blahblahblah&token_type=test";
-    expect(stripIdTokenFromOktaRedirectUri(text)).toBe(
+    expect(stripIdTokenFromString(text)).toBe(
       "localhost:3000/#id_token={ID-TOKEN-OBSCURED}&token_type=test"
     );
   });
@@ -23,16 +20,14 @@ describe("stripIdTokenFromOktaRedirectUri", () => {
 describe("stripIdTokenFromOktaRedirectUri", () => {
   it("empty text", () => {
     const text = "";
-    expect(stripIdTokenFromOperationName(text)).toBe("");
+    expect(stripIdTokenFromString(text)).toBe("");
   });
   it("with no match", () => {
     const text = "/token_type=test";
-    expect(stripIdTokenFromOperationName(text)).toBe(text);
+    expect(stripIdTokenFromString(text)).toBe(text);
   });
   it("with url", () => {
     const text = "/#id_token=blahblahblah";
-    expect(stripIdTokenFromOperationName(text)).toBe(
-      "/#id_token={ID-TOKEN-OBSCURED}"
-    );
+    expect(stripIdTokenFromString(text)).toBe("/#id_token={ID-TOKEN-OBSCURED}");
   });
 });

--- a/frontend/src/app/utils/url.test.ts
+++ b/frontend/src/app/utils/url.test.ts
@@ -1,17 +1,20 @@
-import { stripIdTokenFromString } from "./url";
+import {
+  stripIdTokenFromOktaRedirectUri,
+  stripIdTokenFromOperationName,
+} from "./url";
 
 describe("stripIdTokenFromOktaRedirectUri", () => {
   it("empty text", () => {
     const text = "";
-    expect(stripIdTokenFromString(text)).toBe("");
+    expect(stripIdTokenFromOktaRedirectUri(text)).toBe("");
   });
   it("with no match", () => {
     const text = "localhost:3000/token_type=test";
-    expect(stripIdTokenFromString(text)).toBe(text);
+    expect(stripIdTokenFromOktaRedirectUri(text)).toBe(text);
   });
   it("with url", () => {
     const text = "localhost:3000/#id_token=blahblahblah&token_type=test";
-    expect(stripIdTokenFromString(text)).toBe(
+    expect(stripIdTokenFromOktaRedirectUri(text)).toBe(
       "localhost:3000/#id_token={ID-TOKEN-OBSCURED}&token_type=test"
     );
   });
@@ -20,14 +23,16 @@ describe("stripIdTokenFromOktaRedirectUri", () => {
 describe("stripIdTokenFromOktaRedirectUri", () => {
   it("empty text", () => {
     const text = "";
-    expect(stripIdTokenFromString(text)).toBe("");
+    expect(stripIdTokenFromOperationName(text)).toBe("");
   });
   it("with no match", () => {
     const text = "/token_type=test";
-    expect(stripIdTokenFromString(text)).toBe(text);
+    expect(stripIdTokenFromOperationName(text)).toBe(text);
   });
   it("with url", () => {
     const text = "/#id_token=blahblahblah";
-    expect(stripIdTokenFromString(text)).toBe("/#id_token={ID-TOKEN-OBSCURED}");
+    expect(stripIdTokenFromOperationName(text)).toBe(
+      "/#id_token={ID-TOKEN-OBSCURED}"
+    );
   });
 });

--- a/frontend/src/app/utils/url.test.ts
+++ b/frontend/src/app/utils/url.test.ts
@@ -1,6 +1,6 @@
 import {
   stripIdTokenFromOktaRedirectUri,
-  stripIdTokenFromOperationName,
+  stripIdTokenFromMatchUntilEndOfString,
 } from "./url";
 
 describe("stripIdTokenFromOktaRedirectUri", () => {
@@ -15,7 +15,14 @@ describe("stripIdTokenFromOktaRedirectUri", () => {
   it("with url", () => {
     const text = "localhost:3000/#id_token=blahblahblah&token_type=test";
     expect(stripIdTokenFromOktaRedirectUri(text)).toBe(
-      "localhost:3000/#id_token={ID-TOKEN-OBSCURED}&token_type=test"
+      "localhost:3000/#id_token={ID-TOKEN-OBSCURED}token_type=test"
+    );
+  });
+  it("with prod url", () => {
+    const text =
+      "https://www.simplereport.gov/app/#id_token=sometokenstuff&token_type=Bearer&expires_in=3600&scope=simple_report_prod+openid+simple_report&state=thisisbogus";
+    expect(stripIdTokenFromOktaRedirectUri(text)).toBe(
+      "https://www.simplereport.gov/app/#id_token={ID-TOKEN-OBSCURED}token_type=Bearer&expires_in=3600&scope=simple_report_prod+openid+simple_report&state=thisisbogus"
     );
   });
 });
@@ -23,16 +30,23 @@ describe("stripIdTokenFromOktaRedirectUri", () => {
 describe("stripIdTokenFromOktaRedirectUri", () => {
   it("empty text", () => {
     const text = "";
-    expect(stripIdTokenFromOperationName(text)).toBe("");
+    expect(stripIdTokenFromMatchUntilEndOfString(text)).toBe("");
   });
   it("with no match", () => {
     const text = "/token_type=test";
-    expect(stripIdTokenFromOperationName(text)).toBe(text);
+    expect(stripIdTokenFromMatchUntilEndOfString(text)).toBe(text);
   });
   it("with url", () => {
     const text = "/#id_token=blahblahblah";
-    expect(stripIdTokenFromOperationName(text)).toBe(
+    expect(stripIdTokenFromMatchUntilEndOfString(text)).toBe(
       "/#id_token={ID-TOKEN-OBSCURED}"
+    );
+  });
+  it("with prod url", () => {
+    const text =
+      "https://www.simplereport.gov/app/#id_token=blahblahblah&access_token=anothertoken";
+    expect(stripIdTokenFromMatchUntilEndOfString(text)).toBe(
+      "https://www.simplereport.gov/app/#id_token={ID-TOKEN-OBSCURED}"
     );
   });
 });

--- a/frontend/src/app/utils/url.ts
+++ b/frontend/src/app/utils/url.ts
@@ -29,9 +29,18 @@ export function getUrl(relative = false): string {
   return "http://localhost:3000/";
 }
 
-export function stripIdTokenFromString(string: string) {
+export function stripIdTokenFromOktaRedirectUri(uri: string) {
+  const regexJWTAsQueryParam = /#id_token=(.*)(?=&)/;
+  return stripIdTokenFromString(regexJWTAsQueryParam, uri);
+}
+
+export function stripIdTokenFromOperationName(operationName: string) {
   const regexOperationName = /#id_token=(.*)/;
-  const idTokenFound = string.match(regexOperationName);
+  return stripIdTokenFromString(regexOperationName, operationName);
+}
+
+export function stripIdTokenFromString(regex: RegExp, string: string) {
+  const idTokenFound = string.match(regex);
   if (idTokenFound === null) return string;
   return string.replace(idTokenFound[0], "#id_token={ID-TOKEN-OBSCURED}");
 }

--- a/frontend/src/app/utils/url.ts
+++ b/frontend/src/app/utils/url.ts
@@ -29,18 +29,9 @@ export function getUrl(relative = false): string {
   return "http://localhost:3000/";
 }
 
-export function stripIdTokenFromOktaRedirectUri(uri: string) {
-  const regexJWTAsQueryParam = /#id_token=(.*)(?=&token_type=)/;
-  return stripIdTokenFromString(regexJWTAsQueryParam, uri);
-}
-
-export function stripIdTokenFromOperationName(operationName: string) {
-  const regexOperationName = /#id_token=(.*)($)/;
-  return stripIdTokenFromString(regexOperationName, operationName);
-}
-
-function stripIdTokenFromString(regex: RegExp, string: string) {
-  const idTokenFound = string.match(regex);
+export function stripIdTokenFromString(string: string) {
+  const regexOperationName = /#id_token=(.*)/;
+  const idTokenFound = string.match(regexOperationName);
   if (idTokenFound === null) return string;
   return string.replace(idTokenFound[0], "#id_token={ID-TOKEN-OBSCURED}");
 }

--- a/frontend/src/app/utils/url.ts
+++ b/frontend/src/app/utils/url.ts
@@ -30,11 +30,11 @@ export function getUrl(relative = false): string {
 }
 
 export function stripIdTokenFromOktaRedirectUri(uri: string) {
-  const regexJWTAsQueryParam = /#id_token=(.*)(?=&)/;
+  const regexJWTAsQueryParam = /#id_token=(.*?)&(?!access_token)/;
   return stripIdTokenFromString(regexJWTAsQueryParam, uri);
 }
 
-export function stripIdTokenFromOperationName(operationName: string) {
+export function stripIdTokenFromMatchUntilEndOfString(operationName: string) {
   const regexOperationName = /#id_token=(.*)/;
   return stripIdTokenFromString(regexOperationName, operationName);
 }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

Follow up to https://github.com/CDCgov/prime-simplereport/pull/5528 

Many apologies that we've gone several rounds on this: hopefully this'll be the last one!

## Related Issue

- The prod app insights URL's are different from the lower env we were testing on and so the previous fix didn't actually scrub the tokens from insights. This one (hopefully) fixes that

## Changes Proposed

- Swaps around the regex / adds some more tests that are in line with the prod URL schemas

## Testing

Prod URL's to test Regex with (using something like this [Regex Tester](https://www.regexpal.com/))

`/#id_token=(.*?)&(?!access_token)/`
```
https://www.simplereport.gov/app/#id_token=blahblahblah&access_token=anothertokenwewanttoobscure&token_type=Bearer&expires_in=3600&scope=simple_report_prod+openid+simple_report&state=thisisbogus 
```
becomes 
```
https://www.simplereport.gov/app/#id_token={ID-TOKEN-OBSCURED}token_type=Bearer&expires_in=3600&scope=simple_report_prod+openid+simple_report&state=thisisbogus
```


`/#id_token=(.*)/`
```
https://www.simplereport.gov/app/#id_token=blahblahblahw&access_token=someotherstuff 
```
becomes
```
https://www.simplereport.gov/app/#id_token={ID-TOKEN-OBSCURED}
```

From the previous PR - deployed on dev6
- Log in on dev6 to trigger application insights event
- Go to the logs and search for the [home page event blade](https://portal.azure.com#@9ce70869-60db-44fd-abe8-d2767077fc8f/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2F7d1e3999-6577-4cd5-b296-f518e5c8e677%2FresourceGroups%2Fprime-simple-report-dev%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fprime-simple-report-dev6-insights/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAytITE8Ny0wtL%252BaqUSjPSC1KVSgtylHISCxWUMpMiS%252FJz07NUwIA1X8V2SQAAAA%253D/timespan/PT30M)
- Notice that the id token for the URI redirect is obscured

## Screenshots / Demos
<img width="1043" alt="Screenshot 2023-03-30 at 4 19 41 PM" src="https://user-images.githubusercontent.com/29645040/228967129-fc092c6f-91f1-4289-8ef0-85d8347859f5.png">

