### PR TITLE
only add phone numbers and emails to FHIR if they exist

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -415,9 +415,15 @@ public class FhirConverter {
 
     patient.setId(props.getId());
     patient.addIdentifier().setValue(props.getId());
-    convertPhoneNumbersToContactPoint(props.getPhoneNumbers()).forEach(patient::addTelecom);
-    convertEmailsToContactPoint(ContactPointUse.HOME, props.getEmails())
-        .forEach(patient::addTelecom);
+
+    if (!CollectionUtils.isEmpty(props.getPhoneNumbers())) {
+      convertPhoneNumbersToContactPoint(props.getPhoneNumbers()).forEach(patient::addTelecom);
+    }
+
+    if (!CollectionUtils.isEmpty(props.getEmails())) {
+      convertEmailsToContactPoint(ContactPointUse.HOME, props.getEmails())
+          .forEach(patient::addTelecom);
+    }
     return patient;
   }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- If patient has no values, then it will still generate an invalid block
- Example bundle without valid emails
![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/6fc79833-41f5-412e-9406-cdae863631f2)
- when can we have empty data
  - patient emails are optional
  - there could be historical patient records without phone numbers, not 100% sure, but it doesn't hurt to check in the code.


## Changes Proposed

- only add phone/email if data is provided
