### PR TITLE
Remove commit check e2e spec

### DIFF
--- a/cypress/e2e/00-health_check.cy.js
+++ b/cypress/e2e/00-health_check.cy.js
@@ -1,6 +1,0 @@
-it("Checks if the frontend and backend are responding", () => {
-  const commit_hash = Cypress.env("CHECK_COMMIT");
-  const check_url = Cypress.env("CHECK_URL");
-  cy.visit(check_url);
-  cy.contains(commit_hash);
-});


### PR DESCRIPTION
# E2e PULL REQUEST

## Related Issue

- Since the new changes compiles the images and puts in the git hash in the images, once these image builds are skipped, it makes the hash different since it coming from main.
- The test was also not providing as much value, since its checking the only frontend and it claimed it was checking the backend incorrectly.
- Paired with @BobanL and decided to remove the test, rather than always building the frontend image.