### PR TITLE
Azure alert custom property to Pagerduty

### DIFF
--- a/ops/dev2/alerts.tf
+++ b/ops/dev2/alerts.tf
@@ -26,7 +26,6 @@ module "metric_alerts" {
     "fhir_batched_uploader_function_not_triggering",
     "function_app_memory_alert",
     "fhir_function_app_duration_alert"
-
   ]
 
   action_group_ids = [

--- a/ops/dev4/alerts.tf
+++ b/ops/dev4/alerts.tf
@@ -26,7 +26,6 @@ module "metric_alerts" {
     "fhir_batched_uploader_function_not_triggering",
     "function_app_memory_alert",
     "fhir_function_app_duration_alert"
-
   ]
 
   action_group_ids = [

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -56,11 +56,11 @@ variable "tags" {
 
 # Monitoring settings
 variable "mem_threshold" {
-  default = 1
+  default = 70
 }
 
 variable "cpu_threshold" {
-  default = 1
+  default = 70
 }
 
 variable "cpu_window_size" {

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -103,3 +103,15 @@ variable "function_memory_threshold" {
   description = "The threshold for the function app memory alert in bytes"
   default     = 1200000000
 }
+
+variable "wiki_docs_text" {
+  description = "Custom properties text to include the alert response docs"
+  type        = string
+  default     = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+}
+
+variable "wiki_docs_json" {
+  description = "Custom properties json to include the alert response docs"
+  type        = map(string)
+  default     = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+}

--- a/ops/services/alerts/app_service_metrics/_var.tf
+++ b/ops/services/alerts/app_service_metrics/_var.tf
@@ -56,11 +56,11 @@ variable "tags" {
 
 # Monitoring settings
 variable "mem_threshold" {
-  default = 70
+  default = 1
 }
 
 variable "cpu_threshold" {
-  default = 70
+  default = 1
 }
 
 variable "cpu_window_size" {

--- a/ops/services/alerts/app_service_metrics/database.tf
+++ b/ops/services/alerts/app_service_metrics/database.tf
@@ -22,7 +22,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -33,7 +34,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "db_connection_exhaustion
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.database_id

--- a/ops/services/alerts/app_service_metrics/database.tf
+++ b/ops/services/alerts/app_service_metrics/database.tf
@@ -23,7 +23,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -35,7 +35,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "db_connection_exhaustion
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.database_id

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -29,7 +29,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "graphql_query_validation
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_service_id
@@ -56,7 +57,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "first_error_in_a_week" {
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -105,7 +107,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "account_request_failures
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -140,7 +143,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "experian_auth_failures" 
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -175,7 +179,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "all_experian_auth_failur
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -210,7 +215,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "frontend_error_boundary"
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -30,7 +30,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "graphql_query_validation
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_service_id
@@ -58,7 +58,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "first_error_in_a_week" {
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -108,7 +108,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "account_request_failures
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -144,7 +144,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "experian_auth_failures" 
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -180,7 +180,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "all_experian_auth_failur
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -216,7 +216,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "frontend_error_boundary"
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id

--- a/ops/services/alerts/app_service_metrics/function_triggers.tf
+++ b/ops/services/alerts/app_service_metrics/function_triggers.tf
@@ -56,7 +56,8 @@ requests
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -86,7 +87,8 @@ requests
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 

--- a/ops/services/alerts/app_service_metrics/function_triggers.tf
+++ b/ops/services/alerts/app_service_metrics/function_triggers.tf
@@ -57,7 +57,7 @@ requests
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -88,7 +88,7 @@ requests
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -25,7 +25,8 @@ resource "azurerm_monitor_metric_alert" "cpu_util" {
   dynamic "action" {
     for_each = var.action_group_ids
     content {
-      action_group_id = action.value
+      action_group_id    = action.value
+      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response"}
     }
   }
 }
@@ -51,7 +52,8 @@ resource "azurerm_monitor_metric_alert" "mem_util" {
   dynamic "action" {
     for_each = var.action_group_ids
     content {
-      action_group_id = action.value
+      action_group_id    = action.value
+      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }
@@ -66,7 +68,8 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
   detector_type       = "FailureAnomaliesDetector"
 
   action_group {
-    ids = var.action_group_ids
+    ids             = var.action_group_ids
+    webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -104,7 +107,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -142,7 +146,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -170,7 +175,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -198,7 +204,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -228,7 +235,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -239,7 +247,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "bulk_results_upload" {
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -269,7 +278,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_batched_up
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -298,7 +308,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_fhir_batch
   resource_group_name = var.rg_name
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 
   data_source_id = var.app_insights_id
@@ -346,7 +357,8 @@ ${local.skip_on_weekends}
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }
 
@@ -369,7 +381,8 @@ resource "azurerm_monitor_metric_alert" "function_app_memory_alert" {
   dynamic "action" {
     for_each = var.action_group_ids
     content {
-      action_group_id = action.value
+      action_group_id    = action.value
+      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }
@@ -398,6 +411,7 @@ and duration >= 180000
   }
 
   action {
-    action_group = var.action_group_ids
+    action_group           = var.action_group_ids
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_monitor_metric_alert" "cpu_util" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = var.wiki_docs_json
     }
   }
 }
@@ -53,7 +53,7 @@ resource "azurerm_monitor_metric_alert" "mem_util" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = var.wiki_docs_json
     }
   }
 }
@@ -69,7 +69,7 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
 
   action_group {
     ids             = var.action_group_ids
-    webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -108,7 +108,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -147,7 +147,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -176,7 +176,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -205,7 +205,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -236,7 +236,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -248,7 +248,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "bulk_results_upload" {
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -279,7 +279,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_batched_up
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -309,7 +309,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_fhir_batch
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 
   data_source_id = var.app_insights_id
@@ -358,7 +358,7 @@ ${local.skip_on_weekends}
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }
 
@@ -382,7 +382,7 @@ resource "azurerm_monitor_metric_alert" "function_app_memory_alert" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = var.wiki_docs_json
     }
   }
 }
@@ -412,6 +412,6 @@ and duration >= 180000
 
   action {
     action_group           = var.action_group_ids
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_monitor_metric_alert" "cpu_util" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response"}
+      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }
@@ -53,7 +53,7 @@ resource "azurerm_monitor_metric_alert" "mem_util" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }
@@ -382,7 +382,7 @@ resource "azurerm_monitor_metric_alert" "function_app_memory_alert" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }

--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -72,7 +72,7 @@ resource "azurerm_monitor_metric_alert" "uptime" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = var.wiki_docs_json
     }
   }
 }

--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -71,7 +71,8 @@ resource "azurerm_monitor_metric_alert" "uptime" {
   dynamic "action" {
     for_each = var.action_group_ids
     content {
-      action_group_id = action.value
+      action_group_id    = action.value
+      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }

--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -72,7 +72,7 @@ resource "azurerm_monitor_metric_alert" "uptime" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }

--- a/ops/services/alerts/db_metrics/_var.tf
+++ b/ops/services/alerts/db_metrics/_var.tf
@@ -16,3 +16,9 @@ variable "action_group_ids" {
   description = "The IDs of the monitor action group resources to send events to"
   type        = list(string)
 }
+
+variable "wiki_docs_json" {
+  description = "Custom properties json to include the alert response docs"
+  type        = map(string)
+  default     = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+}

--- a/ops/services/alerts/db_metrics/main.tf
+++ b/ops/services/alerts/db_metrics/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_metric_alert" "db_storage" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }

--- a/ops/services/alerts/db_metrics/main.tf
+++ b/ops/services/alerts/db_metrics/main.tf
@@ -19,7 +19,8 @@ resource "azurerm_monitor_metric_alert" "db_storage" {
   dynamic "action" {
     for_each = var.action_group_ids
     content {
-      action_group_id = action.value
+      action_group_id    = action.value
+      webhook_properties = {"Alert Response Docs": "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
     }
   }
 }

--- a/ops/services/alerts/db_metrics/main.tf
+++ b/ops/services/alerts/db_metrics/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_metric_alert" "db_storage" {
     for_each = var.action_group_ids
     content {
       action_group_id    = action.value
-      webhook_properties = { "Alert Response Docs" : "https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response" }
+      webhook_properties = var.wiki_docs_json
     }
   }
 }

--- a/ops/services/alerts/url_ping_test/_var.tf
+++ b/ops/services/alerts/url_ping_test/_var.tf
@@ -24,3 +24,9 @@ variable "rg_location" {
 variable "tags" {
   default = {}
 }
+
+variable "wiki_docs_text" {
+  description = "Custom properties text to include the alert response docs"
+  type        = string
+  default     = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+}

--- a/ops/services/alerts/url_ping_test/main.tf
+++ b/ops/services/alerts/url_ping_test/main.tf
@@ -54,6 +54,7 @@ resource "azurerm_monitor_metric_alert" "webtest" {
   }
 
   action {
-    action_group_id = var.action_group_id
+    action_group_id        = var.action_group_id
+    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
   }
 }

--- a/ops/services/alerts/url_ping_test/main.tf
+++ b/ops/services/alerts/url_ping_test/main.tf
@@ -55,6 +55,6 @@ resource "azurerm_monitor_metric_alert" "webtest" {
 
   action {
     action_group_id        = var.action_group_id
-    custom_webhook_payload = "{\"Alert Response Docs\": \"https://github.com/CDCgov/prime-simplereport/wiki/Alert-Response\" }"
+    custom_webhook_payload = var.wiki_docs_text
   }
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- partial for #2816 

## Changes Proposed

- Alerts originate from Azure Monitor tooling; this adds a custom property that contains a link to our `Alert Response` wiki page to the payload Azure sends to pagerduty. We may be able to update Pagerduty to ingest that property and do something with it, like include it in the link we send to Slack when an alert is triggered.

## Additional Information

- Pagerduty has a field in the services property that is intended to be a link to docs meant to help resolve issues with that service, but it appears that we can only view it in the Pagerduty dashboard.
- notice of future work that needs to be done

## Testing

- [This is an example of the alert payload](https://prime-cdc.pagerduty.com/incidents/Q2IS8NNN2JXISQ) ( search the page for `Response` and you'll find the custom property )

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README