### PR TITLE
Promote SSL Cert

### DIFF
--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -154,12 +154,12 @@ resource "azurerm_application_gateway" "www_redirect" {
     frontend_ip_configuration_name = local.frontend_config
     frontend_port_name             = local.https_listener
     protocol                       = "Https"
-    ssl_certificate_name           = "new-sr-wildcard"
+    ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
   }
 
   ssl_certificate {
-    name                = "new-sr-wildcard"
-    key_vault_secret_id = "https://simple-report-global.vault.azure.net/secrets/new-sr-wildcard/387cec9bcc254ac7970aa21311b075fc"
+    name                = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
+    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
   }
 
   ssl_policy {

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -256,7 +256,7 @@ resource "azurerm_application_gateway" "load_balancer" {
 
   ssl_certificate {
     name                = "new-sr-wildcard"
-    key_vault_secret_id = "https://simple-report-global.vault.azure.net/secrets/new-sr-wildcard/387cec9bcc254ac7970aa21311b075fc"
+    key_vault_secret_id = "https://simple-report-global.vault.azure.net/secrets/new-sr-wildcard/770f7e5d251f4350b09d74c89d735800"
   }
 
   ssl_policy {

--- a/ops/services/app_gateway/main.tf
+++ b/ops/services/app_gateway/main.tf
@@ -251,12 +251,12 @@ resource "azurerm_application_gateway" "load_balancer" {
     frontend_ip_configuration_name = local.frontend_config
     frontend_port_name             = local.https_listener
     protocol                       = "Https"
-    ssl_certificate_name           = "new-sr-wildcard"
+    ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
   }
 
   ssl_certificate {
-    name                = "new-sr-wildcard"
-    key_vault_secret_id = "https://simple-report-global.vault.azure.net/secrets/new-sr-wildcard/770f7e5d251f4350b09d74c89d735800"
+    name                = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.name
+    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
   }
 
   ssl_policy {

--- a/ops/services/app_service/main.tf
+++ b/ops/services/app_service/main.tf
@@ -200,7 +200,7 @@ resource "azurerm_app_service_certificate" "app" {
   name                = "new-sr-wildcard"
   resource_group_name = var.resource_group_name
   location            = var.resource_group_location
-  key_vault_secret_id = "https://simple-report-global.vault.azure.net/certificates/new-sr-wildcard/387cec9bcc254ac7970aa21311b075fc"
+  key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard_simplereport_gov.secret_id
 }
 
 resource "azurerm_app_service_certificate_binding" "app" {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Reverts this: #7092 

## Changes Proposed

- This reverts the cert hardcoding and will allow us to dynamically pick up the new cert as it's been installed and tested on `pentest` and `dev1`.

## Additional Information

- You're awesome.
- Deploying this as soon as I'm online and it has approvals
- If things break (they shouldn't), the reversion plan is to create a new version with the old cert.

## Testing

- Please check the SSL certs for https://origin-dev.simplereport.gov and https://pentest.simplereport.gov.
   - The cert should be verified by Entrust
   - The cert should be for *.simplereport.gov
   - The cert should expire in December of 2024
   - The cert should also have a leaf and root cert, `Entrust Certification Authority - L1K` and ` Entrust Root Certification Authority - G2`, both of which expire in 2030.
- Our [Terraform plan](https://github.com/CDCgov/prime-simplereport/actions/runs/7217741440) for all environments (minus `dev1` and `pentest`) should update app gateways in place to use the new cert.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README