### PR TITLE
add rsv to livd table sync

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
@@ -1,9 +1,11 @@
 package gov.cdc.usds.simplereport.api.devicetype;
 
+import gov.cdc.usds.simplereport.api.model.errors.DryRunException;
 import gov.cdc.usds.simplereport.service.DeviceTypeSyncService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,7 +14,11 @@ public class DeviceTypeController {
   @Autowired private DeviceTypeSyncService deviceTypeSyncService;
 
   @GetMapping("/devices/sync")
-  public void syncDevices() {
-    deviceTypeSyncService.syncDevices();
+  public void syncDevices(@RequestParam boolean dryRun) {
+    try {
+      deviceTypeSyncService.syncDevices(dryRun);
+    } catch (DryRunException e) {
+      log.info("Dry run");
+    }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/CreateDeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/CreateDeviceType.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
+@ToString
 public class CreateDeviceType {
   private String name;
   private String manufacturer;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
@@ -3,9 +3,11 @@ package gov.cdc.usds.simplereport.api.model;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
+@ToString
 public class SupportedDiseaseTestPerformedInput {
   UUID supportedDisease;
   String testPerformedLoincCode;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/UpdateDeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/UpdateDeviceType.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
+@ToString
 public class UpdateDeviceType {
   private UUID internalId;
   private String name;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/DryRunException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/DryRunException.java
@@ -1,0 +1,7 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+public class DryRunException extends RuntimeException {
+  public DryRunException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java
@@ -121,6 +121,8 @@ public class DeviceTypeSyncService {
       new HashSet<>(Arrays.asList("flu a", "influenza a", "flua", "infa result"));
   private static final Set<String> FLU_B_VENDOR_ANALYTE_NAMES =
       new HashSet<>(Arrays.asList("flu b", "influenza b", "flub", "infb result"));
+  private static final Set<String> RSV_VENDOR_ANALYTE_NAMES =
+      new HashSet<>(Arrays.asList("rsv", "respiratory syncytial virus"));
   public static final int DEFAULT_TEST_LENGTH = 15;
 
   private final DeviceTypeRepository deviceTypeRepository;
@@ -360,6 +362,8 @@ public class DeviceTypeSyncService {
       return Optional.of(diseaseService.fluA());
     } else if (FLU_B_VENDOR_ANALYTE_NAMES.stream().anyMatch(input::contains)) {
       return Optional.of(diseaseService.fluB());
+    } else if (RSV_VENDOR_ANALYTE_NAMES.stream().anyMatch(input::contains)) {
+      return Optional.of(diseaseService.rsv());
     } else {
       return Optional.empty();
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java
@@ -212,22 +212,7 @@ public class DeviceTypeSyncService {
             devicesToSync.put(deviceToSync, new ArrayList<>());
           }
 
-          if (!specimenIdsByDevice.containsKey(deviceIdentifier)) {
-            Set<UUID> allSpecimenTypes =
-                deviceToSync.getSwabTypes().stream()
-                    .map(SpecimenType::getInternalId)
-                    .collect(Collectors.toSet());
-
-            var incomingSpecimenTypes = getSpecimenTypeIdsFromDescription(device);
-
-            if (!incomingSpecimenTypes.isEmpty()) {
-              allSpecimenTypes.addAll(incomingSpecimenTypes);
-            }
-
-            List<UUID> specimenTypesToAdd = new ArrayList<>(allSpecimenTypes);
-
-            specimenIdsByDevice.put(deviceIdentifier, specimenTypesToAdd);
-          }
+          addToSpecimenIdsByDevice(device, specimenIdsByDevice, deviceIdentifier, deviceToSync);
 
           var supportedDisease =
               getSupportedDiseaseFromVendorAnalyte(device.getVendorAnalyteName());
@@ -255,6 +240,29 @@ public class DeviceTypeSyncService {
         (device, testsPerformed) -> syncDevice(device, testsPerformed, specimenIdsByDevice));
     if (dryRun) {
       throw new DryRunException("Dry run, rolling back");
+    }
+  }
+
+  private void addToSpecimenIdsByDevice(
+      LIVDResponse device,
+      HashMap<String, List<UUID>> specimenIdsByDevice,
+      String deviceIdentifier,
+      DeviceType deviceToSync) {
+    if (!specimenIdsByDevice.containsKey(deviceIdentifier)) {
+      Set<UUID> allSpecimenTypes =
+          deviceToSync.getSwabTypes().stream()
+              .map(SpecimenType::getInternalId)
+              .collect(Collectors.toSet());
+
+      var incomingSpecimenTypes = getSpecimenTypeIdsFromDescription(device);
+
+      if (!incomingSpecimenTypes.isEmpty()) {
+        allSpecimenTypes.addAll(incomingSpecimenTypes);
+      }
+
+      List<UUID> specimenTypesToAdd = new ArrayList<>(allSpecimenTypes);
+
+      specimenIdsByDevice.put(deviceIdentifier, specimenTypesToAdd);
     }
   }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #6453 

## Changes Proposed

- Add RSV vendor specimen analytes
- Add additional logging statements and toString to add more information
- Add request param to do a dry run
  - If the parameter is true, it will throw an error which will [rollback the transaction](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/annotation/Transactional.html#:~:text=If%20no%20custom%20rollback%20rules%20are%20configured%20in%20this%20annotation%2C%20the%20transaction%20will%20roll%20back%20on%20RuntimeException%20and%20Error%20but%20not%20on%20checked%20exceptions.). 
- Refactor the `syncDevices` method to reduce complexity to < 15 by pulling out methods
 
## Additional Information
- These are the vendor analyte names for RSV from the LIVD table
```json
[
    "RSV",
    "Respiratory Syncytial Virus",
    "Respiratory Syncyctial Virus (RSV) Result Interpretation",
    "RSV RNA Result",
    "RSV Result",
    "respiratory syncytial virus (RSV) B result",
    "respiratory syncytial virus (RSV) A result",
    "RSV RNA",
    "Respiratory Syncytial Virus A",
    "Respiratory Syncytial Virus B",
    "RSV Interpretation"
]
```
- These are the RSV devices in the LIVD table
```json
[
  {
    "manufacturer": "Applied BioCode, Inc.",
    "model": "BioCode CoV-2 Flu Plus Assay",
    "notes": "Part of flu a block list"
  },
  {
    "manufacturer": "BioFire Diagnostics, LLC",
    "model": "BioFire Respiratory Panel 2.1-EZ (RP2.1-EZ)",
    "notes": "Part of flu a block list"
  },
  {
    "manufacturer": "GenMark Diagnostics, Inc.",
    "model": "ePlex Respiratory Pathogen Panel 2",
    "notes" : "Separate entries for RSV A and RSV B and part of flu a block list"
  },
  {
    "manufacturer": "Luminex Molecular Diagnostics, Inc.",
    "model": "NxTAG Respiratory Pathogen Panel + SARS-CoV-2",
    "notes" : "Separate entries for RSV A and RSV B and part of flu a block list"
  },
  {
    "manufacturer": "QIAGEN GmbH",
    "model": "QIAstat-Dx Respiratory SARS-CoV-2 Panel",
    "notes": "Part of flu a block list"
  },
  {
    "manufacturer" : "Becton, Dickinson and Company (BD)",
    "model" : "BD Respiratory Viral Panel for BD MAX System"
  },
  {
    "manufacturer" : "Abbott",
    "model" : "Alinity m"
  },
  {
    "manufacturer" : "Cepheid",
    "model" : "Xpert Xpress CoV-2/Flu/RSV plus",
    "notes" : "3 entries with different equipmentUid"
  },
  {
    "manufacturer" : "Cepheid",
    "model" : "Xpert Xpress SARS-CoV-2/Flu/RSV",
    "notes" : "3 entries with different equipmentUid"
  },
  {
    "manufacturer" : "Laboratory Corporation of America (Labcorp)",
    "model" : "LDT: Labcorp Seasonal Respiratory Virus RT-PCR DTC Test"
  },
  {
    "manufacturer" : "Laboratory Corporation of America (Labcorp)",
    "model" : "LDT: Labcorp Seasonal Respiratory Virus RT-PCR Test"
  },
  {
    "manufacturer" : "NeuMoDx Molecular, Inc.",
    "model" : "NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay",
    "notes" : "2 entries with different equipmentUid"
  },
  {
    "manufacturer" : "PerkinElmer, Inc.",
    "model" : "PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1",
    "notes" : "2 entries with different equipmentUid"
  }
]
```
- Ran sync in DEV5 before deploying RSV code to be similar to prod. These are the only devices to be updated
```json

  {
    "time": "2023-09-12 21:07:56.240",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=dcf03309-157e-407a-a555-f8e4be4bd2d1, name=null, manufacturer=Becton, Dickinson and Company (BD), model=BD Respiratory Viral Panel for BD MAX System, swabTypes=[8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 52a582e4-d389-42d0-b738-bee51cf5244d], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=00382904419165, testkitNameId=BD Respiratory Viral Panel for BD MAX System_Becton, Dickinson and Company (BD), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=00382904419165, testkitNameId=BD Respiratory Viral Panel for BD MAX System_Becton, Dickinson and Company (BD), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=00382904419165, testkitNameId=BD Respiratory Viral Panel for BD MAX System_Becton, Dickinson and Company (BD), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=00382904419165, testkitNameId=BD Respiratory Viral Panel for BD MAX System_Becton, Dickinson and Company (BD), testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:56.048",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=69e9eb4d-9d7c-4037-837c-15d85c8144c4, name=null, manufacturer=NeuMoDx Molecular, Inc., model=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay, swabTypes=[8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 52a582e4-d389-42d0-b738-bee51cf5244d], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=97098-8, equipmentUid=NeuMoDx 96 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=92131-2, equipmentUid=NeuMoDx 96 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=NeuMoDx 288 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=NeuMoDx 288 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=97098-8, equipmentUid=NeuMoDx 288 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=92131-2, equipmentUid=NeuMoDx 288 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=NeuMoDx 96 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=NeuMoDx 96 Molecular System_NeuMoDx, testkitNameId=NeuMoDx Flu A-B/RSV/SARS-CoV-2 Vantage Assay_NeuMoDx Molecular, Inc., testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:55.897",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=a51f43f3-b76e-49a2-951d-dccd8cb7905e, name=null, manufacturer=Cepheid, model=Xpert Xpress CoV-2/Flu/RSV plus, swabTypes=[8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 532243d7-f04d-4d5b-a5a6-07132e31b7f2, 52a582e4-d389-42d0-b738-bee51cf5244d], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress CoV-2/Flu/RSV plus_Cepheid, testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:55.820",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=a72e8edb-bb54-47b1-83ed-938aaed01122, name=null, manufacturer=Abbott, model=Alinity m, swabTypes=[5676e5f1-84c2-471e-aa81-1ae28a9dd116, 8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 3530df5b-dde3-40eb-881c-b2c842affbfd, edf90158-df15-4e84-953e-2ca17c1c4ce4, ac5daed9-57af-4298-8b27-90b2f0ea56d1, 52a582e4-d389-42d0-b738-bee51cf5244d, 5dbd902d-6057-4a82-8286-a79363898766], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=00884999048034, testkitNameId=Alinity m Resp-4-Plex_Abbott Molecular Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=00884999048034, testkitNameId=Alinity m Resp-4-Plex_Abbott Molecular Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=00884999048034, testkitNameId=Alinity m Resp-4-Plex_Abbott Molecular Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=00884999048034, testkitNameId=00884999049222, testOrderedLoincCode=94500-6), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=00884999048034, testkitNameId=Alinity m Resp-4-Plex_Abbott Molecular Inc., testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:55.737",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=625eec8a-170b-4f0c-b653-a7525781b79d, name=null, manufacturer=Laboratory Corporation of America (Labcorp), model=LDT: Labcorp Seasonal Respiratory Virus RT-PCR DTC Test, swabTypes=[52a582e4-d389-42d0-b738-bee51cf5244d], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR DTC Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR DTC Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=95409-9, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR DTC Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR DTC Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:55.534",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=91e3d4a1-3d28-4ee9-8bb4-f6fac691082d, name=null, manufacturer=Cepheid, model=Xpert Xpress SARS-CoV-2/Flu/RSV, swabTypes=[8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 532243d7-f04d-4d5b-a5a6-07132e31b7f2, ac5daed9-57af-4298-8b27-90b2f0ea56d1], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=92141-1, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=92142-9, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=92131-2, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94502-2, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=92142-9, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=92141-1, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=92131-2, equipmentUid=GeneXpert Xpress System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=92131-2, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=92142-9, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94502-2, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=92141-1, equipmentUid=GeneXpert Dx System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94502-2, equipmentUid=GeneXpert Infinity System_Cepheid, testkitNameId=Xpert Xpress SARS-CoV-2/Flu/RSV_Cepheid, testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:55.412",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=e2c15b69-f839-4506-a957-a724f4a9cc46, name=null, manufacturer=PerkinElmer, Inc., model=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1, swabTypes=[8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 52a582e4-d389-42d0-b738-bee51cf5244d, 5dbd902d-6057-4a82-8286-a79363898766], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=ABI QuantStudio Dx_Thermo Fisher, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=ABI QuantStudio Dx_Thermo Fisher, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=ABI QuantStudio Dx_Thermo Fisher, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=ABI QuantStudio Dx_Thermo Fisher, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94500-6, equipmentUid=CFX96 Touch Real-Time PCR System_BioRad, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=CFX96 Touch Real-Time PCR System_BioRad, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=CFX96 Touch Real-Time PCR System_BioRad, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=CFX96 Touch Real-Time PCR System_BioRad, testkitNameId=PKamp Respiratory SARS-CoV-2 RT-PCR Panel 1_PerkinElmer, Inc., testOrderedLoincCode=95941-1)], testLength=0)"
  },
  {
    "time": "2023-09-12 21:07:55.060",
    "org-id": "766e1455-ad5c-4b68-bd7a-8ac8e068d034",
    "api-user": "boban@skylight.digital",
    "level": "INFO",
    "source": "g.c.u.s.service.DeviceTypeSyncService:339",
    "message": "Updating device UpdateDeviceType(internalId=b47a9279-bfd1-4b5b-b51d-6ec14bbb920c, name=null, manufacturer=Laboratory Corporation of America (Labcorp), model=LDT: Labcorp Seasonal Respiratory Virus RT-PCR Test, swabTypes=[8e07cba1-7a0f-42b7-ba36-df3bd1bf2e28, 52a582e4-d389-42d0-b738-bee51cf5244d, 5dbd902d-6057-4a82-8286-a79363898766], supportedDiseaseTestPerformed=[SupportedDiseaseTestPerformedInput(supportedDisease=7ef85a3c-6e14-4305-8115-79695c8dd673, testPerformedLoincCode=85477-8, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=8e9b7160-3809-4a6a-9780-1520417a1740, testPerformedLoincCode=94533-7, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=f4c35e38-50b3-4224-8d77-f9ef82817908, testPerformedLoincCode=85479-4, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1), SupportedDiseaseTestPerformedInput(supportedDisease=c0c4bcb2-21e1-4dc1-9ec4-fb29f026afe9, testPerformedLoincCode=85478-6, equipmentUid=ABI QuantStudio 7 Flex_Thermo Fisher, testkitNameId=Labcorp Seasonal Respiratory Virus RT-PCR Test_Laboratory Corporation of America (Labcorp), testOrderedLoincCode=95941-1)], testLength=0)"
  }
]
```

## Testing

- Run sync in dev5 https://dev5.simplereport.gov/api/devices/sync?dryRun=true and ensure no new RSV devices are added.
```curl
curl --location 'https://dev5.simplereport.gov/api/devices/sync?dryRun=true' \
--header 'Authorization: Bearer yourToken'
```