### PR TITLE
Remove reference to device_supported_disease table in SupportedDisease

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SupportedDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SupportedDisease.java
@@ -2,15 +2,10 @@ package gov.cdc.usds.simplereport.db.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,14 +22,6 @@ public class SupportedDisease extends IdentifiedEntity {
 
   @Column(nullable = false)
   private String loinc;
-
-  @JsonIgnore
-  @ManyToMany
-  @JoinTable(
-      name = "device_supported_disease",
-      joinColumns = @JoinColumn(name = "supported_disease_id"),
-      inverseJoinColumns = @JoinColumn(name = "device_type_id"))
-  private Set<DeviceType> deviceTypes = new HashSet<>();
 
   @JsonIgnore
   @OneToMany(mappedBy = "supportedDisease")


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Partially resolves #5322 

## Changes Proposed
- Remove reference to the `device_supported_disease` table in `SupportedDisease` model

## Additional Information
Missed this as part of https://github.com/CDCgov/prime-simplereport/pull/5547 😅 

## Testing
Deployed and tested on dev1

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->