### PR TITLE
Reduce assertions in backend tests

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/ApiUserManagementTest.java
@@ -80,7 +80,7 @@ class ApiUserManagementTest extends BaseGraphqlTest {
   }
 
   @Test
-  void whoami_standardUser_okResponses() {
+  void whoami_standardUser_okUserInfoAndPermissions() {
     ObjectNode who =
         (ObjectNode) runQuery("current-user-query", "whoDat", null, null).get("whoami");
     assertEquals("Bobbity", who.get("firstName").asText());
@@ -120,7 +120,12 @@ class ApiUserManagementTest extends BaseGraphqlTest {
             UserPermission.SUBMIT_TEST,
             UserPermission.UPLOAD_RESULTS_SPREADSHEET),
         null);
+  }
 
+  @Test
+  void whoami_standardUser_okOrganizationInfo() {
+    ObjectNode who =
+        (ObjectNode) runQuery("current-user-query", "whoDat", null, null).get("whoami");
     JsonNode orgNode = who.path("organization");
     assertTrue(orgNode.has("id"), "'id' field present on organization");
     assertTrue(orgNode.has("internalId"), "'internalId' field present on organization");


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #5601 

## Changes Proposed
- [Reduces assertions](https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS5961&severities=MAJOR&id=CDCgov_prime-data-input-client&open=AYbHox6aumIXTMEjOmmW) in the following files:
  - `ApiUserManagementTest.java`
  - `TestResultUploadServiceTest.java`

## Additional Information
- As suggested by the ticket, will not reduce assertions in the `FhirConverterTest.java` file

## Testing
- Ensure all backend tests pass

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
