### PR TITLE
Fixed typo in suport admin landing page

### DIFF
--- a/cypress/e2e/01-organization_sign_up.cy.js
+++ b/cypress/e2e/01-organization_sign_up.cy.js
@@ -55,7 +55,7 @@ describe("Organization sign up",() => {
     cy.injectSRAxe();
     cy.checkA11y();
 
-    cy.contains("Identify verification").click();
+    cy.contains("Identity verification").click();
     cy.get("[data-cy=pending-orgs-title]").should("be.visible");
 
     cy.contains("td", `${organization.name}`);

--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -39,7 +39,7 @@ const SupportAdmin = () => {
                 <CategoryMenu heading="Organization">
                   <li>
                     <LinkWithQuery to={`/admin/pending-organizations`}>
-                      Identify verification
+                      Identity verification
                     </LinkWithQuery>
                   </li>
                   <li>

--- a/frontend/src/app/supportAdmin/__snapshots__/SupportAdmin.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/__snapshots__/SupportAdmin.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`SupportAdming loads menu categories 1`] = `
                       class=""
                       href="/admin/pending-organizations"
                     >
-                      Identify verification
+                      Identity verification
                     </a>
                   </li>
                   <li>
@@ -153,7 +153,7 @@ exports[`SupportAdming loads menu categories including Beta 1`] = `
                       class=""
                       href="/admin/pending-organizations"
                     >
-                      Identify verification
+                      Identity verification
                     </a>
                   </li>
                   <li>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

No ticket

## Changes Proposed

Fix the typo in the `Identity verification` link in the support admin landing page.

## Additional Information

None

## Testing

The typo should be fixed.

## Screenshots / Demos
![Screenshot 2023-07-06 at 10 43 41 AM](https://github.com/CDCgov/prime-simplereport/assets/103958711/ed781f79-aac9-4472-906f-e277b0ff011c)
