### PR TITLE
change specimen to random uuid

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -436,10 +436,11 @@ public class FhirConverter {
       String specimenName,
       String collectionCode,
       String collectionName,
-      String id) {
+      String id,
+      String identifier) {
     var specimen = new Specimen();
     specimen.setId(id);
-    specimen.addIdentifier().setValue(id);
+    specimen.addIdentifier().setValue(identifier);
     if (StringUtils.isNotBlank(specimenCode)) {
       var codeableConcept = specimen.getType();
       var coding = codeableConcept.addCoding();
@@ -465,7 +466,8 @@ public class FhirConverter {
         specimenType.getName(),
         specimenType.getCollectionLocationCode(),
         specimenType.getCollectionLocationName(),
-        specimenType.getInternalId().toString());
+        specimenType.getInternalId().toString(),
+        UUID.randomUUID().toString());
   }
 
   public static List<Observation> convertToObservation(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -237,6 +237,7 @@ public class BulkUploadResultsToFhir {
             getDescriptionValue(row.getSpecimenType().value),
             null,
             null,
+            UUID.randomUUID().toString(),
             UUID.randomUUID().toString());
 
     var observation =

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -303,7 +303,7 @@
         },
         "identifier": [
           {
-            "value": "725252ea-50ef-46bd-ae79-c70e1d04b949"
+            "value": "$SPECIMEN_IDENTIFIER"
           }
         ]
       }

--- a/backend/src/test/resources/fhir/specimen.json
+++ b/backend/src/test/resources/fhir/specimen.json
@@ -23,7 +23,7 @@
   },
   "identifier": [
     {
-      "value": "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29"
+      "value": "$SPECIMEN_IDENTIFIER"
     }
   ]
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- ReportStream requires the Specimen Identifier to be unique.

## Changes Proposed

- Set `Specimen.identifier` to random uuid


