### PR TITLE
E2E avoid device name collision

### DIFF
--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -51,7 +51,7 @@ describe("Conducting a COVID test", () => {
   });
   it("completes the test", () => {
     cy.get(queueCard).within(() => {
-      cy.get('select[name="testDevice"]').select(covidOnlyDeviceName);
+      cy.get('select[name="testDevice"]').select(covidOnlyDeviceName).should('have.text', covidOnlyDeviceName);;
       cy.get('.prime-radios input[value="NEGATIVE"]+label').click();
       cy.get(".prime-test-result-submit button").last().click();
     });

--- a/cypress/e2e/09-multiplex_testing.cy.js
+++ b/cypress/e2e/09-multiplex_testing.cy.js
@@ -68,7 +68,7 @@ describe("Testing with multiplex devices", () => {
     cy.checkA11y();
     cy.get(`div[data-testid="test-card-${patient.internalId}"]`).within(
       () => {
-        cy.get('select[name="testDevice"]').select(multiplexDeviceName);
+        cy.get('select[name="testDevice"]').select(multiplexDeviceName).should('have.text', multiplexDeviceName);;
         cy.get('button[type="submit"]').as("submitBtn");
         cy.get("@submitBtn").should("be.disabled");
         cy.get(".multiplex-result-form").contains("COVID-19");

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -63,8 +63,8 @@ export const generateOrganization = () => {
 
 export const generateMultiplexDevice = () => {
   const multiplexDevice = {};
-  multiplexDevice.name = `${testNumber()}-${faker.company.companyName()}-multiplex-device`;
-  multiplexDevice.model = `${testNumber()}-${faker.company.companyName()}-multiplex-model`;
+  multiplexDevice.name = `multiplex-${testNumber()}-${faker.company.companyName()}-device`;
+  multiplexDevice.model = `multiplex-${testNumber()}-${faker.company.companyName()}-model`;
   multiplexDevice.manufacturer = `${testNumber()}-${faker.company.companyName()}`;
   multiplexDevice.isMultiplex = true;
   return multiplexDevice;
@@ -72,8 +72,8 @@ export const generateMultiplexDevice = () => {
 
 export const generateCovidOnlyDevice = () => {
   const covidOnlyDevice = {};
-  covidOnlyDevice.name = `${testNumber()}-${faker.company.companyName()}-covid-device`;
-  covidOnlyDevice.model = `${testNumber()}-${faker.company.companyName()}-covid-model`;
+  covidOnlyDevice.name = `covid-${testNumber()}-${faker.company.companyName()}-device`;
+  covidOnlyDevice.model = `covid-${testNumber()}-${faker.company.companyName()}-model`;
   covidOnlyDevice.manufacturer = `${testNumber()}-${faker.company.companyName()}`;
   covidOnlyDevice.isMultiplex = false
   return covidOnlyDevice;


### PR DESCRIPTION
# E2E PULL REQUEST

## Related Issue
- #5952
- Separating changes from https://github.com/CDCgov/prime-simplereport/pull/5970
- Multiplex and covid devices have very close names, and sometimes it chooses the wrong device in the select
![Conducting a COVID test -- completes the test (failed)](https://github.com/CDCgov/prime-simplereport/assets/4952042/248c0544-2dfb-4327-bfe3-f0c516ff34d9)


## Changes Proposed

- change the beginning of the device names

## Testing

- How should reviewers verify this PR?