### PR TITLE
Add LOINC long names to DeviceTypeDisease

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SupportedDiseaseTestPerformedInput.java
@@ -11,8 +11,10 @@ import lombok.ToString;
 public class SupportedDiseaseTestPerformedInput {
   UUID supportedDisease;
   String testPerformedLoincCode;
+  String testPerformedLoincLongName;
   String equipmentUid;
   String equipmentUidType;
   String testkitNameId;
   String testOrderedLoincCode;
+  String testOrderedLoincLongName;
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -26,10 +26,12 @@ public class DeviceTypeDisease extends IdentifiedEntity {
   private SupportedDisease supportedDisease;
 
   @Column private String testPerformedLoincCode;
+  @Column private String testPerformedLoincLongName;
   @Column private String equipmentUid;
   @Column private String equipmentUidType;
   @Column private String testkitNameId;
   @Column private String testOrderedLoincCode;
+  @Column private String testOrderedLoincLongName;
 
   @Override
   public boolean equals(Object o) {
@@ -47,7 +49,9 @@ public class DeviceTypeDisease extends IdentifiedEntity {
         && Objects.equals(testOrderedLoincCode, that.testOrderedLoincCode)
         && Objects.equals(equipmentUid, that.equipmentUid)
         && Objects.equals(equipmentUidType, that.equipmentUidType)
-        && Objects.equals(testkitNameId, that.testkitNameId);
+        && Objects.equals(testkitNameId, that.testkitNameId)
+        && Objects.equals(testPerformedLoincLongName, that.testPerformedLoincLongName)
+        && Objects.equals(testOrderedLoincLongName, that.testOrderedLoincLongName);
   }
 
   @Override
@@ -59,6 +63,8 @@ public class DeviceTypeDisease extends IdentifiedEntity {
         testOrderedLoincCode,
         equipmentUid,
         equipmentUidType,
-        testkitNameId);
+        testkitNameId,
+        testPerformedLoincLongName,
+        testOrderedLoincLongName);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeService.java
@@ -190,11 +190,12 @@ public class DeviceTypeService {
                           .deviceTypeId(device.getInternalId())
                           .supportedDisease(disease)
                           .testPerformedLoincCode(input.getTestPerformedLoincCode())
+                          .testPerformedLoincLongName(input.getTestPerformedLoincLongName())
                           .testOrderedLoincCode(input.getTestOrderedLoincCode())
+                          .testOrderedLoincLongName(input.getTestOrderedLoincLongName())
                           .equipmentUid(input.getEquipmentUid())
                           .equipmentUidType(input.getEquipmentUidType())
                           .testkitNameId(input.getTestkitNameId())
-                          .testOrderedLoincCode(input.getTestOrderedLoincCode())
                           .build()));
         });
     return deviceTypeDiseaseList;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5219,3 +5219,19 @@ databaseChangeLog:
                     referencedColumnNames: internal_id
         - dropTable:
             tableName: upload_disease_details
+  - changeSet:
+      id: add-loinc-long-names-to-device-type-disease
+      author: ttu8@cdc.gov
+      comment: Add the LOINC long names for the test performed and test ordered LOINC codes to Device Type Disease
+      changes:
+        - addColumn:
+            tableName: device_type_disease
+            columns:
+              - column:
+                  name: test_performed_loinc_long_name
+                  type: text
+                  remarks: testPerformedLoincLongName from LIVD API
+              - column:
+                  name: test_ordered_loinc_long_name
+                  type: text
+                  remarks: testOrderedLoincLongName from LIVD API

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -79,10 +79,12 @@ input UpdateDeviceType {
 input SupportedDiseaseTestPerformedInput {
   supportedDisease: ID!
   testPerformedLoincCode: String!
+  testPerformedLoincLongName: String
   equipmentUid: String
   equipmentUidType: String
   testkitNameId: String
   testOrderedLoincCode: String
+  testOrderedLoincLongName: String
 }
 
 type DeviceType {
@@ -98,10 +100,12 @@ type DeviceType {
 type SupportedDiseaseTestPerformed {
   supportedDisease: SupportedDisease!
   testPerformedLoincCode: String!
+  testPerformedLoincLongName: String
   equipmentUid: String
   equipmentUidType: String
   testkitNameId: String
   testOrderedLoincCode: String
+  testOrderedLoincLongName: String
 }
 
 type SupportedDisease {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -853,19 +853,23 @@ class FhirConverterTest {
             null,
             covidDisease,
             "94500-6",
+            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
             "covidEquipmentUID",
             "covidEquipmentUIDType",
             "covidTestkitNameId",
-            "94500-0");
+            "94500-0",
+            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
     var fluDiseaseTestPerformedCode =
         new DeviceTypeDisease(
             null,
             fluDisease,
             "85477-8",
+            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
             "fluEquipmentUID",
             "fluEquipmentUidType",
             "fluTestkitNameId",
-            "85477-0");
+            "85477-0",
+            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
     ReflectionTestUtils.setField(
         device,
         "supportedDiseaseTestPerformed",
@@ -923,10 +927,12 @@ class FhirConverterTest {
             null,
             covidDisease,
             "94500-6",
+            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
             "covidEquipmentUID",
             "covidEquipmentUIDType",
             "covidTestkitNameId",
-            "94500-0");
+            "94500-0",
+            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
 
     ReflectionTestUtils.setField(result, "internalId", UUID.fromString(id));
     ReflectionTestUtils.setField(
@@ -1674,26 +1680,32 @@ class FhirConverterTest {
                 deviceTypeId,
                 covidDisease,
                 "333-123",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "equipmentUID1",
                 "equipmentUIDType1",
                 "testkitNameId1",
-                null),
+                null,
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"),
             new DeviceTypeDisease(
                 deviceTypeId,
                 fluADisease,
                 "444-123",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "equipmentUID2",
                 "equipmentUIDType2",
                 "testkitNameId2",
-                "95422-2"),
+                "95422-2",
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"),
             new DeviceTypeDisease(
                 deviceTypeId,
                 fluBDisease,
                 "444-456",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "equipmentUID3",
                 "equipmentUIDType3",
                 "testkitNameId3",
-                "95422-2"));
+                "95422-2",
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"));
 
     ReflectionTestUtils.setField(provider, "internalId", providerId);
     ReflectionTestUtils.setField(facility, "internalId", facilityId);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeDataLoaderHelperTest.java
@@ -47,6 +47,10 @@ class DeviceTypeDataLoaderHelperTest {
     String equipmentUidType = "testEquipmentUidType";
     String testkitNameId = "testkitNameId";
     String testOrderedLoinc = "test123OrderedLoinc";
+    String testPerformedLoincLongName =
+        "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection";
+    String testOrderedLoincLongName =
+        "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection";
 
     SupportedDisease supportedDisease1 = mock(SupportedDisease.class);
     SupportedDisease supportedDisease2 = mock(SupportedDisease.class);
@@ -67,26 +71,32 @@ class DeviceTypeDataLoaderHelperTest {
                     device1Id,
                     supportedDisease1,
                     testPerformedLoinc,
+                    testPerformedLoincLongName,
                     equipmentUid,
                     equipmentUidType,
                     testkitNameId,
-                    testOrderedLoinc),
+                    testOrderedLoinc,
+                    testOrderedLoincLongName),
                 new DeviceTypeDisease(
                     device2Id,
                     supportedDisease1,
                     testPerformedLoinc,
+                    testPerformedLoincLongName,
                     equipmentUid,
                     equipmentUidType,
                     testkitNameId,
-                    testOrderedLoinc),
+                    testOrderedLoinc,
+                    testOrderedLoincLongName),
                 new DeviceTypeDisease(
                     device2Id,
                     supportedDisease2,
                     testPerformedLoinc,
+                    testPerformedLoincLongName,
                     equipmentUid,
                     equipmentUidType,
                     testkitNameId,
-                    testOrderedLoinc)));
+                    testOrderedLoinc,
+                    testOrderedLoincLongName)));
 
     // WHEN
     Map<UUID, List<SupportedDisease>> supportedDiseases =
@@ -150,28 +160,40 @@ class DeviceTypeDataLoaderHelperTest {
         DeviceTypeDisease.builder()
             .deviceTypeId(device1Id)
             .testPerformedLoincCode("123")
+            .testPerformedLoincLongName(
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection")
             .supportedDisease(new SupportedDisease())
             .equipmentUid("111")
             .testkitNameId("222")
             .testOrderedLoincCode("234")
+            .testOrderedLoincLongName(
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")
             .build();
     var deviceTypeDisease2 =
         DeviceTypeDisease.builder()
             .deviceTypeId(device1Id)
             .testPerformedLoincCode("456")
+            .testPerformedLoincLongName(
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection")
             .supportedDisease(new SupportedDisease())
             .equipmentUid("333")
             .testkitNameId("444")
             .testOrderedLoincCode("345")
+            .testOrderedLoincLongName(
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")
             .build();
     var deviceTypeDisease3 =
         DeviceTypeDisease.builder()
             .deviceTypeId(device2Id)
             .testPerformedLoincCode("123")
+            .testPerformedLoincLongName(
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection")
             .supportedDisease(new SupportedDisease())
             .equipmentUid("555")
             .testkitNameId("666")
             .testOrderedLoincCode("244")
+            .testOrderedLoincLongName(
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")
             .build();
 
     when(deviceTypeDiseaseRepository.findAllByDeviceTypeIdIn(deviceIdSet))

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/DeviceManagementTest.java
@@ -127,6 +127,10 @@ class DeviceManagementTest extends BaseGraphqlTest {
                         .equipmentUidType("equipmentUid1Type")
                         .testkitNameId("testkitNameId1")
                         .testOrderedLoincCode("loinc3")
+                        .testPerformedLoincLongName(
+                            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection")
+                        .testOrderedLoincLongName(
+                            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")
                         .build()))
             .build();
 
@@ -157,6 +161,10 @@ class DeviceManagementTest extends BaseGraphqlTest {
                         .equipmentUidType("equipmentUidType1")
                         .testkitNameId("testkitNameId1")
                         .testOrderedLoincCode("loinc3")
+                        .testPerformedLoincLongName(
+                            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection")
+                        .testOrderedLoincLongName(
+                            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")
                         .build()))
             .build();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/model/TestEventExportTest.java
@@ -272,18 +272,22 @@ class TestEventExportTest extends BaseRepositoryTest {
                 deviceType1.getInternalId(),
                 dataFactory.getCovidDisease(),
                 "94500-6",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "covidEquipmentUID",
                 "covidEquipmentUIDType",
                 "covidTestkitNameId1",
-                "94500-0"),
+                "94500-0",
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"),
             new DeviceTypeDisease(
                 deviceType1.getInternalId(),
                 dataFactory.getCovidDisease(),
                 "94500-6",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "covidEquipmentUID",
                 "covidEquipmentUIDType",
                 "covidTestkitNameId2",
-                "94500-0")));
+                "94500-0",
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")));
     dataFactory.addDiseasesToDevice(
         deviceType2,
         List.of(
@@ -291,18 +295,22 @@ class TestEventExportTest extends BaseRepositoryTest {
                 deviceType2.getInternalId(),
                 dataFactory.getCovidDisease(),
                 "94500-6",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "covidEquipmentUID1",
                 "covidEquipmentUIDType",
                 "covidTestkitNameId",
-                "94500-0"),
+                "94500-0",
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"),
             new DeviceTypeDisease(
                 deviceType2.getInternalId(),
                 dataFactory.getCovidDisease(),
                 "94500-6",
+                "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
                 "covidEquipmentUID2",
                 "covidEquipmentUIDType",
                 "covidTestkitNameId",
-                "94500-0")));
+                "94500-0",
+                "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection")));
 
     Person person = dataFactory.createFullPerson(org);
     TestOrder testOrder1 = dataFactory.createTestOrder(person, facility);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataBuilder.java
@@ -121,10 +121,12 @@ public class TestDataBuilder {
         UUID.randomUUID(),
         supportedDisease,
         supportedDisease.getLoinc(),
+        "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
         "543212134",
         "MNI",
         "BOOMX2",
-        "95422-2");
+        "95422-2",
+        "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
   }
 
   public static DeviceTypeDisease createDeviceTypeDiseaseForBulkUpload(
@@ -133,10 +135,12 @@ public class TestDataBuilder {
         UUID.randomUUID(),
         supportedDisease,
         supportedDisease.getLoinc(),
+        "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
         "543212134",
         "MNI",
         "BOOMX2",
-        "94534-5");
+        "94534-5",
+        "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
   }
 
   public static DeviceTypeDisease createDeviceTypeDisease() {
@@ -145,10 +149,12 @@ public class TestDataBuilder {
         UUID.randomUUID(),
         supportedDisease,
         supportedDisease.getLoinc(),
+        "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
         "543212134",
         "MNI",
         "BOOMX2",
-        "98670-3");
+        "98670-3",
+        "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
   }
 
   public static DeviceType createDeviceType() {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -943,7 +943,9 @@ export type SupportedDiseaseTestPerformed = {
   equipmentUidType?: Maybe<Scalars["String"]["output"]>;
   supportedDisease: SupportedDisease;
   testOrderedLoincCode?: Maybe<Scalars["String"]["output"]>;
+  testOrderedLoincLongName?: Maybe<Scalars["String"]["output"]>;
   testPerformedLoincCode: Scalars["String"]["output"];
+  testPerformedLoincLongName?: Maybe<Scalars["String"]["output"]>;
   testkitNameId?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -952,7 +954,9 @@ export type SupportedDiseaseTestPerformedInput = {
   equipmentUidType?: InputMaybe<Scalars["String"]["input"]>;
   supportedDisease: Scalars["ID"]["input"];
   testOrderedLoincCode?: InputMaybe<Scalars["String"]["input"]>;
+  testOrderedLoincLongName?: InputMaybe<Scalars["String"]["input"]>;
   testPerformedLoincCode: Scalars["String"]["input"];
+  testPerformedLoincLongName?: InputMaybe<Scalars["String"]["input"]>;
   testkitNameId?: InputMaybe<Scalars["String"]["input"]>;
 };
 


### PR DESCRIPTION
# PULL REQUEST

## Related Issue

- Resolves #7181 

## Changes Proposed
- Adds `test_performed_loinc_long_name` and `test_ordered_loinc_long_name` columns to the `device_type_disease` table
- Updates backend to support these new fields

## Additional Information
- Unblocks #7178 and #7180

## Testing
- deployed on dev2
- start the backend and ensure the new fields get added to the `DeviceTypeDisease` table
