### PR TITLE
remove debounce from updating test queue

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -414,10 +414,15 @@ const QueueItem = ({
           : cacheTestResults.filter(
               (result) => result.diseaseName === MULTIPLEX_DISEASES.COVID_19
             ),
-      }).then(() => {
-        setSaveState("idle");
-        setDirtyState(false);
-      });
+      })
+        .then(() => {
+          setSaveState("idle");
+          setDirtyState(false);
+        })
+        .finally(() => {
+          setSaveState("idle");
+          setDirtyState(false);
+        });
     }
     // eslint-disable-next-line
   }, [deviceId, specimenId, dateTested, cacheTestResults]);

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -414,15 +414,10 @@ const QueueItem = ({
           : cacheTestResults.filter(
               (result) => result.diseaseName === MULTIPLEX_DISEASES.COVID_19
             ),
-      })
-        .then(() => {
-          setSaveState("idle");
-          setDirtyState(false);
-        })
-        .finally(() => {
-          setSaveState("idle");
-          setDirtyState(false);
-        });
+      }).finally(() => {
+        setSaveState("idle");
+        setDirtyState(false);
+      });
     }
     // eslint-disable-next-line
   }, [deviceId, specimenId, dateTested, cacheTestResults]);


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes issue on E2E 04 - Conduct test fails 
  - The test waits for `GetFacilityQueue` query result and then when `NEGATIVE` is selected, it gets cleared. All of the below screenshots are literally 1 frame apart.

![image (2)](https://github.com/CDCgov/prime-simplereport/assets/10108172/34f298ca-1c6c-47ee-b5f5-74ae57715a36)
![image (3)](https://github.com/CDCgov/prime-simplereport/assets/10108172/1e1fff59-5b59-41e5-8346-684d7ddf6484)
![image (4)](https://github.com/CDCgov/prime-simplereport/assets/10108172/2e3288ea-a11d-428d-85eb-8a14e306830b)


## Changes Proposed

- Remove the debouncing for `EditQueueItemMutation`
- Disable all fields while save state is `editing`

## Additional Information

- The bug happens when `GetFacilityQueue` is completed right after updating the queue item. The debounce for update queue item we check if [the state is dirty](https://github.com/CDCgov/prime-simplereport/blob/63712ae9fd3a121c28832c7c9019489c14050a99/frontend/src/app/testQueue/QueueItem.tsx#L409). If it is dirty, [we clear it and then run the mutation in 300 ms](https://github.com/CDCgov/prime-simplereport/blob/63712ae9fd3a121c28832c7c9019489c14050a99/frontend/src/app/testQueue/QueueItem.tsx#L410-L424). While our function is waiting to run, the `GetFacilityQueue` query runs and since the state is not dirty [it will just clear the function run](https://github.com/CDCgov/prime-simplereport/blob/63712ae9fd3a121c28832c7c9019489c14050a99/frontend/src/app/testQueue/QueueItem.tsx#L288-L291).

## Testing

- Edit queue item, click fast 🖱️ 💨 
