### PR TITLE
Added mutation to update feature flags

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsMutationResolver.java
@@ -1,6 +1,5 @@
 package gov.cdc.usds.simplereport.api.featureflags;
 
-import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.db.model.FeatureFlag;
 import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
@@ -18,9 +17,7 @@ public class FeatureFlagsMutationResolver {
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public FeatureFlag updateFeatureFlag(@Argument String name, @Argument boolean value) {
     FeatureFlag featureFlag =
-        featureFlagRepository
-            .findFeatureFlagByName(name)
-            .orElseThrow(() -> new IllegalGraphqlArgumentException("Feature flag not found"));
+        featureFlagRepository.findFeatureFlagByName(name).orElse(new FeatureFlag(name, value));
     featureFlag.setValue(value);
     return featureFlagRepository.save(featureFlag);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsMutationResolver.java
@@ -1,0 +1,27 @@
+package gov.cdc.usds.simplereport.api.featureflags;
+
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
+import gov.cdc.usds.simplereport.db.model.FeatureFlag;
+import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class FeatureFlagsMutationResolver {
+  private final FeatureFlagRepository featureFlagRepository;
+
+  @MutationMapping
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public FeatureFlag updateFeatureFlag(@Argument String name, @Argument boolean value) {
+    FeatureFlag featureFlag =
+        featureFlagRepository
+            .findFeatureFlagByName(name)
+            .orElseThrow(() -> new IllegalGraphqlArgumentException("Feature flag not found"));
+    featureFlag.setValue(value);
+    return featureFlagRepository.save(featureFlag);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/FeatureFlag.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/FeatureFlag.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.db.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class FeatureFlag extends AuditedEntity {
   @Column(nullable = false)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FeatureFlagRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FeatureFlagRepository.java
@@ -1,5 +1,8 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.db.model.FeatureFlag;
+import java.util.Optional;
 
-public interface FeatureFlagRepository extends AuditedEntityRepository<FeatureFlag> {}
+public interface FeatureFlagRepository extends AuditedEntityRepository<FeatureFlag> {
+  Optional<FeatureFlag> findFeatureFlagByName(String name);
+}

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -61,4 +61,5 @@ extend type Mutation {
     accessAllFacilities: Boolean = false,
     facilities: [ID] = [],
     role: Role!): User!
+  updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -370,6 +370,11 @@ type UploadSubmissionPage {
   content: [UploadResult!]!
 }
 
+type FeatureFlag{
+  name: String!
+  value: Boolean!
+}
+
 # Queries and mutations for everyday use
 
 type Query {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsMutationResolverTest.java
@@ -1,0 +1,56 @@
+package gov.cdc.usds.simplereport.api.featureflags;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import gov.cdc.usds.simplereport.api.graphql.BaseGraphqlTest;
+import gov.cdc.usds.simplereport.db.model.FeatureFlag;
+import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class FeatureFlagsMutationResolverTest extends BaseGraphqlTest {
+  @SpyBean private FeatureFlagRepository featureFlagRepository;
+
+  @Test
+  void updateFeatureFlag_notAuthorizedError() {
+    useOrgAdmin();
+    Map<String, Object> variables = Map.of("name", "dummyFeatureEnabled", "value", true);
+    runQuery(
+        "update-feature-flag",
+        "updateFeatureFlag",
+        variables,
+        "header: Unauthorized; body: Please check for errors and try again");
+  }
+
+  @Test
+  void updateFeatureFlag_newFlag_success() {
+    useSuperUser();
+
+    Map<String, Object> variables = Map.of("name", "dummyFeatureEnabled", "value", true);
+
+    FeatureFlag newFlag = new FeatureFlag("dummyFeatureEnabled", true);
+    UUID flagId = UUID.randomUUID();
+    ReflectionTestUtils.setField(newFlag, "internalId", flagId);
+
+    doReturn(Optional.empty())
+        .when(featureFlagRepository)
+        .findFeatureFlagByName("dummyFeatureEnabled");
+    doReturn(newFlag).when(featureFlagRepository).save(any());
+    ObjectNode response = runQuery("update-feature-flag", "updateFeatureFlag", variables, null);
+    ObjectNode featureFlag = (ObjectNode) response.get("updateFeatureFlag");
+    assertEquals("dummyFeatureEnabled", featureFlag.get("name").asText());
+
+    InOrder inOrder = Mockito.inOrder(featureFlagRepository);
+    inOrder.verify(featureFlagRepository).findFeatureFlagByName("dummyFeatureEnabled");
+    inOrder.verify(featureFlagRepository).save(any(FeatureFlag.class));
+  }
+}

--- a/backend/src/test/resources/graphql-test/update-feature-flag.graphql
+++ b/backend/src/test/resources/graphql-test/update-feature-flag.graphql
@@ -1,0 +1,6 @@
+mutation updateFeatureFlag($name: String!, $value: Boolean!){
+ updateFeatureFlag(name:$name, value: $value){
+     name
+     value
+ }
+}

--- a/frontend/src/app/testQueue/TestTimer.test.tsx
+++ b/frontend/src/app/testQueue/TestTimer.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { getAppInsights } from "../TelemetryService";
@@ -98,12 +92,17 @@ describe("TestTimerWidget", () => {
       removeTimer("internal-id");
     });
 
+    const renderWithUser = (testLength: number) => ({
+      user: userEvent.setup(),
+      ...render(<DummyTestTimer testLength={testLength} context={context} />),
+    });
+
     it("tracks a custom event when the timer is started", async () => {
-      render(<DummyTestTimer testLength={15} context={context} />);
+      const { user } = renderWithUser(15);
 
       const startTimer = await screen.findByRole("button");
 
-      await act(async () => await userEvent.click(startTimer));
+      await user.click(startTimer);
       expect(trackEventMock).toHaveBeenCalled();
       expect(trackEventMock).toHaveBeenCalledTimes(1);
       expect(trackEventMock).toHaveBeenCalledWith(
@@ -113,12 +112,11 @@ describe("TestTimerWidget", () => {
     });
 
     it("tracks a custom event when the timer reset", async () => {
-      render(<DummyTestTimer testLength={15} context={context} />);
-
+      const { user } = renderWithUser(15);
       const timerButton = await screen.findByRole("button");
 
       // Start timer
-      await act(async () => await userEvent.click(timerButton));
+      await user.click(timerButton);
       await screen.findByText("15:00");
 
       // The timer does not enter the countdown state instantly, so clicking the
@@ -127,7 +125,7 @@ describe("TestTimerWidget", () => {
       await waitFor(() => findTimer("internal-id")?.tick(Date.now()));
 
       // Reset timer
-      await act(async () => await userEvent.click(timerButton));
+      await user.click(timerButton);
       await screen.findByText("15:00");
 
       expect(trackEventMock).toHaveBeenCalledWith(
@@ -137,11 +135,9 @@ describe("TestTimerWidget", () => {
     });
 
     it("tracks a custom event when the timer reaches zero", async () => {
-      render(<DummyTestTimer testLength={0} context={context} />);
-
+      const { user } = renderWithUser(0);
       const timerButton = await screen.findByRole("button");
-
-      fireEvent.click(timerButton);
+      await user.click(timerButton);
       await screen.findByText("0:00");
       await screen.findByText("RESULT READY");
 
@@ -158,7 +154,6 @@ function DummyTestTimer(props: {
   context: TimerTrackEventMetadata;
 }) {
   const timer = useTestTimer("internal-id", props.testLength);
-
   return <TestTimerWidget timer={timer} context={props.context} />;
 }
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -150,6 +150,12 @@ export type FacilityStats = {
   usersSingleAccessCount?: Maybe<Scalars["Int"]>;
 };
 
+export type FeatureFlag = {
+  __typename?: "FeatureFlag";
+  name: Scalars["String"];
+  value: Scalars["Boolean"];
+};
+
 export type FeedbackMessage = {
   __typename?: "FeedbackMessage";
   errorType: Scalars["String"];
@@ -212,6 +218,7 @@ export type Mutation = {
   submitQueueItem?: Maybe<AddTestResultResponse>;
   updateDeviceType?: Maybe<DeviceType>;
   updateFacility?: Maybe<Facility>;
+  updateFeatureFlag?: Maybe<FeatureFlag>;
   updateOrganization?: Maybe<Scalars["String"]>;
   updatePatient?: Maybe<Patient>;
   updateRegistrationLink?: Maybe<Scalars["String"]>;
@@ -440,6 +447,11 @@ export type MutationUpdateDeviceTypeArgs = {
 
 export type MutationUpdateFacilityArgs = {
   facilityInfo: UpdateFacilityInput;
+};
+
+export type MutationUpdateFeatureFlagArgs = {
+  name: Scalars["String"];
+  value: Scalars["Boolean"];
 };
 
 export type MutationUpdateOrganizationArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #6492 

## Changes Proposed

Create a mutation that allows to create/update a feature flag.
Mutation will only be available for site admins.

## Additional Information
I fixed a flaky frontend test in order to pass all the checks as well.

## Testing

This is deployed in Dev4

- Verify that if the mutation is called with a new flag the row gets created in the table.
- Verify that if the mutation is called with an existing feature flag the data is updated in the table and the new value is returned to the frontend when refreshing the page. The update should get effective after 3 mins so refresh the page then.