### PR TITLE
fix codesmells in test folder

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
     properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
-public class SimpleReportApplicationTests {
+class SimpleReportApplicationTests {
 
   @Autowired private SimpleReportApplication application;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarTypeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/FlexibleDateScalarTypeTest.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import org.junit.jupiter.api.Test;
 
-public class FlexibleDateScalarTypeTest {
+class FlexibleDateScalarTypeTest {
   private final FlexibleDateCoercion converter = new FlexibleDateCoercion();
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/TranslatorTest.java
@@ -25,12 +25,14 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TranslatorTest {
   @Test
@@ -43,28 +45,20 @@ class TranslatorTest {
     assertNull(parseUserShortDate(null));
   }
 
-  @Test
-  void validUserShortDate_withStandardFormatParsesCorrectly() {
-    LocalDate result = parseUserShortDate("2/1/2021");
+  @ParameterizedTest(name = "{0} parses correctly")
+  @MethodSource("namedArguments")
+  void validUserShortDate_parsesCorrectly(String date) {
+    LocalDate result = parseUserShortDate(date);
     assertEquals(2, result.getMonthValue());
     assertEquals(1, result.getDayOfMonth());
     assertEquals(2021, result.getYear());
   }
 
-  @Test
-  void validUserShortDate_withLeadingZerosParsesCorrectly() {
-    LocalDate result = parseUserShortDate("02/01/2021");
-    assertEquals(2, result.getMonthValue());
-    assertEquals(1, result.getDayOfMonth());
-    assertEquals(2021, result.getYear());
-  }
-
-  @Test
-  void validUserShortDate_withShortYearParsesCorrectly() {
-    LocalDate result = parseUserShortDate("2/1/80");
-    assertEquals(2, result.getMonthValue());
-    assertEquals(1, result.getDayOfMonth());
-    assertEquals(1980, result.getYear());
+  static Stream<Arguments> namedArguments() {
+    return Stream.of(
+        Arguments.of(Named.of("Standard format date", "2/1/2021")),
+        Arguments.of(Named.of("Leading zeros date", "02/01/2021")),
+        Arguments.of(Named.of("Short year date", "2/1/21")));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/UserAccountCreationControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/UserAccountCreationControllerTest.java
@@ -11,9 +11,14 @@ import gov.cdc.usds.simplereport.config.authorization.DemoAuthenticationConfigur
 import gov.cdc.usds.simplereport.idp.authentication.DemoOktaAuthentication;
 import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
 import gov.cdc.usds.simplereport.logging.AuditLoggingAdvice;
+import java.util.stream.Stream;
 import javax.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan.Filter;
@@ -383,8 +388,9 @@ class UserAccountCreationControllerTest extends BaseNonSpringBootTestConfigurati
     this._mockMvc.perform(activateSecurityKeyBuilder).andExpect(status().is4xxClientError());
   }
 
-  @Test
-  void activateSecurityKey_failsWithInvalidAttestation() throws Exception {
+  @ParameterizedTest
+  @MethodSource("namedArguments")
+  void activateSecurityKey_fails(String requestBody) throws Exception {
     MockHttpSession session = new MockHttpSession();
     issueActivationRequest(session);
     issueSetPasswordRequest(session);
@@ -393,52 +399,20 @@ class UserAccountCreationControllerTest extends BaseNonSpringBootTestConfigurati
         createPostRequest(session, "", ResourceLinks.USER_ENROLL_SECURITY_KEY_MFA);
 
     MockHttpServletRequestBuilder activateSecurityKeyBuilder =
-        createPostRequest(
-            session,
-            "{\"attestation\":\"\", \"clientData\":\"dataaaaa\"}",
-            ResourceLinks.USER_ACTIVATE_SECURITY_KEY_MFA);
+        createPostRequest(session, requestBody, ResourceLinks.USER_ACTIVATE_SECURITY_KEY_MFA);
 
     performRequestAndGetSession(enrollSecurityKeyBuilder);
 
     this._mockMvc.perform(activateSecurityKeyBuilder).andExpect(status().is4xxClientError());
   }
 
-  @Test
-  void activateSecurityKey_failsWithInvalidClientData() throws Exception {
-    MockHttpSession session = new MockHttpSession();
-    issueActivationRequest(session);
-    issueSetPasswordRequest(session);
-
-    MockHttpServletRequestBuilder enrollSecurityKeyBuilder =
-        createPostRequest(session, "", ResourceLinks.USER_ENROLL_SECURITY_KEY_MFA);
-
-    MockHttpServletRequestBuilder activateSecurityKeyBuilder =
-        createPostRequest(
-            session,
-            "{\"attestation\":\"123456\", \"clientData\":\"\"}",
-            ResourceLinks.USER_ACTIVATE_SECURITY_KEY_MFA);
-
-    performRequestAndGetSession(enrollSecurityKeyBuilder);
-
-    this._mockMvc.perform(activateSecurityKeyBuilder).andExpect(status().is4xxClientError());
-  }
-
-  @Test
-  void activateSecurityKey_failsWithInvalidRequest() throws Exception {
-    MockHttpSession session = new MockHttpSession();
-    issueActivationRequest(session);
-    issueSetPasswordRequest(session);
-
-    MockHttpServletRequestBuilder enrollSecurityKeyBuilder =
-        createPostRequest(session, "", ResourceLinks.USER_ENROLL_SECURITY_KEY_MFA);
-
-    MockHttpServletRequestBuilder activateSecurityKeyBuilder =
-        createPostRequest(
-            session, "{\"attestation\":\"123456\"}", ResourceLinks.USER_ACTIVATE_SECURITY_KEY_MFA);
-
-    performRequestAndGetSession(enrollSecurityKeyBuilder);
-
-    this._mockMvc.perform(activateSecurityKeyBuilder).andExpect(status().is4xxClientError());
+  static Stream<Arguments> namedArguments() {
+    return Stream.of(
+        Arguments.of(
+            Named.of("Invalid Attestation", "{\"attestation\":\"\", \"clientData\":\"dataaaaa\"}")),
+        Arguments.of(
+            Named.of("Invalid client data", "{\"attestation\":\"123456\", \"clientData\":\"\"}")),
+        Arguments.of(Named.of("Invalid request", "{\"attestation\":\"123456\"}")));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/pxp/PatientExperienceControllerTest.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.api.pxp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -411,7 +410,7 @@ class PatientExperienceControllerTest extends BaseFullStackTest {
     mockMvc.perform(builder).andExpect(status().isOk());
     List<TimeOfConsent> tocList = tocService.getTimeOfConsent(patientLink);
     assertNotNull(tocList);
-    assertNotEquals(tocList.size(), 0);
+    assertThat(tocList).isNotEmpty();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/FeatureFlagTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/FeatureFlagTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** ToDo Remove public modifier from this test once Spring for GraphQL migration is done */
-public class FeatureFlagTest {
+class FeatureFlagTest {
   private FeatureFlag featureFlag = new FeatureFlag();
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -14,9 +14,12 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
@@ -32,11 +35,19 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
 
   @Autowired private JacksonTester<Person> _tester;
 
-  @ParameterizedTest
-  @ValueSource(strings = {"race-scalar.json", "race-array.json", "with-facility.json"})
-  void deserialize_stringRace_raceFound(String filename) throws IOException {
-    ObjectContent<Person> ob = _tester.read("/deserialization/" + filename);
+  @ParameterizedTest(name = "deserialize {0}")
+  @MethodSource("namedArguments")
+  void deserialize_raceFound(String filePath) throws IOException {
+    ObjectContent<Person> ob = _tester.read(filePath);
     assertAlexanderHamilton(ob);
+  }
+
+  static Stream<Arguments> namedArguments() {
+    return Stream.of(
+        Arguments.of(Named.of("string race and race found", "/deserialization/race-scalar.json")),
+        Arguments.of(Named.of("array race and race found", "/deserialization/race-array.json")),
+        Arguments.of(
+            Named.of("race found and no facility", "/deserialization/with-facility.json")));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/model/PersonSerializationTest.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
@@ -30,21 +32,10 @@ class PersonSerializationTest extends BaseNonSpringBootTestConfiguration {
 
   @Autowired private JacksonTester<Person> _tester;
 
-  @Test
-  void deserialize_stringRace_raceFound() throws IOException {
-    ObjectContent<Person> ob = _tester.read("/deserialization/race-scalar.json");
-    assertAlexanderHamilton(ob);
-  }
-
-  @Test
-  void deserialize_arrayRace_raceFound() throws IOException {
-    ObjectContent<Person> ob = _tester.read("/deserialization/race-array.json");
-    assertAlexanderHamilton(ob);
-  }
-
-  @Test
-  void deserialize_withFacility_raceFoundNoFacility() throws IOException {
-    ObjectContent<Person> ob = _tester.read("/deserialization/with-facility.json");
+  @ParameterizedTest
+  @ValueSource(strings = {"race-scalar.json", "race-array.json", "with-facility.json"})
+  void deserialize_stringRace_raceFound(String filename) throws IOException {
+    ObjectContent<Person> ob = _tester.read("/deserialization/" + filename);
     assertAlexanderHamilton(ob);
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PatientLinkRepositoryTest.java
@@ -62,9 +62,10 @@ class PatientLinkRepositoryTest extends BaseRepositoryTest {
                 testOrderNoPatientLink.getInternalId()));
 
     // THEN
-    assertThat(found).hasSize(2);
-    assertThat(found).contains(testOrder1MostRecentPatientLink, testOrder2MostRecentPatientLink);
-    assertThat(found).doesNotContain(testOrder1OlderPatientLink, testOrder2OlderPatientLink);
+    assertThat(found)
+        .hasSize(2)
+        .contains(testOrder1MostRecentPatientLink, testOrder2MostRecentPatientLink)
+        .doesNotContain(testOrder1OlderPatientLink, testOrder2OlderPatientLink);
   }
 
   private void mockCreationTime(String date) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -304,7 +304,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(disease1TestPerformed.get().getTestOrderedLoincCode()).isEqualTo("loinc3");
 
     List<SpecimenType> updatedSwabTypes = updatedDevice.getSwabTypes();
-    assertThat(updatedSwabTypes.size()).isEqualTo(1);
+    assertThat(updatedSwabTypes).hasSize(1);
     assertThat(updatedSwabTypes.get(0).getName()).isEqualTo("Mouth");
   }
 
@@ -450,7 +450,7 @@ class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
     assertThat(disease1TestPerformed.get().getTestOrderedLoincCode()).isEqualTo("loinc3");
 
     List<SpecimenType> updatedSwabTypes = updatedDevice.getSwabTypes();
-    assertThat(updatedSwabTypes.size()).isEqualTo(1);
+    assertThat(updatedSwabTypes).hasSize(1);
     assertThat(updatedSwabTypes.get(0).getName()).isEqualTo("Nose");
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationQueueServiceTest.java
@@ -76,7 +76,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
 
     Optional<OrganizationQueueItem> optFetchedQueueItem =
         _service.getUnverifiedQueuedOrganizationByExternalId(editedItem.getExternalId());
-    assertEquals(optFetchedQueueItem.get().getOrganizationName(), "Edited Org Queue Name");
+    assertEquals("Edited Org Queue Name", optFetchedQueueItem.get().getOrganizationName());
   }
 
   @Test
@@ -94,8 +94,8 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
     // re-fetch queue item and see changes reflected
     Optional<OrganizationQueueItem> optFetchedQueueItem =
         _service.getUnverifiedQueuedOrganizationByExternalId(createdQueueItem.getExternalId());
-    assertEquals(optFetchedQueueItem.get().getRequestData().getFirstName(), "Sarah");
-    assertEquals(optFetchedQueueItem.get().getRequestData().getLastName(), "Samuels");
+    assertEquals("Sarah", optFetchedQueueItem.get().getRequestData().getFirstName());
+    assertEquals("Samuels", optFetchedQueueItem.get().getRequestData().getLastName());
   }
 
   @Test
@@ -113,8 +113,8 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
     // re-fetch queue item and see changes reflected
     Optional<OrganizationQueueItem> optFetchedQueueItem =
         _service.getUnverifiedQueuedOrganizationByExternalId(createdQueueItem.getExternalId());
-    assertEquals(optFetchedQueueItem.get().getRequestData().getEmail(), "foo@bar.com");
-    assertEquals(optFetchedQueueItem.get().getRequestData().getWorkPhoneNumber(), "123-456-7890");
+    assertEquals("foo@bar.com", optFetchedQueueItem.get().getRequestData().getEmail());
+    assertEquals("123-456-7890", optFetchedQueueItem.get().getRequestData().getWorkPhoneNumber());
   }
 
   @Test
@@ -139,7 +139,7 @@ class OrganizationQueueServiceTest extends BaseServiceTest<OrganizationQueueServ
                   editedOrgAdminPhone);
             });
     assertEquals(
-        exception.getMessage(), "Requesting edits on an organization that does not exist.");
+        "Requesting edits on an organization that does not exist.", exception.getMessage());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/email/EmailServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/email/EmailServiceTest.java
@@ -165,14 +165,14 @@ class EmailServiceTest extends BaseServiceTest<EmailService> {
 
     assertThat(sentMail.get(0).getFrom().getEmail()).isEqualTo("me@example.com");
     assertThat(sentMail.get(0).getFrom().getName()).isEqualTo("My Display Name");
-    assertEquals(personalization0.getTos().get(0).getEmail(), "test@foo.com");
+    assertEquals("test@foo.com", personalization0.getTos().get(0).getEmail());
 
     // Second email
     Personalization personalization1 = sentMail.get(1).getPersonalization().get(0);
 
     assertThat(sentMail.get(1).getFrom().getEmail()).isEqualTo("me@example.com");
     assertThat(sentMail.get(1).getFrom().getName()).isEqualTo("My Display Name");
-    assertEquals(personalization1.getTos().get(0).getEmail(), "foo@bar.org");
+    assertEquals("foo@bar.org", personalization1.getTos().get(0).getEmail());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/model/PatientEmailsHolderTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/model/PatientEmailsHolderTest.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class PatientEmailsHolderTest {
+class PatientEmailsHolderTest {
   @Test
   void default_returnsDefault() {
     var defaultEmail = "test@fake.com";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/MultiplexUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/MultiplexUtilsTest.java
@@ -1,16 +1,17 @@
 package gov.cdc.usds.simplereport.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class MultiplexUtilsTest {
+class MultiplexUtilsTest {
   @Test
   void inferMultiplexTestOrderLoinc_getsCalledWithEmptySupportedDiseaseTestPerformed() {
-    assertEquals(null, MultiplexUtils.inferMultiplexTestOrderLoinc(new ArrayList<>()));
+    assertNull(MultiplexUtils.inferMultiplexTestOrderLoinc(new ArrayList<>()));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/OrderingProviderRequiredValidatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/OrderingProviderRequiredValidatorTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class OrderingProviderRequiredValidatorTest {
+class OrderingProviderRequiredValidatorTest {
 
   private OrderingProviderRequiredValidator validator;
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5590 and resolves #5596 

## Changes Proposed

- Swap order of actual and expected values in assertEquals()
- Replace tests that only change a single variable with a [`ParameterizedTest`](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests)
- Clean up other minor code smells like removing public identifier from classes

## Testing

- The tests still work!
