### PR TITLE
make Results table test_order_id nullable

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4715,3 +4715,12 @@ databaseChangeLog:
                   columnNames: device_type_id, supported_disease_id
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.device_supported_disease TO ${noPhiUsername};
+  - changeSet:
+      id: drop-test_order_id-not_null_constraint-from-result
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: drop-test_order_id-not_null_constraint-from-result
+        - dropNotNullConstraint:
+            tableName: result
+            columnName: test_order_id


### PR DESCRIPTION
# Database PULL REQUEST

## Related Issue

- DB changes for https://github.com/CDCgov/prime-simplereport/pull/5636
- [dropNotNullConstraint](https://docs.liquibase.com/change-types/drop-not-null-constraint.html) supports auto rollback

