### PR TITLE
remove the null code system from ethnicity

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -267,22 +267,14 @@ public class FhirConverter {
       var ext = new Extension();
       ext.setUrl(ETHNICITY_EXTENSION_URL);
       var codeableConcept = new CodeableConcept();
-      var coding = codeableConcept.addCoding();
+      var coding = codeableConcept.addCoding().setSystem(ETHNICITY_CODE_SYSTEM);
       if (PersonUtils.ETHNICITY_MAP.containsKey(ethnicity)) {
-        if ("refused".equalsIgnoreCase(ethnicity)) {
-          coding.setSystem(NULL_CODE_SYSTEM);
-        } else {
-          coding.setSystem(ETHNICITY_CODE_SYSTEM);
-        }
-        coding.setCode(PersonUtils.ETHNICITY_MAP.get(ethnicity).get(0));
-        coding.setDisplay(PersonUtils.ETHNICITY_MAP.get(ethnicity).get(1));
-
+        coding
+            .setCode(PersonUtils.ETHNICITY_MAP.get(ethnicity).get(0))
+            .setDisplay(PersonUtils.ETHNICITY_MAP.get(ethnicity).get(1));
         codeableConcept.setText(PersonUtils.ETHNICITY_MAP.get(ethnicity).get(1));
       } else {
-        coding.setSystem(NULL_CODE_SYSTEM);
-        coding.setCode(MappingConstants.U_CODE);
-        coding.setDisplay(MappingConstants.UNKNOWN_STRING);
-
+        coding.setCode(MappingConstants.U_CODE).setDisplay(MappingConstants.UNKNOWN_STRING);
         codeableConcept.setText(MappingConstants.UNKNOWN_STRING);
       }
       ext.setValue(codeableConcept);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -332,8 +332,8 @@ class FhirConverterTest {
     return Stream.of(
         arguments("hispanic", ethnicitySystem, "H", "Hispanic or Latino"),
         arguments("not_hispanic", ethnicitySystem, "N", "Not Hispanic or Latino"),
-        arguments("refused", unknownSystem, "U", "unknown"),
-        arguments("shark", unknownSystem, "U", "unknown"));
+        arguments("refused", ethnicitySystem, "U", "unknown"),
+        arguments("shark", ethnicitySystem, "U", "unknown"));
   }
 
   @Test

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -159,7 +159,7 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0189",
                   "code": "U",
                   "display": "unknown"
                 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- [Ethnicity code system](https://terminology.hl7.org/5.1.0/CodeSystem-v2-0189.html) supports the "U"/"UNKNOWN" value so we do not need to use the "NULL" code system.
<img width="351" alt="image" src="https://user-images.githubusercontent.com/10108172/229574301-343e1aed-5bb6-45dd-9b87-f3a59362a410.png">

## Changes Proposed

- Remove the Null code system from ethnicity.

## Testing

