### PR TITLE
fix null race pointer

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -330,20 +330,21 @@ public class FhirConverter {
     return address;
   }
 
-  public Extension convertToRaceExtension(@NotNull String race) {
+  public Extension convertToRaceExtension(String race) {
     var ext = new Extension();
     ext.setUrl(RACE_EXTENSION_URL);
     var codeable = new CodeableConcept();
     var coding = codeable.addCoding();
-    String raceKey = race.toLowerCase();
-    if (StringUtils.isNotBlank(race) && PersonUtils.raceMap.containsKey(raceKey)) {
+    boolean isParseableRace =
+        StringUtils.isNotBlank(race) && PersonUtils.raceMap.containsKey(race.toLowerCase());
+    if (isParseableRace) {
       if (MappingConstants.UNKNOWN_STRING.equalsIgnoreCase(race)
           || "refused".equalsIgnoreCase(race)) {
         coding.setSystem(NULL_CODE_SYSTEM);
       } else {
         coding.setSystem(RACE_CODING_SYSTEM);
       }
-      coding.setCode(PersonUtils.raceMap.get(raceKey));
+      coding.setCode(PersonUtils.raceMap.get(race.toLowerCase()));
       codeable.setText(race);
     } else {
       coding.setSystem(NULL_CODE_SYSTEM);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.api.converter;
 
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_EXTENSION_URL;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NULL_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.DEFAULT_LOCATION_CODE;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.DEFAULT_LOCATION_NAME;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.UNKNOWN_ADDRESS_INDICATOR;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.when;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.parser.IParser;
+import gov.cdc.usds.simplereport.api.MappingConstants;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.Facility;
@@ -305,6 +307,18 @@ class FhirConverterTest {
     assertThat(code.get(0).getSystem()).isEqualTo(codeSystem);
     assertThat(code.get(0).getCode()).isEqualTo(expectedCode);
     assertThat(codeableConcept.getText()).isEqualTo(expectedText);
+  }
+
+  @Test
+  void convertToRaceNull_convertsGracefully() {
+    var actual = fhirConverter.convertToRaceExtension(null);
+    var codeableConcept = actual.castToCodeableConcept(actual.getValue());
+    var code = codeableConcept.getCoding();
+
+    assertThat(code).hasSize(1);
+    assertThat(code.get(0).getSystem()).isEqualTo(NULL_CODE_SYSTEM);
+    assertThat(code.get(0).getCode()).isEqualTo(MappingConstants.UNK_CODE);
+    assertThat(codeableConcept.getText()).isEqualTo(MappingConstants.UNKNOWN_STRING);
   }
 
   private static Stream<Arguments> raceArgs() {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- fixes a null pointer bug as described [here](https://skylight-hq.slack.com/archives/C064P7MHM47/p1706121410459279) and part one of #7214 
- Removes the @NotNull annotation bc apparently it doesn't do anything

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---
