### PR TITLE
Added db changes to create new table that tracks diseases reported wi…

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5097,3 +5097,124 @@ databaseChangeLog:
                   name: equipment_uid_type
                   type: text
                   remarks: Equipment UID from LIVD sync to be used in the universal pipeline
+  - changeSet:
+      id: add-disease_and_destination-columns-to-upload
+      author: tsv7@cdc.gov
+      comment: Add disease and destination(COVID|UNIVERSAL) columns to upload table
+      changes:
+        - tagDatabase:
+            tag: add-disease_and_destination-columns-to-upload
+        - sql:
+            remarks: Create the enumerations needed for pipeline types.
+            sql: |
+              CREATE TYPE ${database.defaultSchemaName}.PIPELINE as ENUM('COVID', 'UNIVERSAL');
+        - addColumn:
+            tableName: upload
+            columns:
+              - column:
+                  name: destination
+                  type: ${database.defaultSchemaName}.PIPELINE
+                  remarks: the pipeline where the results were sent to
+              - column:
+                  name: supported_disease_id
+                  remarks: The disease that was reported.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__upload__supported_disease_id
+                    referencedTableName: supported_disease
+                    referencedColumnNames: internal_id
+      rollback:
+        - dropColumn:
+            tableName: upload
+            columnName: supported_disease_id
+        - sql: |
+            DROP TYPE ${database.defaultSchemaName}.PIPELINE CASCADE;
+  - changeSet:
+      id: create-upload_disease_details-table
+      author: tsv7@cdc.gov
+      comment: creates upload_disease_details table and drops the disease_id column from upload table
+      changes:
+        - tagDatabase:
+            tag: create-upload_disease_details-table
+        - dropColumn:
+            tableName: upload
+            columnName: supported_disease_id
+        - createTable:
+            tableName: upload_disease_details
+            remarks: contains details of each of the diseases reported in the bulk upload.
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: upload_id
+                  remarks: the upload internal id.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__upload_disease_details__upload
+                    references: upload
+              - column:
+                  name: supported_disease_id
+                  remarks: The supported disease reported in the upload.
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__upload_disease_details__supported_disease
+                    references: supported_disease
+              - column:
+                  name: records_count
+                  remarks: The number of records uploaded for the disease.
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  remarks: The creation timestamp for this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: uuid
+                  remarks: The user who created this entity.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__anyentity__created_by
+                    references: api_user
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  remarks: The timestamp for the most recent update of this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_by
+                  type: uuid
+                  remarks: The user who most recently updated this entity.
+                  constraints:
+                    nullable: false
+                    references: api_user
+                    foreignKeyName: fk__anyentity__updated_by
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.upload_disease_details TO ${noPhiUsername};
+      rollback:
+        - addColumn:
+            tableName: upload
+            columns:
+              - column:
+                  name: supported_disease_id
+                  remarks: The disease that was reported.
+                  type: uuid
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__upload__supported_disease_id
+                    referencedTableName: supported_disease
+                    referencedColumnNames: internal_id
+        - dropTable:
+            tableName: upload_disease_details


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

Implements db changes to create new table `upload_disease_details` that will keep the information of the numbers of records per disease reported in an upload.

## Changes Proposed

Remove the `supported_disease_id` column from the upload table.
Create a new table `upload_disease_details` that correlates uploads and diseases plus the count of results reported. 

## Additional Information
The changes to store the count per disease in the upload table (that had as a side effect duplication of data in the rows) was making the code to support the `Submissions` and `Submission` pages way to tangled. Moving the count per disease into a different table will allow us to keep the code cleaner. 

## Testing

- Verify that the new table gets created and the supported_disease_id columns is removed from upload table.
