### PR TITLE
Add equipment uid type to db

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5103,5 +5103,4 @@ databaseChangeLog:
             columns:
               - column:
                   name: equipment_uid_type
-        - sql:
-            remarks: Drop equipment UID type from LIVD sync to be used in the universal pipeline
+                  remarks: Drop equipment UID type from LIVD sync to be used in the universal pipeline

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5097,10 +5097,3 @@ databaseChangeLog:
                   name: equipment_uid_type
                   type: text
                   remarks: Equipment UID from LIVD sync to be used in the universal pipeline
-      rollback:
-        - dropColumn:
-            tableName: device_type_disease
-            columns:
-              - column:
-                  name: equipment_uid_type
-                  remarks: Drop equipment UID type from LIVD sync to be used in the universal pipeline

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5085,3 +5085,23 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'HIV';
+  - changeSet:
+      id: add-equipment-uid-type-to-device-type-disease
+      author: bob@skylight.digital
+      comment: Add column to Device Type Disease for equipment UID type to be populated by the LIVD sync
+      changes:
+        - addColumn:
+            tableName: device_type_disease
+            columns:
+              - column:
+                  name: equipment_uid_type
+                  type: text
+                  remarks: Equipment UID from LIVD sync to be used in the universal pipeline
+      rollback:
+        - dropColumn:
+            tableName: device_type_disease
+            columns:
+              - column:
+                  name: equipment_uid_type
+        - sql:
+            remarks: Drop equipment UID type from LIVD sync to be used in the universal pipeline


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- Part 1 of #6641 that adds the relevant column into the db to be filled by the LIVD sync

## Changes Proposed

- Add equipment uid type to db 

## Testing
- Validate db change locally


## Checklist for Primary Reviewer

- [x] Only database changes are included in this PR
- [x] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [x] Rollback has been verifed locally and in a deployed environment 
