### PR TITLE
handle `null` gender in the FHIR converter

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -200,15 +200,17 @@ public class FhirConverter {
     return new ContactPoint().setUse(use).setSystem(system).setValue(value);
   }
 
-  public AdministrativeGender convertToAdministrativeGender(@NotNull String gender) {
-    switch (gender.toLowerCase()) {
-      case "male", "m":
-        return AdministrativeGender.MALE;
-      case "female", "f":
-        return AdministrativeGender.FEMALE;
-      default:
-        return AdministrativeGender.UNKNOWN;
+  public AdministrativeGender convertToAdministrativeGender(String gender) {
+
+    if (gender == null) {
+      return AdministrativeGender.UNKNOWN;
     }
+
+    return switch (gender.toLowerCase()) {
+      case "male", "m" -> AdministrativeGender.MALE;
+      case "female", "f" -> AdministrativeGender.FEMALE;
+      default -> AdministrativeGender.UNKNOWN;
+    };
   }
 
   public Date convertToDate(@NotNull LocalDate date) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -237,7 +237,8 @@ class FhirConverterTest {
         arguments("Female", AdministrativeGender.FEMALE),
         arguments("MALE", AdministrativeGender.MALE),
         arguments("M", AdministrativeGender.MALE),
-        arguments("fishperson", AdministrativeGender.UNKNOWN));
+        arguments("fishperson", AdministrativeGender.UNKNOWN),
+        arguments(null, AdministrativeGender.UNKNOWN));
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #6209

## Changes Proposed

- Handle the value `null` for gender, this is a quick patch to address the issue
- the `@Transactional` changes will follow in a different PR