### PR TITLE
user can submit covid only for multiplex devices that support it

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.model;
 
+import static gov.cdc.usds.simplereport.service.DiseaseService.COVID19_NAME;
 import static java.lang.Boolean.TRUE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -181,7 +182,7 @@ public class TestEventExport {
   private static Optional<? extends DeviceTypeDisease> getFirstCovidDiseaseInfo(
       List<DeviceTypeDisease> deviceTypeDiseases) {
     return deviceTypeDiseases.stream()
-        .filter(s -> "COVID-19".equals(s.getSupportedDisease().getName()))
+        .filter(s -> COVID19_NAME.equals(s.getSupportedDisease().getName()))
         .findFirst();
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTestEventReportingQueueConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTestEventReportingQueueConfiguration.java
@@ -163,7 +163,6 @@ class AzureTestEventReportingQueueConfiguration {
       if (printSerializedTestEvent) {
         log.info("TestEvent bundled as: {}", toBuffer(testEvent));
       }
-
       return CompletableFuture.completedFuture(null);
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -204,11 +204,23 @@ public class Person extends OrganizationScopedEternalEntity implements PersonEnt
     this.role = PersonRole.STAFF;
   }
 
-  public Person(PersonName names, Organization org, Facility facility, PersonRole role) {
+  public Person(
+      PersonName names,
+      Organization org,
+      Facility facility,
+      PersonRole role,
+      String gender,
+      LocalDate birthDate,
+      StreetAddress address,
+      String race) {
     super(org);
     this.facility = facility;
     this.nameInfo = names;
     this.role = role;
+    this.gender = gender;
+    this.birthDate = birthDate;
+    this.address = address;
+    this.race = race;
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -1,6 +1,9 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import static gov.cdc.usds.simplereport.service.AzureStorageQueueFhirReportingService.COVID_LOINC;
+import static gov.cdc.usds.simplereport.service.DiseaseService.COVID19_NAME;
+import static gov.cdc.usds.simplereport.service.DiseaseService.FLU_A_NAME;
+import static gov.cdc.usds.simplereport.service.DiseaseService.FLU_B_NAME;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
@@ -170,5 +173,18 @@ public class TestEvent extends BaseTestInfo {
             .filter(result -> COVID_LOINC.equals(result.getDisease().getLoinc()))
             .findFirst();
     return resultObject.map(Result::getTestResult);
+  }
+
+  public boolean hasCovidResult() {
+    return this.results.stream()
+        .anyMatch(result -> COVID19_NAME.equals(result.getDisease().getName()));
+  }
+
+  public boolean hasFluResult() {
+    return this.results.stream()
+        .anyMatch(
+            result ->
+                FLU_A_NAME.equals(result.getDisease().getName())
+                    || FLU_B_NAME.equals(result.getDisease().getName()));
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -8,19 +8,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @Transactional
 @Slf4j
+@RequiredArgsConstructor
 public class DiseaseService {
+  public static final String COVID19_NAME = "COVID-19";
+  public static final String FLU_A_NAME = "Flu A";
+  public static final String FLU_B_NAME = "Flu B";
 
-  SupportedDiseaseRepository _supportedDiseaseRepo;
-
-  DiseaseService(SupportedDiseaseRepository repo) {
-    this._supportedDiseaseRepo = repo;
-  }
+  private final SupportedDiseaseRepository _supportedDiseaseRepo;
 
   private SupportedDisease covid;
   private SupportedDisease fluA;
@@ -29,9 +30,9 @@ public class DiseaseService {
   private final Map<UUID, SupportedDisease> supportedDiseaseMap = new HashMap<>();
 
   public void initDiseases() {
-    covid = _supportedDiseaseRepo.findByName("COVID-19").orElse(null);
-    fluA = _supportedDiseaseRepo.findByName("Flu A").orElse(null);
-    fluB = _supportedDiseaseRepo.findByName("Flu B").orElse(null);
+    covid = _supportedDiseaseRepo.findByName(COVID19_NAME).orElse(null);
+    fluA = _supportedDiseaseRepo.findByName(FLU_A_NAME).orElse(null);
+    fluB = _supportedDiseaseRepo.findByName(FLU_B_NAME).orElse(null);
 
     Optional.ofNullable(covid).ifPresent(sd -> supportedDiseaseMap.put(sd.getInternalId(), sd));
     Optional.ofNullable(fluA).ifPresent(sd -> supportedDiseaseMap.put(sd.getInternalId(), sd));
@@ -47,18 +48,14 @@ public class DiseaseService {
   }
 
   public SupportedDisease getDiseaseByName(String name) {
-    switch (name) {
-      case "COVID-19":
-        return covid;
-      case "Flu A":
-        return fluA;
-      case "Flu B":
-        return fluB;
-      default:
-        return _supportedDiseaseRepo
-            .findByName(name)
-            .orElseThrow(() -> new IllegalArgumentException("Disease not found"));
-    }
+    return switch (name) {
+      case COVID19_NAME -> covid;
+      case FLU_A_NAME -> fluA;
+      case FLU_B_NAME -> fluB;
+      default -> _supportedDiseaseRepo
+          .findByName(name)
+          .orElseThrow(() -> new IllegalArgumentException("Disease not found"));
+    };
   }
 
   public SupportedDisease covid() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -342,8 +342,13 @@ public class TestOrderService {
 
       order.setTestEventRef(savedEvent);
       savedOrder = _testOrderRepo.save(order);
-      _testEventReportingService.report(savedEvent);
-      _fhirQueueReportingService.report(testEvent);
+      if (savedEvent.hasCovidResult()) {
+        _testEventReportingService.report(savedEvent);
+      }
+
+      if (savedEvent.hasFluResult()) {
+        _fhirQueueReportingService.report(testEvent);
+      }
     } finally {
       unlockOrder(order.getInternalId());
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -342,13 +342,7 @@ public class TestOrderService {
 
       order.setTestEventRef(savedEvent);
       savedOrder = _testOrderRepo.save(order);
-      if (savedEvent.hasCovidResult()) {
-        _testEventReportingService.report(savedEvent);
-      }
-
-      if (savedEvent.hasFluResult()) {
-        _fhirQueueReportingService.report(testEvent);
-      }
+      reportTestEventToRS(savedEvent);
     } finally {
       unlockOrder(order.getInternalId());
     }
@@ -372,6 +366,16 @@ public class TestOrderService {
     boolean deliveryStatus =
         deliveryStatuses.isEmpty() || deliveryStatuses.stream().anyMatch(status -> status);
     return new AddTestResultResponse(savedOrder, deliveryStatus);
+  }
+
+  private void reportTestEventToRS(TestEvent savedEvent) {
+    if (savedEvent.hasCovidResult()) {
+      _testEventReportingService.report(savedEvent);
+    }
+
+    if (savedEvent.hasFluResult()) {
+      _fhirQueueReportingService.report(savedEvent);
+    }
   }
 
   private Set<Result> editMultiplexResult(TestOrder order, List<MultiplexResultInput> newResults) {
@@ -568,8 +572,7 @@ public class TestOrderService {
         results.forEach(result -> result.setTestEvent(newRemoveEvent));
         _resultRepo.saveAll(results);
 
-        _testEventReportingService.report(newRemoveEvent);
-        _fhirQueueReportingService.report(newRemoveEvent);
+        reportTestEventToRS(newRemoveEvent);
 
         order.setReasonForCorrection(reasonForCorrection);
         order.setTestEventRef(newRemoveEvent);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -206,8 +206,6 @@ class TestResultTest extends BaseGraphqlTest {
         p1, _site, new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate));
     _dataFactory.createTestOrder(
         p2, _site, new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate));
-    //    _dataFactory.createTestOrder(p1, _site);
-    //    _dataFactory.createTestOrder(p2, _site);
     String dateTested = "2020-12-31T14:30:30.001Z";
 
     // The test default standard user is configured to access _site by default,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -199,8 +199,15 @@ class TestResultTest extends BaseGraphqlTest {
     Person p2 = _dataFactory.createMinimalPerson(_org, _site);
     DeviceType d = _site.getDefaultDeviceType();
     SpecimenType s = _site.getDefaultSpecimenType();
-    _dataFactory.createTestOrder(p1, _site);
-    _dataFactory.createTestOrder(p2, _site);
+    Map<String, Boolean> symptoms = Map.of("25064002", true);
+    LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
+
+    _dataFactory.createTestOrder(
+        p1, _site, new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate));
+    _dataFactory.createTestOrder(
+        p2, _site, new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate));
+    //    _dataFactory.createTestOrder(p1, _site);
+    //    _dataFactory.createTestOrder(p2, _site);
     String dateTested = "2020-12-31T14:30:30.001Z";
 
     // The test default standard user is configured to access _site by default,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1440,7 +1440,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
     // to report stream
     verify(testEventReportingService).report(deleteMarkerEvent);
-    verify(fhirQueueReportingService).report(deleteMarkerEvent);
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2030,7 +2030,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.getTestResult(_e.getInternalId()).getTestOrder();
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(correctedTestEvent);
-    verify(fhirQueueReportingService).report(correctedTestEvent);
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   private List<TestEvent> makedata() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -180,7 +180,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(testEventArgumentCaptor.capture());
-    verify(fhirQueueReportingService).report(testEventArgumentCaptor.capture());
+    verifyNoInteractions(fhirQueueReportingService);
     TestEvent sentEvent = testEventArgumentCaptor.getValue();
     assertThat(sentEvent.getPatient().getInternalId()).isEqualTo(patient.getInternalId());
     assertThat(sentEvent.getCovidTestResult().get()).isEqualTo(TestResult.POSITIVE);
@@ -226,7 +226,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         null);
 
     verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
 
     List<TestEvent> testEvents =
         _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
@@ -247,7 +247,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
     assertThat(testEvents.get(1).getPatientHasPriorTests()).isTrue();
     verify(testEventReportingService, times(2)).report(any());
-    verify(fhirQueueReportingService, times(2)).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   @Test
@@ -394,7 +394,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
     verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   @Test
@@ -438,7 +438,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
     verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   @Test
@@ -541,7 +541,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
 
     List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
 
@@ -553,7 +553,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // make sure the second event is sent to storage queue
     verify(testEventReportingService, times(2)).report(any());
-    verify(fhirQueueReportingService, times(2)).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   @Test
@@ -912,7 +912,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertTrue(res.getDeliverySuccess());
     verifyNoInteractions(testResultsDeliveryService);
     verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
+    verifyNoInteractions(fhirQueueReportingService);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -238,7 +238,9 @@ public class TestDataFactory {
   @Transactional
   public Person createMinimalPerson(
       Organization org, Facility fac, PersonName names, PersonRole role) {
-    Person p = new Person(names, org, fac, role);
+    Person p =
+        new Person(names, org, fac, role, "female", LocalDate.now(), getFullAddress(), "black");
+
     personRepository.save(p);
     PhoneNumber pn = new PhoneNumber(p, PhoneType.MOBILE, "503-867-5309");
     phoneNumberRepository.save(pn);

--- a/frontend/src/app/commonComponents/CovidResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/CovidResultGuidance.tsx
@@ -143,16 +143,19 @@ const CovidResultGuidance = (props: Props) => {
       </p>
     );
   }
-  if (result === "UNDETERMINED" || result === "UNKNOWN") {
-    covidGuidanceArray.push(
-      setCovidResultInfo("UNDETERMINED", isPatientApp, t)
-    );
-  }
-  if (result !== "POSITIVE") {
-    covidGuidanceArray.push(setCovidResultInfo("NEGATIVE", isPatientApp, t));
-  }
-  if (result === "POSITIVE") {
-    covidGuidanceArray.push(setCovidResultInfo("POSITIVE", isPatientApp, t));
+
+  switch (result) {
+    case "UNDETERMINED":
+      covidGuidanceArray.push(
+        setCovidResultInfo("UNDETERMINED", isPatientApp, t)
+      );
+      break;
+    case "NEGATIVE":
+      covidGuidanceArray.push(setCovidResultInfo("NEGATIVE", isPatientApp, t));
+      break;
+    case "POSITIVE":
+      covidGuidanceArray.push(setCovidResultInfo("POSITIVE", isPatientApp, t));
+      break;
   }
   return covidGuidanceArray;
 };

--- a/frontend/src/app/commonComponents/MultiplexResultsGuidance.tsx
+++ b/frontend/src/app/commonComponents/MultiplexResultsGuidance.tsx
@@ -5,6 +5,7 @@ import CovidResultGuidance from "../commonComponents/CovidResultGuidance";
 import {
   hasPositiveFluResults,
   getResultByDiseaseName,
+  haCovidResults,
 } from "../utils/testResults";
 
 interface Props {
@@ -59,7 +60,8 @@ const MultiplexResultsGuidance = (props: Props) => {
   const isPatientApp = props.isPatientApp;
   const multiplexEnabled = props.multiplexEnabled;
   const { t } = useTranslation();
-  const needsHeading = multiplexEnabled && hasPositiveFluResults(results);
+  const needsCovidHeading = haCovidResults(results);
+  const needsFluHeading = multiplexEnabled && hasPositiveFluResults(results);
   const testGuidanceArray: any = [];
   const covidResult = getResultByDiseaseName(results, "COVID-19") as TestResult;
   let covidGuidanceElement;
@@ -68,24 +70,24 @@ const MultiplexResultsGuidance = (props: Props) => {
       <CovidResultGuidance
         result={covidResult}
         isPatientApp={isPatientApp}
-        needsHeading={needsHeading}
+        needsHeading={needsCovidHeading}
       />
     );
   } else {
     covidGuidanceElement = (
-      <div className={needsHeading ? "sr-margin-bottom-28px" : ""}>
+      <div className={needsCovidHeading ? "sr-margin-bottom-28px" : ""}>
         <CovidResultGuidance
           result={covidResult}
           isPatientApp={isPatientApp}
-          needsHeading={needsHeading}
+          needsHeading={needsCovidHeading}
         />
       </div>
     );
   }
   testGuidanceArray.push(covidGuidanceElement);
 
-  if (needsHeading) {
-    testGuidanceArray.push(setPositiveFluResultInfo(needsHeading, t));
+  if (needsFluHeading) {
+    testGuidanceArray.push(setPositiveFluResultInfo(needsFluHeading, t));
   }
   return testGuidanceArray;
 };

--- a/frontend/src/app/testQueue/QueueItem.test.tsx
+++ b/frontend/src/app/testQueue/QueueItem.test.tsx
@@ -33,7 +33,9 @@ import QueueItem, {
   QueueItemProps,
 } from "./QueueItem";
 import mockSupportedDiseaseCovid from "./mocks/mockSupportedDiseaseCovid";
-import mockSupportedDiseaseMultiplex from "./mocks/mockSupportedDiseaseMultiplex";
+import mockSupportedDiseaseMultiplex, {
+  mockSupportedDiseaseFlu,
+} from "./mocks/mockSupportedDiseaseMultiplex";
 
 jest.mock("../TelemetryService", () => ({
   getAppInsights: jest.fn(),
@@ -57,11 +59,13 @@ const device1Name = "LumiraDX";
 const device2Name = "Abbott BinaxNow";
 const device3Name = "BD Veritor";
 const device4Name = "Multiplex";
+const device5Name = "MultiplexAndCovidOnly";
 
 const device1Id = "ee4f40b7-ac32-4709-be0a-56dd77bb9609";
 const device2Id = "5c711888-ba37-4b2e-b347-311ca364efdb";
 const device3Id = "32b2ca2a-75e6-4ebd-a8af-b50c7aea1d10";
 const device4Id = "67109f6f-eaee-49d3-b8ff-c61b79a9da8e";
+const device5Id = "da524a8e-672d-4ff4-a4ec-c1e14d0337db";
 
 const deletedDeviceId = "8ab0cafa-8e36-48d6-91fc-6352405e1d91";
 const deletedDeviceName = "Deleted";
@@ -207,6 +211,36 @@ describe("QueueItem", () => {
           },
         ],
       },
+      {
+        internalId: device5Id,
+        name: device5Name,
+        testLength: 15,
+        supportedDiseaseTestPerformed: [
+          ...mockSupportedDiseaseFlu,
+          {
+            supportedDisease: mockSupportedDiseaseCovid[0].supportedDisease,
+            testPerformedLoincCode: "123456",
+            testOrderedLoincCode: "445566",
+          },
+          {
+            supportedDisease: mockSupportedDiseaseCovid[0].supportedDisease,
+            testPerformedLoincCode: "123456",
+            testOrderedLoincCode: "778899",
+          },
+        ],
+        swabTypes: [
+          {
+            name: specimen1Name,
+            internalId: specimen1Id,
+            typeCode: "445297001",
+          },
+          {
+            name: specimen2Name,
+            internalId: specimen2Id,
+            typeCode: "258500001",
+          },
+        ],
+      },
     ],
   };
 
@@ -325,11 +359,12 @@ describe("QueueItem", () => {
       "device-type-dropdown"
     )) as HTMLSelectElement;
 
-    expect(deviceDropdown.options.length).toEqual(4);
+    expect(deviceDropdown.options.length).toEqual(5);
     expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
     expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
     expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
     expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+    expect(deviceDropdown.options[4].label).toEqual("MultiplexAndCovidOnly");
 
     await userEvent.selectOptions(deviceDropdown, "Abbott BinaxNow");
 
@@ -450,12 +485,14 @@ describe("QueueItem", () => {
     await renderQueueItem({ props, mocks });
 
     const deviceDropdown = await getDeciceTypeDropdown();
-    expect(deviceDropdown.options.length).toEqual(5);
+    expect(deviceDropdown.options.length).toEqual(6);
     expect(deviceDropdown.options[0].label).toEqual("");
     expect(deviceDropdown.options[1].label).toEqual("Abbott BinaxNow");
     expect(deviceDropdown.options[2].label).toEqual("BD Veritor");
     expect(deviceDropdown.options[3].label).toEqual("LumiraDX");
     expect(deviceDropdown.options[4].label).toEqual("Multiplex");
+    expect(deviceDropdown.options[5].label).toEqual("MultiplexAndCovidOnly");
+
     expect(deviceDropdown.value).toEqual("");
 
     const swabDropdown = await getSpecimenTypeDropdown();
@@ -588,11 +625,12 @@ describe("QueueItem", () => {
     await renderQueueItem({ props, mocks });
 
     const deviceDropdown = await getDeciceTypeDropdown();
-    expect(deviceDropdown.options.length).toEqual(4);
+    expect(deviceDropdown.options.length).toEqual(5);
     expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
     expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
     expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
     expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+    expect(deviceDropdown.options[4].label).toEqual("MultiplexAndCovidOnly");
     expect(deviceDropdown.value).toEqual(device2Id);
 
     const swabDropdown = await getSpecimenTypeDropdown();
@@ -775,11 +813,12 @@ describe("QueueItem", () => {
       await renderQueueItem({ mocks });
 
       const deviceDropdown = await getDeciceTypeDropdown();
-      expect(deviceDropdown.options.length).toEqual(4);
+      expect(deviceDropdown.options.length).toEqual(5);
       expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
       expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
       expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
       expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+      expect(deviceDropdown.options[4].label).toEqual("MultiplexAndCovidOnly");
 
       // select results
       await userEvent.click(
@@ -818,11 +857,12 @@ describe("QueueItem", () => {
       expect(screen.queryByText("Flu B")).not.toBeInTheDocument();
 
       const deviceDropdown = await getDeciceTypeDropdown();
-      expect(deviceDropdown.options.length).toEqual(4);
+      expect(deviceDropdown.options.length).toEqual(5);
       expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
       expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
       expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
       expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+      expect(deviceDropdown.options[4].label).toEqual("MultiplexAndCovidOnly");
 
       // Change device type to a multiplex device
       await userEvent.selectOptions(deviceDropdown, device4Name);
@@ -1189,6 +1229,43 @@ describe("QueueItem", () => {
     expect(
       screen.queryByText(testProps.queueItem.patient.phoneNumbers![1]!.number!)
     ).not.toBeInTheDocument();
+  });
+
+  describe("when device supports covid only and multiplex", () => {
+    it("should allow you to submit covid only results", async () => {
+      await renderQueueItem({});
+
+      const deviceDropdown = await getDeciceTypeDropdown();
+      expect(deviceDropdown.options.length).toEqual(5);
+      expect(deviceDropdown.options[0].label).toEqual("Abbott BinaxNow");
+      expect(deviceDropdown.options[1].label).toEqual("BD Veritor");
+      expect(deviceDropdown.options[2].label).toEqual("LumiraDX");
+      expect(deviceDropdown.options[3].label).toEqual("Multiplex");
+      expect(deviceDropdown.options[4].label).toEqual("MultiplexAndCovidOnly");
+
+      // Change device type to multiplex
+      await userEvent.selectOptions(deviceDropdown, device4Name);
+      await new Promise((resolve) => setTimeout(resolve, 501));
+
+      // select results
+      await userEvent.click(
+        within(
+          screen.getByTestId(`covid-test-result-${queueItemInfo.internalId}`)
+        ).getByLabelText("Positive", { exact: false })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 501));
+
+      // Notice submit is disabled
+      expect(screen.getByText("Submit")).toBeDisabled();
+
+      // Change device type to multiplex that supports covid only
+      await userEvent.selectOptions(deviceDropdown, device5Name);
+      await new Promise((resolve) => setTimeout(resolve, 501));
+      expect(deviceDropdown.value).toEqual(device5Id);
+
+      // Notice submit is enabled
+      expect(screen.getByText("Submit")).toBeEnabled();
+    });
   });
 
   describe("telemetry", () => {

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -297,6 +297,37 @@ const QueueItem = ({
     return false;
   };
 
+  const doesDeviceSupportMultiplexAndCovidOnlyResult = (deviceId: string) => {
+    if (devicesMap.has(deviceId)) {
+      const deviceTypeCovidDiseases = devicesMap
+        .get(deviceId)!
+        .supportedDiseaseTestPerformed.filter(
+          (disease) =>
+            disease.supportedDisease.name === MULTIPLEX_DISEASES.COVID_19
+        );
+
+      if (deviceTypeCovidDiseases.length >= 1) {
+        const testPerformedLoincs = [
+          ...new Set(
+            deviceTypeCovidDiseases.map((value) => value.testPerformedLoincCode)
+          ),
+        ].filter((item): item is string => !!item);
+        const testOrderedLoincs = [
+          ...new Set(
+            deviceTypeCovidDiseases.map((value) => value.testOrderedLoincCode)
+          ),
+        ].filter((item): item is string => !!item);
+        const hasSingleCovidTestPerformedLoinc =
+          testPerformedLoincs.length === 1;
+        const hasMultipleCovidTestOrderedLoincs = testOrderedLoincs.length > 1;
+        return (
+          hasSingleCovidTestPerformedLoinc && hasMultipleCovidTestOrderedLoincs
+        );
+      }
+    }
+    return false;
+  };
+
   useEffect(() => {
     if (deviceTypeIsInvalid()) {
       setDeviceTypeErrorMessage("Please select a device");
@@ -960,6 +991,9 @@ const QueueItem = ({
                     deviceTypeIsInvalid() ||
                     specimenTypeIsInvalid()
                   }
+                  deviceSupportsCovidOnlyResult={doesDeviceSupportMultiplexAndCovidOnlyResult(
+                    deviceId
+                  )}
                   onSubmit={onTestResultSubmit}
                   onChange={onTestResultChange}
                 />

--- a/frontend/src/app/testQueue/mocks/mockSupportedDiseaseCovid.ts
+++ b/frontend/src/app/testQueue/mocks/mockSupportedDiseaseCovid.ts
@@ -4,6 +4,7 @@ const mockSupportedDiseaseCovid = [
   {
     supportedDisease:
       mockSupportedDiseaseTestPerformedCovid[0].supportedDisease,
+    testPerformedLoincCode: "123456",
   },
 ];
 

--- a/frontend/src/app/testQueue/mocks/mockSupportedDiseaseMultiplex.ts
+++ b/frontend/src/app/testQueue/mocks/mockSupportedDiseaseMultiplex.ts
@@ -2,14 +2,16 @@ import mockSupportedDiseaseTestPerformedMultiplex from "../../supportAdmin/Devic
 
 import mockSupportedDiseaseCovid from "./mockSupportedDiseaseCovid";
 
-let mockSupportedDiseaseFlu = [
+export const mockSupportedDiseaseFlu = [
   {
     supportedDisease:
       mockSupportedDiseaseTestPerformedMultiplex[1].supportedDisease,
+    testPerformedLoincCode: "456789",
   },
   {
     supportedDisease:
       mockSupportedDiseaseTestPerformedMultiplex[2].supportedDisease,
+    testPerformedLoincCode: "789123",
   },
 ];
 

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -106,6 +106,8 @@ query GetFacilityQueue($facilityId: ID!) {
       name
       testLength
       supportedDiseaseTestPerformed {
+        testPerformedLoincCode
+        testOrderedLoincCode
         supportedDisease {
           internalId
           name

--- a/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
@@ -307,14 +307,6 @@ describe("TestResultInputForm", () => {
         diseaseName: MULTIPLEX_DISEASES.COVID_19,
         testResult: TEST_RESULTS.POSITIVE,
       },
-      {
-        diseaseName: MULTIPLEX_DISEASES.FLU_A,
-        testResult: TEST_RESULTS.UNDETERMINED,
-      },
-      {
-        diseaseName: MULTIPLEX_DISEASES.FLU_B,
-        testResult: TEST_RESULTS.UNDETERMINED,
-      },
     ]);
   });
   it("should trigger submit for parent component when submit button is clicked", () => {

--- a/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
@@ -223,6 +223,25 @@ describe("TestResultInputForm", () => {
     await userEvent.click(screen.getByText("Submit"));
     expect(onSubmitFn).toHaveBeenCalledTimes(0);
   });
+  it("should display submit button as enabled when POSITIVE covid and multiplex device that supports covid only", async () => {
+    render(
+      <MultiplexResultInputForm
+        queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
+        testResults={[
+          {
+            diseaseName: MULTIPLEX_DISEASES.COVID_19,
+            testResult: TEST_RESULTS.POSITIVE,
+          },
+        ]}
+        deviceSupportsCovidOnlyResult={true}
+        onChange={onChangeFn}
+        onSubmit={onSubmitFn}
+      />
+    );
+    expect(screen.getByText("Submit")).toBeEnabled();
+    await userEvent.click(screen.getByText("Submit"));
+    expect(onSubmitFn).toHaveBeenCalledTimes(1);
+  });
   it("should send results marked as inconclusive when checkbox is checked", async () => {
     render(
       <MultiplexResultInputForm

--- a/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
@@ -184,16 +184,11 @@ describe("TestResultInputForm", () => {
     expect(screen.getByText("Submit")).toBeEnabled();
   });
 
-  it("should display submit button as disabled when diseases have unset values", async () => {
+  it("should display submit button as disabled when no diseases have set values", async () => {
     render(
       <MultiplexResultInputForm
         queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
-        testResults={[
-          {
-            diseaseName: MULTIPLEX_DISEASES.COVID_19,
-            testResult: TEST_RESULTS.POSITIVE,
-          },
-        ]}
+        testResults={[]}
         onChange={onChangeFn}
         onSubmit={onSubmitFn}
       />

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -153,6 +153,21 @@ const MultiplexResultInputForm: React.FC<Props> = ({
    * */
   const validateForm = () => {
     if (
+      resultsMultiplexFormat.covid === TEST_RESULTS.UNDETERMINED ||
+      resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED ||
+      resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED
+    ) {
+      if (
+        !(
+          resultsMultiplexFormat.covid === resultsMultiplexFormat.fluA &&
+          resultsMultiplexFormat.fluA === resultsMultiplexFormat.fluB
+        )
+      ) {
+        return false;
+      }
+    }
+
+    return (
       inconclusiveCheck ||
       resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||
       resultsMultiplexFormat.covid === TEST_RESULTS.NEGATIVE ||
@@ -160,11 +175,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
         resultsMultiplexFormat.fluA === TEST_RESULTS.NEGATIVE) &&
         (resultsMultiplexFormat.fluB === TEST_RESULTS.POSITIVE ||
           resultsMultiplexFormat.fluB === TEST_RESULTS.NEGATIVE))
-    ) {
-      return true;
-    }
-
-    return false;
+    );
   };
 
   const onResultSubmit = (event: React.FormEvent<HTMLButtonElement>) => {

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -83,6 +83,7 @@ interface Props {
   queueItemId: string;
   testResults: MultiplexResultInput[];
   isSubmitDisabled?: boolean;
+  deviceSupportsCovidOnlyResult?: boolean;
   onChange: (value: MultiplexResult[]) => void;
   onSubmit: () => void;
 }
@@ -91,6 +92,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
   queueItemId,
   testResults,
   isSubmitDisabled,
+  deviceSupportsCovidOnlyResult,
   onSubmit,
   onChange,
 }) => {
@@ -159,29 +161,34 @@ const MultiplexResultInputForm: React.FC<Props> = ({
    * Form Validation
    * */
   const validateForm = () => {
-    if (
+    const anyResultIsInconclusive =
       resultsMultiplexFormat.covid === TEST_RESULTS.UNDETERMINED ||
       resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED ||
-      resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED
-    ) {
-      if (
-        !(
-          resultsMultiplexFormat.covid === resultsMultiplexFormat.fluA &&
-          resultsMultiplexFormat.fluA === resultsMultiplexFormat.fluB
-        )
-      ) {
-        return false;
-      }
-    }
+      resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED;
 
+    const allResultsAreEqual =
+      resultsMultiplexFormat.covid === resultsMultiplexFormat.fluA &&
+      resultsMultiplexFormat.fluA === resultsMultiplexFormat.fluB;
+
+    const covidIsFilled =
+      resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||
+      resultsMultiplexFormat.covid === TEST_RESULTS.NEGATIVE;
+
+    const fluAIsFilled =
+      resultsMultiplexFormat.fluA === TEST_RESULTS.POSITIVE ||
+      resultsMultiplexFormat.fluA === TEST_RESULTS.NEGATIVE;
+
+    const fluBIsFilled =
+      resultsMultiplexFormat.fluB === TEST_RESULTS.POSITIVE ||
+      resultsMultiplexFormat.fluB === TEST_RESULTS.NEGATIVE;
+
+    if (anyResultIsInconclusive && !allResultsAreEqual) {
+      return false;
+    }
     return (
       inconclusiveCheck ||
-      resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||
-      resultsMultiplexFormat.covid === TEST_RESULTS.NEGATIVE ||
-      ((resultsMultiplexFormat.fluA === TEST_RESULTS.POSITIVE ||
-        resultsMultiplexFormat.fluA === TEST_RESULTS.NEGATIVE) &&
-        (resultsMultiplexFormat.fluB === TEST_RESULTS.POSITIVE ||
-          resultsMultiplexFormat.fluB === TEST_RESULTS.NEGATIVE))
+      (deviceSupportsCovidOnlyResult && covidIsFilled) ||
+      (covidIsFilled && fluAIsFilled && fluBIsFilled)
     );
   };
 
@@ -193,7 +200,10 @@ const MultiplexResultInputForm: React.FC<Props> = ({
   return (
     <form className="usa-form maxw-none multiplex-result-form">
       <div className="grid-row grid-gap-2">
-        <div className="grid-col-4">
+        <div
+          className="grid-col-4"
+          data-testid={`covid-test-result-${queueItemId}`}
+        >
           <h2 className="prime-radio__title">COVID-19</h2>
           <RadioGroup
             legend="COVID-19 result"
@@ -217,7 +227,10 @@ const MultiplexResultInputForm: React.FC<Props> = ({
             disabled={isSubmitDisabled}
           />
         </div>
-        <div className="grid-col-4">
+        <div
+          className="grid-col-4"
+          data-testid={`flu-a-test-result-${queueItemId}`}
+        >
           <h2 className="prime-radio__title">Flu A</h2>
           <RadioGroup
             legend="Flu A result"
@@ -241,7 +254,10 @@ const MultiplexResultInputForm: React.FC<Props> = ({
             disabled={isSubmitDisabled}
           />
         </div>
-        <div className="grid-col-4">
+        <div
+          className="grid-col-4"
+          data-testid={`flu-b-test-result-${queueItemId}`}
+        >
           <h2 className="prime-radio__title">Flu B</h2>
           <RadioGroup
             legend="Flu B result"

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -154,10 +154,10 @@ const MultiplexResultInputForm: React.FC<Props> = ({
   const validateForm = () => {
     if (
       inconclusiveCheck ||
-      ((resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||
-        resultsMultiplexFormat.covid === TEST_RESULTS.NEGATIVE) &&
-        (resultsMultiplexFormat.fluA === TEST_RESULTS.POSITIVE ||
-          resultsMultiplexFormat.fluA === TEST_RESULTS.NEGATIVE) &&
+      resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||
+      resultsMultiplexFormat.covid === TEST_RESULTS.NEGATIVE ||
+      ((resultsMultiplexFormat.fluA === TEST_RESULTS.POSITIVE ||
+        resultsMultiplexFormat.fluA === TEST_RESULTS.NEGATIVE) &&
         (resultsMultiplexFormat.fluB === TEST_RESULTS.POSITIVE ||
           resultsMultiplexFormat.fluB === TEST_RESULTS.NEGATIVE))
     ) {

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -187,7 +187,10 @@ const MultiplexResultInputForm: React.FC<Props> = ({
     }
     return (
       inconclusiveCheck ||
-      (deviceSupportsCovidOnlyResult && covidIsFilled) ||
+      (deviceSupportsCovidOnlyResult &&
+        covidIsFilled &&
+        !fluAIsFilled &&
+        !fluBIsFilled) ||
       (covidIsFilled && fluAIsFilled && fluBIsFilled)
     );
   };

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -110,7 +110,14 @@ const MultiplexResultInputForm: React.FC<Props> = ({
     diseaseName: "covid" | "fluA" | "fluB",
     value: TestResult
   ) => {
-    const newResults: MultiplexResultState = { ...resultsMultiplexFormat };
+    let newResults: MultiplexResultState = resultsMultiplexFormat;
+    if (inconclusiveCheck) {
+      newResults = {
+        covid: TEST_RESULTS.UNKNOWN,
+        fluA: TEST_RESULTS.UNKNOWN,
+        fluB: TEST_RESULTS.UNKNOWN,
+      };
+    }
     newResults[diseaseName] = value;
     convertAndSendResults(newResults);
   };

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -14,7 +14,11 @@ import LanguageToggler from "../../patientApp/LanguageToggler";
 import { GetTestResultForPrintDocument } from "../../generated/graphql";
 import { displayFullName } from "../utils";
 import { formatDateWithTimeOption } from "../utils/date";
-import { hasMultiplexResults } from "../utils/testResults";
+import {
+  haCovidResults,
+  hasMultiplexResults,
+  hasPositiveFluResults,
+} from "../utils/testResults";
 import { setLanguage } from "../utils/languages";
 
 interface OrderingProvider {
@@ -185,14 +189,16 @@ export const StaticTestResultModal = ({
             />
           </ul>
         </section>
-        <section className="sr-result-section sr-result-next-steps">
-          <h2>{t("testResult.moreInformation")}</h2>
-          <MultiplexResultsGuidance
-            results={results}
-            isPatientApp={isPatientApp}
-            multiplexEnabled={multiplexEnabled}
-          />
-        </section>
+        {(haCovidResults(results) || hasPositiveFluResults(results)) && (
+          <section className="sr-result-section sr-result-next-steps">
+            <h2>{t("testResult.moreInformation")}</h2>
+            <MultiplexResultsGuidance
+              results={results}
+              isPatientApp={isPatientApp}
+              multiplexEnabled={multiplexEnabled}
+            />
+          </section>
+        )}
       </main>
       <footer>
         <p>

--- a/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultPrintModal.test.tsx.snap
@@ -290,8 +290,13 @@ Object {
                   More information
                 </h2>
                 <div
-                  class=""
+                  class="sr-margin-bottom-28px"
                 >
+                  <p
+                    class="text-bold sr-guidance-heading"
+                  >
+                    For COVID-19:
+                  </p>
                   <p>
                     Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
                   </p>
@@ -661,8 +666,13 @@ your local health department.
                 More information
               </h2>
               <div
-                class=""
+                class="sr-margin-bottom-28px"
               >
+                <p
+                  class="text-bold sr-guidance-heading"
+                >
+                  For COVID-19:
+                </p>
                 <p>
                   Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
                 </p>
@@ -1962,8 +1972,13 @@ Object {
                   More information
                 </h2>
                 <div
-                  class=""
+                  class="sr-margin-bottom-28px"
                 >
+                  <p
+                    class="text-bold sr-guidance-heading"
+                  >
+                    For COVID-19:
+                  </p>
                   <p>
                     Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
                   </p>
@@ -2297,8 +2312,13 @@ your local health department.
                 More information
               </h2>
               <div
-                class=""
+                class="sr-margin-bottom-28px"
               >
+                <p
+                  class="text-bold sr-guidance-heading"
+                >
+                  For COVID-19:
+                </p>
                 <p>
                   Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
                 </p>

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -53,7 +53,6 @@ export function hasPositiveFluResults(results: MultiplexResults): boolean {
 }
 
 export function haCovidResults(results: MultiplexResults): boolean {
-  console.log(results);
   return (
     results.filter((multiplexResult: MultiplexResult) =>
       multiplexResult.disease.name.includes("COVID-19")

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -51,3 +51,12 @@ export function hasPositiveFluResults(results: MultiplexResults): boolean {
     ).length > 0
   );
 }
+
+export function haCovidResults(results: MultiplexResults): boolean {
+  console.log(results);
+  return (
+    results.filter((multiplexResult: MultiplexResult) =>
+      multiplexResult.disease.name.includes("COVID-19")
+    ).length > 0
+  );
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2139,6 +2139,8 @@ export type GetFacilityQueueQuery = {
           testLength: number;
           supportedDiseaseTestPerformed: Array<{
             __typename?: "SupportedDiseaseTestPerformed";
+            testPerformedLoincCode: string;
+            testOrderedLoincCode?: string | null | undefined;
             supportedDisease: {
               __typename?: "SupportedDisease";
               internalId: string;
@@ -6112,6 +6114,8 @@ export const GetFacilityQueueDocument = gql`
         name
         testLength
         supportedDiseaseTestPerformed {
+          testPerformedLoincCode
+          testOrderedLoincCode
           supportedDisease {
             internalId
             name


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- resolves #5074 
- This is being done as a solution to this comment https://github.com/CDCgov/prime-simplereport/pull/5626#issuecomment-1505436174
- This will unblock the [deduping of prod devices](https://github.com/CDCgov/prime-simplereport/pull/5626), which will unblock the [device sync with livd](https://github.com/CDCgov/prime-simplereport/pull/5491), which will unblock the [bulk uploader device validation](https://github.com/CDCgov/prime-simplereport/pull/5542)

## Changes Proposed

- users can submit covid only for multiplex devices that have multiple covid supported disease with different testOrderedLoincs (aka they support multiplex and covid-only)
- this also make the results page aware of flu only/covid only/multiplex results

## Additional Information

- improved noop reporting service logging (it was using TestEventExport for fhir only)
- print fhir bundle on non prod envs

## Testing

- How should reviewers verify this PR? deployed on dev6
- you can test with Alinity M device

![image](https://user-images.githubusercontent.com/4952042/233734601-14d40537-2732-438b-a393-4c8654a94506.png)


<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->