### PR TITLE
highlight headers in errors and guidance for better readability

### DIFF
--- a/frontend/src/app/testResults/uploads/Uploads.scss
+++ b/frontend/src/app/testResults/uploads/Uploads.scss
@@ -2,4 +2,8 @@
   .usa-process-list__heading {
     font-size: 1.17rem;
   }
+
+  mark {
+    background-color: #f0f0f0;
+  }
 }

--- a/frontend/src/app/testResults/uploads/Uploads.test.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.test.tsx
@@ -342,23 +342,27 @@ describe("Uploads", () => {
 
   describe("error guidance", () => {
     it("should give you guidance for missing headers", () => {
-      const guidance = getGuidance({
+      const Guidance = getGuidance({
         errorType: "MISSING_HEADER",
         fieldHeader: "patient_first_name",
       } as EnhancedFeedbackMessage);
 
-      expect(guidance).toEqual(
+      render(<Router>{Guidance}</Router>);
+
+      expect(screen.getByTestId("guidance")).toHaveTextContent(
         "Include a column with patient_first_name as the header."
       );
     });
 
     it("should give you guidance for missing data", () => {
-      const guidance = getGuidance({
+      const Guidance = getGuidance({
         errorType: "MISSING_DATA",
         fieldHeader: "patient_first_name",
       } as EnhancedFeedbackMessage);
 
-      expect(guidance).toEqual(
+      render(<Router>{Guidance}</Router>);
+
+      expect(screen.getByTestId("guidance")).toHaveTextContent(
         "patient_first_name is a required field. Include values in each row under this column."
       );
     });
@@ -372,11 +376,13 @@ describe("Uploads", () => {
 
       render(<Router>{Guidance}</Router>);
 
-      expect(
-        screen.getByText("Follow the instructions under patient_first_name", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("guidance")).toHaveTextContent(
+        "Follow the instructions under patient_first_name in the upload guide."
+      );
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        `/results/upload/submit/guide#patient_first_name`
+      );
     });
 
     it("should give you guidance for optional invalid data", async () => {
@@ -388,12 +394,13 @@ describe("Uploads", () => {
 
       render(<Router>{Guidance}</Router>);
 
-      expect(
-        screen.getByText(
-          "If including patient_middle_name, follow the instructions under patient_middle_name",
-          { exact: false }
-        )
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("guidance")).toHaveTextContent(
+        "If including patient_middle_name, follow the instructions under patient_middle_name in the upload guide."
+      );
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        `/results/upload/submit/guide#patient_middle_name`
+      );
     });
 
     it("should give you guidance for required invalid data with specific acceptable values", async () => {
@@ -405,12 +412,13 @@ describe("Uploads", () => {
 
       render(<Router>{Guidance}</Router>);
 
-      expect(
-        screen.getByText(
-          "Choose from the accepted values listed under patient_ethnicity",
-          { exact: false }
-        )
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("guidance")).toHaveTextContent(
+        "Choose from the accepted values listed under patient_ethnicity in the upload guide."
+      );
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        `/results/upload/submit/guide#patient_ethnicity`
+      );
     });
 
     it("should give you guidance for optional invalid data with specific acceptable values", async () => {
@@ -422,12 +430,13 @@ describe("Uploads", () => {
 
       render(<Router>{Guidance}</Router>);
 
-      expect(
-        screen.getByText(
-          "If including residence_type, choose from the accepted values listed under residence_type",
-          { exact: false }
-        )
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("guidance")).toHaveTextContent(
+        "If including residence_type, choose from the accepted values listed under residence_type in the upload guide."
+      );
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        `/results/upload/submit/guide#residence_type`
+      );
     });
   });
 });

--- a/frontend/src/app/testResults/uploads/Uploads.test.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.test.tsx
@@ -14,6 +14,7 @@ import SRToastContainer from "../../commonComponents/SRToastContainer";
 
 import Uploads, {
   EnhancedFeedbackMessage,
+  getErrorMessage,
   getGuidance,
   groupErrors,
 } from "./Uploads";
@@ -340,7 +341,7 @@ describe("Uploads", () => {
     });
   });
 
-  describe("error guidance", () => {
+  describe("error messages and guidance", () => {
     it("should give you guidance for missing headers", () => {
       const Guidance = getGuidance({
         errorType: "MISSING_HEADER",
@@ -367,7 +368,7 @@ describe("Uploads", () => {
       );
     });
 
-    it("should give you guidance for required invalid data", async () => {
+    it("should give you guidance for required invalid data", () => {
       const Guidance = getGuidance({
         errorType: "INVALID_DATA",
         fieldHeader: "patient_first_name",
@@ -385,7 +386,7 @@ describe("Uploads", () => {
       );
     });
 
-    it("should give you guidance for optional invalid data", async () => {
+    it("should give you guidance for optional invalid data", () => {
       const Guidance = getGuidance({
         errorType: "INVALID_DATA",
         fieldHeader: "patient_middle_name",
@@ -403,7 +404,7 @@ describe("Uploads", () => {
       );
     });
 
-    it("should give you guidance for required invalid data with specific acceptable values", async () => {
+    it("should give you guidance for required invalid data with specific acceptable values", () => {
       const Guidance = getGuidance({
         errorType: "INVALID_DATA",
         fieldHeader: "patient_ethnicity",
@@ -421,7 +422,7 @@ describe("Uploads", () => {
       );
     });
 
-    it("should give you guidance for optional invalid data with specific acceptable values", async () => {
+    it("should give you guidance for optional invalid data with specific acceptable values", () => {
       const Guidance = getGuidance({
         errorType: "INVALID_DATA",
         fieldHeader: "residence_type",
@@ -437,6 +438,41 @@ describe("Uploads", () => {
         "href",
         `/results/upload/submit/guide#residence_type`
       );
+    });
+
+    it("should highlight headers in error messages", () => {
+      const ErrorMessage = getErrorMessage({
+        message:
+          "Invalid equipment_model_name and test_performed_code combination",
+      } as EnhancedFeedbackMessage);
+
+      render(<Router>{ErrorMessage}</Router>);
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent(
+        "Invalid equipment_model_name and test_performed_code combination"
+      );
+      expect(screen.getAllByTestId("highlighted-header")).toHaveLength(2);
+      expect(screen.getAllByTestId("highlighted-header")[0]).toHaveTextContent(
+        "equipment_model_name"
+      );
+      expect(screen.getAllByTestId("highlighted-header")[1]).toHaveTextContent(
+        "test_performed_code"
+      );
+    });
+
+    it("should not highlight anything when no headers exist in error messages", () => {
+      const ErrorMessage = getErrorMessage({
+        message: "Invalid data",
+      } as EnhancedFeedbackMessage);
+
+      render(<Router>{ErrorMessage}</Router>);
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent(
+        "Invalid data"
+      );
+      expect(
+        screen.queryByTestId("highlighted-header")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -63,8 +63,8 @@ export function getErrorMessage(error: EnhancedFeedbackMessage) {
     const headerRegex = /([a-z0-9]+(?:_[a-z0-9]+){1,7})/g;
     return (
       <span data-testid="error-message">
-        {error.message.split(headerRegex).map((value, index) => (
-          <span key={`span-${value}-${index}`}>
+        {error.message.split(headerRegex).map((value) => (
+          <span key={`span-${value}`}>
             {headerRegex.test(value) ? (
               <mark data-testid="highlighted-header">
                 <code>{value}</code>

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -60,7 +60,7 @@ export function groupErrors(
 }
 export function getErrorMessage(error: EnhancedFeedbackMessage) {
   if (error.message) {
-    const headerRegex = /([a-z0-9]+(?:_[a-z0-9]+)+(?:[^\s]+))/g;
+    const headerRegex = /([a-z0-9]+(?:_[a-z0-9]+){1,7})/g;
     return (
       <span data-testid="error-message">
         {error.message.split(headerRegex).map((value, index) => (

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -59,22 +59,24 @@ export function groupErrors(
   return errors;
 }
 export function getErrorMessage(error: EnhancedFeedbackMessage) {
-  if (error.message && error.fieldHeader) {
-    const headerRegex = /([a-z0-9]+(?:_[a-z0-9]+)+(?:_[a-z0-9]+)*)/gi;
-    return error.message.split(headerRegex).map((value, index) => (
-      <span key={index}>
-        {headerRegex.test(value) ? (
-          <mark>
-            <code>{value}</code>
-          </mark>
-        ) : (
-          value
-        )}
+  if (error.message) {
+    const headerRegex = /([a-z0-9]+(?:_[a-z0-9]+)+(?:[^\s]+))/g;
+    return (
+      <span data-testid="error-message">
+        {error.message.split(headerRegex).map((value, index) => (
+          <span key={`span-${value}-${index}`}>
+            {headerRegex.test(value) ? (
+              <mark data-testid="highlighted-header">
+                <code>{value}</code>
+              </mark>
+            ) : (
+              value
+            )}
+          </span>
+        ))}
       </span>
-    ));
+    );
   }
-
-  return <span>{error.message}</span>;
 }
 
 export function getGuidance(error: EnhancedFeedbackMessage) {
@@ -122,40 +124,30 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
       </HashLink>
     );
 
-    let guidance;
-    if (required) {
-      if (specificValues) {
-        guidance = (
-          <span data-testid="guidance">
-            Choose from the accepted values listed under{" "}
-            {highlightHeader(header)} {guideLink}.
-          </span>
-        );
-      } else {
-        guidance = (
-          <span data-testid="guidance">
-            Follow the instructions under {highlightHeader(header)} {guideLink}.
-          </span>
-        );
-      }
+    if (specificValues) {
+      return (
+        <span data-testid="guidance">
+          {required ? (
+            <span>Choose </span>
+          ) : (
+            <span>If including {highlightHeader(header)}, choose </span>
+          )}
+          from the accepted values listed under {highlightHeader(header)}{" "}
+          {guideLink}.
+        </span>
+      );
     } else {
-      if (specificValues) {
-        guidance = (
-          <span data-testid="guidance">
-            If including {highlightHeader(header)}, choose from the accepted
-            values listed under {highlightHeader(header)} {guideLink}.
-          </span>
-        );
-      } else {
-        guidance = (
-          <span data-testid="guidance">
-            If including {highlightHeader(header)}, follow the instructions
-            under {highlightHeader(header)} {guideLink}.
-          </span>
-        );
-      }
+      return (
+        <span data-testid="guidance">
+          {required ? (
+            <span>Follow </span>
+          ) : (
+            <span>If including {highlightHeader(header)}, follow </span>
+          )}
+          the instructions under {highlightHeader(header)} {guideLink}.
+        </span>
+      );
     }
-    return guidance;
   };
 
   if (error.fieldHeader && error.errorType === "MISSING_HEADER") {

--- a/frontend/src/app/testResults/uploads/Uploads.tsx
+++ b/frontend/src/app/testResults/uploads/Uploads.tsx
@@ -99,11 +99,13 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
   );
 
   const getMissingHeaderErrorGuidance = (header: string) => (
-    <span>Include a column with {highlightHeader(header)} as the header.</span>
+    <span data-testid="guidance">
+      Include a column with {highlightHeader(header)} as the header.
+    </span>
   );
 
   const getMissingDataErrorGuidance = (header: string) => (
-    <span>
+    <span data-testid="guidance">
       {highlightHeader(header)} is a required field. Include values in each row
       under this column.
     </span>
@@ -124,14 +126,14 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
     if (required) {
       if (specificValues) {
         guidance = (
-          <span>
+          <span data-testid="guidance">
             Choose from the accepted values listed under{" "}
             {highlightHeader(header)} {guideLink}.
           </span>
         );
       } else {
         guidance = (
-          <span>
+          <span data-testid="guidance">
             Follow the instructions under {highlightHeader(header)} {guideLink}.
           </span>
         );
@@ -139,14 +141,14 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
     } else {
       if (specificValues) {
         guidance = (
-          <span>
+          <span data-testid="guidance">
             If including {highlightHeader(header)}, choose from the accepted
             values listed under {highlightHeader(header)} {guideLink}.
           </span>
         );
       } else {
         guidance = (
-          <span>
+          <span data-testid="guidance">
             If including {highlightHeader(header)}, follow the instructions
             under {highlightHeader(header)} {guideLink}.
           </span>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- part of #5418

## Changes Proposed

- highlight headers in error messages

## Additional Information

### Wrong value
![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/65726d2c-cc31-4bed-bc36-2bf1cb47b6a3)

### Missing column
![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/08f2d99e-cc35-43f8-8a70-0f0db105554d)

### Missing column values
![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/ce383a9e-cd7e-4b19-93a9-078951a148c5)

### Invalid device model and loinc combination
![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/e2e62406-ea85-4a44-bd1e-98e028f9da51)

## Testing

- How should reviewers verify this PR?
