### PR TITLE
Enable sending single FHIR messages in prod

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -49,6 +49,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -79,6 +80,9 @@ public class TestOrderService {
 
   @Qualifier("fhirQueueReportingService")
   private final TestEventReportingService _fhirQueueReportingService;
+
+  @Value("${simple-report.fhir-reporting-enabled:false}")
+  private boolean fhirReportingEnabled;
 
   private final TestResultsDeliveryService testResultsDeliveryService;
   private final DiseaseService _diseaseService;
@@ -360,7 +364,7 @@ public class TestOrderService {
       _testEventReportingService.report(savedEvent);
     }
 
-    if (savedEvent.hasFluResult()) {
+    if (savedEvent.hasFluResult() && fhirReportingEnabled) {
       _fhirQueueReportingService.report(savedEvent);
     }
   }

--- a/backend/src/main/resources/application-azure-dev3.yaml
+++ b/backend/src/main/resources/application-azure-dev3.yaml
@@ -15,5 +15,6 @@ simple-report:
       - https://simple-report-api-dev3.azurewebsites.net
       - https://simple-report-dev3.azureedge.net
       - https://dev3.simplereport.gov
+  fhir-reporting-enabled: false
 twilio:
   enabled: true

--- a/backend/src/main/resources/application-azure-dev3.yaml
+++ b/backend/src/main/resources/application-azure-dev3.yaml
@@ -15,6 +15,5 @@ simple-report:
       - https://simple-report-api-dev3.azurewebsites.net
       - https://simple-report-dev3.azureedge.net
       - https://dev3.simplereport.gov
-  fhir-reporting-enabled: false
 twilio:
   enabled: true

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -3,7 +3,7 @@ spring:
 simple-report:
   azure-reporting-queue:
     enabled: true
-    fhir-queue-enabled: false
+    fhir-queue-enabled: true
     exception-webhook-enabled: true
   patient-link-url: https://www.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://www.simplereport.gov/api/pxp/callback
@@ -19,6 +19,7 @@ simple-report:
       - https://simplereport.gov
   experian:
     enabled: true
+  fhir-reporting-enabled: false
 twilio:
   enabled: true
   from-number: "+14045312484"

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -130,6 +130,7 @@ simple-report:
       - HEAD
       - POST
   batch-size: 1000
+  fhir-reporting-enabled: false
 twilio:
   messaging-service-sid: ${TWILIO_MESSAGING_SID}
 logging:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -130,7 +130,7 @@ simple-report:
       - HEAD
       - POST
   batch-size: 1000
-  fhir-reporting-enabled: false
+  fhir-reporting-enabled: true
 twilio:
   messaging-service-sid: ${TWILIO_MESSAGING_SID}
 logging:


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

we want to use the `resendToReportStream` mutation to send single multiplex test events FHIR messages from our production environment before "opening the floodgates" and sending all multiplex messages to ReportStream in production
previously `fhir-queue-enabled` has been used to turn on sending FHIR messages with multiplex data to the RS universal pipeline in all envs but prod. however our mutation also checks this config, making it impossible to send from production unless this config is set to true

## Changes Proposed

create a temporary new config `simple-report.fhir-reporting-enabled` that is set to off in production so that we can enable the queue in production and support the mutation while still not sending single-entry multiplex results to ReportStream

## Additional Information

open to other ideas on how to do this!

## Testing

deployed to dev3 with `fhir-reporting-enabled: false` and submitted a multiplex result. verified that the covid result ended up in the `test-event-publishing` queue but the `fhir-data-publishing` queue remained empty
then used the resendToReportStream mutation with fhirOnly parameter set to true to send the test event again and verified only the fhir message was added to the fhir queue
deployed to dev3 without the special flag (so intention is that `fhir-reporting-enabled: true`) and verified submitting a result worked as before - submitting a multiplex test result adds messages to both queues