### PR TITLE
Make add patient e2e test rerunnable

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -68,6 +68,24 @@ public class OrganizationResolver {
   }
 
   /**
+   * Retrieves a list of all organizations, filtered by name
+   *
+   * @return a list of organizations
+   */
+  @QueryMapping
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public List<ApiOrganization> organizationsByName(@Argument String name) {
+    List<Organization> orgs = _organizationService.getOrganizationsByName(name);
+    if (orgs.isEmpty()) {
+      return List.of();
+    } else {
+      return orgs.stream()
+          .map(o -> new ApiOrganization(o, _organizationService.getFacilities(o)))
+          .collect(Collectors.toList());
+    }
+  }
+
+  /**
    * Retrieves a list of all pending organizations AND organization queue items
    *
    * @return a list of pending organizations

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -3,6 +3,7 @@
 # which is enforced in the API not in the schema validator.
 extend type Query {
   organizations(identityVerified: Boolean): [Organization!]!
+  organizationsByName(name: String!): [Organization]
   pendingOrganizations: [PendingOrganization!]!
   organization(id: ID!): Organization
   facilityStats(facilityId: ID!): FacilityStats

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -1,10 +1,12 @@
 package gov.cdc.usds.simplereport.api.organization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import gov.cdc.usds.simplereport.api.model.ApiOrganization;
 import gov.cdc.usds.simplereport.api.model.ApiPendingOrganization;
 import gov.cdc.usds.simplereport.api.model.accountrequest.OrganizationAccountRequest;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
@@ -74,5 +76,30 @@ class OrganizationResolverTest {
     assertThat(actual).isNull();
     verify(organizationService).getOrganizationById(id);
     verify(organizationService, times(0)).getFacilities(org);
+  }
+
+  @Test
+  void organizationsByName_success() {
+    String orgName = "org name";
+    Organization org = new Organization(orgName, "type", "123", true);
+    when(organizationService.getOrganizationsByName(orgName)).thenReturn(List.of(org));
+
+    organizationMutationResolver.organizationsByName(orgName);
+
+    verify(organizationService).getOrganizationsByName(orgName);
+    verify(organizationService).getFacilities(org);
+  }
+
+  @Test
+  void organizationsByName_null() {
+    String orgName = "org name";
+    Organization org = new Organization(orgName, "type", "123", true);
+    when(organizationService.getOrganizationsByName(orgName)).thenReturn(List.of());
+
+    List<ApiOrganization> actual = organizationMutationResolver.organizationsByName(orgName);
+
+    assertThat(actual).isEmpty();
+    verify(organizationService).getOrganizationsByName(orgName);
+    verify(organizationService, never()).getFacilities(org);
   }
 }

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,3 +1,5 @@
+global.specRunVersions = new Map();
+
 module.exports = {
   viewportWidth: 1200,
   viewportHeight: 800,
@@ -71,12 +73,12 @@ module.exports = {
         getMultiplexDeviceName() {
           return global.multiplexDeviceName;
         },
-        setSpecName(name) {
-          global.specName = name;
-          return name;
+        setSpecRunVersionName(data) {
+          global.specRunVersions.set(data.specRunName, data.versionName);
+          return null;
         },
-        getSpecName() {
-          return global.specName || null;
+        getSpecRunVersionName(specRunName) {
+          return global.specRunVersions.get(specRunName) || null;
         },
       });
       on("before:browser:launch", (browser = {}, launchOptions = {}) => {

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -71,6 +71,13 @@ module.exports = {
         getMultiplexDeviceName() {
           return global.multiplexDeviceName;
         },
+        setSpecName(name) {
+          global.specName = name;
+          return name;
+        },
+        getSpecName() {
+          return global.specName || null;
+        },
       });
       on("before:browser:launch", (browser = {}, launchOptions = {}) => {
         launchOptions.args = launchOptions.args.filter(

--- a/cypress/e2e/02-add_patient.cy.js
+++ b/cypress/e2e/02-add_patient.cy.js
@@ -12,10 +12,13 @@ describe("Adding a single patient", () => {
     cy.task("setPatientPhone", patient.phone);
     cy.task("getSpecName")
       .then((prevSpecName) => {
+        let currentSpecName = `${testNumber()}-cypress-spec-2`;
         if (prevSpecName) {
-          cleanUpPreviousOrg(prevSpecName);
+          let shouldCleanUpPreviousOrg = prevSpecName != currentSpecName;
+          if (shouldCleanUpPreviousOrg) {
+            cleanUpPreviousOrg(prevSpecName);
+          }
         }
-        let currentSpecName = `${testNumber()}-cypress-spec-2`
         cy.task("setSpecName", currentSpecName)
         setupOrgAndFacility(currentSpecName);
       })

--- a/cypress/e2e/02-add_patient.cy.js
+++ b/cypress/e2e/02-add_patient.cy.js
@@ -1,8 +1,8 @@
 import { generatePatient, loginHooks, testNumber } from "../support/e2e";
-import { cleanUpPreviousOrg, setupOrgAndFacility } from "../utils/setup-utils";
+import { cleanUpPreviousRunSetupData, setupRunData } from "../utils/setup-utils";
 
 const patient = generatePatient();
-
+const specRunName = "spec02";
 describe("Adding a single patient", () => {
   loginHooks();
   before("store patient info", () => {
@@ -10,17 +10,20 @@ describe("Adding a single patient", () => {
     cy.task("setPatientName", patient.fullName);
     cy.task("setPatientDOB", patient.dobForPatientLink);
     cy.task("setPatientPhone", patient.phone);
-    cy.task("getSpecName")
-      .then((prevSpecName) => {
-        let currentSpecName = `${testNumber()}-cypress-spec-2`;
-        if (prevSpecName) {
-          let shouldCleanUpPreviousOrg = prevSpecName != currentSpecName;
-          if (shouldCleanUpPreviousOrg) {
-            cleanUpPreviousOrg(prevSpecName);
-          }
+
+    cy.task("getSpecRunVersionName", specRunName)
+      .then((prevSpecRunVersionName) => {
+        let currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
+
+        if (prevSpecRunVersionName) {
+          cleanUpPreviousRunSetupData(prevSpecRunVersionName);
         }
-        cy.task("setSpecName", currentSpecName)
-        setupOrgAndFacility(currentSpecName);
+        let data = {
+          specRunName: specRunName,
+          versionName: currentSpecRunVersionName
+        };
+        cy.task("setSpecRunVersionName", data)
+        setupRunData(currentSpecRunVersionName);
       })
   });
   it("navigates to the add patient form", () => {

--- a/cypress/e2e/02-add_patient.cy.js
+++ b/cypress/e2e/02-add_patient.cy.js
@@ -1,13 +1,24 @@
-import { generatePatient, loginHooks } from "../support/e2e";
+import { generatePatient, loginHooks, testNumber } from "../support/e2e";
+import { cleanUpPreviousOrg, setupOrgAndFacility } from "../utils/setup-utils";
 
 const patient = generatePatient();
 
 describe("Adding a single patient", () => {
   loginHooks();
   before("store patient info", () => {
+    // TODO: clean up after no tests rely on this patient
     cy.task("setPatientName", patient.fullName);
     cy.task("setPatientDOB", patient.dobForPatientLink);
     cy.task("setPatientPhone", patient.phone);
+    cy.task("getSpecName")
+      .then((prevSpecName) => {
+        if (prevSpecName) {
+          cleanUpPreviousOrg(prevSpecName);
+        }
+        let currentSpecName = `${testNumber()}-cypress-spec-2`
+        cy.task("setSpecName", currentSpecName)
+        setupOrgAndFacility(currentSpecName);
+      })
   });
   it("navigates to the add patient form", () => {
     cy.visit("/");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,7 +26,7 @@
 
 import "cypress-localstorage-commands";
 import { authenticator } from "otplib";
-import { graphqlURL } from "../utils/request-utils";
+import { addOrgToQueueURL, graphqlURL } from "../utils/request-utils";
 
 // read environment variables
 
@@ -91,20 +91,6 @@ Cypress.Commands.add("login", () => {
           });
         });
       });
-    }
-  });
-});
-
-Cypress.Commands.add("selectFacility", () => {
-  cy.get("body").then(($body) => {
-    if (
-      $body
-        .text()
-        .includes(
-          "Please select the testing facility where you are working today.",
-        )
-    ) {
-      cy.get(".usa-card__body").last().click();
     }
   });
 });
@@ -176,6 +162,17 @@ Cypress.Commands.add("makePOSTRequest", (requestBody) => {
       body: requestBody,
     }),
   );
+});
+
+Cypress.Commands.add("makeAccountRequest", (requestBody) => {
+   cy.request({
+     method: "POST",
+     url: addOrgToQueueURL,
+     headers: {
+       "Content-Type": "application/json",
+     },
+     body: requestBody,
+   });
 });
 
 Cypress.Commands.add("injectSRAxe", () => {

--- a/cypress/utils/request-utils.js
+++ b/cypress/utils/request-utils.js
@@ -1,7 +1,6 @@
-export const graphqlURL = `${
-  Cypress.env("BACKEND_URL") || "http://localhost:8080"
-}/graphql`;
-
 export const frontendURL = `${
   Cypress.env("REACT_APP_BASE_URL") || "https://localhost.simplereport.gov/app"
 }/`;
+const backendURL = Cypress.env("BACKEND_URL") || "http://localhost:8080";
+export const graphqlURL = `${backendURL}/graphql`;
+export const addOrgToQueueURL = `${backendURL}/account-request/organization-add-to-queue`;

--- a/cypress/utils/setup-utils.js
+++ b/cypress/utils/setup-utils.js
@@ -1,0 +1,58 @@
+import {
+  accessOrganization,
+  addMockFacility,
+  createOrganization,
+  getOrganizationsByName, getPatientsByFacilityId,
+  markOrganizationAsDeleted, markPatientAsDeleted,
+  verifyPendingOrganization
+} from "./testing-data-utils";
+import { generateUser } from "../support/e2e";
+
+const createOrgName = (specName) => {
+  return `${specName}-org`;
+}
+
+const createFacilityName = (specName) => {
+  return `${specName}-facility`;
+}
+
+const createAndVerifyOrganization = (orgName) => {
+  const adminUser = generateUser();
+  return createOrganization(orgName, adminUser.email)
+    .then((res) => verifyPendingOrganization(res.body.orgExternalId))
+}
+const archivePatientsForFacility = (facilityId) => {
+  return getPatientsByFacilityId(facilityId)
+    .then((res) => {
+      let patients = res.body.data.patients;
+      if (patients.length > 0) {
+        patients.map(
+          (patient) => markPatientAsDeleted(patient.internalId, true))
+      }
+    })
+}
+
+export const cleanUpPreviousOrg = (specName) => {
+  let orgName = createOrgName(specName);
+  getOrganizationsByName(orgName)
+    .then((res) => {
+      let orgs = res.body.data.organizationsByName;
+      let org = orgs.length > 0 ? orgs[0] : null;
+      if (org) {
+        let facilities = org.facilities
+        if (facilities.length > 0) {
+          facilities.map((facility) => archivePatientsForFacility(facility.id))
+        }
+        markOrganizationAsDeleted(org.id, true);
+      }
+    })
+}
+
+export const setupOrgAndFacility = (specName) => {
+  let orgName = createOrgName(specName);
+  let facilityName = createFacilityName(specName);
+  createAndVerifyOrganization(orgName)
+    .then(() => getOrganizationsByName(orgName))
+    .then((res) => accessOrganization(res.body.data.organizationsByName[0].externalId))
+    .then(() => addMockFacility(facilityName))
+};

--- a/cypress/utils/setup-utils.js
+++ b/cypress/utils/setup-utils.js
@@ -8,12 +8,12 @@ import {
 } from "./testing-data-utils";
 import { generateUser } from "../support/e2e";
 
-const createOrgName = (specName) => {
-  return `${specName}-org`;
+const createOrgName = (specRunVersionName) => {
+  return `${specRunVersionName}-org`;
 }
 
-const createFacilityName = (specName) => {
-  return `${specName}-facility`;
+const createFacilityName = (specRunVersionName) => {
+  return `${specRunVersionName}-facility`;
 }
 
 const createAndVerifyOrganization = (orgName) => {
@@ -32,8 +32,8 @@ const archivePatientsForFacility = (facilityId) => {
     })
 }
 
-export const cleanUpPreviousOrg = (specName) => {
-  let orgName = createOrgName(specName);
+export const cleanUpPreviousRunSetupData = (specRunVersionName) => {
+  let orgName = createOrgName(specRunVersionName);
   getOrganizationsByName(orgName)
     .then((res) => {
       let orgs = res.body.data.organizationsByName;
@@ -48,9 +48,9 @@ export const cleanUpPreviousOrg = (specName) => {
     })
 }
 
-export const setupOrgAndFacility = (specName) => {
-  let orgName = createOrgName(specName);
-  let facilityName = createFacilityName(specName);
+export const setupRunData = (specRunVersionName) => {
+  let orgName = createOrgName(specRunVersionName);
+  let facilityName = createFacilityName(specRunVersionName);
   createAndVerifyOrganization(orgName)
     .then(() => getOrganizationsByName(orgName))
     .then((res) => accessOrganization(res.body.data.organizationsByName[0].externalId))

--- a/cypress/utils/testing-data-utils.js
+++ b/cypress/utils/testing-data-utils.js
@@ -1,24 +1,61 @@
+// QUERIES
 export const whoAmI = () => {
   return cy.makePOSTRequest({
     operationName: "WhoAmI",
     variables: {},
-    query: `query WhoAmI {\n  whoami {\n organization {\n  id\n  facilities {\n      id\n    }\n  }\n} \n}`,
+    query: `query WhoAmI {
+      whoami {
+        organization {
+          id
+          facilities {
+            id
+          }
+        }
+      }
+    }`,
   });
 };
-
 export const getOrganizationById = (organizationId) => {
   return cy.makePOSTRequest({
     operationName: "Organization",
     variables: { id: organizationId },
     query: `query Organization($id: ID!) {
-           organization(id: $id){
-            id
-            name
-          }
-        }`,
+      organization(id: $id) {
+        id
+        name
+      }
+    }`,
   });
 };
-
+export const getOrganizationsByName = (organizationName) => {
+  return cy.makePOSTRequest({
+    operationName: "OrganizationsByName",
+    variables: { name: organizationName },
+    query: `query OrganizationsByName($name: String!) {
+      organizationsByName(name: $name) {
+        id
+        name
+        externalId
+        facilities {
+          id
+          name
+          isDeleted
+        }
+      }
+    }`
+  });
+};
+export const getPatientsByFacilityId = (facilityId) => {
+  return cy.makePOSTRequest({
+    operationName: "Patients",
+    variables: { facilityId: facilityId },
+    query: `query Patients($facilityId: ID!) {
+           patients(facilityId: $facilityId){
+            internalId
+           }
+        }`
+  });
+};
 export const getPatientLinkByTestEventId = (testEventId) => {
   return cy.makePOSTRequest({
     operationName: "TestResult",
@@ -32,7 +69,48 @@ export const getPatientLinkByTestEventId = (testEventId) => {
         }`,
   });
 };
-
+// MUTATIONS
+export const verifyPendingOrganization = (orgExternalId) => {
+  return cy.makePOSTRequest({
+    operationName: "VerifyPendingOrganization",
+    variables: {
+      externalId: orgExternalId,
+    },
+    query: `mutation VerifyPendingOrganization(
+      $externalId: String!
+    ) {
+      setOrganizationIdentityVerified(
+        externalId: $externalId,
+        verified: true
+      )
+    }`,
+  });
+};
+export const accessOrganization = (orgExternalId) => {
+  return cy.makePOSTRequest({
+    operationName: "SetCurrentUserTenantDataAccess",
+    variables: {
+      organizationExternalId: orgExternalId,
+    },
+    query: `mutation SetCurrentUserTenantDataAccess(
+      $organizationExternalId: String!
+    ) {
+      setCurrentUserTenantDataAccess(
+        organizationExternalId: $organizationExternalId,
+        justification: "cypress testing"
+      ) {
+        id
+        organization {
+          externalId
+          facilities {
+            id
+            name
+          }
+        }
+      }
+    }`,
+  });
+};
 export const addMockFacility = (facilityName) => {
   return cy.makePOSTRequest({
     operationName: "AddFacility",
@@ -41,6 +119,8 @@ export const addMockFacility = (facilityName) => {
       street: "123 maint street",
       state: "NJ",
       zipCode: "07601",
+      phone: "8002324636",
+      cliaNumber: "12D4567890",
       orderingProviderFirstName: "Jane",
       orderingProviderLastName: "Austen",
       orderingProviderNPI: "1234567890",
@@ -57,6 +137,8 @@ export const addMockFacility = (facilityName) => {
   $street: String!
   $state: String!
   $zipCode: String!
+  $phone: String
+  $cliaNumber: String
   $orderingProviderFirstName: String
   $orderingProviderMiddleName: String
   $orderingProviderLastName: String
@@ -78,6 +160,8 @@ export const addMockFacility = (facilityName) => {
         state: $state
         zipCode: $zipCode
       }
+      phone: $phone
+      cliaNumber: $cliaNumber
       orderingProvider: {
         firstName: $orderingProviderFirstName
         middleName: $orderingProviderMiddleName
@@ -97,5 +181,56 @@ export const addMockFacility = (facilityName) => {
     id
   }
 }`,
+  });
+};
+export const markOrganizationAsDeleted = (orgId, deleted) => {
+  return cy.makePOSTRequest({
+    operationName: "MarkOrganizationAsDeleted",
+    variables: {
+      organizationId: orgId,
+      deleted: deleted,
+    },
+    query: `mutation MarkOrganizationAsDeleted(
+      $organizationId: ID!
+      $deleted: Boolean!
+    ) {
+      markOrganizationAsDeleted(
+        organizationId: $organizationId,
+        deleted: $deleted
+      )
+    }`,
+  });
+};
+export const markPatientAsDeleted = (patientId, deleted) => {
+  return cy.makePOSTRequest({
+    operationName: "MarkPatientAsDeleted",
+    variables: {
+      patientId: patientId,
+      deleted: deleted,
+    },
+    query: `mutation MarkPatientAsDeleted(
+      $patientId: ID!
+      $deleted: Boolean!
+    ) {
+      setPatientIsDeleted(
+        id: $patientId,
+        deleted: $deleted
+      ) {
+        id
+      }
+    }`,
+  });
+};
+
+export const createOrganization = (name, userEmail) => {
+  return cy.makeAccountRequest({
+    "name": name,
+    "type": "camp",
+    "state": "CA",
+    "firstName": "Greg",
+    "middleName": "",
+    "lastName": "McTester",
+    "email": userEmail,
+    "workPhoneNumber": "2123892839"
   });
 };

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -701,6 +701,7 @@ export type Query = {
   organization?: Maybe<Organization>;
   organizationLevelDashboardMetrics?: Maybe<OrganizationLevelDashboardMetrics>;
   organizations: Array<Organization>;
+  organizationsByName?: Maybe<Array<Maybe<Organization>>>;
   patient?: Maybe<Patient>;
   patientExists?: Maybe<Scalars["Boolean"]["output"]>;
   patientExistsWithoutZip?: Maybe<Scalars["Boolean"]["output"]>;
@@ -748,6 +749,10 @@ export type QueryOrganizationLevelDashboardMetricsArgs = {
 
 export type QueryOrganizationsArgs = {
   identityVerified?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+export type QueryOrganizationsByNameArgs = {
+  name: Scalars["String"]["input"];
 };
 
 export type QueryPatientArgs = {


### PR DESCRIPTION
# PULL REQUEST

## Related Issue
- Resolves #6465 to make it rerunnable

## Changes Proposed
- Introduces new `organizationsByName` query to help get organizations by name
- For users running this locally multiple times, the previous org, facility, and patients related to running spec 2 will now be archived before the spec is rerun
- spec 2 can now be re-run without spec 1 having been run previously
   - spec clean up after is not being done since the tests after spec 2 rely on patient, org, and facility being created previously

## Additional Information
- separate PR will be opened once this one is merged in to implement some best practices (e.g. using `data-cy` attribute as selectors, etc...)

## Testing
- run spec 2 locally ensure all data created in the previous run is soft deleted

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
