### PR TITLE
Clean up FHIR feature flags

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReportTestEventToRSEventListener.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReportTestEventToRSEventListener.java
@@ -3,7 +3,6 @@ package gov.cdc.usds.simplereport.service;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -24,9 +23,6 @@ public class ReportTestEventToRSEventListener {
   @Qualifier("fhirQueueReportingService")
   private final TestEventReportingService fhirQueueReportingService;
 
-  @Value("${simple-report.fhir-reporting-enabled:false}")
-  private boolean fhirReportingEnabled;
-
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleEvent(ReportTestEventToRSEvent event) {
     reportTestEventToRS(event.testEvent());
@@ -37,8 +33,6 @@ public class ReportTestEventToRSEventListener {
       testEventReportingService.report(savedEvent);
     }
 
-    if (fhirReportingEnabled) {
-      fhirQueueReportingService.report(savedEvent);
-    }
+    fhirQueueReportingService.report(savedEvent);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -48,8 +48,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -75,15 +73,6 @@ public class TestOrderService {
   private final TestEventRepository _testEventRepo;
   private final PatientLinkService _patientLinkService;
   private final ResultService resultService;
-
-  @Qualifier("csvQueueReportingService")
-  private final TestEventReportingService _testEventReportingService;
-
-  @Qualifier("fhirQueueReportingService")
-  private final TestEventReportingService _fhirQueueReportingService;
-
-  @Value("${simple-report.fhir-reporting-enabled:false}")
-  private boolean fhirReportingEnabled;
 
   private final TestResultsDeliveryService testResultsDeliveryService;
   private final DiseaseService _diseaseService;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -101,9 +101,6 @@ public class TestResultUploadService {
   @Value("${simple-report.processing-mode-code:P}")
   private String processingModeCodeValue;
 
-  @Value("${data-hub.fhir-enabled:false}")
-  private boolean fhirEnabled;
-
   private static final int FIVE_MINUTES_MS = 300 * 1000;
   public static final String PROCESSING_MODE_CODE_COLUMN_NAME = "processing_mode_code";
   private static final String ORDER_TEST_DATE_COLUMN_NAME = "order_test_date";
@@ -364,19 +361,16 @@ public class TestResultUploadService {
     return CompletableFuture.supplyAsync(
         withMDC(
             () -> {
-              if (fhirEnabled) {
-                long start = System.currentTimeMillis();
-                // convert csv to fhir and serialize to json
-                FHIRBundleRecord fhirBundleWithMeta =
-                    fhirConverter.convertToFhirBundles(content, org.getInternalId());
-                UploadResponse response = uploadBundleAsFhir(fhirBundleWithMeta.serializedBundle());
-                log.info(
-                    "FHIR submitted in " + (System.currentTimeMillis() - start) + " milliseconds");
+              long start = System.currentTimeMillis();
+              // convert csv to fhir and serialize to json
+              FHIRBundleRecord fhirBundleWithMeta =
+                  fhirConverter.convertToFhirBundles(content, org.getInternalId());
+              UploadResponse response = uploadBundleAsFhir(fhirBundleWithMeta.serializedBundle());
+              log.info(
+                  "FHIR submitted in " + (System.currentTimeMillis() - start) + " milliseconds");
 
-                return new UniversalSubmissionSummary(
-                    submissionId, org, response, fhirBundleWithMeta.metadata());
-              }
-              return null;
+              return new UniversalSubmissionSummary(
+                  submissionId, org, response, fhirBundleWithMeta.metadata());
             }));
   }
 
@@ -582,7 +576,7 @@ public class TestResultUploadService {
     if (content.length > 0) {
       fhirResponse = submitConditionAgnosticAsFhir(new ByteArrayInputStream(content));
       try {
-        if (fhirResponse != null && fhirResponse.get() != null) {
+        if (fhirResponse.get() != null) {
           fhirResult = mapFhirResponseToUploadResponse(fhirResponse.get(), org, submissionId);
         }
       } catch (CsvProcessingException | ExecutionException | InterruptedException e) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -165,7 +165,6 @@ datahub:
   signing-key: ${DATAHUB_SIGNING_KEY:super-secret-signing-key}
   csv-upload-api-client: "simple_report.csvuploader"
   csv-upload-api-fhir-client: "simple_report.fullelr"
-  fhir-enabled: true
 features:
   hivEnabled: true
   singleEntryRsvEnabled: true

--- a/backend/src/test/java/gov/cdc/usds/simplereport/integration/UploadConditionAgnosticResultsIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/integration/UploadConditionAgnosticResultsIntegrationTest.java
@@ -41,14 +41,12 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SliceTestConfiguration.WithSimpleReportStandardUser
 @AutoConfigureWireMock(port = 9561)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestPropertySource(properties = {"data-hub.fhir-enabled=true"})
 class UploadConditionAgnosticResultsIntegrationTest extends BaseAuthenticatedFullStackTest {
   @Autowired private MockMvc mockMvc;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/integration/UploadTestResultsIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/integration/UploadTestResultsIntegrationTest.java
@@ -42,14 +42,12 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SliceTestConfiguration.WithSimpleReportStandardUser
 @AutoConfigureWireMock(port = 9561)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestPropertySource(properties = {"data-hub.fhir-enabled=true"})
 class UploadTestResultsIntegrationTest extends BaseAuthenticatedFullStackTest {
   @Autowired private MockMvc mockMvc;
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultUploadServiceTest.java
@@ -426,10 +426,8 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  void uploadService_FhirEnabled_UploadSentTwice() {
+  void uploadService_UploadSentTwice() {
     // given
-    ReflectionTestUtils.setField(sut, "fhirEnabled", true);
-
     UploadResponse response = buildUploadResponse();
     var tokenResponse = new TokenResponse();
     tokenResponse.setAccessToken("fake-rs-access-token");
@@ -459,10 +457,8 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  void uploadService_FhirEnabled_FhirFailure_ReportsCSVResult() {
+  void uploadService_FhirFailure_ReportsCSVResult() {
     // given
-    ReflectionTestUtils.setField(sut, "fhirEnabled", true);
-
     var org = factory.saveValidOrganization();
     var csvReportId = UUID.randomUUID();
     var csvResponse = new UploadResponse();
@@ -517,10 +513,8 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   }
 
   @Test
-  void uploadService_FhirEnabled_FhirException_ReportsCSVResult() {
+  void uploadService_FhirException_ReportsCSVResult() {
     // given
-    ReflectionTestUtils.setField(sut, "fhirEnabled", true);
-
     var org = factory.saveValidOrganization();
     var csvReportId = UUID.randomUUID();
     var successfulCsvResponse = new UploadResponse();
@@ -774,8 +768,6 @@ class TestResultUploadServiceTest extends BaseServiceTest<TestResultUploadServic
   @Test
   @SliceTestConfiguration.WithSimpleReportStandardUser
   void uploadService_processCsv_only_submit_fhir_when_flu_only_csv() {
-    ReflectionTestUtils.setField(sut, "fhirEnabled", true);
-
     // GIVEN
     InputStream input = loadCsv("testResultUpload/test-results-upload-valid-flu-only.csv");
     UploadResponse response = buildUploadResponse();

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -275,4 +275,3 @@ datahub:
   url: http://localhost:9561
   api-key: "super-secret-api-key"
   jwt-scope: "simple_report.*.report"
-  fhir-enabled: false


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #7001 

## Changes Proposed

- Clean up FHIR feature flags that are no longer necessary

## Testing

- Deployed to [dev6](https://dev6.simplereport.gov/app/) and confirmed that `rs-batch-publisher-dev6` showed the invocations for the test event