### PR TITLE
fix bug where results stay inconclusive after deselected

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -280,6 +280,9 @@ public class TestOrderService {
 
       if (!results.isEmpty()) {
         editMultiplexResult(order, results);
+      } else {
+        _resultRepo.deleteAll(order.getResults());
+        order.getResults().clear();
       }
       order.setDateTestedBackdate(dateTested);
       return _testOrderRepo.save(order);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Steps to reproduce

- start a test
- select `"Mark test as inconclusive"`
- deselect `"Mark test as inconclusive"`
- wait 30 seconds for events to be updated 
- notice how the test is marked as inconclusive again


## Changes Proposed

- clear all results when inconclusive is deselected

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
