### PR TITLE
Bob/6936 query for admin emails

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/NonexistentOrgException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/NonexistentOrgException.java
@@ -1,0 +1,28 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import java.util.Collections;
+import java.util.List;
+
+/** Exception to throw when a organization does not exist. */
+public class NonexistentOrgException extends RuntimeException implements GraphQLError {
+
+  private static final long serialVersionUID = 1L;
+
+  public NonexistentOrgException() {
+    super("Cannot find organization.");
+  }
+
+  @Override // should-be-defaulted unused interface method
+  public List<SourceLocation> getLocations() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public ErrorClassification getErrorType() {
+    return ErrorType.ExecutionAborted;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -125,4 +125,10 @@ public class OrganizationResolver {
   public FacilityStats facilityStats(@Argument UUID facilityId) {
     return this._organizationService.getFacilityStats(facilityId);
   }
+
+  @QueryMapping
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public List<UUID> getOrgAdminUserIds(@Argument UUID orgId) {
+    return _organizationService.getOrgAdminUserIds(orgId);
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/GraphQlConfig.java
@@ -8,6 +8,7 @@ import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
 import gov.cdc.usds.simplereport.api.model.errors.GenericGraphqlException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlFieldAccessException;
+import gov.cdc.usds.simplereport.api.model.errors.NonexistentOrgException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
 import gov.cdc.usds.simplereport.api.model.errors.OktaAccountUserException;
 import gov.cdc.usds.simplereport.api.model.errors.PrivilegeUpdateFacilityAccessException;
@@ -63,6 +64,12 @@ public class GraphQlConfig {
 
       if (exception instanceof NonexistentUserException) {
         String errorMessage = String.format("header: Cannot find user.; %s", defaultErrorBody);
+        return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
+      }
+
+      if (exception instanceof NonexistentOrgException) {
+        String errorMessage =
+            String.format("header: Cannot find organization.; %s", defaultErrorBody);
         return Mono.just(singletonList(new GenericGraphqlException(errorMessage, errorPath)));
       }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -478,17 +478,15 @@ public class OrganizationService {
         organizationRepository.findById(orgId).orElseThrow(NonexistentOrgException::new);
     List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(org);
 
-    List<UUID> adminIds =
-        adminUserEmails.stream()
-            .map(
-                email -> {
-                  ApiUser foundUser =
-                      apiUserRepository
-                          .findByLoginEmail(email)
-                          .orElseThrow(NonexistentUserException::new);
-                  return foundUser.getInternalId();
-                })
-            .collect(Collectors.toList());
-    return adminIds;
+    return adminUserEmails.stream()
+        .map(
+            email -> {
+              ApiUser foundUser =
+                  apiUserRepository
+                      .findByLoginEmail(email)
+                      .orElseThrow(NonexistentUserException::new);
+              return foundUser.getInternalId();
+            })
+        .collect(Collectors.toList());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -27,6 +27,7 @@ import gov.cdc.usds.simplereport.validators.OrderingProviderRequiredValidator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -489,7 +490,7 @@ public class OrganizationService {
               }
               return foundUser.map(user -> user.getInternalId()).orElse(null);
             })
-        .filter(userId -> userId != null)
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -472,6 +472,7 @@ public class OrganizationService {
     return orgId != null ? orgId : getCurrentOrganization().getInternalId();
   }
 
+  @AuthorizationConfiguration.RequireGlobalAdminUser
   public List<UUID> getOrgAdminUserIds(UUID orgId) {
     Organization org =
         organizationRepository.findById(orgId).orElseThrow(NonexistentOrgException::new);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -483,9 +483,9 @@ public class OrganizationService {
               Optional<ApiUser> foundUser = apiUserRepository.findByLoginEmail(email);
               if (foundUser.isEmpty()) {
                 log.warn(
-                    "Query for admin users in organization ",
-                    orgId,
-                    " found a user in Okta but not in the database. Skipping...");
+                    "Query for admin users in organization "
+                        + orgId
+                        + " found a user in Okta but not in the database. Skipping...");
               }
               return foundUser.map(user -> user.getInternalId()).orElse(null);
             })

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -466,4 +466,9 @@ public class OrganizationService {
   public UUID getPermissibleOrgId(UUID orgId) {
     return orgId != null ? orgId : getCurrentOrganization().getInternalId();
   }
+
+  public List<UUID> getOrgAdminUserIds(UUID orgId) {
+    log.info("Get list of things", orgId);
+    return List.of();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -4,6 +4,8 @@ import gov.cdc.usds.simplereport.api.CurrentOrganizationRolesContextHolder;
 import gov.cdc.usds.simplereport.api.model.FacilityStats;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
+import gov.cdc.usds.simplereport.api.model.errors.NonexistentOrgException;
+import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
@@ -471,18 +473,18 @@ public class OrganizationService {
   }
 
   public List<UUID> getOrgAdminUserIds(UUID orgId) {
-    log.info("Get list of things", orgId);
-
-    // TODO: error handle this
-    Organization org = organizationRepository.findById(orgId).orElseThrow();
+    Organization org =
+        organizationRepository.findById(orgId).orElseThrow(NonexistentOrgException::new);
     List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(org);
 
     List<UUID> adminIds =
         adminUserEmails.stream()
             .map(
                 email -> {
-                  // TODO: error handle this
-                  ApiUser foundUser = apiUserRepository.findByLoginEmail(email).orElseThrow();
+                  ApiUser foundUser =
+                      apiUserRepository
+                          .findByLoginEmail(email)
+                          .orElseThrow(NonexistentUserException::new);
                   return foundUser.getInternalId();
                 })
             .collect(Collectors.toList());

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -7,6 +7,7 @@ extend type Query {
   pendingOrganizations: [PendingOrganization!]!
   organization(id: ID!): Organization
   facilityStats(facilityId: ID!): FacilityStats
+  getOrgAdminUserIds(orgId: ID!): [ID]
 }
 extend type Mutation {
   resendToReportStream(testEventIds: [ID!]!, fhirOnly: Boolean!): Boolean

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -491,7 +491,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     when(oktaRepository.fetchAdminUserEmail(createdOrg)).thenReturn(listWithAnExtraEmail);
     List<UUID> expectedIds =
         listWithAnExtraEmail.stream()
-            .filter(email -> email != "nonexistent@example.com")
+            .filter(email -> !email.equals("nonexistent@example.com"))
             .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
             .collect(Collectors.toList());
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -701,6 +700,7 @@ export type Query = {
   facilities?: Maybe<Array<Maybe<Facility>>>;
   facility?: Maybe<Facility>;
   facilityStats?: Maybe<FacilityStats>;
+  getOrgAdminUserIds?: Maybe<Array<Maybe<Scalars["ID"]["output"]>>>;
   organization?: Maybe<Organization>;
   organizationLevelDashboardMetrics?: Maybe<OrganizationLevelDashboardMetrics>;
   organizations: Array<Organization>;
@@ -739,6 +739,10 @@ export type QueryFacilityArgs = {
 
 export type QueryFacilityStatsArgs = {
   facilityId: Scalars["ID"]["input"];
+};
+
+export type QueryGetOrgAdminUserIdsArgs = {
+  orgId: Scalars["ID"]["input"];
 };
 
 export type QueryOrganizationArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Fixes #6936 

## Changes Proposed

- Adds a mutation endpoint / service method that returns UUID's for admin users of an org when passed an org id.

## Testing

- Hit the endpoint with an org ID and check to see all admin UUID's are returned

This is the query that I setup in Postman in case it's helpful

```gql
query GetOrgAdminUserIds($orgId: ID!) {
	getOrgAdminUserIds(
		orgId: $orgId
	)
}
```
https://github.com/CDCgov/prime-simplereport/assets/29645040/c25aa433-51bb-4123-9d78-64103371f085

deployed on dev3 and got the following return for Boban's org

```
### Admin Users: 
    "data": {
        "usersWithStatus": [
            { (Standard user)
                "id": "f58d6f89-3d1e-49df-9ed0-09f3cfbc19fa",
                "firstName": "Santa",
                "middleName": null,
                "lastName": "Claus",
                "email": "north@pole3.com",
                "status": "PROVISIONED",
                "__typename": "ApiUserWithStatus"
            },
            { (Admin)
                "id": "694d6c40-e524-4063-a60b-fa26175f4e0a",
                "firstName": "Dad",
                "middleName": null,
                "lastName": "inet",
                "email": "dadinet109@etondy.com",
                "status": "ACTIVE",
                "__typename": "ApiUserWithStatus"
            },
            { (Standard user)
                "id": "adcaf8c4-3ef2-4f4b-8f09-f303dd866ecc",
                "firstName": "Eve",
                "middleName": null,
                "lastName": "Riggs",
                "email": "banep43991@muzitp.com",
                "status": "ACTIVE",
                "__typename": "ApiUserWithStatus"
            },
            { (Admin)
                "id": "9b10a573-dc27-40e8-9550-60d219f5a5bb",
                "firstName": "Fletcher", 
                "middleName": null,
                "lastName": "Wheeler",
                "email": "cekok63012@nmaller.com",
                "status": "PROVISIONED",
                "__typename": "ApiUserWithStatus"
            }
        ]
}

### Query return

 "data": {
        "getOrgAdminUserIds": [
            "694d6c40-e524-4063-a60b-fa26175f4e0a",
            "9b10a573-dc27-40e8-9550-60d219f5a5bb"
        ]
    }

```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---