### PR TITLE
feat: enhance Terraform plan workflow with multi-environment support

### DIFF
--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -1,42 +1,77 @@
 name: Ad-hoc Terraform Plan
+run-name: Terraform plan ${{ inputs.env }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
     inputs:
       env:
-        description: "Environment target"
+        description: 'What to plan against'
         required: true
-        default: "prod" 
+        type: choice
+        options:
+          - dev
+          - dev2
+          - dev3
+          - dev4
+          - dev5
+          - dev6
+          - dev7
+          - pentest
+          - test
+          - demo
+          - training
+          - stg
+          - prod
+          - all_environments
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
+  OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
 
 jobs:
-  terraform-plan:
+  matrix_prep:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set_matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: set_matrix
+      run: |
+        if [[ "${{ inputs.env }}" == "all_environments" ]]; then
+          matrix=[{\"env\":\"dev\"},{\"env\":\"dev2\"},{\"env\":\"dev3\"},{\"env\":\"dev4\"},{\"env\":\"dev5\"},{\"env\":\"dev6\"},{\"env\":\"dev7\"},{\"env\":\"pentest\"},{\"env\":\"test\"},{\"env\":\"demo\"},{\"env\":\"training\"},{\"env\":\"stg\"},{\"env\":\"prod\"}]
+        else
+          matrix=[{\"env\":\"${{ inputs.env }}\"}]
+        fi               
+        echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
+  terraform_plan:
+    needs: matrix_prep
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     defaults:
       run:
         working-directory: ./ops
-    env: # all Azure interaction is through Terraform
-      ARM_CLIENT_ID: ${{ secrets.TERRAFORM_ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.TERRAFORM_ARM_TENANT_ID }}
-      OKTA_API_TOKEN: ${{ secrets.OKTA_API_TOKEN_NONPROD }}
     steps:
       - uses: actions/checkout@v4
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Use prod Okta token if required
-        if: ${{ github.event.inputs.env == 'prod' || github.event.inputs.env == 'stg' }}
+        if: ${{ matrix.env == 'prod' || matrix.env == 'stg' || matrix.env == 'training' }}
         run: |
           echo "OKTA_API_TOKEN=${{ secrets.OKTA_API_TOKEN }}" >> "$GITHUB_ENV"
       - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.3
       - name: Terraform Init
-        run: make init-${{ github.event.inputs.env }}
+        run: make init-${{ matrix.env }}
       - name: Build ReportStream function app
         uses: ./.github/actions/build-reportstream-functions
         with:
-          deploy-env: ${{env.DEPLOY_ENV}}
+          deploy-env: ${{ matrix.env }}
       - name: Terraform plan
-        run: make plan-${{ github.event.inputs.env }}
+        run: make plan-${{ matrix.env }}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #6824 

## Changes Proposed 

- Updates the GitHub workflow to provide us with a list of all valid terraform plan options. 
  - dev
  - dev2
  - dev3
  - dev4
  - dev5
  - dev6
  - dev7
  - pentest
  - test
  - demo
  - training
  - stg
  - prod
  - all_environments
- The `all_environments` option runs a plan for all of our valid environments

## Additional Information 

- Possible future work: the terraformChecks and terraformPlan workflow files have a lot of overlap and it would be possible to combine them with some flags to determine behavior.

## Testing 
- Run an ad-hoc terraform plan from this branch against the available options.
  - Visit [this page](https://github.com/CDCgov/prime-simplereport/actions/workflows/terraformPlan.yml)
  - Click  `Run workflow`
  - Select the `alis/6824` branch from the dropdown
  - select the environment you want to plan against

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README