### PR TITLE
feat: Ignore tags

### DIFF
--- a/ops/demo/main.tf
+++ b/ops/demo/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/demo/persistent/main.tf
+++ b/ops/demo/persistent/main.tf
@@ -11,7 +11,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.demo.name
   }
 }
 

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev/persistent/main.tf
+++ b/ops/dev/persistent/main.tf
@@ -10,7 +10,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.dev.name
   }
 }
 

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -8,7 +8,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev2/persistent/main.tf
+++ b/ops/dev2/persistent/main.tf
@@ -12,7 +12,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.dev2.name
   }
 }
 

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -8,7 +8,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev3/persistent/main.tf
+++ b/ops/dev3/persistent/main.tf
@@ -10,7 +10,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.dev3.name
   }
 }
 

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -8,7 +8,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev4/persistent/main.tf
+++ b/ops/dev4/persistent/main.tf
@@ -12,7 +12,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.dev4.name
   }
 }
 

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -8,7 +8,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev5/persistent/main.tf
+++ b/ops/dev5/persistent/main.tf
@@ -12,7 +12,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.dev5.name
   }
 }
 

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -8,7 +8,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev6/persistent/main.tf
+++ b/ops/dev6/persistent/main.tf
@@ -12,7 +12,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.dev6.name
   }
 }
 

--- a/ops/dev7/main.tf
+++ b/ops/dev7/main.tf
@@ -8,7 +8,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/dev7/persistent/main.tf
+++ b/ops/dev7/persistent/main.tf
@@ -12,7 +12,7 @@ locals {
     environment = local.env
     # Resource groups can support multiple environments at the same level. Any resources that are shared between
     # environments should use the "local.env_level" convention where possible.
-    resource_group = "${local.project}-${local.name}-${local.env_level}"
+    resource_group = data.azurerm_resource_group.dev7.name
   }
 }
 

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/pentest/persistent/main.tf
+++ b/ops/pentest/persistent/main.tf
@@ -11,7 +11,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.pentest.name
   }
 }
 

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/prod/persistent/main.tf
+++ b/ops/prod/persistent/main.tf
@@ -12,7 +12,7 @@ locals {
   management_tags = {
     prime-app      = "simplereport"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.prod.name
   }
 }
 

--- a/ops/services/alerts/app_service_metrics/database.tf
+++ b/ops/services/alerts/app_service_metrics/database.tf
@@ -25,6 +25,11 @@ ${local.skip_on_weekends}
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "db_connection_exhaustion" {
@@ -53,5 +58,10 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "db_connection_exhaustion
   trigger {
     operator  = "GreaterThan"
     threshold = 5
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }

--- a/ops/services/alerts/app_service_metrics/exceptions.tf
+++ b/ops/services/alerts/app_service_metrics/exceptions.tf
@@ -48,6 +48,11 @@ AppServiceConsoleLogs
     operator  = "GreaterThan"
     threshold = 2
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "first_error_in_a_week" {
@@ -98,6 +103,11 @@ requests
     operator  = "GreaterThan"
     threshold = 0
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "account_request_failures" {
@@ -133,6 +143,11 @@ ${local.skip_on_weekends}
   trigger {
     operator  = "GreaterThan"
     threshold = 4
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 
@@ -170,6 +185,11 @@ ${local.skip_on_weekends}
     operator  = "GreaterThan"
     threshold = 0
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "all_experian_auth_failures" {
@@ -206,6 +226,11 @@ ${local.skip_on_weekends}
     operator  = "GreaterThan"
     threshold = 2
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "frontend_error_boundary" {
@@ -234,5 +259,10 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "frontend_error_boundary"
   trigger {
     operator  = "GreaterThan"
     threshold = 0
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }

--- a/ops/services/alerts/app_service_metrics/function_triggers.tf
+++ b/ops/services/alerts/app_service_metrics/function_triggers.tf
@@ -59,6 +59,11 @@ requests
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "fhir_batched_uploader_function_not_triggering" {
@@ -89,6 +94,11 @@ requests
   action {
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 

--- a/ops/services/alerts/app_service_metrics/main.tf
+++ b/ops/services/alerts/app_service_metrics/main.tf
@@ -29,6 +29,11 @@ resource "azurerm_monitor_metric_alert" "cpu_util" {
       webhook_properties = var.wiki_docs_json
     }
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_metric_alert" "mem_util" {
@@ -56,6 +61,11 @@ resource "azurerm_monitor_metric_alert" "mem_util" {
       webhook_properties = var.wiki_docs_json
     }
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
@@ -70,6 +80,11 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
   action_group {
     ids             = var.action_group_ids
     webhook_payload = var.wiki_docs_text
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 
@@ -110,6 +125,11 @@ ${local.skip_on_weekends}
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
@@ -149,6 +169,11 @@ ${local.skip_on_weekends}
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_401_410" {
@@ -178,6 +203,11 @@ ${local.skip_on_weekends}
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "http_5xx_errors" {
@@ -206,6 +236,11 @@ ${local.skip_on_weekends}
   action {
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 
@@ -238,6 +273,11 @@ ${local.skip_on_weekends}
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "bulk_results_upload" {
@@ -269,6 +309,11 @@ requests
     operator  = "GreaterThan"
     threshold = 0
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "report_stream_batched_uploader_400" {
@@ -298,6 +343,11 @@ customEvents
   trigger {
     operator  = "GreaterThan"
     threshold = 0
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 
@@ -329,6 +379,11 @@ customEvents
     operator  = "GreaterThan"
     threshold = 0
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "fhir_batched_uploader_single_failure_detected" {
@@ -359,6 +414,11 @@ ${local.skip_on_weekends}
   action {
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 
@@ -413,5 +473,10 @@ and duration >= 180000
   action {
     action_group           = var.action_group_ids
     custom_webhook_payload = var.wiki_docs_text
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }

--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -75,4 +75,9 @@ resource "azurerm_monitor_metric_alert" "uptime" {
       webhook_properties = var.wiki_docs_json
     }
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }

--- a/ops/services/alerts/db_metrics/main.tf
+++ b/ops/services/alerts/db_metrics/main.tf
@@ -23,4 +23,9 @@ resource "azurerm_monitor_metric_alert" "db_storage" {
       webhook_properties = var.wiki_docs_json
     }
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }

--- a/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
+++ b/ops/services/app_functions/report_stream_batched_publisher/infra/main.tf
@@ -100,6 +100,9 @@ resource "azurerm_linux_function_app" "functions" {
     SIMPLE_REPORT_CB_TOKEN           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_callback_token.id})"
   }
   lifecycle {
+    ignore_changes = [
+      tags
+    ]
     replace_triggered_by = [
       azurerm_service_plan.asp
     ]

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -464,6 +464,12 @@ resource "azurerm_application_gateway" "load_balancer" {
   firewall_policy_id = var.firewall_policy_id
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -63,6 +63,11 @@ resource "azurerm_linux_web_app" "service" {
       action                    = "Allow"
     }
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 # Creates a staging slot for the Linux Web App
@@ -109,6 +114,11 @@ resource "azurerm_linux_web_app_slot" "staging" {
       virtual_network_subnet_id = var.lb_subnet_id
       action                    = "Allow"
     }
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 

--- a/ops/services/metabase/service/main.tf
+++ b/ops/services/metabase/service/main.tf
@@ -65,8 +65,10 @@ resource "azurerm_linux_web_app" "metabase" {
       }
     }
   }
-
   lifecycle {
+    ignore_changes = [
+      tags
+    ]
     replace_triggered_by = [
       null_resource.service_plan_id
     ]

--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -37,7 +37,8 @@ resource "azurerm_postgresql_flexible_server" "db" {
   lifecycle {
     ignore_changes = [
       zone,
-      high_availability.0.standby_availability_zone
+      high_availability.0.standby_availability_zone,
+      tags
     ]
   }
 }

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/stg/persistent/main.tf
+++ b/ops/stg/persistent/main.tf
@@ -11,7 +11,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.stg.name
   }
 }
 

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/test/persistent/main.tf
+++ b/ops/test/persistent/main.tf
@@ -10,7 +10,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.test.name
   }
 }
 

--- a/ops/training/main.tf
+++ b/ops/training/main.tf
@@ -6,7 +6,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.rg.name
   }
 }
 

--- a/ops/training/persistent/main.tf
+++ b/ops/training/persistent/main.tf
@@ -11,7 +11,7 @@ locals {
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env
-    resource_group = "${local.project}-${local.name}-${local.env}"
+    resource_group = data.azurerm_resource_group.training.name
   }
 }
 


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #6822 

## Changes Proposed 

- This Pull Request changes the `resource_group` tag to be based on `data.azurerm_resource_group.dev.name` instead of `"${local.project}-${local.name}-${local.env_level}"` or `"${local.project}-${local.name}-${local.env}"`.  This brings consistency across all environment configs as some were using `local.env` which would tag dev(2,3,4,5...) incorrectly. By making this update, we can reduce some future mental overhead when reading through the code to understand which resource group a resource belongs to. *[I'll call out an example inline on a `dev3` file where this caused an inconsistency.](https://github.com/CDCgov/prime-simplereport/pull/6823/files#r1369334260)*
-  This PR also introduces lifecycle blocks to several resources to eliminate needless tag updates. The CDC is pretty much in charge of our tags and we don't use them for any meaningful purpose, we don't need to track or update the values of them.

## Testing 

- Reviewers should verify that the addition of the lifecycle block correctly ignores tag changes to avoid unnecessary updates, these tags do not affect the functionality of the resources.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README