### PR TITLE
Hide RSV from test card in queue

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -7,9 +7,7 @@ import "./ManageDevices.scss";
 import { RegistrationProps } from "../../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
 import { FacilityFormData } from "../FacilityForm";
 import { searchFacilityFormDevices } from "../../../utils/device";
-import {
-  filterRsvFromAllDevices,
-} from "../../../utils/rsvHelper";
+import { filterRsvFromAllDevices } from "../../../utils/rsvHelper";
 
 interface Props {
   deviceTypes: FacilityFormDeviceType[];

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -7,7 +7,9 @@ import "./ManageDevices.scss";
 import { RegistrationProps } from "../../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
 import { FacilityFormData } from "../FacilityForm";
 import { searchFacilityFormDevices } from "../../../utils/device";
-import { filterRsvFromAllDevices } from "../../../utils/rsvHelper";
+import {
+  filterRsvFromAllDevices,
+} from "../../../utils/rsvHelper";
 
 interface Props {
   deviceTypes: FacilityFormDeviceType[];

--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -7,6 +7,7 @@ import "./ManageDevices.scss";
 import { RegistrationProps } from "../../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
 import { FacilityFormData } from "../FacilityForm";
 import { searchFacilityFormDevices } from "../../../utils/device";
+import { filterRsvFromAllDevices } from "../../../utils/rsvHelper";
 
 interface Props {
   deviceTypes: FacilityFormDeviceType[];
@@ -15,42 +16,6 @@ interface Props {
   formCurrentValues: FacilityFormData;
   registrationProps: RegistrationProps;
   onChange: (selectedItems: string[]) => void;
-}
-
-type SupportedDisease = {
-  supportedDisease: {
-    name: string;
-    __typename: "SupportedDisease";
-  };
-};
-
-function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
-  const supportedDiseaseArray =
-    device.supportedDiseaseTestPerformed as SupportedDisease[];
-
-  // no supportedDiseaseTestPerformed defined due to any casting, return empty array
-  if (supportedDiseaseArray === undefined) return [];
-
-  const supportedDiseases = supportedDiseaseArray.map(
-    (sd) => sd.supportedDisease.name
-  );
-  if (supportedDiseases.includes("RSV")) {
-    return supportedDiseaseArray.filter(
-      (d) => d.supportedDisease.name !== "RSV"
-    );
-  }
-  return supportedDiseaseArray;
-}
-
-export function filterRsvFromAllDevices(deviceTypes: FacilityFormDeviceType[]) {
-  let filteredDevices = deviceTypes.map((d) => {
-    d.supportedDiseaseTestPerformed = filterRsvFromSingleDevice(d);
-    return d;
-  });
-  filteredDevices = filteredDevices.filter(
-    (d) => d.supportedDiseaseTestPerformed.length > 0
-  );
-  return filteredDevices;
 }
 
 const ManageDevices: React.FC<Props> = ({

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -755,8 +755,9 @@ const QueueItem = ({
   };
 
   function getDeviceTypeOptions() {
-    let deviceTypes = facility!
-      .deviceTypes as DeviceWithoutModelOrManufacturer[];
+    let deviceTypes = [
+      ...facility!.deviceTypes,
+    ] as DeviceWithoutModelOrManufacturer[];
     if (!singleEntryRsvEnabled) {
       deviceTypes = filterRsvFromAllDevices(deviceTypes);
     }

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -31,7 +31,10 @@ import {
 } from "../testResults/TestResultCorrectionModal";
 import MultiplexResultInputForm from "../testResults/MultiplexResultInputForm";
 import { MULTIPLEX_DISEASES } from "../testResults/constants";
-import { filterRsvFromAllDevices } from "../utils/rsvHelper";
+import {
+  DeviceWithoutModelOrManufacturer,
+  filterRsvFromAllDevices,
+} from "../utils/rsvHelper";
 
 import { ALERT_CONTENT, QUEUE_NOTIFICATION_TYPES } from "./constants";
 import AskOnEntryTag, { areAnswersComplete } from "./AskOnEntryTag";
@@ -752,9 +755,9 @@ const QueueItem = ({
   };
 
   function getDeviceTypeOptions() {
-    let deviceTypes = facility!.deviceTypes;
+    let deviceTypes = facility!
+      .deviceTypes as DeviceWithoutModelOrManufacturer[];
     if (!singleEntryRsvEnabled) {
-      // @ts-ignore
       deviceTypes = filterRsvFromAllDevices(deviceTypes);
     }
     let deviceTypeOptions = [...deviceTypes]

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -7,6 +7,7 @@ import moment, { Moment } from "moment";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { isEqual } from "lodash";
+import { useFeature } from "flagged";
 
 import {
   GetFacilityQueueQuery,
@@ -30,6 +31,7 @@ import {
 } from "../testResults/TestResultCorrectionModal";
 import MultiplexResultInputForm from "../testResults/MultiplexResultInputForm";
 import { MULTIPLEX_DISEASES } from "../testResults/constants";
+import { filterRsvFromAllDevices } from "../utils/rsvHelper";
 
 import { ALERT_CONTENT, QUEUE_NOTIFICATION_TYPES } from "./constants";
 import AskOnEntryTag, { areAnswersComplete } from "./AskOnEntryTag";
@@ -191,6 +193,7 @@ const QueueItem = ({
   facility,
   devicesMap,
 }: QueueItemProps) => {
+  const singleEntryRsvEnabled = useFeature("singleEntryRsvEnabled");
   const testCardElement = useRef() as React.MutableRefObject<HTMLDivElement>;
   const navigate = useNavigate();
   const appInsights = getAppInsights();
@@ -749,7 +752,12 @@ const QueueItem = ({
   };
 
   function getDeviceTypeOptions() {
-    let deviceTypeOptions = [...facility!.deviceTypes]
+    let deviceTypes = facility!.deviceTypes;
+    if (!singleEntryRsvEnabled) {
+      // @ts-ignore
+      deviceTypes = filterRsvFromAllDevices(deviceTypes);
+    }
+    let deviceTypeOptions = [...deviceTypes]
       .sort(alphabetizeByName)
       .map((d) => ({
         label: d.name,

--- a/frontend/src/app/utils/rsvHelper.test.ts
+++ b/frontend/src/app/utils/rsvHelper.test.ts
@@ -1,9 +1,13 @@
 import mockSupportedDiseaseTestPerformedCovid, {
   mockSupportedDiseaseTestPerformedRSV,
-} from "../../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
+} from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
+import {
+  deviceA,
+  deviceB,
+  deviceC,
+} from "../Settings/Facility/Components/ManageDevices.test";
 
-import { deviceA, deviceB, deviceC } from "./ManageDevices.test";
-import { filterRsvFromAllDevices } from "./ManageDevices";
+import { filterRsvFromAllDevices } from "./rsvHelper";
 
 const deviceD = {
   internalId: "device-d",

--- a/frontend/src/app/utils/rsvHelper.ts
+++ b/frontend/src/app/utils/rsvHelper.ts
@@ -8,10 +8,9 @@ export type DeviceWithoutModelOrManufacturer = Omit<
   FacilityFormDeviceType,
   "model" | "manufacturer"
 >;
+type DeviceType = DeviceWithoutModelOrManufacturer | FacilityFormDeviceType;
 
-function filterRsvFromSingleDevice(
-  device: DeviceWithoutModelOrManufacturer | FacilityFormDeviceType
-) {
+function filterRsvFromSingleDevice(device: DeviceType) {
   const supportedDiseaseArray =
     device.supportedDiseaseTestPerformed as SupportedDisease[];
 
@@ -28,8 +27,6 @@ function filterRsvFromSingleDevice(
   }
   return supportedDiseaseArray;
 }
-
-type DeviceType = DeviceWithoutModelOrManufacturer | FacilityFormDeviceType;
 
 export function filterRsvFromAllDevices<AmbiguousDeviceType extends DeviceType>(
   deviceTypes: AmbiguousDeviceType[]

--- a/frontend/src/app/utils/rsvHelper.ts
+++ b/frontend/src/app/utils/rsvHelper.ts
@@ -1,0 +1,34 @@
+type SupportedDisease = {
+  supportedDisease: {
+    name: string;
+    __typename: "SupportedDisease";
+  };
+};
+function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
+  const supportedDiseaseArray =
+    device.supportedDiseaseTestPerformed as SupportedDisease[];
+
+  // no supportedDiseaseTestPerformed defined due to any casting, return empty array
+  if (supportedDiseaseArray === undefined) return [];
+
+  const supportedDiseases = supportedDiseaseArray.map(
+    (sd) => sd.supportedDisease.name
+  );
+  if (supportedDiseases.includes("RSV")) {
+    return supportedDiseaseArray.filter(
+      (d) => d.supportedDisease.name !== "RSV"
+    );
+  }
+  return supportedDiseaseArray;
+}
+
+export function filterRsvFromAllDevices(deviceTypes: FacilityFormDeviceType[]) {
+  let filteredDevices = deviceTypes.map((d) => {
+    d.supportedDiseaseTestPerformed = filterRsvFromSingleDevice(d);
+    return d;
+  });
+  filteredDevices = filteredDevices.filter(
+    (d) => d.supportedDiseaseTestPerformed.length > 0
+  );
+  return filteredDevices;
+}

--- a/frontend/src/app/utils/rsvHelper.ts
+++ b/frontend/src/app/utils/rsvHelper.ts
@@ -4,7 +4,14 @@ type SupportedDisease = {
     __typename: "SupportedDisease";
   };
 };
-function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
+export type DeviceWithoutModelOrManufacturer = Omit<
+  FacilityFormDeviceType,
+  "model" | "manufacturer"
+>;
+
+function filterRsvFromSingleDevice(
+  device: DeviceWithoutModelOrManufacturer | FacilityFormDeviceType
+) {
   const supportedDiseaseArray =
     device.supportedDiseaseTestPerformed as SupportedDisease[];
 
@@ -22,7 +29,11 @@ function filterRsvFromSingleDevice(device: FacilityFormDeviceType) {
   return supportedDiseaseArray;
 }
 
-export function filterRsvFromAllDevices(deviceTypes: FacilityFormDeviceType[]) {
+type DeviceType = DeviceWithoutModelOrManufacturer | FacilityFormDeviceType;
+
+export function filterRsvFromAllDevices<AmbiguousDeviceType extends DeviceType>(
+  deviceTypes: AmbiguousDeviceType[]
+) {
   let filteredDevices = deviceTypes.map((d) => {
     d.supportedDiseaseTestPerformed = filterRsvFromSingleDevice(d);
     return d;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6496 

## Changes Proposed

- Hides RSV from test cards in the test queu

## Additional Information
Thanks to Bob's work in #6539 there was not much to do but leverage Bob's code in the test queue 😸
- moved the functionality introduced in above PR into a separate util file

## Testing
- Have a facility with a combo of RSV devices (RSV only, RSV and flu, RSV and COVID, RSV and flu and COVID)
- Set the `singleEntryRsvEnabled` feature flag to `false`
- Check that test cards with the RSV devices appear as if they do not support RSV 
   - for RSV only devices they should not appear in the Device dropdown on the test queue card
- Ensure that test cards can be submitted as usual

## Screenshots / Demos

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
