### PR TITLE
GHCR: actions/delete-package-versions@v4

### DIFF
--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -1,26 +1,48 @@
 name: Delete old container images
 
-
 on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions:
-  packages: write
-
 jobs:
   clean_ghcr:
-    name: Delete old unused container images
+    name: Delete untagged container images
     runs-on: ubuntu-latest
     steps:
-      - name: Delete all containers older than a month
-        uses: snok/container-retention-policy@v2
-        with:
-          image-names: backend, cypress, database, frontend, frontend-lighthouse, nginx
-          cut-off: One month ago UTC
-          account-type: org
-          org-name: CDCgov
-          keep-at-least: 1
-          skip-tags: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: true
+      # backend, cypress, database, frontend, frontend-lighthouse, nginx
+      - uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'backend'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'cypress'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'database'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'frontend'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'frontend-lighthouse'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'nginx'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Follow-up #6024 and [this PR](https://github.com/CDCgov/prime-simplereport/pull/6607).

## Changes Proposed 

- This PR changes the GitHub Actions workflow to delete any untagged container images for the following: backend, cypress, database, frontend, frontend-lighthouse, and nginx.
  
## Additional Information 

- The change to `actions/delete-package-versions@v4` allows us to delete container images without needing a personal access token. Previously, we were using the `snok/container-retention-policy@v2` action, [which wouldn't work without a PAT](https://github.com/CDCgov/prime-simplereport/actions/runs/6527685897).
- This _only_ deletes untagged images, which is a huge improvement over nothing, but future work would allow us to clean up all images by filtering tags. That functionality is on the radar of `delete-package-versions` folks.

## Testing 

- Reviewers can verify this PR by checking on the GitHub Actions tab following the merge. Ensure there is a reduction or absence of untagged container images in the repository. The workflow runs once every day at 00:00.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README