### PR TITLE
Dan/6338 org user list bug

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -73,6 +73,7 @@ public class LiveOktaRepository implements OktaRepository {
   private final String adminGroupName;
 
   private static final String OKTA_ORG_PROFILE_MATCHER = "profile.name sw \"";
+  private static final int OKTA_PAGE_SIZE = 500;
 
   public LiveOktaRepository(
       AuthorizationProperties authorizationProperties,
@@ -228,12 +229,11 @@ public class LiveOktaRepository implements OktaRepository {
     PagedList<User> pagedUserList = new PagedList<>();
     List<User> allUsers = new ArrayList<>();
     Group orgDefaultOktaGroup = getDefaultOktaGroup(org);
-    int pageSize = 500;
     do {
       pagedUserList =
           (PagedList<User>)
               groupApi.listGroupUsers(
-                  orgDefaultOktaGroup.getId(), pagedUserList.getAfter(), pageSize);
+                  orgDefaultOktaGroup.getId(), pagedUserList.getAfter(), OKTA_PAGE_SIZE);
       allUsers.addAll(pagedUserList);
     } while (pagedUserList.hasMoreItems());
     return allUsers;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -6,6 +6,7 @@ import com.okta.sdk.resource.api.ApplicationGroupsApi;
 import com.okta.sdk.resource.api.GroupApi;
 import com.okta.sdk.resource.api.UserApi;
 import com.okta.sdk.resource.client.ApiException;
+import com.okta.sdk.resource.common.PagedList;
 import com.okta.sdk.resource.group.GroupBuilder;
 import com.okta.sdk.resource.model.Application;
 import com.okta.sdk.resource.model.Error;
@@ -31,6 +32,7 @@ import gov.cdc.usds.simplereport.config.exceptions.MisconfiguredApplicationExcep
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -211,19 +213,30 @@ public class LiveOktaRepository implements OktaRepository {
 
   @Override
   public Set<String> getAllUsersForOrganization(Organization org) {
-    Group orgDefaultOktaGroup = getDefaultOktaGroup(org);
-    var groupUsers = groupApi.listGroupUsers(orgDefaultOktaGroup.getId(), null, null);
-    return groupUsers.stream()
+    return getAllUsersForOrg(org).stream()
         .map(u -> u.getProfile().getLogin())
         .collect(Collectors.toUnmodifiableSet());
   }
 
   @Override
   public Map<String, UserStatus> getAllUsersWithStatusForOrganization(Organization org) {
-    Group orgDefaultOktaGroup = getDefaultOktaGroup(org);
-    var groupUsers = groupApi.listGroupUsers(orgDefaultOktaGroup.getId(), null, null);
-    return groupUsers.stream()
+    return getAllUsersForOrg(org).stream()
         .collect(Collectors.toMap(u -> u.getProfile().getLogin(), User::getStatus));
+  }
+
+  private List<User> getAllUsersForOrg(Organization org) {
+    PagedList<User> pagedUserList = new PagedList<>();
+    List<User> allUsers = new ArrayList<>();
+    Group orgDefaultOktaGroup = getDefaultOktaGroup(org);
+    int pageSize = 500;
+    do {
+      pagedUserList =
+          (PagedList<User>)
+              groupApi.listGroupUsers(
+                  orgDefaultOktaGroup.getId(), pagedUserList.getAfter(), pageSize);
+      allUsers.addAll(pagedUserList);
+    } while (pagedUserList.hasMoreItems());
+    return allUsers;
   }
 
   private Group getDefaultOktaGroup(Organization org) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -587,7 +587,7 @@ class LiveOktaRepositoryTest {
     var mockGroupList = List.of(mockGroup);
     var mockUser = mock(User.class);
     var mockUserProfile = mock(UserProfile.class);
-    PagedList<User> mockedUserList = new PagedList<>(List.of(mockUser), "", "", "");
+    PagedList<User> mockedUserList = new PagedList<>(List.of(mockUser), "", "", null);
     when(groupApi.listGroups(
             eq(groupProfilePrefix),
             isNull(),
@@ -634,7 +634,7 @@ class LiveOktaRepositoryTest {
     var mockGroupList = List.of(mockGroup);
     var mockGroupProfile = mock(GroupProfile.class);
     var mockUser = mock(User.class);
-    PagedList<User> mockUserList = new PagedList<>(List.of(mockUser), "", "", "");
+    PagedList<User> mockUserList = new PagedList<>(List.of(mockUser), "", "", null);
     var mockUserProfile = mock(UserProfile.class);
     when(groupApi.listGroups(
             eq(groupProfilePrefix),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -20,6 +20,7 @@ import com.okta.sdk.resource.api.ApplicationGroupsApi;
 import com.okta.sdk.resource.api.GroupApi;
 import com.okta.sdk.resource.api.UserApi;
 import com.okta.sdk.resource.client.ApiException;
+import com.okta.sdk.resource.common.PagedList;
 import com.okta.sdk.resource.group.GroupBuilder;
 import com.okta.sdk.resource.model.Application;
 import com.okta.sdk.resource.model.Group;
@@ -586,7 +587,7 @@ class LiveOktaRepositoryTest {
     var mockGroupList = List.of(mockGroup);
     var mockUser = mock(User.class);
     var mockUserProfile = mock(UserProfile.class);
-    var mockUserList = List.of(mockUser);
+    PagedList<User> mockedUserList = new PagedList<>(List.of(mockUser), "", "", "");
     when(groupApi.listGroups(
             eq(groupProfilePrefix),
             isNull(),
@@ -599,7 +600,7 @@ class LiveOktaRepositoryTest {
         .thenReturn(mockGroupList);
     when(mockGroup.getProfile()).thenReturn(mockGroupProfile);
     when(mockGroupProfile.getName()).thenReturn(groupProfilePrefix);
-    when(groupApi.listGroupUsers(any(), isNull(), isNull())).thenReturn(mockUserList);
+    when(groupApi.listGroupUsers(any(), any(), any())).thenReturn(mockedUserList);
     when(mockUser.getProfile()).thenReturn(mockUserProfile);
     when(mockUserProfile.getLogin()).thenReturn("email@example.com");
 
@@ -633,7 +634,7 @@ class LiveOktaRepositoryTest {
     var mockGroupList = List.of(mockGroup);
     var mockGroupProfile = mock(GroupProfile.class);
     var mockUser = mock(User.class);
-    var mockUserList = List.of(mockUser);
+    PagedList<User> mockUserList = new PagedList<>(List.of(mockUser), "", "", "");
     var mockUserProfile = mock(UserProfile.class);
     when(groupApi.listGroups(
             eq(groupProfilePrefix),
@@ -648,7 +649,7 @@ class LiveOktaRepositoryTest {
     when(mockGroup.getProfile()).thenReturn(mockGroupProfile);
     when(mockGroupProfile.getName()).thenReturn(groupProfilePrefix);
     when(mockGroup.getId()).thenReturn("1234");
-    when(groupApi.listGroupUsers(eq("1234"), isNull(), isNull())).thenReturn(mockUserList);
+    when(groupApi.listGroupUsers(eq("1234"), any(), any())).thenReturn(mockUserList);
     when(mockUser.getProfile()).thenReturn(mockUserProfile);
     when(mockUserProfile.getLogin()).thenReturn("email@example.com");
     when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -16,6 +16,11 @@
       margin-block-start: 1em;
       margin-block-end: 1em;
     }
+
+    .users-secondary-nav {
+      max-height: 44rem;
+      overflow-y: scroll;
+    }
   }
 
   .users-sidenav-item:hover {

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -29,7 +29,10 @@ const UsersSideNav: React.FC<Props> = ({
   return (
     <div className="display-block users-sidenav">
       <h2 className="users-sidenav-header">Users</h2>
-      <nav className="prime-secondary-nav" aria-label="Tertiary navigation">
+      <nav
+        className="prime-secondary-nav users-secondary-nav"
+        aria-label="Tertiary navigation"
+      >
         <div
           role="tablist"
           aria-owns={getIdsAsString(users)}

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ManageUsersContainer loads the component and displays users successfull
           </h2>
           <nav
             aria-label="Tertiary navigation"
-            class="prime-secondary-nav"
+            class="prime-secondary-nav users-secondary-nav"
           >
             <div
               aria-owns="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b user-tab-1029653e-24d9-428e-83b0-468319948902 user-tab-17656bad-08b6-4fd4-bb9a-ccac54e5ea0a user-tab-60bb9e3a-fe8a-4b81-b894-b01649c95e70 user-tab-0d3fa224-3d56-4382-b89c-9d8e415e59b3 user-tab-17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a"


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- resolves #6338 : UI doesn't display more than 1000 users for a given org.

## Changes Proposed

- In the backend service: paginate through the group users api call we are already making to get all users and return those to the UI.
- add a scroll bar to the users component

## Additional Information

- This is a band-aid fix.  Additional fixes (search component for users and proper pagination) are being tackled as a separate issue.

## Testing

- The pagination functionality itself was tested locally by setting the page size to two and ensuring that it returned all the users.  Not looking to re-verify that in the lower envs.  
- Will deploy to an env that has a decent number of users + facilities.  Verify that the users in okta (filtered by users in the db) are all returned and displayed by the UI.  Mostly looking at layout and design due to the first bullet point.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
