### PR TITLE
add https to app string to make deploy smoke test work

### DIFF
--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -10,7 +10,7 @@ const Chrome = require("selenium-webdriver/chrome");
 
 const appUrl = process.env.REACT_APP_BASE_URL.includes("localhost")
   ? `${process.env.REACT_APP_BASE_URL}/health/deploy-smoke-test`
-  : `${process.env.REACT_APP_BASE_URL}/app/health/deploy-smoke-test`;
+  : `https://${process.env.REACT_APP_BASE_URL}/app/health/deploy-smoke-test`;
 
 console.log(`Running smoke test for ${appUrl}`);
 const options = new Chrome.Options();


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Fixes the script for #7019 by adding the missing URL transfer protocol string
<img width="1219" alt="Screenshot 2024-01-10 at 4 24 32 PM" src="https://github.com/CDCgov/prime-simplereport/assets/29645040/a123cc4c-f394-4731-983f-8aa9e2f65867">

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

