### PR TITLE
Disable timezone conversion in csv covid pipeline

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -171,7 +171,8 @@ public class TestResultUploadService {
 
       // row is passed by object reference here
       modifyRowSpecimenNameToSNOMED(row, headers);
-      modifyRowDatetimeStrings(row, headers);
+      // Disabling timezone conversion for now
+      // modifyRowDatetimeStrings(row, headers);
 
       rows[i] = String.join(",", row);
     }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Currently there are bugs with parsing the csv in the covid pipeline
