### PR TITLE
App service health checks for API and Metabase

### DIFF
--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -90,6 +90,8 @@ resource "azurerm_linux_web_app_slot" "staging" {
   # Configure Docker Image to load on start
   site_config {
     always_on               = "true"
+    health_check_path       = "/health"
+    health_check_eviction_time_in_min = 5
     scm_minimum_tls_version = "1.2"
     use_32_bit_worker       = false
     ftps_state              = "Disabled"

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -89,13 +89,13 @@ resource "azurerm_linux_web_app_slot" "staging" {
 
   # Configure Docker Image to load on start
   site_config {
-    always_on               = "true"
-    health_check_path       = "/health"
+    always_on                         = "true"
+    health_check_path                 = "/health"
     health_check_eviction_time_in_min = 5
-    scm_minimum_tls_version = "1.2"
-    use_32_bit_worker       = false
-    ftps_state              = "Disabled"
-    vnet_route_all_enabled  = false
+    scm_minimum_tls_version           = "1.2"
+    use_32_bit_worker                 = false
+    ftps_state                        = "Disabled"
+    vnet_route_all_enabled            = false
 
     # This application stack is what we use to deploy the docker image to the staging slot
     # After it becomes healthy, we swap the staging slot with the production slot to complete the deployment

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -49,11 +49,13 @@ resource "azurerm_linux_web_app" "service" {
 
   # Configure Docker Image to load on start
   site_config {
-    always_on               = "true"
-    scm_minimum_tls_version = "1.2"
-    use_32_bit_worker       = false
-    ftps_state              = "Disabled"
-    vnet_route_all_enabled  = false
+    always_on                         = "true"
+    health_check_path                 = "/health"
+    health_check_eviction_time_in_min = 5
+    scm_minimum_tls_version           = "1.2"
+    use_32_bit_worker                 = false
+    ftps_state                        = "Disabled"
+    vnet_route_all_enabled            = false
 
     // NOTE: If this code is removed, TF will not automatically delete it with the current provider version! It must be removed manually from the App Service -> Networking blade!
     ip_restriction {

--- a/ops/services/metabase/service/main.tf
+++ b/ops/services/metabase/service/main.tf
@@ -32,11 +32,13 @@ resource "azurerm_linux_web_app" "metabase" {
   virtual_network_subnet_id = var.webapp_subnet_id
 
   site_config {
-    always_on               = true
-    ftps_state              = "Disabled"
-    scm_minimum_tls_version = "1.2"
-    use_32_bit_worker       = false
-    vnet_route_all_enabled  = false
+    always_on                         = true
+    health_check_path                 = "/api/health"
+    health_check_eviction_time_in_min = 5
+    ftps_state                        = "Disabled"
+    scm_minimum_tls_version           = "1.2"
+    use_32_bit_worker                 = false
+    vnet_route_all_enabled            = false
 
     ip_restriction {
       virtual_network_subnet_id = var.lb_subnet_id


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #6217

## Changes Proposed

- It's best practice to have standard health checks configured. These particular health checks help Azure determine if it should try replacing an instance that becomes unhealthy.
- I'm open to changing the 5-minute eviction time frame. Azure allows that to be between 2 and 10 minutes.

## Testing

- If you deploy this to an environment and visit the Azure portal, you can view a health checks tab of the API and Metabase app services to check the configuration and status of the current instances.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README