### PR TITLE
Mike/2920 fix entry only users seeing add patient button

### DIFF
--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,4 +1,5 @@
 import { createStore } from "redux";
+import { TypedUseSelectorHook, useSelector } from "react-redux";
 
 import { COVID_RESULTS } from "../app/constants";
 import { UserPermission } from "../generated/graphql";
@@ -143,5 +144,7 @@ const configureStore = () => {
 export const store = configureStore();
 
 export type RootState = ReturnType<typeof store.getState>;
+
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export default reducers;

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { useLocation } from "react-router-dom";
-import { useSelector } from "react-redux";
 
 import { showError } from "../utils/srToast";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
@@ -11,6 +10,7 @@ import {
   useGetFacilityQueueQuery,
   GetFacilityQueueQuery,
 } from "../../generated/graphql";
+import { useTypedSelector } from "../utils/hooks";
 
 import AddToQueueSearch, {
   StartTestProps,
@@ -77,8 +77,13 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     null
   );
   const canUseCsvUploader = hasPermission(
-    useSelector((state) => (state as any).user.permissions),
+    useTypedSelector((state) => state.user.permissions),
     appPermissions.results.canView
+  );
+
+  const canEditPeople = hasPermission(
+    useTypedSelector((state) => state.user.permissions),
+    appPermissions.people.canEdit
   );
 
   useEffect(() => {
@@ -198,6 +203,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
             patientsInQueue={patientsInQueue}
             startTestPatientId={startTestPatientId}
             setStartTestPatientId={setStartTestPatientId}
+            canEditPeople={canEditPeople}
           />
         </div>
         {createQueueItems(data.queue)}

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -81,7 +81,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     appPermissions.results.canView
   );
 
-  const canEditPeople = hasPermission(
+  const canAddPatient = hasPermission(
     useTypedSelector((state) => state.user.permissions),
     appPermissions.people.canEdit
   );
@@ -203,7 +203,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
             patientsInQueue={patientsInQueue}
             startTestPatientId={startTestPatientId}
             setStartTestPatientId={setStartTestPatientId}
-            canEditPeople={canEditPeople}
+            canAddPatient={canAddPatient}
           />
         </div>
         {createQueueItems(data.queue)}

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -5,12 +5,12 @@ import { useLocation } from "react-router-dom";
 import { showError } from "../utils/srToast";
 import { LinkWithQuery } from "../commonComponents/LinkWithQuery";
 import { appPermissions, hasPermission } from "../permissions";
+import { useAppSelector } from "../store";
 import { PATIENT_TERM } from "../../config/constants";
 import {
   useGetFacilityQueueQuery,
   GetFacilityQueueQuery,
 } from "../../generated/graphql";
-import { useTypedSelector } from "../utils/hooks";
 
 import AddToQueueSearch, {
   StartTestProps,
@@ -77,12 +77,12 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
     null
   );
   const canUseCsvUploader = hasPermission(
-    useTypedSelector((state) => state.user.permissions),
+    useAppSelector((state) => state.user.permissions),
     appPermissions.results.canView
   );
 
   const canAddPatient = hasPermission(
-    useTypedSelector((state) => state.user.permissions),
+    useAppSelector((state) => state.user.permissions),
     appPermissions.people.canEdit
   );
 

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
@@ -152,6 +152,7 @@ describe("AddToSearchQueue - add to queue", () => {
             patientsInQueue={[]}
             startTestPatientId="abc123"
             setStartTestPatientId={setStartTestPatientIdMock}
+            canEditPeople={true}
           />
         </MockedProvider>
       </MemoryRouter>

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
@@ -152,7 +152,7 @@ describe("AddToSearchQueue - add to queue", () => {
             patientsInQueue={[]}
             startTestPatientId="abc123"
             setStartTestPatientId={setStartTestPatientIdMock}
-            canEditPeople={true}
+            canAddPatient={true}
           />
         </MockedProvider>
       </MemoryRouter>

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-new-patient-start.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-new-patient-start.test.tsx
@@ -83,7 +83,7 @@ describe("AddToSearchQueue - new patient begin test", () => {
             patientsInQueue={[]}
             startTestPatientId="48c523e8-7c65-4047-955c-e3f65bb8b58a"
             setStartTestPatientId={setStartTestPatientIdMock}
-            canEditPeople={true}
+            canAddPatient={true}
           />
         </MockedProvider>
       </MemoryRouter>

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-new-patient-start.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-new-patient-start.test.tsx
@@ -83,6 +83,7 @@ describe("AddToSearchQueue - new patient begin test", () => {
             patientsInQueue={[]}
             startTestPatientId="48c523e8-7c65-4047-955c-e3f65bb8b58a"
             setStartTestPatientId={setStartTestPatientIdMock}
+            canEditPeople={true}
           />
         </MockedProvider>
       </MemoryRouter>

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -7,11 +7,6 @@ import {
 } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
-import { Provider } from "react-redux";
-import createMockStore from "redux-mock-store";
-
-import { UserPermission } from "../../../generated/graphql";
-import { initialState } from "../../store";
 
 import AddToQueueSearch, { QUERY_PATIENT } from "./AddToQueueSearch";
 
@@ -76,25 +71,6 @@ const mocks = [
   },
 ];
 
-const mockStore = createMockStore([]);
-
-const standardUser = {
-  id: "a123",
-  firstName: "Bob",
-  lastName: "Bobberoo",
-  middleName: "",
-  suffix: "",
-  email: "bob@example.com",
-  isAdmin: false,
-  roleDescription: "Standard user",
-  permissions: [UserPermission.SearchPatients, UserPermission.EditPatient],
-};
-
-const standardUserStore = mockStore({
-  ...initialState,
-  user: { ...standardUser },
-});
-
 describe("AddToSearchQueue", () => {
   beforeEach(async () => {
     refetchQueueMock = jest.fn();
@@ -103,15 +79,14 @@ describe("AddToSearchQueue", () => {
     render(
       <MemoryRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <Provider store={standardUserStore}>
-            <AddToQueueSearch
-              refetchQueue={refetchQueueMock}
-              facilityId={facilityId}
-              patientsInQueue={[patientInQueue.internalId]}
-              startTestPatientId=""
-              setStartTestPatientId={setStartTestPatientIdMock}
-            />
-          </Provider>
+          <AddToQueueSearch
+            refetchQueue={refetchQueueMock}
+            facilityId={facilityId}
+            patientsInQueue={[patientInQueue.internalId]}
+            startTestPatientId=""
+            setStartTestPatientId={setStartTestPatientIdMock}
+            canEditPeople={true}
+          />
         </MockedProvider>
       </MemoryRouter>
     );

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -85,7 +85,7 @@ describe("AddToSearchQueue", () => {
             patientsInQueue={[patientInQueue.internalId]}
             startTestPatientId=""
             setStartTestPatientId={setStartTestPatientIdMock}
-            canEditPeople={true}
+            canAddPatient={true}
           />
         </MockedProvider>
       </MemoryRouter>

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -7,6 +7,11 @@ import {
 } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import createMockStore from "redux-mock-store";
+
+import { UserPermission } from "../../../generated/graphql";
+import { initialState } from "../../store";
 
 import AddToQueueSearch, { QUERY_PATIENT } from "./AddToQueueSearch";
 
@@ -71,6 +76,25 @@ const mocks = [
   },
 ];
 
+const mockStore = createMockStore([]);
+
+const standardUser = {
+  id: "a123",
+  firstName: "Bob",
+  lastName: "Bobberoo",
+  middleName: "",
+  suffix: "",
+  email: "bob@example.com",
+  isAdmin: false,
+  roleDescription: "Standard user",
+  permissions: [UserPermission.SearchPatients, UserPermission.EditPatient],
+};
+
+const standardUserStore = mockStore({
+  ...initialState,
+  user: { ...standardUser },
+});
+
 describe("AddToSearchQueue", () => {
   beforeEach(async () => {
     refetchQueueMock = jest.fn();
@@ -79,13 +103,15 @@ describe("AddToSearchQueue", () => {
     render(
       <MemoryRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <AddToQueueSearch
-            refetchQueue={refetchQueueMock}
-            facilityId={facilityId}
-            patientsInQueue={[patientInQueue.internalId]}
-            startTestPatientId=""
-            setStartTestPatientId={setStartTestPatientIdMock}
-          />
+          <Provider store={standardUserStore}>
+            <AddToQueueSearch
+              refetchQueue={refetchQueueMock}
+              facilityId={facilityId}
+              patientsInQueue={[patientInQueue.internalId]}
+              startTestPatientId=""
+              setStartTestPatientId={setStartTestPatientIdMock}
+            />
+          </Provider>
         </MockedProvider>
       </MemoryRouter>
     );

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -134,7 +134,7 @@ interface Props {
   patientsInQueue: string[];
   startTestPatientId: string | null;
   setStartTestPatientId: any;
-  canEditPeople: boolean;
+  canAddPatient: boolean;
 }
 
 const AddToQueueSearchBox = ({
@@ -143,7 +143,7 @@ const AddToQueueSearchBox = ({
   patientsInQueue,
   startTestPatientId,
   setStartTestPatientId,
-  canEditPeople,
+  canAddPatient,
 }: Props) => {
   const appInsights = getAppInsights();
 
@@ -279,7 +279,7 @@ const AddToQueueSearchBox = ({
         shouldShowSuggestions={showDropdown}
         loading={debounced !== queryString || loading}
         dropDownRef={dropDownRef}
-        canEditPeople={canEditPeople}
+        canAddPatient={canAddPatient}
       />
     </React.Fragment>
   );

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -134,6 +134,7 @@ interface Props {
   patientsInQueue: string[];
   startTestPatientId: string | null;
   setStartTestPatientId: any;
+  canEditPeople: boolean;
 }
 
 const AddToQueueSearchBox = ({
@@ -142,6 +143,7 @@ const AddToQueueSearchBox = ({
   patientsInQueue,
   startTestPatientId,
   setStartTestPatientId,
+  canEditPeople,
 }: Props) => {
   const appInsights = getAppInsights();
 
@@ -277,6 +279,7 @@ const AddToQueueSearchBox = ({
         shouldShowSuggestions={showDropdown}
         loading={debounced !== queryString || loading}
         dropDownRef={dropDownRef}
+        canEditPeople={canEditPeople}
       />
     </React.Fragment>
   );

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { Story, Meta } from "@storybook/react";
-import createMockStore from "redux-mock-store";
-import { Provider } from "react-redux";
-
-import { UserPermission } from "../../../generated/graphql";
-import { initialState } from "../../store";
 
 import SearchResults, { QueueProps, TestResultsProps } from "./SearchResults";
 
@@ -27,68 +22,22 @@ const patient = {
   },
 };
 
-const mockStore = createMockStore([]);
-
-const standardUser = {
-  id: "a123",
-  firstName: "Bob",
-  lastName: "Bobberoo",
-  middleName: "",
-  suffix: "",
-  email: "bob@example.com",
-  isAdmin: false,
-  roleDescription: "Standard user",
-  permissions: [UserPermission.SearchPatients, UserPermission.EditPatient],
-};
-
-const standardUserStore = mockStore({
-  ...initialState,
-  user: { ...standardUser },
-});
-
-const entryOnlyUserStore = mockStore({
-  ...initialState,
-  user: {
-    ...standardUser,
-    roleDescription: "Test-entry user",
-    permissions: [UserPermission.SearchPatients],
-  },
-});
-
 const RouterWithFacility: React.FC<RouterWithFacilityProps> = ({
   children,
 }) => <MemoryRouter>{children}</MemoryRouter>;
-
-interface TestResultsPropsWithEntryOnlyUser extends TestResultsProps {
-  isEntryOnlyUser?: boolean;
-}
 
 export default {
   title: "Search Results",
   component: SearchResults,
   argTypes: {},
-  decorators: [
-    (Story, context) => (
-      <Provider
-        store={
-          context.args["isEntryOnlyUser"]
-            ? entryOnlyUserStore
-            : standardUserStore
-        }
-      >
-        <Story></Story>
-      </Provider>
-    ),
-  ],
 } as Meta;
 
-const TestResultsTemplate =
-  (): Story<TestResultsPropsWithEntryOnlyUser> => (args) =>
-    (
-      <RouterWithFacility>
-        <SearchResults {...args} />
-      </RouterWithFacility>
-    );
+const TestResultsTemplate = (): Story<TestResultsProps> => (args) =>
+  (
+    <RouterWithFacility>
+      <SearchResults {...args} />
+    </RouterWithFacility>
+  );
 const QueueTemplate = (): Story<QueueProps> => (args) =>
   (
     <RouterWithFacility>
@@ -103,7 +52,7 @@ NoResults.args = {
   loading: false,
   patients: [],
   shouldShowSuggestions: true,
-  isEntryOnlyUser: false,
+  canEditPeople: true,
 };
 
 export const WithResults = TestResultsTemplate();
@@ -113,6 +62,7 @@ WithResults.args = {
   loading: false,
   patients: [patient],
   shouldShowSuggestions: true,
+  canEditPeople: true,
 };
 
 export const QueueResults = QueueTemplate();
@@ -122,4 +72,5 @@ QueueResults.args = {
   patients: [patient],
   patientsInQueue: [],
   shouldShowSuggestions: true,
+  canEditPeople: true,
 };

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.stories.tsx
@@ -52,7 +52,7 @@ NoResults.args = {
   loading: false,
   patients: [],
   shouldShowSuggestions: true,
-  canEditPeople: true,
+  canAddPatient: true,
 };
 
 export const WithResults = TestResultsTemplate();
@@ -62,7 +62,7 @@ WithResults.args = {
   loading: false,
   patients: [patient],
   shouldShowSuggestions: true,
-  canEditPeople: true,
+  canAddPatient: true,
 };
 
 export const QueueResults = QueueTemplate();
@@ -72,5 +72,5 @@ QueueResults.args = {
   patients: [patient],
   patientsInQueue: [],
   shouldShowSuggestions: true,
-  canEditPeople: true,
+  canAddPatient: true,
 };

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -83,7 +83,7 @@ describe("SearchResults", () => {
                 onAddToQueue={jest.fn()}
                 shouldShowSuggestions={true}
                 loading={false}
-                canEditPeople={true}
+                canAddPatient={true}
               />
             }
           />
@@ -106,7 +106,7 @@ describe("SearchResults", () => {
                 onAddToQueue={jest.fn()}
                 shouldShowSuggestions={true}
                 loading={false}
-                canEditPeople={true}
+                canAddPatient={true}
               />
             }
           />
@@ -135,7 +135,7 @@ describe("SearchResults", () => {
                 onAddToQueue={jest.fn()}
                 shouldShowSuggestions={true}
                 loading={false}
-                canEditPeople={false}
+                canAddPatient={false}
               />
             }
           />
@@ -161,7 +161,7 @@ describe("SearchResults", () => {
               onAddToQueue={jest.fn()}
               shouldShowSuggestions={true}
               loading={false}
-              canEditPeople={true}
+              canAddPatient={true}
             />
           }
         />
@@ -185,7 +185,7 @@ describe("SearchResults", () => {
               onAddToQueue={addToQueue}
               shouldShowSuggestions={true}
               loading={false}
-              canEditPeople={true}
+              canAddPatient={true}
             />
           }
         />
@@ -211,7 +211,7 @@ describe("SearchResults", () => {
               shouldShowSuggestions={true}
               loading={false}
               selectedPatient={patients[0]}
-              canEditPeople={true}
+              canAddPatient={true}
             />
           }
         />

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -2,13 +2,9 @@ import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import createMockStore from "redux-mock-store";
-import { Provider } from "react-redux";
 
 import { Patient } from "../../patients/ManagePatients";
 import { PATIENT_TERM } from "../../../config/constants";
-import { initialState } from "../../store";
-import { UserPermission } from "../../../generated/graphql";
 
 import SearchResults from "./SearchResults";
 
@@ -56,34 +52,6 @@ const patients: Patient[] = [
 
 const mockFacilityID = "facility-id-101";
 
-const mockStore = createMockStore([]);
-
-const standardUser = {
-  id: "a123",
-  firstName: "Bob",
-  lastName: "Bobberoo",
-  middleName: "",
-  suffix: "",
-  email: "bob@example.com",
-  isAdmin: false,
-  roleDescription: "Standard user",
-  permissions: [UserPermission.SearchPatients, UserPermission.EditPatient],
-};
-
-const standardUserStore = mockStore({
-  ...initialState,
-  user: { ...standardUser },
-});
-
-const entryOnlyUserStore = mockStore({
-  ...initialState,
-  user: {
-    ...standardUser,
-    roleDescription: "Test-entry user",
-    permissions: [UserPermission.SearchPatients],
-  },
-});
-
 const RouterWithFacility: React.FC<RouterWithFacilityProps> = ({
   children,
 }) => (
@@ -104,23 +72,22 @@ describe("SearchResults", () => {
   describe("No Results", () => {
     it("should say 'No Results' for no matches", () => {
       render(
-        <Provider store={standardUserStore}>
-          <RouterWithFacility>
-            <Route
-              path="/queue"
-              element={
-                <SearchResults
-                  page="queue"
-                  patients={[]}
-                  patientsInQueue={[]}
-                  onAddToQueue={jest.fn()}
-                  shouldShowSuggestions={true}
-                  loading={false}
-                />
-              }
-            />
-          </RouterWithFacility>
-        </Provider>
+        <RouterWithFacility>
+          <Route
+            path="/queue"
+            element={
+              <SearchResults
+                page="queue"
+                patients={[]}
+                patientsInQueue={[]}
+                onAddToQueue={jest.fn()}
+                shouldShowSuggestions={true}
+                loading={false}
+                canEditPeople={true}
+              />
+            }
+          />
+        </RouterWithFacility>
       );
 
       expect(screen.getByText("No results found.")).toBeInTheDocument();
@@ -128,23 +95,22 @@ describe("SearchResults", () => {
 
     it("should show add patient button", async () => {
       render(
-        <Provider store={standardUserStore}>
-          <RouterWithFacility>
-            <Route
-              path="/queue"
-              element={
-                <SearchResults
-                  page="queue"
-                  patients={[]}
-                  patientsInQueue={[]}
-                  onAddToQueue={jest.fn()}
-                  shouldShowSuggestions={true}
-                  loading={false}
-                />
-              }
-            />
-          </RouterWithFacility>
-        </Provider>
+        <RouterWithFacility>
+          <Route
+            path="/queue"
+            element={
+              <SearchResults
+                page="queue"
+                patients={[]}
+                patientsInQueue={[]}
+                onAddToQueue={jest.fn()}
+                shouldShowSuggestions={true}
+                loading={false}
+                canEditPeople={true}
+              />
+            }
+          />
+        </RouterWithFacility>
       );
 
       expect(screen.getByText(`Add new ${PATIENT_TERM}`)).toBeInTheDocument();
@@ -158,23 +124,22 @@ describe("SearchResults", () => {
 
     it("should not show add patient button for entry only user", () => {
       render(
-        <Provider store={entryOnlyUserStore}>
-          <RouterWithFacility>
-            <Route
-              path="/queue"
-              element={
-                <SearchResults
-                  page="queue"
-                  patients={[]}
-                  patientsInQueue={[]}
-                  onAddToQueue={jest.fn()}
-                  shouldShowSuggestions={true}
-                  loading={false}
-                />
-              }
-            />
-          </RouterWithFacility>
-        </Provider>
+        <RouterWithFacility>
+          <Route
+            path="/queue"
+            element={
+              <SearchResults
+                page="queue"
+                patients={[]}
+                patientsInQueue={[]}
+                onAddToQueue={jest.fn()}
+                shouldShowSuggestions={true}
+                loading={false}
+                canEditPeople={false}
+              />
+            }
+          />
+        </RouterWithFacility>
       );
 
       expect(
@@ -185,23 +150,22 @@ describe("SearchResults", () => {
 
   it("should show matching results", () => {
     render(
-      <Provider store={standardUserStore}>
-        <RouterWithFacility>
-          <Route
-            path="/queue"
-            element={
-              <SearchResults
-                page="queue"
-                patients={patients}
-                patientsInQueue={[]}
-                onAddToQueue={jest.fn()}
-                shouldShowSuggestions={true}
-                loading={false}
-              />
-            }
-          />
-        </RouterWithFacility>
-      </Provider>
+      <RouterWithFacility>
+        <Route
+          path="/queue"
+          element={
+            <SearchResults
+              page="queue"
+              patients={patients}
+              patientsInQueue={[]}
+              onAddToQueue={jest.fn()}
+              shouldShowSuggestions={true}
+              loading={false}
+              canEditPeople={true}
+            />
+          }
+        />
+      </RouterWithFacility>
     );
 
     expect(screen.getByText("Washington, George")).toBeInTheDocument();
@@ -210,23 +174,22 @@ describe("SearchResults", () => {
   it("links the non-duplicate patient", () => {
     const addToQueue = jest.fn();
     render(
-      <Provider store={standardUserStore}>
-        <RouterWithFacility>
-          <Route
-            path="/queue"
-            element={
-              <SearchResults
-                page="queue"
-                patients={patients}
-                patientsInQueue={["a123", "c789"]}
-                onAddToQueue={addToQueue}
-                shouldShowSuggestions={true}
-                loading={false}
-              />
-            }
-          />
-        </RouterWithFacility>
-      </Provider>
+      <RouterWithFacility>
+        <Route
+          path="/queue"
+          element={
+            <SearchResults
+              page="queue"
+              patients={patients}
+              patientsInQueue={["a123", "c789"]}
+              onAddToQueue={addToQueue}
+              shouldShowSuggestions={true}
+              loading={false}
+              canEditPeople={true}
+            />
+          }
+        />
+      </RouterWithFacility>
     );
 
     expect(screen.getAllByText("Test in progress")).toHaveLength(2);
@@ -236,24 +199,23 @@ describe("SearchResults", () => {
   it("opens a modal for selected patient", async () => {
     const addToQueue = jest.fn();
     render(
-      <Provider store={standardUserStore}>
-        <RouterWithFacility>
-          <Route
-            path="/queue"
-            element={
-              <SearchResults
-                page="queue"
-                patients={[]}
-                patientsInQueue={[]}
-                onAddToQueue={addToQueue}
-                shouldShowSuggestions={true}
-                loading={false}
-                selectedPatient={patients[0]}
-              />
-            }
-          />
-        </RouterWithFacility>
-      </Provider>
+      <RouterWithFacility>
+        <Route
+          path="/queue"
+          element={
+            <SearchResults
+              page="queue"
+              patients={[]}
+              patientsInQueue={[]}
+              onAddToQueue={addToQueue}
+              shouldShowSuggestions={true}
+              loading={false}
+              selectedPatient={patients[0]}
+              canEditPeople={true}
+            />
+          }
+        />
+      </RouterWithFacility>
     );
 
     expect(screen.getByText("Test questionnaire")).toBeInTheDocument();

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -16,7 +16,7 @@ interface SearchResultsProps {
   loading: boolean;
   dropDownRef?: React.RefObject<HTMLDivElement>;
   selectedPatient?: Patient;
-  canEditPeople: boolean;
+  canAddPatient: boolean;
 }
 
 export interface QueueProps extends SearchResultsProps {
@@ -116,9 +116,9 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
         <div className="margin-bottom-105">No results found.</div>
         <div>
           Check for spelling errors
-          {props.canEditPeople ? (
+          {props.canAddPatient ? (
             <>
-              {" or "}
+              {" or"}
               <Button
                 className="margin-left-1"
                 label={`Add new ${PATIENT_TERM}`}

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -9,6 +9,8 @@ import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
 import { getFacilityIdFromUrl } from "../../utils/url";
 import { PATIENT_TERM } from "../../../config/constants";
+import { useTypedSelector } from "../../utils/hooks";
+import { appPermissions, hasPermission } from "../../permissions";
 
 interface SearchResultsProps {
   patients: Patient[];
@@ -42,6 +44,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
     selectedPatient,
   } = props;
 
+  const user = useTypedSelector((state) => state.user);
   const [dialogPatient, setDialogPatient] = useState<Patient | null>(null);
   const [canAddToQueue, setCanAddToQueue] = useState(false);
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
@@ -54,6 +57,11 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       setCanAddToQueue(true);
     }
   }, [selectedPatient]);
+
+  const canEditPeople = hasPermission(
+    user.permissions,
+    appPermissions.people.canEdit
+  );
 
   function handleSaveCallback(a: any) {
     if (props.page === "queue" && dialogPatient !== null) {
@@ -114,14 +122,21 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       >
         <div className="margin-bottom-105">No results found.</div>
         <div>
-          Check for spelling errors or
-          <Button
-            className="margin-left-1"
-            label={`Add new ${PATIENT_TERM}`}
-            onClick={() => {
-              setRedirect(`/add-patient?facility=${activeFacilityId}`);
-            }}
-          />
+          Check for spelling errors
+          {canEditPeople ? (
+            <>
+              {" or "}
+              <Button
+                className="margin-left-1"
+                label={`Add new ${PATIENT_TERM}`}
+                onClick={() => {
+                  setRedirect(`/add-patient?facility=${activeFacilityId}`);
+                }}
+              />
+            </>
+          ) : (
+            "."
+          )}
         </div>
       </div>
     );

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -9,8 +9,6 @@ import { Patient } from "../../patients/ManagePatients";
 import { AoEAnswersDelivery } from "../AoEForm/AoEForm";
 import { getFacilityIdFromUrl } from "../../utils/url";
 import { PATIENT_TERM } from "../../../config/constants";
-import { useTypedSelector } from "../../utils/hooks";
-import { appPermissions, hasPermission } from "../../permissions";
 
 interface SearchResultsProps {
   patients: Patient[];
@@ -18,6 +16,7 @@ interface SearchResultsProps {
   loading: boolean;
   dropDownRef?: React.RefObject<HTMLDivElement>;
   selectedPatient?: Patient;
+  canEditPeople: boolean;
 }
 
 export interface QueueProps extends SearchResultsProps {
@@ -44,7 +43,6 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
     selectedPatient,
   } = props;
 
-  const user = useTypedSelector((state) => state.user);
   const [dialogPatient, setDialogPatient] = useState<Patient | null>(null);
   const [canAddToQueue, setCanAddToQueue] = useState(false);
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
@@ -57,11 +55,6 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       setCanAddToQueue(true);
     }
   }, [selectedPatient]);
-
-  const canEditPeople = hasPermission(
-    user.permissions,
-    appPermissions.people.canEdit
-  );
 
   function handleSaveCallback(a: any) {
     if (props.page === "queue" && dialogPatient !== null) {
@@ -123,7 +116,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
         <div className="margin-bottom-105">No results found.</div>
         <div>
           Check for spelling errors
-          {canEditPeople ? (
+          {props.canEditPeople ? (
             <>
               {" or "}
               <Button

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -17,11 +17,8 @@ import { Label } from "@trussworks/react-uswds";
 import { displayFullName, facilityDisplayName } from "../utils";
 import { isValidDate } from "../utils/date";
 import { getParameterFromUrl } from "../utils/url";
-import {
-  useDocumentTitle,
-  useOutsideClick,
-  useTypedSelector,
-} from "../utils/hooks";
+import { useDocumentTitle, useOutsideClick } from "../utils/hooks";
+import { useAppSelector } from "../store";
 import Pagination from "../commonComponents/Pagination";
 import {
   COVID_RESULTS,
@@ -190,12 +187,12 @@ export const DetachedTestResultsList = ({
   const allowQuery = debounced.length >= MIN_SEARCH_CHARACTER_COUNT;
 
   const isOrgAdmin = hasPermission(
-    useTypedSelector((state) => state.user.permissions),
+    useAppSelector((state) => state.user.permissions),
     appPermissions.settings.canView
   );
 
   const canAddPatient = hasPermission(
-    useTypedSelector((state) => state.user.permissions),
+    useAppSelector((state) => state.user.permissions),
     appPermissions.people.canEdit
   );
 

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -13,12 +13,15 @@ import React, {
 import moment from "moment";
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
 import { Label } from "@trussworks/react-uswds";
-import { useSelector } from "react-redux";
 
 import { displayFullName, facilityDisplayName } from "../utils";
 import { isValidDate } from "../utils/date";
 import { getParameterFromUrl } from "../utils/url";
-import { useDocumentTitle, useOutsideClick } from "../utils/hooks";
+import {
+  useDocumentTitle,
+  useOutsideClick,
+  useTypedSelector,
+} from "../utils/hooks";
 import Pagination from "../commonComponents/Pagination";
 import {
   COVID_RESULTS,
@@ -187,8 +190,13 @@ export const DetachedTestResultsList = ({
   const allowQuery = debounced.length >= MIN_SEARCH_CHARACTER_COUNT;
 
   const isOrgAdmin = hasPermission(
-    useSelector((state) => (state as any).user.permissions),
+    useTypedSelector((state) => state.user.permissions),
     appPermissions.settings.canView
+  );
+
+  const canEditPeople = hasPermission(
+    useTypedSelector((state) => state.user.permissions),
+    appPermissions.people.canEdit
   );
 
   const [queryPatients, { data: patientData, loading: patientLoading }] =
@@ -479,6 +487,7 @@ export const DetachedTestResultsList = ({
                   shouldShowSuggestions={showDropdown}
                   loading={debounced !== queryString || patientLoading}
                   dropDownRef={dropDownRef}
+                  canEditPeople={canEditPeople}
                 />
               </div>
               <div className="usa-form-group date-filter-group">

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -194,7 +194,7 @@ export const DetachedTestResultsList = ({
     appPermissions.settings.canView
   );
 
-  const canEditPeople = hasPermission(
+  const canAddPatient = hasPermission(
     useTypedSelector((state) => state.user.permissions),
     appPermissions.people.canEdit
   );
@@ -487,7 +487,7 @@ export const DetachedTestResultsList = ({
                   shouldShowSuggestions={showDropdown}
                   loading={debounced !== queryString || patientLoading}
                   dropDownRef={dropDownRef}
-                  canEditPeople={canEditPeople}
+                  canAddPatient={canAddPatient}
                 />
               </div>
               <div className="usa-form-group date-filter-group">

--- a/frontend/src/app/utils/hooks.tsx
+++ b/frontend/src/app/utils/hooks.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useRef } from "react";
+import { TypedUseSelectorHook, useSelector } from "react-redux";
+
+import { RootState } from "../store";
 
 const useOutsideClick = (
   ref: React.RefObject<HTMLDivElement>,
@@ -39,4 +42,6 @@ const useDocumentTitle = (title: string, retainOnUnmount = false) => {
   }, [retainOnUnmount, title]);
 };
 
-export { useOutsideClick, useDocumentTitle };
+const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export { useOutsideClick, useDocumentTitle, useTypedSelector };

--- a/frontend/src/app/utils/hooks.tsx
+++ b/frontend/src/app/utils/hooks.tsx
@@ -1,7 +1,4 @@
 import React, { useEffect, useRef } from "react";
-import { TypedUseSelectorHook, useSelector } from "react-redux";
-
-import { RootState } from "../store";
 
 const useOutsideClick = (
   ref: React.RefObject<HTMLDivElement>,
@@ -42,6 +39,4 @@ const useDocumentTitle = (title: string, retainOnUnmount = false) => {
   }, [retainOnUnmount, title]);
 };
 
-const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
-
-export { useOutsideClick, useDocumentTitle, useTypedSelector };
+export { useOutsideClick, useDocumentTitle };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #2920 

## Changes Proposed

- The "Add New Patient" button should only appear to users who have the _EditPatient_ permission (i.e. entry only users should not be able to see this button)
- Adds `useTypedSelector` hook as a typed version of the Redux `useSelector` hook

## Additional Information

- Updated the relevant regressions tests and Storybook stories to use `canEditPeople` prop
- Refactored the change to handle the permission check in TestQueue and pass it down as a prop to grandchild SearchResults, instead of originally using the Redux selector directly within SearchResults itself
- Not sure yet what our conventions are on renaming files, but it would be nice to add some fixes for consistency (`AddToQueueSearch.tsx` currently exports `AddToQueueSearchBox` and the tests for that component are defined in `AddToQueueSearch-patient-search.test.tsx` instead of simply `AddToQueueSearch.test.tsx`)

## Testing

- Validate that all regression tests pass
- Test that as at least a standard user, you can still access Add New Patient within the search box on the Conduct Tests page
- Test that as an entry only user, you cannot access the Add New Patient button on that page
- Test that `Search Results` stories on the Storybook are all working as expected

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->