### PR TITLE
Pagination component hidden if there are not elements to display

### DIFF
--- a/frontend/src/app/commonComponents/Pagination.tsx
+++ b/frontend/src/app/commonComponents/Pagination.tsx
@@ -83,41 +83,49 @@ const Pagination = ({
   }
 
   return (
-    <nav
-      className={classnames("usa-pagination", className)}
-      role="navigation"
-      aria-label="Pagination"
-    >
-      <ol>
-        {currentPage > 1 && (
-          <li key="prevpage">
-            <Link to={`${currentPage - 1}`} label="Previous Page">
-              <FontAwesomeIcon icon={faAngleLeft as IconProp} /> Prev
-            </Link>
-          </li>
-        )}
-        {pageList.map((pn) =>
-          typeof pn === "number" ? (
-            <li key={pn}>
-              <Link to={pn} label={`Page ${pn}`} active={pn === currentPage}>
-                <span>{pn}</span>
-              </Link>
-            </li>
-          ) : (
-            <li key={pn} aria-hidden="true">
-              …
-            </li>
-          )
-        )}
-        {currentPage < totalPages && (
-          <li key="nextpage">
-            <Link to={`${currentPage + 1}`} label="Next Page">
-              Next <FontAwesomeIcon icon={faAngleRight as IconProp} />
-            </Link>
-          </li>
-        )}
-      </ol>
-    </nav>
+    <>
+      {pageList.length > 0 && (
+        <nav
+          className={classnames("usa-pagination", className)}
+          role="navigation"
+          aria-label="Pagination"
+        >
+          <ol>
+            {currentPage > 1 && (
+              <li key="prevpage">
+                <Link to={`${currentPage - 1}`} label="Previous Page">
+                  <FontAwesomeIcon icon={faAngleLeft as IconProp} /> Prev
+                </Link>
+              </li>
+            )}
+            {pageList.map((pn) =>
+              typeof pn === "number" ? (
+                <li key={pn}>
+                  <Link
+                    to={pn}
+                    label={`Page ${pn}`}
+                    active={pn === currentPage}
+                  >
+                    <span>{pn}</span>
+                  </Link>
+                </li>
+              ) : (
+                <li key={pn} aria-hidden="true">
+                  …
+                </li>
+              )
+            )}
+            {currentPage < totalPages && (
+              <li key="nextpage">
+                <Link to={`${currentPage + 1}`} label="Next Page">
+                  Next <FontAwesomeIcon icon={faAngleRight as IconProp} />
+                </Link>
+              </li>
+            )}
+          </ol>
+        </nav>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5860 

## Changes Proposed

- Add logic to include/create an empty navigation element (aka pagination component) when there are no results

## Additional Information

The SVG elements that I mentioned in the ticket already have an aria-hidden attribute set to `true`. I am not sure why the guided tests flags these icons as visible to the screen reader when they are not.

## Testing

Just check in local that no pagination element exists in the DOM when there are no results.
