### PR TITLE
add cypress cache folder to install and run

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -13,7 +13,7 @@ COPY ./cypress/yarn.lock /app/yarn.lock
 
 WORKDIR /app
 
-RUN yarn install
+RUN CYPRESS_CACHE_FOLDER=./tmp/Cypress yarn install
 
 COPY ./cypress/e2e.sh /app/e2e.sh
 

--- a/cypress/e2e.sh
+++ b/cypress/e2e.sh
@@ -116,5 +116,5 @@ if [[ $RUN_OPEN = true ]]; then
   export CYPRESS_CHECK_URL="$FRONTEND_URL_PATH"
   yarn run cypress open
 else
-  yarn run cypress run --browser "$BROWSER" --spec "$SPEC_PATH" --config-file cypress.config.js --config baseUrl="$TEST_ENV$PUBLIC_URL" --env CHECK_COMMIT="$CHECK_COMMIT",CHECK_URL="$FRONTEND_URL_PATH"
+  CYPRESS_CACHE_FOLDER=./tmp/Cypress yarn run cypress run --browser "$BROWSER" --spec "$SPEC_PATH" --config-file cypress.config.js --config baseUrl="$TEST_ENV$PUBLIC_URL" --env CHECK_COMMIT="$CHECK_COMMIT",CHECK_URL="$FRONTEND_URL_PATH"
 fi;


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- E2E tests don't work
```
cypress  | The cypress npm package is installed, but the Cypress binary is missing.
cypress  | 
cypress  | We expected the binary to be installed here: /root/.cache/Cypress/11.2.0/Cypress/Cypress
```

## Changes Proposed

- add cache location for `yarn install` and `yarn run` for cypress based on this [comment](https://stackoverflow.com/a/62703115)

## Additional Information


## Testing

- Tests work
