### PR TITLE
add new mutations and service methods

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -206,4 +206,16 @@ public class OrganizationMutationResolver {
     }
     return organizationService.markFacilityAsDeleted(facilityId, deleted);
   }
+
+  /**
+   * Method HARD DELETES an Okta group without touching any of the application organization data.
+   * THIS SHOULD ONLY BE USED TO CLEAN UP ORGS CREATED IN OKTA FOR E2E TESTS. DON'T USE THIS METHOD
+   * FOR ANY LIVE OKTA API CALLS
+   */
+  @Transactional
+  @MutationMapping
+  public Organization deleteOktaOrganization(@Argument String orgExternalId) {
+    // throw stuff here?
+    return organizationService.deleteOktaOrganization(orgExternalId);
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -214,7 +214,7 @@ public class OrganizationMutationResolver {
    */
   @Transactional
   @MutationMapping
-  public Organization deleteOktaOrganization(@Argument String orgExternalId) {
-    return organizationService.deleteOktaOrganization(orgExternalId);
+  public Organization deleteE2EOktaOrganizations(@Argument String orgExternalId) {
+    return organizationService.deleteE2EOktaOrganization(orgExternalId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -215,7 +215,6 @@ public class OrganizationMutationResolver {
   @Transactional
   @MutationMapping
   public Organization deleteOktaOrganization(@Argument String orgExternalId) {
-    // throw stuff here?
     return organizationService.deleteOktaOrganization(orgExternalId);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -74,8 +74,9 @@ public class OrganizationResolver {
    */
   @QueryMapping
   @AuthorizationConfiguration.RequireGlobalAdminUser
-  public List<ApiOrganization> organizationsByName(@Argument String name) {
-    List<Organization> orgs = _organizationService.getOrganizationsByName(name);
+  public List<ApiOrganization> organizationsByName(
+      @Argument String name, @Argument Boolean isDeleted) {
+    List<Organization> orgs = _organizationService.getOrganizationsByName(name, isDeleted);
     if (orgs.isEmpty()) {
       return List.of();
     } else {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -12,6 +12,9 @@ public interface OrganizationRepository extends EternalAuditedEntityRepository<O
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.externalId = :externalId")
   Optional<Organization> findByExternalId(String externalId);
 
+  @Query(EternalAuditedEntityRepository.BASE_ALLOW_DELETED_QUERY + " e.externalId = :externalId")
+  Optional<Organization> findByExternalIdIncludingDeleted(String externalId);
+
   @Query(EternalAuditedEntityRepository.BASE_QUERY + " and e.externalId in (:externalIds)")
   List<Organization> findAllByExternalId(Collection<String> externalIds);
 
@@ -23,4 +26,9 @@ public interface OrganizationRepository extends EternalAuditedEntityRepository<O
   @Query(
       EternalAuditedEntityRepository.BASE_QUERY + " and UPPER(e.organizationName) = UPPER(:name)")
   List<Organization> findAllByName(String name);
+
+  @Query(
+      EternalAuditedEntityRepository.BASE_ALLOW_DELETED_QUERY
+          + " UPPER(e.organizationName) = UPPER(:name) and e.isDeleted = :isDeleted")
+  List<Organization> findAllByNameAndDeleted(String name, Boolean isDeleted);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -504,7 +504,7 @@ public class OrganizationService {
    * ANY LIVE OKTA API CALLS
    */
   @AuthorizationConfiguration.RequireGlobalAdminUser
-  public Organization deleteOktaOrganization(String orgExternalId) {
+  public Organization deleteE2EOktaOrganization(String orgExternalId) {
     Organization orgToDelete =
         organizationRepository
             .findByExternalIdIncludingDeleted(orgExternalId)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -153,6 +153,10 @@ public class OrganizationService {
     return organizationRepository.findAllByName(name);
   }
 
+  public List<Organization> getOrganizationsByName(String name, Boolean isDeleted) {
+    return organizationRepository.findAllByNameAndDeleted(name, isDeleted);
+  }
+
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public List<Organization> getOrganizations(Boolean identityVerified) {
     return identityVerified == null
@@ -492,5 +496,20 @@ public class OrganizationService {
             })
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Method HARD DELETES an Okta group without touching any of the application organization data.
+   * SHOULD ONLY BE USED TO CLEAN UP ORGS CREATED IN OKTA FOR E2E TESTS. DON'T USE THIS METHOD FOR
+   * ANY LIVE OKTA API CALLS
+   */
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public Organization deleteOktaOrganization(String orgExternalId) {
+    Organization orgToDelete =
+        organizationRepository
+            .findByExternalIdIncludingDeleted(orgExternalId)
+            .orElseThrow(NonexistentOrgException::new);
+    oktaRepository.deleteOrganization(orgToDelete);
+    return orgToDelete;
   }
 }

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -65,5 +65,5 @@ extend type Mutation {
     facilities: [ID] = [],
     role: Role!): User!
   updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag
-  deleteOktaOrganization(orgExternalId: String!): Organization
+  deleteE2EOktaOrganizations(orgExternalId: String!): Organization
 }

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -3,7 +3,7 @@
 # which is enforced in the API not in the schema validator.
 extend type Query {
   organizations(identityVerified: Boolean): [Organization!]!
-  organizationsByName(name: String!): [Organization]
+  organizationsByName(name: String!, isDeleted: Boolean = false): [Organization]
   pendingOrganizations: [PendingOrganization!]!
   organization(id: ID!): Organization
   facilityStats(facilityId: ID!): FacilityStats
@@ -65,4 +65,5 @@ extend type Mutation {
     facilities: [ID] = [],
     role: Role!): User!
   updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag
+  deleteOktaOrganization(orgExternalId: String!): Organization
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -84,7 +84,7 @@ class OrganizationResolverTest {
     Organization org = new Organization(orgName, "type", "123", true);
     when(organizationService.getOrganizationsByName(orgName)).thenReturn(List.of(org));
 
-    organizationMutationResolver.organizationsByName(orgName);
+    organizationMutationResolver.organizationsByName(orgName, false);
 
     verify(organizationService).getOrganizationsByName(orgName);
     verify(organizationService).getFacilities(org);
@@ -96,7 +96,7 @@ class OrganizationResolverTest {
     Organization org = new Organization(orgName, "type", "123", true);
     when(organizationService.getOrganizationsByName(orgName)).thenReturn(List.of());
 
-    List<ApiOrganization> actual = organizationMutationResolver.organizationsByName(orgName);
+    List<ApiOrganization> actual = organizationMutationResolver.organizationsByName(orgName, false);
 
     assertThat(actual).isEmpty();
     verify(organizationService).getOrganizationsByName(orgName);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -102,4 +102,16 @@ class OrganizationResolverTest {
     verify(organizationService).getOrganizationsByName(orgName);
     verify(organizationService, never()).getFacilities(org);
   }
+
+  @Test
+  void organizationsByNameIsDeleted_success() {
+    String orgName = "org name";
+    Organization org = new Organization(orgName, "type", "123", true);
+    when(organizationService.getOrganizationsByName(orgName, true)).thenReturn(List.of(org));
+
+    organizationMutationResolver.organizationsByName(orgName, true);
+
+    verify(organizationService).getOrganizationsByName(orgName, true);
+    verify(organizationService).getFacilities(org);
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -82,11 +82,11 @@ class OrganizationResolverTest {
   void organizationsByName_success() {
     String orgName = "org name";
     Organization org = new Organization(orgName, "type", "123", true);
-    when(organizationService.getOrganizationsByName(orgName)).thenReturn(List.of(org));
+    when(organizationService.getOrganizationsByName(orgName, false)).thenReturn(List.of(org));
 
     organizationMutationResolver.organizationsByName(orgName, false);
 
-    verify(organizationService).getOrganizationsByName(orgName);
+    verify(organizationService).getOrganizationsByName(orgName, false);
     verify(organizationService).getFacilities(org);
   }
 
@@ -94,12 +94,12 @@ class OrganizationResolverTest {
   void organizationsByName_null() {
     String orgName = "org name";
     Organization org = new Organization(orgName, "type", "123", true);
-    when(organizationService.getOrganizationsByName(orgName)).thenReturn(List.of());
+    when(organizationService.getOrganizationsByName(orgName, false)).thenReturn(List.of());
 
     List<ApiOrganization> actual = organizationMutationResolver.organizationsByName(orgName, false);
 
     assertThat(actual).isEmpty();
-    verify(organizationService).getOrganizationsByName(orgName);
+    verify(organizationService).getOrganizationsByName(orgName, false);
     verify(organizationService, never()).getFacilities(org);
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -36,13 +36,11 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,475 +51,463 @@ import org.springframework.security.access.AccessDeniedException;
 
 class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
-    @Autowired
-    private TestDataFactory testDataFactory;
-    @Autowired
-    private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
-    @Autowired
-    @SpyBean
-    private FacilityRepository facilityRepository;
-    @Autowired
-    private OrganizationRepository organizationRepository;
-    @Autowired
-    private DeviceTypeRepository deviceTypeRepository;
-    @Autowired
-    @SpyBean
-    private OktaRepository oktaRepository;
-    @Autowired
-    @SpyBean
-    private PersonRepository personRepository;
-    @Autowired
-    ApiUserRepository _apiUserRepo;
-    @Autowired
-    private DemoUserConfiguration userConfiguration;
+  @Autowired private TestDataFactory testDataFactory;
+  @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
+  @Autowired @SpyBean private FacilityRepository facilityRepository;
+  @Autowired private OrganizationRepository organizationRepository;
+  @Autowired private DeviceTypeRepository deviceTypeRepository;
+  @Autowired @SpyBean private OktaRepository oktaRepository;
+  @Autowired @SpyBean private PersonRepository personRepository;
+  @Autowired ApiUserRepository _apiUserRepo;
+  @Autowired private DemoUserConfiguration userConfiguration;
+
+  @BeforeEach
+  void setupData() {
+    initSampleData();
+  }
+
+  @Test
+  void getCurrentOrg_success() {
+    Organization org = _service.getCurrentOrganization();
+    assertNotNull(org);
+    assertEquals("DIS_ORG", org.getExternalId());
+  }
+
+  @Test
+  void getOrganizationById_success() {
+    Organization createdOrg = _dataFactory.saveValidOrganization();
+    Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
+    assertNotNull(foundOrg);
+    assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
+  }
+
+  @Test
+  void getOrganizationById_failure() {
+    UUID fakeUUID = UUID.randomUUID();
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class, () -> _service.getOrganizationById(fakeUUID));
+    assertEquals(
+        "An organization with internal_id=" + fakeUUID + " does not exist", caught.getMessage());
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getOrganizationWithExternalIdAsSiteAdmin_success() {
+    Organization createdOrg = _dataFactory.saveValidOrganization();
+    Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
+    assertNotNull(foundOrg);
+    assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
+  }
+
+  @Test
+  void createOrganizationAndFacility_success() {
+    // GIVEN
+    PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "");
+
+    // WHEN
+    Organization org =
+        _service.createOrganizationAndFacility(
+            "Tim's org",
+            "k12",
+            "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
+            "Facility 1",
+            "12345",
+            getAddress(),
+            "123-456-7890",
+            "test@foo.com",
+            List.of(getDeviceConfig().getInternalId()),
+            orderingProviderName,
+            getAddress(),
+            "123-456-7890",
+            "547329472");
+    // THEN
+    assertEquals("Tim's org", org.getOrganizationName());
+    assertFalse(org.getIdentityVerified());
+    assertEquals("d6b3951b-6698-4ee7-9d63-aaadee85bac0", org.getExternalId());
+    List<Facility> facilities = _service.getFacilities(org);
+    assertNotNull(facilities);
+    assertEquals(1, facilities.size());
+
+    Facility fac = facilities.get(0);
+    assertEquals("Facility 1", fac.getFacilityName());
+    assertNull(fac.getDefaultDeviceType());
+
+    PatientSelfRegistrationLink orgLink =
+        patientRegistrationLinkRepository.findByOrganization(org).get();
+    PatientSelfRegistrationLink facLink =
+        patientRegistrationLinkRepository.findByFacility(fac).get();
+    assertEquals(5, orgLink.getLink().length());
+    assertEquals(5, facLink.getLink().length());
+  }
+
+  private DeviceType getDeviceConfig() {
+    return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1");
+  }
+
+  @Test
+  void createOrganizationAndFacility_orderingProviderRequired_failure() {
+    // GIVEN
+    PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
+    StreetAddress mockAddress = getAddress();
+    List<UUID> deviceTypeIds = List.of(getDeviceConfig().getInternalId());
+
+    // THEN
+    assertThrows(
+        OrderingProviderRequiredException.class,
+        () ->
+            _service.createOrganizationAndFacility(
+                "Adam's org",
+                "urgent_care",
+                "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
+                "Facility 1",
+                "12345",
+                mockAddress,
+                "123-456-7890",
+                "test@foo.com",
+                deviceTypeIds,
+                orderProviderName,
+                mockAddress,
+                null,
+                null));
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getOrganizationsAndFacility_filterByIdentityVerified_success() {
+    // GIVEN
+    Organization verifiedOrg = testDataFactory.saveValidOrganization();
+    Organization unverifiedOrg = testDataFactory.saveUnverifiedOrganization();
+
+    // WHEN
+    List<Organization> allOrgs = _service.getOrganizations(null);
+    List<Organization> verifiedOrgs = _service.getOrganizations(true);
+    List<Organization> unverifiedOrgs = _service.getOrganizations(false);
+
+    // THEN
+    assertTrue(allOrgs.size() >= 2);
+    Set<String> allOrgIds =
+        allOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
+    assertTrue(allOrgIds.contains(verifiedOrg.getExternalId()));
+    assertTrue(allOrgIds.contains(unverifiedOrg.getExternalId()));
+
+    assertTrue(verifiedOrgs.size() >= 1);
+    Set<String> verifiedOrgIds =
+        verifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
+    assertTrue(verifiedOrgIds.contains(verifiedOrg.getExternalId()));
+    assertFalse(verifiedOrgIds.contains(unverifiedOrg.getExternalId()));
+
+    assertEquals(1, unverifiedOrgs.size());
+    Set<String> unverifiedOrgIds =
+        unverifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
+    assertFalse(unverifiedOrgIds.contains(verifiedOrg.getExternalId()));
+    assertTrue(unverifiedOrgIds.contains(unverifiedOrg.getExternalId()));
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getFacilitiesIncludeArchived_includeArchived_success() {
+    Organization org = testDataFactory.saveValidOrganization();
+    Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
+    testDataFactory.createValidFacility(org, "Not deleted");
+
+    Set<Facility> archivedFacilities = _service.getFacilitiesIncludeArchived(org, true);
+
+    assertEquals(1, archivedFacilities.size());
+    assertTrue(
+        archivedFacilities.stream()
+            .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getFacilitiesIncludeArchived_excludeArchived_success() {
+    Organization org = testDataFactory.saveValidOrganization();
+    testDataFactory.createArchivedFacility(org, "Delete me");
+    Facility activeFacility = testDataFactory.createValidFacility(org, "Not deleted");
+
+    Set<Facility> facilities = _service.getFacilitiesIncludeArchived(org, false);
+
+    assertEquals(1, facilities.size());
+    assertTrue(
+        facilities.stream()
+            .anyMatch(f -> f.getInternalId().equals(activeFacility.getInternalId())));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void viewArchivedFacilities_success() {
+    Organization org = testDataFactory.saveValidOrganization();
+    Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
+
+    Set<Facility> archivedFacilities = _service.getArchivedFacilities(org);
+
+    assertTrue(
+        archivedFacilities.stream()
+            .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void viewArchivedFacilities_standardUser_failure() {
+    Organization org = testDataFactory.saveValidOrganization();
+    testDataFactory.createArchivedFacility(org, "Delete me");
+
+    assertThrows(AccessDeniedException.class, () -> _service.getArchivedFacilities());
+  }
+
+  @Test
+  @DisplayName("it should allow global admins to mark facility as deleted")
+  @WithSimpleReportSiteAdminUser
+  void deleteFacilityTest_successful() {
+    // GIVEN
+    Organization verifiedOrg = testDataFactory.saveValidOrganization();
+    Facility mistakeFacility =
+        testDataFactory.createValidFacility(verifiedOrg, "This facility is a mistake");
+    // WHEN
+    Facility deletedFacility =
+        _service.markFacilityAsDeleted(mistakeFacility.getInternalId(), true);
+    // THEN
+    assertThat(deletedFacility.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("it should not delete nonexistent facilities")
+  @WithSimpleReportSiteAdminUser
+  void deletedFacilityTest_throwsErrorWhenFacilityNotFound() {
+    UUID orgId = UUID.randomUUID();
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            // fake UUID
+            () -> _service.markFacilityAsDeleted(orgId, true));
+    assertEquals("Facility not found.", caught.getMessage());
+  }
+
+  @Test
+  @DisplayName("it should allow global admins to mark organizations as deleted")
+  @WithSimpleReportSiteAdminUser
+  void deleteOrganizationTest_successful() {
+    // GIVEN
+    Organization verifiedOrg = testDataFactory.saveValidOrganization();
+    // WHEN
+    Organization deletedOrganization =
+        _service.markOrganizationAsDeleted(verifiedOrg.getInternalId(), true);
+    // THEN
+    assertThat(deletedOrganization.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("it should not delete nonexistent organizations")
+  @WithSimpleReportSiteAdminUser
+  void deletedOrganizationTest_throwsErrorWhenOrganizationyNotFound() {
+    UUID orgId = UUID.randomUUID();
+
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            // fake UUID
+            () -> _service.markOrganizationAsDeleted(orgId, true));
+    assertEquals("Organization not found.", caught.getMessage());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void adminUpdateOrganization_not_allowed() {
+    assertSecurityError(() -> _service.updateOrganization("Foo org", "k12"));
+  }
+
+  @Test
+  void verifyOrganizationNoPermissions_noUser_success() {
+    Organization org = testDataFactory.saveUnverifiedOrganization();
+    _service.verifyOrganizationNoPermissions(org.getExternalId());
+
+    org = _service.getOrganization(org.getExternalId());
+    assertTrue(org.getIdentityVerified());
+  }
+
+  @Test
+  void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
+    Organization org = testDataFactory.saveValidOrganization();
+    String orgExternalId = org.getExternalId();
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> _service.verifyOrganizationNoPermissions(orgExternalId));
+
+    assertEquals("Organization is already verified.", e.getMessage());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void getPermissibleOrgId_allowsAccessToCurrentOrg() {
+    var actual = _service.getPermissibleOrgId(_service.getCurrentOrganization().getInternalId());
+    assertEquals(actual, _service.getCurrentOrganization().getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void getPermissibleOrgId_nullIdFallsBackToCurrentOrg() {
+    var actual = _service.getPermissibleOrgId(null);
+    assertEquals(actual, _service.getCurrentOrganization().getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void getPermissibleOrgId_throwsAccessDeniedForInaccessibleOrg() {
+    var inaccessibleOrgId = UUID.randomUUID();
+    assertThrows(
+        AccessDeniedException.class, () -> _service.getPermissibleOrgId(inaccessibleOrgId));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getFacilityStats_notAuthorizedError() {
+    UUID facilityId = UUID.randomUUID();
+    assertThrows(AccessDeniedException.class, () -> _service.getFacilityStats(facilityId));
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getFacilityStats_argumentMissingError() {
+    assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getFacilityStats_facilityNotFoundError() {
+    UUID facilityId = UUID.randomUUID();
+    doReturn(Optional.empty()).when(this.facilityRepository).findById(facilityId);
+    assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getFacilityStats_success() {
+    UUID facilityId = UUID.randomUUID();
+    Facility mockFacility = mock(Facility.class);
+    doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
+    doReturn(2).when(oktaRepository).getUsersInSingleFacility(mockFacility);
+    doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
+    FacilityStats stats = _service.getFacilityStats(facilityId);
+    assertEquals(2, stats.getUsersSingleAccessCount());
+    assertEquals(1, stats.getPatientsSingleAccessCount());
+  }
+
+  @Nested
+  @DisplayName("When updating a facility")
+  class UpdateFacilityTest {
+    private Facility facility;
+    private StreetAddress newFacilityAddress;
+    private StreetAddress newOrderingProviderAddress;
 
     @BeforeEach
-    void setupData() {
-        initSampleData();
+    void beforeEach() {
+      // GIVEN
+      List<Organization> disOrgs = organizationRepository.findAllByName("Dis Organization");
+      assertThat(disOrgs).hasSize(1);
+      Organization disOrg = disOrgs.get(0);
+
+      facility =
+          facilityRepository.findByOrganizationAndFacilityName(disOrg, "Injection Site").get();
+      assertThat(facility).isNotNull();
+      List<DeviceType> devices = deviceTypeRepository.findAll();
+
+      newFacilityAddress = new StreetAddress("0", "1", "2", "3", "4", "5");
+      newOrderingProviderAddress = new StreetAddress("6", "7", "8", "9", "10", "11");
+      PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "Jr.");
+
+      // WHEN
+      _service.updateFacility(
+          facility.getInternalId(),
+          "new name",
+          "new clia",
+          newFacilityAddress,
+          "817-555-6666",
+          "facility@dis.org",
+          orderingProviderName,
+          newOrderingProviderAddress,
+          "npi",
+          "817-555-7777",
+          List.of(devices.get(0).getInternalId(), devices.get(1).getInternalId()));
     }
 
     @Test
-    void getCurrentOrg_success() {
-        Organization org = _service.getCurrentOrganization();
-        assertNotNull(org);
-        assertEquals("DIS_ORG", org.getExternalId());
-    }
-
-    @Test
-    void getOrganizationById_success() {
-        Organization createdOrg = _dataFactory.saveValidOrganization();
-        Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
-        assertNotNull(foundOrg);
-        assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
-    }
-
-    @Test
-    void getOrganizationById_failure() {
-        UUID fakeUUID = UUID.randomUUID();
-        IllegalGraphqlArgumentException caught =
-                assertThrows(
-                        IllegalGraphqlArgumentException.class, () -> _service.getOrganizationById(fakeUUID));
-        assertEquals(
-                "An organization with internal_id=" + fakeUUID + " does not exist", caught.getMessage());
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getOrganizationWithExternalIdAsSiteAdmin_success() {
-        Organization createdOrg = _dataFactory.saveValidOrganization();
-        Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
-        assertNotNull(foundOrg);
-        assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
-    }
-
-    @Test
-    void createOrganizationAndFacility_success() {
-        // GIVEN
-        PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "");
-
-        // WHEN
-        Organization org =
-                _service.createOrganizationAndFacility(
-                        "Tim's org",
-                        "k12",
-                        "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
-                        "Facility 1",
-                        "12345",
-                        getAddress(),
-                        "123-456-7890",
-                        "test@foo.com",
-                        List.of(getDeviceConfig().getInternalId()),
-                        orderingProviderName,
-                        getAddress(),
-                        "123-456-7890",
-                        "547329472");
-        // THEN
-        assertEquals("Tim's org", org.getOrganizationName());
-        assertFalse(org.getIdentityVerified());
-        assertEquals("d6b3951b-6698-4ee7-9d63-aaadee85bac0", org.getExternalId());
-        List<Facility> facilities = _service.getFacilities(org);
-        assertNotNull(facilities);
-        assertEquals(1, facilities.size());
-
-        Facility fac = facilities.get(0);
-        assertEquals("Facility 1", fac.getFacilityName());
-        assertNull(fac.getDefaultDeviceType());
-
-        PatientSelfRegistrationLink orgLink =
-                patientRegistrationLinkRepository.findByOrganization(org).get();
-        PatientSelfRegistrationLink facLink =
-                patientRegistrationLinkRepository.findByFacility(fac).get();
-        assertEquals(5, orgLink.getLink().length());
-        assertEquals(5, facLink.getLink().length());
-    }
-
-    private DeviceType getDeviceConfig() {
-        return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1");
-    }
-
-    @Test
-    void createOrganizationAndFacility_orderingProviderRequired_failure() {
-        // GIVEN
-        PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
-        StreetAddress mockAddress = getAddress();
-        List<UUID> deviceTypeIds = List.of(getDeviceConfig().getInternalId());
-
-        // THEN
-        assertThrows(
-                OrderingProviderRequiredException.class,
-                () ->
-                        _service.createOrganizationAndFacility(
-                                "Adam's org",
-                                "urgent_care",
-                                "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
-                                "Facility 1",
-                                "12345",
-                                mockAddress,
-                                "123-456-7890",
-                                "test@foo.com",
-                                deviceTypeIds,
-                                orderProviderName,
-                                mockAddress,
-                                null,
-                                null));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getOrganizationsAndFacility_filterByIdentityVerified_success() {
-        // GIVEN
-        Organization verifiedOrg = testDataFactory.saveValidOrganization();
-        Organization unverifiedOrg = testDataFactory.saveUnverifiedOrganization();
-
-        // WHEN
-        List<Organization> allOrgs = _service.getOrganizations(null);
-        List<Organization> verifiedOrgs = _service.getOrganizations(true);
-        List<Organization> unverifiedOrgs = _service.getOrganizations(false);
-
-        // THEN
-        assertTrue(allOrgs.size() >= 2);
-        Set<String> allOrgIds =
-                allOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
-        assertTrue(allOrgIds.contains(verifiedOrg.getExternalId()));
-        assertTrue(allOrgIds.contains(unverifiedOrg.getExternalId()));
-
-        assertTrue(verifiedOrgs.size() >= 1);
-        Set<String> verifiedOrgIds =
-                verifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
-        assertTrue(verifiedOrgIds.contains(verifiedOrg.getExternalId()));
-        assertFalse(verifiedOrgIds.contains(unverifiedOrg.getExternalId()));
-
-        assertEquals(1, unverifiedOrgs.size());
-        Set<String> unverifiedOrgIds =
-                unverifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
-        assertFalse(unverifiedOrgIds.contains(verifiedOrg.getExternalId()));
-        assertTrue(unverifiedOrgIds.contains(unverifiedOrg.getExternalId()));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getFacilitiesIncludeArchived_includeArchived_success() {
-        Organization org = testDataFactory.saveValidOrganization();
-        Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
-        testDataFactory.createValidFacility(org, "Not deleted");
-
-        Set<Facility> archivedFacilities = _service.getFacilitiesIncludeArchived(org, true);
-
-        assertEquals(1, archivedFacilities.size());
-        assertTrue(
-                archivedFacilities.stream()
-                        .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getFacilitiesIncludeArchived_excludeArchived_success() {
-        Organization org = testDataFactory.saveValidOrganization();
-        testDataFactory.createArchivedFacility(org, "Delete me");
-        Facility activeFacility = testDataFactory.createValidFacility(org, "Not deleted");
-
-        Set<Facility> facilities = _service.getFacilitiesIncludeArchived(org, false);
-
-        assertEquals(1, facilities.size());
-        assertTrue(
-                facilities.stream()
-                        .anyMatch(f -> f.getInternalId().equals(activeFacility.getInternalId())));
-    }
-
-    @Test
+    @DisplayName("it should update the facility with new values")
     @WithSimpleReportOrgAdminUser
-    void viewArchivedFacilities_success() {
-        Organization org = testDataFactory.saveValidOrganization();
-        Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
+    void updateFacilityTest() {
+      // THEN
+      Facility updatedFacility = facilityRepository.findById(facility.getInternalId()).get();
 
-        Set<Facility> archivedFacilities = _service.getArchivedFacilities(org);
+      assertThat(updatedFacility).isNotNull();
+      assertThat(updatedFacility.getFacilityName()).isEqualTo("new name");
+      assertThat(updatedFacility.getCliaNumber()).isEqualTo("new clia");
+      assertThat(updatedFacility.getTelephone()).isEqualTo("817-555-6666");
+      assertThat(updatedFacility.getEmail()).isEqualTo("facility@dis.org");
+      assertThat(updatedFacility.getAddress()).isEqualTo(newFacilityAddress);
 
-        assertTrue(
-                archivedFacilities.stream()
-                        .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
+      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getFirstName())
+          .isEqualTo("Bill");
+      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getMiddleName())
+          .isEqualTo("Foo");
+      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getLastName())
+          .isEqualTo("Nye");
+      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getSuffix()).isEqualTo("Jr.");
+      assertThat(updatedFacility.getOrderingProvider().getProviderId()).isEqualTo("npi");
+      assertThat(updatedFacility.getOrderingProvider().getAddress())
+          .isEqualTo(newOrderingProviderAddress);
+
+      assertThat(updatedFacility.getDeviceTypes()).hasSize(2);
     }
+  }
 
-    @Test
-    @WithSimpleReportStandardUser
-    void viewArchivedFacilities_standardUser_failure() {
-        Organization org = testDataFactory.saveValidOrganization();
-        testDataFactory.createArchivedFacility(org, "Delete me");
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getOrgAdminUserIds_success() {
+    Organization createdOrg = _dataFactory.saveValidOrganization();
+    List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(createdOrg);
 
-        assertThrows(AccessDeniedException.class, () -> _service.getArchivedFacilities());
-    }
+    List<UUID> expectedIds =
+        adminUserEmails.stream()
+            .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
+            .collect(Collectors.toList());
 
-    @Test
-    @DisplayName("it should allow global admins to mark facility as deleted")
-    @WithSimpleReportSiteAdminUser
-    void deleteFacilityTest_successful() {
-        // GIVEN
-        Organization verifiedOrg = testDataFactory.saveValidOrganization();
-        Facility mistakeFacility =
-                testDataFactory.createValidFacility(verifiedOrg, "This facility is a mistake");
-        // WHEN
-        Facility deletedFacility =
-                _service.markFacilityAsDeleted(mistakeFacility.getInternalId(), true);
-        // THEN
-        assertThat(deletedFacility.isDeleted()).isTrue();
-    }
+    List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
+    assertThat(adminIds).isEqualTo(expectedIds);
+  }
 
-    @Test
-    @DisplayName("it should not delete nonexistent facilities")
-    @WithSimpleReportSiteAdminUser
-    void deletedFacilityTest_throwsErrorWhenFacilityNotFound() {
-        UUID orgId = UUID.randomUUID();
-        IllegalGraphqlArgumentException caught =
-                assertThrows(
-                        IllegalGraphqlArgumentException.class,
-                        // fake UUID
-                        () -> _service.markFacilityAsDeleted(orgId, true));
-        assertEquals("Facility not found.", caught.getMessage());
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getOrgAdminUserIds_throws_forNonExistentOrg() {
+    UUID mismatchedUUID = UUID.fromString("5ebf893a-bb57-48ca-8fc2-1ef6b25e465b");
+    assertThrows(NonexistentOrgException.class, () -> _service.getOrgAdminUserIds(mismatchedUUID));
+  }
 
-    @Test
-    @DisplayName("it should allow global admins to mark organizations as deleted")
-    @WithSimpleReportSiteAdminUser
-    void deleteOrganizationTest_successful() {
-        // GIVEN
-        Organization verifiedOrg = testDataFactory.saveValidOrganization();
-        // WHEN
-        Organization deletedOrganization =
-                _service.markOrganizationAsDeleted(verifiedOrg.getInternalId(), true);
-        // THEN
-        assertThat(deletedOrganization.isDeleted()).isTrue();
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getOrgAdminUserIds_skipsUser_forNonExistentUserInOrg() {
+    Organization createdOrg = _dataFactory.saveValidOrganization();
+    List<String> listWithAnExtraEmail = oktaRepository.fetchAdminUserEmail(createdOrg);
+    listWithAnExtraEmail.add("nonexistent@example.com");
 
-    @Test
-    @DisplayName("it should not delete nonexistent organizations")
-    @WithSimpleReportSiteAdminUser
-    void deletedOrganizationTest_throwsErrorWhenOrganizationyNotFound() {
-        UUID orgId = UUID.randomUUID();
+    when(oktaRepository.fetchAdminUserEmail(createdOrg)).thenReturn(listWithAnExtraEmail);
+    List<UUID> expectedIds =
+        listWithAnExtraEmail.stream()
+            .filter(email -> !email.equals("nonexistent@example.com"))
+            .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
+            .collect(Collectors.toList());
 
-        IllegalGraphqlArgumentException caught =
-                assertThrows(
-                        IllegalGraphqlArgumentException.class,
-                        // fake UUID
-                        () -> _service.markOrganizationAsDeleted(orgId, true));
-        assertEquals("Organization not found.", caught.getMessage());
-    }
+    List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
+    assertThat(adminIds).isEqualTo(expectedIds);
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void adminUpdateOrganization_not_allowed() {
-        assertSecurityError(() -> _service.updateOrganization("Foo org", "k12"));
-    }
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void deleteOktaOrganization_succeeds() {
+    Organization createdOrg = _dataFactory.saveValidOrganization();
+    Organization deletedOrg = _service.deleteOktaOrganization(createdOrg.getExternalId());
 
-    @Test
-    void verifyOrganizationNoPermissions_noUser_success() {
-        Organization org = testDataFactory.saveUnverifiedOrganization();
-        _service.verifyOrganizationNoPermissions(org.getExternalId());
-
-        org = _service.getOrganization(org.getExternalId());
-        assertTrue(org.getIdentityVerified());
-    }
-
-    @Test
-    void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
-        Organization org = testDataFactory.saveValidOrganization();
-        String orgExternalId = org.getExternalId();
-        IllegalStateException e =
-                assertThrows(
-                        IllegalStateException.class,
-                        () -> _service.verifyOrganizationNoPermissions(orgExternalId));
-
-        assertEquals("Organization is already verified.", e.getMessage());
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void getPermissibleOrgId_allowsAccessToCurrentOrg() {
-        var actual = _service.getPermissibleOrgId(_service.getCurrentOrganization().getInternalId());
-        assertEquals(actual, _service.getCurrentOrganization().getInternalId());
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void getPermissibleOrgId_nullIdFallsBackToCurrentOrg() {
-        var actual = _service.getPermissibleOrgId(null);
-        assertEquals(actual, _service.getCurrentOrganization().getInternalId());
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void getPermissibleOrgId_throwsAccessDeniedForInaccessibleOrg() {
-        var inaccessibleOrgId = UUID.randomUUID();
-        assertThrows(
-                AccessDeniedException.class, () -> _service.getPermissibleOrgId(inaccessibleOrgId));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getFacilityStats_notAuthorizedError() {
-        UUID facilityId = UUID.randomUUID();
-        assertThrows(AccessDeniedException.class, () -> _service.getFacilityStats(facilityId));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getFacilityStats_argumentMissingError() {
-        assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getFacilityStats_facilityNotFoundError() {
-        UUID facilityId = UUID.randomUUID();
-        doReturn(Optional.empty()).when(this.facilityRepository).findById(facilityId);
-        assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getFacilityStats_success() {
-        UUID facilityId = UUID.randomUUID();
-        Facility mockFacility = mock(Facility.class);
-        doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
-        doReturn(2).when(oktaRepository).getUsersInSingleFacility(mockFacility);
-        doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
-        FacilityStats stats = _service.getFacilityStats(facilityId);
-        assertEquals(2, stats.getUsersSingleAccessCount());
-        assertEquals(1, stats.getPatientsSingleAccessCount());
-    }
-
-    @Nested
-    @DisplayName("When updating a facility")
-    class UpdateFacilityTest {
-        private Facility facility;
-        private StreetAddress newFacilityAddress;
-        private StreetAddress newOrderingProviderAddress;
-
-        @BeforeEach
-        void beforeEach() {
-            // GIVEN
-            List<Organization> disOrgs = organizationRepository.findAllByName("Dis Organization");
-            assertThat(disOrgs).hasSize(1);
-            Organization disOrg = disOrgs.get(0);
-
-            facility =
-                    facilityRepository.findByOrganizationAndFacilityName(disOrg, "Injection Site").get();
-            assertThat(facility).isNotNull();
-            List<DeviceType> devices = deviceTypeRepository.findAll();
-
-            newFacilityAddress = new StreetAddress("0", "1", "2", "3", "4", "5");
-            newOrderingProviderAddress = new StreetAddress("6", "7", "8", "9", "10", "11");
-            PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "Jr.");
-
-            // WHEN
-            _service.updateFacility(
-                    facility.getInternalId(),
-                    "new name",
-                    "new clia",
-                    newFacilityAddress,
-                    "817-555-6666",
-                    "facility@dis.org",
-                    orderingProviderName,
-                    newOrderingProviderAddress,
-                    "npi",
-                    "817-555-7777",
-                    List.of(devices.get(0).getInternalId(), devices.get(1).getInternalId()));
-        }
-
-        @Test
-        @DisplayName("it should update the facility with new values")
-        @WithSimpleReportOrgAdminUser
-        void updateFacilityTest() {
-            // THEN
-            Facility updatedFacility = facilityRepository.findById(facility.getInternalId()).get();
-
-            assertThat(updatedFacility).isNotNull();
-            assertThat(updatedFacility.getFacilityName()).isEqualTo("new name");
-            assertThat(updatedFacility.getCliaNumber()).isEqualTo("new clia");
-            assertThat(updatedFacility.getTelephone()).isEqualTo("817-555-6666");
-            assertThat(updatedFacility.getEmail()).isEqualTo("facility@dis.org");
-            assertThat(updatedFacility.getAddress()).isEqualTo(newFacilityAddress);
-
-            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getFirstName())
-                    .isEqualTo("Bill");
-            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getMiddleName())
-                    .isEqualTo("Foo");
-            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getLastName())
-                    .isEqualTo("Nye");
-            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getSuffix()).isEqualTo("Jr.");
-            assertThat(updatedFacility.getOrderingProvider().getProviderId()).isEqualTo("npi");
-            assertThat(updatedFacility.getOrderingProvider().getAddress())
-                    .isEqualTo(newOrderingProviderAddress);
-
-            assertThat(updatedFacility.getDeviceTypes()).hasSize(2);
-        }
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getOrgAdminUserIds_success() {
-        Organization createdOrg = _dataFactory.saveValidOrganization();
-        List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(createdOrg);
-
-        List<UUID> expectedIds =
-                adminUserEmails.stream()
-                        .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
-                        .collect(Collectors.toList());
-
-        List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
-        assertThat(adminIds).isEqualTo(expectedIds);
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getOrgAdminUserIds_throws_forNonExistentOrg() {
-        UUID mismatchedUUID = UUID.fromString("5ebf893a-bb57-48ca-8fc2-1ef6b25e465b");
-        assertThrows(NonexistentOrgException.class, () -> _service.getOrgAdminUserIds(mismatchedUUID));
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void getOrgAdminUserIds_skipsUser_forNonExistentUserInOrg() {
-        Organization createdOrg = _dataFactory.saveValidOrganization();
-        List<String> listWithAnExtraEmail = oktaRepository.fetchAdminUserEmail(createdOrg);
-        listWithAnExtraEmail.add("nonexistent@example.com");
-
-        when(oktaRepository.fetchAdminUserEmail(createdOrg)).thenReturn(listWithAnExtraEmail);
-        List<UUID> expectedIds =
-                listWithAnExtraEmail.stream()
-                        .filter(email -> !email.equals("nonexistent@example.com"))
-                        .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
-                        .collect(Collectors.toList());
-
-        List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
-        assertThat(adminIds).isEqualTo(expectedIds);
-    }
-
-    @Test
-    @WithSimpleReportSiteAdminUser
-    void deleteOktaOrganization_succeeds() {
-        Organization createdOrg = _dataFactory.saveValidOrganization();
-        Organization deletedOrg = _service.deleteOktaOrganization(createdOrg.getExternalId());
-
-        assertThat(deletedOrg).isEqualTo(createdOrg);
-        verify(oktaRepository, times(1)).deleteOrganization(createdOrg);
-    }
+    assertThat(deletedOrg).isEqualTo(createdOrg);
+    verify(oktaRepository, times(1)).deleteOrganization(createdOrg);
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -503,9 +503,9 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   @WithSimpleReportSiteAdminUser
-  void deleteOktaOrganization_succeeds() {
+  void deleteE2EOktaOrganization_succeeds() {
     Organization createdOrg = _dataFactory.saveValidOrganization();
-    Organization deletedOrg = _service.deleteOktaOrganization(createdOrg.getExternalId());
+    Organization deletedOrg = _service.deleteE2EOktaOrganization(createdOrg.getExternalId());
 
     assertThat(deletedOrg).isEqualTo(createdOrg);
     verify(oktaRepository, times(1)).deleteOrganization(createdOrg);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.api.model.FacilityStats;
@@ -34,11 +36,13 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -49,453 +53,475 @@ import org.springframework.security.access.AccessDeniedException;
 
 class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
-  @Autowired private TestDataFactory testDataFactory;
-  @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
-  @Autowired @SpyBean private FacilityRepository facilityRepository;
-  @Autowired private OrganizationRepository organizationRepository;
-  @Autowired private DeviceTypeRepository deviceTypeRepository;
-  @Autowired @SpyBean private OktaRepository oktaRepository;
-  @Autowired @SpyBean private PersonRepository personRepository;
-  @Autowired ApiUserRepository _apiUserRepo;
-  @Autowired private DemoUserConfiguration userConfiguration;
-
-  @BeforeEach
-  void setupData() {
-    initSampleData();
-  }
-
-  @Test
-  void getCurrentOrg_success() {
-    Organization org = _service.getCurrentOrganization();
-    assertNotNull(org);
-    assertEquals("DIS_ORG", org.getExternalId());
-  }
-
-  @Test
-  void getOrganizationById_success() {
-    Organization createdOrg = _dataFactory.saveValidOrganization();
-    Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
-    assertNotNull(foundOrg);
-    assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
-  }
-
-  @Test
-  void getOrganizationById_failure() {
-    UUID fakeUUID = UUID.randomUUID();
-    IllegalGraphqlArgumentException caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class, () -> _service.getOrganizationById(fakeUUID));
-    assertEquals(
-        "An organization with internal_id=" + fakeUUID + " does not exist", caught.getMessage());
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getOrganizationWithExternalIdAsSiteAdmin_success() {
-    Organization createdOrg = _dataFactory.saveValidOrganization();
-    Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
-    assertNotNull(foundOrg);
-    assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
-  }
-
-  @Test
-  void createOrganizationAndFacility_success() {
-    // GIVEN
-    PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "");
-
-    // WHEN
-    Organization org =
-        _service.createOrganizationAndFacility(
-            "Tim's org",
-            "k12",
-            "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
-            "Facility 1",
-            "12345",
-            getAddress(),
-            "123-456-7890",
-            "test@foo.com",
-            List.of(getDeviceConfig().getInternalId()),
-            orderingProviderName,
-            getAddress(),
-            "123-456-7890",
-            "547329472");
-    // THEN
-    assertEquals("Tim's org", org.getOrganizationName());
-    assertFalse(org.getIdentityVerified());
-    assertEquals("d6b3951b-6698-4ee7-9d63-aaadee85bac0", org.getExternalId());
-    List<Facility> facilities = _service.getFacilities(org);
-    assertNotNull(facilities);
-    assertEquals(1, facilities.size());
-
-    Facility fac = facilities.get(0);
-    assertEquals("Facility 1", fac.getFacilityName());
-    assertNull(fac.getDefaultDeviceType());
-
-    PatientSelfRegistrationLink orgLink =
-        patientRegistrationLinkRepository.findByOrganization(org).get();
-    PatientSelfRegistrationLink facLink =
-        patientRegistrationLinkRepository.findByFacility(fac).get();
-    assertEquals(5, orgLink.getLink().length());
-    assertEquals(5, facLink.getLink().length());
-  }
-
-  private DeviceType getDeviceConfig() {
-    return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1");
-  }
-
-  @Test
-  void createOrganizationAndFacility_orderingProviderRequired_failure() {
-    // GIVEN
-    PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
-    StreetAddress mockAddress = getAddress();
-    List<UUID> deviceTypeIds = List.of(getDeviceConfig().getInternalId());
-
-    // THEN
-    assertThrows(
-        OrderingProviderRequiredException.class,
-        () ->
-            _service.createOrganizationAndFacility(
-                "Adam's org",
-                "urgent_care",
-                "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
-                "Facility 1",
-                "12345",
-                mockAddress,
-                "123-456-7890",
-                "test@foo.com",
-                deviceTypeIds,
-                orderProviderName,
-                mockAddress,
-                null,
-                null));
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getOrganizationsAndFacility_filterByIdentityVerified_success() {
-    // GIVEN
-    Organization verifiedOrg = testDataFactory.saveValidOrganization();
-    Organization unverifiedOrg = testDataFactory.saveUnverifiedOrganization();
-
-    // WHEN
-    List<Organization> allOrgs = _service.getOrganizations(null);
-    List<Organization> verifiedOrgs = _service.getOrganizations(true);
-    List<Organization> unverifiedOrgs = _service.getOrganizations(false);
-
-    // THEN
-    assertTrue(allOrgs.size() >= 2);
-    Set<String> allOrgIds =
-        allOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
-    assertTrue(allOrgIds.contains(verifiedOrg.getExternalId()));
-    assertTrue(allOrgIds.contains(unverifiedOrg.getExternalId()));
-
-    assertTrue(verifiedOrgs.size() >= 1);
-    Set<String> verifiedOrgIds =
-        verifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
-    assertTrue(verifiedOrgIds.contains(verifiedOrg.getExternalId()));
-    assertFalse(verifiedOrgIds.contains(unverifiedOrg.getExternalId()));
-
-    assertEquals(1, unverifiedOrgs.size());
-    Set<String> unverifiedOrgIds =
-        unverifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
-    assertFalse(unverifiedOrgIds.contains(verifiedOrg.getExternalId()));
-    assertTrue(unverifiedOrgIds.contains(unverifiedOrg.getExternalId()));
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getFacilitiesIncludeArchived_includeArchived_success() {
-    Organization org = testDataFactory.saveValidOrganization();
-    Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
-    testDataFactory.createValidFacility(org, "Not deleted");
-
-    Set<Facility> archivedFacilities = _service.getFacilitiesIncludeArchived(org, true);
-
-    assertEquals(1, archivedFacilities.size());
-    assertTrue(
-        archivedFacilities.stream()
-            .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getFacilitiesIncludeArchived_excludeArchived_success() {
-    Organization org = testDataFactory.saveValidOrganization();
-    testDataFactory.createArchivedFacility(org, "Delete me");
-    Facility activeFacility = testDataFactory.createValidFacility(org, "Not deleted");
-
-    Set<Facility> facilities = _service.getFacilitiesIncludeArchived(org, false);
-
-    assertEquals(1, facilities.size());
-    assertTrue(
-        facilities.stream()
-            .anyMatch(f -> f.getInternalId().equals(activeFacility.getInternalId())));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void viewArchivedFacilities_success() {
-    Organization org = testDataFactory.saveValidOrganization();
-    Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
-
-    Set<Facility> archivedFacilities = _service.getArchivedFacilities(org);
-
-    assertTrue(
-        archivedFacilities.stream()
-            .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void viewArchivedFacilities_standardUser_failure() {
-    Organization org = testDataFactory.saveValidOrganization();
-    testDataFactory.createArchivedFacility(org, "Delete me");
-
-    assertThrows(AccessDeniedException.class, () -> _service.getArchivedFacilities());
-  }
-
-  @Test
-  @DisplayName("it should allow global admins to mark facility as deleted")
-  @WithSimpleReportSiteAdminUser
-  void deleteFacilityTest_successful() {
-    // GIVEN
-    Organization verifiedOrg = testDataFactory.saveValidOrganization();
-    Facility mistakeFacility =
-        testDataFactory.createValidFacility(verifiedOrg, "This facility is a mistake");
-    // WHEN
-    Facility deletedFacility =
-        _service.markFacilityAsDeleted(mistakeFacility.getInternalId(), true);
-    // THEN
-    assertThat(deletedFacility.isDeleted()).isTrue();
-  }
-
-  @Test
-  @DisplayName("it should not delete nonexistent facilities")
-  @WithSimpleReportSiteAdminUser
-  void deletedFacilityTest_throwsErrorWhenFacilityNotFound() {
-    UUID orgId = UUID.randomUUID();
-    IllegalGraphqlArgumentException caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class,
-            // fake UUID
-            () -> _service.markFacilityAsDeleted(orgId, true));
-    assertEquals("Facility not found.", caught.getMessage());
-  }
-
-  @Test
-  @DisplayName("it should allow global admins to mark organizations as deleted")
-  @WithSimpleReportSiteAdminUser
-  void deleteOrganizationTest_successful() {
-    // GIVEN
-    Organization verifiedOrg = testDataFactory.saveValidOrganization();
-    // WHEN
-    Organization deletedOrganization =
-        _service.markOrganizationAsDeleted(verifiedOrg.getInternalId(), true);
-    // THEN
-    assertThat(deletedOrganization.isDeleted()).isTrue();
-  }
-
-  @Test
-  @DisplayName("it should not delete nonexistent organizations")
-  @WithSimpleReportSiteAdminUser
-  void deletedOrganizationTest_throwsErrorWhenOrganizationyNotFound() {
-    UUID orgId = UUID.randomUUID();
-
-    IllegalGraphqlArgumentException caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class,
-            // fake UUID
-            () -> _service.markOrganizationAsDeleted(orgId, true));
-    assertEquals("Organization not found.", caught.getMessage());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void adminUpdateOrganization_not_allowed() {
-    assertSecurityError(() -> _service.updateOrganization("Foo org", "k12"));
-  }
-
-  @Test
-  void verifyOrganizationNoPermissions_noUser_success() {
-    Organization org = testDataFactory.saveUnverifiedOrganization();
-    _service.verifyOrganizationNoPermissions(org.getExternalId());
-
-    org = _service.getOrganization(org.getExternalId());
-    assertTrue(org.getIdentityVerified());
-  }
-
-  @Test
-  void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
-    Organization org = testDataFactory.saveValidOrganization();
-    String orgExternalId = org.getExternalId();
-    IllegalStateException e =
-        assertThrows(
-            IllegalStateException.class,
-            () -> _service.verifyOrganizationNoPermissions(orgExternalId));
-
-    assertEquals("Organization is already verified.", e.getMessage());
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void getPermissibleOrgId_allowsAccessToCurrentOrg() {
-    var actual = _service.getPermissibleOrgId(_service.getCurrentOrganization().getInternalId());
-    assertEquals(actual, _service.getCurrentOrganization().getInternalId());
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void getPermissibleOrgId_nullIdFallsBackToCurrentOrg() {
-    var actual = _service.getPermissibleOrgId(null);
-    assertEquals(actual, _service.getCurrentOrganization().getInternalId());
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void getPermissibleOrgId_throwsAccessDeniedForInaccessibleOrg() {
-    var inaccessibleOrgId = UUID.randomUUID();
-    assertThrows(
-        AccessDeniedException.class, () -> _service.getPermissibleOrgId(inaccessibleOrgId));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getFacilityStats_notAuthorizedError() {
-    UUID facilityId = UUID.randomUUID();
-    assertThrows(AccessDeniedException.class, () -> _service.getFacilityStats(facilityId));
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getFacilityStats_argumentMissingError() {
-    assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getFacilityStats_facilityNotFoundError() {
-    UUID facilityId = UUID.randomUUID();
-    doReturn(Optional.empty()).when(this.facilityRepository).findById(facilityId);
-    assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
-  }
-
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getFacilityStats_success() {
-    UUID facilityId = UUID.randomUUID();
-    Facility mockFacility = mock(Facility.class);
-    doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
-    doReturn(2).when(oktaRepository).getUsersInSingleFacility(mockFacility);
-    doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
-    FacilityStats stats = _service.getFacilityStats(facilityId);
-    assertEquals(2, stats.getUsersSingleAccessCount());
-    assertEquals(1, stats.getPatientsSingleAccessCount());
-  }
-
-  @Nested
-  @DisplayName("When updating a facility")
-  class UpdateFacilityTest {
-    private Facility facility;
-    private StreetAddress newFacilityAddress;
-    private StreetAddress newOrderingProviderAddress;
+    @Autowired
+    private TestDataFactory testDataFactory;
+    @Autowired
+    private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
+    @Autowired
+    @SpyBean
+    private FacilityRepository facilityRepository;
+    @Autowired
+    private OrganizationRepository organizationRepository;
+    @Autowired
+    private DeviceTypeRepository deviceTypeRepository;
+    @Autowired
+    @SpyBean
+    private OktaRepository oktaRepository;
+    @Autowired
+    @SpyBean
+    private PersonRepository personRepository;
+    @Autowired
+    ApiUserRepository _apiUserRepo;
+    @Autowired
+    private DemoUserConfiguration userConfiguration;
 
     @BeforeEach
-    void beforeEach() {
-      // GIVEN
-      List<Organization> disOrgs = organizationRepository.findAllByName("Dis Organization");
-      assertThat(disOrgs).hasSize(1);
-      Organization disOrg = disOrgs.get(0);
-
-      facility =
-          facilityRepository.findByOrganizationAndFacilityName(disOrg, "Injection Site").get();
-      assertThat(facility).isNotNull();
-      List<DeviceType> devices = deviceTypeRepository.findAll();
-
-      newFacilityAddress = new StreetAddress("0", "1", "2", "3", "4", "5");
-      newOrderingProviderAddress = new StreetAddress("6", "7", "8", "9", "10", "11");
-      PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "Jr.");
-
-      // WHEN
-      _service.updateFacility(
-          facility.getInternalId(),
-          "new name",
-          "new clia",
-          newFacilityAddress,
-          "817-555-6666",
-          "facility@dis.org",
-          orderingProviderName,
-          newOrderingProviderAddress,
-          "npi",
-          "817-555-7777",
-          List.of(devices.get(0).getInternalId(), devices.get(1).getInternalId()));
+    void setupData() {
+        initSampleData();
     }
 
     @Test
-    @DisplayName("it should update the facility with new values")
-    @WithSimpleReportOrgAdminUser
-    void updateFacilityTest() {
-      // THEN
-      Facility updatedFacility = facilityRepository.findById(facility.getInternalId()).get();
-
-      assertThat(updatedFacility).isNotNull();
-      assertThat(updatedFacility.getFacilityName()).isEqualTo("new name");
-      assertThat(updatedFacility.getCliaNumber()).isEqualTo("new clia");
-      assertThat(updatedFacility.getTelephone()).isEqualTo("817-555-6666");
-      assertThat(updatedFacility.getEmail()).isEqualTo("facility@dis.org");
-      assertThat(updatedFacility.getAddress()).isEqualTo(newFacilityAddress);
-
-      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getFirstName())
-          .isEqualTo("Bill");
-      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getMiddleName())
-          .isEqualTo("Foo");
-      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getLastName())
-          .isEqualTo("Nye");
-      assertThat(updatedFacility.getOrderingProvider().getNameInfo().getSuffix()).isEqualTo("Jr.");
-      assertThat(updatedFacility.getOrderingProvider().getProviderId()).isEqualTo("npi");
-      assertThat(updatedFacility.getOrderingProvider().getAddress())
-          .isEqualTo(newOrderingProviderAddress);
-
-      assertThat(updatedFacility.getDeviceTypes()).hasSize(2);
+    void getCurrentOrg_success() {
+        Organization org = _service.getCurrentOrganization();
+        assertNotNull(org);
+        assertEquals("DIS_ORG", org.getExternalId());
     }
-  }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getOrgAdminUserIds_success() {
-    Organization createdOrg = _dataFactory.saveValidOrganization();
-    List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(createdOrg);
+    @Test
+    void getOrganizationById_success() {
+        Organization createdOrg = _dataFactory.saveValidOrganization();
+        Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
+        assertNotNull(foundOrg);
+        assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
+    }
 
-    List<UUID> expectedIds =
-        adminUserEmails.stream()
-            .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
-            .collect(Collectors.toList());
+    @Test
+    void getOrganizationById_failure() {
+        UUID fakeUUID = UUID.randomUUID();
+        IllegalGraphqlArgumentException caught =
+                assertThrows(
+                        IllegalGraphqlArgumentException.class, () -> _service.getOrganizationById(fakeUUID));
+        assertEquals(
+                "An organization with internal_id=" + fakeUUID + " does not exist", caught.getMessage());
+    }
 
-    List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
-    assertThat(adminIds).isEqualTo(expectedIds);
-  }
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getOrganizationWithExternalIdAsSiteAdmin_success() {
+        Organization createdOrg = _dataFactory.saveValidOrganization();
+        Organization foundOrg = _service.getOrganizationById(createdOrg.getInternalId());
+        assertNotNull(foundOrg);
+        assertEquals(createdOrg.getExternalId(), foundOrg.getExternalId());
+    }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getOrgAdminUserIds_throws_forNonExistentOrg() {
-    UUID mismatchedUUID = UUID.fromString("5ebf893a-bb57-48ca-8fc2-1ef6b25e465b");
-    assertThrows(NonexistentOrgException.class, () -> _service.getOrgAdminUserIds(mismatchedUUID));
-  }
+    @Test
+    void createOrganizationAndFacility_success() {
+        // GIVEN
+        PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "");
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void getOrgAdminUserIds_skipsUser_forNonExistentUserInOrg() {
-    Organization createdOrg = _dataFactory.saveValidOrganization();
-    List<String> listWithAnExtraEmail = oktaRepository.fetchAdminUserEmail(createdOrg);
-    listWithAnExtraEmail.add("nonexistent@example.com");
+        // WHEN
+        Organization org =
+                _service.createOrganizationAndFacility(
+                        "Tim's org",
+                        "k12",
+                        "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
+                        "Facility 1",
+                        "12345",
+                        getAddress(),
+                        "123-456-7890",
+                        "test@foo.com",
+                        List.of(getDeviceConfig().getInternalId()),
+                        orderingProviderName,
+                        getAddress(),
+                        "123-456-7890",
+                        "547329472");
+        // THEN
+        assertEquals("Tim's org", org.getOrganizationName());
+        assertFalse(org.getIdentityVerified());
+        assertEquals("d6b3951b-6698-4ee7-9d63-aaadee85bac0", org.getExternalId());
+        List<Facility> facilities = _service.getFacilities(org);
+        assertNotNull(facilities);
+        assertEquals(1, facilities.size());
 
-    when(oktaRepository.fetchAdminUserEmail(createdOrg)).thenReturn(listWithAnExtraEmail);
-    List<UUID> expectedIds =
-        listWithAnExtraEmail.stream()
-            .filter(email -> !email.equals("nonexistent@example.com"))
-            .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
-            .collect(Collectors.toList());
+        Facility fac = facilities.get(0);
+        assertEquals("Facility 1", fac.getFacilityName());
+        assertNull(fac.getDefaultDeviceType());
 
-    List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
-    assertThat(adminIds).isEqualTo(expectedIds);
-  }
+        PatientSelfRegistrationLink orgLink =
+                patientRegistrationLinkRepository.findByOrganization(org).get();
+        PatientSelfRegistrationLink facLink =
+                patientRegistrationLinkRepository.findByFacility(fac).get();
+        assertEquals(5, orgLink.getLink().length());
+        assertEquals(5, facLink.getLink().length());
+    }
+
+    private DeviceType getDeviceConfig() {
+        return testDataFactory.createDeviceType("Abbott ID Now", "Abbott", "1");
+    }
+
+    @Test
+    void createOrganizationAndFacility_orderingProviderRequired_failure() {
+        // GIVEN
+        PersonName orderProviderName = new PersonName("Bill", "Foo", "Nye", "");
+        StreetAddress mockAddress = getAddress();
+        List<UUID> deviceTypeIds = List.of(getDeviceConfig().getInternalId());
+
+        // THEN
+        assertThrows(
+                OrderingProviderRequiredException.class,
+                () ->
+                        _service.createOrganizationAndFacility(
+                                "Adam's org",
+                                "urgent_care",
+                                "d6b3951b-6698-4ee7-9d63-aaadee85bac0",
+                                "Facility 1",
+                                "12345",
+                                mockAddress,
+                                "123-456-7890",
+                                "test@foo.com",
+                                deviceTypeIds,
+                                orderProviderName,
+                                mockAddress,
+                                null,
+                                null));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getOrganizationsAndFacility_filterByIdentityVerified_success() {
+        // GIVEN
+        Organization verifiedOrg = testDataFactory.saveValidOrganization();
+        Organization unverifiedOrg = testDataFactory.saveUnverifiedOrganization();
+
+        // WHEN
+        List<Organization> allOrgs = _service.getOrganizations(null);
+        List<Organization> verifiedOrgs = _service.getOrganizations(true);
+        List<Organization> unverifiedOrgs = _service.getOrganizations(false);
+
+        // THEN
+        assertTrue(allOrgs.size() >= 2);
+        Set<String> allOrgIds =
+                allOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
+        assertTrue(allOrgIds.contains(verifiedOrg.getExternalId()));
+        assertTrue(allOrgIds.contains(unverifiedOrg.getExternalId()));
+
+        assertTrue(verifiedOrgs.size() >= 1);
+        Set<String> verifiedOrgIds =
+                verifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
+        assertTrue(verifiedOrgIds.contains(verifiedOrg.getExternalId()));
+        assertFalse(verifiedOrgIds.contains(unverifiedOrg.getExternalId()));
+
+        assertEquals(1, unverifiedOrgs.size());
+        Set<String> unverifiedOrgIds =
+                unverifiedOrgs.stream().map(Organization::getExternalId).collect(Collectors.toSet());
+        assertFalse(unverifiedOrgIds.contains(verifiedOrg.getExternalId()));
+        assertTrue(unverifiedOrgIds.contains(unverifiedOrg.getExternalId()));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getFacilitiesIncludeArchived_includeArchived_success() {
+        Organization org = testDataFactory.saveValidOrganization();
+        Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
+        testDataFactory.createValidFacility(org, "Not deleted");
+
+        Set<Facility> archivedFacilities = _service.getFacilitiesIncludeArchived(org, true);
+
+        assertEquals(1, archivedFacilities.size());
+        assertTrue(
+                archivedFacilities.stream()
+                        .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getFacilitiesIncludeArchived_excludeArchived_success() {
+        Organization org = testDataFactory.saveValidOrganization();
+        testDataFactory.createArchivedFacility(org, "Delete me");
+        Facility activeFacility = testDataFactory.createValidFacility(org, "Not deleted");
+
+        Set<Facility> facilities = _service.getFacilitiesIncludeArchived(org, false);
+
+        assertEquals(1, facilities.size());
+        assertTrue(
+                facilities.stream()
+                        .anyMatch(f -> f.getInternalId().equals(activeFacility.getInternalId())));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void viewArchivedFacilities_success() {
+        Organization org = testDataFactory.saveValidOrganization();
+        Facility deletedFacility = testDataFactory.createArchivedFacility(org, "Delete me");
+
+        Set<Facility> archivedFacilities = _service.getArchivedFacilities(org);
+
+        assertTrue(
+                archivedFacilities.stream()
+                        .anyMatch(f -> f.getInternalId().equals(deletedFacility.getInternalId())));
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void viewArchivedFacilities_standardUser_failure() {
+        Organization org = testDataFactory.saveValidOrganization();
+        testDataFactory.createArchivedFacility(org, "Delete me");
+
+        assertThrows(AccessDeniedException.class, () -> _service.getArchivedFacilities());
+    }
+
+    @Test
+    @DisplayName("it should allow global admins to mark facility as deleted")
+    @WithSimpleReportSiteAdminUser
+    void deleteFacilityTest_successful() {
+        // GIVEN
+        Organization verifiedOrg = testDataFactory.saveValidOrganization();
+        Facility mistakeFacility =
+                testDataFactory.createValidFacility(verifiedOrg, "This facility is a mistake");
+        // WHEN
+        Facility deletedFacility =
+                _service.markFacilityAsDeleted(mistakeFacility.getInternalId(), true);
+        // THEN
+        assertThat(deletedFacility.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("it should not delete nonexistent facilities")
+    @WithSimpleReportSiteAdminUser
+    void deletedFacilityTest_throwsErrorWhenFacilityNotFound() {
+        UUID orgId = UUID.randomUUID();
+        IllegalGraphqlArgumentException caught =
+                assertThrows(
+                        IllegalGraphqlArgumentException.class,
+                        // fake UUID
+                        () -> _service.markFacilityAsDeleted(orgId, true));
+        assertEquals("Facility not found.", caught.getMessage());
+    }
+
+    @Test
+    @DisplayName("it should allow global admins to mark organizations as deleted")
+    @WithSimpleReportSiteAdminUser
+    void deleteOrganizationTest_successful() {
+        // GIVEN
+        Organization verifiedOrg = testDataFactory.saveValidOrganization();
+        // WHEN
+        Organization deletedOrganization =
+                _service.markOrganizationAsDeleted(verifiedOrg.getInternalId(), true);
+        // THEN
+        assertThat(deletedOrganization.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("it should not delete nonexistent organizations")
+    @WithSimpleReportSiteAdminUser
+    void deletedOrganizationTest_throwsErrorWhenOrganizationyNotFound() {
+        UUID orgId = UUID.randomUUID();
+
+        IllegalGraphqlArgumentException caught =
+                assertThrows(
+                        IllegalGraphqlArgumentException.class,
+                        // fake UUID
+                        () -> _service.markOrganizationAsDeleted(orgId, true));
+        assertEquals("Organization not found.", caught.getMessage());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void adminUpdateOrganization_not_allowed() {
+        assertSecurityError(() -> _service.updateOrganization("Foo org", "k12"));
+    }
+
+    @Test
+    void verifyOrganizationNoPermissions_noUser_success() {
+        Organization org = testDataFactory.saveUnverifiedOrganization();
+        _service.verifyOrganizationNoPermissions(org.getExternalId());
+
+        org = _service.getOrganization(org.getExternalId());
+        assertTrue(org.getIdentityVerified());
+    }
+
+    @Test
+    void verifyOrganizationNoPermissions_orgAlreadyVerified_failure() {
+        Organization org = testDataFactory.saveValidOrganization();
+        String orgExternalId = org.getExternalId();
+        IllegalStateException e =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> _service.verifyOrganizationNoPermissions(orgExternalId));
+
+        assertEquals("Organization is already verified.", e.getMessage());
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void getPermissibleOrgId_allowsAccessToCurrentOrg() {
+        var actual = _service.getPermissibleOrgId(_service.getCurrentOrganization().getInternalId());
+        assertEquals(actual, _service.getCurrentOrganization().getInternalId());
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void getPermissibleOrgId_nullIdFallsBackToCurrentOrg() {
+        var actual = _service.getPermissibleOrgId(null);
+        assertEquals(actual, _service.getCurrentOrganization().getInternalId());
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void getPermissibleOrgId_throwsAccessDeniedForInaccessibleOrg() {
+        var inaccessibleOrgId = UUID.randomUUID();
+        assertThrows(
+                AccessDeniedException.class, () -> _service.getPermissibleOrgId(inaccessibleOrgId));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getFacilityStats_notAuthorizedError() {
+        UUID facilityId = UUID.randomUUID();
+        assertThrows(AccessDeniedException.class, () -> _service.getFacilityStats(facilityId));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getFacilityStats_argumentMissingError() {
+        assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getFacilityStats_facilityNotFoundError() {
+        UUID facilityId = UUID.randomUUID();
+        doReturn(Optional.empty()).when(this.facilityRepository).findById(facilityId);
+        assertThrows(IllegalGraphqlArgumentException.class, () -> _service.getFacilityStats(null));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getFacilityStats_success() {
+        UUID facilityId = UUID.randomUUID();
+        Facility mockFacility = mock(Facility.class);
+        doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
+        doReturn(2).when(oktaRepository).getUsersInSingleFacility(mockFacility);
+        doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
+        FacilityStats stats = _service.getFacilityStats(facilityId);
+        assertEquals(2, stats.getUsersSingleAccessCount());
+        assertEquals(1, stats.getPatientsSingleAccessCount());
+    }
+
+    @Nested
+    @DisplayName("When updating a facility")
+    class UpdateFacilityTest {
+        private Facility facility;
+        private StreetAddress newFacilityAddress;
+        private StreetAddress newOrderingProviderAddress;
+
+        @BeforeEach
+        void beforeEach() {
+            // GIVEN
+            List<Organization> disOrgs = organizationRepository.findAllByName("Dis Organization");
+            assertThat(disOrgs).hasSize(1);
+            Organization disOrg = disOrgs.get(0);
+
+            facility =
+                    facilityRepository.findByOrganizationAndFacilityName(disOrg, "Injection Site").get();
+            assertThat(facility).isNotNull();
+            List<DeviceType> devices = deviceTypeRepository.findAll();
+
+            newFacilityAddress = new StreetAddress("0", "1", "2", "3", "4", "5");
+            newOrderingProviderAddress = new StreetAddress("6", "7", "8", "9", "10", "11");
+            PersonName orderingProviderName = new PersonName("Bill", "Foo", "Nye", "Jr.");
+
+            // WHEN
+            _service.updateFacility(
+                    facility.getInternalId(),
+                    "new name",
+                    "new clia",
+                    newFacilityAddress,
+                    "817-555-6666",
+                    "facility@dis.org",
+                    orderingProviderName,
+                    newOrderingProviderAddress,
+                    "npi",
+                    "817-555-7777",
+                    List.of(devices.get(0).getInternalId(), devices.get(1).getInternalId()));
+        }
+
+        @Test
+        @DisplayName("it should update the facility with new values")
+        @WithSimpleReportOrgAdminUser
+        void updateFacilityTest() {
+            // THEN
+            Facility updatedFacility = facilityRepository.findById(facility.getInternalId()).get();
+
+            assertThat(updatedFacility).isNotNull();
+            assertThat(updatedFacility.getFacilityName()).isEqualTo("new name");
+            assertThat(updatedFacility.getCliaNumber()).isEqualTo("new clia");
+            assertThat(updatedFacility.getTelephone()).isEqualTo("817-555-6666");
+            assertThat(updatedFacility.getEmail()).isEqualTo("facility@dis.org");
+            assertThat(updatedFacility.getAddress()).isEqualTo(newFacilityAddress);
+
+            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getFirstName())
+                    .isEqualTo("Bill");
+            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getMiddleName())
+                    .isEqualTo("Foo");
+            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getLastName())
+                    .isEqualTo("Nye");
+            assertThat(updatedFacility.getOrderingProvider().getNameInfo().getSuffix()).isEqualTo("Jr.");
+            assertThat(updatedFacility.getOrderingProvider().getProviderId()).isEqualTo("npi");
+            assertThat(updatedFacility.getOrderingProvider().getAddress())
+                    .isEqualTo(newOrderingProviderAddress);
+
+            assertThat(updatedFacility.getDeviceTypes()).hasSize(2);
+        }
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getOrgAdminUserIds_success() {
+        Organization createdOrg = _dataFactory.saveValidOrganization();
+        List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(createdOrg);
+
+        List<UUID> expectedIds =
+                adminUserEmails.stream()
+                        .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
+                        .collect(Collectors.toList());
+
+        List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
+        assertThat(adminIds).isEqualTo(expectedIds);
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getOrgAdminUserIds_throws_forNonExistentOrg() {
+        UUID mismatchedUUID = UUID.fromString("5ebf893a-bb57-48ca-8fc2-1ef6b25e465b");
+        assertThrows(NonexistentOrgException.class, () -> _service.getOrgAdminUserIds(mismatchedUUID));
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void getOrgAdminUserIds_skipsUser_forNonExistentUserInOrg() {
+        Organization createdOrg = _dataFactory.saveValidOrganization();
+        List<String> listWithAnExtraEmail = oktaRepository.fetchAdminUserEmail(createdOrg);
+        listWithAnExtraEmail.add("nonexistent@example.com");
+
+        when(oktaRepository.fetchAdminUserEmail(createdOrg)).thenReturn(listWithAnExtraEmail);
+        List<UUID> expectedIds =
+                listWithAnExtraEmail.stream()
+                        .filter(email -> !email.equals("nonexistent@example.com"))
+                        .map(email -> _apiUserRepo.findByLoginEmail(email).get().getInternalId())
+                        .collect(Collectors.toList());
+
+        List<UUID> adminIds = _service.getOrgAdminUserIds(createdOrg.getInternalId());
+        assertThat(adminIds).isEqualTo(expectedIds);
+    }
+
+    @Test
+    @WithSimpleReportSiteAdminUser
+    void deleteOktaOrganization_succeeds() {
+        Organization createdOrg = _dataFactory.saveValidOrganization();
+        Organization deletedOrg = _service.deleteOktaOrganization(createdOrg.getExternalId());
+
+        assertThat(deletedOrg).isEqualTo(createdOrg);
+        verify(oktaRepository, times(1)).deleteOrganization(createdOrg);
+    }
 }

--- a/backend/src/test/resources/graphql-test/organization-by-name-query.graphql
+++ b/backend/src/test/resources/graphql-test/organization-by-name-query.graphql
@@ -1,0 +1,15 @@
+query OrganizationByName ($name: String!, $isDeleted: Boolean){
+    organizationsByName(name: $name, isDeleted: $isDeleted) {
+        internalId
+        name
+        type
+        externalId
+        identityVerified
+        patientSelfRegistrationLink
+        facilities{
+            id
+            name
+        }
+        id
+    }
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -201,7 +201,7 @@ export type Mutation = {
   createFacilityRegistrationLink?: Maybe<Scalars["String"]["output"]>;
   createOrganizationRegistrationLink?: Maybe<Scalars["String"]["output"]>;
   createSpecimenType?: Maybe<SpecimenType>;
-  deleteOktaOrganization?: Maybe<Organization>;
+  deleteE2EOktaOrganizations?: Maybe<Organization>;
   editPendingOrganization?: Maybe<Scalars["String"]["output"]>;
   editQueueItem?: Maybe<TestOrder>;
   markDeviceTypeAsDeleted?: Maybe<DeviceType>;
@@ -337,7 +337,7 @@ export type MutationCreateSpecimenTypeArgs = {
   input: CreateSpecimenType;
 };
 
-export type MutationDeleteOktaOrganizationArgs = {
+export type MutationDeleteE2EOktaOrganizationsArgs = {
   orgExternalId: Scalars["String"]["input"];
 };
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -201,6 +200,7 @@ export type Mutation = {
   createFacilityRegistrationLink?: Maybe<Scalars["String"]["output"]>;
   createOrganizationRegistrationLink?: Maybe<Scalars["String"]["output"]>;
   createSpecimenType?: Maybe<SpecimenType>;
+  deleteOktaOrganization?: Maybe<Organization>;
   editPendingOrganization?: Maybe<Scalars["String"]["output"]>;
   editQueueItem?: Maybe<TestOrder>;
   markDeviceTypeAsDeleted?: Maybe<DeviceType>;
@@ -334,6 +334,10 @@ export type MutationCreateOrganizationRegistrationLinkArgs = {
 
 export type MutationCreateSpecimenTypeArgs = {
   input: CreateSpecimenType;
+};
+
+export type MutationDeleteOktaOrganizationArgs = {
+  orgExternalId: Scalars["String"]["input"];
 };
 
 export type MutationEditPendingOrganizationArgs = {
@@ -765,6 +769,7 @@ export type QueryOrganizationsArgs = {
 };
 
 export type QueryOrganizationsByNameArgs = {
+  isDeleted?: InputMaybe<Scalars["Boolean"]["input"]>;
   name: Scalars["String"]["input"];
 };
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part one of #7009 that adds some backend methods / GQL endpoints needed to make that spec rerunnable

Changes to the spec itself forthcoming

## Changes Proposed
- Add a "delete all okta groups associated with org" method / mutation.
     - Tried to make clear that we're only supposed to be calling that method / mutation for e2e's so we're not deleting Okta  orgs by themselves but if there's any other protections that we want to add, let me know 
- Extends the org fetch to also return deleted orgs (without this, the order you delete okta orgs vs application orgs matters)

## Testing
You can use the following mutation to test things

```gql
mutation DeleteOktaOrganization(
      $orgExternalId: String!
    ) {
      deleteOktaOrganization(
        orgExternalId: $orgExternalId,
      ) {
        externalId
      }
    }
```

```gql
query OrganizationsByName($name: String! $isDeleted: Boolean) {
      organizationsByName(name: $name, isDeleted: $isDeleted) {
        id
        name
        externalId
        facilities {
          id
          name
          isDeleted
        }
      }
    }
```
## Checklist for Primary Reviewer
- [x] GraphQL schema changes are backward compatible with older version of the front-end

---
