### PR TITLE
add long names to livd sync

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java
@@ -234,6 +234,8 @@ public class DeviceTypeSyncService {
                       .equipmentUid(device.getEquipmentUid())
                       .equipmentUidType(device.getEquipmentUidType())
                       .testkitNameId(device.getTestKitNameId())
+                      .testOrderedLoincLongName(device.getTestOrderedLoincLongName())
+                      .testPerformedLoincLongName(device.getTestPerformedLoincLongName())
                       .build());
         });
 
@@ -311,6 +313,8 @@ public class DeviceTypeSyncService {
                         .testkitNameId(device.getTestKitNameId())
                         .equipmentUid(device.getEquipmentUid())
                         .equipmentUidType(device.getEquipmentUidType())
+                        .testOrderedLoincLongName(device.getTestOrderedLoincLongName())
+                        .testPerformedLoincLongName(device.getTestPerformedLoincLongName())
                         .build()))
             .build();
     log.info("Device created {}", createdDeviceType);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/reportstream/LIVDResponse.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/reportstream/LIVDResponse.java
@@ -2,12 +2,14 @@ package gov.cdc.usds.simplereport.service.model.reportstream;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@Builder
 public class LIVDResponse {
   private String manufacturer;
   private String model;
@@ -18,4 +20,6 @@ public class LIVDResponse {
   private String testKitNameId;
   private String equipmentUid;
   private String equipmentUidType;
+  private String testOrderedLoincLongName;
+  private String testPerformedLoincLongName;
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceIntegrationTest.java
@@ -79,7 +79,9 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease.getInternalId())
                             .testPerformedLoincCode("000000000")
+                            .testPerformedLoincLongName("000000000 plus some extra stuff")
                             .testOrderedLoincCode("000000000")
+                            .testOrderedLoincLongName("000000000 plus some extra stuff")
                             .equipmentUid("Equipment Uid")
                             .equipmentUidType("Equipment Uid Type")
                             .testkitNameId("TestKit Uid")
@@ -100,6 +102,9 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
                         SupportedDiseaseTestPerformedInput.builder()
                             .supportedDisease(disease.getInternalId())
                             .testPerformedLoincCode("258500001")
+                            .testPerformedLoincLongName("258500001 plus some extra stuff")
+                            .testOrderedLoincCode("253520011")
+                            .testOrderedLoincLongName("253520011 plus some extra stuff")
                             .equipmentUid("Equipment Uid")
                             .equipmentUidType("Equipment Uid Type")
                             .testkitNameId("TestKit Uid")
@@ -112,16 +117,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
   void syncDevices_updatesDevices() {
     LIVDResponse newDevice =
-        new LIVDResponse(
-            "Manufacturer A",
-            "Model A",
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            "influenza A RNA Result",
-            "7777777",
-            "8888888",
-            "Updated TestKit",
-            "Updated Equip",
-            "Updated Equip Type");
+        LIVDResponse.builder()
+            .manufacturer("Manufacturer A")
+            .model("Model A")
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName("influenza A RNA Result")
+            .testPerformedLoincCode("7777777")
+            .testPerformedLoincLongName("7777777 plus some extra stuff")
+            .testOrderedLoincCode("8888888")
+            .testOrderedLoincLongName("8888888 plus some extra stuff")
+            .testKitNameId("Updated TestKit")
+            .equipmentUid("Updated Equip")
+            .equipmentUidType("Updated Equip Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(newDevice);
 
@@ -141,6 +149,8 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
     assertThat(code.getTestkitNameId()).isEqualTo("Updated TestKit");
     assertThat(code.getEquipmentUid()).isEqualTo("Updated Equip");
     assertThat(code.getEquipmentUidType()).isEqualTo("Updated Equip Type");
+    assertThat(code.getTestOrderedLoincLongName()).isEqualTo("8888888 plus some extra stuff");
+    assertThat(code.getTestPerformedLoincLongName()).isEqualTo("7777777 plus some extra stuff");
   }
 
   @ParameterizedTest
@@ -148,16 +158,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
   void syncDevices_createsDevices(String vendorAnalyteName, String expectedDiseaseName) {
     LIVDResponse newDevice =
-        new LIVDResponse(
-            "New Device Manufacturer",
-            "New Device Model",
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            vendorAnalyteName,
-            "8888888",
-            "0123456",
-            "New TestKit",
-            "New Equip",
-            "New Equip Uid Type");
+        LIVDResponse.builder()
+            .manufacturer("New Device Manufacturer")
+            .model("New Device Model")
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName(vendorAnalyteName)
+            .testPerformedLoincCode("8888888")
+            .testPerformedLoincLongName("8888888 plus some extra stuff")
+            .testOrderedLoincCode("0123456")
+            .testOrderedLoincLongName("0123456 plus some extra stuff")
+            .testKitNameId("New TestKit")
+            .equipmentUid("New Equip")
+            .equipmentUidType("New Equip Uid Type")
+            .build();
     List<LIVDResponse> devices = List.of(newDevice);
 
     when(dataHubClient.getLIVDTable()).thenReturn(devices);
@@ -189,27 +202,36 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
         deviceSpecimenTypeRepository.findAllByDeviceTypeId(devA.getInternalId());
     assertThat(deviceSpecimenTypes).hasSize(1);
     LIVDResponse deviceOne =
-        new LIVDResponse(
-            devA.getManufacturer(),
-            devA.getModel(),
-            List.of(SPECIMEN_DESCRIPTION_ONE, SPECIMEN_DESCRIPTION_TWO),
-            "influenza A RNA Result",
-            "0123456",
-            "8888888",
-            "TestKit A",
-            "Equip A",
-            "Equip A Type");
+        LIVDResponse.builder()
+            .manufacturer(devA.getManufacturer())
+            .model(devA.getModel())
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE, SPECIMEN_DESCRIPTION_TWO))
+            .vendorAnalyteName("influenza A RNA Result")
+            .testPerformedLoincCode("0123456")
+            .testPerformedLoincLongName("0123456 plus some extra stuff")
+            .testOrderedLoincCode("8888888")
+            .testOrderedLoincLongName("8888888 plus some extra stuff")
+            .testKitNameId("TestKit A")
+            .equipmentUid("Equip A")
+            .equipmentUidType("Equip A Type")
+            .build();
+
     LIVDResponse deviceTwo =
-        new LIVDResponse(
-            devB.getManufacturer(),
-            devB.getModel(),
-            List.of(SPECIMEN_DESCRIPTION_ONE, SPECIMEN_DESCRIPTION_THREE),
-            "influenza A RNA Result",
-            "0123456",
-            "8888888",
-            "TestKit A",
-            "Equip A",
-            "Equip A Type");
+        LIVDResponse.builder()
+            .manufacturer(devB.getManufacturer())
+            .model(devB.getModel())
+            .vendorSpecimenDescription(
+                List.of(SPECIMEN_DESCRIPTION_ONE, SPECIMEN_DESCRIPTION_THREE))
+            .vendorAnalyteName("influenza A RNA Result")
+            .testPerformedLoincCode("0123456")
+            .testPerformedLoincLongName("0123456 plus some extra stuff")
+            .testOrderedLoincCode("8888888")
+            .testOrderedLoincLongName("8888888 plus some extra stuff")
+            .testKitNameId("TestKit B")
+            .equipmentUid("Equip B")
+            .equipmentUidType("Equip B Type")
+            .build();
+
     List<LIVDResponse> devices = List.of(deviceOne, deviceTwo);
 
     when(dataHubClient.getLIVDTable()).thenReturn(devices);
@@ -249,16 +271,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
   void syncDevices_updatesAssociatedDeviceTypeDiseaseFields() {
     LIVDResponse newDevice =
-        new LIVDResponse(
-            "Manufacturer A",
-            "Model A",
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            "influenza A RNA Result",
-            "7777777",
-            "8888888",
-            "Updated TestKit",
-            "Updated Equip",
-            "Updated Equip Type");
+        LIVDResponse.builder()
+            .manufacturer("Manufacturer A")
+            .model("Model A")
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName("influenza A RNA Result")
+            .testPerformedLoincCode("7777777")
+            .testPerformedLoincLongName("7777777 plus some extra stuff")
+            .testOrderedLoincCode("8888888")
+            .testOrderedLoincLongName("8888888 plus some extra stuff")
+            .testKitNameId("Updated TestKit")
+            .equipmentUid("Updated Equip")
+            .equipmentUidType("Updated Equip Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(newDevice);
 
@@ -284,16 +309,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
     var updatedAt = existingDevice.getUpdatedAt();
 
     LIVDResponse device =
-        new LIVDResponse(
-            existingDevice.getManufacturer(),
-            existingDevice.getModel(),
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            "covid",
-            "000000000",
-            "000000000",
-            "TestKit Uid",
-            "Equipment Uid",
-            "Equipment Uid Type");
+        LIVDResponse.builder()
+            .manufacturer(existingDevice.getManufacturer())
+            .model(existingDevice.getModel())
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName("covid")
+            .testPerformedLoincCode("000000000")
+            .testPerformedLoincLongName("000000000 plus some extra stuff")
+            .testOrderedLoincCode("000000000")
+            .testOrderedLoincLongName("000000000 plus some extra stuff")
+            .testKitNameId("TestKit Uid")
+            .equipmentUid("Equipment Uid")
+            .equipmentUidType("Equipment UID Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(device);
 
@@ -309,16 +337,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
   void syncDevices_skipsInvalidDiseases() {
     LIVDResponse device =
-        new LIVDResponse(
-            "Some manufacturer",
-            "Some model",
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            "invalid disease!",
-            "000000000",
-            "000000000",
-            "TestKit Uid",
-            "Equipment Uid",
-            "Equipment Uid Type");
+        LIVDResponse.builder()
+            .manufacturer("Some manufacturer")
+            .model("Some model")
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName("invalid disease!")
+            .testPerformedLoincCode("000000000")
+            .testPerformedLoincLongName("000000000 plus some extra stuff")
+            .testOrderedLoincCode("000000000")
+            .testOrderedLoincLongName("000000000 plus some extra stuff")
+            .testKitNameId("TestKit Uid")
+            .equipmentUid("Equipment Uid")
+            .equipmentUidType("Equipment UID Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(device);
 
@@ -334,16 +365,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   void syncDevices_avoidsDuplicateDeviceNames() {
     // Define a device with a `model` matching a different value and a new `manufacturer`
     LIVDResponse device =
-        new LIVDResponse(
-            "Shiny New Manufacturer",
-            "Device A",
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            "fluA",
-            "000000000",
-            "000000000",
-            "TestKit Uid",
-            "Equipment Uid",
-            "Equip Uid Type");
+        LIVDResponse.builder()
+            .manufacturer("Shiny New Manufacturer")
+            .model("Device A")
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName("fluA")
+            .testPerformedLoincCode("000000000")
+            .testPerformedLoincLongName("000000000 plus some extra stuff")
+            .testOrderedLoincCode("000000000")
+            .testOrderedLoincLongName("000000000 plus some extra stuff")
+            .testKitNameId("TestKit Uid")
+            .equipmentUid("Equipment Uid")
+            .equipmentUidType("Equipment UID Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(device);
 
@@ -358,16 +392,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
   void syncDevices_skipsConfiguredDevices() {
     LIVDResponse device =
-        new LIVDResponse(
-            "Applied BioCode, Inc.",
-            "BioCode CoV-2 Flu Plus Assay",
-            List.of(SPECIMEN_DESCRIPTION_ONE),
-            "fluA",
-            "000000000",
-            "000000000",
-            "TestKit Uid",
-            "Equipment Uid",
-            "Equipment Uid Type");
+        LIVDResponse.builder()
+            .manufacturer("Applied BioCode, Inc.")
+            .model("BioCode CoV-2 Flu Plus Assay")
+            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorAnalyteName("fluA")
+            .testPerformedLoincCode("000000000")
+            .testPerformedLoincLongName("000000000 plus some extra stuff")
+            .testOrderedLoincCode("000000000")
+            .testOrderedLoincLongName("000000000 plus some extra stuff")
+            .testKitNameId("TestKit Uid")
+            .equipmentUid("Equipment Uid")
+            .equipmentUidType("Equipment UID Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(device);
 
@@ -382,16 +419,19 @@ class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncSer
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
   void syncDevices_skipsForDryRuns() {
     LIVDResponse newDevice =
-        new LIVDResponse(
-            "Dry Run Device Manufacturer",
-            "Dry Run Device Model",
-            List.of("not to be added (123456789^To Be Added^SCT)\r"),
-            "COVID-19",
-            "8888888",
-            "0123456",
-            "Dry Run TestKit",
-            "Dry Run Equip",
-            "Dry Run Equip Type");
+        LIVDResponse.builder()
+            .manufacturer("Dry Run Device Manufacturer")
+            .model("Dry Run Device Model")
+            .vendorSpecimenDescription(List.of("not to be added (123456789^To Be Added^SCT)\n"))
+            .vendorAnalyteName("OVID-19")
+            .testPerformedLoincCode("8888888")
+            .testPerformedLoincLongName("8888888 plus some extra stuff")
+            .testOrderedLoincCode("0123456")
+            .testOrderedLoincLongName("0123456 plus some extra stuff")
+            .testKitNameId("Dry Run TestKit")
+            .equipmentUid("Dry Run Equip")
+            .equipmentUidType("Dry Run Equip Type")
+            .build();
 
     List<LIVDResponse> devices = List.of(newDevice);
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part 1 of #7180 (code changes for device sync)

## Changes Proposed

- Adds the long name descriptions into the relevant parts of the device sync
- Updates the LIVD response object to use the builder interface since the number of params were getting a bit long
- Update tests

## Testing

- deployed in dev2 and did a device sync. Long names seem to be populating [based on Metabase](https://dev2.simplereport.gov/metabase)

![Screenshot 2024-01-25 at 11 46 12 AM](https://github.com/CDCgov/prime-simplereport/assets/29645040/02836eaf-cc80-4412-80a3-8720dacca62c)

- Will do a dry run with someone synchronously once this gets in to validate we'll get back what we expect in prod.


<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---