### PR TITLE
replace manage facility admin screen dropdowns with combos

### DIFF
--- a/cypress/e2e/11-support-manage-facility.cy.js
+++ b/cypress/e2e/11-support-manage-facility.cy.js
@@ -1,19 +1,19 @@
-import {loginHooks, testNumber} from "../support/e2e";
-import {addMockFacility, whoAmI} from "../utils/testing-data-utils";
-import {graphqlURL} from "../utils/request-utils";
-import {aliasGraphqlOperations} from "../utils/graphql-test-utils";
+import { loginHooks, testNumber } from "../support/e2e";
+import { addMockFacility, whoAmI } from "../utils/testing-data-utils";
+import { graphqlURL } from "../utils/request-utils";
+import { aliasGraphqlOperations } from "../utils/graphql-test-utils";
 
 loginHooks();
 describe("Support admin: manage facility", () => {
-  let organizationId="";
+  let organizationId = "";
   let facilityId = "";
   let facilityCreated = {
-    id:"",
-    name:`RainbowCenter-${testNumber()}`,
-  }
+    id: "",
+    name: `RainbowCenter-${testNumber()}`
+  };
 
   before(() => {
-    addMockFacility(facilityCreated.name).then(response=>{
+    addMockFacility(facilityCreated.name).then(response => {
       facilityCreated.id = response.body.data.addFacility.id;
     });
 
@@ -21,9 +21,11 @@ describe("Support admin: manage facility", () => {
       organizationId = res.body.data.whoami.organization.id;
       facilityId = res.body.data.whoami.organization.facilities[0].id;
     });
+  });
 
+  beforeEach(() => {
     cy.intercept("POST", graphqlURL, (req) => {
-      aliasGraphqlOperations(req)
+      aliasGraphqlOperations(req);
     });
   });
 
@@ -62,7 +64,7 @@ describe("Support admin: manage facility", () => {
     cy.contains(`Delete ${facilityCreated.name}`).should("not.exist");
   });
 
-  it("Deletes a facility",()=>{
+  it("Deletes a facility", () => {
     cy.get("button").contains("Delete facility").click();
     cy.get("button").contains("Yes, delete facility").click();
     cy.get(".Toastify").contains(`Facility ${facilityCreated.name} successfully deleted`);

--- a/cypress/e2e/11-support-manage-facility.cy.js
+++ b/cypress/e2e/11-support-manage-facility.cy.js
@@ -40,11 +40,11 @@ describe("Support admin: manage facility", () => {
 
     // selects organization
     cy.wait("@GetAllOrganizations");
-    cy.get("div.bg-base-lightest select").first().select(organizationId);
+    cy.get("div.bg-base-lightest input").first().select(organizationId);
 
     // selects facility
     cy.wait("@GetFacilitiesByOrgId");
-    cy.get("div.bg-base-lightest select").eq(1).select(facilityCreated.id);
+    cy.get("div.bg-base-lightest input").eq(1).select(facilityCreated.id);
 
     // clicks search button
     cy.get("button").contains("Search").click();

--- a/cypress/e2e/11-support-manage-facility.cy.js
+++ b/cypress/e2e/11-support-manage-facility.cy.js
@@ -1,11 +1,12 @@
 import { loginHooks, testNumber } from "../support/e2e";
-import { addMockFacility, whoAmI } from "../utils/testing-data-utils";
+import { addMockFacility, whoAmI, getOrganizationById } from "../utils/testing-data-utils";
 import { graphqlURL } from "../utils/request-utils";
 import { aliasGraphqlOperations } from "../utils/graphql-test-utils";
 
 loginHooks();
 describe("Support admin: manage facility", () => {
   let organizationId = "";
+  let organizationName = "";
   let facilityId = "";
   let facilityCreated = {
     id: "",
@@ -20,7 +21,12 @@ describe("Support admin: manage facility", () => {
     whoAmI().then((res) => {
       organizationId = res.body.data.whoami.organization.id;
       facilityId = res.body.data.whoami.organization.facilities[0].id;
+
+      getOrganizationById(organizationId).then((res) => {
+        organizationName = res.body.data.organization.name;
+      });
     });
+
   });
 
   beforeEach(() => {
@@ -42,23 +48,11 @@ describe("Support admin: manage facility", () => {
     cy.wait("@GetAllOrganizations");
 
     // selects org combo box
-    cy.get("[data-testid=\"org-selection-container\"] " +
-      "> [data-testid=\"combo-box\"] ")
-      .within(() => {
-        // within the org selection box
-        cy.get("[data-testid=\"combo-box-input\"]").click();
-        cy.get(`[data-testid=\"combo-box-option-${organizationId}\"]`).click();
-      });
+    cy.get("input[role=\"combobox\"]").first().type(`${organizationName}{enter}`);
 
     // selects facility combo box
     cy.wait("@GetFacilitiesByOrgId");
-    cy.get("[data-testid=\"facility-selection-container\"] " +
-      "> [data-testid=\"combo-box\"]")
-      .within(() => {
-        // within the org selection box
-        cy.get("[data-testid=\"combo-box-input\"]").click();
-        cy.get(`[data-testid=\"combo-box-option-${facilityCreated.id}\"]`).click();
-      });
+    cy.get("input[role=\"combobox\"]").last().type(`${facilityCreated.name}{enter}`);
 
     // clicks search button
     cy.get("button").contains("Search").click();

--- a/cypress/e2e/11-support-manage-facility.cy.js
+++ b/cypress/e2e/11-support-manage-facility.cy.js
@@ -40,11 +40,25 @@ describe("Support admin: manage facility", () => {
 
     // selects organization
     cy.wait("@GetAllOrganizations");
-    cy.get("div.bg-base-lightest input").first().select(organizationId);
 
-    // selects facility
+    // selects org combo box
+    cy.get("[data-testid=\"org-selection-container\"] " +
+      "> [data-testid=\"combo-box\"] ")
+      .within(() => {
+        // within the org selection box
+        cy.get("[data-testid=\"combo-box-input\"]").click();
+        cy.get(`[data-testid=\"combo-box-option-${organizationId}\"]`).click();
+      });
+
+    // selects facility combo box
     cy.wait("@GetFacilitiesByOrgId");
-    cy.get("div.bg-base-lightest input").eq(1).select(facilityCreated.id);
+    cy.get("[data-testid=\"facility-selection-container\"] " +
+      "> [data-testid=\"combo-box\"]")
+      .within(() => {
+        // within the org selection box
+        cy.get("[data-testid=\"combo-box-input\"]").click();
+        cy.get(`[data-testid=\"combo-box-option-${facilityCreated.id}\"]`).click();
+      });
 
     // clicks search button
     cy.get("button").contains("Search").click();

--- a/cypress/utils/testing-data-utils.js
+++ b/cypress/utils/testing-data-utils.js
@@ -1,32 +1,47 @@
-export const whoAmI=()=>{
+export const whoAmI = () => {
   return cy.makePOSTRequest({
     operationName: "WhoAmI",
     variables: {},
     query:
-      "query WhoAmI {\n  whoami {\n organization {\n  id\n  facilities {\n      id\n    }\n  }\n} \n}",
+      "query WhoAmI {\n  whoami {\n organization {\n  id\n  facilities {\n      id\n    }\n  }\n} \n}"
   });
-}
+};
+
+export const getOrganizationById = (organizationId) => {
+  return cy.makePOSTRequest({
+    operationName: "Organization",
+    variables: { id: organizationId },
+    query:
+      `query Organization($id: ID!) {
+           organization(id: $id){
+            id
+            name
+          }
+        }`
+  });
+};
 
 
-export const addMockFacility=(facilityName)=>{
-return cy.makePOSTRequest({
-  operationName: "AddFacility",
-  variables: {
-    "testingFacilityName":facilityName,
-      "street":"123 maint street",
-      "state":"NJ","zipCode":"07601",
-      "orderingProviderFirstName":"Jane",
-      "orderingProviderLastName":"Austen",
-      "orderingProviderNPI":"1234567890",
-      "orderingProviderStreet":"",
-      "orderingProviderStreetTwo":"",
-      "orderingProviderCity":"",
-      "orderingProviderState":"",
-      "orderingProviderZipCode":"",
-      "orderingProviderPhone":"7328392412",
-      "devices":[]},
-  query:
-    `mutation AddFacility(
+export const addMockFacility = (facilityName) => {
+  return cy.makePOSTRequest({
+    operationName: "AddFacility",
+    variables: {
+      "testingFacilityName": facilityName,
+      "street": "123 maint street",
+      "state": "NJ", "zipCode": "07601",
+      "orderingProviderFirstName": "Jane",
+      "orderingProviderLastName": "Austen",
+      "orderingProviderNPI": "1234567890",
+      "orderingProviderStreet": "",
+      "orderingProviderStreetTwo": "",
+      "orderingProviderCity": "",
+      "orderingProviderState": "",
+      "orderingProviderZipCode": "",
+      "orderingProviderPhone": "7328392412",
+      "devices": []
+    },
+    query:
+      `mutation AddFacility(
   $testingFacilityName: String!
   $street: String!
   $state: String!
@@ -70,6 +85,6 @@ return cy.makePOSTRequest({
   ) {
     id
   }
-}`,
-});
+}`
+  });
 };

--- a/frontend/src/app/commonComponents/ComboBox.tsx
+++ b/frontend/src/app/commonComponents/ComboBox.tsx
@@ -1,5 +1,5 @@
 import { ComboBox as TrussComboBox, Label } from "@trussworks/react-uswds";
-import React, { ComponentPropsWithRef } from "react";
+import React, { ComponentPropsWithRef, forwardRef } from "react";
 
 import Required from "./Required";
 
@@ -10,15 +10,10 @@ export type ComboBoxProps = TrussComponentProps & {
 
 // props here are only the required ones from Truss and can be extended
 // as needed with additional values.
-const ComboBox: React.FC<ComboBoxProps> = ({
-  name,
-  id,
-  options,
-  onChange,
-  disabled,
-  ref,
-  required = false,
-}) => {
+const ComboBox: React.FC<ComboBoxProps> = forwardRef(function (
+  { id, name, required, options, onChange, disabled }: ComboBoxProps,
+  ref
+) {
   return (
     <>
       <Label htmlFor={id}>
@@ -35,6 +30,6 @@ const ComboBox: React.FC<ComboBoxProps> = ({
       />
     </>
   );
-};
+});
 
 export default ComboBox;

--- a/frontend/src/app/commonComponents/ComboBox.tsx
+++ b/frontend/src/app/commonComponents/ComboBox.tsx
@@ -1,0 +1,40 @@
+import { ComboBox as TrussComboBox, Label } from "@trussworks/react-uswds";
+import React, { ComponentPropsWithRef } from "react";
+
+import Required from "./Required";
+
+type TrussComponentProps = ComponentPropsWithRef<typeof TrussComboBox>;
+export type ComboBoxProps = TrussComponentProps & {
+  required?: boolean;
+};
+
+// props here are only the required ones from Truss and can be extended
+// as needed with additional values.
+const ComboBox: React.FC<ComboBoxProps> = ({
+  name,
+  id,
+  options,
+  onChange,
+  disabled,
+  ref,
+  required = false,
+}) => {
+  return (
+    <>
+      <Label htmlFor={id}>
+        {name} {required && <Required />}
+      </Label>
+      <TrussComboBox
+        name={name}
+        id={id}
+        options={options}
+        onChange={onChange}
+        disabled={disabled}
+        ref={ref}
+        inputProps={{ "aria-required": required }}
+      />
+    </>
+  );
+};
+
+export default ComboBox;

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilityInformation.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilityInformation.test.tsx
@@ -6,8 +6,8 @@ import { initialState, ManageFacilityState } from "./ManageFacility";
 describe("Facility Information", () => {
   const handleFacilityDelete = jest.fn();
   const mockManageFacilityState: ManageFacilityState = {
+    orgId: "123",
     facilityId: "123",
-    orgId: "456",
     facility: {
       city: "New York",
       state: "NY",

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilityInformation.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilityInformation.test.tsx
@@ -6,8 +6,8 @@ import { initialState, ManageFacilityState } from "./ManageFacility";
 describe("Facility Information", () => {
   const handleFacilityDelete = jest.fn();
   const mockManageFacilityState: ManageFacilityState = {
-    orgId: "123",
     facilityId: "123",
+    orgId: "456",
     facility: {
       city: "New York",
       state: "NY",

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
@@ -1,13 +1,8 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { ComboBoxRef } from "@trussworks/react-uswds";
+import userEvent from "@testing-library/user-event";
 
 import { Option } from "../../commonComponents/Dropdown";
 
@@ -69,6 +64,7 @@ describe("FacilitySelectFilter", () => {
       </MemoryRouter>
     );
   };
+  const user = userEvent.setup();
 
   it("disables controls when loading data", () => {
     renderWithMocks([], [], initialState);
@@ -90,16 +86,16 @@ describe("FacilitySelectFilter", () => {
       name: /clear facility selection filters/i,
     });
     expect(clearFiltersBtn).toBeEnabled();
-    fireEvent.click(clearFiltersBtn);
+    await act(() => user.click(clearFiltersBtn));
     await waitFor(() => expect(handleClearFilter).toHaveBeenCalled());
   });
 
   it("calls event handlers when organization is selected", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, initialState);
 
-    const [orgDropdown] = getOrgComboBoxElements();
+    const [, orgDropdown] = getOrgComboBoxElements();
 
-    fireEvent.change(orgDropdown, { target: { value: "123" } });
+    await act(() => user.selectOptions(orgDropdown, ["organization-123"]));
     await waitFor(() => expect(handleSelectOrg).toHaveBeenCalled());
   });
 
@@ -110,8 +106,8 @@ describe("FacilitySelectFilter", () => {
       facility: undefined,
     });
 
-    const [facilityDropdown] = getFacilityComboBoxElements();
-    fireEvent.change(facilityDropdown, { target: { value: "123" } });
+    const [, facilityDropdown] = getFacilityComboBoxElements();
+    await act(() => user.selectOptions(facilityDropdown, ["facility-123"]));
     await waitFor(() => expect(handleSelectFacility).toHaveBeenCalled());
   });
 
@@ -126,7 +122,7 @@ describe("FacilitySelectFilter", () => {
       name: /search/i,
     });
     expect(searchBtn).toBeEnabled();
-    fireEvent.click(searchBtn);
+    await act(() => user.click(searchBtn));
 
     await waitFor(() => expect(handleSearch).toHaveBeenCalled());
   });

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
@@ -14,6 +14,25 @@ import { Option } from "../../commonComponents/Dropdown";
 import FacilitySelectFilter from "./FacilitySelectFilter";
 import { initialState, ManageFacilityState } from "./ManageFacility";
 
+export const getOrgComboBoxElements = () => {
+  const orgSelectionDiv = screen.getByTestId("org-selection-container");
+  const orgComboBoxInput = screen.getByLabelText("Organization *");
+  const orgComboBoxList = within(orgSelectionDiv).getByTestId(
+    "combo-box-option-list"
+  );
+  return [orgComboBoxInput, orgComboBoxList] as const;
+};
+
+export const getFacilityComboBoxElements = () => {
+  const facilitySelectionDiv = screen.getByTestId(
+    "facility-selection-container"
+  );
+  const facilityComboBoxInput = screen.getByLabelText("Testing facility *");
+  const facilityComboBoxList = within(facilitySelectionDiv).getByTestId(
+    "combo-box-option-list"
+  );
+  return [facilityComboBoxInput, facilityComboBoxList] as const;
+};
 describe("FacilitySelectFilter", () => {
   const handleClearFilter = jest.fn();
   const handleSelectOrg = jest.fn();
@@ -54,11 +73,8 @@ describe("FacilitySelectFilter", () => {
   it("disables controls when loading data", () => {
     renderWithMocks([], [], initialState);
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgDropdown = within(orgSelectionDiv).getByRole("combobox");
-
-    const facilitySelectionDiv = screen.getByText("Testing facility");
-    const facilityDropdown = within(facilitySelectionDiv).getByRole("combobox");
+    const [orgDropdown] = getOrgComboBoxElements();
+    const [facilityDropdown] = getFacilityComboBoxElements();
 
     expect(facilityDropdown).toBeDisabled();
     expect(orgDropdown).toBeDisabled();
@@ -81,8 +97,7 @@ describe("FacilitySelectFilter", () => {
   it("calls event handlers when organization is selected", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, initialState);
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgDropdown = within(orgSelectionDiv).getByRole("combobox");
+    const [orgDropdown] = getOrgComboBoxElements();
 
     fireEvent.change(orgDropdown, { target: { value: "123" } });
     await waitFor(() => expect(handleSelectOrg).toHaveBeenCalled());
@@ -95,9 +110,7 @@ describe("FacilitySelectFilter", () => {
       orgId: "",
     });
 
-    const facilitySelectionDiv = screen.getByText("Testing facility");
-    const facilityDropdown = within(facilitySelectionDiv).getByRole("combobox");
-
+    const [facilityDropdown] = getFacilityComboBoxElements();
     fireEvent.change(facilityDropdown, { target: { value: "123" } });
     await waitFor(() => expect(handleSelectFacility).toHaveBeenCalled());
   });

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
@@ -101,7 +101,7 @@ describe("FacilitySelectFilter", () => {
 
   it("calls event handlers when facility is selected", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, {
-      orgId: undefined,
+      orgId: "123",
       facilityId: undefined,
       facility: undefined,
     });
@@ -113,7 +113,7 @@ describe("FacilitySelectFilter", () => {
 
   it("calls event handlers when search button is clicked", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, {
-      orgId: undefined,
+      orgId: "123",
       facilityId: "123",
       facility: undefined,
     });

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
@@ -57,11 +57,11 @@ describe("FacilitySelectFilter", () => {
         <FacilitySelectFilter
           organizationOptions={orgOptions}
           facilityOptions={facilityOptions}
-          manageFacilityState={manageFacilityState}
           onClearFilter={handleClearFilter}
           onSelectOrg={handleSelectOrg}
           onSelectFacility={handleSelectFacility}
           onSearch={handleSearch}
+          manageFacilityState={manageFacilityState}
           loading={true}
           orgRef={orgRef}
           facilityRef={facilityRef}
@@ -82,9 +82,9 @@ describe("FacilitySelectFilter", () => {
 
   it("calls handleClearFilter upon clicking clear filters button", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, {
+      orgId: "123",
       facilityId: undefined,
       facility: undefined,
-      orgId: "123",
     });
     const clearFiltersBtn = screen.getByRole("button", {
       name: /clear facility selection filters/i,
@@ -105,9 +105,9 @@ describe("FacilitySelectFilter", () => {
 
   it("calls event handlers when facility is selected", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, {
-      facilityId: "",
+      orgId: undefined,
+      facilityId: undefined,
       facility: undefined,
-      orgId: "",
     });
 
     const [facilityDropdown] = getFacilityComboBoxElements();
@@ -117,9 +117,9 @@ describe("FacilitySelectFilter", () => {
 
   it("calls event handlers when search button is clicked", async () => {
     renderWithMocks(mockOrganizationOptions, mockFacilityOptions, {
+      orgId: undefined,
       facilityId: "123",
       facility: undefined,
-      orgId: undefined,
     });
 
     const searchBtn = screen.getByRole("button", {

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.test.tsx
@@ -11,7 +11,7 @@ import { initialState, ManageFacilityState } from "./ManageFacility";
 
 export const getOrgComboBoxElements = () => {
   const orgSelectionDiv = screen.getByTestId("org-selection-container");
-  const orgComboBoxInput = screen.getByLabelText("Organization *");
+  const orgComboBoxInput = screen.getByLabelText(/organization/i);
   const orgComboBoxList = within(orgSelectionDiv).getByTestId(
     "combo-box-option-list"
   );
@@ -22,7 +22,7 @@ export const getFacilityComboBoxElements = () => {
   const facilitySelectionDiv = screen.getByTestId(
     "facility-selection-container"
   );
-  const facilityComboBoxInput = screen.getByLabelText("Testing facility *");
+  const facilityComboBoxInput = screen.getByLabelText(/testing facility/i);
   const facilityComboBoxList = within(facilitySelectionDiv).getByTestId(
     "combo-box-option-list"
   );

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
@@ -1,21 +1,25 @@
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
-import React from "react";
+import React, { Ref } from "react";
+import { ComboBox, ComboBoxRef } from "@trussworks/react-uswds";
 
-import Dropdown, { Option } from "../../commonComponents/Dropdown";
 import Button from "../../commonComponents/Button/Button";
 import SupportHomeLink from "../SupportHomeLink";
+import { Option } from "../../commonComponents/Dropdown";
+import Required from "../../commonComponents/Required";
 
 import { ManageFacilityState } from "./ManageFacility";
 
 export interface FacilitySelectFilterProps {
   organizationOptions: Option[];
   facilityOptions: Option[];
-  onClearFilter: () => void;
-  onSelectOrg: (e: any) => void;
-  onSelectFacility: (e: any) => void;
-  onSearch: (e: any) => void;
   manageFacilityState: ManageFacilityState;
+  onClearFilter: () => void;
+  onSelectOrg: (selectedOrg: string | undefined) => void;
+  onSelectFacility: (selectedFacility: string | undefined) => void;
+  onSearch: (e: any) => void;
   loading: boolean;
+  facilityRef: Ref<ComboBoxRef> | undefined;
+  orgRef: Ref<ComboBoxRef> | undefined;
 }
 
 const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
@@ -27,6 +31,8 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
   onSelectFacility,
   onSearch,
   loading,
+  facilityRef,
+  orgRef,
 }) => {
   /**
    * HTML
@@ -43,7 +49,7 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
             <div className="desktop:grid-col-auto tablet:grid-col-auto mobile:grid-col-12 margin-top-2 tablet:margin-top-0">
               <Button
                 icon={faSlidersH}
-                disabled={manageFacilityState.orgId === ""}
+                disabled={manageFacilityState.orgId === undefined}
                 onClick={onClearFilter}
                 ariaLabel="Clear facility selection filters"
               >
@@ -58,40 +64,36 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
         className="bg-base-lightest padding-left-3 padding-right-3 padding-bottom-1"
       >
         <div className="grid-row grid-gap padding-bottom-2 flex-align-end">
-          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
-            <Dropdown
-              label="Organization"
-              options={[
-                {
-                  label: "- Select -",
-                  value: "",
-                },
-                ...organizationOptions,
-              ]}
-              onChange={onSelectOrg}
-              selectedValue={manageFacilityState.orgId}
+          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em">
+            <Required label={"Organization"}></Required>
+            <ComboBox
+              name={"Organization"}
+              id={"manage-facility-org-select"}
+              options={organizationOptions}
+              onChange={(val) => {
+                onSelectOrg(val);
+              }}
               disabled={loading}
-              required={true}
+              ref={orgRef}
             />
           </div>
-          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
-            <Dropdown
-              label="Testing facility"
-              options={[
-                {
-                  label: "- Select -",
-                  value: "",
-                },
-                ...facilityOptions,
-              ]}
-              onChange={onSelectFacility}
-              selectedValue={manageFacilityState.facilityId}
+          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em">
+            <Required label={"Testing facility"}></Required>
+            <ComboBox
+              name={"Facility"}
+              id={"manage-facility-facility-select"}
+              options={facilityOptions}
+              onChange={(val) => onSelectFacility(val)}
               disabled={loading}
-              required={true}
+              ref={facilityRef}
             />
           </div>
-          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
-            <Button onClick={onSearch} ariaLabel="Search facility selection">
+          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 ">
+            <Button
+              onClick={onSearch}
+              disabled={manageFacilityState.facilityId === undefined}
+              ariaLabel="Search facility selection"
+            >
               Search
             </Button>
           </div>

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
@@ -85,7 +85,7 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
             className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em"
           >
             <ComboBox
-              name={"Facility"}
+              name={"Testing facility"}
               id={"manage-facility-facility-select"}
               options={facilityOptions}
               onChange={(val) => onSelectFacility(val)}

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
@@ -1,11 +1,11 @@
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
 import React, { Ref } from "react";
-import { ComboBox, ComboBoxRef, Label } from "@trussworks/react-uswds";
+import { ComboBoxRef } from "@trussworks/react-uswds";
 
+import ComboBox from "../../commonComponents/ComboBox";
 import Button from "../../commonComponents/Button/Button";
 import SupportHomeLink from "../SupportHomeLink";
 import { Option } from "../../commonComponents/Dropdown";
-import Required from "../../commonComponents/Required";
 
 import { ManageFacilityState } from "./ManageFacility";
 
@@ -68,9 +68,6 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
             data-testid={"org-selection-container"}
             className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em"
           >
-            <Label htmlFor="manage-facility-org-select">
-              Organization <Required />
-            </Label>
             <ComboBox
               name={"Organization"}
               id={"manage-facility-org-select"}
@@ -80,16 +77,13 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
               }}
               disabled={loading}
               ref={orgRef}
+              required
             />
           </div>
           <div
             data-testid={"facility-selection-container"}
             className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em"
           >
-            <Label htmlFor="manage-facility-facility-select">
-              Testing facility <Required />
-            </Label>
-
             <ComboBox
               name={"Facility"}
               id={"manage-facility-facility-select"}
@@ -97,6 +91,7 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
               onChange={(val) => onSelectFacility(val)}
               disabled={loading}
               ref={facilityRef}
+              required
             />
           </div>
           <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 ">

--- a/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/FacilitySelectFilter.tsx
@@ -1,6 +1,6 @@
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
 import React, { Ref } from "react";
-import { ComboBox, ComboBoxRef } from "@trussworks/react-uswds";
+import { ComboBox, ComboBoxRef, Label } from "@trussworks/react-uswds";
 
 import Button from "../../commonComponents/Button/Button";
 import SupportHomeLink from "../SupportHomeLink";
@@ -64,8 +64,13 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
         className="bg-base-lightest padding-left-3 padding-right-3 padding-bottom-1"
       >
         <div className="grid-row grid-gap padding-bottom-2 flex-align-end">
-          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em">
-            <Required label={"Organization"}></Required>
+          <div
+            data-testid={"org-selection-container"}
+            className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em"
+          >
+            <Label htmlFor="manage-facility-org-select">
+              Organization <Required />
+            </Label>
             <ComboBox
               name={"Organization"}
               id={"manage-facility-org-select"}
@@ -77,8 +82,14 @@ const FacilitySelectFilter: React.FC<FacilitySelectFilterProps> = ({
               ref={orgRef}
             />
           </div>
-          <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em">
-            <Required label={"Testing facility"}></Required>
+          <div
+            data-testid={"facility-selection-container"}
+            className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1 margin-top-1em"
+          >
+            <Label htmlFor="manage-facility-facility-select">
+              Testing facility <Required />
+            </Label>
+
             <ComboBox
               name={"Facility"}
               id={"manage-facility-facility-select"}

--- a/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
@@ -31,6 +31,8 @@ describe("ManageFacility", () => {
       name: /clear facility selection filters/i,
     });
 
+  const user = userEvent.setup();
+
   beforeEach(() => {
     renderWithMocks();
   });
@@ -53,12 +55,10 @@ describe("ManageFacility", () => {
     const [orgComboBoxInput, orgComboBoxList] = getOrgComboBoxElements();
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
-    await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
+    await act(async () => await user.type(orgComboBoxInput, "dis"));
     await act(
       async () =>
-        await userEvent.click(
-          within(orgComboBoxList).getByText("Dis Organization")
-        )
+        await user.click(within(orgComboBoxList).getByText("Dis Organization"))
     );
     expect(orgComboBoxInput).toHaveValue("Dis Organization");
     expect(clearFiltersBtn).toBeEnabled();
@@ -73,16 +73,14 @@ describe("ManageFacility", () => {
     const [orgComboBoxInput, orgComboBoxList] = getOrgComboBoxElements();
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
 
-    await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
+    await act(async () => await user.type(orgComboBoxInput, "dis"));
     await act(
       async () =>
-        await userEvent.click(
-          within(orgComboBoxList).getByText("Dis Organization")
-        )
+        await user.click(within(orgComboBoxList).getByText("Dis Organization"))
     );
 
     await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
-    await act(async () => await userEvent.click(clearFiltersBtn));
+    await act(async () => await user.click(clearFiltersBtn));
 
     await waitFor(() => expect(clearFiltersBtn).toBeDisabled());
     expect(orgComboBoxInput).toHaveValue("");
@@ -98,43 +96,39 @@ describe("ManageFacility", () => {
       getFacilityComboBoxElements();
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
-    await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
+    await act(async () => await user.type(orgComboBoxInput, "dis"));
     await act(
       async () =>
-        await userEvent.click(
-          within(orgComboBoxList).getByText("Dis Organization")
-        )
+        await user.click(within(orgComboBoxList).getByText("Dis Organization"))
     );
 
     await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());
     await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
     await act(
-      async () => await userEvent.type(facilityComboBoxInput, "testing site")
+      async () => await user.type(facilityComboBoxInput, "testing site")
     );
     await act(
       async () =>
-        await userEvent.click(
-          within(facilityComboBoxList).getByText("Testing Site")
-        )
+        await user.click(within(facilityComboBoxList).getByText("Testing Site"))
     );
 
     const searchBtn = screen.getByRole("button", {
       name: /search/i,
     });
-    await act(async () => await userEvent.click(searchBtn));
+    await act(async () => await user.click(searchBtn));
 
     await screen.findByRole("heading", { name: /Testing Site/i });
 
     const deleteFacilityBtn = screen.getByRole("button", {
       name: /delete facility testing site/i,
     });
-    await act(async () => await userEvent.click(deleteFacilityBtn));
+    await act(async () => await user.click(deleteFacilityBtn));
 
     await screen.findByRole("heading", { name: /delete testing site/i });
     const yesDeleteBtn = screen.getByRole("button", {
       name: /yes, delete facility/i,
     });
-    await act(async () => await userEvent.click(yesDeleteBtn));
+    await act(async () => await user.click(yesDeleteBtn));
 
     await waitFor(() =>
       expect(
@@ -158,20 +152,18 @@ describe("ManageFacility", () => {
       getFacilityComboBoxElements();
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
-    await act(async () => await userEvent.type(orgComboBoxInput, "dat"));
+    await act(async () => await user.type(orgComboBoxInput, "dat"));
     await act(
       async () =>
-        await userEvent.click(
-          within(orgComboBoxList).getByText("Dat Organization")
-        )
+        await user.click(within(orgComboBoxList).getByText("Dat Organization"))
     );
 
     await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());
     expect(clearFiltersBtn).toBeEnabled();
-    await act(async () => await userEvent.type(facilityComboBoxInput, "incom"));
+    await act(async () => await user.type(facilityComboBoxInput, "incom"));
     await act(
       async () =>
-        await userEvent.click(
+        await user.click(
           within(facilityComboBoxList).getByText("Incomplete Site")
         )
     );
@@ -179,7 +171,7 @@ describe("ManageFacility", () => {
     const searchBtn = screen.getByRole("button", {
       name: /search/i,
     });
-    await act(async () => await userEvent.click(searchBtn));
+    await act(async () => await user.click(searchBtn));
 
     await screen.findByRole("heading", { name: /Incomplete Site/i });
   });

--- a/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
@@ -54,12 +54,13 @@ describe("ManageFacility", () => {
     );
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
-    await act(async () => {
-      await userEvent.type(orgComboBoxInput, "dis");
-      await userEvent.click(
-        within(orgComboBoxList).getByText("Dis Organization")
-      );
-    });
+    await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
+    await act(
+      async () =>
+        await userEvent.click(
+          within(orgComboBoxList).getByText("Dis Organization")
+        )
+    );
     expect(orgComboBoxInput).toHaveValue("Dis Organization");
     expect(clearFiltersBtn).toBeEnabled();
 
@@ -77,17 +78,16 @@ describe("ManageFacility", () => {
     );
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
 
-    await act(async () => {
-      await userEvent.type(orgComboBoxInput, "dis");
-      await userEvent.click(
-        within(orgComboBoxList).getByText("Dis Organization")
-      );
-    });
+    await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
+    await act(
+      async () =>
+        await userEvent.click(
+          within(orgComboBoxList).getByText("Dis Organization")
+        )
+    );
 
     await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
-    await act(async () => {
-      await userEvent.click(clearFiltersBtn);
-    });
+    await act(async () => await userEvent.click(clearFiltersBtn));
 
     await waitFor(() => expect(clearFiltersBtn).toBeDisabled());
     expect(orgComboBoxInput).toHaveValue("");
@@ -112,45 +112,43 @@ describe("ManageFacility", () => {
     );
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
-    await act(async () => {
-      await userEvent.type(orgComboBoxInput, "dis");
-      await userEvent.click(
-        within(orgComboBoxList).getByText("Dis Organization")
-      );
-    });
+    await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
+    await act(
+      async () =>
+        await userEvent.click(
+          within(orgComboBoxList).getByText("Dis Organization")
+        )
+    );
 
     await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());
     await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
-    await act(async () => {
-      await userEvent.type(facilityComboBoxInput, "testing site");
-      await userEvent.click(
-        within(facilityComboBoxList).getByText("Testing Site")
-      );
-    });
+    await act(
+      async () => await userEvent.type(facilityComboBoxInput, "testing site")
+    );
+    await act(
+      async () =>
+        await userEvent.click(
+          within(facilityComboBoxList).getByText("Testing Site")
+        )
+    );
 
     const searchBtn = screen.getByRole("button", {
       name: /search/i,
     });
-    await act(async () => {
-      await userEvent.click(searchBtn);
-    });
+    await act(async () => await userEvent.click(searchBtn));
 
     await screen.findByRole("heading", { name: /Testing Site/i });
 
     const deleteFacilityBtn = screen.getByRole("button", {
       name: /delete facility testing site/i,
     });
-    await act(async () => {
-      await userEvent.click(deleteFacilityBtn);
-    });
+    await act(async () => await userEvent.click(deleteFacilityBtn));
 
     await screen.findByRole("heading", { name: /delete testing site/i });
     const yesDeleteBtn = screen.getByRole("button", {
       name: /yes, delete facility/i,
     });
-    await act(async () => {
-      await userEvent.click(yesDeleteBtn);
-    });
+    await act(async () => await userEvent.click(yesDeleteBtn));
 
     await waitFor(() =>
       expect(
@@ -176,12 +174,13 @@ describe("ManageFacility", () => {
     );
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
-    await act(async () => {
-      await userEvent.type(orgComboBoxInput, "dat");
-      await userEvent.click(
-        within(orgComboBoxList).getByText("Dat Organization")
-      );
-    });
+    await act(async () => await userEvent.type(orgComboBoxInput, "dat"));
+    await act(
+      async () =>
+        await userEvent.click(
+          within(orgComboBoxList).getByText("Dat Organization")
+        )
+    );
 
     const facilitySelectionDiv = screen.getByText("Testing facility");
     const facilityComboBoxInput =
@@ -192,19 +191,18 @@ describe("ManageFacility", () => {
 
     await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());
     expect(clearFiltersBtn).toBeEnabled();
-    await act(async () => {
-      await userEvent.type(facilityComboBoxInput, "incom");
-      await userEvent.click(
-        within(facilityComboBoxList).getByText("Incomplete Site")
-      );
-    });
+    await act(async () => await userEvent.type(facilityComboBoxInput, "incom"));
+    await act(
+      async () =>
+        await userEvent.click(
+          within(facilityComboBoxList).getByText("Incomplete Site")
+        )
+    );
 
     const searchBtn = screen.getByRole("button", {
       name: /search/i,
     });
-    await act(async () => {
-      await userEvent.click(searchBtn);
-    });
+    await act(async () => await userEvent.click(searchBtn));
 
     await screen.findByRole("heading", { name: /Incomplete Site/i });
   });

--- a/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import userEvent from "@testing-library/user-event";
 
 import {
   DeleteFacilityDocument,
@@ -34,9 +35,9 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgDropdown = screen.getByRole("combobox", { name: /organization/i });
+    const orgSelectionDiv = screen.getByText("Organization");
+    const orgDropdown = within(orgSelectionDiv).getByRole("combobox");
     await waitFor(() => expect(orgDropdown).toBeEnabled());
-    fireEvent.change(orgDropdown, { target: { value: "" } }); // picks -Select- option
 
     expect(clearFiltersBtn).toBeDisabled();
     expect(screen.getByText(/No facility selected/)).toBeInTheDocument();
@@ -46,38 +47,50 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgDropdown = screen.getByRole("combobox", { name: /organization/i });
-    await waitFor(() => expect(orgDropdown).toBeEnabled());
-    fireEvent.change(orgDropdown, {
-      target: { value: "604f2e80-b4b7-4fff-806a-2a77973aa08f" },
-    }); // picks Dis Organization
+    const orgSelectionDiv = screen.getByText("Organization");
+    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
+    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
+      "combo-box-option-list"
+    );
 
-    const facilityDropdown = screen.getByRole("combobox", {
-      name: /facility/i,
+    await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
+    await act(async () => {
+      await userEvent.type(orgComboBoxInput, "dis");
+      await userEvent.click(
+        within(orgComboBoxList).getByText("Dis Organization")
+      );
     });
-    await waitFor(() => expect(facilityDropdown).toBeEnabled());
+    expect(orgComboBoxInput).toHaveValue("Dis Organization");
     expect(clearFiltersBtn).toBeEnabled();
-    fireEvent.change(facilityDropdown, { target: { value: "" } }); // picks -Select-
 
-    await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
-    expect(screen.getByText(/No facility selected/)).toBeInTheDocument();
+    await screen.findByText(/No facility selected/);
   });
 
   it("resets the controls after clicking clear filters", async () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgDropdown = screen.getByRole("combobox", { name: /organization/i });
-    await waitFor(() => expect(orgDropdown).toBeEnabled());
-    fireEvent.change(orgDropdown, {
-      target: { value: "604f2e80-b4b7-4fff-806a-2a77973aa08f" },
-    }); // picks Dis Organization
+    const orgSelectionDiv = screen.getByText("Organization");
+    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
+    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
+      "combo-box-option-list"
+    );
+    await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
+
+    await act(async () => {
+      await userEvent.type(orgComboBoxInput, "dis");
+      await userEvent.click(
+        within(orgComboBoxList).getByText("Dis Organization")
+      );
+    });
 
     await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
-    fireEvent.click(clearFiltersBtn);
+    await act(async () => {
+      await userEvent.click(clearFiltersBtn);
+    });
 
     await waitFor(() => expect(clearFiltersBtn).toBeDisabled());
-    expect(orgDropdown).toHaveValue("");
+    expect(orgComboBoxInput).toHaveValue("");
     expect(screen.getByText(/No facility selected/)).toBeInTheDocument();
   });
 
@@ -85,38 +98,59 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgDropdown = screen.getByRole("combobox", { name: /organization/i });
-    await waitFor(() => expect(orgDropdown).toBeEnabled());
-    fireEvent.change(orgDropdown, {
-      target: { value: "604f2e80-b4b7-4fff-806a-2a77973aa08f" },
-    }); // picks Dis Organization
+    const orgSelectionDiv = screen.getByText("Organization");
+    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
+    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
+      "combo-box-option-list"
+    );
 
-    const facilityDropdown = screen.getByRole("combobox", {
-      name: /facility/i,
+    const facilitySelectionDiv = screen.getByText("Testing facility");
+    const facilityComboBoxInput =
+      within(facilitySelectionDiv).getByRole("combobox");
+    const facilityComboBoxList = within(facilitySelectionDiv).getByTestId(
+      "combo-box-option-list"
+    );
+
+    await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
+    await act(async () => {
+      await userEvent.type(orgComboBoxInput, "dis");
+      await userEvent.click(
+        within(orgComboBoxList).getByText("Dis Organization")
+      );
     });
-    await waitFor(() => expect(facilityDropdown).toBeEnabled());
-    expect(clearFiltersBtn).toBeEnabled();
-    fireEvent.change(facilityDropdown, {
-      target: { value: "1919865a-92eb-4c46-b73b-471b02b131b7" },
-    }); // picks testing site
+
+    await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());
+    await waitFor(() => expect(clearFiltersBtn).toBeEnabled());
+    await act(async () => {
+      await userEvent.type(facilityComboBoxInput, "testing site");
+      await userEvent.click(
+        within(facilityComboBoxList).getByText("Testing Site")
+      );
+    });
 
     const searchBtn = screen.getByRole("button", {
       name: /search/i,
     });
-    fireEvent.click(searchBtn);
+    await act(async () => {
+      await userEvent.click(searchBtn);
+    });
 
     await screen.findByRole("heading", { name: /Testing Site/i });
 
     const deleteFacilityBtn = screen.getByRole("button", {
       name: /delete facility testing site/i,
     });
-    fireEvent.click(deleteFacilityBtn);
+    await act(async () => {
+      await userEvent.click(deleteFacilityBtn);
+    });
 
     await screen.findByRole("heading", { name: /delete testing site/i });
     const yesDeleteBtn = screen.getByRole("button", {
       name: /yes, delete facility/i,
     });
-    fireEvent.click(yesDeleteBtn);
+    await act(async () => {
+      await userEvent.click(yesDeleteBtn);
+    });
 
     await waitFor(() =>
       expect(
@@ -126,8 +160,8 @@ describe("ManageFacility", () => {
 
     // Facility testing site successfully deleted
     // page resets
-    await waitFor(() => expect(orgDropdown).toHaveValue(""));
-    expect(facilityDropdown).toHaveValue("");
+    await waitFor(() => expect(orgComboBoxInput).toHaveValue(""));
+    expect(facilityComboBoxInput).toHaveValue("");
     expect(clearFiltersBtn).toBeDisabled();
   });
 
@@ -135,25 +169,42 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgDropdown = screen.getByRole("combobox", { name: /organization/i });
-    await waitFor(() => expect(orgDropdown).toBeEnabled());
-    fireEvent.change(orgDropdown, {
-      target: { value: "09cdf298-39b3-41b0-92f7-092c2bfe065e" },
-    }); // picks Dis Organization
+    const orgSelectionDiv = screen.getByText("Organization");
+    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
+    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
+      "combo-box-option-list"
+    );
 
-    const facilityDropdown = screen.getByRole("combobox", {
-      name: /facility/i,
+    await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
+    await act(async () => {
+      await userEvent.type(orgComboBoxInput, "dat");
+      await userEvent.click(
+        within(orgComboBoxList).getByText("Dat Organization")
+      );
     });
-    await waitFor(() => expect(facilityDropdown).toBeEnabled());
+
+    const facilitySelectionDiv = screen.getByText("Testing facility");
+    const facilityComboBoxInput =
+      within(facilitySelectionDiv).getByRole("combobox");
+    const facilityComboBoxList = within(facilitySelectionDiv).getByTestId(
+      "combo-box-option-list"
+    );
+
+    await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());
     expect(clearFiltersBtn).toBeEnabled();
-    fireEvent.change(facilityDropdown, {
-      target: { value: "1919865a-92eb-4c46-b73b-471b02b131b8" },
-    }); // picks testing site
+    await act(async () => {
+      await userEvent.type(facilityComboBoxInput, "incom");
+      await userEvent.click(
+        within(facilityComboBoxList).getByText("Incomplete Site")
+      );
+    });
 
     const searchBtn = screen.getByRole("button", {
       name: /search/i,
     });
-    fireEvent.click(searchBtn);
+    await act(async () => {
+      await userEvent.click(searchBtn);
+    });
 
     await screen.findByRole("heading", { name: /Incomplete Site/i });
   });

--- a/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.test.tsx
@@ -11,6 +11,10 @@ import {
 } from "../../../generated/graphql";
 
 import ManageFacility from "./ManageFacility";
+import {
+  getFacilityComboBoxElements,
+  getOrgComboBoxElements,
+} from "./FacilitySelectFilter.test";
 
 describe("ManageFacility", () => {
   const renderWithMocks = () =>
@@ -35,9 +39,8 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgDropdown = within(orgSelectionDiv).getByRole("combobox");
-    await waitFor(() => expect(orgDropdown).toBeEnabled());
+    const [orgComboBoxInput] = getOrgComboBoxElements();
+    await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
 
     expect(clearFiltersBtn).toBeDisabled();
     expect(screen.getByText(/No facility selected/)).toBeInTheDocument();
@@ -47,11 +50,7 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
-    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
-      "combo-box-option-list"
-    );
+    const [orgComboBoxInput, orgComboBoxList] = getOrgComboBoxElements();
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
     await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
@@ -71,11 +70,7 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
-    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
-      "combo-box-option-list"
-    );
+    const [orgComboBoxInput, orgComboBoxList] = getOrgComboBoxElements();
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
 
     await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
@@ -98,18 +93,9 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
-    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
-      "combo-box-option-list"
-    );
-
-    const facilitySelectionDiv = screen.getByText("Testing facility");
-    const facilityComboBoxInput =
-      within(facilitySelectionDiv).getByRole("combobox");
-    const facilityComboBoxList = within(facilitySelectionDiv).getByTestId(
-      "combo-box-option-list"
-    );
+    const [orgComboBoxInput, orgComboBoxList] = getOrgComboBoxElements();
+    const [facilityComboBoxInput, facilityComboBoxList] =
+      getFacilityComboBoxElements();
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
     await act(async () => await userEvent.type(orgComboBoxInput, "dis"));
@@ -167,11 +153,9 @@ describe("ManageFacility", () => {
     const clearFiltersBtn = getClearFilterBtn();
     expect(clearFiltersBtn).toBeDisabled();
 
-    const orgSelectionDiv = screen.getByText("Organization");
-    const orgComboBoxInput = within(orgSelectionDiv).getByRole("combobox");
-    const orgComboBoxList = within(orgSelectionDiv).getByTestId(
-      "combo-box-option-list"
-    );
+    const [orgComboBoxInput, orgComboBoxList] = getOrgComboBoxElements();
+    const [facilityComboBoxInput, facilityComboBoxList] =
+      getFacilityComboBoxElements();
 
     await waitFor(() => expect(orgComboBoxInput).toBeEnabled());
     await act(async () => await userEvent.type(orgComboBoxInput, "dat"));
@@ -180,13 +164,6 @@ describe("ManageFacility", () => {
         await userEvent.click(
           within(orgComboBoxList).getByText("Dat Organization")
         )
-    );
-
-    const facilitySelectionDiv = screen.getByText("Testing facility");
-    const facilityComboBoxInput =
-      within(facilitySelectionDiv).getByRole("combobox");
-    const facilityComboBoxList = within(facilitySelectionDiv).getByTestId(
-      "combo-box-option-list"
     );
 
     await waitFor(() => expect(facilityComboBoxInput).toBeEnabled());

--- a/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { ComboBoxRef } from "@trussworks/react-uswds";
 
 import { Option } from "../../commonComponents/Dropdown";
@@ -169,7 +169,6 @@ const ManageFacility = () => {
    * Delete facility
    */
   const [deleteFacilityMutation] = useDeleteFacilityMutation();
-
   function handleDeleteFacility() {
     if (localState.facilityId) {
       deleteFacilityMutation({

--- a/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.tsx
+++ b/frontend/src/app/supportAdmin/ManageFacility/ManageFacility.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import { ComboBoxRef } from "@trussworks/react-uswds";
 
 import { Option } from "../../commonComponents/Dropdown";
 import {
@@ -27,14 +28,14 @@ type Facility = {
 };
 
 export interface ManageFacilityState {
-  orgId: string;
-  facilityId: string;
+  orgId: string | undefined;
+  facilityId: string | undefined;
   facility: Facility | undefined;
 }
 
 export const initialState: ManageFacilityState = {
-  orgId: "",
-  facilityId: "",
+  facilityId: undefined,
+  orgId: undefined,
   facility: undefined,
 };
 
@@ -42,12 +43,22 @@ const ManageFacility = () => {
   useDocumentTitle(manageFacility);
   const [localState, updateLocalState] =
     useState<ManageFacilityState>(initialState);
+  const orgSelectionRef = useRef<ComboBoxRef>(null);
+  const facilitySelectionRef = useRef<ComboBoxRef>(null);
 
   /**
    * Fetch organizations (on initial load)
    */
   const { data: orgResponse, loading: loadingOrgs } =
-    useGetAllOrganizationsQuery();
+    useGetAllOrganizationsQuery({
+      onCompleted: () => {
+        // for some reason, our combination of Truss + Apollo requires us clear
+        // a non-existent ref so that the options to the org combobox loads
+        // on first try. If we exclude this line, the fetched data doesn't load
+        // on initial render. ¯\_(ツ)_/¯
+        orgSelectionRef.current?.clearSelection();
+      },
+    });
 
   const orgOptions: Option[] =
     orgResponse?.organizations?.map((org) => ({
@@ -64,7 +75,8 @@ const ManageFacility = () => {
   ] = useGetFacilitiesByOrgIdLazyQuery();
 
   const facilitiesOptions: Option[] =
-    localState.orgId === "" || !facilitiesResponse?.organization?.facilities
+    localState.orgId === undefined ||
+    !facilitiesResponse?.organization?.facilities
       ? []
       : facilitiesResponse?.organization?.facilities.map((facility) => ({
           value: facility.id,
@@ -79,52 +91,60 @@ const ManageFacility = () => {
   /**
    * Facility select filter handlers
    */
-  function handleSelectOrganization(e: React.ChangeEvent<HTMLSelectElement>) {
-    const selectedOrg = e.target.value;
-    if (selectedOrg !== "") {
+  function handleSelectOrganization(selectedOrg: string | undefined) {
+    if (selectedOrg) {
       queryGetFacilitiesByOrgId({
         variables: { orgId: selectedOrg },
         fetchPolicy: "no-cache",
-      }).then();
+      }).then(() => facilitySelectionRef.current?.clearSelection());
+
+      updateLocalState({
+        facility: undefined,
+        facilityId: undefined,
+        orgId: selectedOrg,
+      });
+    } else {
+      orgSelectionRef.current?.clearSelection();
+      facilitySelectionRef.current?.clearSelection();
+
+      updateLocalState({
+        facility: undefined,
+        facilityId: undefined,
+        orgId: undefined,
+      });
     }
-
-    updateLocalState((prevState) => ({
-      ...prevState,
-      orgId: selectedOrg,
-      facilityId: "",
-    }));
   }
-  async function handleSelectFacility(e: React.ChangeEvent<HTMLSelectElement>) {
-    const facilityId = e.target.value;
 
+  async function handleSelectFacility(selectedFacility: string | undefined) {
     updateLocalState((prevState) => ({
       ...prevState,
-      facilityId: facilityId,
+      facilityId: selectedFacility,
     }));
   }
 
   async function handleSearch() {
     const facilityId = localState.facilityId;
 
-    if (facilityId === "") {
+    if (facilityId === undefined) {
       updateLocalState((prevState) => ({
         ...prevState,
         facility: undefined,
       }));
     } else {
+      const localSelectedFacilityId = localState.facilityId as string;
       const selectedFacility =
         facilitiesResponse?.organization?.facilities?.filter(
-          (f) => f.id === facilityId
+          (f) => f.id === localSelectedFacilityId
         )?.[0];
 
       const facilityStats = await queryGetFacilityStats({
         fetchPolicy: "no-cache",
-        variables: { facilityId },
+        variables: { facilityId: localSelectedFacilityId },
       }).then((response) => response.data?.facilityStats);
 
       updateLocalState((prevState) => ({
-        orgId: prevState.orgId,
-        facilityId: facilityId,
+        ...prevState,
+        selectedFacilityId: localSelectedFacilityId,
         facility: {
           city: selectedFacility?.city || "",
           state: selectedFacility?.state || "",
@@ -141,23 +161,27 @@ const ManageFacility = () => {
   }
 
   function handleClearFilter() {
-    updateLocalState(initialState);
+    orgSelectionRef.current?.clearSelection();
+    facilitySelectionRef.current?.clearSelection();
   }
 
   /**
    * Delete facility
    */
   const [deleteFacilityMutation] = useDeleteFacilityMutation();
+
   function handleDeleteFacility() {
-    deleteFacilityMutation({
-      variables: { facilityId: localState.facilityId },
-    }).then(() => {
-      showSuccess(
-        "",
-        `Facility ${localState.facility?.name} successfully deleted`
-      );
-      handleClearFilter();
-    });
+    if (localState.facilityId) {
+      deleteFacilityMutation({
+        variables: { facilityId: localState.facilityId },
+      }).then(() => {
+        showSuccess(
+          "",
+          `Facility ${localState.facility?.name} successfully deleted`
+        );
+        handleClearFilter();
+      });
+    }
   }
 
   /**
@@ -171,6 +195,8 @@ const ManageFacility = () => {
           onClearFilter={handleClearFilter}
           onSelectOrg={handleSelectOrganization}
           onSearch={handleSearch}
+          facilityRef={facilitySelectionRef}
+          orgRef={orgSelectionRef}
           facilityOptions={facilitiesOptions}
           organizationOptions={orgOptions}
           manageFacilityState={localState}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Part one of #6393 

Will follow up with the unarchive page in a separate PR.

## Changes Proposed

- Refactor ManageFacility component to use Truss combo boxes rather than our custom dropdown
- Update tests accordingly
- Added a new custom `ComboBox` based on the Truss version with an added `required` prop

## Testing 

deployed on dev5

### Before
![Screenshot 2023-08-31 at 10 04 29 AM](https://github.com/CDCgov/prime-simplereport/assets/29645040/6ca5a00a-1d51-4f89-a512-9f13342345f6)

### After
https://github.com/CDCgov/prime-simplereport/assets/29645040/5c47f1f7-7044-42b1-983e-de77c5ac314a

### Org selection enables facility selection
https://github.com/CDCgov/prime-simplereport/assets/29645040/97a56504-cfff-4f54-98b5-750d91bbcb7d

### Clear filters on individual combos cascade
https://github.com/CDCgov/prime-simplereport/assets/29645040/205b392e-53ca-48a0-b944-454c798be851

### Clear filter button clears both boxes
https://github.com/CDCgov/prime-simplereport/assets/29645040/450e6533-7931-4b37-b903-14a2e2f9f534

### Clear org resets search results 
https://github.com/CDCgov/prime-simplereport/assets/29645040/be723f5f-9f31-4327-885a-3144ab02a69d




## Additional Information

TL;DR: Are we ok sticking with fireEvent / wrapping things in `act` like we're doing currently, or do we think it's worth it to try and prefer `userEvent` / clean `act` warnings in the future? The issue is that using fireEvent / suppressing act warnings with the extra tag [may result in tests that don't catch the behavior they were written for](https://egghead.io/lessons/jest-fix-the-not-wrapped-in-act-warning), as well as resulting in more stable tests because we're accounting for all the state updates that are happening within our component (to the extent React can tell us). On the flip side though, going back and refactoring might be expensive / unfun. I reworked some of the tests in the above fashion [here](https://github.com/CDCgov/prime-simplereport/pull/6461/files) in case more concrete examples are helpful.

If yes, happy to make a ticket and prioritize accordingly alongside the other tech debt work we have in the pipeline. Otherwise, we can revisit if it ever comes up again.


### The issue

In getting this PR in I discovered a couple of issues with the `act` warning React is throwing based on the way that we're setting up our testing suite. I'll outline what I've found here and would love opinions on options to move forward!

As we've addressed in PR's like [this one](https://github.com/CDCgov/prime-simplereport/pull/5950), `act` warnings pop up periodically in our component testing. [These are often useful warnings React offers to notify us about unhandled state changes](https://codilime.com/blog/why-should-you-be-grateful-for-act-warnings-in-react-tests/) within our components that might cause unintended side effects. 

For this PR specifically, we need to use the `userEvent` API rather than the lower-level `fireEvent` to get tests to pass because the combo box is listening for a couple different events to happen in sequence in order to update. This caused a bunch of `act` warnings to pop up and I wanted to present a few options of handling them so we don't unnecessarily clutter our app logs and write more robust tests.

#### Option 0 - Use fireEvent
For the reasons stated above, we can't exactly use fireEvent here because the component we're testing for relies on a bunch of bundled events working together, but we do use this method extensively in other parts of the codebase. [RTL specifically recommends against this option though](https://ph-fritsche.github.io/blog/post/why-userevent), so wanted to call it out as something to potentially move away from so we're testing things in a way more in line with how they [recommend](https://testing-library.com/docs/user-event/intro/#differences-from-fireevent). 

#### Option 1 - Wrap the userEvents in `act`
One way of suppressing the warnings is to wrap the events in an `act` call. [The RTL maintainer again recommends against this](https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning#the-dreaded-act-warning) because the API calls already have `act` wrappers in them and the warnings might be pointing to actual state updates that need addressing. Back when Nick was on the project [he also submitted a PR that called this out](https://github.com/CDCgov/prime-simplereport/pull/3028) and installed [an eslint plugin specifically for this issue](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-unnecessary-act.md). The plugin seems not to be working correctly because it's not yelling at us in instances where it should be.

I've opted to temporarily go this direction to get this PR in, but will mention that this is a bandaid solution since (most) of the `act` warnings are trying to tell us that we have side effects in our component code that could result in more brittle tests.

#### Option 2 - Update dependencies that are causing the issue in the first place and refactor our testing suite
This is, at least in my mind, the "correct" solution, but also the one that will take a bit of work. By using the higher-level interaction API _and_  making sure we're handling all the `act` warnings, we're ensuring that we're covering any side effects that happen within our event handlers / component rendering logic. [This video](https://egghead.io/lessons/jest-fix-the-not-wrapped-in-act-warning) outlines a scenario where the act warning is trying to tell you something useful.

In order for us to  to take advantage of `userEvent` without act warnings though, we need to make sure that the underlying [shared `@testing-library/dom` dependency resolves to the same version.](https://github.com/testing-library/user-event/issues/1104#issuecomment-1460005394). I started exploring this on a separate branch but updating the packages breaks some other tests, so I punted on this for now. If we're in agreement that we want to do this, we'll need to go back and update some old tests so that everything is up to standard (and fix the eslint plugin in the meantime so that it's enforcing the new set of API's).

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
