### PR TITLE
make spec6 rerunnable

### DIFF
--- a/cypress/e2e/06-self_registration.cy.js
+++ b/cypress/e2e/06-self_registration.cy.js
@@ -27,7 +27,7 @@ describe("Patient self registration", () => {
   });
 
   after("clean up patient info", () => {
-    cleanUpRunOktaOrgs(currentSpecRunVersionName, true);
+    cleanUpRunOktaOrgs(currentSpecRunVersionName);
     cleanUpPreviousRunSetupData(currentSpecRunVersionName);
   });
 
@@ -79,17 +79,17 @@ describe("Patient self registration", () => {
     cy.get('input[name="city"]').type(patient.city);
     cy.get(".self-registration-button").first().click();
     cy.get(
-      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
+      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label',
     ).scrollIntoView();
     cy.get(
-      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
+      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label',
     ).click();
 
     cy.checkAccessibility();
 
     cy.get(".modal__container #save-confirmed-address").click();
     cy.get("#self-reg-confirmation").contains(
-      "thanks for completing your patient profile"
+      "thanks for completing your patient profile",
     );
 
     cy.checkAccessibility(); // Confirmation page

--- a/cypress/e2e/06-self_registration.cy.js
+++ b/cypress/e2e/06-self_registration.cy.js
@@ -1,10 +1,39 @@
-import { loginHooks, generatePatient } from "../support/e2e";
+import { loginHooks, generatePatient, testNumber } from "../support/e2e";
+import {
+  cleanUpPreviousRunSetupData,
+  setupRunData,
+  cleanUpRunOktaOrgs,
+} from "../utils/setup-utils";
 
 const patient = generatePatient();
+const specRunName = "spec06";
+const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 describe("Patient self registration", () => {
   loginHooks();
-  it("gets the self registration link and navigates to it", () => {
+  before("store patient info", () => {
+    cy.task("setPatientName", patient.fullName);
+    cy.task("setPatientDOB", patient.dobForPatientLink);
+    cy.task("setPatientPhone", patient.phone);
+
+    cy.task("getSpecRunVersionName", specRunName).then(() => {
+      let data = {
+        specRunName: specRunName,
+        versionName: currentSpecRunVersionName,
+      };
+      cy.task("setSpecRunVersionName", data);
+      setupRunData(currentSpecRunVersionName);
+    });
+  });
+
+  after("clean up patient info", () => {
+    cleanUpRunOktaOrgs(currentSpecRunVersionName, true);
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
+  });
+
+  it("tests the whole patient self registration experience", () => {
+    // gets the self registration link and navigates to it
+
     cy.visit("/settings");
     cy.contains("Patient self-registration").click();
     cy.contains("Patients can now register themselves online");
@@ -14,20 +43,15 @@ describe("Patient self registration", () => {
     cy.checkAccessibility();
 
     cy.get("#org-link").then(($link) => cy.visit($link.val()));
-  });
-  it("loads terms of service", () => {
     cy.contains("Terms of service");
 
     cy.injectSRAxe();
     cy.checkAccessibility(); // Terms of Service
-  });
-  it("accepts the terms of service", () => {
     cy.contains("I agree").click();
     cy.get("#registration-container").contains("General information");
 
     cy.checkAccessibility(); // Info form
-  });
-  it("fills out some of the form fields", () => {
+    // fills out some of the form fields
     cy.get('input[name="firstName"]').type(patient.firstName);
     cy.get('input[name="birthDate"]').type(patient.dobForInput);
     cy.get('input[name="number"]').type(patient.phone);
@@ -44,28 +68,28 @@ describe("Patient self registration", () => {
     cy.get('input[name="ethnicity"][value="refused"]+label').click();
     cy.get('input[name="residentCongregateSetting"][value="NO"]+label').click();
     cy.get('input[name="employedInHealthcare"][value="NO"]+label').click();
-  });
-  it("shows what fields are missing on submit", () => {
+
+    // shows what fields are missing on submit
     cy.get(".self-registration-button").first().click();
     cy.get(".prime-formgroup").contains("Last name is missing");
     cy.get(".prime-formgroup").contains("City is missing");
-  });
-  it("fills out the remaining fields and submits", () => {
+
+    // fills out the remaining fields and submits
     cy.get('input[name="lastName"]').type(patient.lastName);
     cy.get('input[name="city"]').type(patient.city);
     cy.get(".self-registration-button").first().click();
     cy.get(
-      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label',
+      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
     ).scrollIntoView();
     cy.get(
-      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label',
+      '.modal__container input[name="addressSelect-person"][value="userAddress"]+label'
     ).click();
 
     cy.checkAccessibility();
 
     cy.get(".modal__container #save-confirmed-address").click();
     cy.get("#self-reg-confirmation").contains(
-      "thanks for completing your patient profile",
+      "thanks for completing your patient profile"
     );
 
     cy.checkAccessibility(); // Confirmation page


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7009 

## Changes Proposed

- Makes spec six rerunnable with the util methods added in the larger effort.

## Testing

- Run test 6 locally by itself and observe that the Okta and application orgs get created and deleted as needed for the tests

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
