### PR TITLE
Drop device_supported_disease table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4677,3 +4677,39 @@ databaseChangeLog:
                   name: swab_type
                   type: text
                   remarks: The swab type used for this device
+  - changeSet:
+      id: drop-device_supported_disease-join-table
+      author: ttu8@cdc.gov
+      comment: Drop the device_supported_disease join table
+      changes:
+        - tagDatabase:
+            tag: drop-device_supported_disease-join-table
+        - dropTable:
+            tableName: device_supported_disease
+      rollback:
+        - createTable:
+            tableName: device_supported_disease
+            remarks: A usable combination of device type and supported diseases for that device.
+            columns:
+              - column:
+                  name: device_type_id
+                  remarks: The device type for this combination.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_supported_disease__device_type
+                    references: device_type
+              - column:
+                  name: supported_disease_id
+                  remarks: The supported disease for this combination.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__device_supported_disease__supported_disease_type
+                    references: supported_disease
+              - addUniqueConstraint:
+                  tableName: device_supported_disease
+                  constraintName: uk__device_supported_disease
+                  columnNames: device_type_id, supported_disease_id
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.device_supported_disease TO ${noPhiUsername};


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue
- Resolves #5322 

## Changes Proposed
- Drops `device_supported_disease` table that is no longer being used

## Additional Information
N/A

## Testing
- Deployed to dev1 for testing
- Locally tested the database change and the rollback

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->