### PR TITLE
Add patient gender identity field db changes

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5009,3 +5009,17 @@ databaseChangeLog:
             sql: |
               ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'MISSING_HEADER';
       rollback: ""
+  - changeSet:
+      id: add-gender_identity-to-person-table
+      author: zedd@skylight.digital
+      comment: Add gender_identity and person table
+      changes:
+        - tagDatabase:
+            tag: add-gender_identity-to-person-table
+        - addColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: gender_identity
+                  type: text
+                  remarks: represents the persons gender identity


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- #6068

## Changes Proposed

- Add `gender_identity` field to `person` table

<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->