### PR TITLE
remove unused result column from db

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4943,3 +4943,60 @@ databaseChangeLog:
               - column:
                   name: default_device_specimen_type_id
                   type: uuid
+  - changeSet:
+      id: remove-result-from-test_event_no_phi_view
+      author: zedd@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: remove-result-from-test_event_no_phi_view
+        - dropView:
+            viewName: test_event_no_phi_view
+        - createView:
+            viewName: test_event_no_phi_view
+            remarks: A subset of the test_event table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT internal_id, created_at, created_by, updated_at, updated_by, patient_id, organization_id, facility_id, specimen_type_id, device_type_id, survey_data, date_tested_backdate, test_order_id, correction_status, prior_corrected_test_event_id, reason_for_correction FROM ${database.defaultSchemaName}.test_event
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.test_event_no_phi_view TO ${noPhiUsername};
+      rollback:
+        - dropView:
+            viewName: test_event_no_phi_view
+        - createView:
+            viewName: test_event_no_phi_view
+            remarks: A subset of the test_event table with columns containing PHI removed.
+            replaceIfExists: true
+            fullDefinition: false
+            selectQuery: SELECT created_at, created_by, updated_at, updated_by, patient_id, organization_id, result, facility_id, survey_data, date_tested_backdate, test_order_id, correction_status, prior_corrected_test_event_id, internal_id, reason_for_correction FROM ${database.defaultSchemaName}.test_event
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.test_event_no_phi_view TO ${noPhiUsername};
+  - changeSet:
+      id: remove-result-from-test_order-and-test_event
+      author: zedd@skylight.digital
+      comment: remove result columns from test_order and test_event
+      changes:
+        - tagDatabase:
+            tag: remove-result-from-test_order-and-test_event
+        - dropColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: result
+        - dropColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: result
+      rollback:
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: result
+                  type: ${database.defaultSchemaName}.TEST_RESULT
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: result
+                  type: ${database.defaultSchemaName}.TEST_RESULT


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #5951

## Changes Proposed
- merge https://github.com/CDCgov/prime-simplereport/pull/6286 first
- Remove the following unused columns
```
test_order.result 
test_event.result
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->