### PR TITLE
Removing not null constraint on upload.report_id

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4825,3 +4825,15 @@ databaseChangeLog:
           - sql:
               sql: |
                 DROP TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR;
+  - changeSet:
+      id: remove-upload-report-id-not-null-constraint
+      author: dsass@skylight.digital
+      comment: set report Id to be nullable
+      changes:
+        - dropNotNullConstraint:
+            tableName: upload
+            columnName: report_id
+      rollback:
+        - addNotNullConstraint:
+            tableName: upload
+            columnName: report_id


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- resolves #6167 

## Changes Proposed

- remove `NOT NULL` constraint on the `report_id` column of the `upload` table.

## Additional Information

- Error responses from report stream or SimpleReport validation failures will not have a report id.

## Testing

- Easiest way to make report stream requests fail is to use a flu-only device.
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->