### PR TITLE
Update http cache semantics version to close security vulnerability

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -229,11 +229,12 @@
     "webpack": "^5.76.0"
   },
   "resolutions": {
-    "nth-check": "2.1.1",
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
     "fork-ts-checker-webpack-plugin": "6.5.3",
-    "webpack@>5.0.0": "5.76.0",
-    "undici": "5.22.1"
+    "http-cache-semantics": "4.1.1",
+    "nth-check": "2.1.1",
+    "undici": "5.22.1",
+    "webpack@>5.0.0": "5.76.0"
   },
   "msw": {
     "workerDirectory": "/storybook_public"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11251,10 +11251,10 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
-http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+http-cache-semantics@4.1.1, http-cache-semantics@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http-deceiver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- A regular expression denial of service (ReDoS) vulnerability has been discovered in http cache semantics.
- [CWE-400](https://cwe.mitre.org/data/definitions/400.html)
- [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html)

## Changes Proposed

- Update http cache semantics resolution to a version that is not vulnerable

## Additional Info

- This is prep for turning on dependabot security PRs.

## Checklist for Primary Reviewer
### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [x] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README