### PR TITLE
remove spring legacy processing

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -13,9 +13,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
 @Getter
+@AllArgsConstructor
 public class DeviceTypeDisease extends IdentifiedEntity {
 
   @Column(name = "device_type_id")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -13,9 +13,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 @Getter
-@AllArgsConstructor
 public class DeviceTypeDisease extends IdentifiedEntity {
 
   @Column(name = "device_type_id")

--- a/backend/src/main/resources/application-auth-dev.properties
+++ b/backend/src/main/resources/application-auth-dev.properties
@@ -1,2 +1,0 @@
-# backward-compatibility shim
-spring.profiles.include=server-debug

--- a/backend/src/main/resources/application-azure-demo.yaml
+++ b/backend/src/main/resources/application-azure-demo.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: no-security, no-okta-mgmt, create-sample-data, no-okta-auth
 simple-report:
   patient-link-url: https://demo.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://demo.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-dev.yaml
+++ b/backend/src/main/resources/application-azure-dev.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-dev2.yaml
+++ b/backend/src/main/resources/application-azure-dev2.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev2, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-dev3.yaml
+++ b/backend/src/main/resources/application-azure-dev3.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev3, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-dev4.yaml
+++ b/backend/src/main/resources/application-azure-dev4.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev4, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-dev5.yaml
+++ b/backend/src/main/resources/application-azure-dev5.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev5, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-dev6.yaml
+++ b/backend/src/main/resources/application-azure-dev6.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev6, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-dev7.yaml
+++ b/backend/src/main/resources/application-azure-dev7.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-dev7, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-pentest.yaml
+++ b/backend/src/main/resources/application-azure-pentest.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-pentest
 simple-report:
   patient-link-url: https://pentest.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://pentest.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-prod
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-stg.yaml
+++ b/backend/src/main/resources/application-azure-stg.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-stg
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-test.yaml
+++ b/backend/src/main/resources/application-azure-test.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-test, server-debug
 simple-report:
   azure-reporting-queue:
     enabled: true

--- a/backend/src/main/resources/application-azure-training.yaml
+++ b/backend/src/main/resources/application-azure-training.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: no-security, no-okta-mgmt, create-sample-data, no-okta-auth
 simple-report:
   patient-link-url: https://training.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://training.simplereport.gov/api/pxp/callback

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -1,5 +1,4 @@
 spring:
-  profiles.include: no-security, no-okta-mgmt, server-debug, create-sample-data, local, no-okta-auth
   liquibase:
     simplereport:
       user: simple_report_migrations

--- a/backend/src/main/resources/application-e2e.yaml
+++ b/backend/src/main/resources/application-e2e.yaml
@@ -6,8 +6,6 @@ logging:
     org.hibernate: off
     gov.cdc.usds.simplereport.service.AuditService: off
 spring:
-  profiles:
-    include: server-debug, create-sample-devices
   datasource:
     simplereport:
       hikari:

--- a/backend/src/main/resources/application-no-okta-mgmt.yaml
+++ b/backend/src/main/resources/application-no-okta-mgmt.yaml
@@ -1,0 +1,3 @@
+okta:
+  oauth2:
+    client-id: NONE

--- a/backend/src/main/resources/application-okta-local.yaml
+++ b/backend/src/main/resources/application-okta-local.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: server-debug, create-sample-devices
 logging:
   level:
     # NOTE: look in application-dev.yaml for other things that might be worth turning on

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,5 +1,3 @@
-spring:
-  profiles.include: okta-prod
 simple-report:
   cors:
     allowed-origins:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,24 @@
 spring:
-  config:
-    use-legacy-processing: true
+  profiles:
+    group:
+      dev: no-security, no-okta-mgmt, server-debug, create-sample-data, local, no-okta-auth
+      e2e: server-debug, create-sample-devices
+      okta-local: server-debug, create-sample-devices
+      auth-dev: server-debug
+      azure-dev: okta-dev, server-debug
+      azure-dev2: okta-dev2, server-debug
+      azure-dev3: okta-dev3, server-debug
+      azure-dev4: okta-dev4, server-debug
+      azure-dev5: okta-dev5, server-debug
+      azure-dev6: okta-dev6, server-debug
+      azure-dev7: okta-dev7, server-debug
+      azure-pentest: okta-pentest
+      azure-training: no-security, no-okta-mgmt, create-sample-data, no-okta-auth
+      azure-test: okta-test, server-debug
+      azure-demo: no-security, no-okta-mgmt, create-sample-data, no-okta-auth
+      azure-stg: okta-stg
+      azure-prod: okta-prod
+      prod: okta-prod
   main:
     banner-mode: "OFF"
   datasource:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -5,7 +5,6 @@ spring:
       dev: no-security, no-okta-mgmt, server-debug, create-sample-data, local, no-okta-auth
       e2e: server-debug, create-sample-devices
       okta-local: server-debug, create-sample-devices
-      auth-dev: server-debug
       azure-dev: okta-dev, server-debug
       azure-dev2: okta-dev2, server-debug
       azure-dev3: okta-dev3, server-debug

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     group:
+      test: no-security, no-okta-mgmt, no-okta-auth, no-experian
       dev: no-security, no-okta-mgmt, server-debug, create-sample-data, local, no-okta-auth
       e2e: server-debug, create-sample-devices
       okta-local: server-debug, create-sample-devices

--- a/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/SimpleReportApplicationTests.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
     properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
+@ActiveProfiles("test")
 class SimpleReportApplicationTests {
 
   @Autowired private SimpleReportApplication application;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -33,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.ResultMatcher;
@@ -46,6 +47,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
     webEnvironment = WebEnvironment.RANDOM_PORT,
     properties = {"hibernate.query.interceptor.error-level=EXCEPTION"})
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 public abstract class BaseFullStackTest {
 
   @Autowired private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseNonSpringBootTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseNonSpringBootTestConfiguration.java
@@ -4,8 +4,10 @@ import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
 /** Base class to hold common beans required for application startup. */
+@ActiveProfiles("test")
 public class BaseNonSpringBootTestConfiguration {
 
   // Dependencies of TenantDataAccessFilter

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -91,9 +91,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class FhirConverterTest {
   private static final String unknownSystem = "http://terminology.hl7.org/CodeSystem/v3-NullFlavor";
   private static final String raceCodeSystem = "http://terminology.hl7.org/CodeSystem/v3-Race";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/reportstream/ReportStreamCallbackControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/reportstream/ReportStreamCallbackControllerTest.java
@@ -70,7 +70,7 @@ class ReportStreamCallbackControllerTest extends BaseFullStackTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .characterEncoding("UTF-8")
-            .header("x-functions-key", "WATERMELON") // configured in application-default.yaml
+            .header("x-functions-key", "WATERMELON") // configured in application-test.yaml
             .content(requestBody);
 
     String requestId = runBuilderReturningRequestId(mockMvc, builder, status().isOk());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * A base test for Spring Data repository tests. Comes pre-wired with a standard API user to attach
@@ -27,6 +28,7 @@ import org.springframework.context.annotation.Import;
 // isolation between test cases (data could be passed between tests using instance variables). Don't
 // pass data between test cases using instance variables!
 @TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
 public abstract class BaseRepositoryTest {
 
   @Autowired private DbTruncator _truncator;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/AzureStorageQueueFhirReportingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/AzureStorageQueueFhirReportingServiceTest.java
@@ -20,11 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AzureStorageQueueFhirReportingServiceTest {
   @Autowired GitProperties gitProperties;
   @Autowired FhirConverter fhirConverter;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Base class for service-level integration. Avoids setting up servlet and web security, but sets up
@@ -41,6 +42,7 @@ import org.springframework.security.access.AccessDeniedException;
     })
 @Import({SliceTestConfiguration.class, DataSourceConfiguration.class})
 @WithSimpleReportStandardUser
+@ActiveProfiles("test")
 public abstract class BaseServiceTest<T> {
 
   @Autowired private DbTruncator _truncator;

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -1,5 +1,4 @@
 spring:
-  profiles.include: no-security,no-okta-mgmt, no-okta-auth, no-experian
   datasource:
     simplereport:
       hikari:


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- In SpringBoot 2.4 [properties were refactored](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-Config-Data-Migration-Guide), but we skipped it and continued to use the old way by adding `spring.config.use-legacy-processing: true`. This is [no longer available in SpringBoot 3](https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0#migrate-from-legacy-applicationproperties-and-applicationyaml-processing).

## Changes Proposed

- Refactor to replace `spring.profiles.includes` in many of the files with `spring.profiles.group` in the main `application.yaml` file. 
- Rename `application-default` to `application-test` in the test folder to load the properties.
  - Add `@ActiveProfiles("test")` to all test that require the properties to be loaded.

## Additional Information

- The spring boot upgrade currently includes these changes, but can be applied now instead and will make that change a bit smaller.
- The reason why `application-default` was changed to `application-test` is because the profiles that were previously included now need to be set in the main application.yaml file. If we set the group "default" then it could be applied to ALL profiles and not just ones for test. 
  - I have tried to create an `test/resources/application.yaml`  for a partial overwrite, but it completely overwrites all of properties in the `src/resources/application.yaml`. Most of the properties would have to be copied over into the test file if that's the path we choose to go. 

## Testing

- Service works locally and in deployed envs. 
