### PR TITLE
allow admins to get count

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -71,14 +71,16 @@ public class TestResultResolver {
       @Argument String result,
       @Argument String role,
       @Argument Date startDate,
-      @Argument Date endDate) {
+      @Argument Date endDate,
+      @Argument UUID orgId) {
     return tos.getTestResultsCount(
         facilityId,
         patientId,
         Translators.parseTestResult(result),
         Translators.parsePersonRole(role, true),
         startDate,
-        endDate);
+        endDate,
+        orgId);
   }
 
   @MutationMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/AuthorizationConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/AuthorizationConfiguration.java
@@ -115,6 +115,9 @@ public class AuthorizationConfiguration {
           + AUTHORIZER_BEAN
           + ".userHasSpecificPatientSearchPermission(#facilityId, #archivedStatus, #namePrefixMatch, #includeArchivedFacilities)";
 
+  private static final String SPEL_CAN_ACCESS_ORG =
+      "@" + AUTHORIZER_BEAN + ".userHasPermissionToAccessOrg(#orgId)";
+
   /**
    * Apply this annotation if the method should only be called by site-wide administrative users
    * ("superusers").
@@ -155,6 +158,11 @@ public class AuthorizationConfiguration {
           + SPEL_CAN_MANAGE_USER
           + ")")
   public @interface RequirePermissionManageTargetUserNotSelf {}
+
+  @Retention(RUNTIME)
+  @Target(METHOD)
+  @PreAuthorize(SPEL_IS_VALID + " && " + SPEL_CAN_ACCESS_ORG)
+  public @interface RequirePermissionToAccessOrg {}
 
   /**
    * Require the current user to have the {@link UserPermission#READ_ARCHIVED_PATIENT_LIST}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/UserAuthorizationVerifier.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/UserAuthorizationVerifier.java
@@ -26,6 +26,7 @@ import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 import gov.cdc.usds.simplereport.service.model.OrganizationRoles;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -275,5 +276,12 @@ public class UserAuthorizationVerifier {
   public boolean permitAllAccountRequests() {
     _contextHolder.setIsAccountRequest(true);
     return true;
+  }
+
+  public boolean userHasPermissionToAccessOrg(UUID orgId) {
+    if (_authService.isSiteAdmin() || orgId == null) {
+      return true;
+    }
+    return Objects.equals(_orgService.getCurrentOrganization().getInternalId(), orgId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -432,4 +432,9 @@ public class OrganizationService {
     organization.setIsDeleted(deleted);
     return organizationRepository.save(organization);
   }
+
+  @AuthorizationConfiguration.RequirePermissionToAccessOrg
+  public UUID getPermissibleOrgId(UUID orgId) {
+    return orgId != null ? orgId : getCurrentOrganization().getInternalId();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -103,7 +103,8 @@ public class TestOrderService {
       TestResult result,
       PersonRole role,
       Date startDate,
-      Date endDate) {
+      Date endDate,
+      UUID orgId) {
     return (root, query, cb) -> {
       Join<TestEvent, Result> resultJoin = root.join(TestEvent_.results);
       Join<TestEvent, TestOrder> order = root.join(TestEvent_.order);
@@ -120,12 +121,13 @@ public class TestOrderService {
                     root.get(BaseTestInfo_.facility).get(IdentifiedEntity_.internalId),
                     facilityId));
       } else {
+        final UUID finalOrgId = _organizationService.getPermissibleOrgId(orgId);
         p =
             cb.and(
                 p,
                 cb.equal(
-                    root.get(BaseTestInfo_.organization),
-                    _organizationService.getCurrentOrganization()));
+                    root.get(BaseTestInfo_.organization).get(IdentifiedEntity_.internalId),
+                    finalOrgId));
       }
       if (patientId != null) {
         p =
@@ -185,7 +187,7 @@ public class TestOrderService {
         PageRequest.of(pageOffset, pageSize, Sort.by("createdAt").descending());
 
     return _testEventRepo.findAll(
-        buildTestEventSearchFilter(facilityId, patientId, result, role, startDate, endDate),
+        buildTestEventSearchFilter(facilityId, patientId, result, role, startDate, endDate, null),
         pageRequest);
   }
 
@@ -204,7 +206,8 @@ public class TestOrderService {
         PageRequest.of(pageOffset, pageSize, Sort.by("createdAt").descending());
 
     return _testEventRepo.findAll(
-        buildTestEventSearchFilter(null, patientId, result, role, startDate, endDate), pageRequest);
+        buildTestEventSearchFilter(null, patientId, result, role, startDate, endDate, null),
+        pageRequest);
   }
 
   @Transactional(readOnly = true)
@@ -214,10 +217,12 @@ public class TestOrderService {
       TestResult result,
       PersonRole role,
       Date startDate,
-      Date endDate) {
+      Date endDate,
+      UUID orgId) {
     return (int)
         _testEventRepo.count(
-            buildTestEventSearchFilter(facilityId, patientId, result, role, startDate, endDate));
+            buildTestEventSearchFilter(
+                facilityId, patientId, result, role, startDate, endDate, orgId));
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -447,6 +447,7 @@ type Query {
     role: String
     startDate: DateTime
     endDate: DateTime
+    orgId: ID
   ): Int @requiredPermissions(allOf: ["READ_RESULT_LIST"])
   testResult(id: ID!): TestResult
     @requiredPermissions(allOf: ["READ_RESULT_LIST"])

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -318,6 +318,28 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     assertEquals("Organization is already verified.", e.getMessage());
   }
 
+  @Test
+  @WithSimpleReportStandardUser
+  void getPermissibleOrgId_allowsAccessToCurrentOrg() {
+    var actual = _service.getPermissibleOrgId(_service.getCurrentOrganization().getInternalId());
+    assertEquals(actual, _service.getCurrentOrganization().getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void getPermissibleOrgId_nullIdFallsBackToCurrentOrg() {
+    var actual = _service.getPermissibleOrgId(null);
+    assertEquals(actual, _service.getCurrentOrganization().getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void getPermissibleOrgId_throwsAccessDeniedForInaccessibleOrg() {
+    var inaccessibleOrgId = UUID.randomUUID();
+    assertThrows(
+        AccessDeniedException.class, () -> _service.getPermissibleOrgId(inaccessibleOrgId));
+  }
+
   @Nested
   @DisplayName("When updating a facility")
   class UpdateFacilityTest {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -758,6 +758,7 @@ export type QueryTestResultsArgs = {
 export type QueryTestResultsCountArgs = {
   endDate?: InputMaybe<Scalars["DateTime"]>;
   facilityId?: InputMaybe<Scalars["ID"]>;
+  orgId?: InputMaybe<Scalars["ID"]>;
   patientId?: InputMaybe<Scalars["ID"]>;
   result?: InputMaybe<Scalars["String"]>;
   role?: InputMaybe<Scalars["String"]>;


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #6161 

## Changes Proposed

- Add new parameter to getting count
  - If orgId is passed and user isSiteAdmin, then build the query with the orgId
  - If orgId is passed and user doesn't have access to that org, then return AccessDenied. 

## Additional Information

- The way `@Preauthorize` annotations work is the call must be made from outside the class. 
  - For example, if you put an authz check on a new method in `OrganizationService` and call that method from within `OrganizationService`, the check will not be made because it its a self reference to the method and not being made through the proxy. 
    - Read more about [AOP proxies ](https://docs.spring.io/spring-framework/docs/4.0.7.RELEASE/spring-framework-reference/htmlsingle/#aop-understanding-aop-proxies) and the [stackoverflow question](https://stackoverflow.com/questions/26361986/preauthorize-not-working-when-a-secured-method-is-called-from-another-secured-m) l
## Testing

- Deployed on Dev1
- As an admin attempt to run this query against any org
- As a non-admin attempt to run this query against a different org
```gql
query TestResultsCount {
    testResultsCount(orgId: "7ff26e4f-e738-4f0d-8312-81a976ca3d26")
}
```
Valid orgIds
```
        "organizations": [
            {
                "id": "96bef72b-9e17-496a-8220-88dae721c131",
                "name": "Hogwarts"
            },
            {
                "id": "ab8e5754-4389-40bb-b0a9-b9ba86125bfb",
                "name": "Hogwarts :)"
            },
            {
                "id": "494661c3-f5c5-425a-9997-a3202a2c2e4e",
                "name": "testorg"
            },
            {
                "id": "7ae31510-9c15-4395-a76c-f71418c824b2",
                "name": "Cape Coast"
            },
            {
                "id": "7d56ecec-fbb0-4c3e-9e8f-9af95e7c286a",
                "name": "Green Org"
            },
            {
                "id": "7ff26e4f-e738-4f0d-8312-81a976ca3d26",
                "name": "Test org el B"
            },
            {
                "id": "57a31b94-4bce-4eb2-9754-047dc703c814",
                "name": "Friends of Pets Community Group :)"
            },
            {
                "id": "99e9881a-e520-4ece-801e-8719fa786415",
                "name": "Apple"
            },
            {
                "id": "b00d8679-a590-41a9-a011-ab268e2abc57",
                "name": "dfd"
            },
            {
                "id": "06b51daa-4eb0-4931-b166-6978b4d8e9f7",
                "name": "Apples"
            }
        ]
    }
```

