### PR TITLE
disease agnostic bulk upload page

### DIFF
--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-router-dom";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import jwtDecode from "jwt-decode";
+import { useFeature } from "flagged";
 
 import ProtectedRoute from "./commonComponents/ProtectedRoute";
 import Header from "./commonComponents/Header";
@@ -37,6 +38,7 @@ import ResultsNavWrapper from "./testResults/ResultsNavWrapper";
 import DeviceLookupContainer from "./uploads/DeviceLookup/DeviceLookupContainer";
 import UploadPatients from "./patients/UploadPatients";
 import DiseaseSpecificUploadContainer from "./testResults/uploads/DiseaseSpecificUploadContainer";
+import AgnosticUploadContainer from "./testResults/uploads/AgnosticUploadContainer";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -80,6 +82,7 @@ const checkOktaLoginStatus = (
 };
 
 const ReportingApp = () => {
+  const rsvEnabled = useFeature("rsvEnabled");
   const appInsights = getAppInsights();
   const dispatch = useDispatch();
   const location = useLocation();
@@ -250,6 +253,22 @@ const ReportingApp = () => {
                   />
                 }
               />
+              {rsvEnabled && (
+                <Route
+                  path="results/agnostic/upload/submit"
+                  element={
+                    <ProtectedRoute
+                      requiredPermissions={canViewResults}
+                      userPermissions={data.whoami.permissions}
+                      element={
+                        <ResultsNavWrapper>
+                          <AgnosticUploadContainer />
+                        </ResultsNavWrapper>
+                      }
+                    />
+                  }
+                />
+              )}
               <Route
                 path="results/upload/submit/guide"
                 element={

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -30,7 +30,7 @@ import VersionEnforcer from "./VersionEnforcer";
 import { TrainingNotification } from "./commonComponents/TrainingNotification";
 import { MaintenanceBanner } from "./commonComponents/MaintenanceBanner";
 import { Analytics } from "./analytics/Analytics";
-import Uploads from "./testResults/uploads/Uploads";
+import UploadForm from "./testResults/uploads/UploadForm";
 import Schema from "./testResults/uploads/CsvSchemaDocumentation";
 import Submission from "./testResults/submissions/Submission";
 import Submissions from "./testResults/submissions/Submissions";
@@ -244,7 +244,7 @@ const ReportingApp = () => {
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper>
-                        <Uploads />
+                        <UploadForm />
                       </ResultsNavWrapper>
                     }
                   />

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -30,13 +30,13 @@ import VersionEnforcer from "./VersionEnforcer";
 import { TrainingNotification } from "./commonComponents/TrainingNotification";
 import { MaintenanceBanner } from "./commonComponents/MaintenanceBanner";
 import { Analytics } from "./analytics/Analytics";
-import UploadForm from "./testResults/uploads/UploadForm";
 import Schema from "./testResults/uploads/CsvSchemaDocumentation";
 import Submission from "./testResults/submissions/Submission";
 import Submissions from "./testResults/submissions/Submissions";
 import ResultsNavWrapper from "./testResults/ResultsNavWrapper";
 import DeviceLookupContainer from "./uploads/DeviceLookup/DeviceLookupContainer";
 import UploadPatients from "./patients/UploadPatients";
+import DiseaseSpecificUploadContainer from "./testResults/uploads/DiseaseSpecificUploadContainer";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -244,7 +244,7 @@ const ReportingApp = () => {
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper>
-                        <UploadForm />
+                        <DiseaseSpecificUploadContainer />
                       </ResultsNavWrapper>
                     }
                   />

--- a/frontend/src/app/testResults/uploads/AgnosticUploadContainer.test.tsx
+++ b/frontend/src/app/testResults/uploads/AgnosticUploadContainer.test.tsx
@@ -1,0 +1,34 @@
+import { configureAxe } from "jest-axe";
+import { render } from "@testing-library/react";
+import createMockStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+
+import SRToastContainer from "../../commonComponents/SRToastContainer";
+
+import AgnosticUploadContainer from "./AgnosticUploadContainer";
+
+const mockStore = createMockStore([]);
+const store = mockStore();
+const axe = configureAxe({
+  rules: {
+    // disable landmark rules when testing isolated components.
+    region: { enabled: false },
+  },
+});
+
+describe("Agnostic specific upload container test", () => {
+  it("passes axe tests", async () => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SRToastContainer />
+          <AgnosticUploadContainer />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(await axe(document.body)).toHaveNoViolations();
+    expect(document.body).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
@@ -37,7 +37,7 @@ const AgnosticUploadContainer = () => {
       alert={alert}
       uploadType={"Agnostic"}
       spreadsheetTemplateLocation={""}
-      uploadResults={(file) => {
+      uploadResults={(_file) => {
         return Promise.resolve(new Response());
       }}
     />

--- a/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
+
+import UploadForm from "./UploadForm";
+
+const AgnosticUploadContainer = () => {
+  const alert = (
+    <div className="usa-alert usa-alert--info margin-left-105em margin-right-105em maxw-tablet-lg">
+      <div className="usa-alert__body">
+        <h2 className="usa-alert__heading">
+          What is the bulk results uploader?
+        </h2>
+        <p className="usa-alert__text">
+          <em>
+            This feature is in beta. That means it’s new, and we’ll continue to
+            update and improve it for our users. Though the feature is in beta,
+            it will route all the results you submit to the appropriate public
+            health department(s).
+          </em>{" "}
+          <br />
+          <br /> The results uploader allows you to report test results in bulk
+          using a CSV file. While we expect most SimpleReport users will
+          continue to report through the regular process, this feature can serve
+          labs and others with an information system that exports spreadsheets,
+          such as an EMR.{" "}
+          <LinkWithQuery to="/results/upload/submit/guide">
+            <strong>Learn more about how it works</strong>
+          </LinkWithQuery>
+          .
+        </p>
+      </div>
+    </div>
+  );
+  return (
+    <UploadForm
+      alert={alert}
+      uploadType={"Agnostic"}
+      spreadsheetTemplateLocation={""}
+      uploadResults={(file) => {
+        return Promise.resolve(new Response());
+      }}
+    />
+  );
+};
+
+export default AgnosticUploadContainer;

--- a/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
@@ -37,6 +37,7 @@ const AgnosticUploadContainer = () => {
       alert={alert}
       uploadType={"Agnostic"}
       spreadsheetTemplateLocation={""}
+      uploadGuideLocation={""}
       uploadResults={(_file) => {
         return Promise.resolve(new Response());
       }}

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.test.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.test.tsx
@@ -1,0 +1,34 @@
+import { configureAxe } from "jest-axe";
+import { render } from "@testing-library/react";
+import createMockStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+
+import SRToastContainer from "../../commonComponents/SRToastContainer";
+
+import DiseaseSpecificUploadContainer from "./DiseaseSpecificUploadContainer";
+
+const mockStore = createMockStore([]);
+const store = mockStore();
+const axe = configureAxe({
+  rules: {
+    // disable landmark rules when testing isolated components.
+    region: { enabled: false },
+  },
+});
+
+describe("Disease specific upload container test", () => {
+  it("passes axe tests", async () => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SRToastContainer />
+          <DiseaseSpecificUploadContainer />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(await axe(document.body)).toHaveNoViolations();
+    expect(document.body).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -40,7 +40,11 @@ const DiseaseSpecificUploadContainer = () => {
     </div>
   );
   return (
-    <UploadForm alert={alert} uploadResults={FileUploadService.uploadResults} />
+    <UploadForm
+      alert={alert}
+      uploadResults={FileUploadService.uploadResults}
+      uploadType={"Disease Specific"}
+    />
   );
 };
 export default DiseaseSpecificUploadContainer;

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { FileUploadService } from "../../../fileUploadService/FileUploadService";
+import { getAppInsights } from "../../TelemetryService";
+
+import UploadForm from "./UploadForm";
+
+const DiseaseSpecificUploadContainer = () => {
+  const appInsights = getAppInsights();
+
+  const alert = (
+    <div className="usa-alert usa-alert--info margin-left-105em margin-right-105em maxw-tablet-lg">
+      <div className="usa-alert__body">
+        <h2 className="usa-alert__heading">
+          New: Report flu results to California
+        </h2>
+        <p className="usa-alert__text">
+          Organizations sending results to the California Department of Public
+          Health (CDPH) can now use the bulk results upload feature to report
+          positive flu tests. Report COVID-19, flu A, and flu B results all from
+          a single spreadsheet.&nbsp;
+          <a
+            href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"
+            onClick={() => {
+              appInsights?.trackEvent({
+                name: "Access bulk uploader flu guide",
+              });
+            }}
+          >
+            See more information and guidance about flu reporting
+          </a>
+          .
+          <br />
+          <br />
+          All organizations can continue to report COVID-19 results to their
+          public health department using the bulk uploader. Flu reporting will
+          be available in other jurisdictions soon.
+        </p>
+      </div>
+    </div>
+  );
+  return (
+    <UploadForm alert={alert} uploadResults={FileUploadService.uploadResults} />
+  );
+};
+export default DiseaseSpecificUploadContainer;

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -44,6 +44,9 @@ const DiseaseSpecificUploadContainer = () => {
       alert={alert}
       uploadResults={FileUploadService.uploadResults}
       uploadType={"Disease Specific"}
+      spreadsheetTemplateLocation={
+        "/assets/resources/test_results_example_10-3-2022.csv"
+      }
     />
   );
 };

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -47,6 +47,7 @@ const DiseaseSpecificUploadContainer = () => {
       spreadsheetTemplateLocation={
         "/assets/resources/test_results_example_10-3-2022.csv"
       }
+      uploadGuideLocation={"/results/upload/submit/guide"}
     />
   );
 };

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -44,7 +44,7 @@ const TestContainer = () => (
   <Provider store={store}>
     <MemoryRouter>
       <SRToastContainer />
-      <UploadForm />
+      <UploadForm uploadResults={FileUploadService.uploadResults} />
     </MemoryRouter>
   </Provider>
 );

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -48,6 +48,7 @@ const TestContainer = () => (
         uploadResults={FileUploadService.uploadResults}
         uploadType={"Disease Specific"}
         spreadsheetTemplateLocation={""}
+        uploadGuideLocation={""}
       />
     </MemoryRouter>
   </Provider>

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -44,7 +44,10 @@ const TestContainer = () => (
   <Provider store={store}>
     <MemoryRouter>
       <SRToastContainer />
-      <UploadForm uploadResults={FileUploadService.uploadResults} />
+      <UploadForm
+        uploadResults={FileUploadService.uploadResults}
+        uploadType={"Disease Specific"}
+      />
     </MemoryRouter>
   </Provider>
 );

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -47,6 +47,7 @@ const TestContainer = () => (
       <UploadForm
         uploadResults={FileUploadService.uploadResults}
         uploadType={"Disease Specific"}
+        spreadsheetTemplateLocation={""}
       />
     </MemoryRouter>
   </Provider>
@@ -211,6 +212,7 @@ describe("Uploads", () => {
             org: "Test Org",
             "report ID": "fake-report-id",
             user: "testuser@test.org",
+            uploadType: "Disease Specific",
           },
         });
       });
@@ -258,6 +260,7 @@ describe("Uploads", () => {
         properties: {
           org: "Test Org",
           user: "testuser@test.org",
+          uploadType: "Disease Specific",
         },
       });
     });
@@ -313,6 +316,7 @@ describe("Uploads", () => {
           ],
           org: "Test Org",
           user: "testuser@test.org",
+          uploadType: "Disease Specific",
         },
       });
     });

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -12,12 +12,12 @@ import { getAppInsights } from "../../TelemetryService";
 import { FileUploadService } from "../../../fileUploadService/FileUploadService";
 import SRToastContainer from "../../commonComponents/SRToastContainer";
 
-import Uploads, {
+import UploadForm, {
   EnhancedFeedbackMessage,
   getErrorMessage,
   getGuidance,
   groupErrors,
-} from "./Uploads";
+} from "./UploadForm";
 
 jest.mock("../../TelemetryService", () => ({
   ...jest.requireActual("../../TelemetryService"),
@@ -44,7 +44,7 @@ const TestContainer = () => (
   <Provider store={store}>
     <MemoryRouter>
       <SRToastContainer />
-      <Uploads />
+      <UploadForm />
     </MemoryRouter>
   </Provider>
 );

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -165,9 +165,14 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
 interface UploadFormProps {
   uploadResults: (file: File) => Promise<Response>;
   alert?: JSX.Element;
+  uploadType: "Agnostic" | "Disease Specific";
 }
 
-const UploadForm: React.FC<UploadFormProps> = ({ alert, uploadResults }) => {
+const UploadForm: React.FC<UploadFormProps> = ({
+  alert,
+  uploadResults,
+  uploadType,
+}) => {
   useDocumentTitle("Upload spreadsheet");
 
   const appInsights = getAppInsights();
@@ -312,6 +317,7 @@ const UploadForm: React.FC<UploadFormProps> = ({ alert, uploadResults }) => {
           properties: {
             org: orgName,
             user: user?.email,
+            uploadType: uploadType,
           },
         });
       } else {
@@ -326,6 +332,7 @@ const UploadForm: React.FC<UploadFormProps> = ({ alert, uploadResults }) => {
               "report ID": response.reportId,
               org: orgName,
               user: user?.email,
+              uploadType: uploadType,
             },
           });
         }
@@ -346,6 +353,7 @@ const UploadForm: React.FC<UploadFormProps> = ({ alert, uploadResults }) => {
               errors: response.errors,
               org: orgName,
               user: user?.email,
+              uploadType: uploadType,
             },
           });
         }
@@ -383,6 +391,9 @@ const UploadForm: React.FC<UploadFormProps> = ({ alert, uploadResults }) => {
                     onClick={() => {
                       appInsights?.trackEvent({
                         name: "Download spreadsheet template",
+                        properties: {
+                          uploadType: uploadType,
+                        },
                       });
                     }}
                   >

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -164,7 +164,7 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
 
 interface UploadFormProps {
   uploadResults: (file: File) => Promise<Response>;
-  alert?: JSX.Element;
+  alert?: React.JSX.Element;
   uploadType: "Agnostic" | "Disease Specific";
   spreadsheetTemplateLocation: string;
   uploadGuideLocation?: string;
@@ -177,7 +177,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
   spreadsheetTemplateLocation,
   uploadGuideLocation,
 }) => {
-  useDocumentTitle("Upload spreadsheet");
+  useDocumentTitle(`Upload ${uploadType.toLowerCase()} spreadsheet`);
 
   const appInsights = getAppInsights();
   const orgName = useSelector<RootState, string>(

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -166,12 +166,14 @@ interface UploadFormProps {
   uploadResults: (file: File) => Promise<Response>;
   alert?: JSX.Element;
   uploadType: "Agnostic" | "Disease Specific";
+  spreadsheetTemplateLocation: string;
 }
 
 const UploadForm: React.FC<UploadFormProps> = ({
   alert,
   uploadResults,
   uploadType,
+  spreadsheetTemplateLocation,
 }) => {
   useDocumentTitle("Upload spreadsheet");
 
@@ -387,7 +389,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
                 <p className="usa-process-list__heading">
                   Download the{" "}
                   <a
-                    href="/assets/resources/test_results_example_10-3-2022.csv"
+                    href={spreadsheetTemplateLocation}
                     onClick={() => {
                       appInsights?.trackEvent({
                         name: "Download spreadsheet template",

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -167,6 +167,7 @@ interface UploadFormProps {
   alert?: JSX.Element;
   uploadType: "Agnostic" | "Disease Specific";
   spreadsheetTemplateLocation: string;
+  uploadGuideLocation?: string;
 }
 
 const UploadForm: React.FC<UploadFormProps> = ({
@@ -174,6 +175,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
   uploadResults,
   uploadType,
   spreadsheetTemplateLocation,
+  uploadGuideLocation,
 }) => {
   useDocumentTitle("Upload spreadsheet");
 
@@ -380,7 +382,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
               <li className="usa-process-list__item margin-bottom-1em">
                 <p className="usa-process-list__heading">
                   Visit the{" "}
-                  <LinkWithQuery to="/results/upload/submit/guide">
+                  <LinkWithQuery to={uploadGuideLocation ?? ""}>
                     <strong>spreadsheet upload guide</strong>
                   </LinkWithQuery>
                 </p>

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -163,7 +163,7 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
   }
 }
 
-const Uploads = () => {
+const UploadForm = () => {
   useDocumentTitle("Upload spreadsheet");
 
   const appInsights = getAppInsights();
@@ -533,4 +533,4 @@ const Uploads = () => {
   );
 };
 
-export default Uploads;
+export default UploadForm;

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -167,7 +167,7 @@ interface UploadFormProps {
   alert?: React.JSX.Element;
   uploadType: "Agnostic" | "Disease Specific";
   spreadsheetTemplateLocation: string;
-  uploadGuideLocation?: string;
+  uploadGuideLocation: string;
 }
 
 const UploadForm: React.FC<UploadFormProps> = ({
@@ -382,7 +382,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
               <li className="usa-process-list__item margin-bottom-1em">
                 <p className="usa-process-list__heading">
                   Visit the{" "}
-                  <LinkWithQuery to={uploadGuideLocation ?? ""}>
+                  <LinkWithQuery to={uploadGuideLocation}>
                     <strong>spreadsheet upload guide</strong>
                   </LinkWithQuery>
                 </p>

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -7,7 +7,6 @@ import { showError } from "../../utils/srToast";
 import { FeedbackMessage } from "../../../generated/graphql";
 import { useDocumentTitle } from "../../utils/hooks";
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
-import { FileUploadService } from "../../../fileUploadService/FileUploadService";
 import "./Uploads.scss";
 import "../HeaderSizeFix.scss";
 import { getAppInsights } from "../../TelemetryService";
@@ -163,7 +162,12 @@ export function getGuidance(error: EnhancedFeedbackMessage) {
   }
 }
 
-const UploadForm = () => {
+interface UploadFormProps {
+  uploadResults: (file: File) => Promise<Response>;
+  alert?: JSX.Element;
+}
+
+const UploadForm: React.FC<UploadFormProps> = ({ alert, uploadResults }) => {
   useDocumentTitle("Upload spreadsheet");
 
   const appInsights = getAppInsights();
@@ -293,7 +297,7 @@ const UploadForm = () => {
       return;
     }
 
-    FileUploadService.uploadResults(file).then(async (res) => {
+    uploadResults(file).then(async (res) => {
       setIsSubmitting(false);
       setFileInputResetValue(fileInputResetValue + 1);
       setFile(undefined);
@@ -355,35 +359,7 @@ const UploadForm = () => {
         <div className="usa-card__header">
           <h1>Upload your results</h1>
         </div>
-        <div className="usa-alert usa-alert--info margin-left-105em margin-right-105em maxw-tablet-lg">
-          <div className="usa-alert__body">
-            <h2 className="usa-alert__heading">
-              New: Report flu results to California
-            </h2>
-            <p className="usa-alert__text">
-              Organizations sending results to the California Department of
-              Public Health (CDPH) can now use the bulk results upload feature
-              to report positive flu tests. Report COVID-19, flu A, and flu B
-              results all from a single spreadsheet.&nbsp;
-              <a
-                href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"
-                onClick={() => {
-                  appInsights?.trackEvent({
-                    name: "Access bulk uploader flu guide",
-                  });
-                }}
-              >
-                See more information and guidance about flu reporting
-              </a>
-              .
-              <br />
-              <br />
-              All organizations can continue to report COVID-19 results to their
-              public health department using the bulk uploader. Flu reporting
-              will be available in other jurisdictions soon.
-            </p>
-          </div>
-        </div>
+        {alert}
         <div className="usa-card__body padding-y-2 maxw-prose">
           <p>
             Report results in bulk using a comma-separated values (CSV)

--- a/frontend/src/app/testResults/uploads/__snapshots__/AgnosticUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/AgnosticUploadContainer.test.tsx.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Agnostic specific upload container test passes axe tests 1`] = `
+<body>
+  <div>
+    <div
+      class="Toastify"
+    />
+    <div
+      class="grid-row header-size-fix sr-test-results-uploads"
+    >
+      <div
+        class="prime-container card-container"
+      >
+        <div
+          class="usa-card__header"
+        >
+          <h1>
+            Upload your results
+          </h1>
+        </div>
+        <div
+          class="usa-alert usa-alert--info margin-left-105em margin-right-105em maxw-tablet-lg"
+        >
+          <div
+            class="usa-alert__body"
+          >
+            <h2
+              class="usa-alert__heading"
+            >
+              What is the bulk results uploader?
+            </h2>
+            <p
+              class="usa-alert__text"
+            >
+              <em>
+                This feature is in beta. That means it’s new, and we’ll continue to update and improve it for our users. Though the feature is in beta, it will route all the results you submit to the appropriate public health department(s).
+              </em>
+               
+              <br />
+              <br />
+               The results uploader allows you to report test results in bulk using a CSV file. While we expect most SimpleReport users will continue to report through the regular process, this feature can serve labs and others with an information system that exports spreadsheets, such as an EMR.
+               
+              <a
+                class=""
+                href="/results/upload/submit/guide"
+              >
+                <strong>
+                  Learn more about how it works
+                </strong>
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+        <div
+          class="usa-card__body padding-y-2 maxw-prose"
+        >
+          <p>
+            Report results in bulk using a comma-separated values (CSV) spreadsheet. To upload your spreadsheet:
+          </p>
+          <section>
+            <ol
+              class="usa-process-list"
+            >
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Visit the
+                   
+                  <a
+                    class=""
+                    href="/results/upload/submit/guide"
+                  >
+                    <strong>
+                      spreadsheet upload guide
+                    </strong>
+                  </a>
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Download the
+                   
+                  <a
+                    href=""
+                  >
+                    spreadsheet template
+                  </a>
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Following the guide and template, format your data to match SimpleReport requirements
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Save your spreadsheet in a CSV format (file size limit is 50 MB or 10,000 rows)
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Submit your CSV to the uploader below
+                </p>
+              </li>
+            </ol>
+          </section>
+          <div
+            class="usa-form-group margin-bottom-3"
+            data-testid="formGroup"
+          >
+            <div
+              class="sr-single-file-input blank"
+            >
+              <input
+                accept="text/csv, .csv"
+                aria-describedby="file-input-specific-hint"
+                aria-invalid="false"
+                aria-label="Choose CSV file"
+                class="usa-file-input"
+                data-testid="upload-csv-input"
+                id="upload-csv-input"
+                name="upload-csv-input"
+                required=""
+                type="file"
+              />
+              <span
+                id="file-input-specific-hint"
+              >
+                Drag file here or choose from folder
+              </span>
+            </div>
+          </div>
+          <button
+            class="usa-button"
+            data-testid="button"
+            disabled=""
+            type="submit"
+          >
+            <span>
+              Upload your CSV
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/frontend/src/app/testResults/uploads/__snapshots__/AgnosticUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/AgnosticUploadContainer.test.tsx.snap
@@ -72,8 +72,9 @@ exports[`Agnostic specific upload container test passes axe tests 1`] = `
                   Visit the
                    
                   <a
-                    class=""
-                    href="/results/upload/submit/guide"
+                    aria-current="page"
+                    class="active"
+                    href="/"
                   >
                     <strong>
                       spreadsheet upload guide

--- a/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Disease specific upload container test passes axe tests 1`] = `
+<body>
+  <div>
+    <div
+      class="Toastify"
+    />
+    <div
+      class="grid-row header-size-fix sr-test-results-uploads"
+    >
+      <div
+        class="prime-container card-container"
+      >
+        <div
+          class="usa-card__header"
+        >
+          <h1>
+            Upload your results
+          </h1>
+        </div>
+        <div
+          class="usa-alert usa-alert--info margin-left-105em margin-right-105em maxw-tablet-lg"
+        >
+          <div
+            class="usa-alert__body"
+          >
+            <h2
+              class="usa-alert__heading"
+            >
+              New: Report flu results to California
+            </h2>
+            <p
+              class="usa-alert__text"
+            >
+              Organizations sending results to the California Department of Public Health (CDPH) can now use the bulk results upload feature to report positive flu tests. Report COVID-19, flu A, and flu B results all from a single spreadsheet. 
+              <a
+                href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"
+              >
+                See more information and guidance about flu reporting
+              </a>
+              .
+              <br />
+              <br />
+              All organizations can continue to report COVID-19 results to their public health department using the bulk uploader. Flu reporting will be available in other jurisdictions soon.
+            </p>
+          </div>
+        </div>
+        <div
+          class="usa-card__body padding-y-2 maxw-prose"
+        >
+          <p>
+            Report results in bulk using a comma-separated values (CSV) spreadsheet. To upload your spreadsheet:
+          </p>
+          <section>
+            <ol
+              class="usa-process-list"
+            >
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Visit the
+                   
+                  <a
+                    class=""
+                    href="/results/upload/submit/guide"
+                  >
+                    <strong>
+                      spreadsheet upload guide
+                    </strong>
+                  </a>
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Download the
+                   
+                  <a
+                    href="/assets/resources/test_results_example_10-3-2022.csv"
+                  >
+                    spreadsheet template
+                  </a>
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Following the guide and template, format your data to match SimpleReport requirements
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Save your spreadsheet in a CSV format (file size limit is 50 MB or 10,000 rows)
+                </p>
+              </li>
+              <li
+                class="usa-process-list__item margin-bottom-1em"
+              >
+                <p
+                  class="usa-process-list__heading"
+                >
+                  Submit your CSV to the uploader below
+                </p>
+              </li>
+            </ol>
+          </section>
+          <div
+            class="usa-form-group margin-bottom-3"
+            data-testid="formGroup"
+          >
+            <div
+              class="sr-single-file-input blank"
+            >
+              <input
+                accept="text/csv, .csv"
+                aria-describedby="file-input-specific-hint"
+                aria-invalid="false"
+                aria-label="Choose CSV file"
+                class="usa-file-input"
+                data-testid="upload-csv-input"
+                id="upload-csv-input"
+                name="upload-csv-input"
+                required=""
+                type="file"
+              />
+              <span
+                id="file-input-specific-hint"
+              >
+                Drag file here or choose from folder
+              </span>
+            </div>
+          </div>
+          <button
+            class="usa-button"
+            data-testid="button"
+            disabled=""
+            type="submit"
+          >
+            <span>
+              Upload your CSV
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/frontend/src/stories/testResults/UploadForm.stories.tsx
+++ b/frontend/src/stories/testResults/UploadForm.stories.tsx
@@ -6,7 +6,7 @@ import { store } from "../../app/store";
 import { StoryGraphQLProvider } from "../storyMocks";
 import UploadForm from "../../app/testResults/uploads/UploadForm";
 
-type Props = {};
+type Props = React.ComponentProps<typeof UploadForm>;
 
 export default {
   title: "App/Test results/Upload CSV",

--- a/frontend/src/stories/testResults/Uploads.stories.tsx
+++ b/frontend/src/stories/testResults/Uploads.stories.tsx
@@ -3,14 +3,14 @@ import { MemoryRouter } from "react-router-dom";
 import { Meta, StoryFn } from "@storybook/react";
 
 import { store } from "../../app/store";
-import { StoryGraphQLProvider } from "../../stories/storyMocks";
-import Uploads from "../../app/testResults/uploads/Uploads";
+import { StoryGraphQLProvider } from "../storyMocks";
+import UploadForm from "../../app/testResults/uploads/UploadForm";
 
 type Props = {};
 
 export default {
   title: "App/Test results/Upload CSV",
-  component: Uploads,
+  component: UploadForm,
   argTypes: {},
   args: {},
   decorators: [
@@ -25,7 +25,7 @@ export default {
 const Template: StoryFn<Props> = (args) => (
   <Provider store={store}>
     <MemoryRouter>
-      <Uploads {...args} />
+      <UploadForm {...args} />
     </MemoryRouter>
   </Provider>
 );


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6471 

## Changes Proposed

- Convert the existing upload page into a form that can be used in multiple instances without duplicating code.

## Additional Information


## Testing

- 

## Screenshots / Demos


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
