### PR TITLE
fix isDeleted field resolver on Facility

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -29,7 +29,7 @@ public class ApiFacility extends WrappedEntity<Facility> implements LocatedWrapp
     return getWrapped().getEmail();
   }
 
-  public boolean isDeleted() {
+  public boolean getIsDeleted() {
     return getWrapped().isDeleted();
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/OrganizationFacilityTest.java
@@ -78,7 +78,12 @@ class OrganizationFacilityTest extends BaseGraphqlTest {
           List<String> showArchivedResultIds = showArchivedResult.findValuesAsText("id");
           assertTrue(showArchivedResultIds.contains(validFacility.getInternalId().toString()));
           assertTrue(showArchivedResultIds.contains(archivedFacility.getInternalId().toString()));
-
+          showArchivedResult.forEach(
+              node -> {
+                if (node.findValue("name").asText().equals("archived facility")) {
+                  assertTrue(node.findValue("isDeleted").asBoolean());
+                }
+              });
           variables.put("showArchived", false);
           JsonNode noArchivedResult = runQuery("facilities-query", variables).get("facilities");
           List<String> noArchivedResultIds = noArchivedResult.findValuesAsText("id");


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Getting `isDeleted` on facility returns "null" for all facilities

## Changes Proposed

- Rename method to `getIsDeleted` to be picked up by spring graphql

## Additional Information


## Testing

- Previously:
<img width="985" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/f0136d65-8b42-4584-b038-0728a682e448">

Now:
<img width="1008" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/a690e379-75d5-4ed5-90ff-db54802eb34c">