### PR TITLE
fix(postgres_db): rename key vault secret for environment consistency

### DIFF
--- a/ops/services/postgres_db/vault.tf
+++ b/ops/services/postgres_db/vault.tf
@@ -7,7 +7,7 @@ resource "azurerm_key_vault_secret" "db_username" {
 
 //TODO: Change this to use a TF-generated password, like db-password-no-phi. See #3673 for the additional work.
 data "azurerm_key_vault_secret" "db_password" {
-  name         = "simple-report-${var.env_level}-db-password"
+  name         = "simple-report-${var.env}-db-password"
   key_vault_id = var.global_vault_id
 }
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- This resolves an issue where the vault data object is pulled from the wrong vault key. When the vault key value for dev1 was updated, that new value it was pulled in and propagated to dev4 during a deployment.

## Changes Proposed

- This changes the secret that all dev environments look at to determine their password from `simple-report-dev-db-password` to `simple-report-dev4-db-password`, which is environment specific.

## Testing

- We need to run Terraform plans against dev2 through dev7 environments to ensure that Terraform is no longer trying to change the database password. dev4 is an exception; we want dev4 to change its password to the value associated with its password key.
- [dev2 plan.](https://github.com/CDCgov/prime-simplereport/actions/runs/6421146401) :heavy_check_mark: 
- [dev3 plan.](https://github.com/CDCgov/prime-simplereport/actions/runs/6421185682) :heavy_check_mark: 
- [dev4 plan.](https://github.com/CDCgov/prime-simplereport/actions/runs/6421871882) :heavy_check_mark: 
- [dev5 plan.](https://github.com/CDCgov/prime-simplereport/actions/runs/6421933543) :heavy_check_mark: 
- [dev6 plan.](https://github.com/CDCgov/prime-simplereport/actions/runs/6421877447) :heavy_check_mark: 
- [dev7 plan.](https://github.com/CDCgov/prime-simplereport/actions/runs/6421878520) :heavy_check_mark: 

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README