### PR TITLE
hide rsv on manage devices

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -20,26 +20,28 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class FeatureFlagsConfig {
-  @Getter(AccessLevel.NONE)
-  @Setter(AccessLevel.NONE)
-  private final FeatureFlagRepository _repo;
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private final FeatureFlagRepository _repo;
 
-  private boolean multiplexEnabled;
-  private boolean hivEnabled;
-  private boolean rsvEnabled;
+    private boolean multiplexEnabled;
+    private boolean hivEnabled;
+    private boolean rsvEnabled;
+    private boolean singleEntryRsvEnabled;
 
-  @Scheduled(fixedRateString = "60000") // 1 min
-  private void loadFeatureFlagsFromDB() {
-    Iterable<FeatureFlag> flags = _repo.findAll();
-    flags.forEach(flag -> flagMapping(flag.getName(), flag.getValue()));
-  }
-
-  private void flagMapping(String flagName, Boolean flagValue) {
-    switch (flagName) {
-      case "multiplexEnabled" -> setMultiplexEnabled(flagValue);
-      case "hivEnabled" -> setHivEnabled(flagValue);
-      case "rsvEnabled" -> setRsvEnabled(flagValue);
-      default -> log.info("no mapping for " + flagName);
+    @Scheduled(fixedRateString = "60000") // 1 min
+    private void loadFeatureFlagsFromDB() {
+        Iterable<FeatureFlag> flags = _repo.findAll();
+        flags.forEach(flag -> flagMapping(flag.getName(), flag.getValue()));
     }
-  }
+
+    private void flagMapping(String flagName, Boolean flagValue) {
+        switch (flagName) {
+            case "multiplexEnabled" -> setMultiplexEnabled(flagValue);
+            case "hivEnabled" -> setHivEnabled(flagValue);
+            case "rsvEnabled" -> setRsvEnabled(flagValue);
+            case "singleEntryRsvEnabled" -> setSingleEntryRsvEnabled(flagValue);
+            default -> log.info("no mapping for " + flagName);
+        }
+    }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -20,28 +20,28 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class FeatureFlagsConfig {
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
-    private final FeatureFlagRepository _repo;
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.NONE)
+  private final FeatureFlagRepository _repo;
 
-    private boolean multiplexEnabled;
-    private boolean hivEnabled;
-    private boolean rsvEnabled;
-    private boolean singleEntryRsvEnabled;
+  private boolean multiplexEnabled;
+  private boolean hivEnabled;
+  private boolean rsvEnabled;
+  private boolean singleEntryRsvEnabled;
 
-    @Scheduled(fixedRateString = "60000") // 1 min
-    private void loadFeatureFlagsFromDB() {
-        Iterable<FeatureFlag> flags = _repo.findAll();
-        flags.forEach(flag -> flagMapping(flag.getName(), flag.getValue()));
+  @Scheduled(fixedRateString = "60000") // 1 min
+  private void loadFeatureFlagsFromDB() {
+    Iterable<FeatureFlag> flags = _repo.findAll();
+    flags.forEach(flag -> flagMapping(flag.getName(), flag.getValue()));
+  }
+
+  private void flagMapping(String flagName, Boolean flagValue) {
+    switch (flagName) {
+      case "multiplexEnabled" -> setMultiplexEnabled(flagValue);
+      case "hivEnabled" -> setHivEnabled(flagValue);
+      case "rsvEnabled" -> setRsvEnabled(flagValue);
+      case "singleEntryRsvEnabled" -> setSingleEntryRsvEnabled(flagValue);
+      default -> log.info("no mapping for " + flagName);
     }
-
-    private void flagMapping(String flagName, Boolean flagValue) {
-        switch (flagName) {
-            case "multiplexEnabled" -> setMultiplexEnabled(flagValue);
-            case "hivEnabled" -> setHivEnabled(flagValue);
-            case "rsvEnabled" -> setRsvEnabled(flagValue);
-            case "singleEntryRsvEnabled" -> setSingleEntryRsvEnabled(flagValue);
-            default -> log.info("no mapping for " + flagName);
-        }
-    }
+  }
 }

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -25,3 +25,4 @@ twilio:
 features:
   hivEnabled: false
   rsvEnabled: false
+  singleEntryRsvEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -151,7 +151,7 @@ datahub:
 features:
   hivEnabled: true
   rsvEnabled: true
-  singleEntryRsvEnabled: false
+  singleEntryRsvEnabled: true
 slack:
   hook:
     token: ${SLACK_HOOK_TOKEN:foo}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -151,6 +151,7 @@ datahub:
 features:
   hivEnabled: true
   rsvEnabled: true
+  singleEntryRsvEnabled: false
 slack:
   hook:
     token: ${SLACK_HOOK_TOKEN:foo}

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.test.tsx
@@ -16,7 +16,7 @@ import ManageDevices from "./ManageDevices";
 
 let validFacility: FacilityFormData;
 
-const deviceA = {
+export const deviceA = {
   internalId: "device-a",
   name: "Device A",
   model: "Device A",
@@ -25,7 +25,7 @@ const deviceA = {
   swabTypes: [],
   testLength: 10,
 };
-const deviceB = {
+export const deviceB = {
   internalId: "device-b",
   name: "Device B",
   model: "Device B",
@@ -34,7 +34,7 @@ const deviceB = {
   swabTypes: [],
   testLength: 10,
 };
-const deviceC = {
+export const deviceC = {
   internalId: "device-c",
   name: "Device C",
   model: "Device C",
@@ -43,6 +43,7 @@ const deviceC = {
   swabTypes: [],
   testLength: 10,
 };
+
 const onChangeSpy = jest.fn();
 const devices: DeviceType[] = [deviceC, deviceB, deviceA];
 
@@ -84,7 +85,9 @@ function ManageDevicesContainer(props: { facility: FacilityFormData }) {
       newOrg={false}
       formCurrentValues={props.facility}
       onChange={onChangeSpy}
-      registrationProps={{ setFocus: () => {} }}
+      registrationProps={{
+        setFocus: () => {},
+      }}
     />
   );
 }

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -18,6 +18,41 @@ interface Props {
   onChange: (selectedItems: string[]) => void;
 }
 
+type SupportedDisease = {
+  supportedDisease: {
+    name: string;
+    __typename: "SupportedDisease";
+  };
+};
+
+function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
+  const supportedDiseaseArray =
+    device.supportedDiseaseTestPerformed as SupportedDisease[];
+  const supportedDiseases = supportedDiseaseArray.map(
+    (sd) => sd.supportedDisease.name
+  );
+  if (supportedDiseases.length === 1 && supportedDiseases[0] === "RSV") {
+    return [];
+  }
+  if (supportedDiseases.includes("RSV")) {
+    return supportedDiseaseArray.filter(
+      (d) => d.supportedDisease.name !== "RSV"
+    );
+  }
+  return supportedDiseaseArray;
+}
+
+export function filterRsvFromAllDevices(deviceTypes: FacilityFormDeviceType[]) {
+  deviceTypes.map((d) => {
+    d.supportedDiseaseTestPerformed = filterRsvFromSingleDevice(d);
+    return d;
+  });
+  deviceTypes = deviceTypes.filter(
+    (d) => d.supportedDiseaseTestPerformed.length > 0
+  );
+  return deviceTypes;
+}
+
 const ManageDevices: React.FC<Props> = ({
   deviceTypes,
   errors,
@@ -27,6 +62,9 @@ const ManageDevices: React.FC<Props> = ({
   registrationProps,
 }) => {
   const singleEntryRsvEnabled = useFeature("singleEntryRsvEnabled");
+  if (!singleEntryRsvEnabled) {
+    deviceTypes = filterRsvFromAllDevices(deviceTypes);
+  }
 
   const deviceTypeOptions = Array.from(
     deviceTypes.map((device) => ({

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -34,9 +34,6 @@ function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
   const supportedDiseases = supportedDiseaseArray.map(
     (sd) => sd.supportedDisease.name
   );
-  if (supportedDiseases.length === 1 && supportedDiseases[0] === "RSV") {
-    return [];
-  }
   if (supportedDiseases.includes("RSV")) {
     return supportedDiseaseArray.filter(
       (d) => d.supportedDisease.name !== "RSV"

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -46,14 +46,14 @@ function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
 }
 
 export function filterRsvFromAllDevices(deviceTypes: FacilityFormDeviceType[]) {
-  deviceTypes.map((d) => {
+  let filteredDevices = deviceTypes.map((d) => {
     d.supportedDiseaseTestPerformed = filterRsvFromSingleDevice(d);
     return d;
   });
-  deviceTypes = deviceTypes.filter(
+  filteredDevices = filteredDevices.filter(
     (d) => d.supportedDiseaseTestPerformed.length > 0
   );
-  return deviceTypes;
+  return filteredDevices;
 }
 
 const ManageDevices: React.FC<Props> = ({

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -28,6 +28,10 @@ type SupportedDisease = {
 function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
   const supportedDiseaseArray =
     device.supportedDiseaseTestPerformed as SupportedDisease[];
+
+  // no supportedDiseaseTestPerformed defined due to any casting, return empty array
+  if (supportedDiseaseArray === undefined) return [];
+  
   const supportedDiseases = supportedDiseaseArray.map(
     (sd) => sd.supportedDisease.name
   );

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useFeature } from "flagged";
 
 import MultiSelect from "../../../commonComponents/MultiSelect/MultiSelect";
 import DeviceSearchResults from "../../../uploads/DeviceLookup/DeviceSearchResults";
@@ -6,8 +7,6 @@ import "./ManageDevices.scss";
 import { RegistrationProps } from "../../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
 import { FacilityFormData } from "../FacilityForm";
 import { searchFacilityFormDevices } from "../../../utils/device";
-
-import { useFeature } from "flagged";
 
 interface Props {
   deviceTypes: FacilityFormDeviceType[];
@@ -31,7 +30,7 @@ function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
 
   // no supportedDiseaseTestPerformed defined due to any casting, return empty array
   if (supportedDiseaseArray === undefined) return [];
-  
+
   const supportedDiseases = supportedDiseaseArray.map(
     (sd) => sd.supportedDisease.name
   );

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -7,6 +7,8 @@ import { RegistrationProps } from "../../../commonComponents/MultiSelect/MultiSe
 import { FacilityFormData } from "../FacilityForm";
 import { searchFacilityFormDevices } from "../../../utils/device";
 
+import { useFeature } from "flagged";
+
 interface Props {
   deviceTypes: FacilityFormDeviceType[];
   errors: any;
@@ -24,6 +26,8 @@ const ManageDevices: React.FC<Props> = ({
   onChange,
   registrationProps,
 }) => {
+  const singleEntryRsvEnabled = useFeature("singleEntryRsvEnabled");
+
   const deviceTypeOptions = Array.from(
     deviceTypes.map((device) => ({
       label: device.model,

--- a/frontend/src/app/Settings/Facility/Components/RSVFiltering.test.ts
+++ b/frontend/src/app/Settings/Facility/Components/RSVFiltering.test.ts
@@ -1,0 +1,46 @@
+import mockSupportedDiseaseTestPerformedCovid, {
+  mockSupportedDiseaseTestPerformedRSV,
+} from "../../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
+
+import { deviceA, deviceB, deviceC } from "./ManageDevices.test";
+import { filterRsvFromAllDevices } from "./ManageDevices";
+
+const deviceD = {
+  internalId: "device-d",
+  name: "Device D RSV Only",
+  model: "Device D RSV Only",
+  manufacturer: "Manufacturer D",
+  supportedDiseaseTestPerformed: mockSupportedDiseaseTestPerformedRSV,
+  swabTypes: [],
+  testLength: 10,
+};
+
+const deviceE = {
+  internalId: "device-e",
+  name: "Device E COVID and RSV",
+  model: "Device E RSV COVID and RSV",
+  manufacturer: "Manufacturer E",
+  supportedDiseaseTestPerformed: mockSupportedDiseaseTestPerformedRSV.concat(
+    mockSupportedDiseaseTestPerformedCovid
+  ),
+  swabTypes: [],
+  testLength: 10,
+};
+
+describe("filtering functions for RSV single entry", () => {
+  it("filters RSV from devices as expected", () => {
+    const devices = [deviceA, deviceB, deviceC, deviceD, deviceE];
+
+    const filteredDevices = filterRsvFromAllDevices(devices);
+
+    expect(filteredDevices.length).toBe(4);
+    expect(filteredDevices.includes(deviceD)).toBe(false);
+    const shouldBeModifiedDevice = filteredDevices.find(
+      (d) => d.name === "Device E COVID and RSV"
+    ) as FacilityFormDeviceType;
+
+    expect(shouldBeModifiedDevice.supportedDiseaseTestPerformed).toStrictEqual(
+      mockSupportedDiseaseTestPerformedCovid
+    );
+  });
+});

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid.ts
@@ -12,4 +12,18 @@ const mockSupportedDiseaseTestPerformedCovid = [
   },
 ];
 
+export const mockSupportedDiseaseTestPerformedRSV = [
+  {
+    supportedDisease: {
+      internalId: "9a9be4ab-8b6c-4199-9d07-5ca63b3c0fe1",
+      loinc: "LP14244-5",
+      name: "RSV",
+    },
+    testPerformedLoincCode: "4567-1",
+    equipmentUid: "equipmentUid456",
+    testkitNameId: "testkitNameId456",
+    testOrderedLoincCode: "1598-1",
+  },
+];
+
 export default mockSupportedDiseaseTestPerformedCovid;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #6495 

## Changes Proposed

- Adds new single entry RSV feature flag
- Filters out RSV-only devices completely and removes RSV from supported diseases on manage facility device page
- I left out UI tests and only tested the underlying filtering logic so we don't have tests randomly breaking once we turn the flag off but if folks want happy to go back and add

## Testing

- Turn singleEntryRsv feature flag on / off and make sure display updates correctly

## Screenshots / Demos

### Off
#### RSV Included (rsv filtered out, other diseases are included)
https://github.com/CDCgov/prime-simplereport/assets/29645040/bb2577a9-5444-43f6-96eb-3b58b8e51284

#### RSV Only (complete filter)
https://github.com/CDCgov/prime-simplereport/assets/29645040/e286aa07-7308-4047-9dbf-04aea8d530d0

## On
https://github.com/CDCgov/prime-simplereport/assets/29645040/f16a1859-3ab4-47e0-8e9d-4be50cb3dc6b

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
