### PR TITLE
Fix failing TestCard test

### DIFF
--- a/frontend/src/app/commonComponents/TextInput.tsx
+++ b/frontend/src/app/commonComponents/TextInput.tsx
@@ -96,7 +96,6 @@ export const TextInput = ({
               labelClassName
             )}
             htmlFor={id}
-            id={`label-for-${id}`}
             aria-describedby={ariaDescribedBy}
           >
             {required ? <Required label={label} /> : <Optional label={label} />}

--- a/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
+++ b/frontend/src/app/patients/__snapshots__/EditPatient.test.tsx.snap
@@ -103,7 +103,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                   <label
                     class="usa-label"
                     for="103"
-                    id="label-for-103"
                   >
                     First name
                     <abbr
@@ -130,7 +129,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                   <label
                     class="usa-label"
                     for="104"
-                    id="label-for-104"
                   >
                     Middle name
                   </label>
@@ -150,7 +148,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                   <label
                     class="usa-label"
                     for="105"
-                    id="label-for-105"
                   >
                     Last name
                     <abbr
@@ -1925,7 +1922,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                   <label
                     class="usa-label"
                     for="108"
-                    id="label-for-108"
                   >
                     Date of birth (mm/dd/yyyy)
                     <abbr
@@ -2004,7 +2000,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                         <label
                           class="usa-label"
                           for="109"
-                          id="label-for-109"
                         >
                           Primary phone number
                           <abbr
@@ -2196,7 +2191,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                         <label
                           class="usa-label"
                           for="112"
-                          id="label-for-112"
                         >
                           Email address
                         </label>
@@ -3926,7 +3920,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     <label
                       class="usa-label"
                       for="115"
-                      id="label-for-115"
                     >
                       Street address 1
                       <abbr
@@ -3956,7 +3949,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     <label
                       class="usa-label"
                       for="116"
-                      id="label-for-116"
                     >
                       Street address 2
                     </label>
@@ -3979,7 +3971,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     <label
                       class="usa-label"
                       for="117"
-                      id="label-for-117"
                     >
                       City
                       <abbr
@@ -4005,7 +3996,6 @@ exports[`EditPatient facility select input matches screenshot 1`] = `
                     <label
                       class="usa-label"
                       for="118"
-                      id="label-for-118"
                     >
                       County
                     </label>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -293,7 +293,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                   <label
                     class="usa-label"
                     for="41"
-                    id="label-for-41"
                   >
                     Device Name
                     <abbr
@@ -329,7 +328,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                   <label
                     class="usa-label"
                     for="42"
-                    id="label-for-42"
                   >
                     Model
                     <abbr
@@ -365,7 +363,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                   <label
                     class="usa-label"
                     for="43"
-                    id="label-for-43"
                   >
                     Manufacturer
                     <abbr
@@ -401,7 +398,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                   <label
                     class="usa-label"
                     for="44"
-                    id="label-for-44"
                   >
                     Test length (minutes)
                     <abbr
@@ -621,7 +617,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                         <label
                           class="usa-label"
                           for="47"
-                          id="label-for-47"
                         >
                           Test performed code
                           <abbr
@@ -653,7 +648,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                         <label
                           class="usa-label"
                           for="48"
-                          id="label-for-48"
                         >
                           Test ordered code
                           <abbr
@@ -685,7 +679,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                         <label
                           class="usa-label"
                           for="49"
-                          id="label-for-49"
                         >
                           Testkit Name Id
                         </label>
@@ -710,7 +703,6 @@ exports[`update existing devices renders the Device Form 1`] = `
                         <label
                           class="usa-label"
                           for="50"
-                          id="label-for-50"
                         >
                           Equipment Uid
                         </label>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -92,7 +92,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                   <label
                     class="usa-label"
                     for="1"
-                    id="label-for-1"
                   >
                     Device Name
                     <abbr
@@ -127,7 +126,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                   <label
                     class="usa-label"
                     for="2"
-                    id="label-for-2"
                   >
                     Model
                     <abbr
@@ -162,7 +160,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                   <label
                     class="usa-label"
                     for="3"
-                    id="label-for-3"
                   >
                     Manufacturer
                     <abbr
@@ -197,7 +194,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                   <label
                     class="usa-label"
                     for="4"
-                    id="label-for-4"
                   >
                     Test length (minutes)
                     <abbr
@@ -375,7 +371,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                         <label
                           class="usa-label"
                           for="7"
-                          id="label-for-7"
                         >
                           Test performed code
                           <abbr
@@ -406,7 +401,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                         <label
                           class="usa-label"
                           for="8"
-                          id="label-for-8"
                         >
                           Test ordered code
                           <abbr
@@ -437,7 +431,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                         <label
                           class="usa-label"
                           for="9"
-                          id="label-for-9"
                         >
                           Testkit Name Id
                         </label>
@@ -461,7 +454,6 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                         <label
                           class="usa-label"
                           for="10"
-                          id="label-for-10"
                         >
                           Equipment Uid
                         </label>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -255,7 +255,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                   <label
                     class="usa-label"
                     for="1"
-                    id="label-for-1"
                   >
                     Device Name
                     <abbr
@@ -291,7 +290,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                   <label
                     class="usa-label"
                     for="2"
-                    id="label-for-2"
                   >
                     Model
                     <abbr
@@ -327,7 +325,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                   <label
                     class="usa-label"
                     for="3"
-                    id="label-for-3"
                   >
                     Manufacturer
                     <abbr
@@ -363,7 +360,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                   <label
                     class="usa-label"
                     for="4"
-                    id="label-for-4"
                   >
                     Test length (minutes)
                     <abbr
@@ -577,7 +573,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                         <label
                           class="usa-label"
                           for="7"
-                          id="label-for-7"
                         >
                           Test performed code
                           <abbr
@@ -609,7 +604,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                         <label
                           class="usa-label"
                           for="8"
-                          id="label-for-8"
                         >
                           Test ordered code
                           <abbr
@@ -641,7 +635,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                         <label
                           class="usa-label"
                           for="9"
-                          id="label-for-9"
                         >
                           Testkit Name Id
                         </label>
@@ -666,7 +659,6 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                         <label
                           class="usa-label"
                           for="10"
-                          id="label-for-10"
                         >
                           Equipment Uid
                         </label>

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -1144,14 +1144,9 @@ describe("TestCard", () => {
         ).toBeChecked()
       );
 
-      await user.type(
-        screen.getByLabelText("When did the patient's symptoms start?"),
-        "2023-08-15"
-      );
+      await user.type(screen.getByTestId("symptom-date"), "2023-08-15");
       await waitFor(() =>
-        expect(
-          screen.getByLabelText("When did the patient's symptoms start?")
-        ).toHaveValue("2023-08-15")
+        expect(screen.getByTestId("symptom-date")).toHaveValue("2023-08-15")
       );
 
       expect(trackEventMock).toHaveBeenCalledWith({

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -197,7 +197,9 @@ const TestCardForm = ({
           symptoms: JSON.stringify(
             parseSymptoms(state.covidAOEResponses.symptoms)
           ),
-          symptomOnset: state.covidAOEResponses.symptomOnset,
+          symptomOnset: state.covidAOEResponses.symptomOnset
+            ? state.covidAOEResponses.symptomOnset
+            : null,
           pregnancy: state.covidAOEResponses.pregnancy,
         },
       });

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -67,10 +67,11 @@ const CovidAoEForm = ({
   const onSymptomOnsetDateChange = (symptomOnsetDate: string) => {
     onResponseChange({
       ...responses,
-      symptomOnset: moment(symptomOnsetDate).format("YYYY-MM-DD"),
+      symptomOnset: symptomOnsetDate
+        ? moment(symptomOnsetDate).format("YYYY-MM-DD")
+        : undefined,
     });
   };
-
   const onSymptomsChange = (
     event: React.ChangeEvent<HTMLInputElement>,
     currentSymptoms: Record<string, boolean>
@@ -121,7 +122,6 @@ const CovidAoEForm = ({
         <>
           <div className="grid-row grid-gap">
             <TextInput
-              id={"hello"}
               data-testid="symptom-date"
               name="symptom-date"
               type="date"
@@ -129,9 +129,13 @@ const CovidAoEForm = ({
               aria-label="Symptom onset date"
               min={formatDate(new Date("Jan 1, 2020"))}
               max={formatDate(moment().toDate())}
-              value={formatDate(
-                moment(responses.symptomOnset).format("YYYY-MM-DD")
-              )}
+              value={
+                responses.symptomOnset
+                  ? formatDate(
+                      moment(responses.symptomOnset).format("YYYY-MM-DD")
+                    )
+                  : ""
+              }
               onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
             ></TextInput>
           </div>

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -653,7 +653,6 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                           <label
                             class="usa-label"
                             for="12"
-                            id="label-for-12"
                           >
                             When did the patient's symptoms start?
                           </label>
@@ -667,7 +666,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                             min="2020-01-01"
                             name="symptom-date"
                             type="date"
-                            value="Invalid date"
+                            value=""
                           />
                         </div>
                       </div>
@@ -1600,7 +1599,6 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                           <label
                             class="usa-label"
                             for="19"
-                            id="label-for-19"
                           >
                             When did the patient's symptoms start?
                           </label>
@@ -1614,7 +1612,7 @@ exports[`TestQueue should render the new test card when feature enabled 1`] = `
                             min="2020-01-01"
                             name="symptom-date"
                             type="date"
-                            value="Invalid date"
+                            value=""
                           />
                         </div>
                       </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Running frontend tests locally was resulting in the following error for `TestCard › test submission and telemetry › tracks AoE form updates as custom event` test:
```
Maximum call stack size exceeded
RangeError: Maximum call stack size exceeded
    at Math.<anonymous> (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/jest-mock/build/index.js:387:51)
    at Math.mockConstructor (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/jest-mock/build/index.js:170:19)
    at randomIntInRange (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:43:33)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:75:22)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:99:5)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:99:5)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:99:5)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:99:5)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:99:5)
    at doQuickSort (/Users/elisa/skylight/prime-simplereport/frontend/node_modules/source-map/lib/quick-sort.js:99:5)
```

Upon further investigation, it looks like the date format was failing for the symptom onset date because it was trying to format an invalid date:

<img width="492" alt="Screenshot 2023-10-29 at 19 03 54" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/3c27ec23-fef9-46f9-b31e-e62552bcc6ae">

## Changes Proposed

- fix the error from trying to format an invalid date
- send a `null` date instead of an invalid one when updating the AOE form
- remove some unnecessary ids

## Additional Information


## Testing
- Frontend tests should pass
- No error in console when there is a test in the test queue
- Can add and edit symptom onset date
- Deployed on dev5 for testing

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
