### PR TITLE
add "MISSING_HEADER" to "test_result_upload_error" enum in db

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5008,7 +5008,4 @@ databaseChangeLog:
         - sql:
             sql: |
               ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'MISSING_HEADER';
-      rollback:
-        - sql:
-            sql: |
-              ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR REMOVE VALUE 'MISSING_HEADER';
+      rollback: ""

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5000,3 +5000,15 @@ databaseChangeLog:
               - column:
                   name: result
                   type: ${database.defaultSchemaName}.TEST_RESULT
+  - changeSet:
+      id: add-missing-header-to-test_result_upload_error
+      author: boban@skylight.digital
+      comment: add MISSING_HEADER to test_result_upload_error
+      changes:
+        - sql:
+            sql: |
+              ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'MISSING_HEADER';
+      rollback:
+        - sql:
+            sql: |
+              ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR REMOVE VALUE 'MISSING_HEADER';


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Trying to upload a file with a missing required header fails because the DB does not contain the enum value we are trying to send
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/1ca23008-3d40-4161-b2a1-788d6a1f0635)


## Changes Proposed

- Update enum to add `MISSING_HEADER`

## Additional information

- Missing required header creates [an error](https://github.com/CDCgov/prime-simplereport/blob/00da17558d817ebdd3dcfea304e01debcc3065fd/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java#L379) that uses "MISSING_HEADER" enum and then [while saving it throws an error](https://github.com/CDCgov/prime-simplereport/blob/00da17558d817ebdd3dcfea304e01debcc3065fd/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java#L140).
- It is [not possible to remove a value from an enum](https://www.postgresql.org/docs/current/datatype-enum.html#id-1.5.7.15.8:~:text=Existing%20values%20cannot%20be%20removed%20from%20an,An), so roll back is just [empty string](https://docs.liquibase.com/workflows/liquibase-community/using-rollback.html)

## Testing

- Upload a CSV without a required field like this one -> [test_results_example_10-3-2022 (20).csv](https://github.com/CDCgov/prime-simplereport/files/12379010/test_results_example_10-3-2022.20.csv)


