### PR TITLE
feat: add GitHub action for automated container image cleanup

### DIFF
--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -1,0 +1,23 @@
+name: Delete old container images
+
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"  # every day at midnight
+
+jobs:
+  clean_ghcr:
+    name: Delete old unused container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete all test containers older than a month, using a wildcard
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: nginx, backend, frontend, cypress, frontend-lighthouse, database
+          cut-off: One month ago UTC
+          account-type: personal
+          keep-at-least: 1
+          skip-tags: main
+          token: ${{ secrets.GH_RPDP_WORKFLOW_PAT }}
+          dry-run: true

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -3,7 +3,7 @@ name: Delete old container images
 
 on:
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: "0 0 * * *"
 
 permissions:
   packages: write

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Delete all containers older than a month
         uses: snok/container-retention-policy@v2
         with:
-          image-names: nginx, backend, frontend, cypress, frontend-lighthouse, database
+          image-names: backend, cypress, database, frontend, frontend-lighthouse, nginx
           cut-off: One month ago UTC
           account-type: org
           org-name: CDCgov

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -2,22 +2,25 @@ name: Delete old container images
 
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: "0 0 1 * *"  # every day at midnight
+    - cron: "0 0 1 * *"
+
+permissions:
+  packages: write
 
 jobs:
   clean_ghcr:
     name: Delete old unused container images
     runs-on: ubuntu-latest
     steps:
-      - name: Delete all test containers older than a month, using a wildcard
+      - name: Delete all containers older than a month
         uses: snok/container-retention-policy@v2
         with:
           image-names: nginx, backend, frontend, cypress, frontend-lighthouse, database
           cut-off: One month ago UTC
-          account-type: personal
+          account-type: org
+          org-name: CDCgov
           keep-at-least: 1
           skip-tags: main
-          token: ${{ secrets.GH_RPDP_WORKFLOW_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: true

--- a/.github/workflows/updateGradleLocks.yml
+++ b/.github/workflows/updateGradleLocks.yml
@@ -1,6 +1,5 @@
 name: Dependabot Gradle Helper
 on:
-  workflow_dispatch:
   pull_request_target:
     paths: 
       - backend/build.gradle
@@ -28,7 +27,7 @@ jobs:
     # Run when manually requested or when dependabot creates/updates a PR
     # DO NOT run if somebody else updates a PR (a probably unnecessarily strict guard against infinite 
     # workflow loops, in case we ever enable this workflow to trigger other workflows)
-    if: github.event.pull_request.user.login  == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.user.login  == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -36,7 +35,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_WORKFLOW_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0 # Disable shallow clones: we need to be able to push
 

--- a/.github/workflows/updateGradleLocks.yml
+++ b/.github/workflows/updateGradleLocks.yml
@@ -17,16 +17,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # in case we once again need to figure out why this thing is not running, some day...
-  # debug-message:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - run: echo "Actor for this run is ${{github.actor}} and event name is ${{github.event_name}}"
-  #       working-directory: /
+
   update_locks:
     # Run when manually requested or when dependabot creates/updates a PR
-    # DO NOT run if somebody else updates a PR (a probably unnecessarily strict guard against infinite 
-    # workflow loops, in case we ever enable this workflow to trigger other workflows)
     if: github.event.pull_request.user.login  == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #6024 

## Changes Proposed 

- This PR introduces a new GitHub workflow that automatically deletes unused, old container images. The images targeted are `nginx`, `backend`, `frontend`, `cypress`, `frontend-lighthouse`, `database`. The cutoff time for deletion is defined as one month and at least one image will always be kept. We don't delete images with the `main` tag. It uses the [`container-retention-policy`](https://github.com/marketplace/actions/container-retention-policy) action from the GH marketplace.
- Modifications are also made to the Dependabot Gradle Helper workflow. The changes consist of removing the manual trigger option and changing the token used for the GitHub check-out action.

## Additional Information 

- This cleanup action won't run until it's merged to `main`.
- The cleanup functionality helps manage storage by automatically removing older images not in active use. This contributes to efficient resource usage and reduces manual oversight.
- As for Dependabot Gradle Helper workflow changes, by switching the token to `GITHUB_TOKEN`, we improve security because `GITHUB_TOKEN` has more restrictive permissions, and it isn't reliant on a generated PAT. In this case, the `permission` block alone should handle what we need.

Future work:
- After we ensure that the cleanup process is selecting only the images we want to delete, we'll need to remove the `dry-run` flag to enable deletions.
- Keep monitoring the behavior of Dependabot Gradle Helper to check if it's working as intended.

## Testing 

- Reviewers can test the new cleanup workflow by waiting for the scheduled run time and verifying if the specified container images older than a month were appropriately selected for removal.
- The changes to Dependabot Gradle Helper should not affect its functionality. Reviewers can check this by noticing the behavior of Dependabot on the next PR it opens. :crossed_fingers: 

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README