### PR TITLE
Added style to add external link icon and text for sr

### DIFF
--- a/frontend/src/scss/base/_prime-styles.scss
+++ b/frontend/src/scss/base/_prime-styles.scss
@@ -1218,4 +1218,10 @@ a[href^='https:']:not([href*='simplereport.gov']) {
     right: auto;
     content: "External.";
   }
+
+  &::after {
+    margin-top: unset;
+    bottom: 0;
+    height: 100%;
+  }
 }

--- a/frontend/src/scss/base/_prime-styles.scss
+++ b/frontend/src/scss/base/_prime-styles.scss
@@ -1,6 +1,7 @@
 @use "../settings" as *;
 @use "../components" as *;
 @use "@uswds/uswds/packages/usa-prose";
+@use "@uswds/uswds/packages/usa-link";
 
 .prime-home {
   background-color: color("base-lightest");
@@ -1204,5 +1205,17 @@ abbr.usa-hint.usa-hint--required {
     .usa-legend {
       font-weight: bold;
     }
+  }
+}
+
+a[href^='http:']:not([href*='simplereport.gov']),
+a[href^='https:']:not([href*='simplereport.gov']) {
+  @extend .usa-link--external;
+
+  &::before {
+    position: absolute;
+    left: -999em;
+    right: auto;
+    content: "External.";
   }
 }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #5857 

## Changes Proposed

- Include css styling that adds the external link icon to all anchor elements that point to an external site.

## Testing

Verify all links that point to an external site display the external icon.

## Screenshots / Demos
<img width="635" alt="Screenshot 2023-11-03 at 2 34 39 PM" src="https://github.com/CDCgov/prime-simplereport/assets/103958711/8fc8355a-c08c-448b-bbad-728f480fca38">



<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
