### PR TITLE
improve e2e reliability part 2

### DIFF
--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -78,7 +78,6 @@ describe("Conducting a COVID test", () => {
 
     cy.get(queueCard).within(() => {
       cy.get('.prime-radios input[value="NEGATIVE"]+label').click();
-      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]').first().should('be.checked');
     });
 
     cy.wait("@GetFacilityQueue", {timeout: 20000});

--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -77,7 +77,7 @@ describe("Conducting a COVID test", () => {
     cy.wait("@GetFacilityQueue", {timeout: 20000});
 
     cy.get(queueCard).within(() => {
-      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]').first().should("be.enabled").check();
+      cy.get('.prime-radios input[value="NEGATIVE"]+label').click();
       cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]').first().should('be.checked');
     });
 

--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -77,8 +77,8 @@ describe("Conducting a COVID test", () => {
     cy.wait("@GetFacilityQueue", {timeout: 20000});
 
     cy.get(queueCard).within(() => {
-      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]+label').first().should("be.enabled").check();
-      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]+label').first().should('be.checked');
+      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]').first().should("be.enabled").check();
+      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]').first().should('be.checked');
     });
 
     cy.wait("@GetFacilityQueue", {timeout: 20000});

--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -77,13 +77,14 @@ describe("Conducting a COVID test", () => {
     cy.wait("@GetFacilityQueue", {timeout: 20000});
 
     cy.get(queueCard).within(() => {
-      cy.get('.prime-radios input[value="NEGATIVE"]+label').click();
+      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]+label').first().should("be.enabled").check();
+      cy.get('.prime-radios input[type="radio"][value="NEGATIVE"]+label').first().should('be.checked');
     });
 
-    cy.wait("@EditQueueItem");
+    cy.wait("@GetFacilityQueue", {timeout: 20000});
 
     cy.get(queueCard).within(() => {
-      cy.get(".prime-test-result-submit button").last().click();
+      cy.get(".prime-test-result-submit button").last().should("be.enabled").click();
     });
 
     cy.wait("@SubmitQueueItem");

--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -80,10 +80,10 @@ describe("Conducting a COVID test", () => {
       cy.get('.prime-radios input[value="NEGATIVE"]+label').click();
     });
 
-    cy.wait("@GetFacilityQueue", {timeout: 20000});
+    cy.wait("@EditQueueItem");
 
     cy.get(queueCard).within(() => {
-      cy.get(".prime-test-result-submit button").last().should("be.enabled").click();
+      cy.get(".prime-test-result-submit button").last().click();
     });
 
     cy.wait("@SubmitQueueItem");

--- a/cypress/e2e/08-account_creation.cy.js
+++ b/cypress/e2e/08-account_creation.cy.js
@@ -16,7 +16,6 @@ Cypress.Commands.add("setPassword", () => {
   cy.get('input[name="confirm-password"]').type(pass);
   cy.get(submitButton).click();
   cy.contains("Select your security question");
-  cy.injectSRAxe();
   cy.checkA11y();
 });
 
@@ -27,7 +26,6 @@ Cypress.Commands.add("setSecurityQuestion", () => {
   cy.get('input[name="answer"]').type("Jane Doe");
   cy.get(submitButton).click();
   cy.contains("Set up authentication");
-  cy.injectSRAxe();
   cy.checkA11y();
 });
 
@@ -41,7 +39,6 @@ Cypress.Commands.add("mfaSelect", (choice) => {
 
 Cypress.Commands.add("enterPhoneNumber", () => {
   cy.contains("Get your security code via");
-  cy.injectSRAxe();
   cy.checkA11y();
   cy.get('input[name="phone-number"]').type("530867530");
   cy.contains("Get your security code via").click();
@@ -53,7 +50,6 @@ Cypress.Commands.add("enterPhoneNumber", () => {
 
 Cypress.Commands.add("scanQrCode", () => {
   cy.contains("Get your security code via");
-  cy.injectSRAxe();
   cy.checkA11y();
   cy.get(submitButton).click();
 });
@@ -61,7 +57,6 @@ Cypress.Commands.add("scanQrCode", () => {
 Cypress.Commands.add("verifySecurityCode", (code) => {
   cy.contains("Verify your security code.");
   cy.contains('One-time security code');
-  cy.injectSRAxe();
   cy.checkA11y();
   cy.get('input[name="security-code"]').type(code);
   cy.get(submitButton).first().click();
@@ -108,7 +103,6 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
-      cy.injectSRAxe();
       cy.checkA11y();
     });
   });
@@ -120,6 +114,7 @@ describe("Okta account creation", () => {
     it("navigates to the activation link", () => {
       cy.visit("/uac/?activationToken=NOr20VqF5M6m8AnwcSUJ");
       cy.contains("Create your password");
+      cy.injectSRAxe();
     });
     it("sets a password", () => {
       cy.setPassword();
@@ -138,7 +133,6 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
-      cy.injectSRAxe();
       cy.checkA11y();
     });
   });
@@ -150,6 +144,7 @@ describe("Okta account creation", () => {
     it("navigates to the activation link", () => {
       cy.visit("/uac/?activationToken=gqYPzH1FlPzVr0U3tQ7H");
       cy.contains("Create your password");
+      cy.injectSRAxe();
     });
     it("sets a password", () => {
       cy.setPassword();
@@ -168,7 +163,6 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
-      cy.injectSRAxe();
       cy.checkA11y();
     });
   });
@@ -180,6 +174,7 @@ describe("Okta account creation", () => {
     it("navigates to the activation link", () => {
       cy.visit("/uac/?activationToken=wN5mR-8SXao1TP2PLaFe");
       cy.contains("Create your password");
+      cy.injectSRAxe();
     });
     it("sets a password", () => {
       cy.setPassword();
@@ -198,7 +193,6 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
-      cy.injectSRAxe();
       cy.checkA11y();
     });
   });
@@ -210,6 +204,7 @@ describe("Okta account creation", () => {
     it("navigates to the activation link", () => {
       cy.visit("/uac/?activationToken=4OVwdVhc6M1I-UwvLrNX");
       cy.contains("Create your password");
+      cy.injectSRAxe();
     });
     it("sets a password", () => {
       cy.setPassword();
@@ -225,7 +220,6 @@ describe("Okta account creation", () => {
     });
     it("displays a success message", () => {
       cy.contains("Account set up complete");
-      cy.injectSRAxe();
       cy.checkA11y();
     });
   });

--- a/cypress/e2e/09-multiplex_testing.cy.js
+++ b/cypress/e2e/09-multiplex_testing.cy.js
@@ -86,6 +86,7 @@ describe("Testing with multiplex devices", () => {
       );
       cy.get('input[name="inconclusive-tests"]')
         .should("not.be.checked")
+        .should("be.enabled")
         .siblings("label")
         .click();
     });

--- a/cypress/e2e/10-save_and_start_covid_test.cy.js
+++ b/cypress/e2e/10-save_and_start_covid_test.cy.js
@@ -33,6 +33,7 @@ describe('Save and start covid test',()=>{
       cy.get(".sr-patient-list").should('exist');
       cy.get(".sr-patient-list").contains('Loading...').should('not.exist');
       cy.get("#search-field-small").type(lastName);
+      cy.wait("@GetPatientsByFacility")
       cy.get(".sr-patient-list").contains(patientName).should('exist');
     });
 
@@ -71,6 +72,9 @@ describe('Save and start covid test',()=>{
       cy.contains("button", "Continue").click();
       cy.get(".prime-home").contains(patientName);
       cy.url().should("include", "queue");
+
+      cy.wait("@GetFacilityQueue", {timeout: 20000});
+
       // Test a11y on the Test Queue page
       cy.checkA11y();
     });
@@ -116,6 +120,9 @@ describe('Save and start covid test',()=>{
 
       cy.get(".modal__container #save-confirmed-address").click();
       cy.url().should("include", "queue");
+
+      cy.wait("@GetFacilityQueue", {timeout: 20000});
+
       cy.get('input[name="testResultDeliverySms"][value="SMS"]').should(
         "be.disabled"
       );
@@ -139,6 +146,7 @@ describe('Save and start covid test',()=>{
       cy.contains("button", "Continue").click();
       cy.get(".prime-home").contains(patient.firstName);
       cy.url().should("include", "queue");
+      cy.wait("@GetFacilityQueue", {timeout: 20000});
     });
   });
 
@@ -147,11 +155,15 @@ describe('Save and start covid test',()=>{
       cy.visit("/");
       cy.get(".usa-nav-container");
       cy.get("#desktop-conduct-test-nav-link").click();
+
+      cy.wait("@GetFacilityQueue", {timeout: 20000});
+
       cy.get(".card-name").contains(patientName).click();
       cy.get('input[name="middleName"]').clear().type(testNumber().toString(10));
     });
     it("clicks save changes and verifies test queue redirect", () => {
       cy.get(".prime-save-patient-changes").first().click();
+      cy.wait("@UpdatePatient");
     });
     it("verifies test card highlighted", () => {
       cy.wait("@GetFacilityQueue", {timeout: 20000});
@@ -166,14 +178,17 @@ describe('Save and start covid test',()=>{
       cy.visit("/");
       cy.get(".usa-nav-container");
       cy.get("#desktop-patient-nav-link").click();
+
+      cy.wait("@GetPatientsByFacility");
+
       cy.get(".sr-patient-list").contains('Loading...').should('not.exist');
       cy.get("#search-field-small").type(lastName);
       cy.contains("tr", patientName).find(".sr-actions-menu").click();
       cy.contains("Start test").click();
+      cy.wait("@GetFacilityQueue", {timeout: 20000});
     });
 
     it("verifies test card highlighted", () => {
-      cy.wait("@GetFacilityQueue", {timeout: 20000});
       cy.get(".ReactModal__Content").should("not.exist");
       cy.url().should("include", "queue");
       cy.get(".prime-queue-item__info").contains(patientName);


### PR DESCRIPTION
# E2E PULL REQUEST

## Related Issue

- #5952

## Changes Proposed

- add `cy.wait`s to [10-save_and_start_covid_test.cy.js](https://github.com/CDCgov/prime-simplereport/pull/6049/files#diff-6720dde84f3747df4cfbccebf208a752afb82d2d83fa836a2fca3bcbe92a3bd0)
- remove all redundant `cy.injectSRAxe()` in [08-account_creation.cy.js](https://github.com/CDCgov/prime-simplereport/pull/6049/files#diff-4eb59960e64435f8e752584a312385ec5bdc94977a044847f8156af6a740bffa)
- only mark test as inconclusive after the checkbox has been enabled in [09-multiplex_testing.cy.js](https://github.com/CDCgov/prime-simplereport/pull/6049/files#diff-4e8ef30b87da849aeb427f45b3c17b07334d158d17deaa6393306321a50f4465)
