### PR TITLE
remove unused db columns related to device_specimen_type join table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4850,3 +4850,96 @@ databaseChangeLog:
         - addNotNullConstraint:
             tableName: upload
             columnName: report_id
+  - changeSet:
+      id: remove-unused_columns-from-device_specimen_type
+      author: zedd@skylight.digital
+      comment: remove unused columns from device_specimen_type
+      changes:
+        - tagDatabase:
+            tag: remove-unused_columns-from-device_specimen_type
+        - dropColumn:
+            tableName: device_specimen_type
+            columns:
+              - column:
+                  name: internal_id
+              - column:
+                  name: created_at
+              - column:
+                  name: created_by
+              - column:
+                  name: updated_at
+              - column:
+                  name: updated_by
+              - column:
+                  name: is_deleted
+      rollback:
+        - addColumn:
+            tableName: device_specimen_type
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: created_by
+                  type: uuid
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: updated_by
+                  type: uuid
+              - column:
+                  name: is_deleted
+                  type: boolean
+  - changeSet:
+      id: remove-device_specimen_type_id-from-test_order-and-test_event
+      author: zedd@skylight.digital
+      comment: remove device_specimen_type_id columns from test_order and test_event
+      changes:
+        - tagDatabase:
+            tag: remove-device_specimen_type_id-from-test_order-and-test_event
+        - dropColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: device_specimen_type_id
+        - dropColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: device_specimen_type_id
+      rollback:
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: device_specimen_type_id
+                  type: uuid
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: device_specimen_type_id
+                  type: uuid
+  - changeSet:
+      id: remove-default_device_specimen_type_id-from-facility
+      author: zedd@skylight.digital
+      comment: remove default_device_specimen_type_id columns from facility
+      changes:
+        - tagDatabase:
+            tag: remove-default_device_specimen_type_id-from-facility
+        - dropColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_device_specimen_type_id
+      rollback:
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_device_specimen_type_id
+                  type: uuid


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #5951

## Changes Proposed

- Remove the following unused DB columns from the DB

```
device_specimen_type.internal_id
device_specimen_type.created_at
device_specimen_type.created_by
device_specimen_type.updated_at
device_specimen_type.updated_by
device_specimen_type.is_deleted

test_order.device_specimen_type_id
test_event.device_specimen_type_id

facility.default_device_specimen_type_id
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
