### PR TITLE
feat: add permissions to github testing workflow

### DIFF
--- a/.github/workflows/testingWorkflow.yml
+++ b/.github/workflows/testingWorkflow.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
 
 # Check for changes in the backend, cypress, database, frontend, and nginx directories


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- The current `GITHUB_TOKEN` permissions do not allow Dependabot to push images to our GHCR.
  
## Changes Proposed

- Update the permissions of the default `GITHUB_TOKEN`  with `content: read` and `packages: write` permissions; this allows PRs that Dependabot opens to push to our GHCR.  

## Testing

- Merge it and rebase the Dependabot PRs to verify the fix works.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README