### PR TITLE
Make e2e spec 3 rerunnable

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -59,20 +59,6 @@ module.exports = {
         getPatientPhone() {
           return global.patientPhone;
         },
-        setCovidOnlyDeviceName(name) {
-          global.covidOnlyDeviceName = name;
-          return null;
-        },
-        getCovidOnlyDeviceName() {
-          return global.covidOnlyDeviceName;
-        },
-        setMultiplexDeviceName(name) {
-          global.multiplexDeviceName = name;
-          return null;
-        },
-        getMultiplexDeviceName() {
-          return global.multiplexDeviceName;
-        },
         setSpecRunVersionName(data) {
           global.specRunVersions.set(data.specRunName, data.versionName);
           return null;

--- a/cypress/e2e/03-add_devices.cy.js
+++ b/cypress/e2e/03-add_devices.cy.js
@@ -42,6 +42,11 @@ describe("Adding testing devices", () => {
     });
   })
 
+  after("clean up spec data", () => {
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
+    cleanUpRunOktaOrgs(currentSpecRunVersionName);
+  });
+
   it("Adds devices to SimpleReport via admin dashboard", () => {
     visitAdminCreateDevicePage();
     cy.contains("Add new device");

--- a/cypress/e2e/03-add_devices.cy.js
+++ b/cypress/e2e/03-add_devices.cy.js
@@ -1,129 +1,129 @@
 import {
   generateCovidOnlyDevice,
   generateMultiplexDevice,
-  loginHooks,
+  loginHooks, testNumber,
 } from "../support/e2e";
 import { graphqlURL } from "../utils/request-utils";
 import { aliasGraphqlOperations } from "../utils/graphql-test-utils";
-const covidOnlyDevice = generateCovidOnlyDevice();
-const multiplexDevice = generateMultiplexDevice();
+import {
+  accessOrganizationByName,
+  cleanUpPreviousRunSetupData,
+  cleanUpRunOktaOrgs,
+  setupRunData
+} from "../utils/setup-utils";
 
-describe("Adding covid only and multiplex devices", () => {
-  let facility;
+const specRunName = "spec03";
+const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
+
+describe("Adding testing devices", () => {
+  const covidOnlyDevice = generateCovidOnlyDevice();
+  const multiplexDevice = generateMultiplexDevice();
   loginHooks();
 
-  before("store patient info", () => {
-    cy.task("setCovidOnlyDeviceName", covidOnlyDevice.name);
-    cy.task("setMultiplexDeviceName", multiplexDevice.name);
+  before("setup spec data", () => {
+    cy.task("getSpecRunVersionName", specRunName)
+      .then((prevSpecRunVersionName) => {
+        if (prevSpecRunVersionName) {
+          cleanUpPreviousRunSetupData(prevSpecRunVersionName);
+          cleanUpRunOktaOrgs(prevSpecRunVersionName);
+        }
+        let data = {
+          specRunName: specRunName,
+          versionName: currentSpecRunVersionName
+        };
+        cy.task("setSpecRunVersionName", data)
+        setupRunData(currentSpecRunVersionName);
+      })
   });
 
-  context("Add devices", () => {
-    beforeEach(() => {
-      cy.intercept("POST", graphqlURL, (req) => {
-        aliasGraphqlOperations(req);
+  beforeEach("alias graphql operations", () => {
+    cy.intercept("POST", graphqlURL, (req) => {
+      aliasGraphqlOperations(req);
+    });
+  })
+
+  it("Adds devices to SimpleReport via admin dashboard", () => {
+    visitAdminCreateDevicePage();
+    cy.contains("Add new device");
+    cy.contains("Save changes").should("be.not.enabled");
+    cy.injectSRAxe();
+    cy.checkAccessibility();
+    cy.addDevice(covidOnlyDevice);
+
+    visitAdminCreateDevicePage();
+    cy.addDevice(multiplexDevice);
+
+    cy.visit("/admin/manage-devices");
+    cy.wait("@getSpecimenTypes");
+    cy.wait("@getSupportedDiseases");
+    cy.wait("@getDeviceTypeList");
+
+    cy.get('input[role="combobox"]').first().type(multiplexDevice.name);
+    cy.get('li[id="selectDevice--list--option-0"]')
+      .contains(multiplexDevice.name)
+      .click();
+    cy.get('input[name="name"]').should("have.value", multiplexDevice.name);
+    cy.injectSRAxe();
+    cy.checkAccessibility();
+    cy.get('input[name="model"]').should("have.value", multiplexDevice.model);
+    cy.get('input[name="manufacturer"]').should(
+      "have.value",
+      multiplexDevice.manufacturer,
+    );
+    cy.get(".pill").should("have.length", 1);
+    cy.get('select[name="supportedDiseases.0.supportedDisease"')
+      .find(":selected")
+      .should("have.text", "COVID-19");
+    cy.get('input[name="supportedDiseases.0.testPerformedLoincCode"]').should(
+      "have.value",
+      "123-456",
+    );
+    cy.get('select[name="supportedDiseases.1.supportedDisease"')
+      .find(":selected")
+      .should("have.text", "Flu A");
+    cy.get('input[name="supportedDiseases.1.testPerformedLoincCode"]').should(
+      "have.value",
+      "456-789",
+    );
+    cy.get('select[name="supportedDiseases.2.supportedDisease"')
+      .find(":selected")
+      .should("have.text", "Flu B");
+    cy.get('input[name="supportedDiseases.2.testPerformedLoincCode"]').should(
+      "have.value",
+      "789-123",
+    );
+  })
+
+  it("Adds devices to a testing facility", () => {
+    accessOrganizationByName(`${currentSpecRunVersionName}-org`);
+    cy.visit(`/settings/facilities`);
+    cy.get(`[data-cy="${currentSpecRunVersionName}-facility-link"]`).click();
+    cy.contains("Manage devices");
+    cy.injectSRAxe();
+    cy.checkAccessibility();
+    cy.get('input[role="combobox"]').first().type(covidOnlyDevice.name);
+    cy.get(
+      `button[aria-label="Select ${covidOnlyDevice.manufacturer} ${covidOnlyDevice.model}"]`,
+    ).click();
+    cy.get('input[role="combobox"]').first().type(multiplexDevice.name);
+    cy.get(
+      `button[aria-label="Select ${multiplexDevice.manufacturer} ${multiplexDevice.model}"]`,
+    ).click();
+    cy.contains("Save changes").click();
+    cy.get(".modal__content")
+      .find("fieldset")
+      .each((fieldset) => {
+        fieldset.find("label").first().trigger("click");
       });
-    });
-
-    it("Adds a covid only device", () => {
-      cy.visit("/admin/create-device-type");
-      cy.wait("@getSpecimenTypes");
-      cy.wait("@getSupportedDiseases");
-      cy.contains("Add new device");
-      cy.contains("Save changes").should("be.not.enabled");
-      cy.injectSRAxe();
-      cy.checkAccessibility();
-      cy.addDevice(covidOnlyDevice);
-    });
-
-    it("Adds a multiplex device", () => {
-      cy.visit("/admin/create-device-type");
-      cy.wait("@getSpecimenTypes");
-      cy.wait("@getSupportedDiseases");
-      cy.addDevice(multiplexDevice);
-    });
-
-    it("Reviews multiplex device in edit page", () => {
-      cy.visit("/admin/manage-devices");
-      cy.wait("@getSpecimenTypes");
-      cy.wait("@getSupportedDiseases");
-      cy.wait("@getDeviceTypeList");
-
-      cy.get('input[role="combobox"]').first().type(multiplexDevice.name);
-      cy.get('li[id="selectDevice--list--option-0"]')
-        .contains(multiplexDevice.name)
-        .click();
-      cy.get('input[name="name"]').should("have.value", multiplexDevice.name);
-      cy.injectSRAxe();
-      cy.checkAccessibility();
-      cy.get('input[name="model"]').should("have.value", multiplexDevice.model);
-      cy.get('input[name="manufacturer"]').should(
-        "have.value",
-        multiplexDevice.manufacturer,
-      );
-      cy.get(".pill").should("have.length", 1);
-      cy.get('select[name="supportedDiseases.0.supportedDisease"')
-        .find(":selected")
-        .should("have.text", "COVID-19");
-      cy.get('input[name="supportedDiseases.0.testPerformedLoincCode"]').should(
-        "have.value",
-        "123-456",
-      );
-      cy.get('select[name="supportedDiseases.1.supportedDisease"')
-        .find(":selected")
-        .should("have.text", "Flu A");
-      cy.get('input[name="supportedDiseases.1.testPerformedLoincCode"]').should(
-        "have.value",
-        "456-789",
-      );
-      cy.get('select[name="supportedDiseases.2.supportedDisease"')
-        .find(":selected")
-        .should("have.text", "Flu B");
-      cy.get('input[name="supportedDiseases.2.testPerformedLoincCode"]').should(
-        "have.value",
-        "789-123",
-      );
-    });
-  });
-
-  context("Manage facilities - add devices", () => {
-    beforeEach(() => {
-      cy.makePOSTRequest({
-        operationName: "WhoAmI",
-        variables: {},
-        query:
-          "query WhoAmI {\n  whoami {\n organization {\n    facilities {\n      id\n      name\n      __typename\n    }\n    __typename\n  }\n} \n}",
-      }).then((res) => {
-        facility = res.body.data.whoami.organization.facilities[0];
-      });
-      cy.intercept("POST", graphqlURL, (req) => {
-        aliasGraphqlOperations(req);
-      });
-    });
-
-    it("Adds covid only and multiplex devices to the facility", () => {
-      cy.visit(`/settings/facility/${facility.id}`);
-      cy.wait("@GetFacilities");
-      cy.contains("Manage devices");
-      cy.injectSRAxe();
-      cy.checkAccessibility();
-      cy.get('input[role="combobox"]').first().type(covidOnlyDevice.name);
-      cy.get(
-        `button[aria-label="Select ${covidOnlyDevice.manufacturer} ${covidOnlyDevice.model}"]`,
-      ).click();
-      cy.get('input[role="combobox"]').first().type(multiplexDevice.name);
-      cy.get(
-        `button[aria-label="Select ${multiplexDevice.manufacturer} ${multiplexDevice.model}"]`,
-      ).click();
-      cy.contains("Save changes").click();
-      cy.get(".modal__content")
-        .find("fieldset")
-        .each((fieldset) => {
-          fieldset.find("label").first().trigger("click");
-        });
-      cy.get('button[id="save-confirmed-address"]').click();
-      cy.wait("@UpdateFacility");
-      cy.get(".Toastify").contains("Updated Facility");
-      cy.wait("@GetManagedFacilities"); // waits until it goes back to manage facilities page
-    });
-  });
+    cy.get('button[id="save-confirmed-address"]').click();
+    cy.wait("@UpdateFacility");
+    cy.get(".Toastify").contains("Updated Facility");
+    cy.wait("@GetManagedFacilities"); // waits until it goes back to manage facilities page
+  })
 });
+
+const visitAdminCreateDevicePage = () => {
+  cy.visit("/admin/create-device-type");
+  cy.wait("@getSpecimenTypes");
+  cy.wait("@getSupportedDiseases");
+}

--- a/cypress/utils/setup-utils.js
+++ b/cypress/utils/setup-utils.js
@@ -244,3 +244,9 @@ export const setupTestOrder = (
       return submitQueueItem(submitQueueItemVariables);
     });
 };
+
+export const accessOrganizationByName = (orgName) => {
+  return getOrganizationsByName(orgName)
+    .then((res) =>
+      accessOrganization(res.body.data.organizationsByName[0].externalId));
+};

--- a/frontend/src/app/Settings/Facility/ManageFacilities.tsx
+++ b/frontend/src/app/Settings/Facility/ManageFacilities.tsx
@@ -31,7 +31,10 @@ const ManageFacilities: React.FC<Props> = ({ facilities }) => {
               {facilities.map((facility) => (
                 <tr key={facility.id}>
                   <td>
-                    <LinkWithQuery to={`/settings/facility/${facility.id}`}>
+                    <LinkWithQuery
+                      to={`/settings/facility/${facility.id}`}
+                      data-cy={`${facility.name}-link`}
+                    >
                       {facility.name}
                     </LinkWithQuery>
                   </td>


### PR DESCRIPTION
# PULL REQUEST

## Related Issue

- Partially resolves #7006
- Separate PR to refactor the test to use `data-cy` attribute for selectors

## Changes Proposed
- Makes the "add devices" e2e spec rerunnable and runnable without having run the previous specs

## Additional Information
- N/A

## Testing
- Cypress tests should pass

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->