### PR TITLE
remove multiplex feature flag from frontend

### DIFF
--- a/frontend/src/app/commonComponents/MultiplexResultsGuidance.tsx
+++ b/frontend/src/app/commonComponents/MultiplexResultsGuidance.tsx
@@ -59,15 +59,14 @@ const PositiveFluResultInfo = ({
 interface MultiplexResultsGuidanceProps {
   results: MultiplexResult[];
   isPatientApp: boolean;
-  multiplexEnabled: boolean;
 }
-const MultiplexResultsGuidance = (props: MultiplexResultsGuidanceProps) => {
-  const results = props.results;
-  const isPatientApp = props.isPatientApp;
-  const multiplexEnabled = props.multiplexEnabled;
+const MultiplexResultsGuidance: React.FC<MultiplexResultsGuidanceProps> = ({
+  results,
+  isPatientApp,
+}) => {
   const { t } = useTranslation();
   const needsCovidHeading = haCovidResults(results);
-  const needsFluGuidance = multiplexEnabled && hasPositiveFluResults(results);
+  const needsFluGuidance = hasPositiveFluResults(results);
   const covidResult = getResultByDiseaseName(results, "COVID-19") as TestResult;
 
   return (

--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -9,10 +9,9 @@ import {
 } from "../utils/testResults";
 import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../testResults/constants";
 
-interface Props {
+interface TestResultsListProps {
   results: MultiplexResults;
   isPatientApp: boolean;
-  multiplexEnabled: boolean;
 }
 
 const setDiseaseName = (diseaseName: MultiplexDisease, t: translateFn) => {
@@ -92,16 +91,15 @@ const pxpAppResultListItem = (
   );
 };
 
-const TestResultsList = (props: Props) => {
-  const results = props.results;
-  const multiplexEnabled = props.multiplexEnabled;
-  const isPatientApp = props.isPatientApp;
+const TestResultsList: React.FC<TestResultsListProps> = ({
+  results,
+  isPatientApp,
+}) => {
   const { t } = useTranslation();
 
-  const sortedTestResults =
-    multiplexEnabled && hasMultiplexResults(results)
-      ? getSortedResults(results)
-      : [getResultObjByDiseaseName(results, "COVID-19")];
+  const sortedTestResults = hasMultiplexResults(results)
+    ? getSortedResults(results)
+    : [getResultObjByDiseaseName(results, "COVID-19")];
 
   return (
     <>

--- a/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/DownloadResultsCsvModal.tsx
@@ -3,7 +3,6 @@ import Modal from "react-modal";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CSVLink } from "react-csv";
-import { useFeature } from "flagged";
 import { ApolloError } from "@apollo/client";
 
 import { showError } from "../utils/srToast";
@@ -36,7 +35,6 @@ export const DownloadResultsCsvModal = ({
   const csvLink = useRef<
     CSVLink & HTMLAnchorElement & { link: HTMLAnchorElement }
   >(null);
-  const multiplexEnabled = useFeature("multiplexEnabled") as boolean;
   // Disable downloads because backend will hang on over 20k results (#3953)
   const disableDownload = totalEntries > rowsMaxLimit;
 
@@ -69,11 +67,8 @@ export const DownloadResultsCsvModal = ({
     });
 
   const handleComplete = (data: GetFacilityResultsForCsvWithCountQuery) => {
-    if (data.testResultsPage && data.testResultsPage.content) {
-      const csvResults = parseDataForCSV(
-        data.testResultsPage.content,
-        multiplexEnabled
-      );
+    if (data?.testResultsPage?.content) {
+      const csvResults = parseDataForCSV(data.testResultsPage.content);
       setResults(csvResults);
     } else {
       showError("Unknown error downloading results");

--- a/frontend/src/app/testResults/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/TestResultDetailsModal.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 import Modal from "react-modal";
 import classnames from "classnames";
-import { useFeature } from "flagged";
 
 import iconClose from "../../img/close.svg";
 import "./TestResultPrintModal.scss";
@@ -111,9 +110,7 @@ export const DetachedTestResultDetailsModal = ({ data, closeModal }: Props) => {
       ? getResultByDiseaseName(results, MULTIPLEX_DISEASES.COVID_19)
       : "UNKNOWN",
   };
-  const multiplexFeatureFlagEnabled = useFeature("multiplexEnabled");
-  const multiplexEnabled =
-    multiplexFeatureFlagEnabled && results && hasMultiplexResults(results);
+  const multiplexEnabled = results && hasMultiplexResults(results);
   if (multiplexEnabled) {
     displayResult["fluAResult"] = getResultByDiseaseName(
       results,
@@ -234,7 +231,7 @@ export const DetachedTestResultDetailsModal = ({ data, closeModal }: Props) => {
           />
           <DetailsRow
             label="Device"
-            value={deviceType && deviceType.name}
+            value={deviceType?.name}
             removed={removed}
             aria-describedby="result-detail-title"
           />
@@ -314,7 +311,7 @@ const DetailsRow = ({
     <tr>
       <th className={labelColumnClasses}>{label}</th>
       <td className={classnames(tdClasses, removed && strikeClasses)}>
-        {value || "--"}
+        {value ?? "--"}
       </td>
     </tr>
   );

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -191,7 +191,6 @@ export const StaticTestResultModal = ({
             <MultiplexResultsGuidance
               results={results}
               isPatientApp={isPatientApp}
-              multiplexEnabled={multiplexEnabled}
             />
           </section>
         )}

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Modal from "react-modal";
 import classnames from "classnames";
 import { useTranslation } from "react-i18next";
-import { useFeature } from "flagged";
 
 import Button from "../commonComponents/Button/Button";
 import MultiplexResultsGuidance from "../commonComponents/MultiplexResultsGuidance";
@@ -75,7 +74,6 @@ export const StaticTestResultModal = ({
     results,
     dateTested,
   } = testResult;
-  const multiplexEnabled = useFeature("multiplexEnabled") as boolean;
   const isPatientApp = false;
 
   return (
@@ -87,7 +85,7 @@ export const StaticTestResultModal = ({
     >
       <header className="display-flex flex-align-end flex-justify margin-bottom-1">
         <h1>
-          {multiplexEnabled && hasMultiplexResults(results)
+          {hasMultiplexResults(results)
             ? t("testResult.multiplexResultHeader")
             : t("testResult.covidResultHeader")}
         </h1>
@@ -158,7 +156,7 @@ export const StaticTestResultModal = ({
             <li>
               <b>{t("testResult.testingFacility.npi")}</b>
               <div>
-                {facility.orderingProvider.NPI || facility.orderingProvider.npi}
+                {facility.orderingProvider.NPI ?? facility.orderingProvider.npi}
               </div>
             </li>
           </ul>
@@ -198,7 +196,7 @@ export const StaticTestResultModal = ({
       <footer>
         <p>
           {t("testResult.printed")}{" "}
-          {hardcodedPrintDate || new Date().toLocaleString()}
+          {hardcodedPrintDate ?? new Date().toLocaleString()}
         </p>
       </footer>
     </div>

--- a/frontend/src/app/testResults/TestResultPrintModal.tsx
+++ b/frontend/src/app/testResults/TestResultPrintModal.tsx
@@ -182,11 +182,7 @@ export const StaticTestResultModal = ({
               <b>{t("testResult.testDate")}</b>
               <div>{formatDateWithTimeOption(dateTested, true)}</div>
             </li>
-            <TestResultsList
-              results={results}
-              isPatientApp={isPatientApp}
-              multiplexEnabled={multiplexEnabled}
-            />
+            <TestResultsList results={results} isPatientApp={isPatientApp} />
           </ul>
         </section>
         {(haCovidResults(results) || hasPositiveFluResults(results)) && (

--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from "lodash";
-
 import { parseDataForCSV } from "./testResultCSV";
 
 const data = [
@@ -14,6 +12,18 @@ const data = [
       {
         disease: {
           name: "COVID-19",
+        },
+        testResult: "NEGATIVE",
+      },
+      {
+        disease: {
+          name: "Flu A",
+        },
+        testResult: "NEGATIVE",
+      },
+      {
+        disease: {
+          name: "Flu B",
         },
         testResult: "NEGATIVE",
       },
@@ -103,53 +113,23 @@ const result = [
     "Test correction reason": "DUPLICATE_TEST",
     "Test correction status": "REMOVED",
     "Test date": "06/13/2022 7:24pm",
+    "Flu A result": "Negative",
+    "Flu B result": "Negative",
   },
 ];
 
 describe("parseDataForCSV", () => {
-  it("parses non-multiplex data", () => {
-    const multiplexEnabled = false;
-    expect(parseDataForCSV(data, multiplexEnabled)).toEqual(result);
-  });
-
   it("parses multiplex data", () => {
-    const multiplexData = cloneDeep(data);
-    multiplexData[0]["results"].push(
-      {
-        disease: {
-          name: "Flu A",
-        },
-        testResult: "NEGATIVE",
-      },
-      {
-        disease: {
-          name: "Flu B",
-        },
-        testResult: "NEGATIVE",
-      }
-    );
-    const multiplexEnabled = true;
-    const multiplexResult = cloneDeep(result);
-    // @ts-ignore
-    multiplexResult[0]["Flu A result"] = "Negative";
-    // @ts-ignore
-    multiplexResult[0]["Flu B result"] = "Negative";
-    expect(parseDataForCSV(multiplexData, multiplexEnabled)).toEqual(
-      multiplexResult
-    );
+    expect(parseDataForCSV(data)).toEqual(result);
   });
   it("parse data does not fail if tribalAffiliation is null", () => {
-    const multiplexEnabled = false;
     expect(
-      parseDataForCSV(
-        [
-          {
-            ...data[0],
-            patient: { ...data[0].patient, tribalAffiliation: null },
-          },
-        ],
-        multiplexEnabled
-      )
+      parseDataForCSV([
+        {
+          ...data[0],
+          patient: { ...data[0].patient, tribalAffiliation: null },
+        },
+      ])
     ).toEqual(result);
   });
 });

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -8,7 +8,7 @@ import { getResultByDiseaseName } from "./testResults";
 
 import { displayFullName, facilityDisplayName } from "./index";
 
-export function parseDataForCSV(data: any[], multiplexEnabled: boolean) {
+export function parseDataForCSV(data: any[]) {
   return data.sort(byDateTested).map((r: any) => {
     const symptomList = r.symptoms ? symptomsStringToArray(r.symptoms) : [];
 
@@ -27,16 +27,14 @@ export function parseDataForCSV(data: any[], multiplexEnabled: boolean) {
         TEST_RESULT_DESCRIPTIONS[
           getResultByDiseaseName(r.results, "COVID-19") as Results
         ],
-      ...(multiplexEnabled && {
-        "Flu A result":
-          TEST_RESULT_DESCRIPTIONS[
-            getResultByDiseaseName(r.results, "Flu A") as Results
-          ],
-        "Flu B result":
-          TEST_RESULT_DESCRIPTIONS[
-            getResultByDiseaseName(r.results, "Flu B") as Results
-          ],
-      }),
+      "Flu A result":
+        TEST_RESULT_DESCRIPTIONS[
+          getResultByDiseaseName(r.results, "Flu A") as Results
+        ],
+      "Flu B result":
+        TEST_RESULT_DESCRIPTIONS[
+          getResultByDiseaseName(r.results, "Flu B") as Results
+        ],
       "Result reported date": moment(r.dateUpdated).format("MM/DD/YYYY h:mma"),
       "Test correction status": r.correctionStatus,
       "Test correction reason": r.reasonForCorrection,

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -1,7 +1,6 @@
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import React from "react";
-import { useFeature } from "flagged";
 
 import { formatFullName } from "../../app/utils/user";
 import { RootState } from "../../app/store";
@@ -23,7 +22,6 @@ const TestResult = () => {
   const testResult = useSelector<RootState, VerifyV2Response>(
     (state) => state.testResult
   );
-  const multiplexEnabled = useFeature("multiplexEnabled") as boolean;
   const isMultiplex = hasMultiplexResults(testResult.results);
   const fullName = formatFullName(testResult?.patient as any);
   const dateTested = formatDateWithTimeOption(testResult?.dateTested, true);
@@ -47,7 +45,7 @@ const TestResult = () => {
         <div className="grid-container maxw-tablet">
           <div className="card usa-prose">
             <h1 className="font-heading-lg">
-              {multiplexEnabled && isMultiplex
+              {isMultiplex
                 ? t("testResult.multiplexResultHeader")
                 : t("testResult.covidResultHeader")}
             </h1>

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -74,7 +74,6 @@ const TestResult = () => {
               <div className="grid-col usa-prose">
                 <TestResultsList
                   results={testResult.results}
-                  multiplexEnabled={multiplexEnabled}
                   isPatientApp={true}
                 />
               </div>

--- a/frontend/src/patientApp/timeOfTest/TestResult.tsx
+++ b/frontend/src/patientApp/timeOfTest/TestResult.tsx
@@ -86,7 +86,6 @@ const TestResult = () => {
             <MultiplexResultsGuidance
               results={testResult.results}
               isPatientApp={true}
-              multiplexEnabled={multiplexEnabled}
             />
           </div>
         </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Partially finishes #6348  

## Changes Proposed

- Remove all uses in of "multiplexEnabled" feature flag in the front end

## Additional Information

- Additional PRs will be open to make backend and DB changes.

## Testing

- Both multiplex and single entry covid work as expected on https://dev5.simplereport.gov/

## Screenshots / Demos
