### PR TITLE
Fixed code smell: assertThrows [Part 1]

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientRegistrationLinkRepositoryTest.java
@@ -64,12 +64,12 @@ class PatientRegistrationLinkRepositoryTest extends BaseRepositoryTest {
     Organization org = _dataFactory.saveValidOrganization();
     Facility fac = _dataFactory.createValidFacility(org, "Foo Facility");
     _repo.save(new PatientSelfRegistrationLink(fac, "the-link"));
-
+    PatientSelfRegistrationLink patientLink = new PatientSelfRegistrationLink(org, "the-link");
+    _repo.save(patientLink);
     PersistenceException caught =
         assertThrows(
             PersistenceException.class,
             () -> {
-              _repo.save(new PatientSelfRegistrationLink(org, "the-link"));
               flush();
             });
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -145,11 +145,11 @@ class TestOrderRepositoryTest extends BaseRepositoryTest {
     _repo.save(order1);
     flush();
     TestOrder order2 = new TestOrder(patient0, site);
+    _repo.save(order2);
     PersistenceException caught =
         assertThrows(
             PersistenceException.class,
             () -> {
-              _repo.save(order2);
               flush();
             });
     assertEquals(ConstraintViolationException.class, caught.getCause().getClass());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -274,10 +274,12 @@ class DemoOktaRepositoryTest {
         Set.of(OrganizationRole.USER, OrganizationRole.ALL_FACILITIES),
         true);
 
+    String username = BRAD.getUsername();
+
     assertThrows(
         ConflictingUserException.class,
         () -> {
-          _repo.updateUserEmail(AMOS, BRAD.getUsername());
+          _repo.updateUserEmail(AMOS, username);
         });
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -423,10 +423,12 @@ class LiveOktaRepositoryTest {
     var identityAttributes = new IdentityAttributes(username, personName);
     var org = new Organization("orgName", "orgType", "1", true);
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of();
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> _repo.createUser(identityAttributes, org, Set.of(), Set.of(), true));
+            () -> _repo.createUser(identityAttributes, org, facilities, roles, true));
     assertEquals("Cannot create Okta user without last name", caught.getMessage());
   }
 
@@ -437,10 +439,12 @@ class LiveOktaRepositoryTest {
     var identityAttributes = new IdentityAttributes(null, personName);
     var org = new Organization("orgName", "orgType", "1", true);
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of();
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> _repo.createUser(identityAttributes, org, Set.of(), Set.of(), true));
+            () -> _repo.createUser(identityAttributes, org, facilities, roles, true));
     assertEquals("Cannot create Okta user without username", caught.getMessage());
   }
 
@@ -456,10 +460,12 @@ class LiveOktaRepositoryTest {
     when(_client.listGroups(anyString(), isNull(), isNull())).thenReturn(mockGroupList);
     when(_client.listGroups(isNull(), anyString(), isNull())).thenReturn(mockGroupList);
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of();
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> _repo.createUser(identityAttributes, org, Set.of(), Set.of(), true));
+            () -> _repo.createUser(identityAttributes, org, facilities, roles, true));
     assertEquals(
         "Cannot add Okta user to nonexistent organization=" + org.getExternalId(),
         caught.getMessage());
@@ -483,10 +489,12 @@ class LiveOktaRepositoryTest {
     when(mockGroup.getProfile()).thenReturn(mockGroupProfile);
     when(mockGroupProfile.getName()).thenReturn("nonexistent");
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of();
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> _repo.createUser(identityAttributes, org, Set.of(), Set.of(), true));
+            () -> _repo.createUser(identityAttributes, org, facilities, roles, true));
     assertEquals(
         "Cannot add Okta user to nonexistent group=" + groupProfileName, caught.getMessage());
   }
@@ -701,10 +709,12 @@ class LiveOktaRepositoryTest {
         .thenReturn(mockUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of();
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> _repo.updateUserPrivileges(userName, org, Set.of(), Set.of()));
+            () -> _repo.updateUserPrivileges(userName, org, facilities, roles));
     assertEquals("Cannot update role of Okta user with unrecognized username", caught.getMessage());
   }
 
@@ -729,10 +739,12 @@ class LiveOktaRepositoryTest {
     when(mockGroup.getProfile()).thenReturn(mockGroupProfile);
     when(mockGroupProfile.getName()).thenReturn("");
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of();
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () -> _repo.updateUserPrivileges(userName, org, Set.of(), Set.of()));
+            () -> _repo.updateUserPrivileges(userName, org, facilities, roles));
     assertEquals(
         "Cannot update privileges of Okta user in organization they do not belong to.",
         caught.getMessage());
@@ -766,12 +778,12 @@ class LiveOktaRepositoryTest {
         .thenReturn(mockEmptyGroupList);
     when(mockEmptyGroupList.stream()).then(i -> Stream.of());
 
+    Set<Facility> facilities = Set.of();
+    Set<OrganizationRole> roles = Set.of(OrganizationRole.ADMIN);
     Throwable caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
-            () ->
-                _repo.updateUserPrivileges(
-                    userName, org, Set.of(), Set.of(OrganizationRole.ADMIN)));
+            () -> _repo.updateUserPrivileges(userName, org, facilities, roles));
     assertEquals(
         "Cannot add Okta user to nonexistent organization=" + org.getExternalId(),
         caught.getMessage());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
@@ -119,17 +119,24 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
   @Test
   void editQueueItem_failsToFindValidOrg() {
+
+    Optional<String> editedOrgName = Optional.empty();
+    Optional<String> editedOrgAdminFirstName = Optional.empty();
+    Optional<String> editedOrgAdminLastName = Optional.empty();
+    Optional<String> editedOrgAdminEmail = Optional.of("foo@bar.com");
+    Optional<String> editedOrgAdminPhone = Optional.of("123-456-7890");
+
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () -> {
               _service.editQueueItem(
                   "nonsense id",
-                  Optional.empty(),
-                  Optional.empty(),
-                  Optional.empty(),
-                  Optional.of("foo@bar.com"),
-                  Optional.of("123-456-7890"));
+                  editedOrgName,
+                  editedOrgAdminFirstName,
+                  editedOrgAdminLastName,
+                  editedOrgAdminEmail,
+                  editedOrgAdminPhone);
             });
     assertEquals(
         exception.getMessage(), "Requesting edits on an organization that does not exist.");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -126,6 +126,9 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   void createOrganizationAndFacility_orderingProviderRequired_failure() {
     // GIVEN
     PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
+    StreetAddress mockAddress = getAddress();
+    List<UUID> deviceTypeIds = List.of(getDeviceConfig().getInternalId());
+
     // THEN
     assertThrows(
         OrderingProviderRequiredException.class,
@@ -136,12 +139,12 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
                 "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
                 "Facility 1",
                 "12345",
-                getAddress(),
+                mockAddress,
                 "123-456-7890",
                 "test@foo.com",
-                List.of(getDeviceConfig().getInternalId()),
+                deviceTypeIds,
                 orderProviderName,
-                getAddress(),
+                mockAddress,
                 null,
                 null));
   }
@@ -249,11 +252,12 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @DisplayName("it should not delete nonexistent facilities")
   @WithSimpleReportSiteAdminUser
   void deletedFacilityTest_throwsErrorWhenFacilityNotFound() {
+    UUID orgId = UUID.randomUUID();
     IllegalGraphqlArgumentException caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
             // fake UUID
-            () -> _service.markFacilityAsDeleted(UUID.randomUUID(), true));
+            () -> _service.markFacilityAsDeleted(orgId, true));
     assertEquals("Facility not found.", caught.getMessage());
   }
 
@@ -274,11 +278,13 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @DisplayName("it should not delete nonexistent organizations")
   @WithSimpleReportSiteAdminUser
   void deletedOrganizationTest_throwsErrorWhenOrganizationyNotFound() {
+    UUID orgId = UUID.randomUUID();
+
     IllegalGraphqlArgumentException caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
             // fake UUID
-            () -> _service.markOrganizationAsDeleted(UUID.randomUUID(), true));
+            () -> _service.markOrganizationAsDeleted(orgId, true));
     assertEquals("Organization not found.", caught.getMessage());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PatientLinkServiceTest.java
@@ -56,8 +56,8 @@ class PatientLinkServiceTest extends BaseServiceTest<PatientLinkService> {
   void getPatientLink() {
     PatientLink result = _service.getPatientLink(_patientLink.getInternalId());
     assertEquals(result.getInternalId(), _patientLink.getInternalId());
-    assertThrows(
-        InvalidPatientLinkException.class, () -> _service.getPatientLink(UUID.randomUUID()));
+    UUID internalId = UUID.randomUUID();
+    assertThrows(InvalidPatientLinkException.class, () -> _service.getPatientLink(internalId));
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixes #5586 

## Changes Proposed

- Instantiate method parameters in variables before passing them into the method to be tested.

## Additional Information

None

## Testing

- Backend unit testing should pass

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
