### PR TITLE
Add unarchive patient functionality for support admins

### DIFF
--- a/frontend/src/app/supportAdmin/SupportAdmin.tsx
+++ b/frontend/src/app/supportAdmin/SupportAdmin.tsx
@@ -15,6 +15,7 @@ import {
   orgAccessPageTitle,
   orgFacilityColumnTitle,
   usersAndPatientsColumnTitle,
+  unarchivePatientTitle,
 } from "./pageTitles";
 
 type CategoryMenuProps = {
@@ -90,6 +91,11 @@ const SupportAdmin = () => {
                   <li>
                     <LinkWithQuery to="/admin/manage-users">
                       {manageUserPageTitle}
+                    </LinkWithQuery>
+                  </li>
+                  <li>
+                    <LinkWithQuery to="/admin/unarchive-patient">
+                      {unarchivePatientTitle}
                     </LinkWithQuery>
                   </li>
                 </CategoryMenu>

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.test.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.test.tsx
@@ -14,6 +14,7 @@ import createMockStore from "redux-mock-store";
 import { GraphQLError } from "graphql/error";
 import { MemoryRouter } from "react-router-dom";
 import { configureAxe, toHaveNoViolations } from "jest-axe";
+import { v4 as uuidv4 } from "uuid";
 
 import {
   ArchivedStatus,
@@ -21,6 +22,7 @@ import {
   GetOrganizationWithFacilitiesDocument,
   GetPatientsByFacilityWithOrgDocument,
   GetPatientsCountByFacilityWithOrgDocument,
+  UnarchivePatientDocument,
 } from "../../../generated/graphql";
 import * as srToast from "../../utils/srToast";
 
@@ -69,6 +71,86 @@ export const mockOrg2: UnarchivePatientOrganization = {
   facilities: [],
 };
 
+const createMockPatients = (patientNum: number) => {
+  let mockPatients = [];
+  while (patientNum > 0) {
+    let mockUUID = uuidv4();
+    let patient = {
+      birthDate: "1973-11-20",
+      firstName: `User first ${patientNum}`,
+      internalId: mockUUID,
+      isDeleted: true,
+      lastName: `User first ${patientNum}`,
+      middleName: "",
+      facility: null,
+    };
+    mockPatients.push(patient);
+    patientNum--;
+  }
+  return mockPatients;
+};
+
+const mocksWithPatients = [
+  {
+    request: {
+      query: GetOrganizationsDocument,
+      variables: {
+        identityVerified: true,
+      },
+    },
+    result: {
+      data: {
+        organizations: [mockOrg2, mockOrg1],
+      },
+    },
+  },
+  {
+    request: {
+      query: GetOrganizationWithFacilitiesDocument,
+      variables: {
+        id: mockOrg1.internalId,
+      },
+    },
+    result: {
+      data: {
+        organization: mockOrg1,
+      },
+    },
+  },
+  {
+    request: {
+      query: GetPatientsByFacilityWithOrgDocument,
+      variables: {
+        facilityId: mockFacility1.id,
+        pageNumber: 0,
+        pageSize: 20,
+        archivedStatus: ArchivedStatus.Archived,
+        orgExternalId: mockOrg1.externalId,
+      },
+    },
+    result: {
+      data: {
+        patients: [mockPatient1, mockPatient2],
+      },
+    },
+  },
+  {
+    request: {
+      query: GetPatientsCountByFacilityWithOrgDocument,
+      variables: {
+        facilityId: mockFacility1.id,
+        archivedStatus: ArchivedStatus.Archived,
+        orgExternalId: mockOrg1.externalId,
+      },
+    },
+    result: {
+      data: {
+        patientsCount: 2,
+      },
+    },
+  },
+];
+
 const axe = configureAxe({
   rules: {
     // disable landmark rules when testing isolated components.
@@ -78,6 +160,7 @@ const axe = configureAxe({
 
 const mockNavigate = jest.fn();
 const mockLocation = jest.fn();
+
 expect.extend(toHaveNoViolations);
 
 jest.mock("react-router-dom", () => {
@@ -125,7 +208,9 @@ describe("Unarchive patient", () => {
     render(
       <Provider store={mockedStore}>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UnarchivePatient />
+          <MemoryRouter>
+            <UnarchivePatient />
+          </MemoryRouter>
         </MockedProvider>
       </Provider>
     );
@@ -181,7 +266,9 @@ describe("Unarchive patient", () => {
     render(
       <Provider store={mockedStore}>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UnarchivePatient />
+          <MemoryRouter>
+            <UnarchivePatient />
+          </MemoryRouter>
         </MockedProvider>
       </Provider>
     );
@@ -194,6 +281,172 @@ describe("Unarchive patient", () => {
     );
   });
   it("displays patients table on valid search", async () => {
+    render(
+      <Provider store={mockedStore}>
+        <MockedProvider mocks={mocksWithPatients} addTypename={false}>
+          <MemoryRouter>
+            <UnarchivePatient />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
+    );
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText("Loading Organizations …")
+    );
+    await expect(screen.getByText("Clear filters")).toBeDisabled();
+    await searchByOrgAndFacility();
+    checkPatientResultRows();
+    expect(await axe(document.body)).toHaveNoViolations();
+    await act(
+      async () => await userEvent.click(screen.getByText("Clear filters"))
+    );
+    expect(screen.getByLabelText("Testing facility *")).toHaveDisplayValue(
+      "- Select -"
+    );
+    expect(screen.getByLabelText("Organization *")).toHaveDisplayValue(
+      "- Select -"
+    );
+    expect(
+      screen.getByText(
+        "Filter by organization and testing facility to display archived patients."
+      )
+    ).toBeInTheDocument();
+    // show form errors
+    await clickSearch();
+    expect(screen.getByText("Organization is required")).toBeInTheDocument();
+    expect(
+      screen.getByText("Testing facility is required")
+    ).toBeInTheDocument();
+    expect(await axe(document.body)).toHaveNoViolations();
+  });
+
+  it("displays unarchive patient modal and unarchives patient", async () => {
+    let alertErrorSpy: jest.SpyInstance;
+    let alertSuccessSpy: jest.SpyInstance;
+    alertErrorSpy = jest.spyOn(srToast, "showError");
+    alertSuccessSpy = jest.spyOn(srToast, "showSuccess");
+
+    let additionalMocks = [
+      {
+        request: {
+          query: UnarchivePatientDocument,
+          variables: {
+            id: mockPatient1.internalId,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          errors: [
+            new GraphQLError(
+              "A wild error appeared",
+              null,
+              null,
+              null,
+              null,
+              null,
+              { code: "ERROR_CODE" }
+            ),
+          ],
+        },
+      },
+      {
+        request: {
+          query: GetPatientsByFacilityWithOrgDocument,
+          variables: {
+            facilityId: mockFacility1.id,
+            pageNumber: 0,
+            pageSize: 20,
+            archivedStatus: ArchivedStatus.Archived,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            patients: [mockPatient1, mockPatient2],
+          },
+        },
+      },
+      {
+        request: {
+          query: GetPatientsCountByFacilityWithOrgDocument,
+          variables: {
+            facilityId: mockFacility1.id,
+            archivedStatus: ArchivedStatus.Archived,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            patientsCount: 2,
+          },
+        },
+      },
+      {
+        request: {
+          query: UnarchivePatientDocument,
+          variables: {
+            id: mockPatient2.internalId,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            setPatientIsDeleted: {
+              internalId: mockPatient2.internalId,
+            },
+          },
+        },
+      },
+    ];
+
+    mocks = [...mocksWithPatients, ...additionalMocks];
+
+    render(
+      <Provider store={mockedStore}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <MemoryRouter>
+            <UnarchivePatient />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
+    );
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText("Loading Organizations …")
+    );
+    await searchByOrgAndFacility();
+    await act(async () => screen.getAllByText("Unarchive")[0].click());
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      /Are you sure you want to unarchive Gutmann, Rod\?/
+    );
+    await act(async () =>
+      expect(await axe(document.body)).toHaveNoViolations()
+    );
+    await act(async () => screen.getByText("Yes, I'm sure").click());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(alertErrorSpy).toHaveBeenCalledWith(
+        "Please escalate this issue to the SimpleReport team.",
+        "Error unarchiving patient"
+      );
+    });
+    checkPatientResultRows();
+    await act(async () => screen.getAllByText("Unarchive")[1].click());
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      /Are you sure you want to unarchive Mode, Mia\?/
+    );
+    await act(async () => screen.getByText("Yes, I'm sure").click());
+    await waitFor(() => {
+      expect(alertSuccessSpy).toHaveBeenCalledWith(
+        "",
+        "Patient successfully unarchived"
+      );
+    });
+
+    expect(await axe(document.body)).toHaveNoViolations();
+  });
+
+  it("navigates to previous page when archiving last patient on page", async () => {
+    let mockPatientGroup = createMockPatients(20);
     mocks = [
       {
         request: {
@@ -234,7 +487,7 @@ describe("Unarchive patient", () => {
         },
         result: {
           data: {
-            patients: [mockPatient1, mockPatient2],
+            patients: mockPatientGroup,
           },
         },
       },
@@ -249,7 +502,72 @@ describe("Unarchive patient", () => {
         },
         result: {
           data: {
-            patientsCount: 2,
+            patientsCount: 21,
+          },
+        },
+      },
+      {
+        request: {
+          query: GetPatientsByFacilityWithOrgDocument,
+          variables: {
+            facilityId: mockFacility1.id,
+            pageNumber: 1,
+            pageSize: 20,
+            archivedStatus: ArchivedStatus.Archived,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            patients: [mockPatient1],
+          },
+        },
+      },
+      {
+        request: {
+          query: UnarchivePatientDocument,
+          variables: {
+            id: mockPatient1.internalId,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            setPatientIsDeleted: {
+              internalId: mockPatient1.internalId,
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: GetPatientsCountByFacilityWithOrgDocument,
+          variables: {
+            facilityId: mockFacility1.id,
+            archivedStatus: ArchivedStatus.Archived,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            patientsCount: 20,
+          },
+        },
+      },
+      {
+        request: {
+          query: GetPatientsByFacilityWithOrgDocument,
+          variables: {
+            facilityId: mockFacility1.id,
+            pageNumber: 0,
+            pageSize: 20,
+            archivedStatus: ArchivedStatus.Archived,
+            orgExternalId: mockOrg1.externalId,
+          },
+        },
+        result: {
+          data: {
+            patients: mockPatientGroup,
           },
         },
       },
@@ -264,44 +582,36 @@ describe("Unarchive patient", () => {
         </MockedProvider>
       </Provider>
     );
-    await waitForElementToBeRemoved(() =>
-      screen.queryByText("Loading Organizations …")
+    await waitForElementToBeRemoved(() => screen.queryByText(/Loading/i));
+    await searchByOrgAndFacility();
+    await act(async () => screen.getByText("2").closest("a")?.click());
+    await waitForElementToBeRemoved(() => screen.queryByText(/Loading/i));
+    await act(async () => screen.getAllByText("Unarchive")[0].click());
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      /Are you sure you want to unarchive Gutmann, Rod\?/
     );
-    await expect(screen.getByText("Clear filters")).toBeDisabled();
-    await selectDropdown("Organization *", mockOrg1.name);
-    await waitFor(async () =>
-      expect(screen.getByLabelText("Testing facility *")).toHaveTextContent(
-        "Mars Facility"
-      )
-    );
-    await selectDropdown("Testing facility *", mockFacility1.name);
-    await clickSearch();
-    await waitForElementToBeRemoved(() => screen.queryAllByText("Loading..."));
-    checkPatientResultRows();
-    expect(await axe(document.body)).toHaveNoViolations();
-    await act(
-      async () => await userEvent.click(screen.getByText("Clear filters"))
-    );
-    expect(screen.getByLabelText("Testing facility *")).toHaveDisplayValue(
-      "- Select -"
-    );
-    expect(screen.getByLabelText("Organization *")).toHaveDisplayValue(
-      "- Select -"
-    );
-    expect(
-      screen.getByText(
-        "Filter by organization and testing facility to display archived patients."
-      )
-    ).toBeInTheDocument();
-    // show form errors
-    await clickSearch();
-    expect(screen.getByText("Organization is required")).toBeInTheDocument();
-    expect(
-      screen.getByText("Testing facility is required")
-    ).toBeInTheDocument();
-    expect(await axe(document.body)).toHaveNoViolations();
+    await act(async () => screen.getByText("Yes, I'm sure").click());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next")).not.toBeInTheDocument();
+    expect(screen.queryByText("Prev")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
   });
 });
+
+const searchByOrgAndFacility = async () => {
+  await selectDropdown("Organization *", mockOrg1.name);
+  await waitFor(async () =>
+    expect(screen.getByLabelText("Testing facility *")).toHaveTextContent(
+      "Mars Facility"
+    )
+  );
+  await selectDropdown("Testing facility *", mockFacility1.name);
+  await clickSearch();
+  expect(mockNavigate).not.toHaveBeenCalled();
+  await waitForElementToBeRemoved(() => screen.queryAllByText("Loading..."));
+};
+
 export const clickSearch = async () => {
   await act(async () => await userEvent.click(screen.getByText("Search")));
 };

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.tsx
@@ -165,6 +165,7 @@ const UnarchivePatient = () => {
   const handleSelectOrganization = async (selectedOrgInternalId: string) => {
     updateLocalState(() => ({
       ...initialState,
+      orgId: selectedOrgInternalId,
     }));
     if (selectedOrgInternalId) {
       let { data: facilitiesRes } = await queryGetOrgWithFacilities({
@@ -172,7 +173,6 @@ const UnarchivePatient = () => {
       });
       updateLocalState((prevState) => ({
         ...prevState,
-        orgId: selectedOrgInternalId,
         facilities: facilitiesRes?.organization?.facilities || [],
       }));
     }

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientFilters.test.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientFilters.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 
 import { Option } from "../../commonComponents/Select";
 
@@ -49,17 +50,20 @@ describe("unarchive patient filters", () => {
       patientsCount: 2,
       patients: undefined,
       facilities: [mockFacility1, mockFacility2],
+      patient: undefined,
     };
     render(
-      <UnarchivePatientFilters
-        orgOptions={mockOrgOptions}
-        onSelectOrg={onSelectOrg}
-        onSelectFacility={onSelectFacility}
-        onSearch={onSearch}
-        onClearFilter={onClearFilter}
-        loading={false}
-        unarchivePatientState={unarchivePatientState}
-      />
+      <MemoryRouter>
+        <UnarchivePatientFilters
+          orgOptions={mockOrgOptions}
+          onSelectOrg={onSelectOrg}
+          onSelectFacility={onSelectFacility}
+          onSearch={onSearch}
+          onClearFilter={onClearFilter}
+          loading={false}
+          unarchivePatientState={unarchivePatientState}
+        />
+      </MemoryRouter>
     );
     await clickSearch();
     expect(screen.getByText("Organization is required")).toBeInTheDocument();
@@ -76,17 +80,20 @@ describe("unarchive patient filters", () => {
       patientsCount: 2,
       patients: [mockPatient1, mockPatient2],
       facilities: [mockFacility1, mockFacility2],
+      patient: undefined,
     };
     render(
-      <UnarchivePatientFilters
-        orgOptions={mockOrgOptions}
-        onSelectOrg={onSelectOrg}
-        onSelectFacility={onSelectFacility}
-        onSearch={onSearch}
-        onClearFilter={onClearFilter}
-        loading={false}
-        unarchivePatientState={unarchivePatientState}
-      />
+      <MemoryRouter>
+        <UnarchivePatientFilters
+          orgOptions={mockOrgOptions}
+          onSelectOrg={onSelectOrg}
+          onSelectFacility={onSelectFacility}
+          onSearch={onSearch}
+          onClearFilter={onClearFilter}
+          loading={false}
+          unarchivePatientState={unarchivePatientState}
+        />
+      </MemoryRouter>
     );
     await selectDropdown("Organization *", mockOrg1.name);
     expect(onSelectOrg).toHaveBeenCalledTimes(1);
@@ -117,17 +124,20 @@ describe("unarchive patient filters", () => {
       patientsCount: 2,
       patients: [mockPatient1, mockPatient2],
       facilities: [mockFacility1, mockFacility2],
+      patient: undefined,
     };
     render(
-      <UnarchivePatientFilters
-        orgOptions={mockOrgOptions}
-        onSelectOrg={onSelectOrg}
-        onSelectFacility={onSelectFacility}
-        onSearch={onSearch}
-        onClearFilter={onClearFilter}
-        loading={true}
-        unarchivePatientState={unarchivePatientState}
-      />
+      <MemoryRouter>
+        <UnarchivePatientFilters
+          orgOptions={mockOrgOptions}
+          onSelectOrg={onSelectOrg}
+          onSelectFacility={onSelectFacility}
+          onSearch={onSearch}
+          onClearFilter={onClearFilter}
+          loading={true}
+          unarchivePatientState={unarchivePatientState}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByLabelText("Organization *")).toBeDisabled();
     expect(screen.getByLabelText("Testing facility *")).toBeDisabled();

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientFilters.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientFilters.tsx
@@ -5,6 +5,7 @@ import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
 import Select, { Option } from "../../commonComponents/Select";
 import Button from "../../commonComponents/Button/Button";
 import { unarchivePatientTitle } from "../pageTitles";
+import SupportHomeLink from "../SupportHomeLink";
 
 import { UnarchivePatientState } from "./UnarchivePatient";
 
@@ -34,7 +35,10 @@ const UnarchivePatientFilters = ({
 
   return (
     <div className="prime-container card-container">
-      <div className="usa-card__header">
+      <div className="width-full display-block margin-left-3 margin-top-3">
+        <SupportHomeLink />
+      </div>
+      <div className="usa-card__header padding-top-2">
         <div className="desktop:display-flex grid-row width-full">
           <div className="desktop:grid-col-6 desktop:display-flex desktop:flex-row flex-align-center">
             <h1 className="font-sans-lg margin-y-0">{unarchivePatientTitle}</h1>

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientInformation.test.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientInformation.test.tsx
@@ -27,9 +27,11 @@ jest.mock("react-router-dom", () => {
 
 describe("unarchive patient information", () => {
   let handlePaginationClick: jest.Mock;
+  let onUnarchivePatient: jest.Mock;
 
   beforeEach(() => {
     handlePaginationClick = jest.fn();
+    onUnarchivePatient = jest.fn();
   });
 
   it("displays instructions on initial state", async () => {
@@ -41,6 +43,7 @@ describe("unarchive patient information", () => {
       patientsCount: undefined,
       patients: undefined,
       facilities: [],
+      patient: undefined,
     };
     render(
       <MemoryRouter>
@@ -49,6 +52,7 @@ describe("unarchive patient information", () => {
           currentPage={1}
           loading={false}
           handlePaginationClick={handlePaginationClick}
+          onUnarchivePatient={onUnarchivePatient}
         />
       </MemoryRouter>
     );
@@ -69,6 +73,7 @@ describe("unarchive patient information", () => {
       patientsCount: 2,
       patients: [mockPatient1],
       facilities: [mockFacility1, mockFacility2],
+      patient: undefined,
     };
     render(
       <MemoryRouter>
@@ -77,6 +82,7 @@ describe("unarchive patient information", () => {
           currentPage={1}
           loading={true}
           handlePaginationClick={handlePaginationClick}
+          onUnarchivePatient={onUnarchivePatient}
         />
       </MemoryRouter>
     );
@@ -96,6 +102,7 @@ describe("unarchive patient information", () => {
       patientsCount: 3,
       patients: [mockPatient1, mockPatient2],
       facilities: [mockFacility1, mockFacility2],
+      patient: undefined,
     };
     render(
       <MemoryRouter>
@@ -104,6 +111,7 @@ describe("unarchive patient information", () => {
           currentPage={1}
           loading={false}
           handlePaginationClick={handlePaginationClick}
+          onUnarchivePatient={onUnarchivePatient}
         />
       </MemoryRouter>
     );
@@ -132,6 +140,8 @@ describe("unarchive patient information", () => {
     expect(handlePaginationClick).toHaveBeenCalledWith(1);
     await act(async () => screen.getAllByText("2")[0].closest("a")?.click());
     expect(handlePaginationClick).toHaveBeenNthCalledWith(2, 2);
+    await act(async () => screen.getAllByText("Unarchive")[0].click());
+    expect(onUnarchivePatient).toHaveBeenNthCalledWith(1, mockPatient1);
   });
   it("displays no results", async () => {
     let unarchivePatientState: UnarchivePatientState = {
@@ -142,6 +152,7 @@ describe("unarchive patient information", () => {
       patientsCount: 0,
       patients: [],
       facilities: [mockFacility1, mockFacility2],
+      patient: undefined,
     };
     render(
       <MemoryRouter>
@@ -150,6 +161,7 @@ describe("unarchive patient information", () => {
           currentPage={1}
           loading={false}
           handlePaginationClick={handlePaginationClick}
+          onUnarchivePatient={onUnarchivePatient}
         />
       </MemoryRouter>
     );

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientInformation.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientInformation.tsx
@@ -19,12 +19,14 @@ interface UnarchivePatientInformationProps {
   currentPage: number;
   loading: boolean;
   handlePaginationClick: (pageNumber: number) => void;
+  onUnarchivePatient: (patient: UnarchivePatientPatient) => void;
 }
 const UnarchivePatientInformation = ({
   unarchivePatientState,
   currentPage,
   loading,
   handlePaginationClick,
+  onUnarchivePatient,
 }: UnarchivePatientInformationProps) => {
   const displayInstructions =
     unarchivePatientState.patients === undefined &&
@@ -53,6 +55,7 @@ const UnarchivePatientInformation = ({
                   type="button"
                   label="Unarchive"
                   aria-label={`Unarchive ${fullName}`}
+                  onClick={() => onUnarchivePatient(patient)}
                 />
               </td>
             </tr>

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientModal.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatientModal.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import Modal from "react-modal";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import Button from "../../commonComponents/Button/Button";
+import { displayFullName } from "../../utils";
+import { unarchivePatientTitle } from "../pageTitles";
+
+import { UnarchivePatientPatient } from "./UnarchivePatient";
+
+interface Props {
+  onClose: () => void;
+  onUnarchivePatientConfirmation: (patientId: string) => void;
+  patient: UnarchivePatientPatient;
+}
+
+const UnarchivePatientModal: React.FC<Props> = ({
+  onClose,
+  onUnarchivePatientConfirmation,
+  patient,
+}) => {
+  return (
+    <Modal
+      isOpen={true}
+      style={{
+        content: {
+          maxHeight: "90vh",
+          width: "40em",
+          position: "initial",
+        },
+      }}
+      overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
+      contentLabel="Unsaved changes to current user"
+      ariaHideApp={process.env.NODE_ENV !== "test"}
+      onRequestClose={onClose}
+    >
+      <div className="border-0 card-container">
+        <div className="display-flex flex-justify">
+          <h1 className="font-heading-lg margin-top-05 margin-bottom-0">
+            {unarchivePatientTitle}
+          </h1>
+          <button onClick={onClose} className="close-button" aria-label="Close">
+            <span className="fa-layers">
+              <FontAwesomeIcon icon={"circle"} size="2x" inverse />
+              <FontAwesomeIcon icon={"times-circle"} size="2x" />
+            </span>
+          </button>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-205"></div>
+        <div className="grid-row grid-gap">
+          <p>
+            Are you sure you want to unarchive{" "}
+            <strong>
+              {displayFullName(
+                patient.firstName,
+                patient.middleName,
+                patient.lastName
+              )}
+            </strong>
+            ?
+          </p>
+        </div>
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-5 padding-top-205 text-right">
+          <div className="display-flex flex-justify-end">
+            <Button
+              className="margin-right-2"
+              onClick={onClose}
+              variant="unstyled"
+              label="No, go back"
+            />
+            <Button
+              className="margin-right-205"
+              onClick={() => {
+                onUnarchivePatientConfirmation(patient.internalId);
+                onClose();
+              }}
+              label="Yes, I'm sure"
+            />
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default UnarchivePatientModal;

--- a/frontend/src/app/supportAdmin/UnarchivePatients/operations.graphql
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/operations.graphql
@@ -30,9 +30,19 @@ query GetPatientsByFacilityWithOrg($facilityId: ID!, $pageNumber: Int!, $pageSiz
   }
 }
 
-query GetPatientsCountByFacilityWithOrg($facilityId: ID!, $archivedStatus: ArchivedStatus = UNARCHIVED $orgExternalId: String!) {
+query GetPatientsCountByFacilityWithOrg($facilityId: ID!, $archivedStatus: ArchivedStatus = UNARCHIVED, $orgExternalId: String!) {
   patientsCount(
     facilityId: $facilityId,
     archivedStatus: $archivedStatus,
     orgExternalId: $orgExternalId)
+}
+
+mutation UnarchivePatient($id: ID!, $orgExternalId: String!) {
+  setPatientIsDeleted(
+    id: $id,
+    deleted: false,
+    orgExternalId: $orgExternalId
+  ) {
+    internalId
+  }
 }

--- a/frontend/src/app/supportAdmin/__snapshots__/SupportAdmin.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/__snapshots__/SupportAdmin.test.tsx.snap
@@ -130,6 +130,14 @@ exports[`SupportAdmin loads menu categories 1`] = `
                       Manage users
                     </a>
                   </li>
+                  <li>
+                    <a
+                      class=""
+                      href="/admin/unarchive-patient"
+                    >
+                      Unarchive patient
+                    </a>
+                  </li>
                 </ul>
               </div>
             </div>
@@ -269,6 +277,14 @@ exports[`SupportAdmin loads menu categories including Beta 1`] = `
                       href="/admin/manage-users"
                     >
                       Manage users
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      class=""
+                      href="/admin/unarchive-patient"
+                    >
+                      Unarchive patient
                     </a>
                   </li>
                 </ul>

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1917,6 +1917,16 @@ export type GetPatientsCountByFacilityWithOrgQuery = {
   patientsCount?: number | null;
 };
 
+export type UnarchivePatientMutationVariables = Exact<{
+  id: Scalars["ID"];
+  orgExternalId: Scalars["String"];
+}>;
+
+export type UnarchivePatientMutation = {
+  __typename?: "Mutation";
+  setPatientIsDeleted?: { __typename?: "Patient"; internalId: string } | null;
+};
+
 export type SendSupportEscalationMutationVariables = Exact<{
   [key: string]: never;
 }>;
@@ -5968,6 +5978,61 @@ export type GetPatientsCountByFacilityWithOrgLazyQueryHookResult = ReturnType<
 export type GetPatientsCountByFacilityWithOrgQueryResult = Apollo.QueryResult<
   GetPatientsCountByFacilityWithOrgQuery,
   GetPatientsCountByFacilityWithOrgQueryVariables
+>;
+export const UnarchivePatientDocument = gql`
+  mutation UnarchivePatient($id: ID!, $orgExternalId: String!) {
+    setPatientIsDeleted(
+      id: $id
+      deleted: false
+      orgExternalId: $orgExternalId
+    ) {
+      internalId
+    }
+  }
+`;
+export type UnarchivePatientMutationFn = Apollo.MutationFunction<
+  UnarchivePatientMutation,
+  UnarchivePatientMutationVariables
+>;
+
+/**
+ * __useUnarchivePatientMutation__
+ *
+ * To run a mutation, you first call `useUnarchivePatientMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUnarchivePatientMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [unarchivePatientMutation, { data, loading, error }] = useUnarchivePatientMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      orgExternalId: // value for 'orgExternalId'
+ *   },
+ * });
+ */
+export function useUnarchivePatientMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UnarchivePatientMutation,
+    UnarchivePatientMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UnarchivePatientMutation,
+    UnarchivePatientMutationVariables
+  >(UnarchivePatientDocument, options);
+}
+export type UnarchivePatientMutationHookResult = ReturnType<
+  typeof useUnarchivePatientMutation
+>;
+export type UnarchivePatientMutationResult =
+  Apollo.MutationResult<UnarchivePatientMutation>;
+export type UnarchivePatientMutationOptions = Apollo.BaseMutationOptions<
+  UnarchivePatientMutation,
+  UnarchivePatientMutationVariables
 >;
 export const SendSupportEscalationDocument = gql`
   mutation SendSupportEscalation {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

- Resolves #6064 

## Changes Proposed

- Adds unarchive patient functionality for support admins
- Adds a link to the "Unarchive patient" page on the support admin landing page

## Additional Information

N/A

## Testing

available on dev5 for testing

## Screenshots / Demos


https://github.com/CDCgov/prime-simplereport/assets/20211771/1bbab399-f0c0-4b35-b082-ef5d8aa30652


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
