### PR TITLE
use test order to get device & specimen information for test updates

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -55,14 +55,6 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
     super();
   }
 
-  protected BaseTestInfo(BaseTestInfo orig) {
-    this(orig.getPatient(), orig.getFacility());
-  }
-
-  protected BaseTestInfo(Person patient, Facility facility) {
-    this(patient, facility, facility.getDefaultDeviceType(), facility.getDefaultSpecimenType());
-  }
-
   protected BaseTestInfo(
       Person patient, Facility facility, DeviceType deviceType, SpecimenType specimenType) {
     super();
@@ -76,7 +68,11 @@ public abstract class BaseTestInfo extends AuditedEntity implements Organization
 
   protected BaseTestInfo(
       BaseTestInfo cloneInfo, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
-    this(cloneInfo);
+    this(
+        cloneInfo.getPatient(),
+        cloneInfo.getFacility(),
+        cloneInfo.getDeviceType(),
+        cloneInfo.getSpecimenType());
     this.reasonForCorrection = reasonForCorrection;
     this.correctionStatus = correctionStatus;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -90,7 +90,7 @@ public class TestEvent extends BaseTestInfo {
     }
   }
 
-  // Constructor for creating corrections. Copy the original event
+  // Constructor for test removals
   public TestEvent(
       TestEvent event, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
     super(event, correctionStatus, reasonForCorrection);
@@ -103,6 +103,7 @@ public class TestEvent extends BaseTestInfo {
     this.priorCorrectedTestEventId = event.getInternalId();
   }
 
+  // Constructor for test corrections
   public TestEvent(
       TestOrder order, TestCorrectionStatus correctionStatus, String reasonForCorrection) {
     super(order, correctionStatus, reasonForCorrection);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -58,7 +58,7 @@ public class TestOrder extends BaseTestInfo {
     /* for hibernate */ }
 
   public TestOrder(Person patient, Facility facility) {
-    super(patient, facility);
+    super(patient, facility, facility.getDefaultDeviceType(), facility.getDefaultSpecimenType());
     this.orderStatus = OrderStatus.PENDING;
     this.results = new HashSet<>();
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -22,6 +22,7 @@ import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentQueueItemException;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.IdentifiedEntity;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientLink;
 import gov.cdc.usds.simplereport.db.model.Person;
@@ -1447,6 +1448,38 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
   @Test
   @WithSimpleReportOrgAdminUser
+  void markAsErrorTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    DeviceType device = _dataFactory.getGenericDevice();
+    SpecimenType specimen = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+    Person person = _dataFactory.createFullPerson(org);
+    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+    facility.getAddress().setState("ND");
+    _organizationService.updateFacility(
+        facility.getInternalId(),
+        facility.getFacilityName(),
+        facility.getCliaNumber(),
+        facility.getAddress(),
+        facility.getTelephone(),
+        facility.getEmail(),
+        facility.getOrderingProvider().getNameInfo(),
+        facility.getOrderingProvider().getAddress(),
+        facility.getOrderingProvider().getProviderId(),
+        facility.getOrderingProvider().getTelephone(),
+        facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
+
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    TestEvent deletedTest = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+
+    assertEquals(deletedTest.getDeviceType().getInternalId(), device.getInternalId());
+    assertEquals(deletedTest.getSpecimenType().getInternalId(), specimen.getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
   void correctionsTest() {
     Organization org = _organizationService.getCurrentOrganization();
     Facility facility = _organizationService.getFacilities(org).get(0);
@@ -1633,6 +1666,49 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
     assertEquals(0, originalEvent.getTestOrder().getDateTestedBackdate().compareTo(dateTested));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void correctTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    DeviceType device = _dataFactory.getGenericDevice();
+    SpecimenType specimen = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+    Person p = _dataFactory.createFullPerson(org);
+    TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
+
+    facility.getAddress().setState("ND");
+    _organizationService.updateFacility(
+        facility.getInternalId(),
+        facility.getFacilityName(),
+        facility.getCliaNumber(),
+        facility.getAddress(),
+        facility.getTelephone(),
+        facility.getEmail(),
+        facility.getOrderingProvider().getNameInfo(),
+        facility.getOrderingProvider().getAddress(),
+        facility.getOrderingProvider().getProviderId(),
+        facility.getOrderingProvider().getTelephone(),
+        facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
+
+    // Re-open the original test as a correction
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
+
+    // Re-submit the corrected test
+    List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            device.getInternalId(),
+            specimen.getInternalId(),
+            correctedTestResult,
+            p.getInternalId(),
+            null);
+    TestEvent correctedEvent = response.getTestOrder().getTestEvent();
+    assertEquals(correctedEvent.getDeviceType().getInternalId(), device.getInternalId());
+    assertEquals(correctedEvent.getSpecimenType().getInternalId(), specimen.getInternalId());
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves bug #6267 

## Changes Proposed

- When copying a test event/test order use the device & specimen from base test rather than the facility defaults

## Additional Information

- Remove constructors that are only used in one place

## Testing

- in dev4, follow the steps to reproduce the bug and ensure it isn't happening
1. Complete a test event
2. Update devices / facility
3. Correct test event without any changes
4. Should be submitted without device

