### PR TITLE
Add missing mixin for other theme colors

### DIFF
--- a/frontend/src/scss/settings/_prime-variables.scss
+++ b/frontend/src/scss/settings/_prime-variables.scss
@@ -2,24 +2,24 @@
 
 $site-max-width: 1200px;
 
-$theme-color-prime-blue-lightest: "cyan-5";
-$theme-color-prime-blue-light: "blue-10";
-$theme-color-prime-blue: "blue-50";
-$theme-color-prime-blue-dark: "blue-60";
-$theme-color-prime-blue-darkest: "blue-80v";
+$theme-color-prime-blue-lightest: color("cyan-5");
+$theme-color-prime-blue-light: color("blue-10");
+$theme-color-prime-blue: color("blue-50");
+$theme-color-prime-blue-dark: color("blue-60");
+$theme-color-prime-blue-darkest: color("blue-80v");
 
-$theme-color-prime-blue-cool-light: "blue-cool-30v";
-$theme-color-prime-blue-cool-dark: "blue-cool-60v";
+$theme-color-prime-blue-cool-light: color("blue-cool-30v");
+$theme-color-prime-blue-cool-dark: color("blue-cool-60v");
 
-$theme-color-prime-red-lightest: "red-5";
-$theme-color-prime-red-light: "red-30";
-$theme-color-prime-red: "red-60";
-$theme-color-prime-red-dark: "red-60v";
+$theme-color-prime-red-lightest: color("red-5");
+$theme-color-prime-red-light: color("red-30");
+$theme-color-prime-red: color("red-60");
+$theme-color-prime-red-dark: color("red-60v");
 
-$theme-color-prime-green-lightest: "green-cool-5";
-$theme-color-prime-green-light: "green-cool-20v";
-$theme-color-prime-green: "green-cool-40v";
-$theme-color-prime-green-dark: "green-cool-50";
+$theme-color-prime-green-lightest: color("green-cool-5");
+$theme-color-prime-green-light: color("green-cool-20v");
+$theme-color-prime-green: color("green-cool-40v");
+$theme-color-prime-green-dark: color("green-cool-50");
 
 $theme-color-prime-gray-light: color("gray-10");
 $theme-color-prime-gray: color("gray-30");


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Noticed that some of the styles weren't using the correct theme colors and realized I missed using the color mixin for some of the custom theme variables during the USWDS 3.0 upgrade

## Changes Proposed

- Uses color mixin for custom theme variables that were missing it

## Screenshots / Demos

Storybook App > Test Queue > Queue item
`.prime-queue-item__info` correctly applied a blue border

Before
![Screenshot 2023-08-15 204157](https://github.com/CDCgov/prime-simplereport/assets/23287037/d5517fd2-6f6d-43ec-9b14-caf1f6bedb13)

After
![Screenshot 2023-08-15 204243](https://github.com/CDCgov/prime-simplereport/assets/23287037/fbad162d-3487-464c-9848-3ac4a9205c2b)
