### PR TITLE
fix jacoco coverage config

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -170,7 +170,7 @@ checkstyleTest {
 
 jacocoTestReport {
     reports {
-        xml
+        xml.required = true
     }
     dependsOn test // tests are required to run before generating the report
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- looks like the update to gradle 8 mis-configured jacoco
- this fix was tested in this PR https://github.com/CDCgov/prime-simplereport/pull/6771