### PR TITLE
Elisa/6929 result notification bug

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -73,7 +73,9 @@ public class QueueMutationResolver {
             symptomOnset,
             noSymptoms);
 
-    personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);
+    if (testResultDelivery != null) {
+      personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);
+    }
 
     return to.getInternalId()
         .toString(); // this return is unused in the UI. it used to be PatientLinkInternalId
@@ -99,6 +101,8 @@ public class QueueMutationResolver {
     testOrderService.updateTimeOfTestQuestions(
         patientId, pregnancy, symptomsMap, symptomOnset, noSymptoms, genderOfSexualPartners);
 
-    personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);
+    if (testResultDelivery != null) {
+      personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);
+    }
   }
 }


### PR DESCRIPTION
# PULL REQUEST

## Related Issue

Partially resolves #6929

## Changes Proposed

- Fixes the bug where test result notification preferences were not being saved when a patient was added to the queue or their AOE question was being updated

## Additional Information
- in a separate PR, once #7014 is merged in will make sure this is covered in the e2e test

## Testing
- Ensure a patient's test result delivery preferences save even if they are added to the queue or their AOE questions are updated
- available on dev4 for testing with the new card refactor
- available on dev2 for testing with the old test cards

## Screenshots / Demos


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
