### PR TITLE
Agnostic spreadsheet upload guide

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -28,6 +28,7 @@ public class FeatureFlagsConfig {
   private boolean hivEnabled;
   private boolean rsvEnabled;
   private boolean singleEntryRsvEnabled;
+  private boolean agnosticEnabled;
 
   @Scheduled(fixedRateString = "60000") // 1 min
   private void loadFeatureFlagsFromDB() {
@@ -41,6 +42,7 @@ public class FeatureFlagsConfig {
       case "hivEnabled" -> setHivEnabled(flagValue);
       case "rsvEnabled" -> setRsvEnabled(flagValue);
       case "singleEntryRsvEnabled" -> setSingleEntryRsvEnabled(flagValue);
+      case "agnosticEnabled" -> setAgnosticEnabled(flagValue);
       default -> log.info("no mapping for " + flagName);
     }
   }

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -26,3 +26,4 @@ features:
   hivEnabled: false
   rsvEnabled: false
   singleEntryRsvEnabled: false
+  agnosticEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -152,6 +152,7 @@ features:
   hivEnabled: true
   rsvEnabled: true
   singleEntryRsvEnabled: true
+  agnosticEnabled: true
 slack:
   hook:
     token: ${SLACK_HOOK_TOKEN:foo}

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -82,7 +82,7 @@ const checkOktaLoginStatus = (
 };
 
 const ReportingApp = () => {
-  const rsvEnabled = useFeature("rsvEnabled");
+  const agnosticEnabled = useFeature("agnosticEnabled");
   const appInsights = getAppInsights();
   const dispatch = useDispatch();
   const location = useLocation();
@@ -253,21 +253,23 @@ const ReportingApp = () => {
                   />
                 }
               />
-              {rsvEnabled && (
-                <Route
-                  path="results/agnostic/upload/submit"
-                  element={
-                    <ProtectedRoute
-                      requiredPermissions={canViewResults}
-                      userPermissions={data.whoami.permissions}
-                      element={
-                        <ResultsNavWrapper>
-                          <AgnosticUploadContainer />
-                        </ResultsNavWrapper>
-                      }
-                    />
-                  }
-                />
+              {agnosticEnabled && (
+                <>
+                  <Route
+                    path="results/agnostic/upload/submit"
+                    element={
+                      <ProtectedRoute
+                        requiredPermissions={canViewResults}
+                        userPermissions={data.whoami.permissions}
+                        element={
+                          <ResultsNavWrapper>
+                            <AgnosticUploadContainer />
+                          </ResultsNavWrapper>
+                        }
+                      />
+                    }
+                  />
+                </>
               )}
               <Route
                 path="results/upload/submit/guide"

--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -39,6 +39,8 @@ import DeviceLookupContainer from "./uploads/DeviceLookup/DeviceLookupContainer"
 import UploadPatients from "./patients/UploadPatients";
 import DiseaseSpecificUploadContainer from "./testResults/uploads/DiseaseSpecificUploadContainer";
 import AgnosticUploadContainer from "./testResults/uploads/AgnosticUploadContainer";
+import { specificSchemaBuilder } from "./testResults/uploads/specificSchemaBuilder";
+import { agnosticSchemaBuilder } from "./testResults/uploads/agnosticSchemaBuilder";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -73,7 +75,7 @@ const checkOktaLoginStatus = (
       const params = new URLSearchParams(location.hash.slice(1));
       if (params.get("error")) {
         throw new Error(
-          params.get("error_description") || "Unknown Okta error"
+          params.get("error_description") ?? "Unknown Okta error"
         );
       }
       throw new Error("Not authenticated, redirecting to Okta...");
@@ -269,6 +271,23 @@ const ReportingApp = () => {
                       />
                     }
                   />
+                  <Route
+                    path="results/agnostic/upload/submit/guide"
+                    element={
+                      <ProtectedRoute
+                        requiredPermissions={canViewResults}
+                        userPermissions={data.whoami.permissions}
+                        element={
+                          <ResultsNavWrapper>
+                            <Schema
+                              schemaBuilder={agnosticSchemaBuilder}
+                              returnUrl={"/results/agnostic/upload/submit"}
+                            />
+                          </ResultsNavWrapper>
+                        }
+                      />
+                    }
+                  />
                 </>
               )}
               <Route
@@ -279,7 +298,10 @@ const ReportingApp = () => {
                     userPermissions={data.whoami.permissions}
                     element={
                       <ResultsNavWrapper>
-                        <Schema />
+                        <Schema
+                          schemaBuilder={specificSchemaBuilder}
+                          returnUrl={"/results/upload/submit"}
+                        />
                       </ResultsNavWrapper>
                     }
                   />

--- a/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/AgnosticUploadContainer.tsx
@@ -37,7 +37,7 @@ const AgnosticUploadContainer = () => {
       alert={alert}
       uploadType={"Agnostic"}
       spreadsheetTemplateLocation={""}
-      uploadGuideLocation={""}
+      uploadGuideLocation={"/results/agnostic/upload/submit/guide"}
       uploadResults={(_file) => {
         return Promise.resolve(new Response());
       }}

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import { axe } from "jest-axe";
 
 import { getAppInsights } from "../../TelemetryService";
 
@@ -10,6 +11,7 @@ import CsvSchemaDocumentation, {
   CsvSchemaItem,
   getPageTitle,
 } from "./CsvSchemaDocumentation";
+import { specificSchemaBuilder } from "./specificSchemaBuilder";
 
 jest.mock("../../TelemetryService", () => ({
   ...jest.requireActual("../../TelemetryService"),
@@ -148,13 +150,19 @@ describe("CsvSchemaDocumentation tests", () => {
           <Routes>
             <Route
               path={"/results/upload/submit/guide"}
-              element={<CsvSchemaDocumentation />}
+              element={
+                <CsvSchemaDocumentation
+                  schemaBuilder={specificSchemaBuilder}
+                  returnUrl={"/results/upload/submit"}
+                />
+              }
             />
           </Routes>
         </MemoryRouter>
       );
 
       expect(container).toMatchSnapshot();
+      expect(axe(container)).toMatchSnapshot();
     });
     it("logs to App Insights on template download", async () => {
       const mockTrackEvent = jest.fn();
@@ -167,7 +175,12 @@ describe("CsvSchemaDocumentation tests", () => {
           <Routes>
             <Route
               path={"/results/upload/submit/guide"}
-              element={<CsvSchemaDocumentation />}
+              element={
+                <CsvSchemaDocumentation
+                  schemaBuilder={specificSchemaBuilder}
+                  returnUrl={"/results/upload/submit"}
+                />
+              }
             />
           </Routes>
         </MemoryRouter>

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
-import { axe } from "jest-axe";
 
 import { getAppInsights } from "../../TelemetryService";
 
@@ -160,9 +159,7 @@ describe("CsvSchemaDocumentation tests", () => {
           </Routes>
         </MemoryRouter>
       );
-
       expect(container).toMatchSnapshot();
-      expect(axe(container)).toMatchSnapshot();
     });
     it("logs to App Insights on template download", async () => {
       const mockTrackEvent = jest.fn();

--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 import { LinkWithQuery } from "../../commonComponents/LinkWithQuery";
@@ -8,7 +8,7 @@ import { getAppInsights } from "../../TelemetryService";
 import ScrollToTopOnMount from "../../commonComponents/ScrollToTopOnMount";
 import { getFacilityIdFromUrl } from "../../utils/url";
 
-import { schemaBuilder } from "./schemaBuilder";
+import { CsvSchema } from "./specificSchemaBuilder";
 
 export type CsvSchemaItem = {
   name: string;
@@ -152,8 +152,15 @@ export const getPageTitle = (hash: string) => {
   }
 };
 
-/* eslint-disable jsx-a11y/anchor-has-content */
-const CsvSchemaDocumentation = () => {
+interface CsvSchemaDocumentationProps {
+  schemaBuilder: (facilityId: string | null) => CsvSchema;
+  returnUrl: string;
+}
+
+const CsvSchemaDocumentation: React.FC<CsvSchemaDocumentationProps> = ({
+  schemaBuilder,
+  returnUrl,
+}) => {
   let location = useLocation();
   let locationHash = location.hash;
   let pageTitle = getPageTitle(locationHash);
@@ -180,10 +187,7 @@ const CsvSchemaDocumentation = () => {
             >
               <use xlinkHref={iconSprite + "#arrow_back"}></use>
             </svg>
-            <LinkWithQuery
-              to={`/results/upload/submit`}
-              className="margin-left-05"
-            >
+            <LinkWithQuery to={returnUrl} className="margin-left-05">
               Upload spreadsheet
             </LinkWithQuery>
           </div>

--- a/frontend/src/app/testResults/uploads/__snapshots__/AgnosticUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/AgnosticUploadContainer.test.tsx.snap
@@ -72,9 +72,8 @@ exports[`Agnostic specific upload container test passes axe tests 1`] = `
                   Visit the
                    
                   <a
-                    aria-current="page"
-                    class="active"
-                    href="/"
+                    class=""
+                    href="/results/agnostic/upload/submit/guide"
                   >
                     <strong>
                       spreadsheet upload guide

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -6592,8 +6592,6 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 1`
 </div>
 `;
 
-exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 2`] = `Promise {}`;
-
 exports[`CsvSchemaDocumentation tests CsvSchemaDocumentationItem renders a schema item 1`] = `
 <div>
   <h5

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -6592,6 +6592,8 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 1`
 </div>
 `;
 
+exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 2`] = `Promise {}`;
+
 exports[`CsvSchemaDocumentation tests CsvSchemaDocumentationItem renders a schema item 1`] = `
 <div>
   <h5

--- a/frontend/src/app/testResults/uploads/agnosticSchemaBuilder.ts
+++ b/frontend/src/app/testResults/uploads/agnosticSchemaBuilder.ts
@@ -95,7 +95,7 @@ export const agnosticSchemaBuilder = (facilityId: string | null) => {
                   "SNOMED code from lookup table, example: <em>260373001<em>",
                 ],
                 description: [
-                  `Where else can you find it? or find your device on the ${deviceCodeLookupLink}.`,
+                  `Search for the SNOMED code in <a href="https://snomedbrowser.com/" class="usa-link" target="_blank" rel="noreferrer noopener">the SNOMED browser</a> or find your device on the ${deviceCodeLookupLink}.`,
                 ],
               },
               {
@@ -107,7 +107,9 @@ export const agnosticSchemaBuilder = (facilityId: string | null) => {
                   "<mark><code>C</code></mark>",
                   "<mark><code>F</code></mark>",
                 ],
-                description: [`What does this stand for?`],
+                description: [
+                  `The code used to determine if the result is a correction or final.`,
+                ],
               },
               {
                 name: "Test result date",

--- a/frontend/src/app/testResults/uploads/agnosticSchemaBuilder.ts
+++ b/frontend/src/app/testResults/uploads/agnosticSchemaBuilder.ts
@@ -1,0 +1,131 @@
+import { validate } from "uuid";
+
+export const agnosticSchemaBuilder = (facilityId: string | null) => {
+  const validUuid = facilityId && validate(facilityId) ? facilityId : "";
+  const deviceCodeLookupLink = `<a href="${process.env.PUBLIC_URL}/results/upload/submit/code-lookup?facility=${validUuid}" class="usa-link" target="_blank" rel="noreferrer noopener">device code lookup tool</a>`;
+
+  return {
+    fields: [
+      {
+        sections: [
+          {
+            title: "Patient",
+            slug: "patient",
+            items: [
+              {
+                name: "Patient ID",
+                colHeader: "patient_id",
+                required: false,
+                requested: true,
+                examples: ["1234", "P2300"],
+                description: [
+                  "Enter unique patient identifier. This is typically the Medical Record Number. <strong><em>Do not send a Social Security Number</em></strong>.",
+                  "<em>Some jurisdictions may require this field, ReportStream will notify you if this is the case.</em>",
+                ],
+              },
+              {
+                name: "Patient last name",
+                colHeader: "patient_last_name",
+                required: false,
+                requested: true,
+                description: ["Last name, separated from first name"],
+              },
+              {
+                name: "Patient first name",
+                colHeader: "patient_first_name",
+                required: false,
+                requested: true,
+                description: ["First name, separated from last name"],
+              },
+              {
+                name: "Patient name absent reason",
+                colHeader: "patient_name_absent_reason",
+                required: false,
+                requested: false,
+                description: [
+                  "Reason is required if first and last name are not provided.",
+                ],
+              },
+              {
+                name: "Patient gender",
+                colHeader: "patient_admin_gender",
+                required: true,
+                requested: false,
+                acceptedValues: [
+                  "<mark><code>M</code></mark> or <mark><code>Male</code></mark>",
+                  "<mark><code>F</code></mark> or <mark><code>Female</code></mark>",
+                  "<mark><code>O</code></mark> or <mark><code>Other</code></mark>",
+                  "<mark><code>U</code></mark> or <mark><code>Unknown</code></mark>",
+                  "<mark><code>A</code></mark> or <mark><code>Ambiguous</code></mark>",
+                  "<mark><code>N</code></mark> or <mark><code>Not applicable</code></mark>",
+                ],
+                description: [
+                  'Use one of the LOINC codes listed below, which come from the <a href="https://phinvads.cdc.gov/vads/SearchVocab.action" class="usa-link" target="_blank" rel="noreferrer noopener">PHIN VADS system</a>',
+                ],
+              },
+            ],
+          },
+          {
+            title: "Order and result",
+            slug: "order-and-result",
+            items: [
+              {
+                name: "Test performed LOINC code",
+                colHeader: "test_performed_code",
+                required: true,
+                requested: false,
+                format: "00000-0",
+                examples: [
+                  "94534-5",
+                  "94558-4",
+                  "97097-0",
+                  "94507-1",
+                  "94508-9",
+                ],
+                description: [
+                  `Where can you find this? or find your device on the ${deviceCodeLookupLink}, then copy the value for this field.`,
+                ],
+              },
+              {
+                name: "Test result",
+                colHeader: "test_result_value",
+                required: true,
+                requested: false,
+                acceptedValues: [
+                  "SNOMED code from lookup table, example: <em>260373001<em>",
+                ],
+                description: [
+                  `Where else can you find it? or find your device on the ${deviceCodeLookupLink}.`,
+                ],
+              },
+              {
+                name: "Test result status",
+                colHeader: "test_result_status",
+                required: true,
+                requested: false,
+                acceptedValues: [
+                  "<mark><code>C</code></mark>",
+                  "<mark><code>F</code></mark>",
+                ],
+                description: [`What does this stand for?`],
+              },
+              {
+                name: "Test result date",
+                colHeader: "test_result_effective_date",
+                required: true,
+                requested: false,
+                format:
+                  "<code>M/D/YYYY HH:mm TZ</code> is preferred, but <code>M/D/YYYY HH:mm</code> and <code>M/D/YYYY</code> are also acceptable",
+                examples: ["5/23/2023 4:30 CT", "11/2/2022 14:17", "9/21/2022"],
+                description: [
+                  "Include the time and time zone if possible. Time zones can be any common US time zone abbreviation, such as AKDT, AKST, CT, ET, HST, MT, or PT.",
+                  "If you don’t include a time, SimpleReport will default to 12 PM. If you don’t include a time zone, it will default to the time zone of the testing lab address (if available), or ET (Eastern Time).",
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/frontend/src/app/testResults/uploads/specificSchemaBuilder.ts
+++ b/frontend/src/app/testResults/uploads/specificSchemaBuilder.ts
@@ -1,14 +1,35 @@
 import { validate } from "uuid";
 
-export const schemaBuilder = (facilityId: string | null) => {
+export interface CsvSchema {
+  fields: Field[];
+}
+
+export interface Field {
+  sections: Section[];
+}
+
+export interface Section {
+  title: string;
+  slug: string;
+  items: Item[];
+}
+
+export interface Item {
+  name: string;
+  colHeader: string;
+  required: boolean;
+  requested: boolean;
+  examples?: string[];
+  description?: string[];
+  acceptedValues?: string[];
+  format?: string;
+}
+
+export const specificSchemaBuilder = (facilityId: string | null) => {
   const validUuid = facilityId && validate(facilityId) ? facilityId : "";
   const deviceCodeLookupLink = `<a href="${process.env.PUBLIC_URL}/results/upload/submit/code-lookup?facility=${validUuid}" class="usa-link" target="_blank" rel="noreferrer noopener">device code lookup tool</a>`;
 
   return {
-    title: "Example title",
-    summary: "Example summary ...",
-    description:
-      "Documentation for each field in the ReportStream schema [placeholder]",
     fields: [
       {
         sections: [


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #6541 

## Changes Proposed

- Add condition agnostic feature flag
- Pass `schemaBuilder` and `returnUrl` to the schema page
- Set upload guide location for agnostic bulk upload page


## Additional Information

- Upload guide has temporary place holder descriptions as I was going through. 

## Testing

- Visit the agnostic upload page and upload guide!
- https://dev5.simplereport.gov/app/results/agnostic/upload/submit
- https://dev5.simplereport.gov/app/results/agnostic/upload/submit/guide

## Screenshots / Demos

