### PR TITLE
Added assertions to unit testing

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -1,6 +1,9 @@
 package gov.cdc.usds.simplereport;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
@@ -9,8 +12,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
     properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
 public class SimpleReportApplicationTests {
 
+  @Autowired private SimpleReportApplication application;
+
   @Test
   void contextLoads() {
-    // no-op
+    assertThat(application).isNotNull();
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.ibm.icu.impl.Assert;
 import com.okta.sdk.client.Client;
 import com.okta.sdk.error.Error;
 import com.okta.sdk.error.ErrorCause;
@@ -806,13 +805,13 @@ class LiveOktaRepositoryTest {
     Set<Facility> userFacilities = Set.of();
     Set<OrganizationRole> userOrgRoles = Set.of(OrganizationRole.USER);
 
-    try {
-      _repo.updateUserPrivileges(userName, org, userFacilities, userOrgRoles);
-      Assert.fail("Expected an IllegalGraphqlArgumentException to be thrown");
-    } catch (IllegalGraphqlArgumentException e) {
-      assertEquals(
-          "Cannot add Okta user to nonexistent group=" + groupOrgPrefix + ":USER", e.getMessage());
-    }
+    Throwable caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            () -> _repo.updateUserPrivileges(userName, org, userFacilities, userOrgRoles));
+    assertEquals(
+        "Cannot add Okta user to nonexistent group=" + groupOrgPrefix + ":USER",
+        caught.getMessage());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -802,8 +802,12 @@ class LiveOktaRepositoryTest {
     when(mockGroupProfile.getName()).thenReturn(groupOrgDefaultName);
     when(_client.listGroups(isNull(), eq("profile.name sw \"" + groupOrgPrefix + "\""), isNull()))
         .thenReturn(mockGroupList);
+
+    Set<Facility> userFacilities = Set.of();
+    Set<OrganizationRole> userOrgRoles = Set.of(OrganizationRole.USER);
+
     try {
-      _repo.updateUserPrivileges(userName, org, Set.of(), Set.of(OrganizationRole.USER));
+      _repo.updateUserPrivileges(userName, org, userFacilities, userOrgRoles);
       Assert.fail("Expected an IllegalGraphqlArgumentException to be thrown");
     } catch (IllegalGraphqlArgumentException e) {
       assertEquals(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ibm.icu.impl.Assert;
 import com.okta.sdk.client.Client;
 import com.okta.sdk.error.Error;
 import com.okta.sdk.error.ErrorCause;
@@ -801,14 +802,13 @@ class LiveOktaRepositoryTest {
     when(mockGroupProfile.getName()).thenReturn(groupOrgDefaultName);
     when(_client.listGroups(isNull(), eq("profile.name sw \"" + groupOrgPrefix + "\""), isNull()))
         .thenReturn(mockGroupList);
-    Throwable caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class,
-            () ->
-                _repo.updateUserPrivileges(userName, org, Set.of(), Set.of(OrganizationRole.USER)));
-    assertEquals(
-        "Cannot add Okta user to nonexistent group=" + groupOrgPrefix + ":" + OrganizationRole.USER,
-        caught.getMessage());
+    try {
+      _repo.updateUserPrivileges(userName, org, Set.of(), Set.of(OrganizationRole.USER));
+      Assert.fail("Expected an IllegalGraphqlArgumentException to be thrown");
+    } catch (IllegalGraphqlArgumentException e) {
+      assertEquals(
+          "Cannot add Okta user to nonexistent group=" + groupOrgPrefix + ":USER", e.getMessage());
+    }
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -801,6 +801,14 @@ class LiveOktaRepositoryTest {
     when(mockGroupProfile.getName()).thenReturn(groupOrgDefaultName);
     when(_client.listGroups(isNull(), eq("profile.name sw \"" + groupOrgPrefix + "\""), isNull()))
         .thenReturn(mockGroupList);
+    Throwable caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            () ->
+                _repo.updateUserPrivileges(userName, org, Set.of(), Set.of(OrganizationRole.USER)));
+    assertEquals(
+        "Cannot add Okta user to nonexistent group=" + groupOrgPrefix + ":" + OrganizationRole.USER,
+        caught.getMessage());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -67,6 +67,7 @@ import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.TestPropertySource;
 
@@ -1174,8 +1175,11 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Person p = _dataFactory.createMinimalPerson(org, facility);
     _dataFactory.createTestEvent(p, facility);
 
-    _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 10);
+    Page<TestEvent> testEventsByFacility =
+        _service.getFacilityTestEventsResults(
+            facility.getInternalId(), null, null, null, null, null, 0, 10);
+    assertThat(testEventsByFacility.getTotalElements()).isEqualTo(1);
+    assertThat(testEventsByFacility.getTotalPages()).isEqualTo(1);
   }
 
   @Test
@@ -1201,7 +1205,10 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Person p = _dataFactory.createMinimalPerson(org, facility);
     _dataFactory.createTestEvent(p, facility);
 
-    _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
+    Page<TestEvent> testEventsByOrg =
+        _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
+    assertThat(testEventsByOrg.getTotalElements()).isEqualTo(1);
+    assertThat(testEventsByOrg.getTotalPages()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5582 

## Changes Proposed

- Added assertions to the test cases that had none and were listed in the ticket

## Additional Information
None

## Testing

- Ran the tests in local. As there were no code changes to the logic no manual regression testing is needed.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

