### PR TITLE
MFA Setup: update copy for security key setup step

### DIFF
--- a/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.test.tsx
+++ b/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.test.tsx
@@ -1,73 +1,38 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-
-import { MfaComplete } from "../MfaComplete/MfaComplete";
 
 import { MfaSecurityKey } from "./MfaSecurityKey";
 
-jest.mock("../AccountCreationApiService", () => ({
-  AccountCreationApi: {
-    enrollSecurityKeyMfa: () => {
-      return new Promise((res) => {
-        res({ activation: { challenge: "challenge", user: { id: "userId" } } });
-      });
-    },
-    activateSecurityKeyMfa: (attestation: string, clientData: string) => {
-      return new Promise((res, rej) => {
-        if (attestation.length !== 0 && clientData.length !== 0) {
-          res("success");
-        } else {
-          rej("utter failure");
-        }
-      });
-    },
-  },
-}));
-
-jest.mock("../../utils/text", () => ({
-  strToBin: (_str: string) => {
-    return Uint8Array.of(8).fill(2);
-  },
-  binToStr: (_bin: ArrayBuffer) => {
-    return "str";
-  },
-}));
-
-function create(_obj: any) {
-  return new Promise((cred) => {
-    cred({
-      response: {
-        attestationObject: "attestation",
-        clientDataJSON: "clientDataJSON",
-      },
-    });
-  });
-}
-
 describe("MFA Security Key Successful", () => {
-  beforeEach(() => {
-    let credContainer = { create: create };
-    Object.defineProperty(window.navigator, "credentials", {
-      value: credContainer,
-      configurable: true,
-    });
-  });
-
-  it("displays the success page if security key is activated", async () => {
-    // in the real flow, a user has to touch their security key to trigger the enrollment.
-    // it's not possible to mock that, so instead we mock out functions as if the user
-    // had touched their key and assert that they get to the success page.
+  it("displays MFA security key step for unsupported browser", async () => {
     render(
       <MemoryRouter initialEntries={["/enroll-security-key-mfa"]}>
         <Routes>
           <Route path="/enroll-security-key-mfa" element={<MfaSecurityKey />} />
-          <Route path="/success" element={<MfaComplete />} />
         </Routes>
       </MemoryRouter>
     );
 
-    expect(
-      await screen.findByText("Account set up complete")
-    ).toBeInTheDocument();
+    expect(document.body).toMatchSnapshot();
+  });
+
+  it("displays MFA security key step", async () => {
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: jest.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={["/enroll-security-key-mfa"]}>
+        <Routes>
+          <Route path="/enroll-security-key-mfa" element={<MfaSecurityKey />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(document.body).toMatchSnapshot();
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: undefined,
+    });
   });
 });

--- a/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.tsx
+++ b/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.tsx
@@ -16,7 +16,6 @@ export const MfaSecurityKey = () => {
     // if the user's browser doesn't support WebAuthn, display a message telling them to use a different browser
     if (!navigator?.credentials) {
       setUnsupported(true);
-      return;
     }
   }, []);
 

--- a/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.tsx
+++ b/frontend/src/app/accountCreation/MfaSecurityKey/MfaSecurityKey.tsx
@@ -1,63 +1,24 @@
-import { useEffect, useState } from "react";
-import { Navigate } from "react-router-dom";
+import React, { useEffect, useState } from "react";
 
 import { Card } from "../../commonComponents/Card/Card";
 import { CardBackground } from "../../commonComponents/CardBackground/CardBackground";
 import StepIndicator from "../../commonComponents/StepIndicator";
 import { accountCreationSteps } from "../../../config/constants";
-import iconLoader from "../../../img/loader.svg";
-import { AccountCreationApi } from "../AccountCreationApiService";
-import { strToBin, binToStr } from "../../utils/text";
 import { useDocumentTitle } from "../../utils/hooks";
 
 export const MfaSecurityKey = () => {
   useDocumentTitle("Set up authentication via security key");
 
-  const [attestation, setAttestation] = useState("");
-  const [clientData, setClientData] = useState("");
-  const [activated, setActivated] = useState(false);
   const [unsupported, setUnsupported] = useState(false);
 
   useEffect(() => {
-    const enrollKey = async () => {
-      const { activation } = await AccountCreationApi.enrollSecurityKeyMfa();
-      if (!activation.challenge) {
-        return;
-      }
-      const publicKey = Object.assign({}, activation);
-      // Convert activation object's challenge and user id from string to binary
-      publicKey.challenge = strToBin(activation.challenge);
-      publicKey.user.id = strToBin(activation.user.id);
-
-      // navigator.credentials is a global object on WebAuthn-supported clients, used to access WebAuthn API
-      // if the user's browser doesn't support WebAuthn, display a message telling them to use a different browser
-      if (!navigator?.credentials) {
-        setUnsupported(true);
-        return;
-      }
-      navigator.credentials
-        .create({ publicKey })
-        .then(function (newCredential) {
-          // Get attestation and clientData from callback result, convert from binary to string
-          const response = (newCredential as PublicKeyCredential)
-            ?.response as AuthenticatorAttestationResponse;
-          setAttestation(binToStr(response.attestationObject));
-          setClientData(binToStr(response.clientDataJSON));
-        });
-    };
-    enrollKey();
-  }, []);
-
-  useEffect(() => {
-    if (attestation && clientData) {
-      try {
-        AccountCreationApi.activateSecurityKeyMfa(attestation, clientData);
-        setActivated(true);
-      } catch (error: any) {
-        console.error("Error trying to activate security key: ", error);
-      }
+    // navigator.credentials is a global object on WebAuthn-supported clients, used to access WebAuthn API
+    // if the user's browser doesn't support WebAuthn, display a message telling them to use a different browser
+    if (!navigator?.credentials) {
+      setUnsupported(true);
+      return;
     }
-  }, [attestation, clientData]);
+  }, []);
 
   if (unsupported) {
     return (
@@ -77,10 +38,6 @@ export const MfaSecurityKey = () => {
     );
   }
 
-  if (activated) {
-    return <Navigate to="../success" />;
-  }
-
   return (
     <CardBackground>
       <Card logo bodyKicker="Set up your account">
@@ -89,20 +46,22 @@ export const MfaSecurityKey = () => {
           currentStepValue={"2"}
           noLabels={true}
         />
-        <p className="margin-bottom-0">Register your security key.</p>
+        <p className="margin-bottom-0">How to register your security key.</p>
         <ol className="usa-list usa-hint font-ui-2xs">
+          <li>Continue to SimpleReport and log in.</li>
           <li>
-            Insert your Security Key in your computer’s USB port or connect it
-            with a USB cable.
+            Find “Security Key or Biometric Authenticator” in the Okta
+            multifactor authentication menu and click{" "}
+            <span className="text-bold">Setup</span>.
           </li>
-          <li>
-            Once connected, tap the button or gold disk if your key has one.
-          </li>
+          <li>Follow prompts to enroll.</li>
         </ol>
-        <div className="display-flex flex-column flex-align-center">
-          <img className="square-5 chromatic-ignore" src={iconLoader} alt="" />
-        </div>
-        {/* <Button className="margin-top-3" label={"Continue"} type={"submit"} /> */}
+        <a
+          href={"/app/"}
+          className="margin-x-auto display-block width-fit-content usa-button usa-button--primary"
+        >
+          Continue to SimpleReport
+        </a>
       </Card>
     </CardBackground>
   );

--- a/frontend/src/app/accountCreation/MfaSecurityKey/__snapshots__/MfaSecurityKey.test.tsx.snap
+++ b/frontend/src/app/accountCreation/MfaSecurityKey/__snapshots__/MfaSecurityKey.test.tsx.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MFA Security Key Successful displays MFA security key step 1`] = `
+<body>
+  <div>
+    <div
+      class="card__background bg-base-lightest"
+    >
+      <div
+        class="grid-container maxw-mobile-lg usa-section"
+      >
+        <div
+          class="card"
+        >
+          <header
+            class="display-flex flex-column"
+          >
+            <img
+              alt="SimpleReport logo"
+              class="flex-align-self-center maxw-card-lg width-full"
+              src="simplereport-logo-color.svg"
+            />
+            <div
+              class="border-bottom border-base-lighter margin-x-neg-3 margin-top-3"
+            />
+          </header>
+          <p
+            class="font-ui-sm text-bold margin-top-3"
+          >
+            Set up your account
+          </p>
+          <div
+            class="usa-step-indicator usa-step-indicator--counters-sm usa-step-indicator--no-labels margin-y-205"
+          >
+            <div
+              class="usa-step-indicator__segments"
+              role="presentation"
+            >
+              <div
+                aria-current="false"
+                class="usa-step-indicator__segment usa-step-indicator__segment--complete"
+              >
+                <span
+                  class="usa-step-indicator__segment-label"
+                >
+                  Create your password
+                   
+                  <span
+                    class="usa-sr-only"
+                  >
+                    completed
+                  </span>
+                </span>
+              </div>
+              <div
+                aria-current="false"
+                class="usa-step-indicator__segment usa-step-indicator__segment--complete"
+              >
+                <span
+                  class="usa-step-indicator__segment-label"
+                >
+                  Select your security question
+                   
+                  <span
+                    class="usa-sr-only"
+                  >
+                    completed
+                  </span>
+                </span>
+              </div>
+              <div
+                aria-current="true"
+                class="usa-step-indicator__segment usa-step-indicator__segment--current"
+              >
+                <span
+                  class="usa-step-indicator__segment-label"
+                >
+                  Set up authentication
+                   
+                  <span
+                    class="usa-sr-only"
+                  >
+                    completed
+                  </span>
+                </span>
+              </div>
+            </div>
+            <div
+              class="usa-step-indicator__header"
+            >
+              <h1
+                class="usa-step-indicator__heading"
+              >
+                <span
+                  class="usa-step-indicator__heading-counter"
+                >
+                  <span
+                    class="usa-sr-only"
+                  >
+                    Step
+                  </span>
+                  <span
+                    class="usa-step-indicator__current-step margin-right-05"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="usa-step-indicator__total-steps"
+                  >
+                    of 
+                    3
+                  </span>
+                </span>
+                <span
+                  class="usa-step-indicator__heading-text"
+                >
+                  Set up authentication
+                </span>
+              </h1>
+            </div>
+          </div>
+          <p
+            class="margin-bottom-0"
+          >
+            How to register your security key.
+          </p>
+          <ol
+            class="usa-list usa-hint font-ui-2xs"
+          >
+            <li>
+              Continue to SimpleReport and log in.
+            </li>
+            <li>
+              Find “Security Key or Biometric Authenticator” in the Okta multifactor authentication menu and click
+               
+              <span
+                class="text-bold"
+              >
+                Setup
+              </span>
+              .
+            </li>
+            <li>
+              Follow prompts to enroll.
+            </li>
+          </ol>
+          <a
+            class="margin-x-auto display-block width-fit-content usa-button usa-button--primary"
+            href="/app/"
+          >
+            Continue to SimpleReport
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`MFA Security Key Successful displays MFA security key step for unsupported browser 1`] = `
+<body>
+  <div>
+    <div
+      class="card__background bg-base-lightest"
+    >
+      <div
+        class="grid-container maxw-mobile-lg usa-section"
+      >
+        <div
+          class="card"
+        >
+          <header
+            class="display-flex flex-column"
+          >
+            <img
+              alt="SimpleReport logo"
+              class="flex-align-self-center maxw-card-lg width-full"
+              src="simplereport-logo-color.svg"
+            />
+            <div
+              class="border-bottom border-base-lighter margin-x-neg-3 margin-top-3"
+            />
+          </header>
+          <p
+            class="font-ui-sm text-bold margin-top-3"
+          >
+            Unsupported browser
+          </p>
+          <p
+            class="margin-bottom-0"
+          >
+            To register a security key, please use the latest version of a supported browser:
+          </p>
+          <ol
+            class="usa-list usa-hint font-ui-2xs"
+          >
+            <li>
+              Google Chrome
+            </li>
+            <li>
+              Mozilla Firefox
+            </li>
+            <li>
+              Microsoft Edge
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/frontend/src/app/accountCreation/MfaSelect/MfaSelect.test.tsx
+++ b/frontend/src/app/accountCreation/MfaSelect/MfaSelect.test.tsx
@@ -147,9 +147,7 @@ describe("MfaSelect routing", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "Insert your Security Key in your computer’s USB port or connect it with a USB cable."
-        )
+        screen.getByText("How to register your security key.")
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/scss/base/_utilities.scss
+++ b/frontend/src/scss/base/_utilities.scss
@@ -27,3 +27,7 @@
 .bg-error {
   background-color: color("error");
 }
+
+.width-fit-content {
+  width: fit-content;
+}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6215 

## Changes Proposed

- Update the step copy to instruct the user to setup their secret key on their first time login to SimpleReport.

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing
Code is deployed in dev1
- Create a new API user for an org.
- In another browser (use incognito mode) open the invitation link to kick the create account flow and choose a security key as the MFA.
- Verify the copy has been updated and the new button brings you to simple report login.

## Screenshots / Demos
New copy
<img width="492" alt="Screenshot 2023-08-25 at 1 20 37 PM" src="https://github.com/CDCgov/prime-simplereport/assets/103958711/f3e5b921-ea5b-4111-91ba-f1302e4f8e20">
