### PR TITLE
[bug fix] covid device not sticking in test card

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -279,14 +279,6 @@ const QueueItem = ({
       if (supportsMultipleDiseases !== deviceSupportsMultiPlex) {
         updateSupportsMultipleDiseases(deviceSupportsMultiPlex);
       }
-      if (!deviceSupportsMultiPlex) {
-        // filter out non covid results
-        setCacheTestResults(
-          cacheTestResults.filter(
-            (result) => result.diseaseName === MULTIPLEX_DISEASES.COVID_19
-          )
-        );
-      }
     }
     // eslint-disable-next-line
   }, [deviceId]);

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -433,8 +433,12 @@ const QueueItem = ({
           patientId: queueItem.patient?.internalId,
           deviceTypeId: deviceId,
           specimenTypeId: specimenId,
-          results: cacheTestResults,
           dateTested: dateTested,
+          results: doesDeviceSupportMultiPlex(deviceId)
+            ? cacheTestResults
+            : cacheTestResults.filter(
+                (result) => result.diseaseName === MULTIPLEX_DISEASES.COVID_19
+              ),
         },
       });
       testResultsSubmitted(result);


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- changing device to covid only doesn't trigger a backend update (Not sure why!)


1. change the card to a multiplex device, notice the graphql call to update the backend
2. change the card to a covid-only device, notice the missing graphql call to update the backend

looks like triggering the [setCacheTestResults](https://github.com/CDCgov/prime-simplereport/pull/5667/files#diff-02aa88a48980d7ec2ec531bd5c4a68a527613d878cad9470fbcf5d5d903dc523L284) inside the useEffect, is not properly triggering the other useEffect to update the backend

## Changes Proposed

- remove added check to clear invalid cached results! and switched the filtering to update/onsubmit

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
