### PR TITLE
Fix datetime formatter for single digit hours

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
@@ -22,7 +22,7 @@ public class DateTimeUtils {
   private static final int DEFAULT_HOUR = 12;
 
   public static final DateTimeFormatter DATE_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern("M/d/yyyy[ HH:mm]");
+      DateTimeFormatter.ofPattern("M/d/yyyy[ H:mm]");
 
   public static final String TIMEZONE_SUFFIX_REGEX =
       "^(0?[1-9]|1[0-2])/(0?[1-9]|1\\d|2\\d|3[01])/\\d{4}( ([0-1]?\\d|2[0-3]):[0-5]\\d)( \\S+)$";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/DateTimeUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/DateTimeUtilsTest.java
@@ -1,6 +1,8 @@
 package gov.cdc.usds.simplereport.utils;
 
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.DATE_TIME_FORMATTER;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.convertToZonedDateTime;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.parseLocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -8,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.service.ResultsUploaderCachingService;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,5 +59,31 @@ public class DateTimeUtilsTest {
   @Test
   void testConvertToZonedDateTime_withICANNTzIdentifier() {
     testConvertToZonedDateTime("6/28/2023 14:00 US/Samoa", ZoneId.of("US/Samoa"));
+  }
+
+  void test_parseLocalDateTime(String dateTimeString, LocalDateTime expectedDateTime) {
+    var actualDateTime = parseLocalDateTime(dateTimeString, DATE_TIME_FORMATTER);
+    assertThat(expectedDateTime).hasToString(actualDateTime.toString());
+  }
+
+  @Test
+  void parseLocalDateTime_single_digit_hour() {
+    String dateTimeString = "07/13/2023 9:30";
+    LocalDateTime expectedDateTime = LocalDateTime.of(2023, 7, 13, 9, 30);
+    test_parseLocalDateTime(dateTimeString, expectedDateTime);
+  }
+
+  @Test
+  void parseLocalDateTime_two_digit_hour() {
+    String dateTimeString = "07/13/2023 09:30";
+    LocalDateTime expectedDateTime = LocalDateTime.of(2023, 7, 13, 9, 30);
+    test_parseLocalDateTime(dateTimeString, expectedDateTime);
+  }
+
+  @Test
+  void parseLocalDateTime_no_time() {
+    String dateTimeString = "07/13/2023";
+    LocalDateTime expectedDateTime = LocalDateTime.of(2023, 7, 13, 12, 0);
+    test_parseLocalDateTime(dateTimeString, expectedDateTime);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves this production issue [Slack thread](https://skylight-hq.slack.com/archives/C02HKNHGCP6/p1689270851802369)

## Changes Proposed

- Update date time formatter to allow single digit hour