### PR TITLE
add backlink to escalation page

### DIFF
--- a/frontend/src/app/supportAdmin/Escalations/Escalations.tsx
+++ b/frontend/src/app/supportAdmin/Escalations/Escalations.tsx
@@ -5,6 +5,7 @@ import Button from "../../commonComponents/Button/Button";
 import { showSuccess } from "../../utils/srToast";
 import { useDocumentTitle } from "../../utils/hooks";
 import { escalationPageTitle } from "../pageTitles";
+import SupportHomeLink from "../SupportHomeLink";
 
 export const Escalations = () => {
   useDocumentTitle(escalationPageTitle);
@@ -12,44 +13,49 @@ export const Escalations = () => {
 
   return (
     <div className="prime-home flex-1">
-      <div className="grid-container">
-        <div className="grid-row">
-          <form className="prime-container card-container">
-            <div className="usa-card__header">
-              <h1 className="font-heading-lg margin-top-0 margin-bottom-0">
-                Escalate to engineering
-              </h1>
-            </div>
-            <div className="usa-card__body margin-top-1">
-              <div className="grid-row grid-gap margin-top-2">
-                <div className="tablet:grid-col">
-                  <p className="usa-prose">
-                    Use the below button to notify the SimpleReport engineering
-                    team about a tier 2 escalation. Make sure you've filled out
-                    information about the escalation in{" "}
-                    <a
-                      target="_blank"
-                      href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
-                      rel="noreferrer"
-                    >
-                      the Smartsheet tracker
-                    </a>
-                  </p>
-                  <Button
-                    className="width-half margin-top-2 submit-button"
-                    onClick={async () => {
-                      await escalateToSlack();
-                      showSuccess(
-                        "The engineering team has been notified that there's a new escalation and will be in touch shortly",
-                        `Escalation successfully sent`
-                      );
-                    }}
-                    label={"Submit escalation"}
-                  />
+      <div className="usa-card__header padding-top-2">
+        <div className="grid-container">
+          <div className="grid-row">
+            <form className="prime-container card-container">
+              <div className="usa-card__header padding-top-2">
+                <div className="width-full display-block  margin-top-3">
+                  <SupportHomeLink />
+                  <h1 className="desktop:grid-col-fill tablet:grid-col-fill mobile:grid-col-12 font-heading-lg margin-bottom-0">
+                    Escalate to engineering
+                  </h1>
                 </div>
               </div>
-            </div>
-          </form>
+              <div className="usa-card__body margin-top-1">
+                <div className="grid-row grid-gap margin-top-2">
+                  <div className="tablet:grid-col">
+                    <p className="usa-prose">
+                      Use the below button to notify the SimpleReport
+                      engineering team about a tier 2 escalation. Make sure
+                      you've filled out information about the escalation in{" "}
+                      <a
+                        target="_blank"
+                        href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
+                        rel="noreferrer"
+                      >
+                        the Smartsheet tracker
+                      </a>
+                    </p>
+                    <Button
+                      className="width-half margin-top-2 submit-button"
+                      onClick={async () => {
+                        await escalateToSlack();
+                        showSuccess(
+                          "The engineering team has been notified that there's a new escalation and will be in touch shortly",
+                          `Escalation successfully sent`
+                        );
+                      }}
+                      label={"Submit escalation"}
+                    />
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/supportAdmin/Escalations/Escalations.tsx
+++ b/frontend/src/app/supportAdmin/Escalations/Escalations.tsx
@@ -13,45 +13,45 @@ export const Escalations = () => {
 
   return (
     <div className="prime-home flex-1">
-      <div className="usa-card__header padding-top-2">
-        <div className="grid-container">
-          <div className="grid-row">
-            <form className="prime-container card-container">
-              <div className="usa-card__header padding-top-2">
-                <div className="width-full display-block  margin-top-3">
-                  <SupportHomeLink />
-                  <h1 className="desktop:grid-col-fill tablet:grid-col-fill mobile:grid-col-12 font-heading-lg margin-bottom-0">
-                    Escalate to engineering
-                  </h1>
-                </div>
+      <div className="grid-container">
+        <div className="prime-container card-container padding-bottom-3">
+          <div className="usa-card__header">
+            <div className="width-full">
+              <SupportHomeLink />
+              <div className="grid-row width-full margin-top-1">
+                <h1 className="desktop:grid-col-fill tablet:grid-col-fill mobile:grid-col-12 font-heading-lg margin-bottom-0">
+                  Escalate to engineering
+                </h1>
               </div>
-              <div className="usa-card__body margin-top-1">
-                <div className="grid-row grid-gap margin-top-2">
-                  <div className="tablet:grid-col">
-                    <p className="usa-prose">
-                      Use the below button to notify the SimpleReport
-                      engineering team about a tier 2 escalation. Make sure
-                      you've filled out information about the escalation in{" "}
-                      <a
-                        target="_blank"
-                        href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
-                        rel="noreferrer"
-                      >
-                        the Smartsheet tracker
-                      </a>
-                    </p>
-                    <Button
-                      className="width-half margin-top-2 submit-button"
-                      onClick={async () => {
-                        await escalateToSlack();
-                        showSuccess(
-                          "The engineering team has been notified that there's a new escalation and will be in touch shortly",
-                          `Escalation successfully sent`
-                        );
-                      }}
-                      label={"Submit escalation"}
-                    />
-                  </div>
+            </div>
+          </div>
+          <div className="usa-card__body margin-top-1">
+            <form>
+              <div className="grid-row grid-gap margin-top-2">
+                <div className="tablet:grid-col">
+                  <p className="usa-prose">
+                    Use the below button to notify the SimpleReport engineering
+                    team about a tier 2 escalation. Make sure you've filled out
+                    information about the escalation in{" "}
+                    <a
+                      target="_blank"
+                      href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
+                      rel="noreferrer"
+                    >
+                      the Smartsheet tracker
+                    </a>
+                  </p>
+                  <Button
+                    className="width-half margin-top-2 submit-button"
+                    onClick={async () => {
+                      await escalateToSlack();
+                      showSuccess(
+                        "The engineering team has been notified that there's a new escalation and will be in touch shortly",
+                        `Escalation successfully sent`
+                      );
+                    }}
+                    label={"Submit escalation"}
+                  />
                 </div>
               </div>
             </form>

--- a/frontend/src/app/supportAdmin/Escalations/__snapshots__/Escalations.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/Escalations/__snapshots__/Escalations.test.tsx.snap
@@ -14,83 +14,81 @@ exports[`Escalations Renders the page 1`] = `
     class="prime-home flex-1"
   >
     <div
-      class="usa-card__header padding-top-2"
+      class="grid-container"
     >
       <div
-        class="grid-container"
+        class="prime-container card-container padding-bottom-3"
       >
         <div
-          class="grid-row"
+          class="usa-card__header"
         >
-          <form
-            class="prime-container card-container"
+          <div
+            class="width-full"
           >
             <div
-              class="usa-card__header padding-top-2"
+              class="display-flex flex-align-center"
             >
-              <div
-                class="width-full display-block  margin-top-3"
+              <svg
+                aria-hidden="true"
+                class="usa-icon text-base margin-left-neg-2px"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <div
-                  class="display-flex flex-align-center"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="usa-icon text-base margin-left-neg-2px"
-                    focusable="false"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-                    />
-                  </svg>
-                  <a
-                    class="margin-left-05"
-                    href="/admin"
-                  >
-                    Support admin
-                  </a>
-                </div>
-                <h1
-                  class="desktop:grid-col-fill tablet:grid-col-fill mobile:grid-col-12 font-heading-lg margin-bottom-0"
-                >
-                  Escalate to engineering
-                </h1>
-              </div>
+                <path
+                  d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                />
+              </svg>
+              <a
+                class="margin-left-05"
+                href="/admin"
+              >
+                Support admin
+              </a>
             </div>
             <div
-              class="usa-card__body margin-top-1"
+              class="grid-row width-full margin-top-1"
+            >
+              <h1
+                class="desktop:grid-col-fill tablet:grid-col-fill mobile:grid-col-12 font-heading-lg margin-bottom-0"
+              >
+                Escalate to engineering
+              </h1>
+            </div>
+          </div>
+        </div>
+        <div
+          class="usa-card__body margin-top-1"
+        >
+          <form>
+            <div
+              class="grid-row grid-gap margin-top-2"
             >
               <div
-                class="grid-row grid-gap margin-top-2"
+                class="tablet:grid-col"
               >
-                <div
-                  class="tablet:grid-col"
+                <p
+                  class="usa-prose"
                 >
-                  <p
-                    class="usa-prose"
+                  Use the below button to notify the SimpleReport engineering team about a tier 2 escalation. Make sure you've filled out information about the escalation in
+                   
+                  <a
+                    href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
+                    rel="noreferrer"
+                    target="_blank"
                   >
-                    Use the below button to notify the SimpleReport engineering team about a tier 2 escalation. Make sure you've filled out information about the escalation in
-                     
-                    <a
-                      href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      the Smartsheet tracker
-                    </a>
-                  </p>
-                  <button
-                    class="usa-button width-half margin-top-2 submit-button"
-                    type="button"
-                  >
-                    Submit escalation
-                  </button>
-                </div>
+                    the Smartsheet tracker
+                  </a>
+                </p>
+                <button
+                  class="usa-button width-half margin-top-2 submit-button"
+                  type="button"
+                >
+                  Submit escalation
+                </button>
               </div>
             </div>
           </form>

--- a/frontend/src/app/supportAdmin/Escalations/__snapshots__/Escalations.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/Escalations/__snapshots__/Escalations.test.tsx.snap
@@ -14,55 +14,87 @@ exports[`Escalations Renders the page 1`] = `
     class="prime-home flex-1"
   >
     <div
-      class="grid-container"
+      class="usa-card__header padding-top-2"
     >
       <div
-        class="grid-row"
+        class="grid-container"
       >
-        <form
-          class="prime-container card-container"
+        <div
+          class="grid-row"
         >
-          <div
-            class="usa-card__header"
-          >
-            <h1
-              class="font-heading-lg margin-top-0 margin-bottom-0"
-            >
-              Escalate to engineering
-            </h1>
-          </div>
-          <div
-            class="usa-card__body margin-top-1"
+          <form
+            class="prime-container card-container"
           >
             <div
-              class="grid-row grid-gap margin-top-2"
+              class="usa-card__header padding-top-2"
             >
               <div
-                class="tablet:grid-col"
+                class="width-full display-block  margin-top-3"
               >
-                <p
-                  class="usa-prose"
+                <div
+                  class="display-flex flex-align-center"
                 >
-                  Use the below button to notify the SimpleReport engineering team about a tier 2 escalation. Make sure you've filled out information about the escalation in
-                   
-                  <a
-                    href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
-                    rel="noreferrer"
-                    target="_blank"
+                  <svg
+                    aria-hidden="true"
+                    class="usa-icon text-base margin-left-neg-2px"
+                    focusable="false"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    the Smartsheet tracker
+                    <path
+                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                    />
+                  </svg>
+                  <a
+                    class="margin-left-05"
+                    href="/admin"
+                  >
+                    Support admin
                   </a>
-                </p>
-                <button
-                  class="usa-button width-half margin-top-2 submit-button"
-                  type="button"
+                </div>
+                <h1
+                  class="desktop:grid-col-fill tablet:grid-col-fill mobile:grid-col-12 font-heading-lg margin-bottom-0"
                 >
-                  Submit escalation
-                </button>
+                  Escalate to engineering
+                </h1>
               </div>
             </div>
-          </div>
-        </form>
+            <div
+              class="usa-card__body margin-top-1"
+            >
+              <div
+                class="grid-row grid-gap margin-top-2"
+              >
+                <div
+                  class="tablet:grid-col"
+                >
+                  <p
+                    class="usa-prose"
+                  >
+                    Use the below button to notify the SimpleReport engineering team about a tier 2 escalation. Make sure you've filled out information about the escalation in
+                     
+                    <a
+                      href="https://app.smartsheetgov.com/sheets/wwchRWw4jr55WpX8XwC2h9Mr9rVr3Q3hww64pW61"
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      the Smartsheet tracker
+                    </a>
+                  </p>
+                  <button
+                    class="usa-button width-half margin-top-2 submit-button"
+                    type="button"
+                  >
+                    Submit escalation
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
Realized during reviewing other support admin pages that the escalation page was missing a back link to the home page.

- Adding the `SupportHomeLink` component to escalation page after the other pages are getting that breadcrumb
- Tweak the container divs so that the spacing between different support admin pages are the same

## Changes Proposed
Before
![Screenshot 2023-08-28 at 10 24 25 AM](https://github.com/CDCgov/prime-simplereport/assets/29645040/26578fda-1fb5-4bbd-bf60-d18cb1e6c657)

After
![Screenshot 2023-08-28 at 10 30 42 AM](https://github.com/CDCgov/prime-simplereport/assets/29645040/f4bc5b8a-1f07-46ac-ae25-71354c22bb0b)


https://github.com/CDCgov/prime-simplereport/assets/29645040/538912fc-6f9c-4df7-83bd-1eee2fb45c07

