### PR TITLE
Updating tooltip for flu test results

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/pxp/PxpVerifyResponseV2.java
@@ -4,10 +4,10 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.SupportedDiseaseTestResult;
-import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import lombok.Builder;
@@ -17,7 +17,6 @@ import lombok.Getter;
 public class PxpVerifyResponseV2 {
 
   private final UUID testEventId;
-  private final TestResult result;
   private final Set<SupportedDiseaseTestResult> results;
   private final Date dateTested;
   private final String correctionStatus;
@@ -29,8 +28,10 @@ public class PxpVerifyResponseV2 {
   public PxpVerifyResponseV2(Person person, TestEvent testEvent) {
 
     this.testEventId = testEvent.getInternalId();
-    this.result = testEvent.getCovidTestResult().orElseThrow();
     Set<Result> allResults = testEvent.getResults();
+    if (allResults.isEmpty()) {
+      throw new NoSuchElementException("No test results found.");
+    }
     results = new HashSet<>();
     allResults.forEach(
         r -> {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -142,7 +142,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .perform(builder)
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
-            .andExpect(jsonPath("$.result", is("NEGATIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.results[0].testResult", is("NEGATIVE")))
             .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))
@@ -211,7 +210,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .perform(builder)
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.testEventId", is(testEvent.getInternalId().toString())))
-            .andExpect(jsonPath("$.result", is("POSITIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(3)))
             .andExpect(
                 jsonPath(
@@ -289,7 +287,6 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
             .perform(builder)
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.testEventId", is(removedTestEvent.getInternalId().toString())))
-            .andExpect(jsonPath("$.result", is("POSITIVE")))
             .andExpect(jsonPath("$.results", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.results[0].testResult", is("POSITIVE")))
             .andExpect(jsonPath("$.results[0].disease.name", is("COVID-19")))

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -311,7 +311,11 @@ const MultiplexResultInputForm: React.FC<Props> = ({
           <TextWithTooltip
             text="Results info"
             hideText={true}
-            tooltip="COVID-19 results are reported to your public health department. Flu results are not reported at this time."
+            tooltip={
+              isFluOnly
+                ? "Flu results are only reported to California at this time."
+                : "COVID-19 results are reported to your public health department. Flu results are only reported to California at this time."
+            }
             position={isMobile ? "top" : "left"}
           />
         </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolves #6131 

## Changes Proposed

- Update tooltip

## Testing

- How should reviewers verify this PR?

## Screenshots / Demos
Multiplex: 
![Screen Shot 2023-07-17 at 2 39 34 PM](https://github.com/CDCgov/prime-simplereport/assets/7085658/fd072ff4-34dd-4154-8ea0-4fcc0864ee74)
Flu only: 
![Screen Shot 2023-07-17 at 2 40 06 PM](https://github.com/CDCgov/prime-simplereport/assets/7085658/df23e887-14fa-44fa-bb92-d31c893ca685)

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
