### PR TITLE
clean up hasMultiplexResults function

### DIFF
--- a/frontend/src/app/utils/testResults.test.ts
+++ b/frontend/src/app/utils/testResults.test.ts
@@ -4,7 +4,7 @@ import {
   getResultByDiseaseName,
   getResultObjByDiseaseName,
   getSortedResults,
-  hasMultiplexResults,
+  hasMultipleResults,
   hasPositiveFluResults,
 } from "./testResults";
 
@@ -154,43 +154,37 @@ describe("getSortedResults", () => {
   });
 });
 
-describe("hasMultiplexResults", () => {
-  describe("MultiplexResults", () => {
-    let results: MultiplexResult[] = [];
-    it("returns true if it contains a multiplex result", () => {
-      results = [
-        {
-          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
-          testResult: TEST_RESULTS.NEGATIVE,
-        },
-        {
-          disease: { name: MULTIPLEX_DISEASES.FLU_A },
-          testResult: TEST_RESULTS.POSITIVE,
-        },
-        {
-          disease: { name: MULTIPLEX_DISEASES.FLU_B },
-          testResult: TEST_RESULTS.POSITIVE,
-        },
-      ];
-      expect(hasMultiplexResults(results)).toEqual(true);
-    });
-    it("returns false if it only contains one result", () => {
-      results = [
-        {
-          disease: { name: MULTIPLEX_DISEASES.COVID_19 },
-          testResult: TEST_RESULTS.NEGATIVE,
-        },
-      ];
-      expect(hasMultiplexResults(results)).toEqual(false);
-    });
-    it("returns false if has no results", () => {
-      results = [];
-      expect(hasMultiplexResults(results)).toEqual(false);
-    });
-    it("returns false if it contains no results", () => {
-      results = [];
-      expect(hasMultiplexResults(results)).toEqual(false);
-    });
+describe("hasMultipleResults", () => {
+  let results: MultiplexResult[] = [];
+  it("returns true if it contains multiple results", () => {
+    results = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_A },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+      {
+        disease: { name: MULTIPLEX_DISEASES.FLU_B },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+    ];
+    expect(hasMultipleResults(results)).toEqual(true);
+  });
+  it("returns false if it only contains one result", () => {
+    results = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.COVID_19 },
+        testResult: TEST_RESULTS.NEGATIVE,
+      },
+    ];
+    expect(hasMultipleResults(results)).toEqual(false);
+  });
+  it("returns false if has no results", () => {
+    results = [];
+    expect(hasMultipleResults(results)).toEqual(false);
   });
 });
 

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -38,14 +38,6 @@ export function hasMultipleResults(results: MultiplexResults): boolean {
   return results?.length > 1;
 }
 
-export function hasMultiplexResults(results: MultiplexResults): boolean {
-  return results?.length > 1
-    ? results.some(
-        (result: MultiplexResult) => result.disease?.name !== "COVID-19"
-      )
-    : false;
-}
-
 export function hasPositiveFluResults(results: MultiplexResults): boolean {
   return (
     results.filter(


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Followup to #7000 

## Changes Proposed

clean up an unused function - this represents outdated logic from when results were either expected to come as a single Covid result or a group of FluA/FluB/Covid results

## Testing

I think checking that our tests pass should be fine