### PR TITLE
fix backend start for e2e

### DIFF
--- a/cypress/e2e.sh
+++ b/cypress/e2e.sh
@@ -79,13 +79,13 @@ echo
 
 http_response=0
 polls=0
-while [[ $http_response != "200" && $polls -lt 72 ]]; do
+while [[ $http_response != *"UP"* && $polls -lt 72 ]]; do
   ((polls++))
   sleep 5
   echo "Waiting for backend to start at ${TEST_ENV}${BACKEND_URL_PATH}"
   http_response=$(curl -skL -w "%{http_code}" "${TEST_ENV}${BACKEND_URL_PATH}")
 done
-if [[ $http_response -ne 200 ]]; then
+if [[ $http_response -ne *"UP"* ]]; then
   echo 'Backend never started. Exiting...'
   exit 1
 fi

--- a/cypress/e2e.sh
+++ b/cypress/e2e.sh
@@ -85,7 +85,7 @@ while [[ $http_response != *"UP"* && $polls -lt 72 ]]; do
   echo "Waiting for backend to start at ${TEST_ENV}${BACKEND_URL_PATH}"
   http_response=$(curl -skL -w "%{http_code}" "${TEST_ENV}${BACKEND_URL_PATH}")
 done
-if [[ $http_response -ne *"UP"* ]]; then
+if [[ $http_response != *"UP"* ]]; then
   echo 'Backend never started. Exiting...'
   exit 1
 fi

--- a/lighthouse.sh
+++ b/lighthouse.sh
@@ -12,7 +12,7 @@ while [[ $http_response != *"UP"* && $polls -lt 180 ]]; do
   echo "Waiting for backend to start at https://localhost.simplereport.gov/api/actuator/health"
   http_response=$(curl -skL -w "%{http_code}" "https://localhost.simplereport.gov/api/actuator/health")
 done
-if [[ $http_response -ne *"UP"* ]]; then
+if [[ $http_response != *"UP"* ]]; then
   echo 'Backend never started. Exiting...'
   exit 1
 fi

--- a/lighthouse.sh
+++ b/lighthouse.sh
@@ -6,13 +6,13 @@ docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --quiet-pull
 echo "Waiting for backend to start at https://localhost.simplereport.gov/api/actuator/health"
 http_response=0
 polls=0
-while [[ $http_response != "200" && $polls -lt 180 ]]; do
+while [[ $http_response != *"UP"* && $polls -lt 180 ]]; do
   ((polls++))
   sleep 2
   echo "Waiting for backend to start at https://localhost.simplereport.gov/api/actuator/health"
   http_response=$(curl -skL -w "%{http_code}" "https://localhost.simplereport.gov/api/actuator/health")
 done
-if [[ $http_response -ne 200 ]]; then
+if [[ $http_response -ne *"UP"* ]]; then
   echo 'Backend never started. Exiting...'
   exit 1
 fi


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- E2E tests and Light House are waiting the full time for the backend to be up because it is not expecting the http response to have a body. The only reason why this works today is the check to determine to end the script cannot compare an integer (200) with the response string. 

## Changes Proposed

- Expect the http response to contain "UP"

## Additional Information


## Testing

- [E2E test with main](https://github.com/CDCgov/prime-simplereport/actions/runs/6641109780/job/18043017831#step:6:166) 

- [E2E test with this change](https://github.com/CDCgov/prime-simplereport/actions/runs/6643269978/job/18050045149?pr=6841#step:6:504)

