### PR TITLE
export common disease values for TestEvents

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * For latest supported values, see:
@@ -176,11 +178,31 @@ public class TestEventExport {
           .put("Taiwanese", "oan")
           .build();
 
-  private static Optional<? extends DeviceTypeDisease> getCovidDiseaseInfo(
+  private static Optional<? extends DeviceTypeDisease> getFirstCovidDiseaseInfo(
       List<DeviceTypeDisease> deviceTypeDiseases) {
     return deviceTypeDiseases.stream()
         .filter(s -> "COVID-19".equals(s.getSupportedDisease().getName()))
         .findFirst();
+  }
+
+  private static List<DeviceTypeDisease> getCovidDiseaseInfo(
+      List<DeviceTypeDisease> deviceTypeDiseases) {
+    return deviceTypeDiseases.stream()
+        .filter(s -> "COVID-19".equals(s.getSupportedDisease().getName()))
+        .toList();
+  }
+
+  @Nullable
+  private String getCommonCovidDiseaseValue(Function<DeviceTypeDisease, String> diseaseValue) {
+    if (deviceType.isPresent()) {
+      List<DeviceTypeDisease> covidDiseaseInfo =
+          getCovidDiseaseInfo(deviceType.get().getSupportedDiseaseTestPerformed());
+      List<String> distinctValues = covidDiseaseInfo.stream().map(diseaseValue).distinct().toList();
+      if (distinctValues.size() == 1) {
+        return distinctValues.get(0);
+      }
+    }
+    return null;
   }
 
   private String boolToYesNoUnk(Boolean value) {
@@ -600,7 +622,7 @@ public class TestEventExport {
     // This field is mapped to the testPerformedLoinc but was mistakenly named ordered_test_code
     return deviceType
         .map(DeviceType::getSupportedDiseaseTestPerformed)
-        .flatMap(TestEventExport::getCovidDiseaseInfo)
+        .flatMap(TestEventExport::getFirstCovidDiseaseInfo)
         .map(DeviceTypeDisease::getTestPerformedLoincCode)
         .orElse(null);
   }
@@ -627,20 +649,12 @@ public class TestEventExport {
 
   @JsonProperty("Test_Kit_Name_ID")
   public String getTestKitNameId() {
-    return deviceType
-        .map(DeviceType::getSupportedDiseaseTestPerformed)
-        .flatMap(TestEventExport::getCovidDiseaseInfo)
-        .map(DeviceTypeDisease::getTestkitNameId)
-        .orElse(null);
+    return getCommonCovidDiseaseValue(DeviceTypeDisease::getTestkitNameId);
   }
 
   @JsonProperty("Equipment_Model_ID")
   public String getEquipmentModelId() {
-    return deviceType
-        .map(DeviceType::getSupportedDiseaseTestPerformed)
-        .flatMap(TestEventExport::getCovidDiseaseInfo)
-        .map(DeviceTypeDisease::getEquipmentUid)
-        .orElse(null);
+    return getCommonCovidDiseaseValue(DeviceTypeDisease::getEquipmentUid);
   }
 
   @JsonProperty("Test_date")

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -4,6 +4,7 @@ import static gov.cdc.usds.simplereport.test_util.TestDataBuilder.getAddress;
 
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.DeviceTypeSpecimenTypeMapping;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -33,6 +34,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
 import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
 import gov.cdc.usds.simplereport.db.repository.DeviceSpecimenTypeNewRepository;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationQueueRepository;
@@ -100,6 +102,7 @@ public class TestDataFactory {
   @Autowired private DemoOktaRepository oktaRepository;
   @Autowired private TestResultUploadRepository testResultUploadRepository;
   @Autowired private DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
+  @Autowired private DeviceTypeDiseaseRepository deviceTypeDiseaseRepository;
 
   @Autowired private ApiUserService apiUserService;
   @Autowired private DiseaseService diseaseService;
@@ -555,6 +558,17 @@ public class TestDataFactory {
   public DeviceType getGenericDevice() {
     initGenericDeviceTypeAndSpecimenType();
     return genericDeviceType;
+  }
+
+  public SupportedDisease getCovidDisease() {
+    return diseaseService.covid();
+  }
+
+  public DeviceType addDiseasesToDevice(
+      DeviceType deviceType, List<DeviceTypeDisease> deviceTypeDiseases) {
+    deviceTypeDiseaseRepository.saveAll(deviceTypeDiseases);
+    deviceType.getSupportedDiseaseTestPerformed().addAll(deviceTypeDiseases);
+    return deviceTypeRepository.save(deviceType);
   }
 
   public SpecimenType createSpecimenType(


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- to be merged before Device Sync https://github.com/CDCgov/prime-simplereport/pull/5491

## Changes Proposed

- export only common values rather than guessing

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->