### PR TITLE
Flu only bugfix - Inconclusive test results

### DIFF
--- a/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.test.tsx
@@ -184,6 +184,36 @@ describe("TestResultInputForm", () => {
     expect(screen.getByText("Submit")).toBeEnabled();
   });
 
+  it("should render with inconclusive flu only values", () => {
+    render(
+      <MultiplexResultInputForm
+        queueItemId={"5d315d18-82f8-4025-a051-1a509e15c880"}
+        testResults={[
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_A,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
+          {
+            diseaseName: MULTIPLEX_DISEASES.FLU_B,
+            testResult: TEST_RESULTS.UNDETERMINED,
+          },
+        ]}
+        onChange={onChangeFn}
+        onSubmit={onSubmitFn}
+        isFluOnly={true}
+      />
+    );
+
+    expect(screen.getAllByLabelText("Positive (+)")[0]).not.toBeChecked();
+    expect(screen.getAllByLabelText("Positive (+)")[1]).not.toBeChecked();
+    expect(screen.getAllByLabelText("Negative (-)")[0]).not.toBeChecked();
+    expect(screen.getAllByLabelText("Negative (-)")[1]).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /mark test as inconclusive/i })
+    ).toBeChecked();
+    expect(screen.getByText("Submit")).toBeEnabled();
+  });
+
   it("should display submit button as disabled when no diseases have set values", async () => {
     render(
       <MultiplexResultInputForm

--- a/frontend/src/app/testResults/MultiplexResultInputForm.tsx
+++ b/frontend/src/app/testResults/MultiplexResultInputForm.tsx
@@ -102,10 +102,16 @@ const MultiplexResultInputForm: React.FC<Props> = ({
   const isMobile = screen.width <= 600;
   const resultsMultiplexFormat: MultiplexResultState =
     convertFromMultiplexResultInputs(testResults);
-  const inconclusiveCheck =
+  let inconclusiveCheck =
     resultsMultiplexFormat.covid === TEST_RESULTS.UNDETERMINED &&
     resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED &&
     resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED;
+
+  if (isFluOnly) {
+    inconclusiveCheck =
+      resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED &&
+      resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED;
+  }
 
   /**
    * Handle Setting Results
@@ -139,7 +145,7 @@ const MultiplexResultInputForm: React.FC<Props> = ({
     const markedInconclusive = value.target.checked;
     if (markedInconclusive) {
       const inconclusiveState: MultiplexResultState = {
-        covid: TEST_RESULTS.UNDETERMINED,
+        covid: isFluOnly ? TEST_RESULTS.UNKNOWN : TEST_RESULTS.UNDETERMINED,
         fluA: TEST_RESULTS.UNDETERMINED,
         fluB: TEST_RESULTS.UNDETERMINED,
       };
@@ -163,14 +169,22 @@ const MultiplexResultInputForm: React.FC<Props> = ({
    * Form Validation
    * */
   const validateForm = () => {
-    const anyResultIsInconclusive =
+    let anyResultIsInconclusive =
       resultsMultiplexFormat.covid === TEST_RESULTS.UNDETERMINED ||
       resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED ||
       resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED;
 
-    const allResultsAreEqual =
+    let allResultsAreEqual =
       resultsMultiplexFormat.covid === resultsMultiplexFormat.fluA &&
       resultsMultiplexFormat.fluA === resultsMultiplexFormat.fluB;
+
+    if (isFluOnly) {
+      allResultsAreEqual =
+        resultsMultiplexFormat.fluA === resultsMultiplexFormat.fluB;
+      anyResultIsInconclusive =
+        resultsMultiplexFormat.fluA === TEST_RESULTS.UNDETERMINED ||
+        resultsMultiplexFormat.fluB === TEST_RESULTS.UNDETERMINED;
+    }
 
     const covidIsFilled =
       resultsMultiplexFormat.covid === TEST_RESULTS.POSITIVE ||


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolves #6239 

## Changes Proposed

- Bug: `UNDETERMINED` covid results were being included on inconclusive flu only test card submissions.  Adjusting validation and default behavior to ensure that doesn't happen and adding a unit test to cover the case.

## Additional Information


## Testing

- How should reviewers verify this PR?

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
