### PR TITLE
Support HIV on Results and PXP pages

### DIFF
--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -17,6 +17,8 @@ const setDiseaseName = (diseaseName: MultiplexDisease, t: translateFn) => {
       return t("constants.disease.FLUA");
     case MULTIPLEX_DISEASES.FLU_B:
       return t("constants.disease.FLUB");
+    case MULTIPLEX_DISEASES.HIV:
+      return t("constants.disease.HIV");
     case MULTIPLEX_DISEASES.RSV:
       return t("constants.disease.RSV");
     default:

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -3,6 +3,7 @@ export enum MULTIPLEX_DISEASES {
   FLU_A = "Flu A",
   FLU_B = "Flu B",
   RSV = "RSV",
+  HIV = "HIV",
 }
 
 export enum TEST_RESULTS {

--- a/frontend/src/app/testResults/mocks/queries.mock.tsx
+++ b/frontend/src/app/testResults/mocks/queries.mock.tsx
@@ -9,7 +9,6 @@ import {
   GetResultsMultiplexWithCountDocument,
   ArchivedStatus,
 } from "../../../generated/graphql";
-import { testResultDetailsQuery } from "../viewResults/actionMenuModals/TestResultDetailsModal";
 import { QUERY_PATIENT } from "../../testQueue/addToQueue/AddToQueueSearch";
 
 import testResults from "./resultsCovid.mock";
@@ -96,7 +95,7 @@ export const mocks = [
   },
   {
     request: {
-      query: testResultDetailsQuery,
+      query: GetTestResultDetailsDocument,
       variables: {
         id: testResults.content[0].id,
       },

--- a/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
@@ -38,7 +38,8 @@ export const DownloadResultsCsvModal = ({
   >(null);
   // Disable downloads because backend will hang on over 20k results (#3953)
   const disableDownload = totalEntries > rowsMaxLimit;
-  const singleEntryRsvEnabled = useFeature("singleEntryRsvEnabled");
+  const singleEntryRsvEnabled = Boolean(useFeature("singleEntryRsvEnabled"));
+  const hivEnabled = Boolean(useFeature("hivEnabled"));
 
   const filtersPresent = Object.entries(filterParams).some(([key, val]) => {
     // active facility in the facility filter is the default
@@ -71,6 +72,7 @@ export const DownloadResultsCsvModal = ({
     if (data?.testResultsPage?.content) {
       const csvResults = parseDataForCSV(
         singleEntryRsvEnabled,
+        hivEnabled,
         data.testResultsPage.content
       );
       setResults(csvResults);

--- a/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
@@ -95,6 +95,7 @@ const TestResultsFilters: React.FC<TestResultsFiltersProps> = ({
     appPermissions.settings.canView
   );
   const singleEntryRsvEnabled = useFeature("singleEntryRsvEnabled");
+  const hivEnabled = useFeature("hivEnabled");
 
   /**
    * Patient search
@@ -285,6 +286,13 @@ const TestResultsFilters: React.FC<TestResultsFiltersProps> = ({
       label: MULTIPLEX_DISEASES.FLU_B,
     },
   ];
+  if (hivEnabled) {
+    diseaseOptions.push({
+      value: MULTIPLEX_DISEASES.HIV,
+      label: MULTIPLEX_DISEASES.HIV,
+    });
+  }
+
   if (singleEntryRsvEnabled) {
     diseaseOptions.push({
       value: MULTIPLEX_DISEASES.RSV,

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
@@ -59,7 +59,16 @@ multiplexTestResult["results"] = [
   },
 ];
 
-window.print = jest.fn();
+const hivTestResult = JSON.parse(JSON.stringify(nonMultiplexTestResult));
+hivTestResult.results = [
+  {
+    disease: { name: "HIV" as MultiplexDisease },
+    testResult: "POSITIVE" as TestResult,
+    __typename: "MultiplexResult",
+  },
+];
+hivTestResult.genderOfSexualPartners = ["female", "male", "other"];
+hivTestResult.pregnancy = "77386006";
 
 describe("single disease TestResultDetailsModal", () => {
   let component: any;
@@ -116,6 +125,39 @@ describe("multiple diseases TestResultDetailsModal", () => {
     expect(screen.getByText("Flu A result")).toBeInTheDocument();
     expect(screen.getByText("Flu B result")).toBeInTheDocument();
     expect(screen.getByText("RSV result")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Gender of sexual partners")
+    ).not.toBeInTheDocument();
+  });
+
+  it("matches screenshot", () => {
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe("HIV TestResultDetailsModal", () => {
+  let component: any;
+
+  beforeEach(() => {
+    ReactDOM.createPortal = jest.fn((element, _node) => {
+      return element;
+    }) as any;
+
+    component = render(
+      <DetachedTestResultDetailsModal
+        data={{ testResult: hivTestResult }}
+        closeModal={() => {}}
+      />
+    );
+  });
+
+  it("should have HIV specific AOE text", () => {
+    expect(screen.getByText("HIV result")).toBeInTheDocument();
+    expect(screen.queryByText("Symptoms")).not.toBeInTheDocument();
+    expect(screen.queryByText("Symptom onset")).not.toBeInTheDocument();
+    expect(screen.getByText("Gender of sexual partners")).toBeInTheDocument();
+    expect(screen.getByText("Female, Male, Other")).toBeInTheDocument();
+    expect(screen.getByText("Pregnant?")).toBeInTheDocument();
   });
 
   it("matches screenshot", () => {

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultPrintModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultPrintModal.test.tsx
@@ -236,3 +236,33 @@ describe("TestResultPrintModal with RSV and flu results", () => {
     expect(component).toMatchSnapshot();
   });
 });
+
+describe("TestResultPrintModal with HIV results", () => {
+  beforeEach(() => {
+    const hivTestResult = cloneDeep(testResult);
+    hivTestResult.results = [
+      {
+        disease: { name: MULTIPLEX_DISEASES.HIV },
+        testResult: TEST_RESULTS.POSITIVE,
+      },
+    ];
+
+    ReactDOM.createPortal = jest.fn((element, _node) => {
+      return element;
+    }) as any;
+
+    MockDate.set("2021/01/01");
+    render(
+      <DetachedTestResultPrintModal
+        data={{ testResult: hivTestResult }}
+        testResultId="id"
+        closeModal={() => {}}
+      />
+    );
+  });
+
+  it("should render HIV information", () => {
+    expect(screen.getByText("HIV")).toBeInTheDocument();
+    expect(screen.getByText("Positive")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
@@ -1,5 +1,366 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HIV TestResultDetailsModal matches screenshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="display-flex flex-justify"
+      >
+        <h1
+          class="font-heading-lg margin-top-05 margin-bottom-0"
+          id="result-detail-title"
+        >
+          Result details
+        </h1>
+        <div
+          class="sr-time-of-test-buttons"
+        >
+          <button
+            class="modal__close-button"
+            style="cursor: pointer;"
+          >
+            <img
+              alt="Close"
+              class="modal__close-img"
+              src="close.svg"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
+      />
+      <h2
+        class="font-sans-md margin-top-3"
+      >
+        Patient
+      </h2>
+      <div
+        class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1 grid-row flex-row padding-0"
+      >
+        <div
+          class="grid-col padding-2 border-right-1px border-base-lighter"
+        >
+          <span
+            class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+          >
+            Name
+          </span>
+          <span
+            aria-describedby="result-detail-title"
+            class="font-sans-lg"
+          >
+            First Middle Last
+          </span>
+        </div>
+        <div
+          class="grid-col padding-2"
+        >
+          <span
+            class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+          >
+            Date of birth
+          </span>
+          <span
+            aria-describedby="result-detail-title"
+            class="font-sans-lg"
+          >
+            08/07/1990
+          </span>
+        </div>
+      </div>
+      <h2
+        class="font-sans-md margin-top-3"
+      >
+        Test information
+      </h2>
+      <table
+        class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1"
+      >
+        <tbody>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              HIV result
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              POSITIVE
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Test date
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              01/28/2022 5:56pm
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Device
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Fake device
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Pregnant?
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Yes
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Gender of sexual partners
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Female, Male, Other
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 width-card-lg text-left"
+            >
+              Submitted by
+            </th>
+            <td
+              class="padding-y-3"
+            >
+              firstName middle last
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="display-flex flex-justify"
+    >
+      <h1
+        class="font-heading-lg margin-top-05 margin-bottom-0"
+        id="result-detail-title"
+      >
+        Result details
+      </h1>
+      <div
+        class="sr-time-of-test-buttons"
+      >
+        <button
+          class="modal__close-button"
+          style="cursor: pointer;"
+        >
+          <img
+            alt="Close"
+            class="modal__close-img"
+            src="close.svg"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
+    />
+    <h2
+      class="font-sans-md margin-top-3"
+    >
+      Patient
+    </h2>
+    <div
+      class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1 grid-row flex-row padding-0"
+    >
+      <div
+        class="grid-col padding-2 border-right-1px border-base-lighter"
+      >
+        <span
+          class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+        >
+          Name
+        </span>
+        <span
+          aria-describedby="result-detail-title"
+          class="font-sans-lg"
+        >
+          First Middle Last
+        </span>
+      </div>
+      <div
+        class="grid-col padding-2"
+      >
+        <span
+          class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+        >
+          Date of birth
+        </span>
+        <span
+          aria-describedby="result-detail-title"
+          class="font-sans-lg"
+        >
+          08/07/1990
+        </span>
+      </div>
+    </div>
+    <h2
+      class="font-sans-md margin-top-3"
+    >
+      Test information
+    </h2>
+    <table
+      class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1"
+    >
+      <tbody>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            HIV result
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            POSITIVE
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Test date
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            01/28/2022 5:56pm
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Device
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Fake device
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Pregnant?
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Yes
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Gender of sexual partners
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Female, Male, Other
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 width-card-lg text-left"
+          >
+            Submitted by
+          </th>
+          <td
+            class="padding-y-3"
+          >
+            firstName middle last
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`multiple diseases TestResultDetailsModal matches screenshot 1`] = `
 Object {
   "asFragment": [Function],

--- a/frontend/src/app/testResults/viewResults/operations.graphql
+++ b/frontend/src/app/testResults/viewResults/operations.graphql
@@ -1,0 +1,32 @@
+query GetTestResultDetails($id: ID!) {
+  testResult(id: $id) {
+    dateTested
+    results {
+      disease {
+        name
+      }
+      testResult
+    }
+    correctionStatus
+    symptoms
+    symptomOnset
+    pregnancy
+    genderOfSexualPartners
+    deviceType {
+      name
+    }
+    patient {
+      firstName
+      middleName
+      lastName
+      birthDate
+    }
+    createdBy {
+      name {
+        firstName
+        middleName
+        lastName
+      }
+    }
+  }
+}

--- a/frontend/src/app/utils/gender.test.ts
+++ b/frontend/src/app/utils/gender.test.ts
@@ -1,25 +1,18 @@
-import { UNKNOWN } from "../../lang/en";
-
-import { formatGenderOfSexualPartnersForDisplay } from "./gender";
+import { formatGenderOfSexualPartnersForDisplay, UNKNOWN } from "./gender";
 
 describe("formatGenderOfSexualPartnersForDisplay", () => {
   it("displays UNKNOWN if no genders provided", () => {
-    const genders: GenderIdentity[] = [];
+    const genders: string[] = [];
     expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(UNKNOWN);
   });
   it("displays a single gender", () => {
-    const genders: GenderIdentity[] = ["nonbinary"];
+    const genders: string[] = ["nonbinary"];
     expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(
       "Nonbinary or gender non-conforming"
     );
   });
   it("displays genders as a comma-separated list", () => {
-    const genders: GenderIdentity[] = [
-      "female",
-      "male",
-      "transman",
-      "transwoman",
-    ];
+    const genders: string[] = ["female", "male", "transman", "transwoman"];
     expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(
       "Female, Male, Trans masculine or transman, Trans femme or transwoman"
     );

--- a/frontend/src/app/utils/gender.test.ts
+++ b/frontend/src/app/utils/gender.test.ts
@@ -1,0 +1,31 @@
+import { UNKNOWN } from "../../lang/en";
+
+import { formatGenderOfSexualPartnersForDisplay } from "./gender";
+
+describe("formatGenderOfSexualPartnersForDisplay", () => {
+  it("displays UNKNOWN if no genders provided", () => {
+    const genders: GenderIdentity[] = [];
+    expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(UNKNOWN);
+  });
+  it("displays a single gender", () => {
+    const genders: GenderIdentity[] = ["nonbinary"];
+    expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(
+      "Nonbinary or gender non-conforming"
+    );
+  });
+  it("displays genders as a comma-separated list", () => {
+    const genders: GenderIdentity[] = [
+      "female",
+      "male",
+      "transman",
+      "transwoman",
+    ];
+    expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(
+      "Female, Male, Trans masculine or transman, Trans femme or transwoman"
+    );
+  });
+  it("displays unknown if gender values are not supported", () => {
+    const genders: string[] = ["admin", "user"];
+    expect(formatGenderOfSexualPartnersForDisplay(genders)).toBe(UNKNOWN);
+  });
+});

--- a/frontend/src/app/utils/gender.ts
+++ b/frontend/src/app/utils/gender.ts
@@ -1,0 +1,25 @@
+import { UNKNOWN } from "../../lang/en";
+
+enum GenderIdentities {
+  female = "Female",
+  male = "Male",
+  transwoman = "Trans femme or transwoman",
+  transman = "Trans masculine or transman",
+  nonbinary = "Nonbinary or gender non-conforming",
+  other = "Other",
+  refused = "Prefer not to answer",
+}
+
+export const formatGenderOfSexualPartnersForDisplay = (
+  genders: string[]
+): string => {
+  if (genders.length > 0) {
+    let gendersDisplay = genders
+      .map((gender) => {
+        return GenderIdentities[gender as GenderIdentity] || null;
+      })
+      .filter(Boolean); // remove any null values from array;
+    return gendersDisplay.length > 0 ? gendersDisplay.join(", ") : UNKNOWN;
+  }
+  return UNKNOWN;
+};

--- a/frontend/src/app/utils/gender.ts
+++ b/frontend/src/app/utils/gender.ts
@@ -1,25 +1,23 @@
-import { UNKNOWN } from "../../lang/en";
-
-enum GenderIdentities {
-  female = "Female",
-  male = "Male",
-  transwoman = "Trans femme or transwoman",
-  transman = "Trans masculine or transman",
-  nonbinary = "Nonbinary or gender non-conforming",
-  other = "Other",
-  refused = "Prefer not to answer",
-}
+export const UNKNOWN = "Unknown";
+export const GenderIdentityDisplay: { [K in GenderIdentity]: string } = {
+  female: "Female",
+  male: "Male",
+  transwoman: "Trans femme or transwoman",
+  transman: "Trans masculine or transman",
+  nonbinary: "Nonbinary or gender non-conforming",
+  other: "Other",
+  refused: "Prefer not to answer",
+} as const;
 
 export const formatGenderOfSexualPartnersForDisplay = (
   genders: string[]
 ): string => {
-  if (genders.length > 0) {
-    let gendersDisplay = genders
-      .map((gender) => {
-        return GenderIdentities[gender as GenderIdentity] || null;
-      })
-      .filter(Boolean); // remove any null values from array;
-    return gendersDisplay.length > 0 ? gendersDisplay.join(", ") : UNKNOWN;
-  }
-  return UNKNOWN;
+  let gendersDisplay = genders
+    .filter((gender): gender is GenderIdentity => {
+      return Object.keys(GenderIdentityDisplay).includes(
+        gender as GenderIdentity
+      );
+    })
+    .map((g) => GenderIdentityDisplay[g]);
+  return gendersDisplay.length > 0 ? gendersDisplay.join(", ") : UNKNOWN;
 };

--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -33,6 +33,12 @@ const data = [
         },
         testResult: "UNDETERMINED",
       },
+      {
+        disease: {
+          name: "HIV",
+        },
+        testResult: "POSITIVE",
+      },
     ],
     correctionStatus: "REMOVED",
     reasonForCorrection: "DUPLICATE_TEST",
@@ -78,9 +84,9 @@ const data = [
     noSymptoms: false,
     symptomOnset: null,
   },
-];
+] as TestResult[];
 
-const resultNoRSV = [
+const resultNoRSVOrHIV = [
   {
     "COVID-19 result": "Negative",
     "Device manufacturer": "Access Bio, Inc.",
@@ -126,18 +132,19 @@ const resultNoRSV = [
 
 const result = [
   {
-    ...resultNoRSV[0],
+    ...resultNoRSVOrHIV[0],
     "RSV result": "Inconclusive",
+    "HIV result": "Positive",
   },
 ];
 
 describe("parseDataForCSV", () => {
   it("parses multiplex data", () => {
-    expect(parseDataForCSV(true, data)).toEqual(result);
+    expect(parseDataForCSV(true, true, data)).toEqual(result);
   });
   it("parse data does not fail if tribalAffiliation is null", () => {
     expect(
-      parseDataForCSV(true, [
+      parseDataForCSV(true, true, [
         {
           ...data[0],
           patient: { ...data[0].patient, tribalAffiliation: null },
@@ -145,7 +152,7 @@ describe("parseDataForCSV", () => {
       ])
     ).toEqual(result);
   });
-  it("doesn't include RSV if parameter is false", () => {
-    expect(parseDataForCSV(false, data)).toEqual(resultNoRSV);
+  it("doesn't include RSV or HIV if includeRSV and includeHIV are false", () => {
+    expect(parseDataForCSV(false, false, data)).toEqual(resultNoRSVOrHIV);
   });
 });

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -5,13 +5,18 @@ import {
   Results,
 } from "../testResults/viewResults/TestResultsList";
 import { TEST_RESULT_DESCRIPTIONS } from "../constants";
+import { MULTIPLEX_DISEASES } from "../testResults/constants";
 
 import { symptomsStringToArray, hasSymptomsForView } from "./symptoms";
 import { getResultByDiseaseName } from "./testResults";
 
 import { displayFullName, facilityDisplayName } from "./index";
 
-export function parseDataForCSV(includeRSV: any, data: any[]) {
+export function parseDataForCSV(
+  includeRSV: boolean,
+  includeHIV: boolean,
+  data: TestResult[]
+) {
   return data.sort(byDateTested).map((r: any) => {
     const symptomList = r.symptoms ? symptomsStringToArray(r.symptoms) : [];
 
@@ -82,18 +87,21 @@ export function parseDataForCSV(includeRSV: any, data: any[]) {
       "Patient is employed in healthcare": r.patient.employedInHealthcare,
     };
 
-    return includeRSV
-      ? {
-          ...csvData1,
-          "RSV result":
-            TEST_RESULT_DESCRIPTIONS[
-              getResultByDiseaseName(r.results, "RSV") as Results
-            ],
-          ...csvData2,
-        }
-      : {
-          ...csvData1,
-          ...csvData2,
-        };
+    return {
+      ...csvData1,
+      ...(includeHIV && {
+        "HIV result":
+          TEST_RESULT_DESCRIPTIONS[
+            getResultByDiseaseName(r.results, MULTIPLEX_DISEASES.HIV) as Results
+          ],
+      }),
+      ...(includeRSV && {
+        "RSV result":
+          TEST_RESULT_DESCRIPTIONS[
+            getResultByDiseaseName(r.results, MULTIPLEX_DISEASES.RSV) as Results
+          ],
+      }),
+      ...csvData2,
+    };
   });
 }

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -56,6 +56,20 @@ export function hasCovidResults(results: MultiplexResults): boolean {
   );
 }
 
+export function hasDiseaseSpecificResults(
+  results: MultiplexResults | null,
+  diseaseName: MultiplexDisease
+): boolean {
+  if (results) {
+    return (
+      results.filter((multiplexResult: MultiplexResult) =>
+        multiplexResult.disease.name.includes(diseaseName)
+      ).length > 0
+    );
+  }
+  return false;
+}
+
 export function hasPositiveRsvResults(results: MultiplexResults): boolean {
   return (
     results.filter(

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -61,11 +61,7 @@ export function hasDiseaseSpecificResults(
   diseaseName: MultiplexDisease
 ): boolean {
   if (results) {
-    return (
-      results.filter((multiplexResult: MultiplexResult) =>
-        multiplexResult.disease.name.includes(diseaseName)
-      ).length > 0
-    );
+    return results.map((result) => result.disease.name).includes(diseaseName);
   }
   return false;
 }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -2684,44 +2684,6 @@ export type MarkTestAsCorrectionMutation = {
   } | null;
 };
 
-export type GetTestResultDetailsQueryVariables = Exact<{
-  id: Scalars["ID"]["input"];
-}>;
-
-export type GetTestResultDetailsQuery = {
-  __typename?: "Query";
-  testResult?: {
-    __typename?: "TestResult";
-    dateTested?: any | null;
-    correctionStatus?: string | null;
-    symptoms?: string | null;
-    symptomOnset?: any | null;
-    pregnancy?: string | null;
-    results?: Array<{
-      __typename?: "MultiplexResult";
-      testResult: string;
-      disease: { __typename?: "SupportedDisease"; name: string };
-    } | null> | null;
-    deviceType?: { __typename?: "DeviceType"; name: string } | null;
-    patient?: {
-      __typename?: "Patient";
-      firstName?: string | null;
-      middleName?: string | null;
-      lastName?: string | null;
-      birthDate?: any | null;
-    } | null;
-    createdBy?: {
-      __typename?: "ApiUser";
-      name: {
-        __typename?: "NameInfo";
-        firstName?: string | null;
-        middleName?: string | null;
-        lastName: string;
-      };
-    } | null;
-  } | null;
-};
-
 export type GetTestResultForTextQueryVariables = Exact<{
   id: Scalars["ID"]["input"];
 }>;
@@ -2753,6 +2715,45 @@ export type SendSmsMutationVariables = Exact<{
 export type SendSmsMutation = {
   __typename?: "Mutation";
   sendPatientLinkSmsByTestEventId?: boolean | null;
+};
+
+export type GetTestResultDetailsQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type GetTestResultDetailsQuery = {
+  __typename?: "Query";
+  testResult?: {
+    __typename?: "TestResult";
+    dateTested?: any | null;
+    correctionStatus?: string | null;
+    symptoms?: string | null;
+    symptomOnset?: any | null;
+    pregnancy?: string | null;
+    genderOfSexualPartners?: Array<string | null> | null;
+    results?: Array<{
+      __typename?: "MultiplexResult";
+      testResult: string;
+      disease: { __typename?: "SupportedDisease"; name: string };
+    } | null> | null;
+    deviceType?: { __typename?: "DeviceType"; name: string } | null;
+    patient?: {
+      __typename?: "Patient";
+      firstName?: string | null;
+      middleName?: string | null;
+      lastName?: string | null;
+      birthDate?: any | null;
+    } | null;
+    createdBy?: {
+      __typename?: "ApiUser";
+      name: {
+        __typename?: "NameInfo";
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName: string;
+      };
+    } | null;
+  } | null;
 };
 
 export type GetDeviceTypesForLookupQueryVariables = Exact<{
@@ -7975,90 +7976,6 @@ export type MarkTestAsCorrectionMutationOptions = Apollo.BaseMutationOptions<
   MarkTestAsCorrectionMutation,
   MarkTestAsCorrectionMutationVariables
 >;
-export const GetTestResultDetailsDocument = gql`
-  query getTestResultDetails($id: ID!) {
-    testResult(id: $id) {
-      dateTested
-      results {
-        disease {
-          name
-        }
-        testResult
-      }
-      correctionStatus
-      symptoms
-      symptomOnset
-      pregnancy
-      deviceType {
-        name
-      }
-      patient {
-        firstName
-        middleName
-        lastName
-        birthDate
-      }
-      createdBy {
-        name {
-          firstName
-          middleName
-          lastName
-        }
-      }
-    }
-  }
-`;
-
-/**
- * __useGetTestResultDetailsQuery__
- *
- * To run a query within a React component, call `useGetTestResultDetailsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTestResultDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTestResultDetailsQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetTestResultDetailsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >(GetTestResultDetailsDocument, options);
-}
-export function useGetTestResultDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetTestResultDetailsQuery,
-    GetTestResultDetailsQueryVariables
-  >(GetTestResultDetailsDocument, options);
-}
-export type GetTestResultDetailsQueryHookResult = ReturnType<
-  typeof useGetTestResultDetailsQuery
->;
-export type GetTestResultDetailsLazyQueryHookResult = ReturnType<
-  typeof useGetTestResultDetailsLazyQuery
->;
-export type GetTestResultDetailsQueryResult = Apollo.QueryResult<
-  GetTestResultDetailsQuery,
-  GetTestResultDetailsQueryVariables
->;
 export const GetTestResultForTextDocument = gql`
   query getTestResultForText($id: ID!) {
     testResult(id: $id) {
@@ -8171,6 +8088,91 @@ export type SendSmsMutationResult = Apollo.MutationResult<SendSmsMutation>;
 export type SendSmsMutationOptions = Apollo.BaseMutationOptions<
   SendSmsMutation,
   SendSmsMutationVariables
+>;
+export const GetTestResultDetailsDocument = gql`
+  query GetTestResultDetails($id: ID!) {
+    testResult(id: $id) {
+      dateTested
+      results {
+        disease {
+          name
+        }
+        testResult
+      }
+      correctionStatus
+      symptoms
+      symptomOnset
+      pregnancy
+      genderOfSexualPartners
+      deviceType {
+        name
+      }
+      patient {
+        firstName
+        middleName
+        lastName
+        birthDate
+      }
+      createdBy {
+        name {
+          firstName
+          middleName
+          lastName
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetTestResultDetailsQuery__
+ *
+ * To run a query within a React component, call `useGetTestResultDetailsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTestResultDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTestResultDetailsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetTestResultDetailsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetTestResultDetailsQuery,
+    GetTestResultDetailsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetTestResultDetailsQuery,
+    GetTestResultDetailsQueryVariables
+  >(GetTestResultDetailsDocument, options);
+}
+export function useGetTestResultDetailsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetTestResultDetailsQuery,
+    GetTestResultDetailsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetTestResultDetailsQuery,
+    GetTestResultDetailsQueryVariables
+  >(GetTestResultDetailsDocument, options);
+}
+export type GetTestResultDetailsQueryHookResult = ReturnType<
+  typeof useGetTestResultDetailsQuery
+>;
+export type GetTestResultDetailsLazyQueryHookResult = ReturnType<
+  typeof useGetTestResultDetailsLazyQuery
+>;
+export type GetTestResultDetailsQueryResult = Apollo.QueryResult<
+  GetTestResultDetailsQuery,
+  GetTestResultDetailsQueryVariables
 >;
 export const GetDeviceTypesForLookupDocument = gql`
   query getDeviceTypesForLookup {

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -2,8 +2,14 @@ const YES = "Yes";
 const NO = "No";
 const OTHER = "Other";
 const REFUSED = "Prefer not to answer";
-const UNKNOWN = "Unknown";
+export const UNKNOWN = "Unknown";
 const NOT_SURE = "Not sure";
+
+const FEMALE = "Female";
+const MALE = "Male";
+const TRANSWOMAN = "Trans femme or transwoman";
+const TRANSMAN = "Trans masculine or transman";
+const NONBINARY = "Nonbinary or gender non-conforming";
 
 export const en = {
   translation: {
@@ -34,6 +40,7 @@ export const en = {
         FLUA: "Flu A",
         FLUB: "Flu B",
         RSV: "RSV",
+        HIV: "HIV",
       },
       role: {
         STAFF: "Staff",
@@ -51,18 +58,18 @@ export const en = {
         refused: REFUSED,
       },
       genderIdentity: {
-        female: "Female",
-        male: "Male",
-        transwoman: "Trans femme or transwoman",
-        transman: "Trans masculine or transman",
-        nonbinary: "Nonbinary or gender non-conforming",
+        female: FEMALE,
+        male: MALE,
+        transwoman: TRANSWOMAN,
+        transman: TRANSMAN,
+        nonbinary: NONBINARY,
         other: "Gender identity not listed here",
         refused: REFUSED,
       },
       gender: {
-        female: "Female",
-        male: "Male",
-        other: "Other",
+        female: FEMALE,
+        male: MALE,
+        other: OTHER,
         refused: REFUSED,
       },
       ethnicity: {

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -1,16 +1,13 @@
+import { GenderIdentityDisplay, UNKNOWN } from "../app/utils/gender";
+
 const YES = "Yes";
 const NO = "No";
 const OTHER = "Other";
 const REFUSED = "Prefer not to answer";
-export const UNKNOWN = "Unknown";
 const NOT_SURE = "Not sure";
 
-const FEMALE = "Female";
-const MALE = "Male";
-const TRANSWOMAN = "Trans femme or transwoman";
-const TRANSMAN = "Trans masculine or transman";
-const NONBINARY = "Nonbinary or gender non-conforming";
-
+const FEMALE = GenderIdentityDisplay.female;
+const MALE = GenderIdentityDisplay.male;
 export const en = {
   translation: {
     header: "COVID-19 testing portal",
@@ -60,9 +57,9 @@ export const en = {
       genderIdentity: {
         female: FEMALE,
         male: MALE,
-        transwoman: TRANSWOMAN,
-        transman: TRANSMAN,
-        nonbinary: NONBINARY,
+        transwoman: GenderIdentityDisplay.transwoman,
+        transman: GenderIdentityDisplay.transman,
+        nonbinary: GenderIdentityDisplay.nonbinary,
         other: "Gender identity not listed here",
         refused: REFUSED,
       },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -40,6 +40,7 @@ export const es: LanguageConfig = {
         FLUA: "Flu A",
         FLUB: "Flu B",
         RSV: "VRS",
+        HIV: "VIH",
       },
       role: {
         STAFF: "Personal",


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Resolves #7077 

## Changes Proposed
- Displays HIV in the Test Results page "Condition" filter when `hivEnabled` feature flag is on
<img width="1240" alt="Screenshot 2024-01-16 at 16 43 25" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/b0839c86-97e3-40cb-8b57-3da4ee9caeb6">

- Display "HIV result" in CSV when clicking "Download results"
<img width="994" alt="Screenshot 2024-01-16 at 16 45 43" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/8603eaca-5f91-4a0a-bdf9-aeab05a42e80">

- Print modal displays HIV results
<img width="762" alt="Screenshot 2024-01-16 at 16 47 40" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/3a5ec3df-9cab-4688-abf3-33a29dad225d">

- View details includes HIV results and AOE questions (pregnant and gender of sexual partners)
<img width="824" alt="Screenshot 2024-01-16 at 16 48 33" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/839e2aa5-8981-478a-acc3-bfc2dd976490">

- PXP page of a HIV test result
<img width="1511" alt="Screenshot 2024-01-16 at 17 21 46" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/d0cfab0d-3917-4374-87cc-8ae40d08ab1b">


## Additional Information
- This PR does not address copy for the "More information" section or its translation for pxp test results and print pages (covered in #7080)

## Testing
- available on dev2 for testing

## Screenshots / Demos
- Please see above

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
