### PR TITLE
Fix nav header accessibility issues

### DIFF
--- a/frontend/src/app/commonComponents/ChangeUser.tsx
+++ b/frontend/src/app/commonComponents/ChangeUser.tsx
@@ -4,12 +4,14 @@ const ChangeUser = () => {
   }
 
   const getLink = (email: string, name: string) => (
-    <a
-      className="ghost-user-link"
-      href={`/#access_token=SR-DEMO-LOGIN%20${email}`}
-    >
-      Login as {name}
-    </a>
+    <li>
+      <a
+        className="ghost-user-link"
+        href={`/#access_token=SR-DEMO-LOGIN%20${email}`}
+      >
+        Login as {name}
+      </a>
+    </li>
   );
 
   return (

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -16,6 +16,7 @@ export interface Option {
 interface Props {
   options: Option[];
   label?: string | React.ReactNode;
+  ariaLabel?: string;
   name?: string;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   selectedValue: string;
@@ -36,6 +37,7 @@ type SelectProps = JSX.IntrinsicElements["select"];
 const Dropdown: React.FC<Props & SelectProps> = ({
   options,
   label,
+  ariaLabel,
   name,
   onChange,
   disabled,
@@ -91,6 +93,7 @@ const Dropdown: React.FC<Props & SelectProps> = ({
             )}
             name={name}
             id={id}
+            aria-label={ariaLabel}
             aria-required={required || "false"}
             onChange={onChange}
             value={selectedValue || defaultOption || ""}

--- a/frontend/src/app/commonComponents/Header.scss
+++ b/frontend/src/app/commonComponents/Header.scss
@@ -25,9 +25,11 @@
   }
 
   .role-tag {
+    border-bottom: 1px #dfe1e2 solid;
     // $theme-color-prime-gray:
     color: #71767a;
     margin-top: 0.5rem;
+    padding-bottom: 1rem;
   }
 
   .header-link-icon {
@@ -100,7 +102,7 @@
   .navlink__support {
     display: flex;
     align-items: center;
-    margin-top: 0.75rem !important;
+    margin-top: 0.75rem;
 
     button {
       color: #005ea2;

--- a/frontend/src/app/commonComponents/Header.test.tsx
+++ b/frontend/src/app/commonComponents/Header.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+import "../../i18n";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { MockedProvider } from "@apollo/client/testing";
+import configureStore from "redux-mock-store";
+import { configureAxe } from "jest-axe";
+
+import Header from "./Header";
+
+const axe = configureAxe({
+  rules: {
+    // disable landmark rules when testing isolated components.
+    region: { enabled: false },
+  },
+});
+const mockStore = configureStore([]);
+const store = mockStore({
+  organization: {
+    name: "Organization Name",
+  },
+  user: {
+    firstName: "Kim",
+    lastName: "Mendoza",
+    roleDescription: "Admin user",
+  },
+  facilities: [
+    { id: "1", name: "Facility One" },
+    { id: "2", name: "Facility Two" },
+  ],
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const original = jest.requireActual("react-router-dom");
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("Header", () => {
+  it("displays correctly", async () => {
+    render(
+      <Provider store={store}>
+        <MockedProvider>
+          <MemoryRouter>
+            <Header />
+          </MemoryRouter>
+        </MockedProvider>
+      </Provider>
+    );
+    expect(document.body).toMatchSnapshot();
+    expect(await axe(document.body)).toHaveNoViolations();
+  });
+});

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -230,7 +230,6 @@ const Header: React.FC<{}> = () => {
       <li className="usa-sidenav__item role-tag">
         {formatRole(user.roleDescription)}
       </li>
-      <hr />
       <li className="usa-sidenav__item navlink__support">
         <div className="header-link-icon sparkle-icon-mask"></div>
         <a
@@ -281,6 +280,13 @@ const Header: React.FC<{}> = () => {
             className={item.className}
             data-testid={`${deviceType}-${item.dataTestId}`}
             id={`${deviceType}-${item.dataTestId}`}
+            role={item.hasSubmenu ? "button" : "link"}
+            aria-expanded={item.hasSubmenu ? staffDetailsVisible : undefined}
+            aria-controls={
+              item.hasSubmenu
+                ? `${deviceType}-${item.dataTestId}-submenu`
+                : undefined
+            }
           >
             {deviceType === "desktop" ? item.icon : item.mobileDisplayText}
           </LinkWithQuery>
@@ -288,8 +294,9 @@ const Header: React.FC<{}> = () => {
           staffDetailsVisible &&
           deviceType === "desktop" ? (
             <div
+              id={`${deviceType}-${item.dataTestId}-submenu`}
               ref={staffDefailsRef}
-              aria-label="Primary navigation"
+              aria-label="Account navigation"
               className={classNames("prime-staff-infobox", {
                 "is-prime-staff-infobox-visible": staffDetailsVisible,
               })}
@@ -326,7 +333,7 @@ const Header: React.FC<{}> = () => {
         </button>
 
         <nav
-          aria-label="Primary navigation"
+          aria-label="Primary mobile navigation"
           className={classNames(
             "usa-nav",
             "prime-nav",
@@ -350,13 +357,12 @@ const Header: React.FC<{}> = () => {
           </ul>
           <div className="usa-nav__primary mobile-sublist-container">
             {secondaryNavSublist("mobile")}
-            <hr />
-
             <label id="mobile-facility-label" className="usa-label ">
               Facility
             </label>
             <div className="prime-facility-select facility-select-mobile-container">
               <Dropdown
+                ariaLabel="Select testing facility"
                 selectedValue={facility.id}
                 onChange={onFacilitySelect}
                 className={"mobile-facility-select"}
@@ -373,14 +379,14 @@ const Header: React.FC<{}> = () => {
       </div>
 
       <nav
-        aria-label="Primary navigation"
+        aria-label="Primary desktop navigation"
         className="usa-nav prime-nav desktop-nav"
       >
         {mainNavList("desktop")}
         {facilities && facilities.length > 0 ? (
           <div className="prime-facility-select">
             <Dropdown
-              aria-label={"Select facility"}
+              ariaLabel="Select testing facility"
               selectedValue={facility.id}
               onChange={onFacilitySelect}
               options={facilities.map(({ name, id }) => ({

--- a/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
@@ -1,0 +1,302 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header displays correctly 1`] = `
+<body>
+  <div>
+    <div
+      class="usa-nav-container prime-header"
+    >
+      <div
+        class="usa-navbar"
+      >
+        <div
+          class="usa-logo"
+          id="basic-logo"
+        >
+          <a
+            aria-label="Home"
+            class=""
+            href="/queue"
+            title="Home"
+          >
+            <img
+              alt="SimpleReport"
+              class="width-card desktop:width-full"
+              src="simplereport-logo-color.svg"
+            />
+          </a>
+          <div
+            class="prime-organization-name"
+          >
+            Organization Name
+          </div>
+        </div>
+        <button
+          class="usa-menu-btn"
+        >
+          Menu
+        </button>
+        <nav
+          aria-label="Primary mobile navigation"
+          class="usa-nav prime-nav desktop:display-none mobile-nav"
+        >
+          <button
+            class="fa-layers fa-fw fa-2x usa-nav__close prime-nav-close-button"
+            title="close menu"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-rectangle-xmark "
+              data-icon="rectangle-xmark"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zM175 175c9.4-9.4 24.6-9.4 33.9 0l47 47 47-47c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-47 47 47 47c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-47-47-47 47c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l47-47-47-47c-9.4-9.4-9.4-24.6 0-33.9z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <ul
+            class="usa-nav__primary usa-accordion mobile-secondary-nav-container"
+          >
+            <li
+              class="usa-nav__primary-item nav__primary-item-icon"
+            >
+              <a
+                class="prime-nav-link"
+                data-testid="mobile-settings-button"
+                href="/settings"
+                id="mobile-settings-button"
+                role="link"
+              >
+                Settings
+              </a>
+            </li>
+          </ul>
+          <div
+            class="usa-nav__primary mobile-sublist-container"
+          >
+            <ul
+              class="usa-sidenav__sublist"
+            >
+              <li
+                class="usa-sidenav__item span-full-name"
+              >
+                Kim Mendoza
+              </li>
+              <li
+                class="usa-sidenav__item role-tag"
+              >
+                Admin
+              </li>
+              <li
+                class="usa-sidenav__item navlink__support"
+              >
+                <div
+                  class="header-link-icon sparkle-icon-mask"
+                />
+                <a
+                  data-testid="mobile-whats-new-link"
+                  href="https://www.simplereport.gov/using-simplereport/whats-new"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  What's new
+                </a>
+              </li>
+              <li
+                class="usa-sidenav__item navlink__support"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-circle-question header-link-icon"
+                  data-icon="circle-question"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <a
+                  data-testid="mobile-support-link"
+                  href="https://www.simplereport.gov/support"
+                  target="none"
+                >
+                  Support
+                </a>
+              </li>
+              <li
+                class="usa-sidenav__item navlink__support"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-right-from-bracket header-link-icon"
+                  data-icon="right-from-bracket"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M377.9 105.9L500.7 228.7c7.2 7.2 11.3 17.1 11.3 27.3s-4.1 20.1-11.3 27.3L377.9 406.1c-6.4 6.4-15 9.9-24 9.9c-18.7 0-33.9-15.2-33.9-33.9l0-62.1-128 0c-17.7 0-32-14.3-32-32l0-64c0-17.7 14.3-32 32-32l128 0 0-62.1c0-18.7 15.2-33.9 33.9-33.9c9 0 17.6 3.6 24 9.9zM160 96L96 96c-17.7 0-32 14.3-32 32l0 256c0 17.7 14.3 32 32 32l64 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-64 0c-53 0-96-43-96-96L0 128C0 75 43 32 96 32l64 0c17.7 0 32 14.3 32 32s-14.3 32-32 32z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <button
+                  class="usa-button usa-button--unstyled"
+                  type="button"
+                >
+                   Log out
+                </button>
+              </li>
+            </ul>
+            <label
+              class="usa-label "
+              id="mobile-facility-label"
+            >
+              Facility
+            </label>
+            <div
+              class="prime-facility-select facility-select-mobile-container"
+            >
+              <div
+                class="usa-form-group prime-dropdown  mobile-facility-select"
+              >
+                <select
+                  aria-label="Select testing facility"
+                  aria-required="false"
+                  class="usa-select"
+                  id="1"
+                >
+                  <option
+                    aria-selected="false"
+                    value="1"
+                  >
+                    Facility One
+                  </option>
+                  <option
+                    aria-selected="false"
+                    value="2"
+                  >
+                    Facility Two
+                  </option>
+                </select>
+              </div>
+            </div>
+            <button
+              class="touchpoints-wrapper sr-app-touchpoints-button"
+            >
+              How can we improve SimpleReport?
+            </button>
+          </div>
+        </nav>
+      </div>
+      <nav
+        aria-label="Primary desktop navigation"
+        class="usa-nav prime-nav desktop-nav"
+      >
+        <div
+          class="prime-facility-select"
+        >
+          <div
+            class="usa-form-group prime-dropdown "
+          >
+            <select
+              aria-label="Select testing facility"
+              aria-required="false"
+              class="usa-select"
+              id="2"
+            >
+              <option
+                aria-selected="false"
+                value="1"
+              >
+                Facility One
+              </option>
+              <option
+                aria-selected="false"
+                value="2"
+              >
+                Facility Two
+              </option>
+            </select>
+          </div>
+        </div>
+        <ul
+          class="usa-nav__primary usa-accordion"
+        >
+          <li
+            class="usa-nav__primary-item nav__primary-item-icon"
+          >
+            <a
+              aria-controls="desktop-user-button-submenu"
+              aria-current="page"
+              aria-expanded="false"
+              class="prime-nav-link active"
+              data-testid="desktop-user-button"
+              href="/"
+              id="desktop-user-button"
+              role="button"
+            >
+              <svg
+                aria-hidden="false"
+                aria-label="My account"
+                class="svg-inline--fa fa-circle-user "
+                data-icon="circle-user"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M399 384.2C376.9 345.8 335.4 320 288 320H224c-47.4 0-88.9 25.8-111 64.2c35.2 39.2 86.2 63.8 143 63.8s107.8-24.7 143-63.8zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm256 16a72 72 0 1 0 0-144 72 72 0 1 0 0 144z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
+          </li>
+          <li
+            class="usa-nav__primary-item nav__primary-item-icon"
+          >
+            <a
+              class="prime-nav-link"
+              data-testid="desktop-settings-button"
+              href="/settings"
+              id="desktop-settings-button"
+              role="link"
+            >
+              <svg
+                aria-hidden="false"
+                aria-label="Settings"
+                class="svg-inline--fa fa-gear "
+                data-icon="gear"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M495.9 166.6c3.2 8.7 .5 18.4-6.4 24.6l-43.3 39.4c1.1 8.3 1.7 16.8 1.7 25.4s-.6 17.1-1.7 25.4l43.3 39.4c6.9 6.2 9.6 15.9 6.4 24.6c-4.4 11.9-9.7 23.3-15.8 34.3l-4.7 8.1c-6.6 11-14 21.4-22.1 31.2c-5.9 7.2-15.7 9.6-24.5 6.8l-55.7-17.7c-13.4 10.3-28.2 18.9-44 25.4l-12.5 57.1c-2 9.1-9 16.3-18.2 17.8c-13.8 2.3-28 3.5-42.5 3.5s-28.7-1.2-42.5-3.5c-9.2-1.5-16.2-8.7-18.2-17.8l-12.5-57.1c-15.8-6.5-30.6-15.1-44-25.4L83.1 425.9c-8.8 2.8-18.6 .3-24.5-6.8c-8.1-9.8-15.5-20.2-22.1-31.2l-4.7-8.1c-6.1-11-11.4-22.4-15.8-34.3c-3.2-8.7-.5-18.4 6.4-24.6l43.3-39.4C64.6 273.1 64 264.6 64 256s.6-17.1 1.7-25.4L22.4 191.2c-6.9-6.2-9.6-15.9-6.4-24.6c4.4-11.9 9.7-23.3 15.8-34.3l4.7-8.1c6.6-11 14-21.4 22.1-31.2c5.9-7.2 15.7-9.6 24.5-6.8l55.7 17.7c13.4-10.3 28.2-18.9 44-25.4l12.5-57.1c2-9.1 9-16.3 18.2-17.8C227.3 1.2 241.5 0 256 0s28.7 1.2 42.5 3.5c9.2 1.5 16.2 8.7 18.2 17.8l12.5 57.1c15.8 6.5 30.6 15.1 44 25.4l55.7-17.7c8.8-2.8 18.6-.3 24.5 6.8c8.1 9.8 15.5 20.2 22.1 31.2l4.7 8.1c6.1 11 11.4 22.4 15.8 34.3zM256 336a80 80 0 1 0 0-160 80 80 0 1 0 0 160z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #6410 

## Changes Proposed
<img width="1200" alt="Screenshot 2023-09-11 at 23 00 32" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/8a861d48-7c9c-4daa-8060-5689800cdd32">

- Account icon in header
  - set `role` to `button` instead of `link`
  - add [`aria-expanded`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) and set to `true/false` depending the state of the submenu
  - add [`aria-controls`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
- Fix other accessibility issues found when adding jest-axe test to `<Header>` component


## Additional Information
- Adding the jest-axe test to the `<Header>` component revealed that the axe dev tool test didn't run the tests on certain parts of the nav header unless the Account icon button was clicked and expanded.
- Some changes in this PR addresses the issues flagged by the jest-axe tests

## Testing

- deployed on dev2

## Screenshots / Demos

**Before**

<img width="1608" alt="Screenshot 2023-09-11 at 22 56 28" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/d26519f4-e8ac-490a-9376-0f4274e64b29">

**After**

<img width="1616" alt="Screenshot 2023-09-11 at 22 55 51" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/f4d49be3-2292-4119-b5a0-13bb9c5bcb37">

⚠️ The line styling in between the "USER NAME" and "USER ROLE" in the Account dropdown has changed slightly since we cannot use `<hr>` element in a `<ul>` element 

<img width="1600" alt="Screenshot 2023-09-11 at 22 55 16" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/3fd4ae31-2895-42ae-a8c4-65ac1538f528">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
