### PR TITLE
Populate ordering provider zip from the provider

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -605,7 +605,7 @@ public class TestEventExport {
 
   @JsonProperty("Ordering_provider_zip_code")
   public String getOrderingProviderZipCode() {
-    return this.getTestingLabZipCode();
+    return provider.map(Provider::getZipCode).orElse(null);
   }
 
   @JsonProperty("Ordering_provider_county")


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

CA is comparing our FHIR messages and Covid CSVs and was confused why our Covid message for a specific event included an ordering provider ZIP but the FHIR message did not. On investigation, I found that the provider for that event doesn't have a ZIP code and we are building the Covid export CSV using the testing lab zip instead

I believe this might've been a miss during https://github.com/CDCgov/prime-simplereport/pull/213

## Changes Proposed

populate `Ordering_provider_zip_code` with the ZIP from the provider, if it exists

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->