### PR TITLE
return focus to patient details link on results detail close

### DIFF
--- a/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
+++ b/frontend/src/app/testResults/mocks/resultsMultiplex.mock.tsx
@@ -149,7 +149,7 @@ const data = [
   {
     ...testThree,
     disease: "Flu A",
-    result: "POSITIVE",
+    testResult: "POSITIVE",
   },
   {
     ...testThree,

--- a/frontend/src/app/testResults/viewResults/ResultsTable.test.tsx
+++ b/frontend/src/app/testResults/viewResults/ResultsTable.test.tsx
@@ -116,22 +116,6 @@ describe("Component ResultsTable", () => {
   });
 
   it("result details modal populates when patient name is clicked and returns focus to patient name when closed", async () => {
-    const mockStore = configureStore([]);
-    const store = mockStore({
-      organization: {
-        name: "Organization Name",
-      },
-      user: {
-        firstName: "Kim",
-        lastName: "Mendoza",
-      },
-      facilities: [
-        { id: "1", name: "Facility 1" },
-        { id: "2", name: "Facility 2" },
-      ],
-      facility: { id: "1", name: "Facility 1" },
-    });
-
     const renderWithUser = (results: Result[]) => ({
       user: userEvent.setup(),
       ...render(
@@ -229,32 +213,51 @@ describe("Component ResultsTable", () => {
   });
 });
 
-const testToMock =
-  TEST_RESULTS_MULTIPLEX.content[TEST_RESULTS_MULTIPLEX.totalElements - 2];
-const mockResultData = {
-  dateTested: testToMock.dateTested,
-  disease: testToMock.disease,
-  testResult: testToMock.testResult,
-  correctionStatus: testToMock.correctionStatus,
-  deviceType: testToMock.deviceType,
-  patient: testToMock.patient,
-  createdBy: testToMock.createdBy,
-  symptoms: undefined,
-  symptomOnset: undefined,
-  pregnancy: undefined,
-};
-const TestResultDetailsMock = [
-  {
+const mockStore = configureStore([]);
+const store = mockStore({
+  organization: {
+    name: "Organization Name",
+  },
+  user: {
+    firstName: "Kim",
+    lastName: "Mendoza",
+  },
+  facilities: [
+    { id: "1", name: "Facility 1" },
+    { id: "2", name: "Facility 2" },
+  ],
+  facility: { id: "1", name: "Facility 1" },
+});
+
+const mockDataToReturn = TEST_RESULTS_MULTIPLEX.content.map((testToMock) => {
+  const mockResultData = {
+    dateTested: testToMock.dateTested,
+    disease: testToMock.disease,
+    testResult: testToMock.testResult,
+    correctionStatus: testToMock.correctionStatus,
+    deviceType: testToMock.deviceType,
+    patient: testToMock.patient,
+    createdBy: testToMock.createdBy,
+    symptoms: undefined,
+    symptomOnset: undefined,
+    pregnancy: undefined,
+  };
+  return { id: testToMock.id, data: mockResultData };
+});
+
+const TestResultDetailsMock = mockDataToReturn.map((mockData) => {
+  const mockQuery = {
     request: {
       query: GetTestResultDetailsDocument,
       variables: {
-        id: testToMock.id,
+        id: mockData.id,
       },
     },
     result: {
       data: {
-        testResult: mockResultData,
+        testResult: mockData.data,
       },
     },
-  },
-];
+  };
+  return mockQuery;
+});

--- a/frontend/src/app/testResults/viewResults/ResultsTable.tsx
+++ b/frontend/src/app/testResults/viewResults/ResultsTable.tsx
@@ -161,7 +161,10 @@ const generateResultRows = (
               r.patient?.lastName
             )}
             onClick={() =>
-              onActionSelect({ modalType: "NAME DETAILS", testResult: r })
+              onActionSelect({
+                modalType: "DETAILS TRIGGERED FROM NAME LINK",
+                testResult: r,
+              })
             }
             className="sr-link__primary"
           />
@@ -212,7 +215,7 @@ type ActionInformation = {
     | "TEXT"
     | "DETAILS"
     | "EMAIL"
-    | "NAME DETAILS";
+    | "DETAILS TRIGGERED FROM NAME LINK";
   testResult: Result | undefined;
 };
 
@@ -303,7 +306,7 @@ const ResultsTable = ({ results, hasFacility }: ResultsTableListProps) => {
       <TestResultDetailsModal
         isOpen={
           actionSelected.modalType === "DETAILS" ||
-          actionSelected.modalType === "NAME DETAILS"
+          actionSelected.modalType === "DETAILS TRIGGERED FROM NAME LINK"
         }
         testResult={actionSelected.testResult}
         closeModal={() => {

--- a/frontend/src/app/testResults/viewResults/ResultsTable.tsx
+++ b/frontend/src/app/testResults/viewResults/ResultsTable.tsx
@@ -161,7 +161,7 @@ const generateResultRows = (
               r.patient?.lastName
             )}
             onClick={() =>
-              onActionSelect({ modalType: "DETAILS", testResult: r })
+              onActionSelect({ modalType: "NAME DETAILS", testResult: r })
             }
             className="sr-link__primary"
           />
@@ -205,7 +205,14 @@ interface ResultsTableListProps {
 }
 
 type ActionInformation = {
-  modalType: "NONE" | "PRINT" | "CORRECTION" | "TEXT" | "DETAILS" | "EMAIL";
+  modalType:
+    | "NONE"
+    | "PRINT"
+    | "CORRECTION"
+    | "TEXT"
+    | "DETAILS"
+    | "EMAIL"
+    | "NAME DETAILS";
   testResult: Result | undefined;
 };
 
@@ -294,10 +301,15 @@ const ResultsTable = ({ results, hasFacility }: ResultsTableListProps) => {
         }}
       />
       <TestResultDetailsModal
-        isOpen={actionSelected.modalType === "DETAILS"}
+        isOpen={
+          actionSelected.modalType === "DETAILS" ||
+          actionSelected.modalType === "NAME DETAILS"
+        }
         testResult={actionSelected.testResult}
         closeModal={() => {
-          setFocusOnActionMenu("view");
+          if (actionSelected.modalType === "DETAILS") {
+            setFocusOnActionMenu("view");
+          }
           dismissModal();
         }}
       />


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #6928 

## Changes Proposed

- Adds an extra state trigger / check to return focus to the right element on the closing of the results detail modal
- Adds a regression test to catch this case

## Testing
deployed on dev2

- Open modal from the patient name button on the results table and on close, confirm focus gets returned correctly.

## Screenshots / Demos

### Before
https://github.com/CDCgov/prime-simplereport/assets/29645040/33c875b8-7a3d-4460-94b1-e55c3fe76ecf

### After
https://github.com/CDCgov/prime-simplereport/assets/29645040/b6619aff-fe35-4920-a41d-1b966a0483f2


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
