### PR TITLE
sync prod specimen with livd via manual migration

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/DeviceMigrationController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/DeviceMigrationController.java
@@ -15,4 +15,9 @@ public class DeviceMigrationController {
     deviceMigrationService.mergeDuplicateDevices();
     return "Done";
   }
+
+  @GetMapping("/specimenTypes/updateSpecimenTypes")
+  public String updateSpecimenTypes() {
+    return deviceMigrationService.updateSpecimenTypes();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/SpecimenTypeRepository.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SpecimenTypeRepository extends EternalAuditedEntityRepository<SpecimenType> {
@@ -9,6 +10,8 @@ public interface SpecimenTypeRepository extends EternalAuditedEntityRepository<S
   List<SpecimenType> findAll();
 
   SpecimenType findByInternalId(UUID internalID);
+
+  Optional<SpecimenType> findByTypeCode(String typeCode);
 
   List<SpecimenType> findAllByInternalIdIn(List<UUID> uuids);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceMigrationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceMigrationService.java
@@ -3,9 +3,13 @@ package gov.cdc.usds.simplereport.service;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
+import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +20,7 @@ public class DeviceMigrationService {
 
   private final DeviceTypeRepository deviceTypeRepository;
   private final FacilityRepository facilityRepository;
+  private final SpecimenTypeRepository specimenTypeRepository;
 
   List<Pair> duplicateDevices =
       List.of(
@@ -38,6 +43,68 @@ public class DeviceMigrationService {
           new Pair("Sofia SARS FIA (Antigen)", "Quidel Sofia SARS (Antigen)"),
           new Pair("Cepheid Xpert Xpress (RT-PCR)", "GeneXpert Xpress (RT-PCR)"),
           new Pair("Xpert Xpress - Flu + COVID-19 (RT-PCR)", "Xpert Xpress - COVID-19 (RT-PCR)"));
+
+  List<SpecimenEntry> specimenEntries =
+      List.of(
+          new SpecimenEntry("Anterior nares swab", "697989009"),
+          new SpecimenEntry("Mid-turbinate nasal swab", "871810001"),
+          new SpecimenEntry("Nasopharyngeal swab", "258500001"),
+          new SpecimenEntry("Throat swab", "258529004"),
+          new SpecimenEntry("Nasopharyngeal washings", "258467004"),
+          new SpecimenEntry("Nasopharyngeal aspirate", "258411007"),
+          new SpecimenEntry("Nasal aspirate specimen", "429931000124105"),
+          new SpecimenEntry("Swab of internal nose", "445297001"),
+          new SpecimenEntry("Nasopharyngeal and oropharyngeal swab", "433801000124107"),
+          new SpecimenEntry("Serum specimen", "119364003"),
+          new SpecimenEntry("Plasma specimen", "119361006"),
+          new SpecimenEntry("Venous blood specimen", "122555007"),
+          new SpecimenEntry("Bronchoalveolar lavage fluid sample", "258607008"),
+          new SpecimenEntry("Whole blood sample", "258580003"),
+          new SpecimenEntry("Capillary blood specimen", "122554006"),
+          new SpecimenEntry("Sputum specimen", "119334006"),
+          new SpecimenEntry("Nasal washings", "433871000124101"),
+          new SpecimenEntry("Oral saliva sample", "258560004"),
+          new SpecimenEntry("Sputum specimen obtained by sputum induction", "258610001"),
+          new SpecimenEntry("Coughed sputum specimen", "119335007"),
+          new SpecimenEntry("Specimen from trachea obtained by aspiration", "445447003"),
+          new SpecimenEntry("Lower respiratory fluid sample", "309171007"),
+          new SpecimenEntry("Oral fluid specimen", "441620008"),
+          new SpecimenEntry("Specimen obtained by bronchial aspiration", "441903006"),
+          new SpecimenEntry("Exhaled air specimen", "119336008"),
+          new SpecimenEntry("Dried blood spot specimen", "440500007"));
+
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public String updateSpecimenTypes() {
+
+    ArrayList<String> log = new ArrayList<>();
+
+    for (SpecimenEntry entry : specimenEntries) {
+      Optional<SpecimenType> optionalSpecimenType =
+          specimenTypeRepository.findByTypeCode(entry.loinc);
+
+      if (optionalSpecimenType.isPresent()) {
+        SpecimenType specimenType = optionalSpecimenType.get();
+
+        if (!specimenType.getName().equals(entry.name)) {
+          log.add(
+              "* setting specimenType name from: '"
+                  + specimenType.getName()
+                  + "' to: '"
+                  + entry.name
+                  + "'");
+          specimenType.setName(entry.name);
+          specimenTypeRepository.save(specimenType);
+        } else {
+          log.add("= " + specimenType.getName() + " was left unchanged");
+        }
+      } else {
+        specimenTypeRepository.save(new SpecimenType(entry.name, entry.loinc));
+        log.add("+ created specimenType name: " + entry.name + " typecode: " + entry.loinc);
+      }
+    }
+
+    return String.join("\n", log);
+  }
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public void mergeDuplicateDevices() {
@@ -67,4 +134,6 @@ public class DeviceMigrationService {
   }
 
   public record Pair(String original, String duplicate) {}
+
+  public record SpecimenEntry(String name, String loinc) {}
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceMigrationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceMigrationServiceTest.java
@@ -35,6 +35,75 @@ class DeviceMigrationServiceTest extends BaseServiceTest<DeviceMigrationService>
   private SpecimenType specimenType;
 
   @Test
+  void updateSpecimenTypeTest() {
+
+    // GIVEN
+    specimenTypeRepository.deleteAll();
+    List<SpecimenType> prodSpecimenTypes =
+        List.of(
+            new SpecimenType("Plasma Specimen", "119361006"),
+            new SpecimenType("Serum Specimen", "119364003"),
+            new SpecimenType("Whole Blood Sample", "258580003"),
+            new SpecimenType("Nasopharyngeal Swab", "258500001"),
+            new SpecimenType("Mid-Turbinate Nasal Swab", "871810001"),
+            new SpecimenType("Anterior Nasal Swab", "697989009"),
+            new SpecimenType("Nasal Swab", "445297001"),
+            new SpecimenType("Oropharyngeal Swab", "258529004"),
+            new SpecimenType("Nasopharyngeal Wash", "258467004"),
+            new SpecimenType("Nasal and Throat Swab Combination", "433801000124107"),
+            new SpecimenType("Nasal Washings", "433871000124101"),
+            new SpecimenType("Bronchoalveolar Lavage", "258607008"),
+            new SpecimenType("Sputum", "119334006"),
+            new SpecimenType("Lower Respiratory Tract Aspirates", "309171007"),
+            new SpecimenType("Nasal Wash/Aspirate", "429931000124105"),
+            new SpecimenType("Saliva", "258560004"),
+            new SpecimenType("Nasopharyngeal aspirate", "258411007"),
+            new SpecimenType("Tracheal Aspirates", "445447003"),
+            new SpecimenType("Induced Sputum", "258610001"),
+            new SpecimenType("Expectorated Sputum", "119335007"));
+    specimenTypeRepository.saveAll(prodSpecimenTypes);
+    assertThat(specimenTypeRepository.findAll()).hasSize(20);
+
+    // WHEN
+    String log = deviceMigrationService.updateSpecimenTypes();
+
+    // THEN
+    assertThat(specimenTypeRepository.findAll()).hasSize(26);
+    assertThat(log)
+        .isEqualTo(
+            """
+      * setting specimenType name from: 'Anterior Nasal Swab' to: 'Anterior nares swab'
+      * setting specimenType name from: 'Mid-Turbinate Nasal Swab' to: 'Mid-turbinate nasal swab'
+      * setting specimenType name from: 'Nasopharyngeal Swab' to: 'Nasopharyngeal swab'
+      * setting specimenType name from: 'Oropharyngeal Swab' to: 'Throat swab'
+      * setting specimenType name from: 'Nasopharyngeal Wash' to: 'Nasopharyngeal washings'
+      = Nasopharyngeal aspirate was left unchanged
+      * setting specimenType name from: 'Nasal Wash/Aspirate' to: 'Nasal aspirate specimen'
+      * setting specimenType name from: 'Nasal Swab' to: 'Swab of internal nose'
+      * setting specimenType name from: 'Nasal and Throat Swab Combination' to: 'Nasopharyngeal and oropharyngeal swab'
+      * setting specimenType name from: 'Serum Specimen' to: 'Serum specimen'
+      * setting specimenType name from: 'Plasma Specimen' to: 'Plasma specimen'
+      + created specimenType name: Venous blood specimen typecode: 122555007
+      * setting specimenType name from: 'Bronchoalveolar Lavage' to: 'Bronchoalveolar lavage fluid sample'
+      * setting specimenType name from: 'Whole Blood Sample' to: 'Whole blood sample'
+      + created specimenType name: Capillary blood specimen typecode: 122554006
+      * setting specimenType name from: 'Sputum' to: 'Sputum specimen'
+      * setting specimenType name from: 'Nasal Washings' to: 'Nasal washings'
+      * setting specimenType name from: 'Saliva' to: 'Oral saliva sample'
+      * setting specimenType name from: 'Induced Sputum' to: 'Sputum specimen obtained by sputum induction'
+      * setting specimenType name from: 'Expectorated Sputum' to: 'Coughed sputum specimen'
+      * setting specimenType name from: 'Tracheal Aspirates' to: 'Specimen from trachea obtained by aspiration'
+      * setting specimenType name from: 'Lower Respiratory Tract Aspirates' to: 'Lower respiratory fluid sample'
+      + created specimenType name: Oral fluid specimen typecode: 441620008
+      + created specimenType name: Specimen obtained by bronchial aspiration typecode: 441903006
+      + created specimenType name: Exhaled air specimen typecode: 119336008
+      + created specimenType name: Dried blood spot specimen typecode: 440500007
+      """
+                .trim());
+    System.out.println(log);
+  }
+
+  @Test
   void mergeDuplicateDevicesTest() {
 
     // GIVEN


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Sync prod specimenTypes with livd table

## Changes Proposed

- Add manual hook code to perform the data migration


```
* setting specimenType name from: 'Anterior Nasal Swab' to: 'Anterior nares swab'
* setting specimenType name from: 'Mid-Turbinate Nasal Swab' to: 'Mid-turbinate nasal swab'
* setting specimenType name from: 'Nasopharyngeal Swab' to: 'Nasopharyngeal swab'
* setting specimenType name from: 'Oropharyngeal Swab' to: 'Throat swab'
* setting specimenType name from: 'Nasopharyngeal Wash' to: 'Nasopharyngeal washings'
= Nasopharyngeal aspirate was left unchanged
* setting specimenType name from: 'Nasal Wash/Aspirate' to: 'Nasal aspirate specimen'
* setting specimenType name from: 'Nasal Swab' to: 'Swab of internal nose'
* setting specimenType name from: 'Nasal and Throat Swab Combination' to: 'Nasopharyngeal and oropharyngeal swab'
* setting specimenType name from: 'Serum Specimen' to: 'Serum specimen'
* setting specimenType name from: 'Plasma Specimen' to: 'Plasma specimen'
+ created specimenType name: Venous blood specimen typecode: 122555007
* setting specimenType name from: 'Bronchoalveolar Lavage' to: 'Bronchoalveolar lavage fluid sample'
* setting specimenType name from: 'Whole Blood Sample' to: 'Whole blood sample'
+ created specimenType name: Capillary blood specimen typecode: 122554006
* setting specimenType name from: 'Sputum' to: 'Sputum specimen'
* setting specimenType name from: 'Nasal Washings' to: 'Nasal washings'
* setting specimenType name from: 'Saliva' to: 'Oral saliva sample'
* setting specimenType name from: 'Induced Sputum' to: 'Sputum specimen obtained by sputum induction'
* setting specimenType name from: 'Expectorated Sputum' to: 'Coughed sputum specimen'
* setting specimenType name from: 'Tracheal Aspirates' to: 'Specimen from trachea obtained by aspiration'
* setting specimenType name from: 'Lower Respiratory Tract Aspirates' to: 'Lower respiratory fluid sample'
+ created specimenType name: Oral fluid specimen typecode: 441620008
+ created specimenType name: Specimen obtained by bronchial aspiration typecode: 441903006
+ created specimenType name: Exhaled air specimen typecode: 119336008
+ created specimenType name: Dried blood spot specimen typecode: 440500007
```

- this code will be removed once we perform the sync in all envs

## Testing

- How should reviewers verify this PR? please validate against the LIVD table. I can use a new set of eyes

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->