### PR TITLE
Fixed i18n warning in CovidResultGuidance test

### DIFF
--- a/frontend/src/app/commonComponents/CovidResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/CovidResultGuidance.test.tsx
@@ -3,6 +3,7 @@ import { render } from "@testing-library/react";
 import { TEST_RESULTS } from "../testResults/constants";
 
 import CovidResultGuidance from "./CovidResultGuidance";
+import "../../i18n";
 
 describe("CovidResultGuidance", () => {
   const cases = [

--- a/frontend/src/app/commonComponents/__snapshots__/CovidResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/CovidResultGuidance.test.tsx.snap
@@ -5,93 +5,117 @@ exports[`CovidResultGuidance displays guidance for "NEGATIVE" result 1`] = `
   <p
     class="text-bold sr-guidance-heading"
   >
-    testResult.notes.h1
+    For COVID-19:
   </p>
   <p>
-    testResult.notes.negative.p0
+    Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
   </p>
   <ul
     class="sr-multi-column"
   >
     <li>
-      testResult.notes.negative.symptoms.li0
+      Fever or chills
     </li>
     <li>
-      testResult.notes.negative.symptoms.li1
+      Cough
     </li>
     <li>
-      testResult.notes.negative.symptoms.li2
+      Shortness of breath or difficulty breathing
     </li>
     <li>
-      testResult.notes.negative.symptoms.li3
+      Fatigue
     </li>
     <li>
-      testResult.notes.negative.symptoms.li4
+      Muscle or body aches
     </li>
     <li>
-      testResult.notes.negative.symptoms.li5
+      Headache
     </li>
     <li>
-      testResult.notes.negative.symptoms.li6
+      Loss of taste or smell
     </li>
     <li>
-      testResult.notes.negative.symptoms.li7
+      Sore throat
     </li>
     <li>
-      testResult.notes.negative.symptoms.li8
+      Congestion or runny nose
     </li>
     <li>
-      testResult.notes.negative.symptoms.li9
+      Nausea or vomiting
     </li>
     <li>
-      testResult.notes.negative.symptoms.li10
+      Diarrhea
     </li>
   </ul>
+  <p>
+    For more information, please visit the 
+    <a
+      href="https://www.cdc.gov/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Centers for Disease Control and Prevention (CDC)
+    </a>
+     website or contact
+your local health department.
+  </p>
 </div>
 `;
 
 exports[`CovidResultGuidance displays guidance for "NEGATIVE" result 2`] = `
 <div>
   <p>
-    testResult.notes.negative.p0
+    Contact your health care provider to decide if additional testing is needed, especially if you experience any of these symptoms:
   </p>
   <ul
     class=""
   >
     <li>
-      testResult.notes.negative.symptoms.li0
+      Fever or chills
     </li>
     <li>
-      testResult.notes.negative.symptoms.li1
+      Cough
     </li>
     <li>
-      testResult.notes.negative.symptoms.li2
+      Shortness of breath or difficulty breathing
     </li>
     <li>
-      testResult.notes.negative.symptoms.li3
+      Fatigue
     </li>
     <li>
-      testResult.notes.negative.symptoms.li4
+      Muscle or body aches
     </li>
     <li>
-      testResult.notes.negative.symptoms.li5
+      Headache
     </li>
     <li>
-      testResult.notes.negative.symptoms.li6
+      Loss of taste or smell
     </li>
     <li>
-      testResult.notes.negative.symptoms.li7
+      Sore throat
     </li>
     <li>
-      testResult.notes.negative.symptoms.li8
+      Congestion or runny nose
     </li>
     <li>
-      testResult.notes.negative.symptoms.li9
+      Nausea or vomiting
     </li>
     <li>
-      testResult.notes.negative.symptoms.li10
+      Diarrhea
     </li>
   </ul>
+  <p>
+    For more information, please visit the 
+    <a
+      href="https://www.cdc.gov/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Centers for Disease Control and Prevention (CDC)
+    </a>
+     website or contact
+your local health department.
+  </p>
 </div>
 `;
 
@@ -100,50 +124,80 @@ exports[`CovidResultGuidance displays guidance for "POSITIVE" result 1`] = `
   <p
     class="text-bold sr-guidance-heading"
   >
-    testResult.notes.h1
+    For COVID-19:
   </p>
   <p>
-    testResult.notes.positive.p1
+    Most people who get COVID-19 are able to recover at home. Make sure to follow CDC guidelines and local laws for people who are recovering at home and their caregivers, including:
   </p>
   <ul>
     <li>
-      testResult.notes.positive.guidelines.li0
+      Stay home when you are sick, except to get medical care.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li1
+      Stay home for 5 days. If you have no symptoms or your symptoms are resolving after 5 days, you can leave your house. Continue to wear a mask around others for 5 additional days.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li2
+      If you are self isolating at home where others live, use a separate room and bathroom for sick household members (if possible). Clean any shared rooms as needed, to avoid transmitting the virus.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li3
+      Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li4
+      If soap and water are not available, use an alcohol-based hand sanitizer with at least 60% alcohol.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li5
-    </li>
-  </ul>
-  <ul>
-    <li>
-      testResult.notes.positive.emergency.li0
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li1
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li2
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li3
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li4
+      Have a supply of clean, disposable face masks. Everyone, no matter their COVID-19 diagnosis, should wear face masks while in the home.
     </li>
   </ul>
   <p>
-    testResult.notes.positive.p3
+    Watch for symptoms and learn when to seek emergency medical attention: 
+    <a
+      href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Symptoms of COVID-19
+    </a>
+     (cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html). If someone is showing any of these signs, seek emergency medical care immediately:
+  </p>
+  <ul>
+    <li>
+      Trouble breathing
+    </li>
+    <li>
+      Persistent chest pain/pressure
+    </li>
+    <li>
+      Confusion
+    </li>
+    <li>
+      Inability to wake or stay awake
+    </li>
+    <li>
+      Bluish lips or face
+    </li>
+  </ul>
+  <p>
+    Call 911 or call ahead to your local emergency room: Notify the operator that you are seeking care for someone who has or may have COVID-19.
+  </p>
+  <p>
+    For more information go to 
+    <a
+      href="https://www.cdc.gov/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      CDC.gov
+    </a>
+     or call 1-800-CDC-INFO (1-800-232-4636). Use the 
+    <a
+      href="https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      County Check Tool
+    </a>
+     (cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html) to understand your Community Level (COVID-19 risk and hospital capacity in your area), tips for prevention, and how to find vaccine, testing, and treatment resources.
   </p>
 </div>
 `;
@@ -151,47 +205,75 @@ exports[`CovidResultGuidance displays guidance for "POSITIVE" result 1`] = `
 exports[`CovidResultGuidance displays guidance for "POSITIVE" result 2`] = `
 <div>
   <p>
-    testResult.notes.positive.p1
+    Most people who get COVID-19 are able to recover at home. Make sure to follow CDC guidelines and local laws for people who are recovering at home and their caregivers, including:
   </p>
   <ul>
     <li>
-      testResult.notes.positive.guidelines.li0
+      Stay home when you are sick, except to get medical care.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li1
+      Stay home for 5 days. If you have no symptoms or your symptoms are resolving after 5 days, you can leave your house. Continue to wear a mask around others for 5 additional days.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li2
+      If you are self isolating at home where others live, use a separate room and bathroom for sick household members (if possible). Clean any shared rooms as needed, to avoid transmitting the virus.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li3
+      Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li4
+      If soap and water are not available, use an alcohol-based hand sanitizer with at least 60% alcohol.
     </li>
     <li>
-      testResult.notes.positive.guidelines.li5
-    </li>
-  </ul>
-  <ul>
-    <li>
-      testResult.notes.positive.emergency.li0
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li1
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li2
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li3
-    </li>
-    <li>
-      testResult.notes.positive.emergency.li4
+      Have a supply of clean, disposable face masks. Everyone, no matter their COVID-19 diagnosis, should wear face masks while in the home.
     </li>
   </ul>
   <p>
-    testResult.notes.positive.p3
+    Watch for symptoms and learn when to seek emergency medical attention: 
+    <a
+      href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html"
+    >
+      Symptoms of COVID-19
+    </a>
+     (cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html). If someone is showing any of these signs, seek emergency medical care immediately:
+  </p>
+  <ul>
+    <li>
+      Trouble breathing
+    </li>
+    <li>
+      Persistent chest pain/pressure
+    </li>
+    <li>
+      Confusion
+    </li>
+    <li>
+      Inability to wake or stay awake
+    </li>
+    <li>
+      Bluish lips or face
+    </li>
+  </ul>
+  <p>
+    Call 911 or call ahead to your local emergency room: Notify the operator that you are seeking care for someone who has or may have COVID-19.
+  </p>
+  <p>
+    For more information go to 
+    <a
+      href="https://www.cdc.gov/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      CDC.gov
+    </a>
+     or call 1-800-CDC-INFO (1-800-232-4636). Use the 
+    <a
+      href="https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      County Check Tool
+    </a>
+     (cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html) to understand your Community Level (COVID-19 risk and hospital capacity in your area), tips for prevention, and how to find vaccine, testing, and treatment resources.
   </p>
 </div>
 `;
@@ -201,10 +283,10 @@ exports[`CovidResultGuidance displays guidance for "UNDETERMINED" result 1`] = `
   <p
     class="text-bold sr-guidance-heading"
   >
-    testResult.notes.h1
+    For COVID-19:
   </p>
   <p>
-    testResult.notes.inconclusive.p0
+    An inconclusive result is neither positive nor negative. This can happen because of problems with the sample collection, a very early-stage COVID-19 infection, or for patients with COVID-19 that are close to recovery. With an inconclusive result, collecting and testing another sample is recommended.
   </p>
 </div>
 `;
@@ -212,10 +294,10 @@ exports[`CovidResultGuidance displays guidance for "UNDETERMINED" result 1`] = `
 exports[`CovidResultGuidance displays guidance for "UNDETERMINED" result 2`] = `
 <div>
   <p>
-    testResult.notes.inconclusive.p0
+    An inconclusive result is neither positive nor negative. This can happen because of problems with the sample collection, a very early-stage COVID-19 infection, or for patients with COVID-19 that are close to recovery. With an inconclusive result, collecting and testing another sample is recommended.
   </p>
   <p>
-    testResult.notes.inconclusive.p1
+    Please make an appointment for another test as soon as possible. If you’ve gotten tested due to COVID-19 symptoms, it is recommended that you self-isolate until you get your new test results.
   </p>
 </div>
 `;
@@ -225,7 +307,7 @@ exports[`CovidResultGuidance displays guidance for "UNKNOWN" result 1`] = `
   <p
     class="text-bold sr-guidance-heading"
   >
-    testResult.notes.h1
+    For COVID-19:
   </p>
 </div>
 `;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes a runtime i18n warning in jest tests `react-i18next:: You will need to pass in an i18next instance by using i18nextReactModule`

## Changes Proposed

Followed the implementation for other components that used translation and imported the configuration file to the test.

## Testing

Verify that the warning for `src/app/commonComponents/CovidResultGuidance.test.tsx` no longer shows. 

