### PR TITLE
Attach Application Insights objects to global Log Analytics Workspace

### DIFF
--- a/ops/pentest/persistent/.terraform.lock.hcl
+++ b/ops/pentest/persistent/.terraform.lock.hcl
@@ -5,7 +5,6 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.56.0"
   constraints = "~> 3.55"
   hashes = [
-    "h1:LEcmSqmNoexpH6NuglCS8dwLyZctQ6YAee2B9FL/9Cc=",
     "h1:qoV9BwWKSQ2znS9w9o8XTfUKSawX3tZlKRy36AkyNwg=",
     "zh:0c35cf5c57edc337cc8a63399b605f1ec3316841869098f6b5b1f40f76f03d04",
     "zh:230b82b9ef64983505920a66e655f8ca807fccf6e0e2ccbdb5ede301871270b2",
@@ -26,7 +25,6 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "~> 3.5"
   hashes = [
-    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -47,7 +45,6 @@ provider "registry.terraform.io/okta/okta" {
   version     = "3.46.0"
   constraints = "~> 3.45"
   hashes = [
-    "h1:TtoJ+D96IIxr4660CGZeTd3VQQCkGZHHgSylhsy/B2A=",
     "h1:efq7Hv5KDfuIIffVSi541msYTcv4HmID5xzVO8ZJzdc=",
     "zh:033e9c282bfb1a47be6701b2d56da14c9cb214079f445adf0a3cf2be3bf546e4",
     "zh:0a49da96635c42cc118e507c171e2fb228d8789a9eeaf3de4b01cd47a624751a",

--- a/ops/pentest/persistent/.terraform.lock.hcl
+++ b/ops/pentest/persistent/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.56.0"
   constraints = "~> 3.55"
   hashes = [
+    "h1:LEcmSqmNoexpH6NuglCS8dwLyZctQ6YAee2B9FL/9Cc=",
     "h1:qoV9BwWKSQ2znS9w9o8XTfUKSawX3tZlKRy36AkyNwg=",
     "zh:0c35cf5c57edc337cc8a63399b605f1ec3316841869098f6b5b1f40f76f03d04",
     "zh:230b82b9ef64983505920a66e655f8ca807fccf6e0e2ccbdb5ede301871270b2",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "~> 3.5"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/okta/okta" {
   version     = "3.46.0"
   constraints = "~> 3.45"
   hashes = [
+    "h1:TtoJ+D96IIxr4660CGZeTd3VQQCkGZHHgSylhsy/B2A=",
     "h1:efq7Hv5KDfuIIffVSi541msYTcv4HmID5xzVO8ZJzdc=",
     "zh:033e9c282bfb1a47be6701b2d56da14c9cb214079f445adf0a3cf2be3bf546e4",
     "zh:0a49da96635c42cc118e507c171e2fb228d8789a9eeaf3de4b01cd47a624751a",

--- a/ops/services/monitoring/main.tf
+++ b/ops/services/monitoring/main.tf
@@ -14,6 +14,7 @@ resource "azurerm_application_insights" "app_insights" {
   resource_group_name = var.rg_name
   name                = "prime-simple-report-${var.env}-insights"
   disable_ip_masking  = false
+  workspace_id        = data.azurerm_log_analytics_workspace.law.id
 
   daily_data_cap_in_gb = var.ai_ingest_cap_gb
   retention_in_days    = var.ai_retention_days


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #6218.

## Changes Proposed

- Attach existing Insights object to global analytics workspace.

## Additional Information

- Log Analytics should offer additional features above what is currently offered. These are likely worth a further look for diagnostic/on-call purposes.

## Testing

- Test to ensure usual queries and other methods of diagnostics are still operational after the migration.
- This item has been deployed to `pentest`, and remains available accordingly for verification.


## Checklist for Primary Reviewer
### Infrastructure
- [x] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

