### PR TITLE
Remove list of patient count from h1

### DIFF
--- a/frontend/src/app/patients/ManagePatients.scss
+++ b/frontend/src/app/patients/ManagePatients.scss
@@ -1,9 +1,6 @@
 .sr-showing-patients-on-page {
-  margin-left: 2rem;
   color: #555;
-  font-size: 50%;
-  vertical-align: middle;
-  font-weight: normal;
+  font-size: 0.69rem;
 }
 
 .sr-patient-list {

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -306,9 +306,11 @@ export const DetachedManagePatients = ({
         <div className="grid-row">
           <div className="prime-container card-container">
             <div className="usa-card__header">
-              <h1 className="font-sans-lg">
-                {PATIENT_TERM_PLURAL_CAP}
-                <span className="sr-showing-patients-on-page">
+              <div className="display-flex flex-align-center">
+                <h1 className="font-sans-lg margin-y-0">
+                  {PATIENT_TERM_PLURAL_CAP}
+                </h1>
+                <span className="sr-showing-patients-on-page margin-left-4">
                   {totalEntries === undefined ? (
                     "Loading..."
                   ) : (
@@ -319,7 +321,7 @@ export const DetachedManagePatients = ({
                     </>
                   )}
                 </span>
-              </h1>
+              </div>
               <div>{showActionButtons()}</div>
             </div>
             <div className="display-flex flex-row bg-base-lightest padding-x-3 padding-y-2">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #5821 

## Changes Proposed

Removes "Loading" and the patient entry count from the `<h1>` on the Patients page

## Additional Information
The design of the page changed slightly with this change but in my opinion it looks better because everything is vertically aligned. I thought the change was insignificant enough not to rope in design. Let me know what you all think 😅

## Testing
The `<h1>` of the page when testing the structure should only say "Patients"
Available on dev7

## Screenshots / Demos

**Before**
<img width="1918" alt="Screenshot 2023-06-01 at 17 52 57" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/8636a5f3-a77a-4d1c-8b33-83149d36e93c">

<img width="1313" alt="Screenshot 2023-06-01 at 17 53 20" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/5ef942aa-7f77-453e-97d0-ea343a25b17f">


**After**
<img width="1908" alt="Screenshot 2023-06-01 at 17 57 10" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/b80c379b-41c0-4132-a1ed-9440cfee188a">
<img width="1245" alt="Screenshot 2023-06-01 at 17 57 28" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/f097a48a-d132-4df0-957a-73519c7ecc40">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
