### PR TITLE
Adding to merge queue triggers required branch protection checks

### DIFF
--- a/.github/workflows/checkGraphql.yml
+++ b/.github/workflows/checkGraphql.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main

--- a/.github/workflows/terraformChecks.yml
+++ b/.github/workflows/terraformChecks.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
+    types:
+      - checks_requested
 
 defaults:
   run:

--- a/.github/workflows/testingWorkflow.yml
+++ b/.github/workflows/testingWorkflow.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

We want to use a merge queue when merging to main. Once a PR is in the merge queue, it will be put in a merge group (potentially with other PRs, but unlikely if we configure it to require a minimum of 1 PR to start a merge operation). A merge group will only be merged once all required branch protection checks pass, so we have to trigger the workflows that run jobs that have the required checks.
See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues

## Changes Proposed

Trigger workflows with required checks on the [merge_groups](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group) event 

## Testing

Tough to test without me turning on the merge queue functionality first. But the merge queue won't work if we don't add these triggers.