### PR TITLE
refactor: use okta url variable for Okta domain in Header component

### DIFF
--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -101,12 +101,10 @@ const Header: React.FC<{}> = () => {
     localStorage.removeItem("access_token");
     localStorage.removeItem("id_token");
     // Determine which Okta domain to use for logout
-    const oktaDomain =
-      process.env.NODE_ENV !== "development" ? "okta" : "oktapreview";
+    const oktaDomain = process.env.REACT_APP_OKTA_URL;
     window.location.replace(
-      "https://hhs-prime." +
-        encodeURIComponent(oktaDomain) +
-        ".com/oauth2/default/v1/logout" +
+      oktaDomain +
+        "/oauth2/default/v1/logout" +
         `?id_token_hint=${encodeURIComponent(id_token || "")}` +
         `&post_logout_redirect_uri=${encodeURIComponent(
           process.env.REACT_APP_BASE_URL || ""


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolve #6019 

## Changes Proposed

- Use `REACT_APP_OKTA_URL` to set the logout path.

## Additional Information

- This is deployed out to dev4, but it should fix all lower envs that use our Okta preview instance

## Testing

1. Try logging out of an environment that uses the okta preview instance. (This should fail! :sob:)
2. Deploy to an environment
3. Log in.
4. Try logging out. (This should succeed! :smile:)

## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
