### PR TITLE
Remove test result count from header

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.scss
+++ b/frontend/src/app/testResults/TestResultsList.scss
@@ -132,9 +132,7 @@
 .sr-showing-results-on-page {
   margin-left: 2rem;
   color: #555;
-  font-size: 50%;
-  vertical-align: middle;
-  font-weight: normal;
+  font-size: 0.69rem;
 }
 
 .search-input_without_submit_button {

--- a/frontend/src/app/testResults/TestResultsList.scss
+++ b/frontend/src/app/testResults/TestResultsList.scss
@@ -130,7 +130,6 @@
 }
 
 .sr-showing-results-on-page {
-  margin-left: 2rem;
   color: #555;
   font-size: 0.69rem;
 }

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -432,10 +432,10 @@ export const DetachedTestResultsList = ({
       <div className="prime-container card-container sr-test-results-list">
         <div className="sticky-heading">
           <div className="usa-card__header">
-            <div className="display-flex flex-align-baseline">
-              <h1 className="font-sans-lg margin-top-0">Test results</h1>
+            <div className="display-flex flex-align-center">
+              <h1 className="font-sans-lg margin-y-0">Test results</h1>
               {!loading && (
-                <span className="sr-showing-results-on-page">
+                <span className="sr-showing-results-on-page margin-left-4">
                   {getResultCountText(totalEntries, pageNumber, entriesPerPage)}
                 </span>
               )}

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -432,14 +432,15 @@ export const DetachedTestResultsList = ({
       <div className="prime-container card-container sr-test-results-list">
         <div className="sticky-heading">
           <div className="usa-card__header">
-            <h1 className="font-sans-lg">
-              Test results
+            q{" "}
+            <div className="display-flex flex-align-baseline">
+              <h1 className="font-sans-lg margin-top-0">Test results</h1>
               {!loading && (
                 <span className="sr-showing-results-on-page">
                   {getResultCountText(totalEntries, pageNumber, entriesPerPage)}
                 </span>
               )}
-            </h1>
+            </div>
             <div>
               <DownloadResultsCSVButton
                 filterParams={filterParams}

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -432,7 +432,6 @@ export const DetachedTestResultsList = ({
       <div className="prime-container card-container sr-test-results-list">
         <div className="sticky-heading">
           <div className="usa-card__header">
-            q{" "}
             <div className="display-flex flex-align-baseline">
               <h1 className="font-sans-lg margin-top-0">Test results</h1>
               {!loading && (

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -14,16 +14,20 @@ exports[`TestResultsList should render a list of tests 1`] = `
         <div
           class="usa-card__header"
         >
-          <h1
-            class="font-sans-lg"
+          <div
+            class="display-flex flex-align-baseline"
           >
-            Test results
+            <h1
+              class="font-sans-lg margin-top-0"
+            >
+              Test results
+            </h1>
             <span
               class="sr-showing-results-on-page"
             >
               Showing 1-3 of 3
             </span>
-          </h1>
+          </div>
           <div>
             <button
               class="usa-button usa-button--outline"

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -15,15 +15,15 @@ exports[`TestResultsList should render a list of tests 1`] = `
           class="usa-card__header"
         >
           <div
-            class="display-flex flex-align-baseline"
+            class="display-flex flex-align-center"
           >
             <h1
-              class="font-sans-lg margin-top-0"
+              class="font-sans-lg margin-y-0"
             >
               Test results
             </h1>
             <span
-              class="sr-showing-results-on-page"
+              class="sr-showing-results-on-page margin-left-4"
             >
               Showing 1-3 of 3
             </span>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6392 

## Changes Proposed

- Move count information outside of h1

## Additional Information

## Screenshots / Demos

New: 
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/7307140d-a180-474d-8882-2ba184084d1f)
Old:
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/c814dd95-8e36-4be8-b257-45ca35b636b6)