### PR TITLE
change string name from `loinc` to `specimenSNOMED`

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -445,9 +445,9 @@ public class BulkUploadResultsToFhir {
     return null;
   }
 
-  private String getSpecimenTypeName(String loinc) {
-    if (loinc != null) {
-      return resultsUploaderCachingService.getSNOMEDToSpecimenTypeNameMap().get(loinc);
+  private String getSpecimenTypeName(String specimenSNOMED) {
+    if (specimenSNOMED != null) {
+      return resultsUploaderCachingService.getSNOMEDToSpecimenTypeNameMap().get(specimenSNOMED);
     }
     return null;
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- https://github.com/CDCgov/prime-simplereport/pull/6302#discussion_r1289161738

## Changes Proposed

- correct a misnomer, change string name from `loinc` to `specimenSNOMED`