### PR TITLE
make aria label in the test results list unique

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -213,7 +213,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing 1-3 of 3"));
+    expect(await screen.findByText("Showing 1-5 of 5"));
     expect(
       screen.getByRole("columnheader", { name: /covid-19/i })
     ).toBeInTheDocument();
@@ -287,7 +287,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing 1-3 of 3"));
+    expect(await screen.findByText("Showing 1-5 of 5"));
 
     expect(
       screen.getByRole("columnheader", { name: /covid-19/i })

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -394,7 +394,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
               >
                 <button
-                  aria-label="Click for more detailed results information for Gerard, Sam G"
+                  aria-label="Click for more detailed results information for Gerard, Sam G conducted on March 19th 2021, 7:27:21 pm"
                   class="usa-button usa-button--unstyled sr-link__primary"
                   type="button"
                 >
@@ -474,7 +474,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
               >
                 <button
-                  aria-label="Click for more detailed results information for Colleer, Barde X"
+                  aria-label="Click for more detailed results information for Colleer, Barde X conducted on March 18th 2021, 7:27:21 pm"
                   class="usa-button usa-button--unstyled sr-link__primary"
                   type="button"
                 >
@@ -554,7 +554,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
               >
                 <button
-                  aria-label="Click for more detailed results information for Cragell, Barb Whitaker"
+                  aria-label="Click for more detailed results information for Cragell, Barb Whitaker conducted on March 17th 2021, 7:27:23 pm"
                   class="usa-button usa-button--unstyled sr-link__primary"
                   type="button"
                 >

--- a/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
@@ -129,6 +129,85 @@ const data = [
     symptoms: '{"someSymptom":"true"}',
     __typename: "TestResult",
   },
+  {
+    internalId: "41b64baa-2ede-4f05-8c6e-66f8638644bd",
+    dateTested: "2021-03-20T19:27:21.052Z",
+    results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
+    correctionStatus: "ORIGINAL",
+    deviceType: {
+      internalId: "8c1a8efe-8951-4f84-a4c9-dcea561d7fbb",
+      name: "Abbott IDNow",
+      __typename: "DeviceType",
+    },
+    patient: {
+      internalId: "f74ad245-3a69-44b5-bb6d-efe06308bb85",
+      firstName: "Rupert",
+      middleName: "G",
+      lastName: "Purrington",
+      birthDate: "1960-11-07",
+      gender: "male",
+      role: "RESIDENT",
+      lookupId: null,
+      email: "sam@gerard.com",
+      __typename: "Patient",
+    },
+    createdBy: {
+      nameInfo: {
+        firstName: "Ethan",
+        middleName: "",
+        lastName: "Entry",
+      },
+    },
+    patientLink: {
+      internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
+    },
+    facility: {
+      name: "Facility 1",
+    },
+    noSymptoms: false,
+    symptoms: '{"someSymptom":"true"}',
+    __typename: "TestResult",
+  },
+  {
+    internalId: "bee09228-9063-45ac-93fd-35e8ca86aff5",
+    dateTested: "2021-03-20T19:28:21.052Z",
+    dateUpdated: "2021-03-20T19:29:21.052Z",
+    results: [{ disease: { name: "COVID-19" }, testResult: "POSITIVE" }],
+    correctionStatus: "CORRECTED",
+    deviceType: {
+      internalId: "8c1a8efe-8951-4f84-a4c9-dcea561d7fbb",
+      name: "Abbott IDNow",
+      __typename: "DeviceType",
+    },
+    patient: {
+      internalId: "f74ad245-3a69-44b5-bb6d-efe06308bb85",
+      firstName: "Rupert",
+      middleName: "G",
+      lastName: "Purrington",
+      birthDate: "1960-11-07",
+      gender: "male",
+      role: "RESIDENT",
+      lookupId: null,
+      email: "sam@gerard.com",
+      __typename: "Patient",
+    },
+    createdBy: {
+      nameInfo: {
+        firstName: "Ethan",
+        middleName: "",
+        lastName: "Entry",
+      },
+    },
+    patientLink: {
+      internalId: "68c543e8-7c65-4047-955c-e3f65bb8b58a",
+    },
+    facility: {
+      name: "Facility 1",
+    },
+    noSymptoms: false,
+    symptoms: '{"someSymptom":"true"}',
+    __typename: "TestResult",
+  },
 ];
 const TEST_RESULTS_MULTIPLEX = {
   content: data,

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.test.tsx
@@ -142,6 +142,28 @@ describe("Component ResultsTable", () => {
     expect(screen.getByText("Flu B")).toBeInTheDocument();
   });
 
+  it("renders multiple results for the same patient with different aria labels", () => {
+    render(
+      <ResultsTable
+        results={TEST_RESULTS_MULTIPLEX_CONTENT}
+        setPrintModalId={setPrintModalIdFn}
+        setMarkCorrectionId={setMarkCorrectionIdFn}
+        setDetailsModalId={setDetailsModalIdFn}
+        setTextModalId={setTextModalIdFn}
+        setEmailModalTestResultId={setEmailModalTestResultIdFn}
+        hasMultiplexResults={true}
+        hasFacility={false}
+      />
+    );
+
+    const userResults = screen.getAllByText(
+      "Purrington, Rupert G"
+    ) as HTMLButtonElement[];
+
+    const userAriaLabels = userResults.map((r) => r.getAttribute("aria-label"));
+    expect(new Set(userAriaLabels).size).toBe(userResults.length);
+  });
+
   describe("actions menu", () => {
     describe("text result action", () => {
       it("includes `Text result` if patient has mobile number", async () => {

--- a/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
+++ b/frontend/src/app/testResults/resultsTable/ResultsTable.tsx
@@ -1,5 +1,6 @@
 import React, { Dispatch, SetStateAction } from "react";
 import classnames from "classnames";
+import moment from "moment";
 
 import { PATIENT_TERM_CAP } from "../../../config/constants";
 import { TEST_RESULT_DESCRIPTIONS } from "../../constants";
@@ -13,6 +14,21 @@ import { MULTIPLEX_DISEASES } from "../constants";
 import { toLowerCaseHyphenate } from "../../utils/text";
 import { TestResult, PhoneNumber, Maybe } from "../../../generated/graphql";
 import { getResultObjByDiseaseName } from "../../utils/testResults";
+
+export const TEST_RESULT_ARIA_TIME_FORMAT = "MMMM Do YYYY, h:mm:ss a";
+export function formatTestResultAriaLabel(result: TestResult) {
+  const patientFullName = displayFullName(
+    result.patient?.firstName,
+    result.patient?.middleName,
+    result.patient?.lastName
+  );
+
+  const displayPatientDate =
+    result.correctionStatus === "ORIGINAL"
+      ? moment(result.dateTested).format(TEST_RESULT_ARIA_TIME_FORMAT)
+      : moment(result.dateUpdated).format(TEST_RESULT_ARIA_TIME_FORMAT);
+  return `Click for more detailed results information for ${patientFullName} conducted on ${displayPatientDate}`;
+}
 
 export const generateTableHeaders = (
   hasMultiplexResults: boolean,
@@ -179,11 +195,7 @@ const generateResultRows = (
         <td className="patient-name-cell">
           <Button
             variant="unstyled"
-            ariaLabel={`Click for more detailed results information for ${displayFullName(
-              r.patient?.firstName,
-              r.patient?.middleName,
-              r.patient?.lastName
-            )}`}
+            ariaLabel={formatTestResultAriaLabel(r)}
             label={displayFullName(
               r.patient?.firstName,
               r.patient?.middleName,


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fix is an outcome of the recent [aria label fix](https://github.com/CDCgov/prime-simplereport/pull/5975) violating aria-label accessibility issues.
<img width="956" alt="Screenshot 2023-06-20 at 10 06 28 PM" src="https://github.com/CDCgov/prime-simplereport/assets/29645040/99ba3812-ac49-4626-b04e-148d8f5d0349">

## Changes Proposed

- Added test time / date to the aria label so the label is unique
- Added a regression test to make sure the aria-label is unique for multiple tests

## Testing
- Verify the screenreading output is still accessible enough / actually is unique

## Screenshots / Demos
<img width="738" alt="Screenshot 2023-06-20 at 10 21 33 PM" src="https://github.com/CDCgov/prime-simplereport/assets/29645040/d90ec5be-4190-4543-a4ad-b6f05633102d">



<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
