### PR TITLE
use /actuator/health for backend health checks

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/OktaLocalSecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/OktaLocalSecurityConfiguration.java
@@ -42,8 +42,6 @@ public class OktaLocalSecurityConfiguration extends WebSecurityConfigurerAdapter
     http.cors()
         .and()
         .authorizeRequests()
-        .antMatchers("/")
-        .permitAll()
         .antMatchers(HttpMethod.OPTIONS, "/**")
         .permitAll()
         .antMatchers(HttpMethod.GET, WebConfiguration.HEALTH_CHECK)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/OktaLocalSecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/OktaLocalSecurityConfiguration.java
@@ -44,8 +44,6 @@ public class OktaLocalSecurityConfiguration extends WebSecurityConfigurerAdapter
         .authorizeRequests()
         .antMatchers(HttpMethod.OPTIONS, "/**")
         .permitAll()
-        .antMatchers(HttpMethod.GET, WebConfiguration.HEALTH_CHECK)
-        .permitAll()
         .antMatchers("/echo/**", "/authTest/**")
         .permitAll()
         .requestMatchers(EndpointRequest.to(HealthEndpoint.class))

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -50,8 +50,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers(HttpMethod.OPTIONS, "/**")
         .permitAll()
-        .antMatchers(HttpMethod.GET, WebConfiguration.HEALTH_CHECK)
-        .permitAll()
         .antMatchers("/echo/**", "/authTest/**")
         .permitAll()
         .requestMatchers(EndpointRequest.to(HealthEndpoint.class))

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -48,8 +48,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     http.cors()
         .and()
         .authorizeRequests()
-        .antMatchers("/")
-        .permitAll()
         .antMatchers(HttpMethod.OPTIONS, "/**")
         .permitAll()
         .antMatchers(HttpMethod.GET, WebConfiguration.HEALTH_CHECK)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
@@ -6,17 +6,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @ConditionalOnWebApplication
 public class WebConfiguration implements WebMvcConfigurer {
 
-  public static final String HEALTH_CHECK = "/health";
   public static final String PATIENT_EXPERIENCE = "/pxp/**";
   public static final String TWILIO_CALLBACK = "/pxp/callback";
   public static final String RS_QUEUE_CALLBACK = "/reportstream/callback";
@@ -33,11 +30,6 @@ public class WebConfiguration implements WebMvcConfigurer {
   public static final String GRAPH_QL = "/graphql";
 
   @Autowired private RestLoggingInterceptor _loggingInterceptor;
-
-  @Override
-  public void addViewControllers(ViewControllerRegistry registry) {
-    registry.addStatusController(HEALTH_CHECK, HttpStatus.OK);
-  }
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {

--- a/backend/src/main/resources/static/index.html
+++ b/backend/src/main/resources/static/index.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-
-</head>
-<body>  
-</body>
-</html>

--- a/cypress/e2e.sh
+++ b/cypress/e2e.sh
@@ -22,7 +22,7 @@ EOF
 SPEC_PATH="cypress/e2e/**"
 TEST_ENV="https://localhost.simplereport.gov"
 CHECK_COMMIT="$(git rev-parse HEAD)"
-BACKEND_URL_PATH="/api/health"
+BACKEND_URL_PATH="/api/actuator/health"
 PUBLIC_URL="/app"
 FRONTEND_URL_PATH="/health/commit"
 RUN_OPEN=false

--- a/lighthouse.sh
+++ b/lighthouse.sh
@@ -3,14 +3,14 @@
 echo "Starting docker containers"
 docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --quiet-pull
 
-echo "Waiting for backend to start at https://localhost.simplereport.gov/api/health"
+echo "Waiting for backend to start at https://localhost.simplereport.gov/api/actuator/health"
 http_response=0
 polls=0
 while [[ $http_response != "200" && $polls -lt 180 ]]; do
   ((polls++))
   sleep 2
-  echo "Waiting for backend to start at https://localhost.simplereport.gov/api/health"
-  http_response=$(curl -skL -w "%{http_code}" "https://localhost.simplereport.gov/api/health")
+  echo "Waiting for backend to start at https://localhost.simplereport.gov/api/actuator/health"
+  http_response=$(curl -skL -w "%{http_code}" "https://localhost.simplereport.gov/api/actuator/health")
 done
 if [[ $http_response -ne 200 ]]; then
   echo 'Backend never started. Exiting...'

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -147,7 +147,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     unhealthy_threshold                       = 3
 
     match {
-      body = "UP"
+      body        = "UP"
       status_code = [200]
     }
   }
@@ -162,7 +162,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     unhealthy_threshold                       = 3
 
     match {
-      body = "UP"
+      body        = "UP"
       status_code = [200]
     }
   }

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -124,6 +124,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     protocol                            = "Http"
     request_timeout                     = 60
     pick_host_name_from_backend_address = true
+    probe_name                          = "be-http"
   }
 
   backend_http_settings {
@@ -133,6 +134,37 @@ resource "azurerm_application_gateway" "load_balancer" {
     protocol                            = "Https"
     request_timeout                     = 60
     pick_host_name_from_backend_address = true
+    probe_name                          = "be-https"
+  }
+
+  probe {
+    name                                      = "be-http"
+    interval                                  = 10
+    path                                      = "/actuator/health"
+    pick_host_name_from_backend_http_settings = true
+    protocol                                  = "Http"
+    timeout                                   = 10
+    unhealthy_threshold                       = 3
+
+    match {
+      body = "UP"
+      status_code = [200]
+    }
+  }
+
+  probe {
+    name                                      = "be-https"
+    interval                                  = 10
+    path                                      = "/actuator/health"
+    pick_host_name_from_backend_http_settings = true
+    protocol                                  = "Https"
+    timeout                                   = 10
+    unhealthy_threshold                       = 3
+
+    match {
+      body = "UP"
+      status_code = [200]
+    }
   }
 
   # ------- Backend Metabase App -------------------------
@@ -174,6 +206,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     protocol                            = "Http"
     request_timeout                     = 20
     pick_host_name_from_backend_address = true
+    probe_name                          = "be-http"
   }
 
   backend_http_settings {
@@ -183,6 +216,7 @@ resource "azurerm_application_gateway" "load_balancer" {
     protocol                            = "Https"
     request_timeout                     = 20
     pick_host_name_from_backend_address = true
+    probe_name                          = "be-https"
   }
 
   # ------- Listeners -------------------------

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_linux_web_app" "service" {
   # Configure Docker Image to load on start
   site_config {
     always_on                         = "true"
-    health_check_path                 = "/health"
+    health_check_path                 = "/actuator/health"
     health_check_eviction_time_in_min = 5
     scm_minimum_tls_version           = "1.2"
     use_32_bit_worker                 = false
@@ -90,7 +90,7 @@ resource "azurerm_linux_web_app_slot" "staging" {
   # Configure Docker Image to load on start
   site_config {
     always_on                         = "true"
-    health_check_path                 = "/health"
+    health_check_path                 = "/actuator/health"
     health_check_eviction_time_in_min = 5
     scm_minimum_tls_version           = "1.2"
     use_32_bit_worker                 = false

--- a/ops/services/metabase/service/main.tf
+++ b/ops/services/metabase/service/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_linux_web_app" "metabase" {
 
   site_config {
     always_on                         = true
-    health_check_path                 = "/api/health"
+    health_check_path                 = "/api/actuator/health"
     health_check_eviction_time_in_min = 5
     ftps_state                        = "Disabled"
     scm_minimum_tls_version           = "1.2"

--- a/ops/services/metabase/service/main.tf
+++ b/ops/services/metabase/service/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_linux_web_app" "metabase" {
 
   site_config {
     always_on                         = true
-    health_check_path                 = "/api/actuator/health"
+    health_check_path                 = "/api/health"
     health_check_eviction_time_in_min = 5
     ftps_state                        = "Disabled"
     scm_minimum_tls_version           = "1.2"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- During the Spring boot 3 update, we noticed that the [deployments](https://github.com/CDCgov/prime-simplereport/actions/workflows/deployDev.yml?query=branch%3Aboban%2Fspring-upgrade) were failing because the app gateway was checking the health status on the `/` endpoint. The `/` endpoint was failing our security rules because we did not also permit access to `/index.html`. It seems better that we just remove access to `/` and then use `/actuator/health` for health check accross the app.

## Changes Proposed

- Add probe to app_gateway for backend services that will check the `/actuator/health` endpoint
- Replace all places where the backend's `/health` was being check with `/actuator/health`
- Remove access to `/` endpoint in security config
- Remove `index.html`

## Additional Information

- The `/health` endpoint only ever returns 200 OK which is not that useful. SpringBoot already gives us more information in actuator so I thought it would be best to just remove it to reduce confusion.
- App Gateway uses health probes to do backend health checks and app services uses the new endpoint
Dev5 now:
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/5024a0c8-efc4-44b9-8eaf-33b68cb31a68)
<img width="1422" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/888cfbe8-fd87-4e08-a654-2c24dd098135">
<img width="1145" alt="image" src="https://github.com/CDCgov/prime-simplereport/assets/10108172/e754c0fe-96c8-4587-993c-ac5b715f2118">

Dev6:
![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/d79ab0e7-ffdb-4a22-81c9-b87be23207ba)

![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/bb4b2f9a-4845-43e3-9c02-ddacfd6502e7)

![image](https://github.com/CDCgov/prime-simplereport/assets/10108172/450ec053-1e58-4e86-ab17-fb25532d3003)


## Testing

- Verify 401 not authorized on [`/health`](https://dev5.simplereport.gov/api/health) and [`/`](https://dev5.simplereport.gov/api/) and 200 OK on [`/actuator/health`](https://dev5.simplereport.gov/api/actuator/health)
- Application can be deployed, feel free to redeploy to dev5 (Currently deployed on dev5)