### PR TITLE
Update Gradle lock workflow change

### DIFF
--- a/.github/workflows/updateGradleLocks.yml
+++ b/.github/workflows/updateGradleLocks.yml
@@ -1,7 +1,7 @@
 name: Dependabot Gradle Helper
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths: 
       - backend/build.gradle
 
@@ -28,14 +28,14 @@ jobs:
     # Run when manually requested or when dependabot creates/updates a PR
     # DO NOT run if somebody else updates a PR (a probably unnecessarily strict guard against infinite 
     # workflow loops, in case we ever enable this workflow to trigger other workflows)
-    if: github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
+    if: github.actor == 'dependabot[bot]' || github.actor == 'alismx' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_WORKFLOW_PAT }} # https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0 # Disable shallow clones: we need to be able to push
       - name: Set up JDK ${{env.JAVA_VERSION}}

--- a/.github/workflows/updateGradleLocks.yml
+++ b/.github/workflows/updateGradleLocks.yml
@@ -28,7 +28,7 @@ jobs:
     # Run when manually requested or when dependabot creates/updates a PR
     # DO NOT run if somebody else updates a PR (a probably unnecessarily strict guard against infinite 
     # workflow loops, in case we ever enable this workflow to trigger other workflows)
-    if: github.actor == 'dependabot[bot]' || github.actor == 'alismx' || github.event_name == 'workflow_dispatch'
+    if: github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- [This job failed
](https://github.com/CDCgov/prime-simplereport/actions/runs/5991772141/job/16250472681?pr=6423) and this is an attempt to resolve the issue

## Changes Proposed

- Update `pull_request` to `pull_request_target`  and use the repo `GITHUB_TOKEN`

## Additional Information

- [GithHub info](https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests)
- [GitHub Issue](https://github.com/dependabot/dependabot-core/issues/3253)
- After this PR is merged, I'll rebase [this PR](https://github.com/CDCgov/prime-simplereport/pull/6423), which will test this change

## Testing

- Not much to do except try it. The pains of updating CI.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README