### PR TITLE
Update package names in GitHub Container Registry cleanup workflow

### DIFF
--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -11,38 +11,44 @@ jobs:
     steps:
       # backend, cypress, database, frontend, frontend-lighthouse, nginx
       - uses: actions/delete-package-versions@v4
-        with: 
-          package-name: 'backend'
+        with:
+          package-name: 'prime-simplereport/backend'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
       - uses: actions/delete-package-versions@v4
-        with: 
-          package-name: 'cypress'
+        with:
+          package-name: 'prime-simplereport/cypress'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
       - uses: actions/delete-package-versions@v4
-        with: 
-          package-name: 'database'
+        with:
+          package-name: 'prime-simplereport/database'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
       - uses: actions/delete-package-versions@v4
-        with: 
-          package-name: 'frontend'
+        with:
+          package-name: 'prime-simplereport/db'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
       - uses: actions/delete-package-versions@v4
-        with: 
-          package-name: 'frontend-lighthouse'
+        with:
+          package-name: 'prime-simplereport/frontend'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
       - uses: actions/delete-package-versions@v4
-        with: 
-          package-name: 'nginx'
+        with:
+          package-name: 'prime-simplereport/frontend-lighthouse'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-name: 'prime-simplereport/nginx'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolves #6024 

## Changes Proposed 

- This PR updates the GitHub actions workflow for cleaning up package versions in the GitHub Container Registry (GHCR).

## Testing 

- This job demonstrates that these jobs should now work: https://github.com/CDCgov/prime-simplereport/actions/runs/7402085965/job/20139210403
- Reviewers should verify this PR by checking if the GitHub packages match the package names for this repo.

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README