### PR TITLE
assign users to group one by one

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -489,9 +488,9 @@ class LiveOktaRepositoryTest {
       verify(mockUserBuilder).setMiddleName(personName.getMiddleName());
       verify(mockUserBuilder).setLastName(personName.getLastName());
       verify(mockUserBuilder).setHonorificSuffix(personName.getSuffix());
-      verify(mockUserBuilder).setGroups(anyList());
       verify(mockUserBuilder).buildAndCreate(userApi);
       verify(mockUserBuilder).setActive(true);
+      verify(groupApi).assignUserToGroup("gid123", "uid123");
       assertEquals(org.getExternalId(), actual.orElseThrow().getOrganizationExternalId());
       assertEquals(Set.of(OrganizationRole.NO_ACCESS), actual.get().getGrantedRoles());
     }
@@ -682,6 +681,7 @@ class LiveOktaRepositoryTest {
     var mockGroupListSearch = List.of(mockGroup);
     var mockGroupProfile = mock(GroupProfile.class);
     var mockUserBuilder = mock(UserBuilder.class);
+    var mockUser = mock(User.class);
 
     when(groupApi.listGroups(
             eq(groupProfilePrefix),
@@ -697,6 +697,7 @@ class LiveOktaRepositoryTest {
             isNull(), isNull(), isNull(), isNull(), isNull(), anyString(), isNull(), isNull()))
         .thenReturn(mockGroupListSearch);
     when(mockGroup.getProfile()).thenReturn(mockGroupProfile);
+    when(mockGroup.getId()).thenReturn("gid123");
     when(mockGroupProfile.getName()).thenReturn(groupProfileName);
     when(mockUserBuilder.setFirstName(firstName)).thenReturn(mockUserBuilder);
     when(mockUserBuilder.setMiddleName(middleName)).thenReturn(mockUserBuilder);
@@ -704,8 +705,9 @@ class LiveOktaRepositoryTest {
     when(mockUserBuilder.setHonorificSuffix(suffix)).thenReturn(mockUserBuilder);
     when(mockUserBuilder.setLogin(email)).thenReturn(mockUserBuilder);
     when(mockUserBuilder.setEmail(email)).thenReturn(mockUserBuilder);
-    when(mockUserBuilder.setGroups(anyList())).thenReturn(mockUserBuilder);
     when(mockUserBuilder.setActive(true)).thenReturn(mockUserBuilder);
+    when(mockUserBuilder.buildAndCreate(any())).thenReturn(mockUser);
+    when(mockUser.getId()).thenReturn("uid123");
     return mockUserBuilder;
   }
 

--- a/wiremock/stubs/mappings/org/api_v1_groups_00g228nrj9QDJ10y61d7_users_00u228n97qLeXJKqT1d7.json
+++ b/wiremock/stubs/mappings/org/api_v1_groups_00g228nrj9QDJ10y61d7_users_00u228n97qLeXJKqT1d7.json
@@ -1,0 +1,32 @@
+{
+  "id" : "db4b73d2-957d-4329-b51c-1c56b8fd22a3",
+  "name" : "api_v1_groups_00g228nrj9QDJ10y61d7_users_00u228n97qLeXJKqT1d7",
+  "request" : {
+    "url" : "/api/v1/groups/00g228nrj9QDJ10y61d7/users/00u228n97qLeXJKqT1d7",
+    "method" : "PUT"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Date" : "Fri, 25 Aug 2023 13:13:35 GMT",
+      "Server" : "nginx",
+      "x-okta-request-id" : "4663963bcd66e737a0435bcde8d466da",
+      "x-xss-protection" : "0",
+      "p3p" : "CP=\"HONK\"",
+      "set-cookie" : [ "sid=\"\";Version=1;Path=/;Max-Age=0", "autolaunch_triggered=\"\"; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/", "JSESSIONID=2A124ABB0DE127CE07D5205AA64CF9FD; Path=/; Secure; HttpOnly" ],
+      "content-security-policy" : "default-src 'self' hhs-prime.oktapreview.com *.oktacdn.com; connect-src 'self' hhs-prime.oktapreview.com hhs-prime-admin.oktapreview.com *.oktacdn.com *.mixpanel.com *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com *.mtls.oktapreview.com hhs-prime.kerberos.oktapreview.com https://oinmanager.okta.com data:; script-src 'unsafe-inline' 'unsafe-eval' 'self' hhs-prime.oktapreview.com *.oktacdn.com; style-src 'unsafe-inline' 'self' hhs-prime.oktapreview.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com; frame-src 'self' hhs-prime.oktapreview.com hhs-prime-admin.oktapreview.com login.okta.com; img-src 'self' hhs-prime.oktapreview.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com data: blob:; font-src 'self' hhs-prime.oktapreview.com data: *.oktacdn.com fonts.gstatic.com; frame-ancestors 'self'",
+      "x-rate-limit-limit" : "300",
+      "x-rate-limit-remaining" : "299",
+      "x-rate-limit-reset" : "1692969274",
+      "cache-control" : "no-cache, no-store",
+      "pragma" : "no-cache",
+      "expires" : "0",
+      "x-okta-edge-log" : "rlInfo=PRL_SSWS_TOKEN:PCL_SSWS_TOKEN:CAT_C orgId=00o5z62umqu9IqC5x1d6 dbri=NO MOCA=0.024 DB_TX=0.000 APP=0.187 DB=0.002 clInfo=OC_1:PCL_1 oRevL=1",
+      "x-frame-options" : "SAMEORIGIN",
+      "Strict-Transport-Security" : "max-age=315360000; includeSubDomains"
+    }
+  },
+  "uuid" : "db4b73d2-957d-4329-b51c-1c56b8fd22a3",
+  "persistent" : true,
+  "insertionIndex" : 27
+}

--- a/wiremock/stubs/mappings/org/api_v1_groups_00g228nyd7uuGaG1L1d7_users_00u228n97qLeXJKqT1d7.json
+++ b/wiremock/stubs/mappings/org/api_v1_groups_00g228nyd7uuGaG1L1d7_users_00u228n97qLeXJKqT1d7.json
@@ -1,0 +1,32 @@
+{
+  "id" : "db4b73d2-957d-4329-b51c-1c56b8fd22a3",
+  "name" : "api_v1_groups_00g228nyd7uuGaG1L1d7_users_00u228n97qLeXJKqT1d7",
+  "request" : {
+    "url" : "/api/v1/groups/00g228nyd7uuGaG1L1d7/users/00u228n97qLeXJKqT1d7",
+    "method" : "PUT"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Date" : "Fri, 25 Aug 2023 13:13:35 GMT",
+      "Server" : "nginx",
+      "x-okta-request-id" : "4663963bcd66e737a0435bcde8d466da",
+      "x-xss-protection" : "0",
+      "p3p" : "CP=\"HONK\"",
+      "set-cookie" : [ "sid=\"\";Version=1;Path=/;Max-Age=0", "autolaunch_triggered=\"\"; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/", "JSESSIONID=2A124ABB0DE127CE07D5205AA64CF9FD; Path=/; Secure; HttpOnly" ],
+      "content-security-policy" : "default-src 'self' hhs-prime.oktapreview.com *.oktacdn.com; connect-src 'self' hhs-prime.oktapreview.com hhs-prime-admin.oktapreview.com *.oktacdn.com *.mixpanel.com *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com *.mtls.oktapreview.com hhs-prime.kerberos.oktapreview.com https://oinmanager.okta.com data:; script-src 'unsafe-inline' 'unsafe-eval' 'self' hhs-prime.oktapreview.com *.oktacdn.com; style-src 'unsafe-inline' 'self' hhs-prime.oktapreview.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com; frame-src 'self' hhs-prime.oktapreview.com hhs-prime-admin.oktapreview.com login.okta.com; img-src 'self' hhs-prime.oktapreview.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com data: blob:; font-src 'self' hhs-prime.oktapreview.com data: *.oktacdn.com fonts.gstatic.com; frame-ancestors 'self'",
+      "x-rate-limit-limit" : "300",
+      "x-rate-limit-remaining" : "299",
+      "x-rate-limit-reset" : "1692969274",
+      "cache-control" : "no-cache, no-store",
+      "pragma" : "no-cache",
+      "expires" : "0",
+      "x-okta-edge-log" : "rlInfo=PRL_SSWS_TOKEN:PCL_SSWS_TOKEN:CAT_C orgId=00o5z62umqu9IqC5x1d6 dbri=NO MOCA=0.024 DB_TX=0.000 APP=0.187 DB=0.002 clInfo=OC_1:PCL_1 oRevL=1",
+      "x-frame-options" : "SAMEORIGIN",
+      "Strict-Transport-Security" : "max-age=315360000; includeSubDomains"
+    }
+  },
+  "uuid" : "db4b73d2-957d-4329-b51c-1c56b8fd22a3",
+  "persistent" : true,
+  "insertionIndex" : 27
+}

--- a/wiremock/stubs/mappings/org/api_v1_users-d2c41957-0331-4c20-a597-7002630980ab.json
+++ b/wiremock/stubs/mappings/org/api_v1_users-d2c41957-0331-4c20-a597-7002630980ab.json
@@ -5,7 +5,7 @@
     "url" : "/api/v1/users?activate=false&provider=false",
     "method" : "POST",
     "bodyPatterns" : [ {
-      "equalToJson" : "{\"profile\":{\"firstName\":\"Greg\",\"lastName\":\"McTester\",\"login\":\"${json-unit.any-string}\",\"email\":\"${json-unit.any-string}\"},\"groupIds\":[\"00g228nyd7uuGaG1L1d7\",\"00g228nrj9QDJ10y61d7\"]}",
+      "equalToJson" : "{\"profile\":{\"firstName\":\"Greg\",\"lastName\":\"McTester\",\"login\":\"${json-unit.any-string}\",\"email\":\"${json-unit.any-string}\"}}",
       "ignoreArrayOrder" : true,
       "ignoreExtraElements" : true
     } ]


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #6214 

## Changes Proposed

- When creating a user, assign groups using the group api and not the user builder because of the [20 group limit when creating a user](https://developer.okta.com/docs/reference/api/users/#response-example-7:~:text=The%20request%20may%20specify%20up%20to%2020%20group%20ids.). 

## Additional Information


## Testing

- Deployed in dev 7 - create a user with more than 20 groups
https://github.com/CDCgov/prime-simplereport/assets/10108172/6464bb07-5762-423c-8a1a-e5797dfd197b

