### PR TITLE
Bob/fix mutation error states

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -1,12 +1,9 @@
 package gov.cdc.usds.simplereport.api.apiuser;
 
-import static gov.cdc.usds.simplereport.service.ApiUserService.MOVE_USER_ARGUMENT_ERROR;
-
 import gov.cdc.usds.simplereport.api.Translators;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.User;
 import gov.cdc.usds.simplereport.api.model.UserInput;
-import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -172,19 +169,13 @@ public class UserMutationResolver {
       @Argument boolean accessAllFacilities,
       @Argument List<UUID> facilities,
       @Argument Role role) {
-    try {
-      List<UUID> facilityIdsToAssign = facilities == null ? List.of() : facilities;
-      _us.updateUserPrivilegesAndGroupAccess(
-          username,
-          orgExternalId,
-          accessAllFacilities,
-          facilityIdsToAssign,
-          role.toOrganizationRole());
-      return new User(_us.getUserByLoginEmail(username));
-
-    } catch (IllegalArgumentException e) {
-      throw new IllegalGraphqlArgumentException(
-          "Error updating user privileges and / or group access: " + MOVE_USER_ARGUMENT_ERROR);
-    }
+    List<UUID> facilityIdsToAssign = facilities == null ? List.of() : facilities;
+    _us.updateUserPrivilegesAndGroupAccess(
+        username,
+        orgExternalId,
+        accessAllFacilities,
+        facilityIdsToAssign,
+        role.toOrganizationRole());
+    return new User(_us.getUserByLoginEmail(username));
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/PrivilegeUpdateFacilityAccessException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/PrivilegeUpdateFacilityAccessException.java
@@ -1,0 +1,32 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import java.util.Collections;
+import java.util.List;
+
+/** Exception to throw when a facility ID can't be found in an organization query */
+public class PrivilegeUpdateFacilityAccessException extends RuntimeException
+    implements GraphQLError {
+
+  private static final long serialVersionUID = 1L;
+
+  public static final String PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR =
+      "Operation must specify a list of facilities for the user to access or allow them access to all facilities";
+
+  public PrivilegeUpdateFacilityAccessException() {
+    super(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR);
+  }
+
+  @Override // should-be-defaulted unused interface method
+  public List<SourceLocation> getLocations() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public ErrorClassification getErrorType() {
+    return ErrorType.ExecutionAborted;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlConfig.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlFieldAccessException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
 import gov.cdc.usds.simplereport.api.model.errors.OktaAccountUserException;
+import gov.cdc.usds.simplereport.api.model.errors.PrivilegeUpdateFacilityAccessException;
 import gov.cdc.usds.simplereport.api.model.errors.RestrictedAccessUserException;
 import gov.cdc.usds.simplereport.api.model.errors.TestEventSerializationFailureException;
 import gov.cdc.usds.simplereport.api.model.errors.UnidentifiedFacilityException;
@@ -99,6 +100,13 @@ public class GraphQlConfig {
       }
 
       if (exception instanceof UnidentifiedFacilityException) {
+        String errorMessage =
+            "header: Error updating user privileges and / or group access; body: "
+                + exception.getMessage();
+        return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
+      }
+
+      if (exception instanceof PrivilegeUpdateFacilityAccessException) {
         String errorMessage =
             "header: Error updating user privileges and / or group access; body: "
                 + exception.getMessage();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
 import gov.cdc.usds.simplereport.api.model.errors.OktaAccountUserException;
+import gov.cdc.usds.simplereport.api.model.errors.PrivilegeUpdateFacilityAccessException;
 import gov.cdc.usds.simplereport.api.model.errors.RestrictedAccessUserException;
 import gov.cdc.usds.simplereport.api.model.errors.UnidentifiedFacilityException;
 import gov.cdc.usds.simplereport.api.model.errors.UnidentifiedUserException;
@@ -71,9 +72,6 @@ public class ApiUserService {
   @Autowired private WebhookContextHolder _webhookContextHolder;
 
   @Autowired private ApiUserContextHolder _apiUserContextHolder;
-
-  public static final String MOVE_USER_ARGUMENT_ERROR =
-      "Operation must specify a list of facilities for the user to access or allow them access to all facilities";
 
   private void createUserUpdatedAuditLog(Object authorId, Object updatedUserId) {
     log.info("User with id={} updated by user with id={}", authorId, updatedUserId);
@@ -724,7 +722,7 @@ public class ApiUserService {
       throws IllegalGraphqlArgumentException {
 
     if (!allFacilitiesAccess && facilities.isEmpty()) {
-      throw new IllegalArgumentException(MOVE_USER_ARGUMENT_ERROR);
+      throw new PrivilegeUpdateFacilityAccessException();
     }
 
     Organization newOrg = _orgService.getOrganization(orgExternalId);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -1,6 +1,6 @@
 package gov.cdc.usds.simplereport.service;
 
-import static gov.cdc.usds.simplereport.service.ApiUserService.MOVE_USER_ARGUMENT_ERROR;
+import static gov.cdc.usds.simplereport.api.model.errors.PrivilegeUpdateFacilityAccessException.PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,11 +14,13 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.api.model.ApiUserWithStatus;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
-import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
 import gov.cdc.usds.simplereport.api.model.errors.OktaAccountUserException;
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.RestrictedAccessUserException;
+import gov.cdc.usds.simplereport.api.model.errors.PrivilegeUpdateFacilityAccessException;
 import gov.cdc.usds.simplereport.api.model.errors.UnidentifiedFacilityException;
+
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.Facility;
@@ -33,6 +35,7 @@ import gov.cdc.usds.simplereport.service.model.UserInfo;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -40,6 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.UserStatus;
@@ -51,528 +55,535 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
-  @Autowired @SpyBean ApiUserRepository _apiUserRepo;
-  @Autowired @SpyBean OktaRepository _oktaRepo;
-  @Autowired OrganizationService _organizationService;
-  @Autowired FacilityRepository facilityRepository;
-  @Autowired private TestDataFactory _dataFactory;
+    @Autowired
+    @SpyBean
+    ApiUserRepository _apiUserRepo;
+    @Autowired
+    @SpyBean
+    OktaRepository _oktaRepo;
+    @Autowired
+    OrganizationService _organizationService;
+    @Autowired
+    FacilityRepository facilityRepository;
+    @Autowired
+    private TestDataFactory _dataFactory;
 
-  Set<UUID> emptySet = Collections.emptySet();
+    Set<UUID> emptySet = Collections.emptySet();
 
-  @BeforeEach
-  void cleanup() {
-    reset(_apiUserRepo);
-    reset(_oktaRepo);
-  }
+    @BeforeEach
+    void cleanup() {
+        reset(_apiUserRepo);
+        reset(_oktaRepo);
+    }
 
-  // The next several retrieval tests expect the demo users as they are defined in the
-  // no-security and no-okta-mgmt profiles
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getUsersInCurrentOrg_adminUser_success() {
-    initSampleData();
-    List<ApiUser> users = _service.getUsersInCurrentOrg();
-    assertEquals(5, users.size());
-    assertEquals("admin@example.com", users.get(0).getLoginEmail());
-    assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
-    assertEquals("bobbity@example.com", users.get(1).getLoginEmail());
-    assertEquals("Bobberoo", users.get(1).getNameInfo().getLastName());
-    assertEquals("nobody@example.com", users.get(2).getLoginEmail());
-    assertEquals("Nixon", users.get(2).getNameInfo().getLastName());
-    assertEquals("notruby@example.com", users.get(3).getLoginEmail());
-    assertEquals("Reynolds", users.get(3).getNameInfo().getLastName());
-    assertEquals("allfacilities@example.com", users.get(4).getLoginEmail());
-    assertEquals("Williams", users.get(4).getNameInfo().getLastName());
-  }
+    // The next several retrieval tests expect the demo users as they are defined in the
+    // no-security and no-okta-mgmt profiles
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getUsersInCurrentOrg_adminUser_success() {
+        initSampleData();
+        List<ApiUser> users = _service.getUsersInCurrentOrg();
+        assertEquals(5, users.size());
+        assertEquals("admin@example.com", users.get(0).getLoginEmail());
+        assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
+        assertEquals("bobbity@example.com", users.get(1).getLoginEmail());
+        assertEquals("Bobberoo", users.get(1).getNameInfo().getLastName());
+        assertEquals("nobody@example.com", users.get(2).getLoginEmail());
+        assertEquals("Nixon", users.get(2).getNameInfo().getLastName());
+        assertEquals("notruby@example.com", users.get(3).getLoginEmail());
+        assertEquals("Reynolds", users.get(3).getNameInfo().getLastName());
+        assertEquals("allfacilities@example.com", users.get(4).getLoginEmail());
+        assertEquals("Williams", users.get(4).getNameInfo().getLastName());
+    }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUsersInCurrentOrg_superUser_error() {
-    assertSecurityError(_service::getUsersInCurrentOrg);
-  }
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUsersInCurrentOrg_superUser_error() {
+        assertSecurityError(_service::getUsersInCurrentOrg);
+    }
 
-  @Test
-  void getUsersInCurrentOrg_standardUser_error() {
-    assertSecurityError(_service::getUsersInCurrentOrg);
-  }
+    @Test
+    void getUsersInCurrentOrg_standardUser_error() {
+        assertSecurityError(_service::getUsersInCurrentOrg);
+    }
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getUsersAndStatusInCurrentOrg_success() {
-    initSampleData();
-    List<ApiUserWithStatus> users = _service.getUsersAndStatusInCurrentOrg();
-    assertEquals(5, users.size());
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getUsersAndStatusInCurrentOrg_success() {
+        initSampleData();
+        List<ApiUserWithStatus> users = _service.getUsersAndStatusInCurrentOrg();
+        assertEquals(5, users.size());
 
-    checkApiUserWithStatus(users.get(0), "admin@example.com", "Andrews", UserStatus.ACTIVE);
-    checkApiUserWithStatus(users.get(1), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
-    checkApiUserWithStatus(users.get(2), "nobody@example.com", "Nixon", UserStatus.ACTIVE);
-    checkApiUserWithStatus(users.get(3), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
-    checkApiUserWithStatus(
-        users.get(4), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
-  }
+        checkApiUserWithStatus(users.get(0), "admin@example.com", "Andrews", UserStatus.ACTIVE);
+        checkApiUserWithStatus(users.get(1), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
+        checkApiUserWithStatus(users.get(2), "nobody@example.com", "Nixon", UserStatus.ACTIVE);
+        checkApiUserWithStatus(users.get(3), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
+        checkApiUserWithStatus(
+                users.get(4), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
+    }
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getUser_adminUser_success() {
-    initSampleData();
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getUser_adminUser_success() {
+        initSampleData();
 
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-    UserInfo userInfo = _service.getUser(apiUser.getInternalId());
+        UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-    assertEquals(email, userInfo.getEmail());
-    roleCheck(
-        userInfo,
-        EnumSet.of(
-            OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
-  }
+        assertEquals(email, userInfo.getEmail());
+        roleCheck(
+                userInfo,
+                EnumSet.of(
+                        OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
+    }
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getUser_adminUserWrongOrg_error() {
-    initSampleData();
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getUser_adminUserWrongOrg_error() {
+        initSampleData();
 
-    // captain@pirate.com is a member of DAT_ORG, but requester is admin of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
-    assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
-  }
+        // captain@pirate.com is a member of DAT_ORG, but requester is admin of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
+        assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
+    }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUser_superUser_success() {
-    initSampleData();
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUser_superUser_success() {
+        initSampleData();
 
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-    UserInfo userInfo = _service.getUser(apiUser.getInternalId());
+        UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-    assertEquals(email, userInfo.getEmail());
-    roleCheck(
-        userInfo,
-        EnumSet.of(
-            OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
-  }
+        assertEquals(email, userInfo.getEmail());
+        roleCheck(
+                userInfo,
+                EnumSet.of(
+                        OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
+    }
 
-  @Test
-  void getUser_standardUser_error() {
-    initSampleData();
+    @Test
+    void getUser_standardUser_error() {
+        initSampleData();
 
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail("allfacilities@example.com").get();
-    assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
-  }
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail("allfacilities@example.com").get();
+        assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
+    }
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void createUserInCurrentOrg_orgAdmin_success() {
-    initSampleData();
-    var facilityIdSet =
-        facilityRepository
-            .findAllByOrganization(_organizationService.getCurrentOrganization())
-            .stream()
-            .map(IdentifiedEntity::getInternalId)
-            .collect(Collectors.toSet());
-    UserInfo newUserInfo =
-        _service.createUserInCurrentOrg(
-            "newuser@example.com",
-            new PersonName("First", "Middle", "Last", "Jr"),
-            Role.USER,
-            false,
-            facilityIdSet);
-
-    assertEquals("newuser@example.com", newUserInfo.getEmail());
-
-    PersonName personName = newUserInfo.getNameInfo();
-    assertEquals("First", personName.getFirstName());
-    assertEquals("Middle", personName.getMiddleName());
-    assertEquals("Last", personName.getLastName());
-    assertEquals("Jr", personName.getSuffix());
-    assertThat(facilityIdSet)
-        .hasSameElementsAs(
-            newUserInfo.getFacilities().stream()
-                .map(IdentifiedEntity::getInternalId)
-                .collect(Collectors.toSet()));
-    assertThat(newUserInfo.getRoles())
-        .hasSameElementsAs(List.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void createUserInCurrentOrg_reprovisionDeletedUser_success() {
-    initSampleData();
-    // disable a user from this organization
-    ApiUser orgUser = _apiUserRepo.findByLoginEmail("nobody@example.com").get();
-    orgUser.setIsDeleted(true);
-    _apiUserRepo.save(orgUser);
-    _oktaRepo.setUserIsActive(orgUser.getLoginEmail(), false);
-
-    UserInfo reprovisionedUserInfo =
-        _service.createUserInCurrentOrg(
-            "nobody@example.com",
-            new PersonName("First", "Middle", "Last", "Jr"),
-            Role.USER,
-            true,
-            Set.of());
-
-    // the user will be re-enabled and updated
-    assertEquals("nobody@example.com", reprovisionedUserInfo.getEmail());
-
-    var facilities =
-        facilityRepository
-            .findAllByOrganization(_organizationService.getCurrentOrganization())
-            .stream()
-            .map(IdentifiedEntity::getInternalId)
-            .toList();
-    PersonName personName = reprovisionedUserInfo.getNameInfo();
-    assertEquals("First", personName.getFirstName());
-    assertEquals("Middle", personName.getMiddleName());
-    assertEquals("Last", personName.getLastName());
-    assertEquals("Jr", personName.getSuffix());
-    assertThat(
-            reprovisionedUserInfo.getFacilities().stream()
-                .map(IdentifiedEntity::getInternalId)
-                .toList())
-        .hasSameElementsAs(facilities);
-    assertThat(reprovisionedUserInfo.getRoles())
-        .hasSameElementsAs(
-            List.of(
-                OrganizationRole.NO_ACCESS,
-                OrganizationRole.USER,
-                OrganizationRole.ALL_FACILITIES));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void createUserInCurrentOrg_enabledUserExists_error() {
-    initSampleData();
-
-    PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
-
-    ConflictingUserException caught =
-        assertThrows(
-            ConflictingUserException.class,
-            () ->
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void createUserInCurrentOrg_orgAdmin_success() {
+        initSampleData();
+        var facilityIdSet =
+                facilityRepository
+                        .findAllByOrganization(_organizationService.getCurrentOrganization())
+                        .stream()
+                        .map(IdentifiedEntity::getInternalId)
+                        .collect(Collectors.toSet());
+        UserInfo newUserInfo =
                 _service.createUserInCurrentOrg(
-                    "allfacilities@example.com", personName, Role.USER, false, emptySet));
+                        "newuser@example.com",
+                        new PersonName("First", "Middle", "Last", "Jr"),
+                        Role.USER,
+                        false,
+                        facilityIdSet);
 
-    assertEquals("A user with this email address already exists.", caught.getMessage());
-  }
+        assertEquals("newuser@example.com", newUserInfo.getEmail());
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void createUserInCurrentOrg_disabledUser_conflictingUser_error() {
-    initSampleData();
+        PersonName personName = newUserInfo.getNameInfo();
+        assertEquals("First", personName.getFirstName());
+        assertEquals("Middle", personName.getMiddleName());
+        assertEquals("Last", personName.getLastName());
+        assertEquals("Jr", personName.getSuffix());
+        assertThat(facilityIdSet)
+                .hasSameElementsAs(
+                        newUserInfo.getFacilities().stream()
+                                .map(IdentifiedEntity::getInternalId)
+                                .collect(Collectors.toSet()));
+        assertThat(newUserInfo.getRoles())
+                .hasSameElementsAs(List.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
+    }
 
-    // disable a user from another organization
-    ApiUser wrongOrgUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
-    wrongOrgUser.setIsDeleted(true);
-    _apiUserRepo.save(wrongOrgUser);
-    _oktaRepo.setUserIsActive(wrongOrgUser.getLoginEmail(), false);
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void createUserInCurrentOrg_reprovisionDeletedUser_success() {
+        initSampleData();
+        // disable a user from this organization
+        ApiUser orgUser = _apiUserRepo.findByLoginEmail("nobody@example.com").get();
+        orgUser.setIsDeleted(true);
+        _apiUserRepo.save(orgUser);
+        _oktaRepo.setUserIsActive(orgUser.getLoginEmail(), false);
 
-    PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
-
-    ConflictingUserException caught =
-        assertThrows(
-            ConflictingUserException.class,
-            () ->
+        UserInfo reprovisionedUserInfo =
                 _service.createUserInCurrentOrg(
-                    "captain@pirate.com", personName, Role.USER, false, emptySet));
+                        "nobody@example.com",
+                        new PersonName("First", "Middle", "Last", "Jr"),
+                        Role.USER,
+                        true,
+                        Set.of());
 
-    assertEquals("A user with this email address already exists.", caught.getMessage());
-  }
+        // the user will be re-enabled and updated
+        assertEquals("nobody@example.com", reprovisionedUserInfo.getEmail());
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getAllUsersByOrganization_success() {
-    Organization org = _dataFactory.saveValidOrganization();
-    _dataFactory.createValidApiUser("allfacilities@example.com", org);
-    _dataFactory.createValidApiUser("nofacilities@example.com", org);
-    UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
-    _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
+        var facilities =
+                facilityRepository
+                        .findAllByOrganization(_organizationService.getCurrentOrganization())
+                        .stream()
+                        .map(IdentifiedEntity::getInternalId)
+                        .toList();
+        PersonName personName = reprovisionedUserInfo.getNameInfo();
+        assertEquals("First", personName.getFirstName());
+        assertEquals("Middle", personName.getMiddleName());
+        assertEquals("Last", personName.getLastName());
+        assertEquals("Jr", personName.getSuffix());
+        assertThat(
+                reprovisionedUserInfo.getFacilities().stream()
+                        .map(IdentifiedEntity::getInternalId)
+                        .toList())
+                .hasSameElementsAs(facilities);
+        assertThat(reprovisionedUserInfo.getRoles())
+                .hasSameElementsAs(
+                        List.of(
+                                OrganizationRole.NO_ACCESS,
+                                OrganizationRole.USER,
+                                OrganizationRole.ALL_FACILITIES));
+    }
 
-    Organization differentOrg =
-        _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
-    _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void createUserInCurrentOrg_enabledUserExists_error() {
+        initSampleData();
 
-    List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
-    assertEquals(3, activeUsers.size());
-    List<String> activeUserEmails =
-        activeUsers.stream()
-            .map(activeUser -> activeUser.getLoginEmail())
-            .sorted()
-            .collect(Collectors.toList());
-    assertEquals(
-        activeUserEmails,
-        List.of(
-            "allfacilities@example.com", "nofacilities@example.com", "somefacilities@example.com"));
-  }
+        PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void editUserName_orgAdmin_success() {
-    initSampleData();
+        ConflictingUserException caught =
+                assertThrows(
+                        ConflictingUserException.class,
+                        () ->
+                                _service.createUserInCurrentOrg(
+                                        "allfacilities@example.com", personName, Role.USER, false, emptySet));
 
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
-    PersonName newName = apiUser.getNameInfo();
-    newName.setFirstName("NewFirst");
-    newName.setMiddleName("NewFirst");
-    newName.setLastName("NewFirst");
-    newName.setSuffix("NewFirst");
+        assertEquals("A user with this email address already exists.", caught.getMessage());
+    }
 
-    UserInfo userInfo = _service.updateUser(apiUser.getInternalId(), newName);
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void createUserInCurrentOrg_disabledUser_conflictingUser_error() {
+        initSampleData();
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    assertEquals(apiUser.getNameInfo().getFirstName(), newName.getFirstName());
-    assertEquals(apiUser.getNameInfo().getMiddleName(), newName.getMiddleName());
-    assertEquals(apiUser.getNameInfo().getLastName(), newName.getLastName());
-    assertEquals(apiUser.getNameInfo().getSuffix(), newName.getSuffix());
-  }
+        // disable a user from another organization
+        ApiUser wrongOrgUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
+        wrongOrgUser.setIsDeleted(true);
+        _apiUserRepo.save(wrongOrgUser);
+        _oktaRepo.setUserIsActive(wrongOrgUser.getLoginEmail(), false);
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void editUserEmail_orgAdmin_success() {
-    initSampleData();
+        PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
 
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    final String newEmail = "newemail@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        ConflictingUserException caught =
+                assertThrows(
+                        ConflictingUserException.class,
+                        () ->
+                                _service.createUserInCurrentOrg(
+                                        "captain@pirate.com", personName, Role.USER, false, emptySet));
 
-    UserInfo userInfo = _service.updateUserEmail(apiUser.getInternalId(), newEmail);
+        assertEquals("A user with this email address already exists.", caught.getMessage());
+    }
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    assertEquals(userInfo.getEmail(), newEmail);
-  }
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getAllUsersByOrganization_success() {
+        Organization org = _dataFactory.saveValidOrganization();
+        _dataFactory.createValidApiUser("allfacilities@example.com", org);
+        _dataFactory.createValidApiUser("nofacilities@example.com", org);
+        UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
+        _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void resetUserPassword_orgAdmin_success() {
-    initSampleData();
+        Organization differentOrg =
+                _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
+        _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
 
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
+        assertEquals(3, activeUsers.size());
+        List<String> activeUserEmails =
+                activeUsers.stream()
+                        .map(activeUser -> activeUser.getLoginEmail())
+                        .sorted()
+                        .collect(Collectors.toList());
+        assertEquals(
+                activeUserEmails,
+                List.of(
+                        "allfacilities@example.com", "nofacilities@example.com", "somefacilities@example.com"));
+    }
 
-    UserInfo userInfo = _service.resetUserPassword(apiUser.getInternalId());
-    verify(_oktaRepo, times(1)).resetUserPassword(email);
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void editUserName_orgAdmin_success() {
+        initSampleData();
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-  }
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        PersonName newName = apiUser.getNameInfo();
+        newName.setFirstName("NewFirst");
+        newName.setMiddleName("NewFirst");
+        newName.setLastName("NewFirst");
+        newName.setSuffix("NewFirst");
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void reactivateUser_orgAdmin_success() {
-    initSampleData();
+        UserInfo userInfo = _service.updateUser(apiUser.getInternalId(), newName);
 
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+        assertEquals(apiUser.getNameInfo().getFirstName(), newName.getFirstName());
+        assertEquals(apiUser.getNameInfo().getMiddleName(), newName.getMiddleName());
+        assertEquals(apiUser.getNameInfo().getLastName(), newName.getLastName());
+        assertEquals(apiUser.getNameInfo().getSuffix(), newName.getSuffix());
+    }
 
-    UserInfo userInfo = _service.reactivateUser(apiUser.getInternalId());
-    verify(_oktaRepo, times(1)).reactivateUser(email);
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void editUserEmail_orgAdmin_success() {
+        initSampleData();
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-  }
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        final String newEmail = "newemail@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void reactivateAndResetUserPassword_orgAdmin_success() {
-    initSampleData();
-    final String email = "allfacilities@example.com"; // member of DIS_ORG
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        UserInfo userInfo = _service.updateUserEmail(apiUser.getInternalId(), newEmail);
 
-    UserInfo userInfo = _service.reactivateUserAndResetPassword(apiUser.getInternalId());
-    verify(_oktaRepo, times(1)).reactivateUser(email);
-    verify(_oktaRepo, times(1)).resetUserPassword(email);
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+        assertEquals(userInfo.getEmail(), newEmail);
+    }
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-  }
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void resetUserPassword_orgAdmin_success() {
+        initSampleData();
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void resendActivationEmail_orgAdmin_success() {
-    initSampleData();
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-    final String email = "allfacilities@example.com";
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        UserInfo userInfo = _service.resetUserPassword(apiUser.getInternalId());
+        verify(_oktaRepo, times(1)).resetUserPassword(email);
 
-    UserInfo userInfo = _service.resendActivationEmail(apiUser.getInternalId());
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    }
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-  }
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void reactivateUser_orgAdmin_success() {
+        initSampleData();
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUserByLoginEmail_success() {
-    initSampleData();
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-    String email = "allfacilities@example.com";
-    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
-    UserInfo userInfo = _service.getUserByLoginEmail(email);
+        UserInfo userInfo = _service.reactivateUser(apiUser.getInternalId());
+        verify(_oktaRepo, times(1)).reactivateUser(email);
 
-    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    assertEquals(email, userInfo.getEmail());
-    assertEquals(UserStatus.ACTIVE, userInfo.getUserStatus());
-    assertEquals(false, userInfo.getIsAdmin());
-    assertThat(userInfo.getFacilities()).hasSize(2);
-    assertThat(userInfo.getPermissions()).hasSize(10);
-  }
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUserByLoginEmail_user_not_found() {
-    doReturn(Optional.empty()).when(this._apiUserRepo).findByLoginEmailIncludeArchived(anyString());
-    NonexistentUserException caught =
-        assertThrows(
-            NonexistentUserException.class,
-            () -> _service.getUserByLoginEmail("nonexistent@email.com"));
-    assertEquals("Cannot find user.", caught.getMessage());
-  }
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void reactivateAndResetUserPassword_orgAdmin_success() {
+        initSampleData();
+        final String email = "allfacilities@example.com"; // member of DIS_ORG
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUserByLoginEmail_accountWithNoOktaGroups_Error() {
-    initSampleData();
-    String email = "allfacilities@example.com";
-    PartialOktaUser oktaUser =
-        PartialOktaUser.builder()
-            .isSiteAdmin(false)
-            .status(UserStatus.ACTIVE)
-            .organizationRoleClaims(Optional.empty())
-            .build();
+        UserInfo userInfo = _service.reactivateUserAndResetPassword(apiUser.getInternalId());
+        verify(_oktaRepo, times(1)).reactivateUser(email);
+        verify(_oktaRepo, times(1)).resetUserPassword(email);
 
-    when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
-    OktaAccountUserException caught =
-        assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
-    assertEquals(
-        "User is not configured correctly: the okta account is not properly setup.",
-        caught.getMessage());
-  }
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUserByLoginEmail_accountNotFoundInOkta_Error() {
-    initSampleData();
-    String email = "allfacilities@example.com";
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void resendActivationEmail_orgAdmin_success() {
+        initSampleData();
 
-    when(this._oktaRepo.findUser(anyString())).thenThrow(IllegalGraphqlArgumentException.class);
-    OktaAccountUserException caught =
-        assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
-    assertEquals(
-        "User is not configured correctly: the okta account is not properly setup.",
-        caught.getMessage());
-  }
+        final String email = "allfacilities@example.com";
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getUserByLoginEmail_UnauthorizedSiteAdminAccount_Error() {
-    initSampleData();
-    String email = "allfacilities@example.com";
-    PartialOktaUser oktaUser =
-        PartialOktaUser.builder()
-            .isSiteAdmin(true)
-            .status(UserStatus.ACTIVE)
-            .organizationRoleClaims(Optional.empty())
-            .build();
+        UserInfo userInfo = _service.resendActivationEmail(apiUser.getInternalId());
 
-    when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
-    RestrictedAccessUserException caught =
-        assertThrows(
-            RestrictedAccessUserException.class, () -> _service.getUserByLoginEmail(email));
-    assertEquals("Site admin account cannot be accessed.", caught.getMessage());
-  }
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    }
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getUserByLoginEmail_not_authorized() {
-    AccessDeniedException caught =
-        assertThrows(
-            AccessDeniedException.class, () -> _service.getUserByLoginEmail("example@email.com"));
-    assertEquals("Access is denied", caught.getMessage());
-  }
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUserByLoginEmail_success() {
+        initSampleData();
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void updateUserPrivilegesAndGroupAccess_assignToAllFacilities_success() {
-    initSampleData();
-    final String email = "allfacilities@example.com";
-    Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
-    String orgToMoveExternalId = orgToTestMovementTo.getExternalId();
+        String email = "allfacilities@example.com";
+        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+        UserInfo userInfo = _service.getUserByLoginEmail(email);
 
-    _service.updateUserPrivilegesAndGroupAccess(
-        email, orgToMoveExternalId, true, List.of(), OrganizationRole.ADMIN);
-    verify(_oktaRepo, times(1))
-        .updateUserPrivilegesAndGroupAccess(
-            email, orgToTestMovementTo, Set.of(), OrganizationRole.ADMIN, true);
-  }
+        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+        assertEquals(email, userInfo.getEmail());
+        assertEquals(UserStatus.ACTIVE, userInfo.getUserStatus());
+        assertEquals(false, userInfo.getIsAdmin());
+        assertThat(userInfo.getFacilities()).hasSize(2);
+        assertThat(userInfo.getPermissions()).hasSize(10);
+    }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void
-      updateUserPrivilegesAndGroupAccess_assignToAllFalseWithoutFacilities_throwsIllegalArgException() {
-    initSampleData();
-    final String email = "allfacilities@example.com";
-    Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
-    String moveOrgExternalId = orgToTestMovementTo.getExternalId();
-    List<UUID> emptyList = List.of();
-    IllegalArgumentException caught =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                _service.updateUserPrivilegesAndGroupAccess(
-                    email, moveOrgExternalId, false, emptyList, OrganizationRole.USER));
-    assertEquals(MOVE_USER_ARGUMENT_ERROR, caught.getMessage());
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUserByLoginEmail_user_not_found() {
+        doReturn(Optional.empty()).when(this._apiUserRepo).findByLoginEmailIncludeArchived(anyString());
+        NonexistentUserException caught =
+                assertThrows(
+                        NonexistentUserException.class,
+                        () -> _service.getUserByLoginEmail("nonexistent@email.com"));
+        assertEquals("Cannot find user.", caught.getMessage());
+    }
 
-    IllegalArgumentException caught2 =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                _service.updateUserPrivilegesAndGroupAccess(
-                    email, moveOrgExternalId, false, OrganizationRole.USER));
-    assertEquals(MOVE_USER_ARGUMENT_ERROR, caught2.getMessage());
-  }
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUserByLoginEmail_accountWithNoOktaGroups_Error() {
+        initSampleData();
+        String email = "allfacilities@example.com";
+        PartialOktaUser oktaUser =
+                PartialOktaUser.builder()
+                        .isSiteAdmin(false)
+                        .status(UserStatus.ACTIVE)
+                        .organizationRoleClaims(Optional.empty())
+                        .build();
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void updateUserPrivilegesAndGroupAccess_facilityToMoveNotFoundInOrg_throwsException() {
-    initSampleData();
-    final String email = "allfacilities@example.com";
-    Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
-    String moveOrgExternalId = orgToTestMovementTo.getExternalId();
+        when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
+        OktaAccountUserException caught =
+                assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
+        assertEquals(
+                "User is not configured correctly: the okta account is not properly setup.",
+                caught.getMessage());
+    }
 
-    Organization differentOrg =
-        _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
-    Facility facilityThatShouldThrowError = _dataFactory.createValidFacility(differentOrg);
-    List<UUID> facilityListThatShouldThrowId =
-        List.of(facilityThatShouldThrowError.getInternalId());
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUserByLoginEmail_accountNotFoundInOkta_Error() {
+        initSampleData();
+        String email = "allfacilities@example.com";
 
-    UnidentifiedFacilityException caught =
-        assertThrows(
-            UnidentifiedFacilityException.class,
-            () ->
-                _service.updateUserPrivilegesAndGroupAccess(
-                    email,
-                    moveOrgExternalId,
-                    false,
-                    facilityListThatShouldThrowId,
-                    OrganizationRole.USER));
-    String expectedError =
-        "Facilities with id(s) "
-            + facilityListThatShouldThrowId
-            + " for org "
-            + moveOrgExternalId
-            + " weren't found. Check those facility id(s) exist in the specified organization";
-    assertEquals(expectedError, caught.getMessage());
-  }
+        when(this._oktaRepo.findUser(anyString())).thenThrow(IllegalGraphqlArgumentException.class);
+        OktaAccountUserException caught =
+                assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
+        assertEquals(
+                "User is not configured correctly: the okta account is not properly setup.",
+                caught.getMessage());
+    }
 
-  private void roleCheck(final UserInfo userInfo, final Set<OrganizationRole> expected) {
-    EnumSet<OrganizationRole> actual = EnumSet.copyOf(userInfo.getRoles());
-    assertEquals(expected, actual);
-  }
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getUserByLoginEmail_UnauthorizedSiteAdminAccount_Error() {
+        initSampleData();
+        String email = "allfacilities@example.com";
+        PartialOktaUser oktaUser =
+                PartialOktaUser.builder()
+                        .isSiteAdmin(true)
+                        .status(UserStatus.ACTIVE)
+                        .organizationRoleClaims(Optional.empty())
+                        .build();
 
-  private void checkApiUserWithStatus(
-      ApiUserWithStatus user, String email, String lastName, UserStatus expectedStatus) {
-    assertEquals(email, user.getEmail());
-    assertEquals(lastName, user.getLastName());
-    assertEquals(expectedStatus, user.getStatus());
-  }
+        when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
+        RestrictedAccessUserException caught =
+                assertThrows(
+                        RestrictedAccessUserException.class, () -> _service.getUserByLoginEmail(email));
+        assertEquals("Site admin account cannot be accessed.", caught.getMessage());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getUserByLoginEmail_not_authorized() {
+        AccessDeniedException caught =
+                assertThrows(
+                        AccessDeniedException.class, () -> _service.getUserByLoginEmail("example@email.com"));
+        assertEquals("Access is denied", caught.getMessage());
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void updateUserPrivilegesAndGroupAccess_assignToAllFacilities_success() {
+        initSampleData();
+        final String email = "allfacilities@example.com";
+        Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
+        String orgToMoveExternalId = orgToTestMovementTo.getExternalId();
+
+        _service.updateUserPrivilegesAndGroupAccess(
+                email, orgToMoveExternalId, true, List.of(), OrganizationRole.ADMIN);
+        verify(_oktaRepo, times(1))
+                .updateUserPrivilegesAndGroupAccess(
+                        email, orgToTestMovementTo, Set.of(), OrganizationRole.ADMIN, true);
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void
+    updateUserPrivilegesAndGroupAccess_assignToAllFalseWithoutFacilities_throwsPrivilegeUpdateFacilityAccessException() {
+        initSampleData();
+        final String email = "allfacilities@example.com";
+        Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
+        String moveOrgExternalId = orgToTestMovementTo.getExternalId();
+        List<UUID> emptyList = List.of();
+        PrivilegeUpdateFacilityAccessException caught =
+                assertThrows(
+                        PrivilegeUpdateFacilityAccessException.class,
+                        () ->
+                                _service.updateUserPrivilegesAndGroupAccess(
+                                        email, moveOrgExternalId, false, emptyList, OrganizationRole.USER));
+        assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught.getMessage());
+
+        PrivilegeUpdateFacilityAccessException caught2 =
+                assertThrows(
+                        PrivilegeUpdateFacilityAccessException.class,
+                        () ->
+                                _service.updateUserPrivilegesAndGroupAccess(
+                                        email, moveOrgExternalId, false, OrganizationRole.USER));
+        assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught2.getMessage());
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void updateUserPrivilegesAndGroupAccess_facilityToMoveNotFoundInOrg_throwsException() {
+        initSampleData();
+        final String email = "allfacilities@example.com";
+        Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
+        String moveOrgExternalId = orgToTestMovementTo.getExternalId();
+
+        Organization differentOrg =
+                _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
+        Facility facilityThatShouldThrowError = _dataFactory.createValidFacility(differentOrg);
+        List<UUID> facilityListThatShouldThrowId =
+                List.of(facilityThatShouldThrowError.getInternalId());
+
+        UnidentifiedFacilityException caught =
+                assertThrows(
+                        UnidentifiedFacilityException.class,
+                        () ->
+                                _service.updateUserPrivilegesAndGroupAccess(
+                                        email,
+                                        moveOrgExternalId,
+                                        false,
+                                        facilityListThatShouldThrowId,
+                                        OrganizationRole.USER));
+        String expectedError =
+                "Facilities with id(s) "
+                        + facilityListThatShouldThrowId
+                        + " for org "
+                        + moveOrgExternalId
+                        + " weren't found. Check those facility id(s) exist in the specified organization";
+        assertEquals(expectedError, caught.getMessage());
+    }
+
+    private void roleCheck(final UserInfo userInfo, final Set<OrganizationRole> expected) {
+        EnumSet<OrganizationRole> actual = EnumSet.copyOf(userInfo.getRoles());
+        assertEquals(expected, actual);
+    }
+
+    private void checkApiUserWithStatus(
+            ApiUserWithStatus user, String email, String lastName, UserStatus expectedStatus) {
+        assertEquals(email, user.getEmail());
+        assertEquals(lastName, user.getLastName());
+        assertEquals(expectedStatus, user.getStatus());
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -14,13 +14,12 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.api.model.ApiUserWithStatus;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
 import gov.cdc.usds.simplereport.api.model.errors.OktaAccountUserException;
-import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
-import gov.cdc.usds.simplereport.api.model.errors.RestrictedAccessUserException;
 import gov.cdc.usds.simplereport.api.model.errors.PrivilegeUpdateFacilityAccessException;
+import gov.cdc.usds.simplereport.api.model.errors.RestrictedAccessUserException;
 import gov.cdc.usds.simplereport.api.model.errors.UnidentifiedFacilityException;
-
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.Facility;
@@ -35,7 +34,6 @@ import gov.cdc.usds.simplereport.service.model.UserInfo;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
-
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -43,7 +41,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.UserStatus;
@@ -55,535 +52,528 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = "hibernate.query.interceptor.error-level=ERROR")
 class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
-    @Autowired
-    @SpyBean
-    ApiUserRepository _apiUserRepo;
-    @Autowired
-    @SpyBean
-    OktaRepository _oktaRepo;
-    @Autowired
-    OrganizationService _organizationService;
-    @Autowired
-    FacilityRepository facilityRepository;
-    @Autowired
-    private TestDataFactory _dataFactory;
+  @Autowired @SpyBean ApiUserRepository _apiUserRepo;
+  @Autowired @SpyBean OktaRepository _oktaRepo;
+  @Autowired OrganizationService _organizationService;
+  @Autowired FacilityRepository facilityRepository;
+  @Autowired private TestDataFactory _dataFactory;
 
-    Set<UUID> emptySet = Collections.emptySet();
+  Set<UUID> emptySet = Collections.emptySet();
 
-    @BeforeEach
-    void cleanup() {
-        reset(_apiUserRepo);
-        reset(_oktaRepo);
-    }
+  @BeforeEach
+  void cleanup() {
+    reset(_apiUserRepo);
+    reset(_oktaRepo);
+  }
 
-    // The next several retrieval tests expect the demo users as they are defined in the
-    // no-security and no-okta-mgmt profiles
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getUsersInCurrentOrg_adminUser_success() {
-        initSampleData();
-        List<ApiUser> users = _service.getUsersInCurrentOrg();
-        assertEquals(5, users.size());
-        assertEquals("admin@example.com", users.get(0).getLoginEmail());
-        assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
-        assertEquals("bobbity@example.com", users.get(1).getLoginEmail());
-        assertEquals("Bobberoo", users.get(1).getNameInfo().getLastName());
-        assertEquals("nobody@example.com", users.get(2).getLoginEmail());
-        assertEquals("Nixon", users.get(2).getNameInfo().getLastName());
-        assertEquals("notruby@example.com", users.get(3).getLoginEmail());
-        assertEquals("Reynolds", users.get(3).getNameInfo().getLastName());
-        assertEquals("allfacilities@example.com", users.get(4).getLoginEmail());
-        assertEquals("Williams", users.get(4).getNameInfo().getLastName());
-    }
+  // The next several retrieval tests expect the demo users as they are defined in the
+  // no-security and no-okta-mgmt profiles
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getUsersInCurrentOrg_adminUser_success() {
+    initSampleData();
+    List<ApiUser> users = _service.getUsersInCurrentOrg();
+    assertEquals(5, users.size());
+    assertEquals("admin@example.com", users.get(0).getLoginEmail());
+    assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
+    assertEquals("bobbity@example.com", users.get(1).getLoginEmail());
+    assertEquals("Bobberoo", users.get(1).getNameInfo().getLastName());
+    assertEquals("nobody@example.com", users.get(2).getLoginEmail());
+    assertEquals("Nixon", users.get(2).getNameInfo().getLastName());
+    assertEquals("notruby@example.com", users.get(3).getLoginEmail());
+    assertEquals("Reynolds", users.get(3).getNameInfo().getLastName());
+    assertEquals("allfacilities@example.com", users.get(4).getLoginEmail());
+    assertEquals("Williams", users.get(4).getNameInfo().getLastName());
+  }
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUsersInCurrentOrg_superUser_error() {
-        assertSecurityError(_service::getUsersInCurrentOrg);
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUsersInCurrentOrg_superUser_error() {
+    assertSecurityError(_service::getUsersInCurrentOrg);
+  }
 
-    @Test
-    void getUsersInCurrentOrg_standardUser_error() {
-        assertSecurityError(_service::getUsersInCurrentOrg);
-    }
+  @Test
+  void getUsersInCurrentOrg_standardUser_error() {
+    assertSecurityError(_service::getUsersInCurrentOrg);
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getUsersAndStatusInCurrentOrg_success() {
-        initSampleData();
-        List<ApiUserWithStatus> users = _service.getUsersAndStatusInCurrentOrg();
-        assertEquals(5, users.size());
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getUsersAndStatusInCurrentOrg_success() {
+    initSampleData();
+    List<ApiUserWithStatus> users = _service.getUsersAndStatusInCurrentOrg();
+    assertEquals(5, users.size());
 
-        checkApiUserWithStatus(users.get(0), "admin@example.com", "Andrews", UserStatus.ACTIVE);
-        checkApiUserWithStatus(users.get(1), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
-        checkApiUserWithStatus(users.get(2), "nobody@example.com", "Nixon", UserStatus.ACTIVE);
-        checkApiUserWithStatus(users.get(3), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
-        checkApiUserWithStatus(
-                users.get(4), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
-    }
+    checkApiUserWithStatus(users.get(0), "admin@example.com", "Andrews", UserStatus.ACTIVE);
+    checkApiUserWithStatus(users.get(1), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
+    checkApiUserWithStatus(users.get(2), "nobody@example.com", "Nixon", UserStatus.ACTIVE);
+    checkApiUserWithStatus(users.get(3), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
+    checkApiUserWithStatus(
+        users.get(4), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getUser_adminUser_success() {
-        initSampleData();
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getUser_adminUser_success() {
+    initSampleData();
 
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-        UserInfo userInfo = _service.getUser(apiUser.getInternalId());
+    UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-        assertEquals(email, userInfo.getEmail());
-        roleCheck(
-                userInfo,
-                EnumSet.of(
-                        OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
-    }
+    assertEquals(email, userInfo.getEmail());
+    roleCheck(
+        userInfo,
+        EnumSet.of(
+            OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getUser_adminUserWrongOrg_error() {
-        initSampleData();
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getUser_adminUserWrongOrg_error() {
+    initSampleData();
 
-        // captain@pirate.com is a member of DAT_ORG, but requester is admin of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
-        assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
-    }
+    // captain@pirate.com is a member of DAT_ORG, but requester is admin of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
+    assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
+  }
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUser_superUser_success() {
-        initSampleData();
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUser_superUser_success() {
+    initSampleData();
 
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-        UserInfo userInfo = _service.getUser(apiUser.getInternalId());
+    UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-        assertEquals(email, userInfo.getEmail());
-        roleCheck(
-                userInfo,
-                EnumSet.of(
-                        OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
-    }
+    assertEquals(email, userInfo.getEmail());
+    roleCheck(
+        userInfo,
+        EnumSet.of(
+            OrganizationRole.NO_ACCESS, OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
+  }
 
-    @Test
-    void getUser_standardUser_error() {
-        initSampleData();
+  @Test
+  void getUser_standardUser_error() {
+    initSampleData();
 
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail("allfacilities@example.com").get();
-        assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
-    }
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail("allfacilities@example.com").get();
+    assertSecurityError(() -> _service.getUser(apiUser.getInternalId()));
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void createUserInCurrentOrg_orgAdmin_success() {
-        initSampleData();
-        var facilityIdSet =
-                facilityRepository
-                        .findAllByOrganization(_organizationService.getCurrentOrganization())
-                        .stream()
-                        .map(IdentifiedEntity::getInternalId)
-                        .collect(Collectors.toSet());
-        UserInfo newUserInfo =
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void createUserInCurrentOrg_orgAdmin_success() {
+    initSampleData();
+    var facilityIdSet =
+        facilityRepository
+            .findAllByOrganization(_organizationService.getCurrentOrganization())
+            .stream()
+            .map(IdentifiedEntity::getInternalId)
+            .collect(Collectors.toSet());
+    UserInfo newUserInfo =
+        _service.createUserInCurrentOrg(
+            "newuser@example.com",
+            new PersonName("First", "Middle", "Last", "Jr"),
+            Role.USER,
+            false,
+            facilityIdSet);
+
+    assertEquals("newuser@example.com", newUserInfo.getEmail());
+
+    PersonName personName = newUserInfo.getNameInfo();
+    assertEquals("First", personName.getFirstName());
+    assertEquals("Middle", personName.getMiddleName());
+    assertEquals("Last", personName.getLastName());
+    assertEquals("Jr", personName.getSuffix());
+    assertThat(facilityIdSet)
+        .hasSameElementsAs(
+            newUserInfo.getFacilities().stream()
+                .map(IdentifiedEntity::getInternalId)
+                .collect(Collectors.toSet()));
+    assertThat(newUserInfo.getRoles())
+        .hasSameElementsAs(List.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void createUserInCurrentOrg_reprovisionDeletedUser_success() {
+    initSampleData();
+    // disable a user from this organization
+    ApiUser orgUser = _apiUserRepo.findByLoginEmail("nobody@example.com").get();
+    orgUser.setIsDeleted(true);
+    _apiUserRepo.save(orgUser);
+    _oktaRepo.setUserIsActive(orgUser.getLoginEmail(), false);
+
+    UserInfo reprovisionedUserInfo =
+        _service.createUserInCurrentOrg(
+            "nobody@example.com",
+            new PersonName("First", "Middle", "Last", "Jr"),
+            Role.USER,
+            true,
+            Set.of());
+
+    // the user will be re-enabled and updated
+    assertEquals("nobody@example.com", reprovisionedUserInfo.getEmail());
+
+    var facilities =
+        facilityRepository
+            .findAllByOrganization(_organizationService.getCurrentOrganization())
+            .stream()
+            .map(IdentifiedEntity::getInternalId)
+            .toList();
+    PersonName personName = reprovisionedUserInfo.getNameInfo();
+    assertEquals("First", personName.getFirstName());
+    assertEquals("Middle", personName.getMiddleName());
+    assertEquals("Last", personName.getLastName());
+    assertEquals("Jr", personName.getSuffix());
+    assertThat(
+            reprovisionedUserInfo.getFacilities().stream()
+                .map(IdentifiedEntity::getInternalId)
+                .toList())
+        .hasSameElementsAs(facilities);
+    assertThat(reprovisionedUserInfo.getRoles())
+        .hasSameElementsAs(
+            List.of(
+                OrganizationRole.NO_ACCESS,
+                OrganizationRole.USER,
+                OrganizationRole.ALL_FACILITIES));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void createUserInCurrentOrg_enabledUserExists_error() {
+    initSampleData();
+
+    PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
+
+    ConflictingUserException caught =
+        assertThrows(
+            ConflictingUserException.class,
+            () ->
                 _service.createUserInCurrentOrg(
-                        "newuser@example.com",
-                        new PersonName("First", "Middle", "Last", "Jr"),
-                        Role.USER,
-                        false,
-                        facilityIdSet);
+                    "allfacilities@example.com", personName, Role.USER, false, emptySet));
 
-        assertEquals("newuser@example.com", newUserInfo.getEmail());
+    assertEquals("A user with this email address already exists.", caught.getMessage());
+  }
 
-        PersonName personName = newUserInfo.getNameInfo();
-        assertEquals("First", personName.getFirstName());
-        assertEquals("Middle", personName.getMiddleName());
-        assertEquals("Last", personName.getLastName());
-        assertEquals("Jr", personName.getSuffix());
-        assertThat(facilityIdSet)
-                .hasSameElementsAs(
-                        newUserInfo.getFacilities().stream()
-                                .map(IdentifiedEntity::getInternalId)
-                                .collect(Collectors.toSet()));
-        assertThat(newUserInfo.getRoles())
-                .hasSameElementsAs(List.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
-    }
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void createUserInCurrentOrg_disabledUser_conflictingUser_error() {
+    initSampleData();
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void createUserInCurrentOrg_reprovisionDeletedUser_success() {
-        initSampleData();
-        // disable a user from this organization
-        ApiUser orgUser = _apiUserRepo.findByLoginEmail("nobody@example.com").get();
-        orgUser.setIsDeleted(true);
-        _apiUserRepo.save(orgUser);
-        _oktaRepo.setUserIsActive(orgUser.getLoginEmail(), false);
+    // disable a user from another organization
+    ApiUser wrongOrgUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
+    wrongOrgUser.setIsDeleted(true);
+    _apiUserRepo.save(wrongOrgUser);
+    _oktaRepo.setUserIsActive(wrongOrgUser.getLoginEmail(), false);
 
-        UserInfo reprovisionedUserInfo =
+    PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
+
+    ConflictingUserException caught =
+        assertThrows(
+            ConflictingUserException.class,
+            () ->
                 _service.createUserInCurrentOrg(
-                        "nobody@example.com",
-                        new PersonName("First", "Middle", "Last", "Jr"),
-                        Role.USER,
-                        true,
-                        Set.of());
+                    "captain@pirate.com", personName, Role.USER, false, emptySet));
 
-        // the user will be re-enabled and updated
-        assertEquals("nobody@example.com", reprovisionedUserInfo.getEmail());
+    assertEquals("A user with this email address already exists.", caught.getMessage());
+  }
 
-        var facilities =
-                facilityRepository
-                        .findAllByOrganization(_organizationService.getCurrentOrganization())
-                        .stream()
-                        .map(IdentifiedEntity::getInternalId)
-                        .toList();
-        PersonName personName = reprovisionedUserInfo.getNameInfo();
-        assertEquals("First", personName.getFirstName());
-        assertEquals("Middle", personName.getMiddleName());
-        assertEquals("Last", personName.getLastName());
-        assertEquals("Jr", personName.getSuffix());
-        assertThat(
-                reprovisionedUserInfo.getFacilities().stream()
-                        .map(IdentifiedEntity::getInternalId)
-                        .toList())
-                .hasSameElementsAs(facilities);
-        assertThat(reprovisionedUserInfo.getRoles())
-                .hasSameElementsAs(
-                        List.of(
-                                OrganizationRole.NO_ACCESS,
-                                OrganizationRole.USER,
-                                OrganizationRole.ALL_FACILITIES));
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getAllUsersByOrganization_success() {
+    Organization org = _dataFactory.saveValidOrganization();
+    _dataFactory.createValidApiUser("allfacilities@example.com", org);
+    _dataFactory.createValidApiUser("nofacilities@example.com", org);
+    UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
+    _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void createUserInCurrentOrg_enabledUserExists_error() {
-        initSampleData();
+    Organization differentOrg =
+        _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
+    _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
 
-        PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
+    List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
+    assertEquals(3, activeUsers.size());
+    List<String> activeUserEmails =
+        activeUsers.stream()
+            .map(activeUser -> activeUser.getLoginEmail())
+            .sorted()
+            .collect(Collectors.toList());
+    assertEquals(
+        activeUserEmails,
+        List.of(
+            "allfacilities@example.com", "nofacilities@example.com", "somefacilities@example.com"));
+  }
 
-        ConflictingUserException caught =
-                assertThrows(
-                        ConflictingUserException.class,
-                        () ->
-                                _service.createUserInCurrentOrg(
-                                        "allfacilities@example.com", personName, Role.USER, false, emptySet));
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void editUserName_orgAdmin_success() {
+    initSampleData();
 
-        assertEquals("A user with this email address already exists.", caught.getMessage());
-    }
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+    PersonName newName = apiUser.getNameInfo();
+    newName.setFirstName("NewFirst");
+    newName.setMiddleName("NewFirst");
+    newName.setLastName("NewFirst");
+    newName.setSuffix("NewFirst");
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void createUserInCurrentOrg_disabledUser_conflictingUser_error() {
-        initSampleData();
+    UserInfo userInfo = _service.updateUser(apiUser.getInternalId(), newName);
 
-        // disable a user from another organization
-        ApiUser wrongOrgUser = _apiUserRepo.findByLoginEmail("captain@pirate.com").get();
-        wrongOrgUser.setIsDeleted(true);
-        _apiUserRepo.save(wrongOrgUser);
-        _oktaRepo.setUserIsActive(wrongOrgUser.getLoginEmail(), false);
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    assertEquals(apiUser.getNameInfo().getFirstName(), newName.getFirstName());
+    assertEquals(apiUser.getNameInfo().getMiddleName(), newName.getMiddleName());
+    assertEquals(apiUser.getNameInfo().getLastName(), newName.getLastName());
+    assertEquals(apiUser.getNameInfo().getSuffix(), newName.getSuffix());
+  }
 
-        PersonName personName = new PersonName("First", "Middle", "Last", "Jr");
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void editUserEmail_orgAdmin_success() {
+    initSampleData();
 
-        ConflictingUserException caught =
-                assertThrows(
-                        ConflictingUserException.class,
-                        () ->
-                                _service.createUserInCurrentOrg(
-                                        "captain@pirate.com", personName, Role.USER, false, emptySet));
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    final String newEmail = "newemail@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-        assertEquals("A user with this email address already exists.", caught.getMessage());
-    }
+    UserInfo userInfo = _service.updateUserEmail(apiUser.getInternalId(), newEmail);
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getAllUsersByOrganization_success() {
-        Organization org = _dataFactory.saveValidOrganization();
-        _dataFactory.createValidApiUser("allfacilities@example.com", org);
-        _dataFactory.createValidApiUser("nofacilities@example.com", org);
-        UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
-        _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    assertEquals(userInfo.getEmail(), newEmail);
+  }
 
-        Organization differentOrg =
-                _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
-        _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void resetUserPassword_orgAdmin_success() {
+    initSampleData();
 
-        List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
-        assertEquals(3, activeUsers.size());
-        List<String> activeUserEmails =
-                activeUsers.stream()
-                        .map(activeUser -> activeUser.getLoginEmail())
-                        .sorted()
-                        .collect(Collectors.toList());
-        assertEquals(
-                activeUserEmails,
-                List.of(
-                        "allfacilities@example.com", "nofacilities@example.com", "somefacilities@example.com"));
-    }
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void editUserName_orgAdmin_success() {
-        initSampleData();
+    UserInfo userInfo = _service.resetUserPassword(apiUser.getInternalId());
+    verify(_oktaRepo, times(1)).resetUserPassword(email);
 
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
-        PersonName newName = apiUser.getNameInfo();
-        newName.setFirstName("NewFirst");
-        newName.setMiddleName("NewFirst");
-        newName.setLastName("NewFirst");
-        newName.setSuffix("NewFirst");
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+  }
 
-        UserInfo userInfo = _service.updateUser(apiUser.getInternalId(), newName);
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void reactivateUser_orgAdmin_success() {
+    initSampleData();
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-        assertEquals(apiUser.getNameInfo().getFirstName(), newName.getFirstName());
-        assertEquals(apiUser.getNameInfo().getMiddleName(), newName.getMiddleName());
-        assertEquals(apiUser.getNameInfo().getLastName(), newName.getLastName());
-        assertEquals(apiUser.getNameInfo().getSuffix(), newName.getSuffix());
-    }
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void editUserEmail_orgAdmin_success() {
-        initSampleData();
+    UserInfo userInfo = _service.reactivateUser(apiUser.getInternalId());
+    verify(_oktaRepo, times(1)).reactivateUser(email);
 
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        final String newEmail = "newemail@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+  }
 
-        UserInfo userInfo = _service.updateUserEmail(apiUser.getInternalId(), newEmail);
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void reactivateAndResetUserPassword_orgAdmin_success() {
+    initSampleData();
+    final String email = "allfacilities@example.com"; // member of DIS_ORG
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-        assertEquals(userInfo.getEmail(), newEmail);
-    }
+    UserInfo userInfo = _service.reactivateUserAndResetPassword(apiUser.getInternalId());
+    verify(_oktaRepo, times(1)).reactivateUser(email);
+    verify(_oktaRepo, times(1)).resetUserPassword(email);
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void resetUserPassword_orgAdmin_success() {
-        initSampleData();
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+  }
 
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void resendActivationEmail_orgAdmin_success() {
+    initSampleData();
 
-        UserInfo userInfo = _service.resetUserPassword(apiUser.getInternalId());
-        verify(_oktaRepo, times(1)).resetUserPassword(email);
+    final String email = "allfacilities@example.com";
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    }
+    UserInfo userInfo = _service.resendActivationEmail(apiUser.getInternalId());
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void reactivateUser_orgAdmin_success() {
-        initSampleData();
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+  }
 
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUserByLoginEmail_success() {
+    initSampleData();
 
-        UserInfo userInfo = _service.reactivateUser(apiUser.getInternalId());
-        verify(_oktaRepo, times(1)).reactivateUser(email);
+    String email = "allfacilities@example.com";
+    ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+    UserInfo userInfo = _service.getUserByLoginEmail(email);
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    }
+    assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
+    assertEquals(email, userInfo.getEmail());
+    assertEquals(UserStatus.ACTIVE, userInfo.getUserStatus());
+    assertEquals(false, userInfo.getIsAdmin());
+    assertThat(userInfo.getFacilities()).hasSize(2);
+    assertThat(userInfo.getPermissions()).hasSize(10);
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void reactivateAndResetUserPassword_orgAdmin_success() {
-        initSampleData();
-        final String email = "allfacilities@example.com"; // member of DIS_ORG
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUserByLoginEmail_user_not_found() {
+    doReturn(Optional.empty()).when(this._apiUserRepo).findByLoginEmailIncludeArchived(anyString());
+    NonexistentUserException caught =
+        assertThrows(
+            NonexistentUserException.class,
+            () -> _service.getUserByLoginEmail("nonexistent@email.com"));
+    assertEquals("Cannot find user.", caught.getMessage());
+  }
 
-        UserInfo userInfo = _service.reactivateUserAndResetPassword(apiUser.getInternalId());
-        verify(_oktaRepo, times(1)).reactivateUser(email);
-        verify(_oktaRepo, times(1)).resetUserPassword(email);
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUserByLoginEmail_accountWithNoOktaGroups_Error() {
+    initSampleData();
+    String email = "allfacilities@example.com";
+    PartialOktaUser oktaUser =
+        PartialOktaUser.builder()
+            .isSiteAdmin(false)
+            .status(UserStatus.ACTIVE)
+            .organizationRoleClaims(Optional.empty())
+            .build();
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    }
+    when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
+    OktaAccountUserException caught =
+        assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
+    assertEquals(
+        "User is not configured correctly: the okta account is not properly setup.",
+        caught.getMessage());
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void resendActivationEmail_orgAdmin_success() {
-        initSampleData();
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUserByLoginEmail_accountNotFoundInOkta_Error() {
+    initSampleData();
+    String email = "allfacilities@example.com";
 
-        final String email = "allfacilities@example.com";
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
+    when(this._oktaRepo.findUser(anyString())).thenThrow(IllegalGraphqlArgumentException.class);
+    OktaAccountUserException caught =
+        assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
+    assertEquals(
+        "User is not configured correctly: the okta account is not properly setup.",
+        caught.getMessage());
+  }
 
-        UserInfo userInfo = _service.resendActivationEmail(apiUser.getInternalId());
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getUserByLoginEmail_UnauthorizedSiteAdminAccount_Error() {
+    initSampleData();
+    String email = "allfacilities@example.com";
+    PartialOktaUser oktaUser =
+        PartialOktaUser.builder()
+            .isSiteAdmin(true)
+            .status(UserStatus.ACTIVE)
+            .organizationRoleClaims(Optional.empty())
+            .build();
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-    }
+    when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
+    RestrictedAccessUserException caught =
+        assertThrows(
+            RestrictedAccessUserException.class, () -> _service.getUserByLoginEmail(email));
+    assertEquals("Site admin account cannot be accessed.", caught.getMessage());
+  }
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUserByLoginEmail_success() {
-        initSampleData();
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getUserByLoginEmail_not_authorized() {
+    AccessDeniedException caught =
+        assertThrows(
+            AccessDeniedException.class, () -> _service.getUserByLoginEmail("example@email.com"));
+    assertEquals("Access is denied", caught.getMessage());
+  }
 
-        String email = "allfacilities@example.com";
-        ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
-        UserInfo userInfo = _service.getUserByLoginEmail(email);
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void updateUserPrivilegesAndGroupAccess_assignToAllFacilities_success() {
+    initSampleData();
+    final String email = "allfacilities@example.com";
+    Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
+    String orgToMoveExternalId = orgToTestMovementTo.getExternalId();
 
-        assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
-        assertEquals(email, userInfo.getEmail());
-        assertEquals(UserStatus.ACTIVE, userInfo.getUserStatus());
-        assertEquals(false, userInfo.getIsAdmin());
-        assertThat(userInfo.getFacilities()).hasSize(2);
-        assertThat(userInfo.getPermissions()).hasSize(10);
-    }
+    _service.updateUserPrivilegesAndGroupAccess(
+        email, orgToMoveExternalId, true, List.of(), OrganizationRole.ADMIN);
+    verify(_oktaRepo, times(1))
+        .updateUserPrivilegesAndGroupAccess(
+            email, orgToTestMovementTo, Set.of(), OrganizationRole.ADMIN, true);
+  }
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUserByLoginEmail_user_not_found() {
-        doReturn(Optional.empty()).when(this._apiUserRepo).findByLoginEmailIncludeArchived(anyString());
-        NonexistentUserException caught =
-                assertThrows(
-                        NonexistentUserException.class,
-                        () -> _service.getUserByLoginEmail("nonexistent@email.com"));
-        assertEquals("Cannot find user.", caught.getMessage());
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void
+      updateUserPrivilegesAndGroupAccess_assignToAllFalseWithoutFacilities_throwsPrivilegeUpdateFacilityAccessException() {
+    initSampleData();
+    final String email = "allfacilities@example.com";
+    Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
+    String moveOrgExternalId = orgToTestMovementTo.getExternalId();
+    List<UUID> emptyList = List.of();
+    PrivilegeUpdateFacilityAccessException caught =
+        assertThrows(
+            PrivilegeUpdateFacilityAccessException.class,
+            () ->
+                _service.updateUserPrivilegesAndGroupAccess(
+                    email, moveOrgExternalId, false, emptyList, OrganizationRole.USER));
+    assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught.getMessage());
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUserByLoginEmail_accountWithNoOktaGroups_Error() {
-        initSampleData();
-        String email = "allfacilities@example.com";
-        PartialOktaUser oktaUser =
-                PartialOktaUser.builder()
-                        .isSiteAdmin(false)
-                        .status(UserStatus.ACTIVE)
-                        .organizationRoleClaims(Optional.empty())
-                        .build();
+    PrivilegeUpdateFacilityAccessException caught2 =
+        assertThrows(
+            PrivilegeUpdateFacilityAccessException.class,
+            () ->
+                _service.updateUserPrivilegesAndGroupAccess(
+                    email, moveOrgExternalId, false, OrganizationRole.USER));
+    assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught2.getMessage());
+  }
 
-        when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
-        OktaAccountUserException caught =
-                assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
-        assertEquals(
-                "User is not configured correctly: the okta account is not properly setup.",
-                caught.getMessage());
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void updateUserPrivilegesAndGroupAccess_facilityToMoveNotFoundInOrg_throwsException() {
+    initSampleData();
+    final String email = "allfacilities@example.com";
+    Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
+    String moveOrgExternalId = orgToTestMovementTo.getExternalId();
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUserByLoginEmail_accountNotFoundInOkta_Error() {
-        initSampleData();
-        String email = "allfacilities@example.com";
+    Organization differentOrg =
+        _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
+    Facility facilityThatShouldThrowError = _dataFactory.createValidFacility(differentOrg);
+    List<UUID> facilityListThatShouldThrowId =
+        List.of(facilityThatShouldThrowError.getInternalId());
 
-        when(this._oktaRepo.findUser(anyString())).thenThrow(IllegalGraphqlArgumentException.class);
-        OktaAccountUserException caught =
-                assertThrows(OktaAccountUserException.class, () -> _service.getUserByLoginEmail(email));
-        assertEquals(
-                "User is not configured correctly: the okta account is not properly setup.",
-                caught.getMessage());
-    }
+    UnidentifiedFacilityException caught =
+        assertThrows(
+            UnidentifiedFacilityException.class,
+            () ->
+                _service.updateUserPrivilegesAndGroupAccess(
+                    email,
+                    moveOrgExternalId,
+                    false,
+                    facilityListThatShouldThrowId,
+                    OrganizationRole.USER));
+    String expectedError =
+        "Facilities with id(s) "
+            + facilityListThatShouldThrowId
+            + " for org "
+            + moveOrgExternalId
+            + " weren't found. Check those facility id(s) exist in the specified organization";
+    assertEquals(expectedError, caught.getMessage());
+  }
 
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getUserByLoginEmail_UnauthorizedSiteAdminAccount_Error() {
-        initSampleData();
-        String email = "allfacilities@example.com";
-        PartialOktaUser oktaUser =
-                PartialOktaUser.builder()
-                        .isSiteAdmin(true)
-                        .status(UserStatus.ACTIVE)
-                        .organizationRoleClaims(Optional.empty())
-                        .build();
+  private void roleCheck(final UserInfo userInfo, final Set<OrganizationRole> expected) {
+    EnumSet<OrganizationRole> actual = EnumSet.copyOf(userInfo.getRoles());
+    assertEquals(expected, actual);
+  }
 
-        when(this._oktaRepo.findUser(anyString())).thenReturn(oktaUser);
-        RestrictedAccessUserException caught =
-                assertThrows(
-                        RestrictedAccessUserException.class, () -> _service.getUserByLoginEmail(email));
-        assertEquals("Site admin account cannot be accessed.", caught.getMessage());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getUserByLoginEmail_not_authorized() {
-        AccessDeniedException caught =
-                assertThrows(
-                        AccessDeniedException.class, () -> _service.getUserByLoginEmail("example@email.com"));
-        assertEquals("Access is denied", caught.getMessage());
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void updateUserPrivilegesAndGroupAccess_assignToAllFacilities_success() {
-        initSampleData();
-        final String email = "allfacilities@example.com";
-        Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
-        String orgToMoveExternalId = orgToTestMovementTo.getExternalId();
-
-        _service.updateUserPrivilegesAndGroupAccess(
-                email, orgToMoveExternalId, true, List.of(), OrganizationRole.ADMIN);
-        verify(_oktaRepo, times(1))
-                .updateUserPrivilegesAndGroupAccess(
-                        email, orgToTestMovementTo, Set.of(), OrganizationRole.ADMIN, true);
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void
-    updateUserPrivilegesAndGroupAccess_assignToAllFalseWithoutFacilities_throwsPrivilegeUpdateFacilityAccessException() {
-        initSampleData();
-        final String email = "allfacilities@example.com";
-        Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
-        String moveOrgExternalId = orgToTestMovementTo.getExternalId();
-        List<UUID> emptyList = List.of();
-        PrivilegeUpdateFacilityAccessException caught =
-                assertThrows(
-                        PrivilegeUpdateFacilityAccessException.class,
-                        () ->
-                                _service.updateUserPrivilegesAndGroupAccess(
-                                        email, moveOrgExternalId, false, emptyList, OrganizationRole.USER));
-        assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught.getMessage());
-
-        PrivilegeUpdateFacilityAccessException caught2 =
-                assertThrows(
-                        PrivilegeUpdateFacilityAccessException.class,
-                        () ->
-                                _service.updateUserPrivilegesAndGroupAccess(
-                                        email, moveOrgExternalId, false, OrganizationRole.USER));
-        assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught2.getMessage());
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void updateUserPrivilegesAndGroupAccess_facilityToMoveNotFoundInOrg_throwsException() {
-        initSampleData();
-        final String email = "allfacilities@example.com";
-        Organization orgToTestMovementTo = _dataFactory.saveValidOrganization();
-        String moveOrgExternalId = orgToTestMovementTo.getExternalId();
-
-        Organization differentOrg =
-                _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
-        Facility facilityThatShouldThrowError = _dataFactory.createValidFacility(differentOrg);
-        List<UUID> facilityListThatShouldThrowId =
-                List.of(facilityThatShouldThrowError.getInternalId());
-
-        UnidentifiedFacilityException caught =
-                assertThrows(
-                        UnidentifiedFacilityException.class,
-                        () ->
-                                _service.updateUserPrivilegesAndGroupAccess(
-                                        email,
-                                        moveOrgExternalId,
-                                        false,
-                                        facilityListThatShouldThrowId,
-                                        OrganizationRole.USER));
-        String expectedError =
-                "Facilities with id(s) "
-                        + facilityListThatShouldThrowId
-                        + " for org "
-                        + moveOrgExternalId
-                        + " weren't found. Check those facility id(s) exist in the specified organization";
-        assertEquals(expectedError, caught.getMessage());
-    }
-
-    private void roleCheck(final UserInfo userInfo, final Set<OrganizationRole> expected) {
-        EnumSet<OrganizationRole> actual = EnumSet.copyOf(userInfo.getRoles());
-        assertEquals(expected, actual);
-    }
-
-    private void checkApiUserWithStatus(
-            ApiUserWithStatus user, String email, String lastName, UserStatus expectedStatus) {
-        assertEquals(email, user.getEmail());
-        assertEquals(lastName, user.getLastName());
-        assertEquals(expectedStatus, user.getStatus());
-    }
+  private void checkApiUserWithStatus(
+      ApiUserWithStatus user, String email, String lastName, UserStatus expectedStatus) {
+    assertEquals(email, user.getEmail());
+    assertEquals(lastName, user.getLastName());
+    assertEquals(expectedStatus, user.getStatus());
+  }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixing some error state handling as mentioned in [this comment](https://github.com/CDCgov/prime-simplereport/pull/6359#issuecomment-1695954207) 

## Changes Proposed

- Moves error handling logic out of the resolver so things get thrown more descriptively.

## Testing

Deployed in dev 2

Try mutating with
- `accessAllFacility=false` and an empty facility array
- A facility array with a UUID that isn't in the org (using something like https://www.uuidgenerator.net/)
-  A bad user name

Each one should throw with a custom error message.

https://github.com/CDCgov/prime-simplereport/assets/29645040/aadd009b-cce9-4ecc-812f-fdb7bab1a14a

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->