### PR TITLE
Johanna/5539 patient upload analytics

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTelemetryConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTelemetryConfiguration.java
@@ -11,7 +11,7 @@ public class AzureTelemetryConfiguration {
 
   @Bean
   @Scope("singleton")
-  TelemetryClient getTelemetryClient() {
+  public TelemetryClient getTelemetryClient() {
     return new TelemetryClient();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -88,8 +88,6 @@ public class PatientBulkUploadServiceAsync {
       final Map<String, String> row = CsvValidatorUtils.getNextRow(valueIterator);
 
       try {
-        // ToDo remove after testing is done for upload
-        throw new IllegalArgumentException();
 
         PatientUploadRow extractedData = new PatientUploadRow(row);
 
@@ -168,6 +166,9 @@ public class PatientBulkUploadServiceAsync {
           patientsList.clear();
           phoneNumbersList.clear();
         }
+        // ToDo remove after testing is done for upload
+        throw new IllegalArgumentException();
+
       } catch (IllegalArgumentException | NullPointerException e) {
         sendEmail(
             uploaderEmail,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Async;
@@ -218,6 +219,8 @@ public class PatientBulkUploadServiceAsync {
   }
 
   private void logProcessingFailure(String errorMessage, String externalId, UUID facilityId) {
+    MDC.put("orgId", externalId);
+    MDC.put("facilityId", facilityId.toString());
     log.error(errorMessage + " for organization " + externalId + " and facility " + facilityId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -228,6 +228,5 @@ public class PatientBulkUploadServiceAsync {
     this.appInsights
         .getTelemetryClient()
         .trackTrace(errorMessage, SeverityLevel.Error, customProperties);
-    // log.error(errorMessage + " for organization " + externalId + " and facility " + facilityId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -9,8 +9,10 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.convertRace
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.convertSexToDatabaseValue;
 
 import com.fasterxml.jackson.databind.MappingIterator;
+import com.microsoft.applicationinsights.telemetry.SeverityLevel;
 import gov.cdc.usds.simplereport.api.model.filerow.PatientUploadRow;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
+import gov.cdc.usds.simplereport.config.AzureTelemetryConfiguration;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
@@ -32,7 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Async;
@@ -55,6 +57,8 @@ public class PatientBulkUploadServiceAsync {
 
   @Value("${simple-report.patient-link-url:https://simplereport.gov/pxp?plid=}")
   private String patientLinkUrl;
+
+  @Autowired private AzureTelemetryConfiguration appInsights;
 
   @Async
   @Transactional
@@ -84,6 +88,9 @@ public class PatientBulkUploadServiceAsync {
       final Map<String, String> row = CsvValidatorUtils.getNextRow(valueIterator);
 
       try {
+        // ToDo remove after testing is done for upload
+        throw new IllegalArgumentException();
+
         PatientUploadRow extractedData = new PatientUploadRow(row);
 
         // Fetch address information
@@ -219,8 +226,11 @@ public class PatientBulkUploadServiceAsync {
   }
 
   private void logProcessingFailure(String errorMessage, String externalId, UUID facilityId) {
-    MDC.put("orgId", externalId);
-    MDC.put("facilityId", facilityId.toString());
-    log.error(errorMessage + " for organization " + externalId + " and facility " + facilityId);
+    Map<String, String> customProperties =
+        Map.of("orgId", externalId, "facilityId", facilityId.toString());
+    this.appInsights
+        .getTelemetryClient()
+        .trackTrace(errorMessage, SeverityLevel.Error, customProperties);
+    // log.error(errorMessage + " for organization " + externalId + " and facility " + facilityId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PatientBulkUploadServiceAsync.java
@@ -166,9 +166,6 @@ public class PatientBulkUploadServiceAsync {
           patientsList.clear();
           phoneNumbersList.clear();
         }
-        // ToDo remove after testing is done for upload
-        throw new IllegalArgumentException();
-
       } catch (IllegalArgumentException | NullPointerException e) {
         sendEmail(
             uploaderEmail,
@@ -178,7 +175,6 @@ public class PatientBulkUploadServiceAsync {
 
         String errorMessage = "Error uploading patient roster";
         logProcessingFailure(errorMessage, currentOrganization.getExternalId(), facilityId);
-
         throw new IllegalArgumentException(errorMessage);
       }
     }

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -98,7 +98,6 @@ const UploadPatients = () => {
   }
 
   function trackValidationErrors(validationErrors: ValidationError[]): void {
-    // clean the values for the type of error `androgynous is not an acceptable value for the biological_sex column.`
     const trackErrors: Promise<any>[] = validationErrors.map(
       (error) =>
         new Promise<any>((res) => {

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -327,12 +327,22 @@ const UploadPatients = () => {
                 <a
                   href="/using-simplereport/manage-people-you-test/bulk-upload-patients/#preparing-your-spreadsheet-data"
                   className={"usa-button margin-right-105"}
+                  onClick={() =>
+                    appInsights?.trackEvent({
+                      name: "viewPatientBulkUploadGuide",
+                    })
+                  }
                 >
                   View patient bulk upload guide
                 </a>
                 <a
                   href="/assets/resources/patient_upload_example.csv"
                   className={"usa-button usa-button--outline"}
+                  onClick={() =>
+                    appInsights?.trackEvent({
+                      name: "downloadPatientBulkUploadSample",
+                    })
+                  }
                 >
                   Download spreadsheet template
                 </a>

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -35,9 +35,9 @@ type ErrorMessage = {
 };
 
 type ValidationError = {
-  scope: "item";
+  scope?: "item";
   message: string;
-  indices: number[] | null;
+  indices?: number[] | null;
 };
 
 const UploadPatients = () => {
@@ -229,6 +229,7 @@ const UploadPatients = () => {
           includeGuide: true,
         });
         setFileValid(false);
+        trackValidationErrors([{ message: "File missing or empty." }]);
         return;
       }
 
@@ -246,6 +247,7 @@ const UploadPatients = () => {
           includeGuide: false,
         });
         setFileValid(false);
+        trackValidationErrors([{ message: "File too large (size)." }]);
         return;
       }
 
@@ -264,6 +266,9 @@ const UploadPatients = () => {
           includeGuide: false,
         });
         setFileValid(false);
+        trackValidationErrors([
+          { message: "File too large (number of rows)." },
+        ]);
         return;
       }
 

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -104,6 +104,13 @@ const UploadPatients = () => {
       if (response.status === "FAILURE") {
         setStatus("fail");
         if (response?.errors?.length) {
+          appInsights?.trackTrace(
+            { message: "patientUpload_validationError", severityLevel: 1 },
+            Object.assign(
+              {},
+              ...response?.errors.map((error: any) => ({ [error.message]: "" }))
+            )
+          );
           setErrorMessage({
             header: "Error: File not accepted",
             body: (

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -18,6 +18,7 @@ import { showError } from "../utils/srToast";
 import { FileUploadService } from "../../fileUploadService/FileUploadService";
 import iconLoader from "../../img/loader.svg";
 import { getFacilityIdFromUrl } from "../utils/url";
+import { maskPatientUploadValidationError } from "../utils/dataMasking";
 import {
   MAX_CSV_UPLOAD_BYTES,
   MAX_CSV_UPLOAD_ROW_COUNT,
@@ -26,7 +27,6 @@ import {
 import { AddPatientHeader } from "./Components/AddPatientsHeader";
 
 import "./UploadPatients.scss";
-import { maskPatientUploadValidationError } from "../utils/dataMasking";
 
 type ErrorMessage = {
   header: string;

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -102,13 +102,15 @@ const UploadPatients = () => {
         new Promise<any>((res) => {
           const exception: IAutoExceptionTelemetry = {
             columnNumber: 0,
-            error: new Error("patient upload validation error"),
+            error: null,
             lineNumber: 0,
             url: "/app/upload-patients",
             message: error.message,
-            typeName: "patient upload validation error",
           };
-          appInsights?.trackException({ exception, severityLevel: 1 });
+          appInsights?.trackException(
+            { id: crypto.randomUUID(), exception, severityLevel: 1 },
+            { exceptionType: "patientUploadValidationError" }
+          );
           return res;
         })
     );

--- a/frontend/src/app/patients/UploadPatients.tsx
+++ b/frontend/src/app/patients/UploadPatients.tsx
@@ -26,6 +26,7 @@ import {
 import { AddPatientHeader } from "./Components/AddPatientsHeader";
 
 import "./UploadPatients.scss";
+import { maskPatientUploadValidationError } from "../utils/dataMasking";
 
 type ErrorMessage = {
   header: string;
@@ -97,6 +98,7 @@ const UploadPatients = () => {
   }
 
   function trackValidationErrors(validationErrors: ValidationError[]): void {
+    // clean the values for the type of error `androgynous is not an acceptable value for the biological_sex column.`
     const trackErrors: Promise<any>[] = validationErrors.map(
       (error) =>
         new Promise<any>((res) => {
@@ -105,7 +107,7 @@ const UploadPatients = () => {
             error: null,
             lineNumber: 0,
             url: "/app/upload-patients",
-            message: error.message,
+            message: maskPatientUploadValidationError(error.message),
           };
           appInsights?.trackException(
             { id: crypto.randomUUID(), exception, severityLevel: 1 },

--- a/frontend/src/app/utils/dataMasking.test.ts
+++ b/frontend/src/app/utils/dataMasking.test.ts
@@ -1,0 +1,33 @@
+import { maskPatientUploadValidationError } from "./dataMasking";
+
+describe("dataMasking.ts", () => {
+  describe("maskPatientUploadValidationError", () => {
+    it("checks validation error and skips masking", () => {
+      const validationErrors = [
+        "The header for column employed_in_healthcare is missing or invalid.",
+        "File is missing data in the state column.",
+      ];
+
+      for (let i = 0; i < validationErrors.length; i++) {
+        expect(
+          maskPatientUploadValidationError(validationErrors[i])
+        ).not.toContain("[user_input]");
+      }
+    });
+
+    it("checks validation error and masks user entry", () => {
+      const validationErrors = [
+        "group home is not an acceptable value for the resident_congregate_setting column.",
+        "androgynous is not an acceptable value for the biological_sex column.",
+        "latinx is not an acceptable value for the ethnicity column.",
+        "11/3/8 is not an acceptable value for the date_of_birth column.",
+      ];
+
+      for (let i = 0; i < validationErrors.length; i++) {
+        expect(maskPatientUploadValidationError(validationErrors[i])).toContain(
+          "[user_input]"
+        );
+      }
+    });
+  });
+});

--- a/frontend/src/app/utils/dataMasking.ts
+++ b/frontend/src/app/utils/dataMasking.ts
@@ -1,0 +1,17 @@
+/**
+ * Converts an error with pattern `[input value] is not an acceptable value for the [column_name] column.`
+ *  to `[user_input] is not an acceptable value for the biological_sex column.`
+ */
+export function maskPatientUploadValidationError(
+  validationError: string
+): string {
+  const regex = new RegExp(
+    /^(.*) is not an acceptable value for the (.*) column./g
+  );
+  if (regex.test(validationError)) {
+    return `[user_input] ${validationError.substring(
+      validationError.search("is not an acceptable value for the")
+    )}`;
+  }
+  return validationError;
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5539 (partially)

## Changes Proposed

- Replace the logging method from @Slf4j with a custom trace log to set the error message as a static/common text and adding the organization and facility information as custom dimensions instead.

## Additional Information

With this change a trace log will still be generated and developers can still look for this log with the org and facility information.

## Testing
I manually tested in dev 2

- Verify that the trace log still gets generated (this will be hard to test... I manually tested this by pushing code that breaks and checking the log that way.
![Screenshot 2023-04-10 at 3 34 04 PM](https://user-images.githubusercontent.com/103958711/230982297-c61e24c8-1bd8-4a22-baa1-a2eb78950f02.png)


# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5539 (partially)

## Changes Proposed

- Add logic to create customEvents to track the user actions: view guide, download sample csv
- Add logic to create customExceptions to track the validation errors that are presented to the user.

## Additional Information

- Errors to track empty file, file too big and file with too many rows were also added.

## Testing

Code was tested in dev2.

- Upload a file that displays validation errors and verify that the respective logs are created.
- Click on the user guide and verify that the log gets created.
- Click on download sample file and verify that the log gets created.
