### PR TITLE
Add testLength offset to specimen collection date in single-entry FHIR

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -960,7 +960,7 @@ public class FhirConverter {
                     testEvent.getSpecimenType(),
                     uuidGenerator.randomUUID(),
                     specimenCollectionDate,
-                    dateTested))
+                    specimenCollectionDate))
             .resultObservations(
                 convertToObservation(
                     testEvent.getResults(),

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.Nullable;
  * practice.
  */
 public class TestEventExport {
-  private static final int FALLBACK_DEFAULT_TEST_MINUTES = 15;
+  public static final int FALLBACK_DEFAULT_TEST_MINUTES = 15;
   public static final String USA = "USA";
   private String processingModeCode = "P";
   private final TestEvent testEvent;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -34,6 +34,7 @@ import gov.cdc.usds.simplereport.utils.DateGenerator;
 import gov.cdc.usds.simplereport.utils.UUIDGenerator;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -994,6 +995,15 @@ class FhirConverterTest {
             "$CURRENT_DATE_TIMEZONE",
             new DateTimeType(
                     date, TemporalPrecisionEnum.SECOND, TimeZone.getTimeZone(ZoneOffset.UTC))
+                .getValueAsString());
+
+    expectedSerialized =
+        expectedSerialized.replace(
+            "$EFFECTIVE_DATETIME_ZONE",
+            new DateTimeType(
+                    new Date(date.toInstant().minus(Duration.ofMinutes(15)).toEpochMilli()),
+                    TemporalPrecisionEnum.SECOND,
+                    TimeZone.getTimeZone(ZoneOffset.UTC))
                 .getValueAsString());
 
     JSONAssert.assertEquals(expectedSerialized, actualSerialized, true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1441,7 +1441,7 @@ class FhirConverterTest {
     supportedTestOrders.add(TestDataBuilder.createDeviceTypeDisease(fluADisease));
     supportedTestOrders.add(TestDataBuilder.createDeviceTypeDisease(fluBDisease));
     var deviceType =
-        new DeviceType("name", "manufacturer", "model", 0, new ArrayList<>(), supportedTestOrders);
+        new DeviceType("name", "manufacturer", "model", 7, new ArrayList<>(), supportedTestOrders);
 
     var specimenType = new SpecimenType("name", "typeCode");
     var provider =

--- a/backend/src/test/resources/fhir/bundle-integration-testing.json
+++ b/backend/src/test/resources/fhir/bundle-integration-testing.json
@@ -116,7 +116,7 @@
         "subject": {
           "reference": "Patient/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
         },
-        "effectiveDateTime": "2021-09-01T10:31:30+00:00",
+        "effectiveDateTime": "2021-09-01T10:16:30+00:00",
         "issued": "2023-05-24T19:33:06+00:00",
         "specimen": [
           {

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -306,7 +306,11 @@
           {
             "value": "$SPECIMEN_IDENTIFIER"
           }
-        ]
+        ],
+        "receivedTime": "2023-07-14T15:52:34+00:00",
+        "collection": {
+          "collectedDateTime": "2023-07-14T15:45:34+00:00"
+        }
       }
     },
     {

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -307,7 +307,7 @@
             "value": "$SPECIMEN_IDENTIFIER"
           }
         ],
-        "receivedTime": "2023-07-14T15:52:34+00:00",
+        "receivedTime": "2023-07-14T15:45:34+00:00",
         "collection": {
           "collectedDateTime": "2023-07-14T15:45:34+00:00"
         }

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -96,7 +96,7 @@
           }
         ],
         "status":"final",
-        "effectiveDateTime": "2023-07-14T15:52:34+00:00",
+        "effectiveDateTime": "2023-07-14T15:45:34+00:00",
         "code":{
           "coding":[
             {

--- a/backend/src/test/resources/fhir/diagnosticReport.json
+++ b/backend/src/test/resources/fhir/diagnosticReport.json
@@ -2,7 +2,7 @@
   "resourceType": "DiagnosticReport",
   "id": "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29",
   "status": "final",
-  "effectiveDateTime": "$CURRENT_DATE_TIMEZONE",
+  "effectiveDateTime": "$EFFECTIVE_DATETIME_ZONE",
   "code": {
     "coding": [
       {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #6357

## Changes Proposed

- Add testLength offset to specimen collection date and diagnostic effective date in single-entry FHIR
- add offset to `OBR-7` fields
- Coordinate with RS to remove their immplementation of the offset from the Universal Pipeline before this is merged.
