### PR TITLE
don't fetch loggedInUser in ManageUsers

### DIFF
--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -76,6 +76,9 @@ describe("Conducting a COVID test", () => {
     // then it won't trigger a network call
     cy.wait("@GetFacilityQueue", {timeout: 20000});
 
+    // Wait for the FacilityQueue results to populate
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
     cy.get(queueCard).within(() => {
       cy.contains('label', 'Negative (-)').click();
     });

--- a/cypress/e2e/04-conduct_test.cy.js
+++ b/cypress/e2e/04-conduct_test.cy.js
@@ -77,6 +77,8 @@ describe("Conducting a COVID test", () => {
     cy.wait("@GetFacilityQueue", {timeout: 20000});
 
     // Wait for the FacilityQueue results to populate
+    // To be resolved in #6079
+    // https://github.com/CDCgov/prime-simplereport/pull/6464#discussion_r1313361521
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(100);
     cy.get(queueCard).within(() => {

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -221,6 +221,7 @@ const ManageUsers: React.FC<Props> = ({
 
       const fullName = displayFullName(firstName, "", lastName);
 
+      await getUsers();
       updateActiveUser({
         ...newUserInvite,
         id: addedUser,
@@ -258,7 +259,7 @@ const ManageUsers: React.FC<Props> = ({
       const fullName = displayFullName(firstName, "", lastName);
       showSuccess("", `User name changed to ${fullName}`);
       refetchUser();
-      users = (await getUsers()).data.usersWithStatus ?? [];
+      await getUsers();
     } catch (e: any) {
       setError(e);
     }
@@ -330,6 +331,7 @@ const ManageUsers: React.FC<Props> = ({
       const nextUser: LimitedUser =
         sortedUsers[0].id === userId ? sortedUsers[1] : sortedUsers[0];
 
+      await getUsers();
       updateActiveUser(nextUser);
       showSuccess("", `User account removed for ${fullName}`);
     } catch (e: any) {

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -123,13 +123,15 @@ const ManageUsers: React.FC<Props> = ({
   );
 
   const [queryUserWithPermissions] = useGetUserLazyQuery({
-    variables: { id: activeUser ? activeUser.id : loggedInUser.id },
+    variables: { id: activeUser?.id },
     fetchPolicy: "no-cache",
     onCompleted: (data) => updateUserWithPermissions(data.user),
   });
 
   useEffect(() => {
-    queryUserWithPermissions();
+    if (activeUser) {
+      queryUserWithPermissions();
+    }
   }, [activeUser, queryUserWithPermissions]);
 
   // only updates the local state

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -122,7 +122,7 @@ const ManageUsers: React.FC<Props> = ({
     sortedUsers?.[0]
   );
 
-  useGetUserQuery({
+  const { refetch: refetchUser } = useGetUserQuery({
     variables: { id: activeUser?.id },
     fetchPolicy: "no-cache",
     skip: !activeUser?.id,
@@ -259,9 +259,7 @@ const ManageUsers: React.FC<Props> = ({
       });
       const fullName = displayFullName(firstName, "", lastName);
       showSuccess("", `User name changed to ${fullName}`);
-      updateLocalUserState("firstName", firstName);
-      updateLocalUserState("lastName", lastName);
-      await getUsers();
+      await refetchUser();
     } catch (e: any) {
       setError(e);
     }
@@ -276,7 +274,7 @@ const ManageUsers: React.FC<Props> = ({
         },
       });
       showSuccess("", `User email address changed to ${emailAddress}`);
-      updateLocalUserState("email", emailAddress);
+      await refetchUser();
       await getUsers();
     } catch (e: any) {}
   };

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -261,6 +261,7 @@ const ManageUsers: React.FC<Props> = ({
       showSuccess("", `User name changed to ${fullName}`);
       updateLocalUserState("firstName", firstName);
       updateLocalUserState("lastName", lastName);
+      await getUsers();
     } catch (e: any) {
       setError(e);
     }

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -180,7 +180,6 @@ const ManageUsers: React.FC<Props> = ({
       },
     })
       .then(async () => {
-        await getUsers();
         updateIsUserEdited(false);
         const fullName = displayFullName(
           userWithPermissions?.firstName,
@@ -222,7 +221,6 @@ const ManageUsers: React.FC<Props> = ({
 
       const fullName = displayFullName(firstName, "", lastName);
 
-      await getUsers();
       updateActiveUser({
         ...newUserInvite,
         id: addedUser,
@@ -260,6 +258,7 @@ const ManageUsers: React.FC<Props> = ({
       const fullName = displayFullName(firstName, "", lastName);
       showSuccess("", `User name changed to ${fullName}`);
       await refetchUser();
+      users = (await getUsers()).data.usersWithStatus ?? [];
     } catch (e: any) {
       setError(e);
     }
@@ -275,7 +274,6 @@ const ManageUsers: React.FC<Props> = ({
       });
       showSuccess("", `User email address changed to ${emailAddress}`);
       await refetchUser();
-      await getUsers();
     } catch (e: any) {}
   };
 
@@ -332,7 +330,6 @@ const ManageUsers: React.FC<Props> = ({
       const nextUser: LimitedUser =
         sortedUsers[0].id === userId ? sortedUsers[1] : sortedUsers[0];
 
-      await getUsers();
       updateActiveUser(nextUser);
       showSuccess("", `User account removed for ${fullName}`);
     } catch (e: any) {

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -257,7 +257,7 @@ const ManageUsers: React.FC<Props> = ({
       });
       const fullName = displayFullName(firstName, "", lastName);
       showSuccess("", `User name changed to ${fullName}`);
-      await refetchUser();
+      refetchUser();
       users = (await getUsers()).data.usersWithStatus ?? [];
     } catch (e: any) {
       setError(e);


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6412 

## Changes Proposed

- Only fetch active user and never just the logged in user. 
- Fix E2E conduct test by just adding a wait

## Additional Information

- ActiveUser was always defaulted to logged in user if there is no value, which is not necessary since the current logged in user will always be either in the org or a SU.
- Remove the use of lazy query and just use the [skip parameter](https://www.apollographql.com/docs/react/data/queries/#skip) in apollo.  
- ~Update local state for update email and user's name.~
  - ~If this isn't ok we can always just use [refetch](https://www.apollographql.com/docs/react/data/queries/#refetch) from the query~

## Testing

- Go to an org with no users
- Add a user
  - Update user name and email 
- Delete the user
  - no error should appear, no extra calls should be made to fetch a user

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
