### PR TITLE
replace h2 with h3 for analytics dashboard

### DIFF
--- a/frontend/src/app/analytics/Analytics.scss
+++ b/frontend/src/app/analytics/Analytics.scss
@@ -45,6 +45,13 @@
       font-size: 19px;
     }
 
+    h3 {
+      height: 25px;
+      font-weight: 400;
+      margin: 0;
+      font-size: 19px;
+    }
+
     p {
       height: 25px;
       font-size: 20px;

--- a/frontend/src/app/analytics/Analytics.scss
+++ b/frontend/src/app/analytics/Analytics.scss
@@ -38,13 +38,6 @@
       margin: auto;
     }
 
-    h2 {
-      height: 25px;
-      font-weight: 400;
-      margin: 0;
-      font-size: 19px;
-    }
-
     h3 {
       height: 25px;
       font-weight: 400;

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -244,7 +244,7 @@ export const Analytics = (props: Props) => {
                   <div className="grid-row grid-gap">
                     <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-row">
-                        <h2>Tests conducted</h2>
+                        <h3>Tests conducted</h3>
                         <span className="font-sans-3xl text-bold margin-y-auto">
                           {totalTests}
                         </span>
@@ -253,7 +253,7 @@ export const Analytics = (props: Props) => {
                     </div>
                     <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-align-center">
-                        <h2>Positive tests</h2>
+                        <h3>Positive tests</h3>
                         <span className="font-sans-3xl text-bold margin-y-auto">
                           {positiveTests}
                         </span>
@@ -266,7 +266,7 @@ export const Analytics = (props: Props) => {
                     </div>
                     <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-align-center">
-                        <h2>Negative tests</h2>
+                        <h3>Negative tests</h3>
                         <span className="font-sans-3xl text-bold margin-y-auto">
                           {negativeTests}
                         </span>
@@ -275,7 +275,7 @@ export const Analytics = (props: Props) => {
                     </div>
                     <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-align-center">
-                        <h2>Positivity rate</h2>
+                        <h3>Positivity rate</h3>
                         <span className="font-sans-3xl text-bold margin-y-auto">
                           {positivityRate !== null
                             ? positivityRate.toFixed(1) + "%"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5810 

## Changes Proposed

- Replace `h3` with `h2` for the data headings

## Additional Information

- Same style as H2 was used 

## Screenshots / Demos
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/0293bb70-4899-4678-bf66-0e98fc1d582b)
