### PR TITLE
Use `data-cy` attribute for add patient spec

### DIFF
--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "plugins": ["cypress"],
-  "extends": ["plugin:cypress/recommended"]
+  "extends": ["plugin:cypress/recommended"],
+  "rules": {
+    "cypress/require-data-selectors": "warn"
+  }
 }

--- a/cypress/e2e/02-add_patient.cy.js
+++ b/cypress/e2e/02-add_patient.cy.js
@@ -26,59 +26,50 @@ describe("Adding a single patient", () => {
         setupRunData(currentSpecRunVersionName);
       })
   });
-  it("navigates to the add patient form", () => {
-    cy.visit("/");
-    cy.get(".usa-nav-container");
-    cy.get("#desktop-patient-nav-link").click();
-    cy.get(".prime-container");
-    cy.get("#add-patient").click();
-    cy.get("#individual_add-patient").click();
-    cy.get(".prime-edit-patient").contains("Add new patient");
+  it("navigates to and fills out add patient form", () => {
+    cy.visit('/');
+    cy.get('[data-cy="desktop-patient-nav-link"]').click();
+    cy.get('[data-cy="add-patients-button"]').click();
+    cy.get('[data-cy="individual"]').click();
+    cy.get('[data-cy="add-patient-header"]').contains("Add new patient");
     cy.injectSRAxe();
-    cy.checkAccessibility(); // Patient form
-  });
-  it("fills out some of the form fields", () => {
-    cy.get('input[name="firstName"]').type(patient.firstName);
-    cy.get('input[name="birthDate"]').type(patient.dobForInput);
-    cy.get('input[name="number"]').type(patient.phone);
-    cy.get('input[value="MOBILE"]+label').click();
-    cy.get('input[name="gender"][value="female"]+label').click();
-    cy.get('input[name="genderIdentity"][value="female"]+label').click();
-    cy.get('input[name="street"]').type(patient.address);
-    cy.get('select[name="state"]').select(patient.state);
-    cy.get('input[name="zipCode"]').type(patient.zip);
-    cy.get('select[name="role"]').select("STUDENT");
-    cy.get(".prime-edit-patient").contains("Student ID");
-    cy.get('input[name="lookupId"]').type(patient.studentId);
-    cy.get('input[name="race"][value="other"]+label').click();
-    cy.get('input[name="ethnicity"][value="refused"]+label').click();
-    cy.get('input[name="residentCongregateSetting"][value="NO"]+label').click();
-    cy.get('input[name="employedInHealthcare"][value="NO"]+label').click();
-  });
-  it("shows what fields are missing on submit", () => {
-    cy.get(".prime-save-patient-changes").first().click();
-
-    cy.get(".prime-edit-patient").contains("Last name is missing");
-    cy.get(".prime-edit-patient").contains("Testing facility is missing");
-    cy.get(".prime-edit-patient").contains("City is missing");
-  });
-  it("fills out the remaining fields, submits and checks for the patient", () => {
-    cy.get('input[name="lastName"]').type(patient.lastName);
-    cy.get('input[name="city"]').type(patient.city);
-    cy.get('select[name="facilityId"]').select("All facilities");
-    cy.get(".prime-save-patient-changes").first().click();
-    cy.get(
-      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label',
-    ).click();
-
-    cy.checkAccessibility();
-
-    cy.get(".modal__container #save-confirmed-address").click();
-    cy.get(".usa-card__header").contains("Patients");
-    cy.get(".usa-card__header").contains("Showing");
-    cy.get("#search-field-small").type(patient.lastName);
-    cy.get(".prime-container").contains(patient.fullName);
-
-    cy.checkAccessibility();
+    cy.checkAccessibility(); // empty patient form
+    // fill out form
+    cy.get('[data-cy="personForm-firstName-input"]').type(patient.firstName);
+    cy.get('[data-cy="personForm-dob-input"]').type(patient.dobForInput);
+    cy.get('[data-cy="phone-input-0"]').type(patient.phone);
+    cy.get('[data-cy="radio-group-option-phoneType-0-MOBILE"]').click();
+    cy.get('[data-cy="radio-group-option-genderIdentity-female"]').click();
+    cy.get('[data-cy="radio-group-option-gender-female"]').click();
+    cy.get('[data-cy="street-input"]').type(patient.address);
+    cy.get('[data-cy="state-input"]').select(patient.state);
+    cy.get('[data-cy="zip-input"]').type(patient.zip);
+    cy.get('[data-cy="personForm-role-input"]').select("STUDENT");
+    cy.get('[data-cy="add-patient-page"]').contains("Student ID");
+    cy.get('[data-cy="personForm-lookupId-input"]').type(patient.studentId);
+    cy.get('[data-cy="radio-group-option-race-other"]').click();
+    cy.get('[data-cy="radio-group-option-ethnicity-refused"]').click();
+    cy.get('[data-cy="radio-group-option-residentCongregateSetting-NO"]').click();
+    cy.get('[data-cy="radio-group-option-employedInHealthcare-NO"]').click();
+    cy.get('[data-cy="add-patient-save-button"]').eq(0).click();
+    // check for errors
+    cy.get('[data-cy="add-patient-page"]').contains("Last name is missing");
+    cy.get('[data-cy="add-patient-page"]').contains("Testing facility is missing");
+    cy.get('[data-cy="add-patient-page"]').contains("City is missing");
+    cy.checkAccessibility(); // patient form with errors
+    // fill out remaining form
+    cy.get('[data-cy="personForm-lastName-input"]').type(patient.lastName);
+    cy.get('[data-cy="city-input"]').type(patient.city);
+    cy.get('[data-cy="personForm-facility-input"]').select("All facilities");
+    cy.get('[data-cy="add-patient-save-button"]').eq(0).click();
+    cy.get('[data-cy="radio-group-option-addressSelect-person-userAddress"]').click();
+    cy.checkAccessibility(); // address validation modal
+    cy.get('[data-cy="save-address-confirmation-button"]').click();
+    // check for newly created patient on Manage Patients page
+    cy.get('[data-cy="manage-patients-header"]').contains("Patients");
+    cy.get('[data-cy="manage-patients-header"]').contains("Showing");
+    cy.get('[data-cy="manage-patients-search-input"]').type(patient.lastName);
+    cy.get('[data-cy="manage-patients-page"]').contains(patient.fullName);
+    cy.checkAccessibility(); // manage patients page
   });
 });

--- a/cypress/e2e/10-save_and_start_covid_test.cy.js
+++ b/cypress/e2e/10-save_and_start_covid_test.cy.js
@@ -28,13 +28,12 @@ describe("Save and start covid test", () => {
   context("edit patient and save and start test", () => {
     it("searches for the patient", () => {
       cy.visit("/");
-      cy.get(".usa-nav-container");
-      cy.get("#desktop-patient-nav-link").click();
-      cy.get(".sr-patient-list").should("exist");
-      cy.get(".sr-patient-list").contains("Loading...").should("not.exist");
-      cy.get("#search-field-small").type(lastName);
+      cy.get('[data-cy="desktop-patient-nav-link"]').click();
+      cy.get('[data-cy="manage-patients-header"]').contains("Patients");
+      cy.get('[data-cy="manage-patients-header"]').contains("Showing");
+      cy.get('[data-cy="manage-patients-search-input"]').type(lastName);
       cy.wait("@GetPatientsByFacility");
-      cy.get(".sr-patient-list").contains(patientName).should("exist");
+      cy.get('[data-cy="manage-patients-page"]').contains(patientName);
     });
 
     it("edits the found patient and clicks save and start test ", () => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -31,8 +31,8 @@ const getDobFormat = () => {
 // Generate a random patient
 export const generatePatient = () => {
   const patient = {};
-  patient.firstName = faker.name.firstName();
-  patient.lastName = faker.name.lastName();
+  patient.firstName = faker.person.firstName();
+  patient.lastName = faker.person.lastName();
   patient.fullName = `${patient.lastName}, ${patient.firstName}`;
   patient.dob = dayjs(
     faker.date.between({ from: "1920-01-01", to: "2002-12-31" }),
@@ -44,7 +44,7 @@ export const generatePatient = () => {
   patient.city = "Definitely not Washington";
   patient.state = "DC";
   patient.zip = "20503";
-  patient.studentId = faker.datatype.uuid();
+  patient.studentId = faker.string.uuid();
   return patient;
 };
 

--- a/frontend/src/app/commonComponents/AddressConfirmationModal.tsx
+++ b/frontend/src/app/commonComponents/AddressConfirmationModal.tsx
@@ -222,6 +222,7 @@ export const AddressConfirmationModal = <T extends string>({
             disabled={addressSuggestionConfig.some(
               ({ key }) => !selectedAddress[key]
             )}
+            dataCy="save-address-confirmation-button"
           >
             {t("address.save")}
           </Button>

--- a/frontend/src/app/commonComponents/Button/Button.tsx
+++ b/frontend/src/app/commonComponents/Button/Button.tsx
@@ -25,6 +25,7 @@ interface Props {
   ariaHidden?: boolean;
   ariaLabel?: string;
   ref?: React.RefObject<HTMLButtonElement> | null;
+  dataCy?: string;
 }
 
 const Button = ({
@@ -40,6 +41,7 @@ const Button = ({
   id,
   ariaHidden,
   ariaLabel,
+  dataCy,
 }: Props) => (
   <button
     type={type}
@@ -56,6 +58,7 @@ const Button = ({
     onClick={onClick}
     aria-describedby={ariaDescribedBy || undefined}
     aria-label={ariaLabel}
+    data-cy={dataCy}
   >
     {icon && <FontAwesomeIcon icon={icon} className="margin-right-1" />}
     {label || children}

--- a/frontend/src/app/commonComponents/Dropdown.tsx
+++ b/frontend/src/app/commonComponents/Dropdown.tsx
@@ -29,6 +29,7 @@ interface Props {
   validationStatus?: "error" | "success";
   selectClassName?: string;
   hintText?: string | React.ReactNode;
+  dataCy?: string;
   registrationProps?: UseFormRegisterReturn<any>;
 }
 
@@ -50,6 +51,7 @@ const Dropdown: React.FC<Props & SelectProps> = ({
   errorMessage,
   selectClassName,
   hintText,
+  dataCy,
   registrationProps,
   ...inputProps
 }) => {
@@ -98,6 +100,7 @@ const Dropdown: React.FC<Props & SelectProps> = ({
             onChange={onChange}
             value={selectedValue || defaultOption || ""}
             disabled={disabled}
+            data-cy={dataCy}
             {...inputProps}
             {...(validationStatus === "error"
               ? { "aria-describedby": `error_${id}`, "aria-invalid": true }

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -158,6 +158,7 @@ const Header: React.FC<{}> = () => {
                 onClick={() => setMenuVisible(false)}
                 className={item.className}
                 id={`${deviceType}-${item.key}`}
+                data-cy={`${deviceType}-${item.key}`}
               >
                 {item.displayText}
               </LinkWithQuery>

--- a/frontend/src/app/commonComponents/Input.tsx
+++ b/frontend/src/app/commonComponents/Input.tsx
@@ -18,6 +18,7 @@ interface Props<T> {
   hintText?: string;
   min?: number | string;
   max?: number | string;
+  dataCy?: string;
 }
 
 export const Input = <T extends { [key: string]: any }>({
@@ -36,6 +37,7 @@ export const Input = <T extends { [key: string]: any }>({
   hintText,
   min,
   max,
+  dataCy,
 }: Props<T>): React.ReactElement => {
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(field)(e.target.value);
@@ -66,6 +68,7 @@ export const Input = <T extends { [key: string]: any }>({
       min={min}
       max={max}
       hintText={hintText}
+      dataCy={dataCy}
     />
   );
 };

--- a/frontend/src/app/commonComponents/MenuButton.tsx
+++ b/frontend/src/app/commonComponents/MenuButton.tsx
@@ -35,6 +35,7 @@ export const MenuButton = (props: Props) => (
             ? `${item.name.split(" ")[0].toLowerCase()}_${props.id}`
             : undefined
         }
+        data-cy={item.name}
       >
         {item.content ?? item.name}
       </MenuItem>

--- a/frontend/src/app/commonComponents/RadioGroup.tsx
+++ b/frontend/src/app/commonComponents/RadioGroup.tsx
@@ -127,7 +127,7 @@ const RadioGroup = <T extends string>({
                   <label
                     className={labelClasses}
                     htmlFor={uid(c.value)}
-                    data-cy={`radio-group-option-${c.value}`}
+                    data-cy={`radio-group-option-${name}-${c.value}`}
                   >
                     {c.label}
                     {c.labelDescription && (

--- a/frontend/src/app/commonComponents/Select.tsx
+++ b/frontend/src/app/commonComponents/Select.tsx
@@ -24,6 +24,7 @@ interface Props<T> {
   selectClassName?: string;
   disabled?: boolean;
   className?: string;
+  dataCy?: string;
   registrationProps?: UseFormRegisterReturn<any>;
 }
 
@@ -42,6 +43,7 @@ const Select = <T extends string>({
   selectClassName,
   disabled,
   className,
+  dataCy,
   registrationProps,
 }: Props<T>): React.ReactElement => {
   const onChangeWrapper = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -64,6 +66,7 @@ const Select = <T extends string>({
       selectClassName={selectClassName}
       disabled={disabled}
       className={className}
+      dataCy={dataCy}
       registrationProps={registrationProps}
     />
   );

--- a/frontend/src/app/commonComponents/TextInput.tsx
+++ b/frontend/src/app/commonComponents/TextInput.tsx
@@ -44,6 +44,7 @@ interface Props {
   labelClassName?: string;
   min?: number | string;
   max?: number | string;
+  dataCy?: string;
   registrationProps?: UseFormRegisterReturn<any>;
 }
 
@@ -74,6 +75,7 @@ export const TextInput = ({
   labelClassName,
   min,
   max,
+  dataCy,
   registrationProps,
   ...inputProps
 }: Props & InputProps): React.ReactElement => {
@@ -129,6 +131,7 @@ export const TextInput = ({
             ref={inputRef}
             data-format={format}
             data-format-message={formatMessage}
+            data-cy={dataCy}
             {...inputProps}
             {...(validationStatus === "error"
               ? { "aria-describedby": `error_${id}`, "aria-invalid": true }

--- a/frontend/src/app/patients/AddPatient.tsx
+++ b/frontend/src/app/patients/AddPatient.tsx
@@ -315,6 +315,7 @@ const AddPatient = () => {
         label={
           loading ? `${t("common.button.saving")}...` : t("common.button.save")
         }
+        dataCy={"add-patient-save-button"}
       />
     </>
   );
@@ -344,7 +345,7 @@ const AddPatient = () => {
   }
 
   return (
-    <div className={"prime-edit-patient prime-home"}>
+    <div className={"prime-edit-patient prime-home"} data-cy="add-patient-page">
       <div className={"grid-container margin-bottom-4 maxw-desktop-lg"}>
         <DuplicatePatientModal
           showModal={

--- a/frontend/src/app/patients/Components/AddPatientsHeader.tsx
+++ b/frontend/src/app/patients/Components/AddPatientsHeader.tsx
@@ -14,7 +14,7 @@ interface Props {
 export const AddPatientHeader = (props: Props) => {
   return (
     <>
-      <div className="display-flex flex-justify">
+      <div className="display-flex flex-justify" data-cy="add-patient-header">
         <div>
           <div className="display-flex flex-align-center">
             <svg

--- a/frontend/src/app/patients/Components/FacilitySelect.tsx
+++ b/frontend/src/app/patients/Components/FacilitySelect.tsx
@@ -11,6 +11,7 @@ interface Props {
   validationStatus: (name: keyof PersonFormData) => "error" | undefined;
   errors: { [key: string]: string | undefined };
   hidden?: boolean;
+  dataCy?: string;
 }
 
 const ALL_FACILITIES = "~~ALL-FACILITIES~~";
@@ -47,6 +48,7 @@ const FacilitySelect: React.FC<Props> = (props) => {
       options={facilityList}
       defaultSelect={true}
       required
+      dataCy={props.dataCy}
     />
   );
 };

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -246,6 +246,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
                 validateField(idx, "type");
               }}
               errors={errors[idx] || {}}
+              dataCy={`phone-input-${idx}`}
             />
             {!isPrimary && (
               <div className="flex-align-self-end">

--- a/frontend/src/app/patients/Components/PersonAddressField.tsx
+++ b/frontend/src/app/patients/Components/PersonAddressField.tsx
@@ -71,6 +71,7 @@ const PersonAddressField: React.FC<PersonAddressFieldProps> = (
               field="street"
               label={t("patient.form.contact.street1")}
               required
+              dataCy={"street-input"}
             />
           </div>
           <div className="usa-form">
@@ -86,6 +87,7 @@ const PersonAddressField: React.FC<PersonAddressFieldProps> = (
               field="city"
               label={t("patient.form.contact.city")}
               required
+              dataCy={"city-input"}
             />
             {view !== PersonFormView.SELF_REGISTRATION && (
               <Input
@@ -111,6 +113,7 @@ const PersonAddressField: React.FC<PersonAddressFieldProps> = (
                     validationStatus={errors.state ? "error" : undefined}
                     errorMessage={errors.state}
                     required
+                    dataCy={"state-input"}
                   />
                 </div>
                 <div className="mobile-lg:grid-col-6">
@@ -119,6 +122,7 @@ const PersonAddressField: React.FC<PersonAddressFieldProps> = (
                     field="zipCode"
                     label={t("patient.form.contact.zip")}
                     required
+                    dataCy={"zip-input"}
                   />
                 </div>
               </div>

--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -400,6 +400,7 @@ const PersonForm = (props: Props) => {
             field="firstName"
             required={view !== PersonFormView.PXP}
             disabled={view === PersonFormView.PXP}
+            dataCy="personForm-firstName-input"
           />
           <Input
             {...commonInputProps}
@@ -413,6 +414,7 @@ const PersonForm = (props: Props) => {
             label={t("patient.form.general.lastName")}
             required={view !== PersonFormView.PXP}
             disabled={view === PersonFormView.PXP}
+            dataCy="personForm-lastName-input"
           />
         </div>
         <div className="usa-form">
@@ -424,12 +426,14 @@ const PersonForm = (props: Props) => {
             options={ROLE_VALUES}
             defaultOption={t("common.defaultDropdownOption")}
             defaultSelect={true}
+            dataCy={"personForm-role-input"}
           />
           {patient.role === "STUDENT" && (
             <Input
               {...commonInputProps}
               field="lookupId"
               label={t("patient.form.general.studentId")}
+              dataCy={"personForm-lookupId-input"}
             />
           )}
           {view !== PersonFormView.SELF_REGISTRATION && (
@@ -442,6 +446,7 @@ const PersonForm = (props: Props) => {
               validationStatus={validationStatus}
               errors={errors}
               hidden={props.hideFacilitySelect}
+              dataCy={"personForm-facility-input"}
             />
           )}
           <div className="usa-form-group">
@@ -480,6 +485,7 @@ const PersonForm = (props: Props) => {
             disabled={view === PersonFormView.PXP}
             min={formatDate(new Date("Jan 1, 1900"))}
             max={formatDate(new Date())}
+            dataCy="personForm-dob-input"
           />
         </div>
       </FormGroup>

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -270,7 +270,7 @@ export const DetachedManagePatients = ({
           id={"add-patient"}
           buttonContent={
             <>
-              <span className={"margin-right-1"}>
+              <span className={"margin-right-1"} data-cy="add-patients-button">
                 Add {PATIENT_TERM_PLURAL}
               </span>
               <FontAwesomeIcon icon={faCaretDown as IconProp} />
@@ -317,11 +317,11 @@ export const DetachedManagePatients = ({
   }
 
   return (
-    <div className="prime-home flex-1">
+    <div className="prime-home flex-1" data-cy="manage-patients-page">
       <div className="grid-container">
         <div className="grid-row">
           <div className="prime-container card-container">
-            <div className="usa-card__header">
+            <div className="usa-card__header" data-cy="manage-patients-header">
               <div className="display-flex flex-align-center">
                 <h1 className="font-sans-lg margin-y-0">
                   {PATIENT_TERM_PLURAL_CAP}
@@ -356,6 +356,7 @@ export const DetachedManagePatients = ({
                   subsequentFocusId === FOCUS_ON_SEARCH_BAR_ON_NEXT_RENDER
                 }
                 showSubmitButton={false}
+                dataCy="manage-patients-search-input"
               />
             </div>
             <div className="usa-card__body sr-patient-list">

--- a/frontend/src/app/patients/PatientsNav.tsx
+++ b/frontend/src/app/patients/PatientsNav.tsx
@@ -15,7 +15,7 @@ const PatientsNav = () => {
     >
       <ul className="usa-nav__secondary-links prime-nav">
         <li className="usa-nav__secondary-item padding-left-0">
-          <LinkWithQuery to={`/add-patient`} end className={classNameByActive}>
+          <LinkWithQuery to={`/add-patient`} className={classNameByActive}>
             Add individual {PATIENT_TERM}
           </LinkWithQuery>
         </li>

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     aria-disabled="false"
                     aria-required="true"
                     class="usa-input"
+                    data-cy="personForm-firstName-input"
                     id="103"
                     name="firstName"
                     type="text"
@@ -162,6 +163,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     aria-disabled="false"
                     aria-required="true"
                     class="usa-input"
+                    data-cy="personForm-lastName-input"
                     id="105"
                     name="lastName"
                     type="text"
@@ -184,6 +186,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                   <select
                     aria-required="false"
                     class="usa-select"
+                    data-cy="personForm-role-input"
                     id="106"
                     name="role"
                   >
@@ -237,6 +240,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                   <select
                     aria-required="true"
                     class="usa-select"
+                    data-cy="personForm-facility-input"
                     id="107"
                     name="facilityId"
                   >
@@ -1936,6 +1940,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     aria-disabled="false"
                     aria-required="true"
                     class="usa-input"
+                    data-cy="personForm-dob-input"
                     id="108"
                     max="2021-08-01"
                     min="1900-01-01"
@@ -2013,6 +2018,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                         <input
                           aria-required="true"
                           class="usa-input"
+                          data-cy="phone-input-0"
                           data-testid="phoneInput-0"
                           id="109"
                           name="number"
@@ -2058,7 +2064,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                             />
                             <label
                               class="usa-radio__label"
-                              data-cy="radio-group-option-MOBILE"
+                              data-cy="radio-group-option-phoneType-0-MOBILE"
                               for="110-val-MOBILE"
                             >
                               Mobile
@@ -2077,7 +2083,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                             />
                             <label
                               class="usa-radio__label"
-                              data-cy="radio-group-option-LANDLINE"
+                              data-cy="radio-group-option-phoneType-0-LANDLINE"
                               for="110-val-LANDLINE"
                             >
                               Landline
@@ -2138,7 +2144,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                           />
                           <label
                             class="usa-radio__label"
-                            data-cy="radio-group-option-SMS"
+                            data-cy="radio-group-option-testResultDeliveryText-SMS"
                             for="111-val-SMS"
                           >
                             Yes, text all mobile numbers on file.
@@ -2158,7 +2164,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                           />
                           <label
                             class="usa-radio__label"
-                            data-cy="radio-group-option-NONE"
+                            data-cy="radio-group-option-testResultDeliveryText-NONE"
                             for="111-val-NONE"
                           >
                             No
@@ -2258,7 +2264,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-EMAIL"
+                          data-cy="radio-group-option-testResultDeliveryEmail-EMAIL"
                           for="113-val-EMAIL"
                         >
                           Yes
@@ -2278,7 +2284,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NONE"
+                          data-cy="radio-group-option-testResultDeliveryEmail-NONE"
                           for="113-val-NONE"
                         >
                           No
@@ -3933,6 +3939,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     <input
                       aria-required="true"
                       class="usa-input"
+                      data-cy="street-input"
                       id="115"
                       name="street"
                       type="text"
@@ -3984,6 +3991,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     <input
                       aria-required="true"
                       class="usa-input"
+                      data-cy="city-input"
                       id="117"
                       name="city"
                       type="text"
@@ -4094,7 +4102,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-native"
+                        data-cy="radio-group-option-race-native"
                         for="119-val-native"
                       >
                         American Indian/Alaskan Native
@@ -4113,7 +4121,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-asian"
+                        data-cy="radio-group-option-race-asian"
                         for="119-val-asian"
                       >
                         Asian
@@ -4132,7 +4140,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-black"
+                        data-cy="radio-group-option-race-black"
                         for="119-val-black"
                       >
                         Black/African American
@@ -4151,7 +4159,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-pacific"
+                        data-cy="radio-group-option-race-pacific"
                         for="119-val-pacific"
                       >
                         Native Hawaiian/other Pacific Islander
@@ -4170,7 +4178,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-white"
+                        data-cy="radio-group-option-race-white"
                         for="119-val-white"
                       >
                         White
@@ -4189,7 +4197,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-other"
+                        data-cy="radio-group-option-race-other"
                         for="119-val-other"
                       >
                         Other
@@ -4208,7 +4216,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-refused"
+                        data-cy="radio-group-option-race-refused"
                         for="119-val-refused"
                       >
                         Prefer not to answer
@@ -4538,7 +4546,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-hispanic"
+                        data-cy="radio-group-option-ethnicity-hispanic"
                         for="120-val-hispanic"
                       >
                         Yes
@@ -4557,7 +4565,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-not_hispanic"
+                        data-cy="radio-group-option-ethnicity-not_hispanic"
                         for="120-val-not_hispanic"
                       >
                         No
@@ -4576,7 +4584,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-refused"
+                        data-cy="radio-group-option-ethnicity-refused"
                         for="120-val-refused"
                       >
                         Prefer not to answer
@@ -4614,7 +4622,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-female"
+                        data-cy="radio-group-option-genderIdentity-female"
                         for="121-val-female"
                       >
                         Female
@@ -4633,7 +4641,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-male"
+                        data-cy="radio-group-option-genderIdentity-male"
                         for="121-val-male"
                       >
                         Male
@@ -4652,7 +4660,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-transwoman"
+                        data-cy="radio-group-option-genderIdentity-transwoman"
                         for="121-val-transwoman"
                       >
                         Trans femme or transwoman
@@ -4671,7 +4679,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-transman"
+                        data-cy="radio-group-option-genderIdentity-transman"
                         for="121-val-transman"
                       >
                         Trans masculine or transman
@@ -4690,7 +4698,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-nonbinary"
+                        data-cy="radio-group-option-genderIdentity-nonbinary"
                         for="121-val-nonbinary"
                       >
                         Nonbinary or gender non-conforming
@@ -4709,7 +4717,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-other"
+                        data-cy="radio-group-option-genderIdentity-other"
                         for="121-val-other"
                       >
                         Gender identity not listed here
@@ -4728,7 +4736,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-refused"
+                        data-cy="radio-group-option-genderIdentity-refused"
                         for="121-val-refused"
                       >
                         Prefer not to answer
@@ -4778,7 +4786,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-female"
+                        data-cy="radio-group-option-gender-female"
                         for="122-val-female"
                       >
                         Female
@@ -4797,7 +4805,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-male"
+                        data-cy="radio-group-option-gender-male"
                         for="122-val-male"
                       >
                         Male
@@ -4816,7 +4824,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-other"
+                        data-cy="radio-group-option-gender-other"
                         for="122-val-other"
                       >
                         Other
@@ -4835,7 +4843,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-refused"
+                        data-cy="radio-group-option-gender-refused"
                         for="122-val-refused"
                       >
                         Prefer not to answer
@@ -4892,7 +4900,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-YES"
+                        data-cy="radio-group-option-residentCongregateSetting-YES"
                         for="123-val-YES"
                       >
                         Yes
@@ -4911,7 +4919,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NO"
+                        data-cy="radio-group-option-residentCongregateSetting-NO"
                         for="123-val-NO"
                       >
                         No
@@ -4930,7 +4938,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NOT_SURE"
+                        data-cy="radio-group-option-residentCongregateSetting-NOT_SURE"
                         for="123-val-NOT_SURE"
                       >
                         Not sure
@@ -4969,7 +4977,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-YES"
+                        data-cy="radio-group-option-employedInHealthcare-YES"
                         for="124-val-YES"
                       >
                         Yes
@@ -4988,7 +4996,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NO"
+                        data-cy="radio-group-option-employedInHealthcare-NO"
                         for="124-val-NO"
                       >
                         No
@@ -5007,7 +5015,7 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NOT_SURE"
+                        data-cy="radio-group-option-employedInHealthcare-NOT_SURE"
                         for="124-val-NOT_SURE"
                       >
                         Not sure

--- a/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/UploadPatients.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
       >
         <div
           class="display-flex flex-justify"
+          data-cy="add-patient-header"
         >
           <div>
             <div
@@ -164,7 +165,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-oneFacility"
+                        data-cy="radio-group-option-facilitySector-oneFacility"
                         for="1-val-oneFacility"
                       >
                         One facility
@@ -183,7 +184,7 @@ exports[`Upload Patient displays the upload patients page correctly 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-allFacility"
+                        data-cy="radio-group-option-facilitySector-allFacility"
                         for="1-val-allFacility"
                       >
                         All facilities

--- a/frontend/src/app/testQueue/TestCard/__snapshots__/TestCard.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCard/__snapshots__/TestCard.test.tsx.snap
@@ -396,7 +396,7 @@ Object {
                             />
                             <label
                               class="usa-radio__label"
-                              data-cy="radio-group-option-POSITIVE"
+                              data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                               for="3-val-POSITIVE"
                             >
                               Positive (+)
@@ -415,7 +415,7 @@ Object {
                             />
                             <label
                               class="usa-radio__label"
-                              data-cy="radio-group-option-NEGATIVE"
+                              data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                               for="3-val-NEGATIVE"
                             >
                               Negative (-)
@@ -434,7 +434,7 @@ Object {
                             />
                             <label
                               class="usa-radio__label"
-                              data-cy="radio-group-option-UNDETERMINED"
+                              data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-UNDETERMINED"
                               for="3-val-UNDETERMINED"
                             >
                               Inconclusive
@@ -487,7 +487,7 @@ Object {
                                 />
                                 <label
                                   class="usa-radio__label"
-                                  data-cy="radio-group-option-77386006"
+                                  data-cy="radio-group-option-pregnancy-77386006"
                                   for="4-val-77386006"
                                 >
                                   Yes
@@ -506,7 +506,7 @@ Object {
                                 />
                                 <label
                                   class="usa-radio__label"
-                                  data-cy="radio-group-option-60001007"
+                                  data-cy="radio-group-option-pregnancy-60001007"
                                   for="4-val-60001007"
                                 >
                                   No
@@ -525,7 +525,7 @@ Object {
                                 />
                                 <label
                                   class="usa-radio__label"
-                                  data-cy="radio-group-option-261665006"
+                                  data-cy="radio-group-option-pregnancy-261665006"
                                   for="4-val-261665006"
                                 >
                                   Prefer not to answer
@@ -571,7 +571,7 @@ Object {
                                 />
                                 <label
                                   class="usa-radio__label"
-                                  data-cy="radio-group-option-YES"
+                                  data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
                                   for="5-val-YES"
                                 >
                                   Yes
@@ -591,7 +591,7 @@ Object {
                                 />
                                 <label
                                   class="usa-radio__label"
-                                  data-cy="radio-group-option-NO"
+                                  data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
                                   for="5-val-NO"
                                 >
                                   No

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -253,7 +253,7 @@ Object {
                     />
                     <label
                       class="usa-radio__label"
-                      data-cy="radio-group-option-POSITIVE"
+                      data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                       for="3-val-POSITIVE"
                     >
                       Positive (+)
@@ -272,7 +272,7 @@ Object {
                     />
                     <label
                       class="usa-radio__label"
-                      data-cy="radio-group-option-NEGATIVE"
+                      data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                       for="3-val-NEGATIVE"
                     >
                       Negative (-)
@@ -291,7 +291,7 @@ Object {
                     />
                     <label
                       class="usa-radio__label"
-                      data-cy="radio-group-option-UNDETERMINED"
+                      data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-UNDETERMINED"
                       for="3-val-UNDETERMINED"
                     >
                       Inconclusive
@@ -344,7 +344,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-77386006"
+                          data-cy="radio-group-option-pregnancy-77386006"
                           for="4-val-77386006"
                         >
                           Yes
@@ -363,7 +363,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-60001007"
+                          data-cy="radio-group-option-pregnancy-60001007"
                           for="4-val-60001007"
                         >
                           No
@@ -382,7 +382,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-261665006"
+                          data-cy="radio-group-option-pregnancy-261665006"
                           for="4-val-261665006"
                         >
                           Prefer not to answer
@@ -428,7 +428,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-YES"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
                           for="5-val-YES"
                         >
                           Yes
@@ -448,7 +448,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NO"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
                           for="5-val-NO"
                         >
                           No
@@ -827,7 +827,7 @@ Object {
                   />
                   <label
                     class="usa-radio__label"
-                    data-cy="radio-group-option-POSITIVE"
+                    data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                     for="3-val-POSITIVE"
                   >
                     Positive (+)
@@ -846,7 +846,7 @@ Object {
                   />
                   <label
                     class="usa-radio__label"
-                    data-cy="radio-group-option-NEGATIVE"
+                    data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                     for="3-val-NEGATIVE"
                   >
                     Negative (-)
@@ -865,7 +865,7 @@ Object {
                   />
                   <label
                     class="usa-radio__label"
-                    data-cy="radio-group-option-UNDETERMINED"
+                    data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-UNDETERMINED"
                     for="3-val-UNDETERMINED"
                   >
                     Inconclusive
@@ -918,7 +918,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-77386006"
+                        data-cy="radio-group-option-pregnancy-77386006"
                         for="4-val-77386006"
                       >
                         Yes
@@ -937,7 +937,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-60001007"
+                        data-cy="radio-group-option-pregnancy-60001007"
                         for="4-val-60001007"
                       >
                         No
@@ -956,7 +956,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-261665006"
+                        data-cy="radio-group-option-pregnancy-261665006"
                         for="4-val-261665006"
                       >
                         Prefer not to answer
@@ -1002,7 +1002,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-YES"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
                         for="5-val-YES"
                       >
                         Yes
@@ -1022,7 +1022,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NO"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
                         for="5-val-NO"
                       >
                         No
@@ -1385,7 +1385,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                           for="16-val-POSITIVE"
                         >
                           Positive (+)
@@ -1404,7 +1404,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                           for="16-val-NEGATIVE"
                         >
                           Negative (-)
@@ -1453,7 +1453,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                           for="17-val-POSITIVE"
                         >
                           Positive (+)
@@ -1472,7 +1472,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                           for="17-val-NEGATIVE"
                         >
                           Negative (-)
@@ -1945,7 +1945,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-POSITIVE"
+                        data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                         for="16-val-POSITIVE"
                       >
                         Positive (+)
@@ -1964,7 +1964,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NEGATIVE"
+                        data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                         for="16-val-NEGATIVE"
                       >
                         Negative (-)
@@ -2013,7 +2013,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-POSITIVE"
+                        data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                         for="17-val-POSITIVE"
                       >
                         Positive (+)
@@ -2032,7 +2032,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NEGATIVE"
+                        data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                         for="17-val-NEGATIVE"
                       >
                         Negative (-)
@@ -2484,7 +2484,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                           for="8-val-POSITIVE"
                         >
                           Positive (+)
@@ -2504,7 +2504,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                           for="8-val-NEGATIVE"
                         >
                           Negative (-)
@@ -2553,7 +2553,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                           for="9-val-POSITIVE"
                         >
                           Positive (+)
@@ -2573,7 +2573,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                           for="9-val-NEGATIVE"
                         >
                           Negative (-)
@@ -2622,7 +2622,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                           for="10-val-POSITIVE"
                         >
                           Positive (+)
@@ -2642,7 +2642,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                           for="10-val-NEGATIVE"
                         >
                           Negative (-)
@@ -2785,7 +2785,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-77386006"
+                          data-cy="radio-group-option-pregnancy-77386006"
                           for="12-val-77386006"
                         >
                           Yes
@@ -2804,7 +2804,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-60001007"
+                          data-cy="radio-group-option-pregnancy-60001007"
                           for="12-val-60001007"
                         >
                           No
@@ -2823,7 +2823,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-261665006"
+                          data-cy="radio-group-option-pregnancy-261665006"
                           for="12-val-261665006"
                         >
                           Prefer not to answer
@@ -2869,7 +2869,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-YES"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
                           for="13-val-YES"
                         >
                           Yes
@@ -2889,7 +2889,7 @@ Object {
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NO"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
                           for="13-val-NO"
                         >
                           No
@@ -3273,7 +3273,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-POSITIVE"
+                        data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                         for="8-val-POSITIVE"
                       >
                         Positive (+)
@@ -3293,7 +3293,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NEGATIVE"
+                        data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                         for="8-val-NEGATIVE"
                       >
                         Negative (-)
@@ -3342,7 +3342,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-POSITIVE"
+                        data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                         for="9-val-POSITIVE"
                       >
                         Positive (+)
@@ -3362,7 +3362,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NEGATIVE"
+                        data-cy="radio-group-option-flu-a-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                         for="9-val-NEGATIVE"
                       >
                         Negative (-)
@@ -3411,7 +3411,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-POSITIVE"
+                        data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                         for="10-val-POSITIVE"
                       >
                         Positive (+)
@@ -3431,7 +3431,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NEGATIVE"
+                        data-cy="radio-group-option-flu-b-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                         for="10-val-NEGATIVE"
                       >
                         Negative (-)
@@ -3574,7 +3574,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-77386006"
+                        data-cy="radio-group-option-pregnancy-77386006"
                         for="12-val-77386006"
                       >
                         Yes
@@ -3593,7 +3593,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-60001007"
+                        data-cy="radio-group-option-pregnancy-60001007"
                         for="12-val-60001007"
                       >
                         No
@@ -3612,7 +3612,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-261665006"
+                        data-cy="radio-group-option-pregnancy-261665006"
                         for="12-val-261665006"
                       >
                         Prefer not to answer
@@ -3658,7 +3658,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-YES"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
                         for="13-val-YES"
                       >
                         Yes
@@ -3678,7 +3678,7 @@ Object {
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NO"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
                         for="13-val-NO"
                       >
                         No

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/__snapshots__/CovidResultInputGroup.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/__snapshots__/CovidResultInputGroup.test.tsx.snap
@@ -39,7 +39,7 @@ Object {
             />
             <label
               class="usa-radio__label"
-              data-cy="radio-group-option-POSITIVE"
+              data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-POSITIVE"
               for="1-val-POSITIVE"
             >
               Positive (+)
@@ -58,7 +58,7 @@ Object {
             />
             <label
               class="usa-radio__label"
-              data-cy="radio-group-option-NEGATIVE"
+              data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-NEGATIVE"
               for="1-val-NEGATIVE"
             >
               Negative (-)
@@ -77,7 +77,7 @@ Object {
             />
             <label
               class="usa-radio__label"
-              data-cy="radio-group-option-UNDETERMINED"
+              data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-UNDETERMINED"
               for="1-val-UNDETERMINED"
             >
               Inconclusive

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/__snapshots__/MultiplexResultInputGroup.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/__snapshots__/MultiplexResultInputGroup.test.tsx.snap
@@ -45,7 +45,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="13-val-POSITIVE"
                 >
                   Positive (+)
@@ -64,7 +64,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="13-val-NEGATIVE"
                 >
                   Negative (-)
@@ -113,7 +113,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="14-val-POSITIVE"
                 >
                   Positive (+)
@@ -132,7 +132,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="14-val-NEGATIVE"
                 >
                   Negative (-)
@@ -300,7 +300,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="9-val-POSITIVE"
                 >
                   Positive (+)
@@ -319,7 +319,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="9-val-NEGATIVE"
                 >
                   Negative (-)
@@ -368,7 +368,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="10-val-POSITIVE"
                 >
                   Positive (+)
@@ -387,7 +387,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="10-val-NEGATIVE"
                 >
                   Negative (-)
@@ -436,7 +436,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="11-val-POSITIVE"
                 >
                   Positive (+)
@@ -455,7 +455,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="11-val-NEGATIVE"
                 >
                   Negative (-)
@@ -623,7 +623,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="5-val-POSITIVE"
                 >
                   Positive (+)
@@ -643,7 +643,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="5-val-NEGATIVE"
                 >
                   Negative (-)
@@ -692,7 +692,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="6-val-POSITIVE"
                 >
                   Positive (+)
@@ -712,7 +712,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="6-val-NEGATIVE"
                 >
                   Negative (-)
@@ -761,7 +761,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="7-val-POSITIVE"
                 >
                   Positive (+)
@@ -781,7 +781,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="7-val-NEGATIVE"
                 >
                   Negative (-)
@@ -949,7 +949,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="1-val-POSITIVE"
                 >
                   Positive (+)
@@ -968,7 +968,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-covid-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="1-val-NEGATIVE"
                 >
                   Negative (-)
@@ -1018,7 +1018,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="2-val-POSITIVE"
                 >
                   Positive (+)
@@ -1037,7 +1037,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-a-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="2-val-NEGATIVE"
                 >
                   Negative (-)
@@ -1087,7 +1087,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-POSITIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-POSITIVE"
                   for="3-val-POSITIVE"
                 >
                   Positive (+)
@@ -1106,7 +1106,7 @@ Object {
                 />
                 <label
                   class="usa-radio__label"
-                  data-cy="radio-group-option-NEGATIVE"
+                  data-cy="radio-group-option-flu-b-test-result-QUEUE-ITEM-ID-NEGATIVE"
                   for="3-val-NEGATIVE"
                 >
                   Negative (-)

--- a/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/QueueItem.test.tsx.snap
@@ -365,7 +365,7 @@ exports[`QueueItem matches snapshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-POSITIVE"
+                        data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-POSITIVE"
                         for="3-val-POSITIVE"
                       >
                         Positive (+)
@@ -384,7 +384,7 @@ exports[`QueueItem matches snapshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-NEGATIVE"
+                        data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NEGATIVE"
                         for="3-val-NEGATIVE"
                       >
                         Negative (-)
@@ -403,7 +403,7 @@ exports[`QueueItem matches snapshot 1`] = `
                       />
                       <label
                         class="usa-radio__label"
-                        data-cy="radio-group-option-UNDETERMINED"
+                        data-cy="radio-group-option-covid-test-result-1b02363b-ce71-4f30-a2d6-d82b56a91b39-UNDETERMINED"
                         for="3-val-UNDETERMINED"
                       >
                         Inconclusive

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -438,7 +438,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                               />
                               <label
                                 class="usa-radio__label"
-                                data-cy="radio-group-option-POSITIVE"
+                                data-cy="radio-group-option-covid-test-result-abc-POSITIVE"
                                 for="9-val-POSITIVE"
                               >
                                 Positive (+)
@@ -457,7 +457,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                               />
                               <label
                                 class="usa-radio__label"
-                                data-cy="radio-group-option-NEGATIVE"
+                                data-cy="radio-group-option-covid-test-result-abc-NEGATIVE"
                                 for="9-val-NEGATIVE"
                               >
                                 Negative (-)
@@ -476,7 +476,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                               />
                               <label
                                 class="usa-radio__label"
-                                data-cy="radio-group-option-UNDETERMINED"
+                                data-cy="radio-group-option-covid-test-result-abc-UNDETERMINED"
                                 for="9-val-UNDETERMINED"
                               >
                                 Inconclusive
@@ -529,7 +529,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-77386006"
+                                    data-cy="radio-group-option-pregnancy-77386006"
                                     for="10-val-77386006"
                                   >
                                     Yes
@@ -548,7 +548,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-60001007"
+                                    data-cy="radio-group-option-pregnancy-60001007"
                                     for="10-val-60001007"
                                   >
                                     No
@@ -567,7 +567,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-261665006"
+                                    data-cy="radio-group-option-pregnancy-261665006"
                                     for="10-val-261665006"
                                   >
                                     Prefer not to answer
@@ -614,7 +614,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-YES"
+                                    data-cy="radio-group-option-has-any-symptoms-abc-YES"
                                     for="11-val-YES"
                                   >
                                     Yes
@@ -633,7 +633,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-NO"
+                                    data-cy="radio-group-option-has-any-symptoms-abc-NO"
                                     for="11-val-NO"
                                   >
                                     No
@@ -1384,7 +1384,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                               />
                               <label
                                 class="usa-radio__label"
-                                data-cy="radio-group-option-POSITIVE"
+                                data-cy="radio-group-option-covid-test-result-def-POSITIVE"
                                 for="16-val-POSITIVE"
                               >
                                 Positive (+)
@@ -1403,7 +1403,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                               />
                               <label
                                 class="usa-radio__label"
-                                data-cy="radio-group-option-NEGATIVE"
+                                data-cy="radio-group-option-covid-test-result-def-NEGATIVE"
                                 for="16-val-NEGATIVE"
                               >
                                 Negative (-)
@@ -1422,7 +1422,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                               />
                               <label
                                 class="usa-radio__label"
-                                data-cy="radio-group-option-UNDETERMINED"
+                                data-cy="radio-group-option-covid-test-result-def-UNDETERMINED"
                                 for="16-val-UNDETERMINED"
                               >
                                 Inconclusive
@@ -1475,7 +1475,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-77386006"
+                                    data-cy="radio-group-option-pregnancy-77386006"
                                     for="17-val-77386006"
                                   >
                                     Yes
@@ -1494,7 +1494,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-60001007"
+                                    data-cy="radio-group-option-pregnancy-60001007"
                                     for="17-val-60001007"
                                   >
                                     No
@@ -1513,7 +1513,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-261665006"
+                                    data-cy="radio-group-option-pregnancy-261665006"
                                     for="17-val-261665006"
                                   >
                                     Prefer not to answer
@@ -1560,7 +1560,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-YES"
+                                    data-cy="radio-group-option-has-any-symptoms-def-YES"
                                     for="18-val-YES"
                                   >
                                     Yes
@@ -1579,7 +1579,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                                   />
                                   <label
                                     class="usa-radio__label"
-                                    data-cy="radio-group-option-NO"
+                                    data-cy="radio-group-option-has-any-symptoms-def-NO"
                                     for="18-val-NO"
                                   >
                                     No
@@ -2367,7 +2367,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-covid-test-result-abc-POSITIVE"
                           for="3-val-POSITIVE"
                         >
                           Positive (+)
@@ -2386,7 +2386,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-covid-test-result-abc-NEGATIVE"
                           for="3-val-NEGATIVE"
                         >
                           Negative (-)
@@ -2405,7 +2405,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-UNDETERMINED"
+                          data-cy="radio-group-option-covid-test-result-abc-UNDETERMINED"
                           for="3-val-UNDETERMINED"
                         >
                           Inconclusive
@@ -2787,7 +2787,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-POSITIVE"
+                          data-cy="radio-group-option-covid-test-result-def-POSITIVE"
                           for="6-val-POSITIVE"
                         >
                           Positive (+)
@@ -2806,7 +2806,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-NEGATIVE"
+                          data-cy="radio-group-option-covid-test-result-def-NEGATIVE"
                           for="6-val-NEGATIVE"
                         >
                           Negative (-)
@@ -2825,7 +2825,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         />
                         <label
                           class="usa-radio__label"
-                          data-cy="radio-group-option-UNDETERMINED"
+                          data-cy="radio-group-option-covid-test-result-def-UNDETERMINED"
                           for="6-val-UNDETERMINED"
                         >
                           Inconclusive

--- a/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
@@ -19,6 +19,7 @@ type Props = {
   focusOnMount?: boolean;
   showSubmitButton?: boolean;
   labeledBy?: string;
+  dataCy?: string;
 };
 
 const SearchInput = ({
@@ -32,6 +33,7 @@ const SearchInput = ({
   focusOnMount,
   showSubmitButton = true,
   labeledBy,
+  dataCy,
 }: Props) => {
   const classes = classnames(
     "usa-search",
@@ -70,6 +72,7 @@ const SearchInput = ({
             onFocus={onInputChange}
             aria-labelledby={labeledBy}
             style={!showSubmitButton ? { borderRight: "solid 1px" } : undefined}
+            data-cy={dataCy}
           />
           <button
             type="submit"


### PR DESCRIPTION
# PULL REQUEST

## Related Issue

- Resolves #6465 

## Changes Proposed

- use `data-cy` attributes to target elements for cypress spec 2

## Additional Information


## Testing

- e2e test should pass
- no functionality should be affected