### PR TITLE
fix bug adding new user

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -317,9 +317,17 @@ public class LiveOktaRepository implements OktaRepository {
 
   public Optional<OrganizationRoleClaims> updateUserPrivileges(
       String username, Organization org, Set<Facility> facilities, Set<OrganizationRole> roles) {
-    UserList users = _client.listUsers(null, null, generateLoginSearchTerm(username), null, null);
-    throwErrorIfEmpty(users.stream(), "Cannot update role of Okta user with unrecognized username");
-    User user = users.single();
+    var searchUserStream =
+        _client.listUsers(null, null, generateLoginSearchTerm(username), null, null).stream();
+    var qUserStream = _client.listUsers(username, null, null, null, null).stream();
+    var userStream = Stream.concat(searchUserStream, qUserStream).distinct();
+    User user =
+        userStream
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalGraphqlArgumentException(
+                        "Cannot update role of Okta user with unrecognized username"));
 
     String orgId = org.getExternalId();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -667,6 +667,8 @@ class LiveOktaRepositoryTest {
     var groupOrgDefaultName = groupOrgPrefix + ":NO_ACCESS";
     var orgRole = OrganizationRole.ADMIN;
     var mockUserList = mock(UserList.class);
+    var mockQUserList = mock(UserList.class);
+
     var mockUser = mock(User.class);
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
@@ -674,11 +676,14 @@ class LiveOktaRepositoryTest {
     var mockFullGroupList = mock(GroupList.class);
     var mockAdminGroup = mock(Group.class);
     var mockAdminGroupProfile = mock(GroupProfile.class);
+
     when(_client.listUsers(
             isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
+    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(mockQUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
-    when(mockUserList.single()).thenReturn(mockUser);
+    when(mockQUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUser.listGroups()).thenReturn(mockGroupList);
     when(mockGroupList.stream())
         .then(i -> Stream.of(mockGroup))
@@ -705,11 +710,15 @@ class LiveOktaRepositoryTest {
     var userName = "fraud@example.com";
     var org = new Organization("orgName", "orgType", "1", true);
     var mockUserList = mock(UserList.class);
+    var mockQUserList = mock(UserList.class);
 
     when(_client.listUsers(
             isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
+    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(mockQUserList);
     when(mockUserList.stream()).then(i -> Stream.of());
+    when(mockQUserList.stream()).then(i -> Stream.of());
 
     Set<Facility> facilities = Set.of();
     Set<OrganizationRole> roles = Set.of();
@@ -726,6 +735,7 @@ class LiveOktaRepositoryTest {
     var org = new Organization("orgName", "orgType", "1", true);
 
     var mockUserList = mock(UserList.class);
+    var mockQUserList = mock(UserList.class);
     var mockUser = mock(User.class);
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
@@ -733,8 +743,10 @@ class LiveOktaRepositoryTest {
     when(_client.listUsers(
             isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
+    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(mockQUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
-    when(mockUserList.single()).thenReturn(mockUser);
+    when(mockQUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUser.listGroups()).thenReturn(mockGroupList);
     when(mockGroupList.stream()).then(i -> Stream.of(mockGroup));
     when(mockGroup.getType()).thenReturn(GroupType.OKTA_GROUP);
@@ -760,6 +772,7 @@ class LiveOktaRepositoryTest {
     var groupOrgDefaultName = groupOrgPrefix + ":NO_ACCESS";
 
     var mockUserList = mock(UserList.class);
+    var mockQUserList = mock(UserList.class);
     var mockUser = mock(User.class);
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
@@ -769,8 +782,10 @@ class LiveOktaRepositoryTest {
     when(_client.listUsers(
             isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
+    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(mockQUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
-    when(mockUserList.single()).thenReturn(mockUser);
+    when(mockQUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUser.listGroups()).thenReturn(mockGroupList);
     when(mockGroupList.stream()).then(i -> Stream.of(mockGroup));
     when(mockGroup.getType()).thenReturn(GroupType.OKTA_GROUP);
@@ -799,6 +814,7 @@ class LiveOktaRepositoryTest {
     var groupOrgDefaultName = groupOrgPrefix + ":NO_ACCESS";
 
     var mockUserList = mock(UserList.class);
+    var mockQUserList = mock(UserList.class);
     var mockUser = mock(User.class);
     var mockGroupList = mock(GroupList.class);
     var mockGroup = mock(Group.class);
@@ -806,8 +822,10 @@ class LiveOktaRepositoryTest {
     when(_client.listUsers(
             isNull(), isNull(), eq("profile.login eq \"" + userName + "\""), isNull(), isNull()))
         .thenReturn(mockUserList);
+    when(_client.listUsers(eq(userName), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(mockQUserList);
     when(mockUserList.stream()).then(i -> Stream.of(mockUser));
-    when(mockUserList.single()).thenReturn(mockUser);
+    when(mockQUserList.stream()).then(i -> Stream.of(mockUser));
     when(mockUser.listGroups()).thenReturn(mockGroupList);
     when(mockGroupList.stream()).then(i -> Stream.of(mockGroup));
     when(mockGroup.getType()).thenReturn(GroupType.OKTA_GROUP);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -78,7 +78,8 @@ class LiveOktaRepositoryTest {
   void getOrganizationRoleClaimsForUser() {
     String username = "fraud@example.com";
 
-    UserList userList = mock(UserList.class);
+    UserList searchUserList = mock(UserList.class);
+    UserList qUserList = mock(UserList.class);
     User user = mock(User.class);
     GroupList groupList = mock(GroupList.class);
     Group group1 = mock(Group.class);
@@ -91,9 +92,10 @@ class LiveOktaRepositoryTest {
     GroupProfile groupProfile4 = mock(GroupProfile.class);
 
     when(_client.listUsers(null, null, "profile.login eq \"" + username + "\"", null, null))
-        .thenReturn(userList);
-    when(userList.stream()).thenReturn(Stream.of(user));
-    when(userList.single()).thenReturn(user);
+        .thenReturn(searchUserList);
+    when(_client.listUsers(username, null, null, null, null)).thenReturn(qUserList);
+    when(searchUserList.stream()).thenReturn(Stream.of(user));
+    when(qUserList.stream()).thenReturn(Stream.of(user));
     when(user.listGroups()).thenReturn(groupList);
     when(groupList.stream()).thenReturn(Stream.of(group1, group2, group3, group4));
     when(group1.getType()).thenReturn(GroupType.OKTA_GROUP);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Quick fix to #5945 

## Changes Proposed

- Use both the search and q results to fetch a user when updating user privileges.

## Additional Information

- When users are added, Okta's backend needs time to propogate the new user to be `searchable` and by the time we attempt to update the users permissions the user is not available.  This is similar to the issue we previously had with [groups](https://github.com/okta/okta-sdk-java/issues/750). By using both the search and q results we can make sure this isn't a problem.
- This is a TEMP fix until the refactor to just set roles and facilities in a single mutation is done. 

## Testing

- Test adding a new user in any env, it will probably fail. Test again in dev3 and it should work!


