### PR TITLE
fix: environment context for GH `vars`

### DIFF
--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -40,6 +40,7 @@ jobs:
 
   build_frontend:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.deploy_env }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-frontend


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Fix dev deployments

## Changes Proposed

- Give the frontend build job the environment context so that it can access the okta client id variable

## Testing

- Deploy this branch to your preferred dev environment and check the okta login.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README