### PR TITLE
do not add empty list in header

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -149,23 +149,36 @@ const Header: React.FC<{}> = () => {
       key: "patient-nav-link",
     },
   ];
-  const mainNavList = (deviceType: string) =>
-    mainNavContent.map((item) => {
+  const mainNavList = (deviceType: "desktop" | "mobile") => {
+    let navList = mainNavContent
+      .map((item) => {
+        return (
+          item.displayPermissions && (
+            <li key={item.key} className="usa-nav__primary-item">
+              <LinkWithQuery
+                to={item.url}
+                onClick={() => setMenuVisible(false)}
+                className={item.className}
+                id={`${deviceType}-${item.key}`}
+              >
+                {item.displayText}
+              </LinkWithQuery>
+            </li>
+          )
+        );
+      })
+      .filter((item) => item);
+    if (deviceType === "mobile" && navList?.length > 0) {
       return (
-        <li key={item.key} className="usa-nav__primary-item">
-          {item.displayPermissions ? (
-            <LinkWithQuery
-              to={item.url}
-              onClick={() => setMenuVisible(false)}
-              className={item.className}
-              id={`${deviceType}-${item.key}`}
-            >
-              {item.displayText}
-            </LinkWithQuery>
-          ) : null}
-        </li>
+        <ul className="usa-nav__primary usa-accordion mobile-main-nav-container">
+          {navList}
+        </ul>
       );
-    });
+    } else if (deviceType === "desktop" && navList?.length > 0) {
+      return <ul className="usa-nav__primary usa-accordion">{navList}</ul>;
+    }
+  };
+
   const secondaryNavContent = [
     {
       url: "#",
@@ -331,9 +344,7 @@ const Header: React.FC<{}> = () => {
           >
             <FontAwesomeIcon icon={"window-close"} />
           </button>
-          <ul className="usa-nav__primary usa-accordion mobile-main-nav-container">
-            {mainNavList("mobile")}
-          </ul>
+          {mainNavList("mobile")}
           <ul className="usa-nav__primary usa-accordion mobile-secondary-nav-container">
             {secondaryNav("mobile")}
           </ul>
@@ -365,9 +376,7 @@ const Header: React.FC<{}> = () => {
         aria-label="Primary navigation"
         className="usa-nav prime-nav desktop-nav"
       >
-        <ul className="usa-nav__primary usa-accordion">
-          {mainNavList("desktop")}
-        </ul>
+        {mainNavList("desktop")}
         {facilities && facilities.length > 0 ? (
           <div className="prime-facility-select">
             <Dropdown


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6411 

## Changes Proposed

- Only include the list in the header only if there is something inside.

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- Deployed in dev 1

## Screenshots / Demos

Desktop nav:
Now: 
<img width="1624" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/46da00f1-61ac-4c8f-b15c-90f2df16303e">
Before:
<img width="1624" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/591860a6-da14-4fa2-a167-2fca821d7917">

Mobile Nav
Now:
<img width="1624" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/b7b01699-ded9-4b23-b651-f79c67ccd578">
Before:
<img width="1624" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/41d5fcc2-f7b2-4651-a95c-2365a88c0167">


Still works when user ghosts into org:
<img width="1624" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/4abd09f6-8f78-4214-81cd-c8d3bb522419">
