### PR TITLE
fix: hardcode environment names in deployStg and deployTest workflows

### DIFF
--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -69,8 +69,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ env.DEPLOY_ENV }}
-      url: https://${{ env.DEPLOY_ENV }}.simplereport.gov
+      name: stg
+      url: https://stg.simplereport.gov
     needs: [prerelease_backend]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -69,8 +69,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ env.DEPLOY_ENV }}
-      url: https://${{ env.DEPLOY_ENV }}.simplereport.gov
+      name: test
+      url: https://test.simplereport.gov
     needs: [prerelease_backend]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Changes Proposed

- The Deployment environments for staging and testing in the Github actions workflows have been changed to be hardcoded instead of environment variables. This is reflected in two files, `.github/workflows/deployStg.yml` and `.github/workflows/deployTest.yml`. 

## Additional Information

- I'm not sure why the env var context doesn't appear to be available at this point in the deploys; I'll follow up this PR with more investigation to better understand the limitations at play.

## Testing

- Reviewers should verify that the correct URLs and environment names are properly hardcoded in the GitHub workflow files for test and staging environments.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
