### PR TITLE
SSL certificate for Azure Application Gateway

### DIFF
--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -154,12 +154,12 @@ resource "azurerm_application_gateway" "www_redirect" {
     frontend_ip_configuration_name = local.frontend_config
     frontend_port_name             = local.https_listener
     protocol                       = "Https"
-    ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
+    ssl_certificate_name           = "new-sr-wildcard"
   }
 
   ssl_certificate {
-    name                = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
-    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
+    name                = "new-sr-wildcard"
+    key_vault_secret_id = "https://simple-report-global.vault.azure.net/secrets/new-sr-wildcard/387cec9bcc254ac7970aa21311b075fc"
   }
 
   ssl_policy {

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -251,12 +251,12 @@ resource "azurerm_application_gateway" "load_balancer" {
     frontend_ip_configuration_name = local.frontend_config
     frontend_port_name             = local.https_listener
     protocol                       = "Https"
-    ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
+    ssl_certificate_name           = "new-sr-wildcard"
   }
 
   ssl_certificate {
-    name                = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
-    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
+    name                = "new-sr-wildcard"
+    key_vault_secret_id = "https://simple-report-global.vault.azure.net/secrets/new-sr-wildcard/387cec9bcc254ac7970aa21311b075fc"
   }
 
   ssl_policy {


### PR DESCRIPTION
# DEVOPS PULL REQUEST WIP

## Related Issue

- #5932 

## Changes Proposed

- The purpose of this PR is to hardcode the current SSL cert; it is known to work correctly. 
- Benefits of this approach:
   - I will not need to do manual state imports in Terraform via my local machine.
   - I can create a new version of the cert without it getting picked up automatically and applied on the next deployment.

## Additional Information

- I wonder if applying this cert dynamically brings any value to us; it seems to me that it would more likely cause problems. The SSL cert, as it stands, will always need to be updated and tested manually before it can be changed. Hardcoding it in this way or a similar way might reduce mental overhead and the chances that we will mess this rotation up. :smile: 
- After the new cert is tested and verified to work, the intention is to either:
  - revert this change to dynamically pull in the new cert after it's known to work
  - ||
  - hardcode the new cert values
- This is a process problem and we should work to improve it over time, I created this ticket to get us thinking about it:  #7090 

## Testing

- Terraform plan against all environments should indicate that we aren't changing anything related to these updates with this PR. We're hardcoding a known good value so I can test creating a new value without it being picked up on the next deployment: https://github.com/CDCgov/prime-simplereport/actions/runs/7200725433/job/19615293739

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README