### PR TITLE
Mike/6932 universal pipeline for all

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueFhirReportingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AzureStorageQueueFhirReportingService.java
@@ -25,17 +25,13 @@ public final class AzureStorageQueueFhirReportingService implements TestEventRep
 
   @Override
   public CompletableFuture<Void> reportAsync(TestEvent testEvent) {
-    if (testEvent.getResults().stream()
-        .anyMatch(result -> !COVID_LOINC.equals(result.getDisease().getLoinc()))) {
-      log.trace("Dispatching TestEvent [{}] to Azure storage queue", testEvent.getInternalId());
-      var parser = context.newJsonParser();
-      return queueClient
-          .sendMessage(
-              parser.encodeResourceToString(
-                  fhirConverter.createFhirBundle(testEvent, gitProperties, processingModeCode)))
-          .toFuture()
-          .thenApply(result -> null);
-    }
-    return CompletableFuture.completedFuture(null);
+    log.trace("Dispatching TestEvent [{}] to Azure storage queue", testEvent.getInternalId());
+    var parser = context.newJsonParser();
+    return queueClient
+        .sendMessage(
+            parser.encodeResourceToString(
+                fhirConverter.createFhirBundle(testEvent, gitProperties, processingModeCode)))
+        .toFuture()
+        .thenApply(result -> null);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReportTestEventToRSEventListener.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReportTestEventToRSEventListener.java
@@ -37,7 +37,7 @@ public class ReportTestEventToRSEventListener {
       testEventReportingService.report(savedEvent);
     }
 
-    if (savedEvent.hasFluResult() && fhirReportingEnabled) {
+    if (fhirReportingEnabled) {
       fhirQueueReportingService.report(savedEvent);
     }
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -187,7 +187,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(testEventArgumentCaptor.capture());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
     TestEvent sentEvent = testEventArgumentCaptor.getValue();
     TestResult testResult = sentEvent.getCovidTestResult().get();
     assertThat(sentEvent.getPatient().getInternalId()).isEqualTo(patient.getInternalId());
@@ -236,7 +236,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         null);
 
     verify(testEventReportingService).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
 
     List<TestEvent> testEvents =
         _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
@@ -257,7 +257,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
     assertThat(testEvents.get(1).getPatientHasPriorTests()).isTrue();
     verify(testEventReportingService, times(2)).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService, times(2)).report(any());
   }
 
   @Test
@@ -408,7 +408,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
     verify(testEventReportingService).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
   }
 
   @Test
@@ -454,7 +454,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(0, queue.size());
     verify(testEventReportingService).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
   }
 
   @Test
@@ -563,7 +563,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
 
     List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
 
@@ -575,7 +575,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     // make sure the second event is sent to storage queue
     verify(testEventReportingService, times(2)).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService, times(2)).report(any());
   }
 
   @Test
@@ -934,7 +934,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertTrue(res.getDeliverySuccess());
     verifyNoInteractions(testResultsDeliveryService);
     verify(testEventReportingService).report(any());
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
   }
 
   @Test
@@ -1466,7 +1466,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
     // to report stream
     verify(testEventReportingService).report(deleteMarkerEvent);
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
   }
 
   @Test
@@ -2149,7 +2149,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.getTestResult(_e.getInternalId()).getTestOrder();
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(correctedTestEvent);
-    verifyNoInteractions(fhirQueueReportingService);
+    verify(fhirQueueReportingService).report(any());
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #6932

## Changes Proposed

- Send all single entry test events to the universal pipeline even if it doesn't have a flu result

## Testing

- How should reviewers verify this PR?
- Use [dev3](https://dev3.simplereport.gov/) to submit a test and check `rs-batch-publisher-dev3` to verify the test event id was reported successfully

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---