### PR TITLE
Bug fix: CSV modal text should reflect if disease filter is applied

### DIFF
--- a/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.test.tsx
@@ -154,6 +154,72 @@ describe("DownloadResultsCsvModal with filters and under 20k results", () => {
   });
 });
 
+describe("DownloadResultsCsvModal with disease filter and under 20k results", () => {
+  beforeEach(() => {
+    ReactDOM.createPortal = jest.fn((element, _node) => {
+      return element;
+    }) as any;
+
+    render(
+      <MockedProvider mocks={[]}>
+        <DownloadResultsCsvModal
+          filterParams={{ disease: "Flu A" }}
+          modalIsOpen={true}
+          closeModal={() => {}}
+          totalEntries={15}
+          activeFacilityId={mockFacilityID}
+        />
+      </MockedProvider>
+    );
+  });
+
+  it("shows correct modal text", async () => {
+    const downloadButton = await screen.findByText("Download results");
+    expect(downloadButton).toBeEnabled();
+    expect(
+      await screen.findByText("Download test results")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Download results with current search filters applied?"
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+describe("DownloadResultsCsvModal with current facility filter and under 20k results", () => {
+  beforeEach(() => {
+    ReactDOM.createPortal = jest.fn((element, _node) => {
+      return element;
+    }) as any;
+
+    render(
+      <MockedProvider mocks={[]}>
+        <DownloadResultsCsvModal
+          filterParams={{ filterFacilityId: mockFacilityID }}
+          modalIsOpen={true}
+          closeModal={() => {}}
+          totalEntries={15}
+          activeFacilityId={mockFacilityID}
+        />
+      </MockedProvider>
+    );
+  });
+
+  it("shows correct modal text", async () => {
+    const downloadButton = await screen.findByText("Download results");
+    expect(downloadButton).toBeEnabled();
+    expect(
+      await screen.findByText("Download test results")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Download results without any search filters applied?"
+      )
+    ).toBeInTheDocument();
+  });
+});
+
 describe("DownloadResultsCsvModal with over 20k results", () => {
   let component: any;
 

--- a/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
@@ -38,14 +38,13 @@ export const DownloadResultsCsvModal = ({
   // Disable downloads because backend will hang on over 20k results (#3953)
   const disableDownload = totalEntries > rowsMaxLimit;
 
-  const filtersPresent =
-    filterParams.patientId ||
-    filterParams.startDate ||
-    filterParams.endDate ||
-    filterParams.role ||
-    filterParams.result ||
-    (filterParams.filterFacilityId &&
-      filterParams.filterFacilityId !== activeFacilityId);
+  const filtersPresent = Object.entries(filterParams).some(([key, val]) => {
+    // active facility in the facility filter is the default
+    if (key === "filterFacilityId") {
+      return val !== activeFacilityId;
+    }
+    return val;
+  });
 
   const variables: ResultsQueryVariables = {
     facilityId:


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Found a small bug while adding RSV to the CSV download schema - the CSV modal text doesn't update if a disease filter is present but it should

## Changes Proposed

iterate through the filtersPresent object for any filters rather than hardcoding to check each property 

## Testing

deploying to `dev4`

## Screenshots / Demos
before:

https://github.com/CDCgov/prime-simplereport/assets/6401323/e910055d-a82d-416a-ab8f-b82eb8ef7827

after:

https://github.com/CDCgov/prime-simplereport/assets/6401323/41481fbb-bba7-4fa0-92cd-58a963216383

