### PR TITLE
Manually purge client containers to prevent TF hiccups.

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-demo-db-client --resource-group prime-simple-report-demo --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -54,6 +54,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev2-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev3-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev4-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev5.yml
+++ b/.github/workflows/deployDev5.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev5-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev6.yml
+++ b/.github/workflows/deployDev6.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev6-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployDev7.yml
+++ b/.github/workflows/deployDev7.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-dev7-db-client --resource-group prime-simple-report-dev --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-pentest-db-client --resource-group prime-simple-report-pentest --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-prod-db-client --resource-group prime-simple-report-prod --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -63,6 +63,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-stg-db-client --resource-group prime-simple-report-stg --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -55,6 +55,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-test-db-client --resource-group prime-simple-report-test --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Purge DB Client Container
+        run: |
+          az container delete --name simple-report-training-db-client --resource-group prime-simple-report-training --yes
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- This theoretically fully resolves #6287.

## Changes Proposed

- Manually delete `db-client` container instances using `az container delete` command, rather than relying on TF delete and replace.

## Additional Information

- Azure appears to have a buggy implementation of its containers in relation to TF. This may be resolved in a future provider version, but for now, containers will, on occasion, become stuck when destroyed and then recreated by TF. Containers will hang in either a `waiting` or `pending` status. Multiple RCAs have been conducted, and each time, no usable information is gleaned; Azure does not record logs for many of the failures, and will simply report an internal server error for the remaining instances. It appears as though this is an issue with Azure's built-in container orchestration.
- Repeated remediations of this issue have demonstrated that manual container deletes reliably unstick TF on the next attempt. This PR should remove that human element.
- In the event that this fix also fails...the only other option is to create a static version of the db-client image that is only rebuilt on certain occasions.

## Testing

- Careful inspection of the files changed is the best verification we can ask for on this one. Individuals who are feeling daring can attempt to deploy to a development environment.
- Tests have been successfully run on `pentest` and `dev4`.


## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification
