### PR TITLE
Johanna/5859 remove search button in search bar

### DIFF
--- a/frontend/src/app/commonComponents/FormGroup.tsx
+++ b/frontend/src/app/commonComponents/FormGroup.tsx
@@ -1,19 +1,24 @@
 import React from "react";
 
-interface Props {
+interface FormGroupProps {
   title: string;
   children: React.ReactNode;
+  asSectionGroup?: boolean;
 }
 
-const FormGroup = (props: Props) => (
-  <form className="prime-formgroup">
-    <fieldset className="usa-fieldset">
-      <legend className="prime-formgroup-heading usa-legend">
-        {props.title}
-      </legend>
-      {props.children}
-    </fieldset>
-  </form>
-);
+const FormGroup = (props: FormGroupProps) => {
+  const WappringEl = props.asSectionGroup ? "div" : "form";
+
+  return (
+    <WappringEl className="prime-formgroup">
+      <fieldset className="usa-fieldset">
+        <legend className="prime-formgroup-heading usa-legend">
+          {props.title}
+        </legend>
+        {props.children}
+      </fieldset>
+    </WappringEl>
+  );
+};
 
 export default FormGroup;

--- a/frontend/src/app/commonComponents/FormGroup.tsx
+++ b/frontend/src/app/commonComponents/FormGroup.tsx
@@ -7,17 +7,17 @@ interface FormGroupProps {
 }
 
 const FormGroup = (props: FormGroupProps) => {
-  const WappringEl = props.asSectionGroup ? "div" : "form";
+  const WrappingEl = props.asSectionGroup ? "div" : "form";
 
   return (
-    <WappringEl className="prime-formgroup">
+    <WrappingEl className="prime-formgroup">
       <fieldset className="usa-fieldset">
         <legend className="prime-formgroup-heading usa-legend">
           {props.title}
         </legend>
         {props.children}
       </fieldset>
-    </WappringEl>
+    </WrappingEl>
   );
 };
 

--- a/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEForm.tsx
@@ -267,7 +267,7 @@ const AoEForm: React.FC<Props> = ({
     <div>
       <form className="display-flex flex-column padding-bottom-4">
         <RequiredMessage />
-        <FormGroup title="Results">
+        <FormGroup title="Results" asSectionGroup>
           <div className="prime-formgroup__wrapper">
             <RadioGroup
               legend="Would you like to receive a copy of your results via text message?"
@@ -317,7 +317,7 @@ const AoEForm: React.FC<Props> = ({
             />
           </div>
         </FormGroup>
-        <FormGroup title="Symptoms">
+        <FormGroup title="Symptoms" asSectionGroup>
           <SymptomInputs
             noSymptoms={noSymptoms}
             setNoSymptoms={setNoSymptoms}
@@ -333,7 +333,7 @@ const AoEForm: React.FC<Props> = ({
         </FormGroup>
 
         {patient.gender?.toLowerCase() !== "male" && (
-          <FormGroup title="Pregnancy">
+          <FormGroup title="Pregnancy" asSectionGroup>
             <RadioGroup
               legend="Are you currently pregnant?"
               name="pregnancy"

--- a/frontend/src/app/testQueue/TestQueue.test.tsx
+++ b/frontend/src/app/testQueue/TestQueue.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   render,
   screen,
   waitFor,
@@ -67,17 +68,13 @@ describe("TestQueue", () => {
         </MockedProvider>
       </MemoryRouter>
     );
-    await new Promise((resolve) => setTimeout(resolve, 501));
 
-    await waitFor(
-      async () => {
-        expect(
-          screen.getByLabelText(
-            `Search for a ${PATIENT_TERM} to start their test`
-          )
-        ).toBeInTheDocument();
-      },
-      { timeout: 1000 }
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText(
+          `Search for a ${PATIENT_TERM} to start their test`
+        )
+      )
     );
 
     expect(await screen.findByText("Doe, John A"));
@@ -99,9 +96,9 @@ describe("TestQueue", () => {
     const removeButton = await screen.findByLabelText(
       "Close test for Doe, John A"
     );
-    await userEvent.click(removeButton);
+    await act(async () => await userEvent.click(removeButton));
     const confirmButton = await screen.findByText("Yes", { exact: false });
-    await userEvent.click(confirmButton);
+    await act(async () => await userEvent.click(confirmButton));
     expect(
       screen.getByText("Submitting test data for Doe, John A...")
     ).toBeInTheDocument();
@@ -208,7 +205,10 @@ describe("TestQueue", () => {
       expect(await screen.findByText("Doe, John A")).toBeInTheDocument();
       expect(await screen.findByText("Smith, Jane")).toBeInTheDocument();
 
-      await userEvent.click(screen.getAllByText("Test questionnaire")[0]);
+      await act(
+        async () =>
+          await userEvent.click(screen.getAllByText("Test questionnaire")[0])
+      );
     });
 
     it("should open test questionnaire and display emails and phone numbers correctly", () => {

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -37,12 +37,14 @@ exports[`TestQueue should render the test queue 1`] = `
                 id="search-field-small"
                 name="search"
                 placeholder="Search for a patient to start their test"
+                style="border-right: 1px solid;"
                 type="search"
                 value=""
               />
               <button
                 class="usa-button"
                 disabled=""
+                style="display: none;"
                 type="submit"
               >
                 <img

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-add-to-queue.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
@@ -126,7 +126,7 @@ jest.mock("./SearchResults", () => {
         type="submit"
         onClick={() => sr.onAddToQueue(mockPatient, mockAoeAnswers, "create")}
       >
-        I'm a magic fake button click me please
+        Begin test (mock button)
       </button>
     );
   };
@@ -168,9 +168,16 @@ describe("AddToSearchQueue - add to queue", () => {
       srToast,
       "showAlertNotification"
     );
-    await userEvent.type(screen.getByRole("searchbox"), "bar");
 
-    await userEvent.click(screen.getAllByRole("button")[1]);
+    await act(
+      async () => await userEvent.type(screen.getByRole("searchbox"), "bar")
+    );
+    await act(
+      async () =>
+        await userEvent.click(
+          screen.getByRole("button", { name: /begin test \(mock button\)/i })
+        )
+    );
 
     expect(queryPatientMockIsDone).toBe(true);
     expect(addPatientMockIsDone).toBe(true);
@@ -184,9 +191,15 @@ describe("AddToSearchQueue - add to queue", () => {
   });
 
   it("tracks custom telemetry event", async () => {
-    await userEvent.type(screen.getByRole("searchbox"), "bar");
-
-    await userEvent.click(screen.getAllByRole("button")[1]);
+    await act(
+      async () => await userEvent.type(screen.getByRole("searchbox"), "bar")
+    );
+    await act(
+      async () =>
+        await userEvent.click(
+          screen.getByRole("button", { name: /begin test \(mock button\)/i })
+        )
+    );
 
     expect(trackEventMock).toBeCalledWith({ name: "Add Patient To Queue" });
   });

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch-patient-search.test.tsx
@@ -3,7 +3,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
@@ -98,7 +97,6 @@ describe("AddToSearchQueue", () => {
       fireEvent.change(screen.getByRole("searchbox"), {
         target: { value: "a" },
       });
-      fireEvent.click(screen.getByRole("button"));
 
       expect(screen.queryByText("Searching...")).not.toBeInTheDocument();
     });
@@ -107,14 +105,8 @@ describe("AddToSearchQueue", () => {
       fireEvent.change(screen.getByRole("searchbox"), {
         target: { value: "bar" },
       });
-      fireEvent.click(screen.getByRole("button"));
-
-      expect(screen.getByText("Searching...")).toBeInTheDocument();
       await waitForElementToBeRemoved(() => screen.queryByText("Searching..."));
 
-      await waitFor(() => {
-        expect(screen.queryByText("Searching...")).not.toBeInTheDocument();
-      });
       expect(
         await screen.findByText("Cragell, Barb Whitaker")
       ).toBeInTheDocument();
@@ -125,12 +117,8 @@ describe("AddToSearchQueue", () => {
       fireEvent.change(screen.getByRole("searchbox"), {
         target: { value: "joh" },
       });
-      fireEvent.click(screen.getByRole("button"));
 
-      expect(screen.getByText("Searching...")).toBeInTheDocument();
       await waitForElementToBeRemoved(() => screen.queryByText("Searching..."));
-
-      expect(screen.queryByText("Searching...")).not.toBeInTheDocument();
       expect(
         await screen.findByText("Wilhelm, John Jenkins")
       ).toBeInTheDocument();

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -207,10 +207,6 @@ const AddToQueueSearchBox = ({
     setDebounced(event.target.value);
   };
 
-  const onSearchClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-  };
-
   const onAddToQueue = (
     patient: Patient,
     {
@@ -264,11 +260,11 @@ const AddToQueueSearchBox = ({
   return (
     <React.Fragment>
       <SearchInput
-        onSearchClick={onSearchClick}
         onInputChange={onInputChange}
         queryString={debounced}
         disabled={!allowQuery}
         placeholder={`Search for a ${PATIENT_TERM} to start their test`}
+        showSubmitButton={false}
       />
       <SearchResults
         page="queue"

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Patient } from "../../patients/ManagePatients";
@@ -114,7 +114,10 @@ describe("SearchResults", () => {
       );
 
       expect(screen.getByText(`Add new ${PATIENT_TERM}`)).toBeInTheDocument();
-      await userEvent.click(screen.getByText(`Add new ${PATIENT_TERM}`));
+      await act(
+        async () =>
+          await userEvent.click(screen.getByText(`Add new ${PATIENT_TERM}`))
+      );
       expect(
         screen.getByText(
           `Redirected to /add-patient?facility=${mockFacilityID}`

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -135,7 +135,10 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
     );
   } else {
     resultsContent = (
-      <table className="usa-table usa-table--borderless">
+      <table
+        className="usa-table usa-table--borderless"
+        aria-describedby={"patient-result-table-desc"}
+      >
         <thead>
           <tr>
             <th scope="col">Full name</th>
@@ -161,7 +164,16 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
   }
 
   const results = (
-    <div className="card-container shadow-3 results-dropdown" ref={dropDownRef}>
+    <div
+      className="card-container shadow-3 results-dropdown"
+      ref={dropDownRef}
+      aria-live="polite"
+      role="region"
+      aria-atomic="true"
+    >
+      <div className="sr-only" id={"patient-result-table-desc"}>
+        patient search results
+      </div>
       <div className="usa-card__body results-dropdown__body">
         {resultsContent}
       </div>

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -171,7 +171,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
       role="region"
       aria-atomic="true"
     >
-      <div className="sr-only" id={"patient-result-table-desc"}>
+      <div className="usa-sr-only" id={"patient-result-table-desc"}>
         patient search results
       </div>
       <div className="usa-card__body results-dropdown__body">

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookup.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookup.tsx
@@ -127,6 +127,7 @@ const DeviceLookup = (props: Props) => {
             queryString={debounced}
             placeholder={"Search for a device"}
             labeledBy="select-device"
+            showSubmitButton={false}
           />
           <DeviceSearchResults
             devices={searchDevices(props.deviceOptions, queryString)}

--- a/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
@@ -109,7 +109,7 @@ const DeviceSearchResults = (props: SearchResultsProps) => {
       role="region"
       aria-atomic="true"
     >
-      <div className="sr-only" id={"device-result-table-desc"}>
+      <div className="usa-sr-only" id={"device-result-table-desc"}>
         device search results
       </div>
       <div className="usa-card__body results-dropdown__body">

--- a/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceSearchResults.tsx
@@ -48,7 +48,10 @@ const DeviceSearchResults = (props: SearchResultsProps) => {
     );
   } else {
     resultsContent = (
-      <table className="usa-table usa-table--borderless">
+      <table
+        className="usa-table usa-table--borderless"
+        aria-describedby={"device-result-table-desc"}
+      >
         <thead>
           <tr>
             <th scope="col">Manufacturer</th>
@@ -99,7 +102,16 @@ const DeviceSearchResults = (props: SearchResultsProps) => {
     );
   }
   const results = (
-    <div className="card-container shadow-3 results-dropdown" ref={dropDownRef}>
+    <div
+      className="card-container shadow-3 results-dropdown"
+      ref={dropDownRef}
+      aria-live="polite"
+      role="region"
+      aria-atomic="true"
+    >
+      <div className="sr-only" id={"device-result-table-desc"}>
+        device search results
+      </div>
       <div className="usa-card__body results-dropdown__body">
         {resultsContent}
       </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5859

## Changes Proposed

- Set the prop that hides the search button in the search input for the conduct test and device lookup pages.
- Add alia live prop to the search results of those two pages so the results get announced by the screen reader

## Additional Information
Some unit testing clean up also was done to the related unit testing files.

## Testing
This ticket is small but if someone needs to test the search functionality in the conduct test and device lookup pages the code is available in Dev5.

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
