### PR TITLE
clean up rsv feature flag

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -462,7 +462,7 @@ public class TestResultRow implements FileRow {
       return false;
     }
     String disease = diseaseSpecificLoincMap.get(testPerformedCode);
-    return disease != null && (!RSV_NAME.equals(disease) || featureFlagsConfig.isRsvEnabled());
+    return disease != null;
   }
 
   private boolean validModelTestPerformedCombination(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -25,7 +25,6 @@ public class FeatureFlagsConfig {
   private final FeatureFlagRepository _repo;
 
   private boolean hivEnabled;
-  private boolean rsvEnabled;
   private boolean singleEntryRsvEnabled;
   private boolean agnosticEnabled;
   private boolean agnosticBulkUploadEnabled;
@@ -40,7 +39,6 @@ public class FeatureFlagsConfig {
   private void flagMapping(String flagName, Boolean flagValue) {
     switch (flagName) {
       case "hivEnabled" -> setHivEnabled(flagValue);
-      case "rsvEnabled" -> setRsvEnabled(flagValue);
       case "singleEntryRsvEnabled" -> setSingleEntryRsvEnabled(flagValue);
       case "agnosticEnabled" -> setAgnosticEnabled(flagValue);
       case "agnosticBulkUploadEnabled" -> setAgnosticBulkUploadEnabled(flagValue);

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -24,7 +24,6 @@ twilio:
   from-number: "+14045312484"
 features:
   hivEnabled: false
-  rsvEnabled: false
   singleEntryRsvEnabled: false
   agnosticEnabled: false
   testCardRefactorEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -150,7 +150,6 @@ datahub:
   fhir-enabled: true
 features:
   hivEnabled: true
-  rsvEnabled: true
   singleEntryRsvEnabled: true
   agnosticEnabled: true
   testCardRefactorEnabled: true

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/featureflags/FeatureFlagsControllerTest.java
@@ -14,7 +14,6 @@ class FeatureFlagsControllerTest {
 
   @BeforeEach
   void setup() {
-    _mockFeatureFlagConfig.setRsvEnabled(true);
     this.featureFlagsController = new FeatureFlagsController();
     ReflectionTestUtils.setField(
         this.featureFlagsController, "featureFlags", _mockFeatureFlagConfig);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/FileValidatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/FileValidatorTest.java
@@ -303,30 +303,6 @@ class FileValidatorTest {
   }
 
   @Test
-  void testResults_validFile_rsvOnly() {
-    // GIVEN
-    when(featureFlagsConfig.isRsvEnabled()).thenReturn(true);
-    InputStream input = loadCsv("testResultUpload/test-results-upload-valid-rsv-only.csv");
-    // WHEN
-    List<FeedbackMessage> errors = testResultFileValidator.validate(input);
-    // THEN
-    assertThat(errors).isEmpty();
-  }
-
-  @Test
-  void testResults_validFile_rsvDisabled() {
-    // GIVEN
-    when(featureFlagsConfig.isRsvEnabled()).thenReturn(false);
-    InputStream input = loadCsv("testResultUpload/test-results-upload-valid-rsv-only.csv");
-    // WHEN
-    List<FeedbackMessage> errors = testResultFileValidator.validate(input);
-    // THEN
-    assertThat(errors).hasSize(1);
-    assertThat(errors.get(0).getMessage())
-        .isEqualTo("Invalid equipment_model_name and test_performed_code combination");
-  }
-
-  @Test
   void testResultsFile_invalidHeaders() {
     // GIVEN
     InputStream input = new ByteArrayInputStream("invalid\nyes".getBytes());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/FileValidatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/FileValidatorTest.java
@@ -303,6 +303,16 @@ class FileValidatorTest {
   }
 
   @Test
+  void testResults_validFile_rsvOnly() {
+    // GIVEN
+    InputStream input = loadCsv("testResultUpload/test-results-upload-valid-rsv-only.csv");
+    // WHEN
+    List<FeedbackMessage> errors = testResultFileValidator.validate(input);
+    // THEN
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
   void testResultsFile_invalidHeaders() {
     // GIVEN
     InputStream input = new ByteArrayInputStream("invalid\nyes".getBytes());

--- a/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/ManageDeviceTypeFormContainer.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Navigate } from "react-router-dom";
-import { useFeature } from "flagged";
 
 import {
   DeviceType,
@@ -20,7 +19,6 @@ import DeviceForm from "./DeviceForm";
 
 const ManageDeviceTypeFormContainer = () => {
   useDocumentTitle(editDevicePageTitle);
-  const rsvEnabled = useFeature("rsvEnabled");
 
   const [submitted, setSubmitted] = useState(false);
   const [activeFacility] = useSelectedFacility();
@@ -81,10 +79,6 @@ const ManageDeviceTypeFormContainer = () => {
       })
     );
 
-    const supportedDiseaseOptions = rsvEnabled
-      ? supportedDiseaseData
-      : supportedDiseaseData.filter((d) => d.label !== "RSV");
-
     const devices = Array.from(
       deviceTypeResults.deviceTypes.map(
         (devicesTypes) => devicesTypes as DeviceType
@@ -96,7 +90,7 @@ const ManageDeviceTypeFormContainer = () => {
         formTitle={editDevicePageTitle}
         saveDeviceType={updateDevice}
         swabOptions={swabOptions}
-        supportedDiseaseOptions={supportedDiseaseOptions}
+        supportedDiseaseOptions={supportedDiseaseData}
         deviceOptions={devices}
       />
     );


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixes #6497 

## Changes Proposed

- Cleans up the RSV feature flag now that the feature is live in prod

## Testing
Make sure there aren't any regressions on the following pages (and that I haven't missed anything)
- Admin select screen (RSV selectable in the "additional diseases" options in device management)

![Screenshot 2023-10-24 at 10 26 38 AM](https://github.com/CDCgov/prime-simplereport/assets/29645040/7fbf47a1-40b5-4dab-a46c-2f27f3e22837)

- In the test result uploader (we should be able to submit RSV results now)

Uploaded the following CSV and got the following result. Notice the 4 vs 3 result count between UP and COVID-only that indicates that we've submitted an RSV result

```
patient_id,patient_last_name,patient_first_name,patient_middle_name,patient_street,patient_street2,patient_city,patient_state,patient_zip_code,patient_county,patient_phone_number,patient_dob,patient_gender,patient_race,patient_ethnicity,patient_preferred_language,patient_email,accession_number,equipment_model_name,test_performed_code,test_result,order_test_date,specimen_collection_date,testing_lab_specimen_received_date,test_result_date,date_result_released,specimen_type,ordering_provider_id,ordering_provider_last_name,ordering_provider_first_name,ordering_provider_middle_name,ordering_provider_street,ordering_provider_street2,ordering_provider_city,ordering_provider_state,ordering_provider_zip_code,ordering_provider_phone_number,testing_lab_clia,testing_lab_name,testing_lab_street,testing_lab_street2,testing_lab_city,testing_lab_state,testing_lab_zip_code,testing_lab_phone_number,pregnant,employed_in_healthcare,symptomatic_for_disease,illness_onset_date,resident_congregate_setting,residence_type,hospitalized,icu,ordering_facility_name,ordering_facility_street,ordering_facility_street2,ordering_facility_city,ordering_facility_state,ordering_facility_zip_code,ordering_facility_phone_number,comment,test_result_status
1234,Doe,Jane,,123 Main St,,Birmingham,AL,35226,Jefferson,205-999-2800,1/20/1962,F,White,Not Hispanic or Latino,,,42daf9c8-9deb-4636-a040-380bde2b44cd,BinaxNOW COVID-19 Ag Card,94558-4,Detected,12/20/2021 14:00,12/20/2021 14:00,12/20/2021 14:00,12/20/2021 14:00,12/20/2021 14:00,Swab of internal nose,1013012657,Smith MD,John,,400 Main Street,,Birmingham,AL,35228,205-888-2000,01D1058442,My Urgent Care,400 Main Street,,Birmingham,AL,35228,205-888-2000,N,N,N,,N,,N,N,My Urgent Care,400 Main Street,Suite 100,Birmingham,AL,35228,205-888-2000,Test Comment,
P2300,Doe,Rich,,444 Hawkins Rd,,Hoover,AL,35226,Jefferson,205-333-3300,3/4/1972,F,Asian,Not Hispanic or Latino,French,,12200-A,BinaxNOW COVID-19 Ag Card,94558-4,Positive,1/5/2022 12:00,1/5/2022 12:00,1/5/2022 12:00,1/5/2022 12:00,1/5/2022 12:00,Swab of internal nose,1013012670,Jones MD,Mary,,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,01D1058443,My Urgent Care-Hoover,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,Y,N,Y,,Y,57656006,Y,N,My Urgent Care-Hoover,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,,
P2300,Doe,Rich,,444 Hawkins Rd,,Hoover,AL,35226,Jefferson,205-333-3300,3/4/1972,F,Asian,Not Hispanic or Latino,eng,,12200-B,BinaxNOW COVID-19 Ag Card,94558-4,Negative,1/5/2022 15:00,1/5/2022 15:00,1/5/2022 15:00,1/5/2022 15:00,1/5/2022 15:00,Swab of internal nose,1013012670,Jones MD,Mary,,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,01D1058443,My Urgent Care-Hoover,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,N,N,Y,,Y,Hospital,Y,N,My Urgent Care-Hoover,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,,
P2300,Doe,Rich,,444 Hawkins Rd,,Hoover,AL,35226,Jefferson,205-333-3300,3/4/1972,F,Asian,Not Hispanic or Latino,eng,,12200-B,BinaxNOW COVID-19 Ag Card,94558-5,Negative,1/5/2022 15:00,1/5/2022 15:00,1/5/2022 15:00,1/5/2022 15:00,1/5/2022 15:00,Swab of internal nose,1013012670,Jones MD,Mary,,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,01D1058443,My Urgent Care-Hoover,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,N,N,Y,,Y,Hospital,Y,N,My Urgent Care-Hoover,800 Doctors Way,,Birmingham,AL,35244,205-888-2300,,
```

https://github.com/CDCgov/prime-simplereport/assets/29645040/2c4c357e-ef19-47b7-b651-15b7dd1214f3

Verify also that the tests that got changed have been refactored correctly

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->