### PR TITLE
admin hiv csv upload and basic endpoint

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/uploads/FileUploadController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/uploads/FileUploadController.java
@@ -54,7 +54,7 @@ public class FileUploadController {
     if (featureFlagsConfig.isHivEnabled()) {
       assertCsvFileType(file);
       try (InputStream resultsUpload = file.getInputStream()) {
-        return testResultUploadService.processUniversalResultCSV(resultsUpload);
+        return testResultUploadService.processHIVResultCSV(resultsUpload);
       } catch (IOException e) {
         log.error("Test result CSV encountered an unexpected error", e);
         throw new CsvProcessingException("Unable to process test result CSV upload");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -4,8 +4,9 @@ import gov.cdc.usds.simplereport.db.model.FeatureFlag;
 import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,28 +17,27 @@ import org.springframework.stereotype.Component;
 @EnableScheduling
 @Setter
 @Getter
+@RequiredArgsConstructor
+@Slf4j
 public class FeatureFlagsConfig {
-  @Autowired
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
-  private FeatureFlagRepository _repo;
+  private final FeatureFlagRepository _repo;
 
   private boolean multiplexEnabled;
+  private boolean hivEnabled;
 
   @Scheduled(fixedRateString = "60000") // 1 min
   private void loadFeatureFlagsFromDB() {
     Iterable<FeatureFlag> flags = _repo.findAll();
-    flags.forEach(
-        flag -> {
-          flagMapping(flag.getName(), flag.getValue());
-        });
+    flags.forEach(flag -> flagMapping(flag.getName(), flag.getValue()));
   }
 
   private void flagMapping(String flagName, Boolean flagValue) {
     switch (flagName) {
-      case "multiplexEnabled":
-        setMultiplexEnabled(flagValue);
-        break;
+      case "multiplexEnabled" -> setMultiplexEnabled(flagValue);
+      case "hivEnabled" -> setHivEnabled(flagValue);
+      default -> log.info("no mapping for " + flagName);
     }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
@@ -26,6 +26,7 @@ public class WebConfiguration implements WebMvcConfigurer {
   public static final String FEATURE_FLAGS = "/feature-flags";
   public static final String PATIENT_UPLOAD = "/upload/patients";
   public static final String RESULT_UPLOAD = "/upload/results";
+  public static final String HIV_RESULT_UPLOAD = "/upload/hiv-results";
   public static final String GRAPH_QL = "/graphql";
 
   @Autowired private PatientExperienceLoggingInterceptor _loggingInterceptor;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -183,4 +183,9 @@ public class TestResultUploadService {
 
     return _client.getSubmission(result.getReportId(), r.getAccessToken());
   }
+
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public TestResultUpload processHIVResultCSV(InputStream csvStream) {
+    return null;
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -186,6 +186,7 @@ public class TestResultUploadService {
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public TestResultUpload processHIVResultCSV(InputStream csvStream) {
-    return null;
+    FeedbackMessage[] empty = {};
+    return new TestResultUpload(UUID.randomUUID(), UploadStatus.PENDING, 0, null, empty, empty);
   }
 }

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -5,5 +5,5 @@ simple-report:
     allowed-origins:
       - https://www.simplereport.gov
       - https://simplereport.gov
-feature:
+features:
   hivEnabled: false

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -5,3 +5,5 @@ simple-report:
     allowed-origins:
       - https://www.simplereport.gov
       - https://simplereport.gov
+feature:
+  hivEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -145,4 +145,5 @@ datahub:
   jwt-scope: "simple_report.*.report"
   signing-key: ${DATAHUB_SIGNING_KEY:super-secret-signing-key}
   csv-upload-api-client: "simple_report.csvuploader"
-
+features:
+  hivEnabled: true

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsControllerTest.java
@@ -7,14 +7,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-/** ToDo Remove public modifiers from this test class once Spring for GraphQL migration is done */
 class FeatureFlagsControllerTest {
 
   private FeatureFlagsController featureFlagsController;
-  private FeatureFlagsConfig _mockFeatureFlagConfig = new FeatureFlagsConfig();
+  private final FeatureFlagsConfig _mockFeatureFlagConfig = new FeatureFlagsConfig(null);
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     _mockFeatureFlagConfig.setMultiplexEnabled(true);
     this.featureFlagsController = new FeatureFlagsController();
     ReflectionTestUtils.setField(
@@ -22,7 +21,7 @@ class FeatureFlagsControllerTest {
   }
 
   @Test
-  public void endpointReturnsFeatureFlagsConfigObj() {
+  void endpointReturnsFeatureFlagsConfigObj() {
     assertEquals(this._mockFeatureFlagConfig, this.featureFlagsController.getFeatureFlags());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
 import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
-import gov.cdc.usds.simplereport.service.PatientBulkUploadService;
 import gov.cdc.usds.simplereport.service.TestResultUploadService;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +21,6 @@ import org.springframework.web.multipart.MultipartFile;
 @ExtendWith(SpringExtension.class)
 class FileUploadControllerTest {
 
-  @Mock private PatientBulkUploadService patientBulkUploadService;
   @Mock private TestResultUploadService testResultUploadService;
   @Mock private FeatureFlagsConfig featureFlagsConfig;
   @InjectMocks private FileUploadController fileUploadController;
@@ -47,7 +45,6 @@ class FileUploadControllerTest {
     when(file.getContentType()).thenReturn("text/csv");
     when(file.getInputStream()).thenThrow(IOException.class);
 
-    fileUploadController.handleHIVResultsUpload(file);
     assertThrows(
         CsvProcessingException.class, () -> fileUploadController.handleHIVResultsUpload(file));
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
@@ -48,12 +48,4 @@ class FileUploadControllerTest {
     assertThrows(
         CsvProcessingException.class, () -> fileUploadController.handleHIVResultsUpload(file));
   }
-
-  @Test
-  void handleHIVResultsUpload_throwsUnsupportedOperationException_whenHivIsDisabled() {
-    when(featureFlagsConfig.isHivEnabled()).thenReturn(false);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> fileUploadController.handleHIVResultsUpload(null));
-  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.uploads;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -8,9 +9,13 @@ import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
 import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
+import gov.cdc.usds.simplereport.db.model.TestResultUpload;
+import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
 import gov.cdc.usds.simplereport.service.TestResultUploadService;
+import gov.cdc.usds.simplereport.service.model.reportstream.FeedbackMessage;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,12 +34,17 @@ class FileUploadControllerTest {
   void handleHIVResultsUpload_successful() throws IOException {
     var file = mock(MultipartFile.class);
     var stream = mock(InputStream.class);
+    FeedbackMessage[] empty = {};
+    var expected =
+        new TestResultUpload(UUID.randomUUID(), UploadStatus.SUCCESS, 0, null, empty, empty);
     when(featureFlagsConfig.isHivEnabled()).thenReturn(true);
     when(file.getContentType()).thenReturn("text/csv");
     when(file.getInputStream()).thenReturn(stream);
+    when(testResultUploadService.processHIVResultCSV(stream)).thenReturn(expected);
 
-    fileUploadController.handleHIVResultsUpload(file);
+    var actual = fileUploadController.handleHIVResultsUpload(file);
 
+    assertThat(actual).isEqualTo(expected);
     verify(testResultUploadService, times(1)).processHIVResultCSV(stream);
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
@@ -37,7 +37,7 @@ class FileUploadControllerTest {
 
     fileUploadController.handleHIVResultsUpload(file);
 
-    verify(testResultUploadService, times(1)).processUniversalResultCSV(stream);
+    verify(testResultUploadService, times(1)).processHIVResultCSV(stream);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/uploads/FileUploadControllerTest.java
@@ -1,0 +1,62 @@
+package gov.cdc.usds.simplereport.api.uploads;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
+import gov.cdc.usds.simplereport.service.PatientBulkUploadService;
+import gov.cdc.usds.simplereport.service.TestResultUploadService;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(SpringExtension.class)
+class FileUploadControllerTest {
+
+  @Mock private PatientBulkUploadService patientBulkUploadService;
+  @Mock private TestResultUploadService testResultUploadService;
+  @Mock private FeatureFlagsConfig featureFlagsConfig;
+  @InjectMocks private FileUploadController fileUploadController;
+
+  @Test
+  void handleHIVResultsUpload_successful() throws IOException {
+    var file = mock(MultipartFile.class);
+    var stream = mock(InputStream.class);
+    when(featureFlagsConfig.isHivEnabled()).thenReturn(true);
+    when(file.getContentType()).thenReturn("text/csv");
+    when(file.getInputStream()).thenReturn(stream);
+
+    fileUploadController.handleHIVResultsUpload(file);
+
+    verify(testResultUploadService, times(1)).processUniversalResultCSV(stream);
+  }
+
+  @Test
+  void handleHIVResultsUpload_handlesIoException() throws IOException {
+    var file = mock(MultipartFile.class);
+    when(featureFlagsConfig.isHivEnabled()).thenReturn(true);
+    when(file.getContentType()).thenReturn("text/csv");
+    when(file.getInputStream()).thenThrow(IOException.class);
+
+    fileUploadController.handleHIVResultsUpload(file);
+    assertThrows(
+        CsvProcessingException.class, () -> fileUploadController.handleHIVResultsUpload(file));
+  }
+
+  @Test
+  void handleHIVResultsUpload_throwsUnsupportedOperationException_whenHivIsDisabled() {
+    when(featureFlagsConfig.isHivEnabled()).thenReturn(false);
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> fileUploadController.handleHIVResultsUpload(null));
+  }
+}

--- a/frontend/src/app/supportAdmin/HIVUpload/HivUploadForm.tsx
+++ b/frontend/src/app/supportAdmin/HIVUpload/HivUploadForm.tsx
@@ -66,7 +66,6 @@ export const HivUploadForm = () => {
               <h1>Upload HIV CSV</h1>
             </div>
             <div className="usa-card__body padding-y-2 maxw-prose">
-              <pre>{JSON.stringify(response, null, 2)}</pre>
               <FormGroup className="margin-bottom-3">
                 <SingleFileInput
                   key={fileInputResetValue}
@@ -90,6 +89,7 @@ export const HivUploadForm = () => {
                 )}
                 {!isSubmitting && <span>Upload your CSV</span>}
               </Button>
+              <pre>{JSON.stringify(response, null, 2)}</pre>
             </div>
           </div>
         </div>

--- a/frontend/src/app/supportAdmin/HIVUpload/HivUploadForm.tsx
+++ b/frontend/src/app/supportAdmin/HIVUpload/HivUploadForm.tsx
@@ -1,0 +1,99 @@
+import { FormGroup } from "@trussworks/react-uswds";
+import React, { useState } from "react";
+
+import Button from "../../commonComponents/Button/Button";
+import SingleFileInput from "../../commonComponents/SingleFileInput";
+import { useDocumentTitle } from "../../utils/hooks";
+import { showError } from "../../utils/srToast";
+import { FileUploadService } from "../../../fileUploadService/FileUploadService";
+
+export const HivUploadForm = () => {
+  useDocumentTitle("Upload HIV CSV");
+
+  const [buttonIsDisabled, setButtonIsDisabled] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [file, setFile] = useState<File>();
+  const [response, setResponse] = useState<any>();
+  const [fileInputResetValue, setFileInputResetValue] = useState(0);
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setButtonIsDisabled(true);
+    setFile(undefined);
+
+    try {
+      if (!event?.currentTarget?.files?.length) {
+        return; //no files
+      }
+      const currentFile = event.currentTarget.files.item(0);
+      if (!currentFile) {
+        return;
+      }
+      setFile(currentFile);
+      setButtonIsDisabled(false);
+    } catch (err: any) {
+      showError(err.toString(), "An unexpected error happened");
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setButtonIsDisabled(true);
+    if (!file) {
+      setIsSubmitting(false);
+      setResponse({ error: "Empty file" });
+      setFileInputResetValue(fileInputResetValue + 1);
+      return;
+    }
+
+    FileUploadService.uploadHIVResults(file).then(async (res) => {
+      setFileInputResetValue(fileInputResetValue + 1);
+      setIsSubmitting(false);
+      setFile(undefined);
+      const response = await res.json();
+      setResponse(response);
+    });
+  };
+
+  return (
+    <div className="prime-home flex-1">
+      <div className="grid-container">
+        <div className="grid-row">
+          <div className="prime-container card-container">
+            <div className="usa-card__header">
+              <h1>Upload HIV CSV</h1>
+            </div>
+            <div className="usa-card__body padding-y-2 maxw-prose">
+              <pre>{JSON.stringify(response, null, 2)}</pre>
+              <FormGroup className="margin-bottom-3">
+                <SingleFileInput
+                  key={fileInputResetValue}
+                  id="upload-csv-input"
+                  name="upload-csv-input"
+                  ariaLabel="Choose CSV file"
+                  accept="text/csv, .csv"
+                  onChange={(e) => handleFileChange(e)}
+                  required
+                />
+              </FormGroup>
+              <Button
+                type="submit"
+                onClick={(e) => handleSubmit(e)}
+                disabled={buttonIsDisabled || file?.name?.length === 0}
+              >
+                {isSubmitting && (
+                  <span>
+                    <span>Processing file...</span>
+                  </span>
+                )}
+                {!isSubmitting && <span>Upload your CSV</span>}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -1,8 +1,11 @@
+import { useFeature } from "flagged";
+
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { useDocumentTitle } from "../utils/hooks";
 
 const SupportAdmin = () => {
   useDocumentTitle("Support admin");
+  const hivEnabled = useFeature("hivEnabled") as boolean;
 
   return (
     <div className="prime-home flex-1">
@@ -42,6 +45,13 @@ const SupportAdmin = () => {
                   Organization data
                 </LinkWithQuery>
               </div>
+              {hivEnabled && (
+                <div>
+                  <LinkWithQuery to="/admin/hiv-csv-upload">
+                    Beta - HIV CSV Upload
+                  </LinkWithQuery>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/app/supportAdmin/SupportAdminRoutes.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdminRoutes.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { useFeature } from "flagged";
 
 import AddOrganizationAdminFormContainer from "./AddOrganizationAdmin/AddOrganizationAdminFormContainer";
 import DeviceTypeFormContainer from "./DeviceType/DeviceTypeFormContainer";
@@ -7,12 +8,15 @@ import TenantDataAccessFormContainer from "./TenantDataAccess/TenantDataAccessFo
 import SupportAdmin from "./SupportAdmin";
 import PendingOrganizationsContainer from "./PendingOrganizations/PendingOrganizationsContainer";
 import ManageDeviceTypeFormContainer from "./DeviceType/ManageDeviceTypeFormContainer";
+import { HivUploadForm } from "./HIVUpload/HivUploadForm";
 
 interface Props {
   isAdmin: boolean;
 }
 
 const SupportAdminRoutes: React.FC<Props> = ({ isAdmin }) => {
+  const hivEnabled = useFeature("hivEnabled") as boolean;
+
   if (!isAdmin) {
     return <Navigate to="/queue" />;
   }
@@ -35,6 +39,9 @@ const SupportAdminRoutes: React.FC<Props> = ({ isAdmin }) => {
         path="tenant-data-access"
         element={<TenantDataAccessFormContainer />}
       />
+      {hivEnabled && (
+        <Route path="hiv-csv-upload" element={<HivUploadForm />} />
+      )}
       <Route path="/" element={<SupportAdmin />} />
     </Routes>
   );

--- a/frontend/src/fileUploadService/FileUploadService.test.ts
+++ b/frontend/src/fileUploadService/FileUploadService.test.ts
@@ -64,4 +64,29 @@ describe("FileUploadService", () => {
       });
     });
   });
+
+  describe("uploading hiv results", () => {
+    const csvFile = new File(["bar"], "results.csv");
+
+    it("calls fetch with the correct data", async () => {
+      // GIVEN
+      const expectedBody = new FormData();
+      expectedBody.append("file", csvFile);
+
+      // WHEN
+      await FileUploadService.uploadHIVResults(csvFile);
+
+      // THEN
+      expect(fetch).toHaveBeenCalledWith(`${backendUrl}/upload/hiv-results`, {
+        body: expectedBody,
+        headers: {
+          "Access-Control-Request-Headers": "Authorization",
+          Authorization: "Bearer access-token-123",
+          ...appInsightsHeaders,
+        },
+        method: "POST",
+        mode: "cors",
+      });
+    });
+  });
 });

--- a/frontend/src/fileUploadService/FileUploadService.ts
+++ b/frontend/src/fileUploadService/FileUploadService.ts
@@ -50,4 +50,8 @@ export class FileUploadService {
   static uploadResults(csvFile: File) {
     return fetch(api.getURL("/upload/results"), getInitOptions(csvFile));
   }
+
+  static uploadHIVResults(csvFile: File) {
+    return fetch(api.getURL("/upload/hiv-results"), getInitOptions(csvFile));
+  }
 }


### PR DESCRIPTION
# PULL REQUEST

## Related Issue

- Resolves #5613

## Changes Proposed

- Add a `hivEnabled` flag, which is set to true for all environment except for prod (false).
- Add an `/upload/hiv-results` endpoint
  - Uses a `@Preauthorize` annotation to return a 403 if `hivEnabled` is false.
  - If true, checkCSV file and then return a minimal `TestResultUpload` object.
- Add a support admin screen for `/admin/hiv-csv-upload`
  - This will only be accessible if `hivEnabled == true`
  - The response from the backend will be printed underneath the submit button
![image](https://user-images.githubusercontent.com/10108172/231845595-ca665ff3-be8e-4f15-9780-3fdccf4dd91e.png)

## Additional Information

- Testing was not included in the front end admin screen since it's only available in lower environments and is only for testing the endpoint.


## Testing

- Example locally when `hivEnabled` is false (in db)
https://user-images.githubusercontent.com/10108172/231869730-524b1f6c-a1a9-44fa-9a6a-066e900540f1.mp4


- Deployed in dev2!

