### PR TITLE
pointing SR staging to RS prod

### DIFF
--- a/ops/stg/_data.tf
+++ b/ops/stg/_data.tf
@@ -192,22 +192,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-prod"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-prod"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-prod"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-prod"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

-  resolves #5930 

## Changes Proposed

- We are pointing our staging environment at report stream's prod environment. (Tests will come through marked with a test flag).  This is so we can test the full integration (SR -> RS -> STLT) for the bulk result fhir integration (with flu test results) with dummy data.

## Additional Information

- This is similar to what we are already doing for the single entry test result flow.

## Testing

- Testing will involve uploading a file with dummy data in `stg`, verifying that it was sent successfully to Report Stream and then following up with them to ensure it made it all the way through to CA.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->