### PR TITLE
Fixed type mismatch between resultsTable and TestResultsList

### DIFF
--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -277,6 +277,12 @@ exports[`QueueItem matches snapshot 1`] = `
                     >
                       Multiplex
                     </option>
+                    <option
+                      aria-selected="false"
+                      value="da524a8e-672d-4ff4-a4ec-c1e14d0337db"
+                    >
+                      MultiplexAndCovidOnly
+                    </option>
                   </select>
                 </div>
               </div>

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -47,6 +47,7 @@ import {
   GetFacilityResultsMultiplexWithCountQuery,
   useGetAllFacilitiesQuery,
   useGetFacilityResultsMultiplexWithCountQuery,
+  Maybe,
 } from "../../generated/graphql";
 import { waitForElement } from "../utils/elements";
 
@@ -159,12 +160,19 @@ export const DetachedTestResultsList = ({
   clearFilterParams,
   maxDate = moment().format("YYYY-MM-DD"),
 }: DetachedTestResultsListProps) => {
-  const [printModalId, setPrintModalId] = useState(undefined);
-  const [markCorrectionId, setMarkCorrectionId] = useState(undefined);
-  const [detailsModalId, setDetailsModalId] = useState<string>();
-  const [textModalId, setTextModalId] = useState<string>();
-  const [emailModalTestResultId, setEmailModalTestResultId] =
-    useState<string>();
+  const [printModalId, setPrintModalId] = useState<Maybe<string> | undefined>(
+    undefined
+  );
+  const [markCorrectionId, setMarkCorrectionId] = useState<
+    Maybe<string> | undefined
+  >(undefined);
+  const [detailsModalId, setDetailsModalId] = useState<
+    Maybe<string> | undefined
+  >();
+  const [textModalId, setTextModalId] = useState<Maybe<string> | undefined>();
+  const [emailModalTestResultId, setEmailModalTestResultId] = useState<
+    Maybe<string> | undefined
+  >();
   const [showSuggestion, setShowSuggestion] = useState(true);
   const [startDateError, setStartDateError] = useState<string | undefined>();
   const [endDateError, setEndDateError] = useState<string | undefined>();

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -43,6 +43,7 @@ import Select from "../commonComponents/Select";
 import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 import { appPermissions, hasPermission } from "../permissions";
 import {
+  TestResult,
   GetFacilityResultsMultiplexWithCountQuery,
   useGetAllFacilitiesQuery,
   useGetFacilityResultsMultiplexWithCountQuery,
@@ -552,7 +553,7 @@ export const DetachedTestResultsList = ({
         </div>
         <div title="filtered-result">
           <ResultsTable
-            results={testResults}
+            results={testResults as TestResult[]}
             setPrintModalId={setPrintModalId}
             setMarkCorrectionId={setMarkCorrectionId}
             setDetailsModalId={setDetailsModalId}

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
@@ -4,10 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { PATIENT_TERM_CAP } from "../../../config/constants";
 import TEST_RESULTS_MULTIPLEX from "../mocks/resultsMultiplex.mock";
 import TEST_RESULT_COVID from "../mocks/resultsCovid.mock";
+import { TestResult } from "../../../generated/graphql";
 
 import ResultsTable, { generateTableHeaders } from "./ResultsTable";
 
-const TEST_RESULTS_MULTIPLEX_CONTENT = TEST_RESULTS_MULTIPLEX.content;
+const TEST_RESULTS_MULTIPLEX_CONTENT =
+  TEST_RESULTS_MULTIPLEX.content as TestResult[];
 describe("Method generateTableHeaders", () => {
   const table = (headers: JSX.Element) => (
     <table>
@@ -100,7 +102,7 @@ describe("Component ResultsTable", () => {
   it("checks table with covid results", () => {
     render(
       <ResultsTable
-        results={[TEST_RESULT_COVID.content[0]]}
+        results={[TEST_RESULT_COVID.content[0]] as TestResult[]}
         setPrintModalId={setPrintModalIdFn}
         setMarkCorrectionId={setMarkCorrectionIdFn}
         setDetailsModalId={setDetailsModalIdFn}
@@ -202,7 +204,9 @@ describe("Component ResultsTable", () => {
     });
     describe("email result action", () => {
       it("includes `Email result` if patient email address", async () => {
-        const testResultPatientEmail = [TEST_RESULTS_MULTIPLEX_CONTENT[0]];
+        const testResultPatientEmail: TestResult[] = [
+          TEST_RESULTS_MULTIPLEX_CONTENT[0],
+        ];
 
         render(
           <ResultsTable

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
@@ -69,12 +69,12 @@ function createActionItemList(
   const actionItems = [];
   actionItems.push({
     name: "Print result",
-    action: () => setPrintModalId(r.internalId as String),
+    action: () => setPrintModalId(r.internalId),
   });
   if (r.patient?.email) {
     actionItems.push({
       name: "Email result",
-      action: () => setEmailModalTestResultId(r.internalId as String),
+      action: () => setEmailModalTestResultId(r.internalId),
     });
   }
 
@@ -85,19 +85,19 @@ function createActionItemList(
   ) {
     actionItems.push({
       name: "Text result",
-      action: () => setTextModalId(r.internalId as String),
+      action: () => setTextModalId(r.internalId),
     });
   }
 
   if (!removed) {
     actionItems.push({
       name: "Correct result",
-      action: () => setMarkCorrectionId(r.internalId as String),
+      action: () => setMarkCorrectionId(r.internalId),
     });
   }
   actionItems.push({
     name: "View details",
-    action: () => setDetailsModalId(r.internalId as String),
+    action: () => setDetailsModalId(r.internalId),
   });
   return actionItems;
 }
@@ -180,7 +180,7 @@ const generateResultRows = (
               r.patient?.middleName,
               r.patient?.lastName
             )}
-            onClick={() => setDetailsModalId(r.internalId as String)}
+            onClick={() => setDetailsModalId(r.internalId)}
             className="sr-link__primary"
           />
           <span className="display-block text-base font-ui-2xs">
@@ -204,7 +204,7 @@ const generateResultRows = (
         {hasFacility && (
           <td className="test-facility-cell">
             {facilityDisplayName(
-              r.facility?.name as String,
+              r.facility?.name as string,
               r.facility?.isDeleted as boolean
             )}
           </td>

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import classnames from "classnames";
 
 import { PATIENT_TERM_CAP } from "../../../config/constants";
@@ -58,13 +58,15 @@ export const generateTableHeaders = (
 );
 
 function createActionItemList(
-  setPrintModalId: Function,
+  setPrintModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
   r: TestResult,
-  setEmailModalTestResultId: Function,
-  setTextModalId: Function,
+  setEmailModalTestResultId: Dispatch<
+    SetStateAction<Maybe<string> | undefined>
+  >,
+  setTextModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
   removed: boolean,
-  setMarkCorrectionId: Function,
-  setDetailsModalId: Function
+  setMarkCorrectionId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
+  setDetailsModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>
 ) {
   const actionItems = [];
   actionItems.push({
@@ -104,11 +106,13 @@ function createActionItemList(
 
 const generateResultRows = (
   testResults: Array<TestResult>,
-  setPrintModalId: Function,
-  setMarkCorrectionId: Function,
-  setDetailsModalId: Function,
-  setTextModalId: Function,
-  setEmailModalTestResultId: Function,
+  setPrintModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
+  setMarkCorrectionId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
+  setDetailsModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
+  setTextModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>,
+  setEmailModalTestResultId: Dispatch<
+    SetStateAction<Maybe<string> | undefined>
+  >,
   hasMultiplexResults: boolean,
   hasFacility: boolean
 ) => {
@@ -219,11 +223,13 @@ const generateResultRows = (
 
 interface ResultsTableListProps {
   results: Array<TestResult>;
-  setPrintModalId: Function;
-  setMarkCorrectionId: Function;
-  setDetailsModalId: Function;
-  setTextModalId: Function;
-  setEmailModalTestResultId: Function;
+  setPrintModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>;
+  setMarkCorrectionId: Dispatch<SetStateAction<Maybe<string> | undefined>>;
+  setDetailsModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>;
+  setTextModalId: Dispatch<SetStateAction<Maybe<string> | undefined>>;
+  setEmailModalTestResultId: Dispatch<
+    SetStateAction<Maybe<string> | undefined>
+  >;
   hasMultiplexResults: boolean;
   hasFacility: boolean;
 }

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
@@ -1,4 +1,4 @@
-import React, { SetStateAction } from "react";
+import React from "react";
 import classnames from "classnames";
 
 import { PATIENT_TERM_CAP } from "../../../config/constants";
@@ -11,7 +11,7 @@ import { ActionsMenu } from "../../commonComponents/ActionsMenu";
 import { byDateTested } from "../TestResultsList";
 import { MULTIPLEX_DISEASES } from "../constants";
 import { toLowerCaseHyphenate } from "../../utils/text";
-import { TestResult, PhoneNumber } from "../../../generated/graphql";
+import { TestResult, PhoneNumber, Maybe } from "../../../generated/graphql";
 import { getResultObjByDiseaseName } from "../../utils/testResults";
 
 export const generateTableHeaders = (
@@ -58,13 +58,13 @@ export const generateTableHeaders = (
 );
 
 function createActionItemList(
-  setPrintModalId: SetStateAction<String>,
+  setPrintModalId: Function,
   r: TestResult,
-  setEmailModalTestResultId: SetStateAction<String>,
-  setTextModalId: SetStateAction<String>,
+  setEmailModalTestResultId: Function,
+  setTextModalId: Function,
   removed: boolean,
-  setMarkCorrectionId: SetStateAction<String>,
-  setDetailsModalId: SetStateAction<String>
+  setMarkCorrectionId: Function,
+  setDetailsModalId: Function
 ) {
   const actionItems = [];
   actionItems.push({
@@ -79,7 +79,9 @@ function createActionItemList(
   }
 
   if (
-    r.patient?.phoneNumbers?.some((pn: PhoneNumber) => pn.type === "MOBILE")
+    r.patient?.phoneNumbers?.some(
+      (pn: Maybe<PhoneNumber>) => pn?.type === "MOBILE"
+    )
   ) {
     actionItems.push({
       name: "Text result",
@@ -102,11 +104,11 @@ function createActionItemList(
 
 const generateResultRows = (
   testResults: Array<TestResult>,
-  setPrintModalId: SetStateAction<String>,
-  setMarkCorrectionId: SetStateAction<String>,
-  setDetailsModalId: SetStateAction<String>,
-  setTextModalId: SetStateAction<String>,
-  setEmailModalTestResultId: SetStateAction<String>,
+  setPrintModalId: Function,
+  setMarkCorrectionId: Function,
+  setDetailsModalId: Function,
+  setTextModalId: Function,
+  setEmailModalTestResultId: Function,
   hasMultiplexResults: boolean,
   hasFacility: boolean
 ) => {
@@ -208,7 +210,7 @@ const generateResultRows = (
           </td>
         )}
         <td className="actions-cell">
-          <ActionsMenu items={actionItems} id={r.internalId as String} />
+          <ActionsMenu items={actionItems} id={r.internalId as string} />
         </td>
       </tr>
     );
@@ -217,11 +219,11 @@ const generateResultRows = (
 
 interface ResultsTableListProps {
   results: Array<TestResult>;
-  setPrintModalId: SetStateAction<String>;
-  setMarkCorrectionId: SetStateAction<String>;
-  setDetailsModalId: SetStateAction<String>;
-  setTextModalId: SetStateAction<String>;
-  setEmailModalTestResultId: SetStateAction<String>;
+  setPrintModalId: Function;
+  setMarkCorrectionId: Function;
+  setDetailsModalId: Function;
+  setTextModalId: Function;
+  setEmailModalTestResultId: Function;
   hasMultiplexResults: boolean;
   hasFacility: boolean;
 }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- I added typing to the ResultsTable in a previous PR but didn't made sure the types matched or were added to the component that uses ResultsTable. 

## Changes Proposed

- Modify the types in ResultsTable and add casting to TestResultList

## Additional Information

- The addition of types should not break any functionality as type checks is a process done at compilation time not runtime.

## Testing

- Verify the test result table loads

