### PR TITLE
Restore vm subnet to PROD due to existing lock on obsolete resource.

### DIFF
--- a/ops/services/virtual_network/main.tf
+++ b/ops/services/virtual_network/main.tf
@@ -20,6 +20,15 @@ resource "azurerm_virtual_network" "vn" {
   tags = var.management_tags
 }
 
+resource "azurerm_subnet" "vms" {
+  count                                          = var.env == "prod" ? 1 : 0
+  name                                           = "${var.env}-vms"
+  resource_group_name                            = var.resource_group_name
+  virtual_network_name                           = azurerm_virtual_network.vn.name
+  address_prefixes                               = [cidrsubnet(var.network_address, 8, 252)] # X.X.252.0/24
+  enforce_private_link_endpoint_network_policies = true
+}
+
 resource "azurerm_subnet" "lbs" {
   name                 = "${local.subnet_basename}-lb"
   resource_group_name  = var.resource_group_name


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- A lock exists on an old copy of the old production database, prior to the conversion to Azure Flexible Server. The presence of this lock is preventing the deprecated `vm` subnet from being deleted.

## Changes Proposed

- Restore the `vm` subnet for `prod` ONLY to allow the remainder of the deployment to go through. Bastion objects and the like have already been deleted.

## Additional Information

- A ticket will be filed with the CDC to remove the lock.
- A subsequent PR will be created to undo this temporary change once the above ticket is marked as complete.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!