### PR TITLE
Disable db validate jobs

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -125,21 +125,3 @@ jobs:
             :siren-gif: Deploy to ${{ env.DEPLOY_ENV }} failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -118,21 +118,3 @@ jobs:
           header: "Dev Notice:"
           message: "This environment has email delivery enabled. Do not use real email addresses."
           env: ${{ env.DEPLOY_ENV }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -110,21 +110,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -110,21 +110,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -110,21 +110,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev5.yml
+++ b/.github/workflows/deployDev5.yml
@@ -110,21 +110,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev6.yml
+++ b/.github/workflows/deployDev6.yml
@@ -110,21 +110,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{ env.DEPLOY_ENV }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployDev7.yml
+++ b/.github/workflows/deployDev7.yml
@@ -110,21 +110,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -106,21 +106,3 @@ jobs:
         with:
           client-tarball: client.tgz
           deploy-env: ${{env.DEPLOY_ENV}}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -134,21 +134,3 @@ jobs:
             :siren-gif: Deploy to ${{ env.DEPLOY_ENV }} failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -136,21 +136,3 @@ jobs:
             :siren-gif: Deploy to ${{ env.DEPLOY_ENV }} failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -126,21 +126,3 @@ jobs:
             :siren-gif: Deploy to ${{ env.DEPLOY_ENV }} failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -126,21 +126,3 @@ jobs:
             :siren-gif: Deploy to ${{ env.DEPLOY_ENV }} failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}
-  db_validate:
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: DB Liquibase Validate
-        uses: ./.github/actions/db-actions
-        with:
-          deploy_env: ${{ env.DEPLOY_ENV }}
-          action: validate
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          acr_repo_url: ${{ secrets.ACR_REPO_URL }}
-          acr_admin_username: ${{ secrets.ACR_ADMIN_USERNAME }}
-          acr_admin_pasword: ${{ secrets.ACR_ADMIN_PASWORD }}
-          terraform_arm_client_id: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-          terraform_arm_client_secret: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-          terraform_arm_subscription_id: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-          terraform_arm_tenant_id: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- These jobs  are having several issues in  our deployment pipeline, disabling for now.

## Changes Proposed

- removes db validate from deployments

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README