### PR TITLE
Partially fix pagination on Results page

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestResultRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestResultRepository.java
@@ -1,0 +1,3 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+public class TestResultRepository {}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestResultRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestResultRepository.java
@@ -1,3 +1,0 @@
-package gov.cdc.usds.simplereport.db.repository;
-
-public class TestResultRepository {}

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -89,7 +89,7 @@ describe("TestResultsList", () => {
     expect(
       await screen.findByText("Cragell, Barb Whitaker")
     ).toBeInTheDocument();
-    expect(await screen.findByText("Showing 1-3 of 3"));
+    expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
     expect(await screen.findByText(/Testing facility/i));
     expect(container).toMatchSnapshot();
   });
@@ -115,7 +115,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing 1-1 of 1"));
+    expect(await screen.findByText("Showing results for 1-1 of 1 tests"));
     expect(await screen.findByLabelText("Date range (start)"));
     expect(await screen.findByDisplayValue("2021-03-18"));
 
@@ -172,7 +172,9 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing 1-2 of 2")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Showing results for 1-2 of 2 tests")
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole("columnheader", { name: /facility/i })
@@ -197,7 +199,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing 1-9 of 9"));
+    expect(await screen.findByText("Showing results for 1-9 of 9 tests"));
     expect(
       screen.getByRole("columnheader", { name: /condition/i })
     ).toBeInTheDocument();
@@ -226,7 +228,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing 1-9 of 9"));
+    expect(await screen.findByText("Showing results for 1-9 of 9 tests"));
 
     expect(
       screen.getByRole("columnheader", { name: /condition/i })
@@ -480,7 +482,9 @@ describe("TestResultsList", () => {
 
     it("opens the test detail modal from the actions menu", async () => {
       const { user } = renderWithUser();
-      expect(await screen.findByText("Showing 1-3 of 3")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Showing results for 1-3 of 3 tests")
+      ).toBeInTheDocument();
       expect(
         await screen.findByText("Test Results", { exact: false })
       ).toBeInTheDocument();
@@ -496,7 +500,7 @@ describe("TestResultsList", () => {
 
     it("opens the email test results modal", async () => {
       const { user } = renderWithUser();
-      expect(await screen.findByText("Showing 1-3 of 3"));
+      expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
       expect(
         screen.getByText("Test Results", { exact: false })
       ).toBeInTheDocument();
@@ -511,7 +515,7 @@ describe("TestResultsList", () => {
 
     it("opens the download test results modal and shows how many rows the csv will have", async () => {
       const { user } = renderWithUser();
-      expect(await screen.findByText("Showing 1-3 of 3"));
+      expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
       expect(
         screen.getByText("Test Results", { exact: false })
       ).toBeInTheDocument();
@@ -532,7 +536,7 @@ describe("TestResultsList", () => {
     it("closes the download test results modal after downloading", async () => {
       const { user } = renderWithUser();
       // source of "navigation not implemented" error
-      expect(await screen.findByText("Showing 1-3 of 3"));
+      expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
       expect(
         screen.getByText("Test Results", { exact: false })
       ).toBeInTheDocument();
@@ -566,7 +570,7 @@ describe("TestResultsList", () => {
 
     it("opens the download test results modal after applying filters and shows how many rows the csv will have", async () => {
       const { user } = renderWithUser();
-      expect(await screen.findByText("Showing 1-3 of 3"));
+      expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
       expect(
         screen.getByText("Test Results", { exact: false })
       ).toBeInTheDocument();
@@ -574,7 +578,7 @@ describe("TestResultsList", () => {
       await user.selectOptions(screen.getByLabelText("Test result"), [
         "NEGATIVE",
       ]);
-      expect(await screen.findByText("Showing 1-2 of 2"));
+      expect(await screen.findByText("Showing results for 1-2 of 2 tests"));
       const downloadButton = screen.getByText("Download results", {
         exact: false,
       });
@@ -595,7 +599,7 @@ describe("TestResultsList", () => {
     describe("patient has no email", () => {
       it("doesnt show the button to print results", async () => {
         const { user } = renderWithUser();
-        expect(await screen.findByText("Showing 1-3 of 3"));
+        expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
         expect(
           screen.getByText("Test Results", { exact: false })
         ).toBeInTheDocument();
@@ -642,7 +646,7 @@ describe("TestResultsList", () => {
     describe("return focus after modal close", () => {
       // source of the React key prop warning
       const clickActionMenu = async (user: UserEvent) => {
-        expect(await screen.findByText("Showing 1-3 of 3"));
+        expect(await screen.findByText("Showing results for 1-3 of 3 tests"));
         const actionMenuButton =
           document.querySelectorAll(".rc-menu-button")[0];
 

--- a/frontend/src/app/testResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/TestResultsList.test.tsx
@@ -199,7 +199,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing results for 1-9 of 9 tests"));
+    expect(await screen.findByText("Showing results for 1-5 of 5 tests"));
     expect(
       screen.getByRole("columnheader", { name: /condition/i })
     ).toBeInTheDocument();
@@ -228,7 +228,7 @@ describe("TestResultsList", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Showing results for 1-9 of 9 tests"));
+    expect(await screen.findByText("Showing results for 1-5 of 5 tests"));
 
     expect(
       screen.getByRole("columnheader", { name: /condition/i })

--- a/frontend/src/app/testResults/TestResultsList.tsx
+++ b/frontend/src/app/testResults/TestResultsList.tsx
@@ -52,7 +52,6 @@ import TestResultDetailsModal from "./TestResultDetailsModal";
 import DownloadResultsCSVButton from "./DownloadResultsCsvButton";
 import ResultsTable, {
   generateTableHeaders,
-  getEnrichedMultiplexResultsFromTestEvent,
 } from "./resultsTable/ResultsTable";
 
 export const ALL_FACILITIES_ID = "all";
@@ -91,7 +90,7 @@ const getResultCountText = (
   const from = totalEntries === 0 ? 0 : (pageNumber - 1) * entriesPerPage + 1;
   const to = Math.min(entriesPerPage * pageNumber, totalEntries);
 
-  return `Showing ${from}-${to} of ${totalEntries}`;
+  return `Showing results for ${from}-${to} of ${totalEntries} tests`;
 };
 
 const getFilteredPatientName = (
@@ -690,10 +689,7 @@ const TestResultsList = () => {
   if (results.error) {
     throw results.error;
   }
-  const totalEntries =
-    getEnrichedMultiplexResultsFromTestEvent(
-      results.data?.testResultsPage?.content as TestResult[]
-    ).length || 0;
+  const totalEntries = results.data?.testResultsPage?.totalElements || 0;
 
   return (
     <DetachedTestResultsList

--- a/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
             <span
               class="sr-showing-results-on-page margin-left-4"
             >
-              Showing 1-3 of 3
+              Showing results for 1-3 of 3 tests
             </span>
           </div>
           <div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Interim fix for #6658 
This just makes it so users can use the page links to page through all their test events, but count of rows per page is still irregular.

## Changes Proposed

Pass in the total number of test events to `DetachedTestResultsList` and update the test result count text to clarify the numbers are referring to tests, not results.

## Additional Information

This unblocks customers so they page through their test events, but we can skip this if we just want to go ahead with the full fix.

## Testing

Deployed to `dev4`. Pagination should work as before.
Cases to cover:
* a set of filter criteria matching > 20 test events (you should be able to click the page links to navigate to result rows for other test events)
* a set of filter criteria matching < 20 test events but those test events have > 20 results (results should all show up on one page)

## Screenshots / Demos
[Screen Recording 2023-09-29 at 4.43.52 PM.zip](https://github.com/CDCgov/prime-simplereport/files/12772766/Screen.Recording.2023-09-29.at.4.43.52.PM.zip)
