### PR TITLE
Fix photo number remove button causing redirect/reload

### DIFF
--- a/frontend/src/app/patients/Components/ManageEmails.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.tsx
@@ -153,6 +153,7 @@ const ManageEmails: React.FC<Props> = ({
             {idx > 0 ? (
               <div className="flex-align-self-end">
                 <button
+                  type={"button"}
                   className="usa-button--unstyled padding-105 height-5 cursor-pointer"
                   data-testid={`delete-email-${idx}`}
                   onClick={() => onEmailRemove(idx)}

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -8,7 +8,7 @@ import Input from "../../commonComponents/Input";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import {
   toggleDeliveryPreferenceSms,
-  getSelectedDeliveryPreferencesSms
+  getSelectedDeliveryPreferencesSms,
 } from "../../utils/deliveryPreferences";
 import { useTranslatedConstants } from "../../constants";
 import { PhoneNumberErrors, usePersonSchemata } from "../personSchema";
@@ -27,14 +27,14 @@ interface Props {
 }
 
 const ManagePhoneNumbers: React.FC<Props> = ({
-                                               phoneNumbers,
-                                               testResultDelivery,
-                                               updatePhoneNumbers,
-                                               updateTestResultDelivery,
-                                               phoneNumberValidator,
-                                               unknownPhoneNumber,
-                                               setUnknownPhoneNumber
-                                             }) => {
+  phoneNumbers,
+  testResultDelivery,
+  updatePhoneNumbers,
+  updateTestResultDelivery,
+  phoneNumberValidator,
+  unknownPhoneNumber,
+  setUnknownPhoneNumber,
+}) => {
   const [errors, setErrors] = useState<PhoneNumberErrors[]>([]);
 
   const { t } = useTranslation();
@@ -48,11 +48,11 @@ const ManagePhoneNumbers: React.FC<Props> = ({
       phoneNumbers.length > 0
         ? phoneNumbers
         : [
-          {
-            type: "",
-            number: ""
-          }
-        ],
+            {
+              type: "",
+              number: "",
+            },
+          ],
     [phoneNumbers]
   );
 
@@ -68,14 +68,14 @@ const ManagePhoneNumbers: React.FC<Props> = ({
         }
         const newFieldValues = secondaryField
           ? {
-            ...error,
-            [field]: "",
-            [secondaryField]: ""
-          }
+              ...error,
+              [field]: "",
+              [secondaryField]: "",
+            }
           : {
-            ...error,
-            [field]: ""
-          };
+              ...error,
+              [field]: "",
+            };
         return newFieldValues;
       });
       setErrors(newErrors);
@@ -101,7 +101,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
           const newErrors = [...existingErrors];
           newErrors[idx] = {
             ...newErrors[idx],
-            [field]: getValidationError(e)
+            [field]: getValidationError(e),
           };
 
           return newErrors;
@@ -113,7 +113,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
       phoneNumbersOrDefault,
       clearError,
       phoneNumberUpdateSchema,
-      getValidationError
+      getValidationError,
     ]
   );
 
@@ -153,7 +153,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
               const newErrors = [...existingErrors];
               newErrors[idx] = {
                 ...newErrors[idx],
-                [field]: getValidationError(e)
+                [field]: getValidationError(e),
               };
 
               return newErrors;
@@ -167,7 +167,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
     errors,
     phoneNumberUpdateSchema,
     phoneNumbersOrDefault,
-    getValidationError
+    getValidationError,
   ]);
 
   const onPhoneTypeChange = (index: number, newPhoneType: string) => {
@@ -175,7 +175,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
 
     newPhoneNumbers[index] = {
       ...newPhoneNumbers[index],
-      type: newPhoneType
+      type: newPhoneType,
     };
 
     updatePhoneNumbers(newPhoneNumbers);
@@ -186,7 +186,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
 
     newPhoneNumbers[index] = {
       ...newPhoneNumbers[index],
-      number: newPhoneNumber
+      number: newPhoneNumber,
     };
 
     updatePhoneNumbers(newPhoneNumbers);
@@ -209,7 +209,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
     const newPhoneNumbers = Array.from(phoneNumbersOrDefault);
     newPhoneNumbers.push({
       type: "",
-      number: ""
+      number: "",
     });
     updatePhoneNumbers(newPhoneNumbers);
     setTimeout(() => {

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -251,6 +251,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
             {!isPrimary && (
               <div className="flex-align-self-end">
                 <button
+                    type={"button"}
                   className="usa-button--unstyled padding-105 height-5 cursor-pointer"
                   onClick={() => onPhoneNumberRemove(idx)}
                   aria-label={`Delete additional phone number ${phoneNumber.number.trim()}`}

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.tsx
@@ -8,7 +8,7 @@ import Input from "../../commonComponents/Input";
 import RadioGroup from "../../commonComponents/RadioGroup";
 import {
   toggleDeliveryPreferenceSms,
-  getSelectedDeliveryPreferencesSms,
+  getSelectedDeliveryPreferencesSms
 } from "../../utils/deliveryPreferences";
 import { useTranslatedConstants } from "../../constants";
 import { PhoneNumberErrors, usePersonSchemata } from "../personSchema";
@@ -27,14 +27,14 @@ interface Props {
 }
 
 const ManagePhoneNumbers: React.FC<Props> = ({
-  phoneNumbers,
-  testResultDelivery,
-  updatePhoneNumbers,
-  updateTestResultDelivery,
-  phoneNumberValidator,
-  unknownPhoneNumber,
-  setUnknownPhoneNumber,
-}) => {
+                                               phoneNumbers,
+                                               testResultDelivery,
+                                               updatePhoneNumbers,
+                                               updateTestResultDelivery,
+                                               phoneNumberValidator,
+                                               unknownPhoneNumber,
+                                               setUnknownPhoneNumber
+                                             }) => {
   const [errors, setErrors] = useState<PhoneNumberErrors[]>([]);
 
   const { t } = useTranslation();
@@ -48,11 +48,11 @@ const ManagePhoneNumbers: React.FC<Props> = ({
       phoneNumbers.length > 0
         ? phoneNumbers
         : [
-            {
-              type: "",
-              number: "",
-            },
-          ],
+          {
+            type: "",
+            number: ""
+          }
+        ],
     [phoneNumbers]
   );
 
@@ -68,14 +68,14 @@ const ManagePhoneNumbers: React.FC<Props> = ({
         }
         const newFieldValues = secondaryField
           ? {
-              ...error,
-              [field]: "",
-              [secondaryField]: "",
-            }
+            ...error,
+            [field]: "",
+            [secondaryField]: ""
+          }
           : {
-              ...error,
-              [field]: "",
-            };
+            ...error,
+            [field]: ""
+          };
         return newFieldValues;
       });
       setErrors(newErrors);
@@ -101,7 +101,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
           const newErrors = [...existingErrors];
           newErrors[idx] = {
             ...newErrors[idx],
-            [field]: getValidationError(e),
+            [field]: getValidationError(e)
           };
 
           return newErrors;
@@ -113,7 +113,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
       phoneNumbersOrDefault,
       clearError,
       phoneNumberUpdateSchema,
-      getValidationError,
+      getValidationError
     ]
   );
 
@@ -153,7 +153,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
               const newErrors = [...existingErrors];
               newErrors[idx] = {
                 ...newErrors[idx],
-                [field]: getValidationError(e),
+                [field]: getValidationError(e)
               };
 
               return newErrors;
@@ -167,7 +167,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
     errors,
     phoneNumberUpdateSchema,
     phoneNumbersOrDefault,
-    getValidationError,
+    getValidationError
   ]);
 
   const onPhoneTypeChange = (index: number, newPhoneType: string) => {
@@ -175,7 +175,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
 
     newPhoneNumbers[index] = {
       ...newPhoneNumbers[index],
-      type: newPhoneType,
+      type: newPhoneType
     };
 
     updatePhoneNumbers(newPhoneNumbers);
@@ -186,7 +186,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
 
     newPhoneNumbers[index] = {
       ...newPhoneNumbers[index],
-      number: newPhoneNumber,
+      number: newPhoneNumber
     };
 
     updatePhoneNumbers(newPhoneNumbers);
@@ -209,7 +209,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
     const newPhoneNumbers = Array.from(phoneNumbersOrDefault);
     newPhoneNumbers.push({
       type: "",
-      number: "",
+      number: ""
     });
     updatePhoneNumbers(newPhoneNumbers);
     setTimeout(() => {
@@ -251,7 +251,7 @@ const ManagePhoneNumbers: React.FC<Props> = ({
             {!isPrimary && (
               <div className="flex-align-self-end">
                 <button
-                    type={"button"}
+                  type={"button"}
                   className="usa-button--unstyled padding-105 height-5 cursor-pointer"
                   onClick={() => onPhoneNumberRemove(idx)}
                   aria-label={`Delete additional phone number ${phoneNumber.number.trim()}`}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- #5678 

## Changes Proposed

- Remove button for phone number was a raw `<button>` element without any `type` which defaults to native HTML form `submit` functionality when within the larger `<form>` element

## Testing

- Deployed on [dev7](https://dev7.simplereport.gov/app/)
- See if you can replicate the redirect/reload behavior with the phone number remove button

## Screenshots / Demos

https://github.com/CDCgov/prime-simplereport/assets/23287037/62415abd-cc45-411b-8d3d-ad738af059a0

