### PR TITLE
fix focus bug

### DIFF
--- a/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
+++ b/frontend/src/app/Settings/Facility/Components/ManageDevices.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { useFeature } from "flagged";
 
 import MultiSelect from "../../../commonComponents/MultiSelect/MultiSelect";
-import DeviceSearchResults from "../../../uploads/DeviceLookup/DeviceSearchResults";
 import "./ManageDevices.scss";
 import { RegistrationProps } from "../../../commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown";
 import { FacilityFormData } from "../FacilityForm";
 import { searchFacilityFormDevices } from "../../../utils/device";
 import { filterRsvFromAllDevices } from "../../../utils/rsvHelper";
+import DeviceSearchResults from "../../../uploads/DeviceLookup/DeviceSearchResults";
 
 interface Props {
   deviceTypes: FacilityFormDeviceType[];

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
@@ -682,20 +682,23 @@ describe("MultiSelectDropdown component", () => {
       expect(screen.getByTestId("multi-select-option-list")).toBeVisible();
     });
 
-    it("hides options list when clicking away and input has focus", () => {
+    it("hides options list when clicking away and input has focus", async () => {
       const user = userEvent.setup();
       render(
-        <MultiSelectDropdown
-          id="favorite-fruit"
-          name="favorite-fruit"
-          options={fruitOptions}
-          onChange={jest.fn()}
-        />
+        <>
+          <MultiSelectDropdown
+            id="favorite-fruit"
+            name="favorite-fruit"
+            options={fruitOptions}
+            onChange={jest.fn()}
+          />
+        </>
       );
 
-      user.click(screen.getByTestId("multi-select-input"));
-      user.click(document.body);
+      await user.click(screen.getByTestId("multi-select-input"));
+      await user.click(document.body);
 
+      expect(screen.getByTestId("multi-select-input")).not.toHaveFocus();
       expect(screen.getByTestId("multi-select-input")).toHaveAttribute(
         "aria-expanded",
         "false"

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
@@ -683,6 +683,7 @@ describe("MultiSelectDropdown component", () => {
     });
 
     it("hides options list when clicking away and input has focus", () => {
+      const user = userEvent.setup();
       render(
         <MultiSelectDropdown
           id="favorite-fruit"
@@ -692,7 +693,7 @@ describe("MultiSelectDropdown component", () => {
         />
       );
 
-      fireEvent.click(screen.getByTestId("multi-select-input"));
+      user.click(screen.getByTestId("multi-select-input"));
       fireEvent.blur(screen.getByTestId("multi-select-input"));
 
       expect(screen.getByTestId("multi-select-input")).toHaveAttribute(

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.test.tsx
@@ -694,7 +694,7 @@ describe("MultiSelectDropdown component", () => {
       );
 
       user.click(screen.getByTestId("multi-select-input"));
-      fireEvent.blur(screen.getByTestId("multi-select-input"));
+      user.click(document.body);
 
       expect(screen.getByTestId("multi-select-input")).toHaveAttribute(
         "aria-expanded",

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -267,7 +267,14 @@ export const MultiSelectDropdown = ({
       !newTarget ||
       (newTarget instanceof Node && !containerRef.current?.contains(newTarget));
 
-    if (newTargetIsOutside && !state.isOpen) {
+    const blurConditionsForRegularList =
+      !state.isExtended && newTargetIsOutside;
+
+    // don't blur if we're clicking within the list but outside the input (ie on table labels)
+    const blurConditionsForExtendedList =
+      state.isExtended && newTargetIsOutside && !state.isOpen;
+
+    if (blurConditionsForRegularList || blurConditionsForExtendedList) {
       dispatch({ type: ActionTypes.BLUR });
     }
   };

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -39,6 +39,7 @@ export enum FocusMode {
   Input,
   Item,
 }
+
 export interface RegistrationProps {
   inputTextRef?: Ref<any>;
   setFocus: Function;
@@ -266,7 +267,7 @@ export const MultiSelectDropdown = ({
       !newTarget ||
       (newTarget instanceof Node && !containerRef.current?.contains(newTarget));
 
-    if (newTargetIsOutside && !state.isExtended) {
+    if (newTargetIsOutside && !state.isOpen) {
       dispatch({ type: ActionTypes.BLUR });
     }
   };
@@ -307,11 +308,14 @@ export const MultiSelectDropdown = ({
         onChange={(e): void =>
           dispatch({ type: ActionTypes.UPDATE_FILTER, value: e.target.value })
         }
-        onClick={(): void => dispatch({ type: ActionTypes.OPEN_LIST })}
+        onClick={(): void => {
+          dispatch({ type: ActionTypes.OPEN_LIST });
+        }}
         onBlur={handleInputBlur}
         onKeyDown={handleInputKeyDown(dispatch, state, selectOption)}
         value={state.inputValue}
         focused={state.focusMode === FocusMode.Input}
+        // focused={false}
         role="combobox"
         aria-label={placeholder}
         aria-labelledby={`label-for-${id}`}

--- a/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/frontend/src/app/commonComponents/MultiSelect/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -315,7 +315,6 @@ export const MultiSelectDropdown = ({
         onKeyDown={handleInputKeyDown(dispatch, state, selectOption)}
         value={state.inputValue}
         focused={state.focusMode === FocusMode.Input}
-        // focused={false}
         role="combobox"
         aria-label={placeholder}
         aria-labelledby={`label-for-${id}`}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #6842 

## Changes Proposed

- The root cause of the issue was a custom input blur handler in our multiselect that wasn't triggering correctly. Switched the handler to fire blur when the dropdown list was open (rather than never firing at all for the extended component) and it seems to have fixed the issue.

## Additional Information
- Related PR [here](https://github.com/CDCgov/prime-simplereport/pull/6507). The extra prop was added to fix a Safari-specific input issue, which I double checked for a regression.
- Also double checked that the other place the multiselect is used (the device form) is still working correctly

## Testing

- Check that the bug is fixed and that there aren't obvious regressions on this page / the device page

## Screenshots / Demos


### Focus bug is fixed
https://github.com/CDCgov/prime-simplereport/assets/29645040/c740d05f-f3d5-4247-b9f6-1b7d1746aaac

### Clicking in the expanded dropdown doesn't close the list
https://github.com/CDCgov/prime-simplereport/assets/29645040/e28489f0-44d8-4cdf-96f8-16846bd543f8

### Can still add devices on Safari
https://github.com/CDCgov/prime-simplereport/assets/29645040/e8ec7c63-1a2d-4354-bb2c-bdf51e0a37b3

### Device form multiselect still adds devices
https://github.com/CDCgov/prime-simplereport/assets/29645040/8455867e-f6c5-4c8c-809c-183d77d0853e

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
