### PR TITLE
move the hiv feature flag to the correct prod config

### DIFF
--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -22,3 +22,5 @@ simple-report:
 twilio:
   enabled: true
   from-number: "+14045312484"
+features:
+  hivEnabled: false

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -5,5 +5,3 @@ simple-report:
     allowed-origins:
       - https://www.simplereport.gov
       - https://simplereport.gov
-features:
-  hivEnabled: false


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- After checking prod, I noticed that the HIV beta was enabled and visible. 

## Changes Proposed

- After reviewing the properties, the profile being used in our deployed environments are actually `application-azure-{env}.yaml` and they never reference the `application-prod`. 

## Additional Information

## Testing
