### PR TITLE
Bob/6084 reactivate user modal

### DIFF
--- a/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import {
+  act,
   render,
   screen,
   waitFor,
@@ -10,29 +11,95 @@ import {
 } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 import { AnyAction, Store } from "redux";
+import userEvent from "@testing-library/user-event";
+import { cloneDeep } from "lodash";
 
 import {
   GetUserDocument,
   GetUsersAndStatusDocument,
 } from "../../../generated/graphql";
 
-import ManageUsersContainer from "./ManageUsersContainer";
+import ManageUsersContainer, {
+  SITE_ADMIN_ROLE_DESC,
+} from "./ManageUsersContainer";
+import {
+  ORG_ADMIN_REACTIVATE_COPY,
+  SITE_ADMIN_REACTIVATE_COPY,
+} from "./ReactivateUserModal";
 
 describe("ManageUsersContainer", () => {
   const mockStore = configureStore([]);
-  const store = mockStore({
+  const storeData = {
     organization: {
       name: "Organization Name",
     },
     user: {
       firstName: "Kim",
       lastName: "Mendoza",
+      roleDescription: "Admin user",
     },
     facilities: [
       { id: "1", name: "Facility 1" },
       { id: "2", name: "Facility 2" },
     ],
-  });
+  };
+  const mockedUsersWithStatus = [
+    {
+      id: "3a4a221d-a8ca-42b3-aa03-37b93266025b",
+      firstName: "Ben",
+      middleName: "Billy",
+      lastName: "Barnes",
+      email: "ben@example.com",
+      status: "ACTIVE",
+      __typename: "ApiUserWithStatus",
+    },
+    {
+      id: "1029653e-24d9-428e-83b0-468319948902",
+      firstName: "Bob",
+      middleName: null,
+      lastName: "Bobberoo",
+      email: "bob@example.com",
+      status: "ACTIVE",
+      __typename: "ApiUserWithStatus",
+    },
+    {
+      id: "60bb9e3a-fe8a-4b81-b894-b01649c95e70",
+      firstName: "Jamar",
+      middleName: "Donald",
+      lastName: "Jackson",
+      email: "jamar@example.com",
+      status: "ACTIVE",
+      __typename: "ApiUserWithStatus",
+    },
+    {
+      id: "0d3fa224-3d56-4382-b89c-9d8e415e59b3",
+      firstName: "Ruby",
+      middleName: "Raven",
+      lastName: "Reynolds",
+      email: "ruby@example.com",
+      status: "ACTIVE",
+      __typename: "ApiUserWithStatus",
+    },
+    {
+      id: "17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a",
+      firstName: "Sarah",
+      middleName: "Sally",
+      lastName: "Samuels",
+      email: "sarah@example.com",
+      status: "ACTIVE",
+      __typename: "ApiUserWithStatus",
+    },
+    {
+      id: "17656bad-08b6-4fd4-bb9a-ccac54e5ea0a",
+      firstName: "Nicole",
+      middleName: "Suspended",
+      lastName: "Carter",
+      email: "nicole@example.com",
+      status: "SUSPENDED",
+      __typename: "ApiUserWithStatus",
+    },
+  ];
+  const store = mockStore(storeData);
   const mocks: MockedResponse[] = [
     {
       request: {
@@ -42,53 +109,7 @@ describe("ManageUsersContainer", () => {
       },
       result: {
         data: {
-          usersWithStatus: [
-            {
-              id: "3a4a221d-a8ca-42b3-aa03-37b93266025b",
-              firstName: "Ben",
-              middleName: "Billy",
-              lastName: "Barnes",
-              email: "ben@example.com",
-              status: "ACTIVE",
-              __typename: "ApiUserWithStatus",
-            },
-            {
-              id: "1029653e-24d9-428e-83b0-468319948902",
-              firstName: "Bob",
-              middleName: null,
-              lastName: "Bobberoo",
-              email: "bob@example.com",
-              status: "ACTIVE",
-              __typename: "ApiUserWithStatus",
-            },
-            {
-              id: "60bb9e3a-fe8a-4b81-b894-b01649c95e70",
-              firstName: "Jamar",
-              middleName: "Donald",
-              lastName: "Jackson",
-              email: "jamar@example.com",
-              status: "ACTIVE",
-              __typename: "ApiUserWithStatus",
-            },
-            {
-              id: "0d3fa224-3d56-4382-b89c-9d8e415e59b3",
-              firstName: "Ruby",
-              middleName: "Raven",
-              lastName: "Reynolds",
-              email: "ruby@example.com",
-              status: "ACTIVE",
-              __typename: "ApiUserWithStatus",
-            },
-            {
-              id: "17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a",
-              firstName: "Sarah",
-              middleName: "Sally",
-              lastName: "Samuels",
-              email: "sarah@example.com",
-              status: "ACTIVE",
-              __typename: "ApiUserWithStatus",
-            },
-          ],
+          usersWithStatus: mockedUsersWithStatus,
         },
       },
     },
@@ -110,6 +131,87 @@ describe("ManageUsersContainer", () => {
             permissions: [],
             email: "ben@example.com",
             status: "ACTIVE",
+            organization: {
+              testingFacility: [
+                {
+                  id: "3ea40184-b7d6-4807-b924-747a316a86a6",
+                  name: "Testing Site",
+                  __typename: "Facility",
+                },
+              ],
+              __typename: "Organization",
+            },
+            __typename: "User",
+          },
+        },
+      },
+    },
+  ];
+
+  const supendedUserMocks: MockedResponse[] = [
+    {
+      request: {
+        operationName: "GetUsersAndStatus",
+        query: GetUsersAndStatusDocument,
+        variables: {},
+      },
+      result: {
+        data: {
+          usersWithStatus: mockedUsersWithStatus,
+        },
+      },
+    },
+    {
+      request: {
+        operationName: "GetUser",
+        query: GetUserDocument,
+        variables: { id: "3a4a221d-a8ca-42b3-aa03-37b93266025b" },
+      },
+      result: {
+        data: {
+          user: {
+            id: "3a4a221d-a8ca-42b3-aa03-37b93266025b",
+            firstName: "Ben",
+            middleName: "Billy",
+            lastName: "Barnes",
+            roleDescription: "Misconfigured user",
+            role: null,
+            permissions: [],
+            email: "ben@example.com",
+            status: "ACTIVE",
+            organization: {
+              testingFacility: [
+                {
+                  id: "3ea40184-b7d6-4807-b924-747a316a86a6",
+                  name: "Testing Site",
+                  __typename: "Facility",
+                },
+              ],
+              __typename: "Organization",
+            },
+            __typename: "User",
+          },
+        },
+      },
+    },
+    {
+      request: {
+        operationName: "GetUser",
+        query: GetUserDocument,
+        variables: { id: "17656bad-08b6-4fd4-bb9a-ccac54e5ea0a" },
+      },
+      result: {
+        data: {
+          user: {
+            id: "17656bad-08b6-4fd4-bb9a-ccac54e5ea0a",
+            firstName: "Nicole",
+            middleName: "Suspended",
+            lastName: "Carter",
+            roleDescription: "Standard user",
+            role: "Standard user",
+            permissions: [],
+            email: "nicole@example.com",
+            status: "SUSPENDED",
             organization: {
               testingFacility: [
                 {
@@ -160,5 +262,33 @@ describe("ManageUsersContainer", () => {
     const notFoundMock = [{ ...mocks[0], result: {} }];
     renderComponentWithMocks(notFoundMock, store);
     await screen.findByText(/Error: Users not found/i);
+  });
+
+  it("when user is an org admin , modal copy reflects the reactivate only flow", async () => {
+    renderComponentWithMocks(supendedUserMocks, store);
+
+    const suspendedUser = await screen.findByText("Carter, Nicole Suspended");
+    await act(async () => await userEvent.click(suspendedUser));
+
+    const reactivateButton = await screen.findByText("Activate user");
+    await act(async () => await userEvent.click(reactivateButton));
+    const sureButton = await screen.findByText("Yes", { exact: false });
+    expect(await screen.findByText(ORG_ADMIN_REACTIVATE_COPY));
+  });
+
+  it("when user is a site admin , modal copy reflects the reset password flow", async () => {
+    const storeWithSiteAdminUser = cloneDeep(storeData);
+    storeWithSiteAdminUser.user.roleDescription = SITE_ADMIN_ROLE_DESC;
+    const testMockStore = mockStore(storeWithSiteAdminUser);
+
+    renderComponentWithMocks(supendedUserMocks, testMockStore);
+
+    const suspendedUser = await screen.findByText("Carter, Nicole Suspended");
+    await act(async () => await userEvent.click(suspendedUser));
+
+    const reactivateButton = await screen.findByText("Activate user");
+    await act(async () => await userEvent.click(reactivateButton));
+    const sureButton = await screen.findByText("Yes", { exact: false });
+    expect(await screen.findByText(SITE_ADMIN_REACTIVATE_COPY));
   });
 });

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -90,6 +90,14 @@ const REACTIVATE_USER = gql`
   }
 `;
 
+const REACTIVATE_USER_AND_RESET_PASSWORD = gql`
+  mutation ReactivateUserAndResetPassword($id: ID!) {
+    reactivateUserAndResetPassword(id: $id) {
+      id
+    }
+  }
+`;
+
 const ADD_USER_TO_ORG = gql`
   mutation AddUserToCurrentOrg(
     $firstName: String
@@ -119,16 +127,25 @@ export interface UserFacilitySetting {
   name: string;
 }
 
+export const SITE_ADMIN_ROLE_DESC = "Admin user (SU)";
+
 const ManageUsersContainer = () => {
   useDocumentTitle("Manage users");
 
   const loggedInUser = useSelector<RootState, User>((state) => state.user);
+  const loggedInUserIsSiteAdmin =
+    loggedInUser.roleDescription.includes(SITE_ADMIN_ROLE_DESC);
+
   const allFacilities = useSelector<RootState, UserFacilitySetting[]>(
     (state) => state.facilities
   );
   const [updateUserPrivileges] = useMutation(UPDATE_USER_PRIVILEGES);
   const [deleteUser] = useMutation(DELETE_USER);
-  const [reactivateUser] = useMutation(REACTIVATE_USER);
+  const [reactivateUser] = useMutation(
+    loggedInUserIsSiteAdmin
+      ? REACTIVATE_USER_AND_RESET_PASSWORD
+      : REACTIVATE_USER
+  );
   const [addUserToOrg] = useMutation(ADD_USER_TO_ORG);
   const [updateUserName] = useUpdateUserNameMutation();
   const [updateUserEmail] = useEditUserEmailMutation();

--- a/frontend/src/app/Settings/Users/ReactivateUserModal.tsx
+++ b/frontend/src/app/Settings/Users/ReactivateUserModal.tsx
@@ -5,8 +5,12 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Button from "../../commonComponents/Button/Button";
 import { displayFullName } from "../../utils";
 
-import { SettingsUser } from "./ManageUsersContainer";
+import { SettingsUser, SITE_ADMIN_ROLE_DESC } from "./ManageUsersContainer";
+
 import "./ManageUsers.scss";
+import { useSelector } from "react-redux";
+
+import { RootState } from "../../store";
 
 interface Props {
   onClose: () => void;
@@ -14,11 +18,20 @@ interface Props {
   user: SettingsUser;
 }
 
+const ORG_ADMIN_REACTIVATE_COPY =
+  "Are you sure you want to reactivate this account?";
+const SITE_ADMIN_REACTIVATE_COPY =
+  "When you reactivate their account, the user will need to choose a new password. Do you want to reactivate this account?";
+
 const ReactivateUserModal: React.FC<Props> = ({
   onClose,
   onReactivateUser,
   user,
 }) => {
+  const loggedInUser = useSelector<RootState, User>((state) => state.user);
+  const loggedInUserIsSiteAdmin =
+    loggedInUser.roleDescription.includes(SITE_ADMIN_ROLE_DESC);
+
   return (
     <Modal
       isOpen={true}
@@ -62,7 +75,11 @@ const ReactivateUserModal: React.FC<Props> = ({
               6AM EST, their account will be deactivated again.
             </strong>
           </p>
-          <p>Are you sure you want to reactivate this account?</p>
+          <p>
+            {loggedInUserIsSiteAdmin
+              ? SITE_ADMIN_REACTIVATE_COPY
+              : ORG_ADMIN_REACTIVATE_COPY}
+          </p>
         </div>
         <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
           <div className="display-flex flex-justify-end">

--- a/frontend/src/app/Settings/Users/ReactivateUserModal.tsx
+++ b/frontend/src/app/Settings/Users/ReactivateUserModal.tsx
@@ -17,9 +17,9 @@ interface Props {
   user: SettingsUser;
 }
 
-const ORG_ADMIN_REACTIVATE_COPY =
+export const ORG_ADMIN_REACTIVATE_COPY =
   "Are you sure you want to reactivate this account?";
-const SITE_ADMIN_REACTIVATE_COPY =
+export const SITE_ADMIN_REACTIVATE_COPY =
   "When you reactivate their account, the user will need to choose a new password. Do you want to reactivate this account?";
 
 const ReactivateUserModal: React.FC<Props> = ({

--- a/frontend/src/app/Settings/Users/ReactivateUserModal.tsx
+++ b/frontend/src/app/Settings/Users/ReactivateUserModal.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import Modal from "react-modal";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useSelector } from "react-redux";
 
 import Button from "../../commonComponents/Button/Button";
 import { displayFullName } from "../../utils";
+import { RootState } from "../../store";
 
 import { SettingsUser, SITE_ADMIN_ROLE_DESC } from "./ManageUsersContainer";
 
 import "./ManageUsers.scss";
-import { useSelector } from "react-redux";
-
-import { RootState } from "../../store";
 
 interface Props {
   onClose: () => void;

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`ManageUsersContainer loads the component and displays users successfull
             class="prime-secondary-nav"
           >
             <div
-              aria-owns="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b user-tab-1029653e-24d9-428e-83b0-468319948902 user-tab-60bb9e3a-fe8a-4b81-b894-b01649c95e70 user-tab-0d3fa224-3d56-4382-b89c-9d8e415e59b3 user-tab-17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a"
+              aria-owns="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b user-tab-1029653e-24d9-428e-83b0-468319948902 user-tab-17656bad-08b6-4fd4-bb9a-ccac54e5ea0a user-tab-60bb9e3a-fe8a-4b81-b894-b01649c95e70 user-tab-0d3fa224-3d56-4382-b89c-9d8e415e59b3 user-tab-17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a"
               class="usa-sidenav"
               role="tablist"
             >
@@ -81,6 +81,32 @@ exports[`ManageUsersContainer loads the component and displays users successfull
                   <span
                     class="sidenav-user-status padding-left-0"
                   />
+                </button>
+              </div>
+              <div
+                class="usa-sidenav__item users-sidenav-item"
+              >
+                <button
+                  aria-label="Carter, Nicole Suspended"
+                  aria-selected="false"
+                  class="usa-button--unstyled text-ink text-no-underline padding-105 padding-right-2 padding-left-3"
+                  id="user-tab-17656bad-08b6-4fd4-bb9a-ccac54e5ea0a"
+                  role="tab"
+                  style="cursor: pointer;"
+                >
+                  <div
+                    class="sidenav-user-name"
+                  >
+                    Carter, Nicole Suspended
+                  </div>
+                  <svg>
+                    account-deactivated.svg
+                  </svg>
+                  <span
+                    class="sidenav-user-status"
+                  >
+                    Account deactivated
+                  </span>
                 </button>
               </div>
               <div


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes #6084 by adding branching logic to call the reactivate only / reactivate with reset password mutations depending on if the user logged in is a site or org admin

## Changes Proposed

- Adds a check for logged-in user status into the reactivate user handler function
- Invokes the relevant mutation added in a previous PR based on the status of the logged in user

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
