### PR TITLE
Deprecate includeArchived field

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientResolver.java
@@ -26,42 +26,31 @@ public class PatientResolver {
     _os = os;
   }
 
-  private ArchivedStatus getArchivedStatus(Boolean includeArchived, ArchivedStatus archivedStatus) {
-    ArchivedStatus status;
-    if (includeArchived != null) {
-      status =
-          Boolean.TRUE.equals(includeArchived) ? ArchivedStatus.ALL : ArchivedStatus.UNARCHIVED;
-    } else {
-      status = archivedStatus != null ? archivedStatus : ArchivedStatus.UNARCHIVED;
-    }
-    return status;
-  }
-
   // authorization happens in calls to PersonService
-  // will update as part of #6062
   @QueryMapping
   public List<Person> patients(
       @Argument UUID facilityId,
       @Argument int pageNumber,
       @Argument int pageSize,
-      @Argument Boolean includeArchived,
       @Argument ArchivedStatus archivedStatus,
       @Argument String namePrefixMatch,
       @Argument boolean includeArchivedFacilities) {
-    ArchivedStatus status = getArchivedStatus(includeArchived, archivedStatus);
     return _ps.getPatients(
-        facilityId, pageNumber, pageSize, status, namePrefixMatch, includeArchivedFacilities);
+        facilityId,
+        pageNumber,
+        pageSize,
+        archivedStatus,
+        namePrefixMatch,
+        includeArchivedFacilities);
   }
 
   // authorization happens in calls to PersonService
   @QueryMapping
   public long patientsCount(
       @Argument UUID facilityId,
-      @Argument Boolean includeArchived,
       @Argument ArchivedStatus archivedStatus,
       @Argument String namePrefixMatch) {
-    ArchivedStatus status = getArchivedStatus(includeArchived, archivedStatus);
-    return _ps.getPatientsCount(facilityId, status, namePrefixMatch, false);
+    return _ps.getPatientsCount(facilityId, archivedStatus, namePrefixMatch, false);
   }
 
   @QueryMapping

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -383,6 +383,7 @@ type Query {
     pageSize: Int = 5000
     includeArchived: Boolean = false
       @requiredPermissions(allOf: ["READ_ARCHIVED_PATIENT_LIST"])
+      @deprecated(reason: "use archivedStatus")
     archivedStatus: ArchivedStatus = UNARCHIVED
       @requiredPermissions(allOf: ["READ_ARCHIVED_PATIENT_LIST"])
     namePrefixMatch: String
@@ -394,6 +395,7 @@ type Query {
     facilityId: ID
     includeArchived: Boolean = false
       @requiredPermissions(allOf: ["READ_ARCHIVED_PATIENT_LIST"])
+      @deprecated(reason: "use archivedStatus")
     archivedStatus: ArchivedStatus = UNARCHIVED
       @requiredPermissions(allOf: ["READ_ARCHIVED_PATIENT_LIST"])
     namePrefixMatch: String

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/patient/PatientResolverTest.java
@@ -56,7 +56,7 @@ class PatientResolverTest extends BaseServiceTest<PersonService> {
   }
 
   @Test
-  void patients_withIncludeArchived_callsServiceWithArchivedStatus() {
+  void patients_callsService() {
     var personService = mock(PersonService.class);
     var orgService = mock(OrganizationService.class);
     var org = TestDataBuilder.createValidOrganization();
@@ -66,29 +66,13 @@ class PatientResolverTest extends BaseServiceTest<PersonService> {
     var sut = new PatientResolver(personService, orgService);
     var facilityId = UUID.randomUUID();
 
-    sut.patients(facilityId, 0, 100, true, null, null, false);
-
-    verify(personService).getPatients(facilityId, 0, 100, ArchivedStatus.ALL, null, false);
-  }
-
-  @Test
-  void patients_withArchivedStatus_callsServiceWithArchivedStatus() {
-    var personService = mock(PersonService.class);
-    var orgService = mock(OrganizationService.class);
-    var org = TestDataBuilder.createValidOrganization();
-
-    when(orgService.getCurrentOrganization()).thenReturn(org);
-
-    var sut = new PatientResolver(personService, orgService);
-    var facilityId = UUID.randomUUID();
-
-    sut.patients(facilityId, 0, 100, null, ArchivedStatus.ARCHIVED, null, false);
+    sut.patients(facilityId, 0, 100, ArchivedStatus.ARCHIVED, null, false);
 
     verify(personService).getPatients(facilityId, 0, 100, ArchivedStatus.ARCHIVED, null, false);
   }
 
   @Test
-  void patientsCount_withIncludeArchived_callsServiceWithArchivedStatus() {
+  void patientsCount_callsService() {
     var personService = mock(PersonService.class);
     var orgService = mock(OrganizationService.class);
     var org = TestDataBuilder.createValidOrganization();
@@ -98,24 +82,8 @@ class PatientResolverTest extends BaseServiceTest<PersonService> {
     var sut = new PatientResolver(personService, orgService);
     var facilityId = UUID.randomUUID();
 
-    sut.patientsCount(facilityId, false, null, null);
+    sut.patientsCount(facilityId, ArchivedStatus.UNARCHIVED, null);
 
     verify(personService).getPatientsCount(facilityId, ArchivedStatus.UNARCHIVED, null, false);
-  }
-
-  @Test
-  void patientsCount_withArchivedStatus_callsServiceWithArchivedStatus() {
-    var personService = mock(PersonService.class);
-    var orgService = mock(OrganizationService.class);
-    var org = TestDataBuilder.createValidOrganization();
-
-    when(orgService.getCurrentOrganization()).thenReturn(org);
-
-    var sut = new PatientResolver(personService, orgService);
-    var facilityId = UUID.randomUUID();
-
-    sut.patients(facilityId, 0, 100, null, ArchivedStatus.UNARCHIVED, null, false);
-
-    verify(personService).getPatients(facilityId, 0, 100, ArchivedStatus.UNARCHIVED, null, false);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
Resolves #6062 
See https://github.com/CDCgov/prime-simplereport/pull/6128 for context
See #6156 for first half of work for 6062

## Changes Proposed
Deprecates the `includeArchived` field in favor of `archivedStatus` for `patients` and `patientsCount` queries.

## Additional Information
N/A

## Testing

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
