### PR TITLE
Add health checks to db_client container.

### DIFF
--- a/ops/services/container_instances/db_client/image/Dockerfile
+++ b/ops/services/container_instances/db_client/image/Dockerfile
@@ -5,5 +5,6 @@ RUN unset HISTFILE
 RUN bash -ic 'unset HISTFILE'
 RUN bash -ic 'set +o history'
 RUN echo 'unset HISTFILE' >> /etc/profile.d/disable.history.sh
+RUN touch /tmp/healthy
 ENV PSQL_HISTORY=/export/.psql_history
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -36,7 +36,7 @@ resource "azurerm_container_group" "db_client" {
     }
 
     readiness_probe {
-      exec                  = ["cat", "/tmp/healthy"]
+      exec                  = ["/bin/sh", "-c", "touch /tmp/healthy"]
       initial_delay_seconds = 30
     }
 

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -19,6 +19,12 @@ resource "azurerm_container_group" "db_client" {
     cpu    = "1"
     memory = "1.5"
 
+    // Not a real port but *a* port is required, so expose a port the container hopefully doesn't respond to
+    ports {
+      port     = 1234
+      protocol = "TCP"
+    }
+
     volume {
       name       = "${var.name}-${var.env}-db-client-volume"
       read_only  = false

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -36,13 +36,14 @@ resource "azurerm_container_group" "db_client" {
     }
 
     readiness_probe {
-      exec                  = ["/bin/sh", "-c", "cat /tmp/healthy"]
+      exec                  = ["cat", "/tmp/healthy"]
       initial_delay_seconds = 30
     }
 
     liveness_probe {
       exec                  = ["cat", "/tmp/healthy"]
       initial_delay_seconds = 30
+      period_seconds        = 10
     }
   }
 }

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -36,11 +36,13 @@ resource "azurerm_container_group" "db_client" {
     }
 
     readiness_probe {
-      exec = ["/bin/sh", "-c", "touch /tmp/healthy"]
+      exec                  = ["/bin/sh", "-c", "touch /tmp/healthy"]
+      initial_delay_seconds = 10
     }
 
     liveness_probe {
-      exec = ["cat", "/tmp/healthy"]
+      exec                  = ["cat", "/tmp/healthy"]
+      initial_delay_seconds = 10
     }
   }
 }

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -36,7 +36,7 @@ resource "azurerm_container_group" "db_client" {
     }
 
     readiness_probe {
-      exec = ["/bin/sh","-c","touch /tmp/healthy"]
+      exec = ["/bin/sh", "-c", "touch /tmp/healthy"]
     }
 
     liveness_probe {

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -36,7 +36,7 @@ resource "azurerm_container_group" "db_client" {
     }
 
     readiness_probe {
-      exec                  = ["/bin/sh", "-c", "touch /tmp/healthy"]
+      exec                  = ["cat", "/tmp/healthy"]
       initial_delay_seconds = 30
     }
 

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -5,7 +5,7 @@ resource "azurerm_container_group" "db_client" {
   ip_address_type     = "Private"
   subnet_ids          = [var.subnet_id]
   os_type             = "Linux"
-  restart_policy      = "Always"
+  restart_policy      = "OnFailure"
 
   image_registry_credential {
     username = var.acr_username
@@ -33,6 +33,14 @@ resource "azurerm_container_group" "db_client" {
       storage_account_name = var.storage_account_name
       storage_account_key  = var.storage_account_key
       share_name           = var.storage_share_name
+    }
+
+    readiness_probe {
+      exec = ["/bin/sh","-c","touch /tmp/healthy"]
+    }
+
+    liveness_probe {
+      exec = ["cat", "/tmp/healthy"]
     }
   }
 }

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -36,7 +36,7 @@ resource "azurerm_container_group" "db_client" {
     }
 
     readiness_probe {
-      exec                  = ["/bin/sh", "-c", "touch /tmp/healthy"]
+      exec                  = ["/bin/sh", "-c", "cat /tmp/healthy"]
       initial_delay_seconds = 30
     }
 

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -37,12 +37,12 @@ resource "azurerm_container_group" "db_client" {
 
     readiness_probe {
       exec                  = ["/bin/sh", "-c", "touch /tmp/healthy"]
-      initial_delay_seconds = 10
+      initial_delay_seconds = 30
     }
 
     liveness_probe {
       exec                  = ["cat", "/tmp/healthy"]
-      initial_delay_seconds = 10
+      initial_delay_seconds = 30
     }
   }
 }

--- a/ops/services/container_instances/db_client/infra/db_client.tf
+++ b/ops/services/container_instances/db_client/infra/db_client.tf
@@ -19,12 +19,6 @@ resource "azurerm_container_group" "db_client" {
     cpu    = "1"
     memory = "1.5"
 
-    // Not a real port but *a* port is required, so expose a port the container hopefully doesn't respond to
-    ports {
-      port     = 1234
-      protocol = "TCP"
-    }
-
     volume {
       name       = "${var.name}-${var.env}-db-client-volume"
       read_only  = false


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Attempts to address #6287.

## Changes Proposed

- Adds readiness and liveness probes to `db-client` container instances.
- Modifies container restart policy.

## Additional Information

- There isn't a guarantee that this fix will actually work. The fix in question can only be proven by exclusion, which means that we will only know if it fails (in which case, we will see another failed deployment to an environment).
- This has been tested on `pentest` through multiple deployments, without a recorded failure.
- Azure seems to report at least one failed readiness and liveness check on each deployment. These are reported as warnings, and no further failures occur thereafter. The warnings can be safely ignored.
- If this fix fails, another fix has been developed that will forcibly purge the container instance via the `az` command line prior to initializing Terraform.

## Testing

- Testing can only truly occur over a long period of time.
- Basic smoke tests have been run, including for container stability and ability to connect to the container and downstream database for commands.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
