### PR TITLE
Add testEventId to test result response

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/AddTestResultResponse.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/AddTestResultResponse.java
@@ -1,29 +1,36 @@
 package gov.cdc.usds.simplereport.api.model;
 
 import gov.cdc.usds.simplereport.db.model.TestOrder;
+import java.util.UUID;
 
 public class AddTestResultResponse {
-  private TestOrder _testOrder;
-  private Boolean _deliveryStatus;
+  private TestOrder testOrder;
+  private Boolean deliveryStatus;
+  private UUID testEventId;
 
   public AddTestResultResponse(TestOrder testOrder, Boolean deliveryStatus) {
-    this._testOrder = testOrder;
-    this._deliveryStatus = deliveryStatus;
+    this.testOrder = testOrder;
+    this.deliveryStatus = deliveryStatus;
+    this.testEventId = testOrder.getTestEvent().getInternalId();
   }
 
   public AddTestResultResponse(TestOrder testOrder) {
-    this._testOrder = testOrder;
+    this.testOrder = testOrder;
   }
 
   public TestOrder getTestOrder() {
-    return this._testOrder;
+    return this.testOrder;
   }
 
   public ApiTestOrder getTestResult() {
-    return new ApiTestOrder(_testOrder);
+    return new ApiTestOrder(testOrder);
   }
 
   public Boolean getDeliverySuccess() {
-    return _deliveryStatus;
+    return deliveryStatus;
+  }
+
+  public UUID getTestEventId() {
+    return testEventId;
   }
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -357,6 +357,7 @@ type AggregateFacilityMetrics {
 type AddTestResultResponse {
   testResult: TestOrder!
   deliverySuccess: Boolean
+  testEventId: ID!
 }
 
 type PatientLink {

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -48,6 +48,7 @@ mutation SubmitQueueItem(
             internalId
         }
         deliverySuccess
+        testEventId
     }
 }
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -46,6 +46,7 @@ export type AddFacilityInput = {
 export type AddTestResultResponse = {
   __typename?: "AddTestResultResponse";
   deliverySuccess?: Maybe<Scalars["Boolean"]["output"]>;
+  testEventId: Scalars["ID"]["output"];
   testResult: TestOrder;
 };
 
@@ -2234,6 +2235,7 @@ export type SubmitQueueItemMutation = {
   submitQueueItem?: {
     __typename?: "AddTestResultResponse";
     deliverySuccess?: boolean | null;
+    testEventId: string;
     testResult: { __typename?: "TestOrder"; internalId: string };
   } | null;
 };
@@ -6870,6 +6872,7 @@ export const SubmitQueueItemDocument = gql`
         internalId
       }
       deliverySuccess
+      testEventId
     }
   }
 `;


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Supports #7007 

## Changes Proposed

- Adds `testEventId` to AddTestResultResponse so that e2e spec 5 can correctly retrieve the test event id it needs to then retrieve a patient link.

## Additional Information

- Follow up PR for the actual spec changes for #7007 

## Testing

- Verify no regression, this will also be covered by the follow up PR for #7007 