### PR TITLE
Updated error message

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -313,6 +313,9 @@ describe("FacilityForm", () => {
   });
 
   describe("CLIA number validation", () => {
+    const expectedError =
+      "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense";
+
     describe("when validation is required for state", () => {
       beforeEach(() => {
         jest
@@ -341,9 +344,6 @@ describe("FacilityForm", () => {
 
         await userEvent.type(cliaInput, "12F3456789");
         await userEvent.tab();
-
-        const expectedError =
-          "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense";
 
         expect(
           await screen.findByText(expectedError, {
@@ -452,9 +452,6 @@ describe("FacilityForm", () => {
         await userEvent.clear(cliaInput);
         await userEvent.type(cliaInput, "12Z3456789");
         await userEvent.tab();
-
-        const expectedError =
-          "Special temporary CLIAs are only valid in CA, IL, VT, WA, and WY.";
 
         expect(
           await screen.findByText(expectedError, {

--- a/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.test.tsx
@@ -342,7 +342,8 @@ describe("FacilityForm", () => {
         await userEvent.type(cliaInput, "12F3456789");
         await userEvent.tab();
 
-        const expectedError = "CLIA number should be 10 characters";
+        const expectedError =
+          "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense";
 
         expect(
           await screen.findByText(expectedError, {

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -93,20 +93,10 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
   name: yup.string().required("Facility name is missing"),
   cliaNumber: yup
     .string()
-    .required(
-      "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense"
-    )
+    .required()
     .test(
       "facility-clia",
-      ({ value }) => {
-        if (
-          (value.length === 10 && value[2] === "Z") ||
-          (!!value[0] && /[a-zA-Z]/.test(value[0]))
-        ) {
-          return "Special temporary CLIAs are only valid in CA, IL, VT, WA, and WY.";
-        }
-        return "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense";
-      },
+      "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense",
       (input, facility) => {
         if (!stateRequiresCLIANumberValidation(facility.parent.state)) {
           return true;

--- a/frontend/src/app/Settings/Facility/facilitySchema.ts
+++ b/frontend/src/app/Settings/Facility/facilitySchema.ts
@@ -93,17 +93,19 @@ export const facilitySchema: yup.SchemaOf<RequiredFacilityFields> = yup.object({
   name: yup.string().required("Facility name is missing"),
   cliaNumber: yup
     .string()
-    .required("CLIA number should be 10 characters (##D#######)")
+    .required(
+      "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense"
+    )
     .test(
       "facility-clia",
       ({ value }) => {
         if (
           (value.length === 10 && value[2] === "Z") ||
-          /[a-zA-Z]/.test(value[0])
+          (!!value[0] && /[a-zA-Z]/.test(value[0]))
         ) {
           return "Special temporary CLIAs are only valid in CA, IL, VT, WA, and WY.";
         }
-        return "CLIA number should be 10 characters (##D#######)";
+        return "CLIA numbers must be 10 characters (##D#######), or a special temporary number from CA, IL, VT, WA, WY, or the Department of Defense";
       },
       (input, facility) => {
         if (!stateRequiresCLIANumberValidation(facility.parent.state)) {


### PR DESCRIPTION

# FRONTEND PULL REQUEST

## Related Issue

- Resolves #4725 

## Changes Proposed

- Set the message field in the Yup schema as a static string value.
- Update unit testing

## Testing

PR is deployed in Dev2. Verify that the error message shows when the CLIA number is empty or incorrect

## Screenshots / Demos
<img width="550" alt="Screenshot 2023-04-05 at 12 27 50 PM" src="https://user-images.githubusercontent.com/103958711/230156594-d8f2dbb6-9c08-4d98-b403-44fd27865aed.png">
