### PR TITLE
add a waitfor loading to be not in the document

### DIFF
--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.test.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.test.tsx
@@ -580,10 +580,14 @@ describe("Unarchive patient", () => {
         </MockedProvider>
       </Provider>
     );
-    await waitForElementToBeRemoved(() => screen.queryByText(/Loading/i));
+    await waitFor(() =>
+      expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument()
+    );
     await searchByOrgAndFacility();
     await act(async () => screen.getByText("2").closest("a")?.click());
-    await waitForElementToBeRemoved(() => screen.queryByText(/Loading/i));
+    await waitFor(() =>
+      expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument()
+    );
     await act(async () => screen.getAllByText("Unarchive")[0].click());
     expect(screen.getByRole("dialog")).toHaveTextContent(
       /Are you sure you want to unarchive Gutmann, Rod\?/

--- a/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.test.tsx
+++ b/frontend/src/app/supportAdmin/UnarchivePatients/UnarchivePatient.test.tsx
@@ -589,6 +589,9 @@ describe("Unarchive patient", () => {
       /Are you sure you want to unarchive Gutmann, Rod\?/
     );
     await act(async () => screen.getByText("Yes, I'm sure").click());
+    await waitFor(() =>
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+    );
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.queryByText("2")).not.toBeInTheDocument();
     expect(screen.queryByText("Next")).not.toBeInTheDocument();


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Unarchive patient test randomly will fail with the error. 
  - https://github.com/CDCgov/prime-simplereport/actions/runs/6037844294/job/16385814281#step:6:1003

## Changes Proposed

- WaitFor loading to not be in the document

## Additional Information


## Testing



## Screenshots / Demos

- Ran 500 times
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/fa4821b4-3419-4d30-8e94-e4824447d6be)