### PR TITLE
Remove unused repo in the upload service

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -11,7 +11,6 @@ import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.TestResultUpload;
 import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
-import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
 import gov.cdc.usds.simplereport.service.errors.InvalidBulkTestResultUploadException;
 import gov.cdc.usds.simplereport.service.errors.InvalidRSAPrivateKeyException;
@@ -49,7 +48,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class TestResultUploadService {
   private final TestResultUploadRepository _repo;
-  private final SpecimenTypeRepository specimenTypeRepository;
   private final DataHubClient _client;
   private final OrganizationService _orgService;
   private final ResultsUploaderDeviceValidationService resultsUploaderDeviceValidationService;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
@@ -23,7 +23,6 @@ import gov.cdc.usds.simplereport.api.model.errors.DependencyFailureException;
 import gov.cdc.usds.simplereport.api.model.filerow.TestResultRow;
 import gov.cdc.usds.simplereport.db.model.TestResultUpload;
 import gov.cdc.usds.simplereport.db.model.auxiliary.UploadStatus;
-import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
 import gov.cdc.usds.simplereport.service.errors.InvalidBulkTestResultUploadException;
 import gov.cdc.usds.simplereport.service.model.reportstream.FeedbackMessage;
@@ -74,7 +73,6 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   @Captor private ArgumentCaptor<String> accessTokenCaptor;
   @Mock private DataHubClient dataHubMock;
   @Mock private TestResultUploadRepository repoMock;
-  @Mock private SpecimenTypeRepository specimenTypeRepositoryMock;
   @Mock private OrganizationService orgServiceMock;
   @Mock private ResultsUploaderDeviceValidationService resultsUploaderDeviceValidationServiceMock;
   @Mock private TokenAuthentication tokenAuthMock;
@@ -401,8 +399,6 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
     response.setErrors(new FeedbackMessage[] {});
     response.setWarnings(new FeedbackMessage[] {});
     when(dataHubMock.uploadCSV(any())).thenReturn(response);
-    when(specimenTypeRepositoryMock.findAll())
-        .thenReturn(List.of(_dataFactory.getGenericSpecimen()));
     when(resultsUploaderDeviceValidationServiceMock.getSpecimenTypeNameToSNOMEDMap())
         .thenReturn(Map.of("nasal swab", "000111222"));
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- clean up unused repo inside `TestResultUploadService.java`

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->