### PR TITLE
fix broken e2e and add Disease Agnostic/Specific upload stories

### DIFF
--- a/.github/workflows/testingWorkflow.yml
+++ b/.github/workflows/testingWorkflow.yml
@@ -163,6 +163,14 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           image_name: frontend
           platform: ${{ matrix.platform }}
+          build_args: |
+            "REACT_APP_OKTA_URL=http://wiremock:8088"
+            "REACT_APP_OKTA_CLIENT_ID=0oa1k0163nAwfVxNW1d7"
+            "REACT_APP_BASE_URL=https://localhost.simplereport.gov"
+            "REACT_APP_BACKEND_URL=https://localhost.simplereport.gov/api"
+            "PUBLIC_URL=/app/"
+            "REACT_APP_OKTA_ENABLED=true"
+            "REACT_APP_DISABLE_MAINTENANCE_BANNER=true"
 
   build_frontend_lighthouse_image:
     if: needs.frontend_changes.outputs.has_changes == 'true' || inputs.force_build == 'true' || github.ref == 'refs/heads/main'

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -177,7 +177,9 @@ const UploadForm: React.FC<UploadFormProps> = ({
   spreadsheetTemplateLocation,
   uploadGuideLocation,
 }) => {
-  useDocumentTitle(`Upload ${uploadType.toLowerCase()} spreadsheet`);
+  useDocumentTitle(
+    `Upload ${uploadType && uploadType.toLowerCase()} spreadsheet`
+  );
 
   const appInsights = getAppInsights();
   const orgName = useSelector<RootState, string>(

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -177,9 +177,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
   spreadsheetTemplateLocation,
   uploadGuideLocation,
 }) => {
-  useDocumentTitle(
-    `Upload ${uploadType && uploadType.toLowerCase()} spreadsheet`
-  );
+  useDocumentTitle(`Upload ${uploadType.toLowerCase()} spreadsheet`);
 
   const appInsights = getAppInsights();
   const orgName = useSelector<RootState, string>(

--- a/frontend/src/stories/testResults/UploadForm.stories.tsx
+++ b/frontend/src/stories/testResults/UploadForm.stories.tsx
@@ -4,13 +4,11 @@ import { Meta, StoryFn } from "@storybook/react";
 
 import { store } from "../../app/store";
 import { StoryGraphQLProvider } from "../storyMocks";
-import UploadForm from "../../app/testResults/uploads/UploadForm";
-
-type Props = React.ComponentProps<typeof UploadForm>;
+import DiseaseSpecificUploadContainer from "../../app/testResults/uploads/DiseaseSpecificUploadContainer";
+import AgnosticUploadContainer from "../../app/testResults/uploads/AgnosticUploadContainer";
 
 export default {
   title: "App/Test results/Upload CSV",
-  component: UploadForm,
   argTypes: {},
   args: {},
   decorators: [
@@ -22,13 +20,24 @@ export default {
   ],
 } as Meta;
 
-const Template: StoryFn<Props> = (args) => (
+const DiseaseSpecificTemplate: StoryFn<{}> = () => (
   <Provider store={store}>
     <MemoryRouter>
-      <UploadForm {...args} />
+      <DiseaseSpecificUploadContainer />
     </MemoryRouter>
   </Provider>
 );
 
-export const Default = Template.bind({});
-Default.args = {};
+export const DiseaseSpecificUpload = DiseaseSpecificTemplate.bind({});
+DiseaseSpecificUpload.args = {};
+
+const DiseaseAgnosticTemplate: StoryFn<{}> = () => (
+  <Provider store={store}>
+    <MemoryRouter>
+      <AgnosticUploadContainer />
+    </MemoryRouter>
+  </Provider>
+);
+
+export const DiseaseAgnosticUpload = DiseaseAgnosticTemplate.bind({});
+DiseaseAgnosticUpload.args = {};


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Looks like a change went in that broke storybook, specifically this line https://github.com/CDCgov/prime-simplereport/blob/fbabd633de46b8083056b9625843af5051767bbf/frontend/src/app/testResults/uploads/UploadForm.tsx#L180

![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/13549c19-d718-4d4d-ac1f-f79a5a4e5762)

- the architecture changes broke the e2e frontend image

![image](https://github.com/CDCgov/prime-simplereport/assets/4952042/20235300-e0bc-4b71-a3bb-fa2858667521)

## Fix
- add `DiseaseAgnostic` and `DiseaseSpecific` stories
- add back e2e frontend image build args


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
