### PR TITLE
Add 2 patients to DIS_ORG on startup

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -1,14 +1,22 @@
 package gov.cdc.usds.simplereport.config;
 
+import static gov.cdc.usds.simplereport.api.Translators.parseState;
+import static gov.cdc.usds.simplereport.api.Translators.parseString;
+
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.FacilityBuilder;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
+import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResultDeliveryPreference;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -27,6 +35,7 @@ public class InitialSetupProperties {
   private final List<String> configuredDeviceTypes;
   private final List<ConfigFacility> facilities;
   private final List<ConfigPatientRegistrationLink> patientRegistrationLinks;
+  private final List<ConfigPatient> patients;
 
   public List<Organization> getOrganizations() {
     return organizations.stream()
@@ -108,6 +117,45 @@ public class InitialSetupProperties {
 
     public PatientSelfRegistrationLink makePatientRegistrationLink(Facility fac, String link) {
       return new PatientSelfRegistrationLink(fac, link);
+    }
+  }
+
+  @Value
+  public static class ConfigPatient {
+    String firstName;
+    String lastName;
+    String birthDate;
+    String organizationExternalId;
+
+    public Person makePatient(
+        Organization org, String firstName, String lastName, String birthDate) {
+      DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("M/d/yyyy");
+      LocalDate localDateBirthDate = LocalDate.parse(birthDate, dateTimeFormat);
+      StreetAddress patientAddress =
+          new StreetAddress(
+              parseString("123 Main Street"),
+              parseString(""),
+              parseString("Minneapolis"),
+              parseState("MN"),
+              parseString("55407"),
+              parseString("Hennepin"));
+      return Person.builder()
+          .firstName(firstName)
+          .lastName(lastName)
+          .birthDate(localDateBirthDate)
+          .facility(null)
+          .organization(org)
+          .address(patientAddress)
+          .country("USA")
+          .race("other")
+          .ethnicity("not_hispanic")
+          .gender("male")
+          .genderIdentity("male")
+          .employedInHealthcare(true)
+          .residentCongregateSetting(true)
+          .role(PersonRole.STAFF)
+          .testResultDeliveryPreference(TestResultDeliveryPreference.NONE)
+          .build();
     }
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -408,8 +408,7 @@ public class OrganizationInitializingService {
                 .filter(
                     fp ->
                         fp.getLastName().equals(p.getLastName())
-                            && fp.getFirstName().equals(p.getFirstName())
-                            && !fp.isDeleted())
+                            && fp.getFirstName().equals(p.getFirstName()))
                 .findFirst();
         if (foundPatient.isEmpty()) {
           Person createdPatient =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.service;
 import com.okta.sdk.resource.client.ApiException;
 import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
+import gov.cdc.usds.simplereport.config.InitialSetupProperties.ConfigPatient;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties.ConfigPatientRegistrationLink;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.config.authorization.PermissionHolder;
@@ -15,6 +16,7 @@ import gov.cdc.usds.simplereport.db.model.DeviceTypeDisease;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
+import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
 import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
@@ -23,6 +25,7 @@ import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PatientRegistrationLinkRepository;
+import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
@@ -57,6 +60,7 @@ public class OrganizationInitializingService {
   private final OktaRepository _oktaRepo;
   private final ApiUserService _userService;
   private final DemoUserConfiguration _demoUserConfiguration;
+  private final PersonRepository _personRepository;
   private final PatientRegistrationLinkRepository _prlRepository;
   private final DiseaseService diseaseService;
 
@@ -124,7 +128,7 @@ public class OrganizationInitializingService {
             });
 
     configurePatientRegistrationLinks(_props.getPatientRegistrationLinks(), facilitiesByName);
-
+    createPatients(_props.getPatients());
     // Abusing the class name "OrganizationInitializingService" a little, but the
     // users are in the org.
     List<DemoUser> users = _demoUserConfiguration.getAllUsers();
@@ -385,6 +389,35 @@ public class OrganizationInitializingService {
     if (!link.isPresent()) {
       PatientSelfRegistrationLink prl = p.makePatientRegistrationLink(org, p.getLink());
       savePatientSelfRegistrationLink(p, prl);
+    }
+  }
+
+  public void createPatients(List<ConfigPatient> patients) {
+    if (patients != null && !patients.isEmpty()) {
+      for (ConfigPatient p : patients) {
+        Optional<Organization> orgLookup = _orgRepo.findByExternalId(p.getOrganizationExternalId());
+
+        if (!orgLookup.isPresent()) {
+          return;
+        }
+
+        Organization org = orgLookup.get();
+        String fullName = String.format("%s %s", p.getFirstName(), p.getLastName());
+        Optional<Person> foundPatient =
+            _personRepository.findAll().stream()
+                .filter(
+                    fp ->
+                        fp.getLastName().equals(p.getLastName())
+                            && fp.getFirstName().equals(p.getFirstName())
+                            && !fp.isDeleted())
+                .findFirst();
+        if (foundPatient.isEmpty()) {
+          Person createdPatient =
+              p.makePatient(org, p.getFirstName(), p.getLastName(), p.getBirthDate());
+          log.info(String.format("Creating patient: %s with DOB %s", fullName, p.getBirthDate()));
+          _personRepository.save(createdPatient);
+        }
+      }
     }
   }
 }

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -182,12 +182,12 @@ simple-report-initialization:
     - link: downTwn
       facility-name: Downtown Clinic
   patients:
-    - first-name: "SRPatient1"
-      last-name: "DemoUser"
+    - first-name: "Mary"
+      last-name: "Meade"
       birth-date: "01/01/1980"
       organization-external-id: DIS_ORG
-    - first-name: "SRPatient2"
-      last-name: "DemoUser"
+    - first-name: "Edward"
+      last-name: "Eaves"
       birth-date: "01/01/1980"
       organization-external-id: DIS_ORG
 simple-report:

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -181,6 +181,15 @@ simple-report-initialization:
       facility-name: Uptown Clinic
     - link: downTwn
       facility-name: Downtown Clinic
+  patients:
+    - first-name: "SRPatient1"
+      last-name: "DemoUser"
+      birth-date: "01/01/1980"
+      organization-external-id: DIS_ORG
+    - first-name: "SRPatient2"
+      last-name: "DemoUser"
+      birth-date: "01/01/1980"
+      organization-external-id: DIS_ORG
 simple-report:
   demo-users:
     site-admin-emails:

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationInitializingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationInitializingServiceTest.java
@@ -1,0 +1,106 @@
+package gov.cdc.usds.simplereport.service;
+
+import static gov.cdc.usds.simplereport.test_util.TestDataFactory.DEFAULT_ORG_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.cdc.usds.simplereport.config.InitialSetupProperties;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.repository.PersonRepository;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OrganizationInitializingServiceTest extends BaseServiceTest<DiseaseService> {
+  @Autowired private TestDataFactory _dataFactory;
+  @Autowired private PersonRepository _personRepository;
+  @Autowired OrganizationInitializingService _organizationInitializingService;
+
+  private Organization _org;
+
+  @BeforeEach
+  public void setup() {
+    _org = _dataFactory.saveValidOrganization();
+    _dataFactory.createValidFacility(_org);
+  }
+
+  @Test
+  void createPatients_success_addsPatients() {
+    String firstPatientFirstName = "John";
+    String firstPatientLastName = "Doe";
+    String firstPatientBirthDate = "03/03/2020";
+
+    String secondPatientFirstName = "Mary";
+    String secondPatientLastName = "Jane";
+    String secondPatientBirthDate = "01/01/2010";
+
+    InitialSetupProperties.ConfigPatient firstPatient =
+        new InitialSetupProperties.ConfigPatient(
+            firstPatientFirstName, firstPatientLastName, firstPatientBirthDate, DEFAULT_ORG_ID);
+    InitialSetupProperties.ConfigPatient secondPatient =
+        new InitialSetupProperties.ConfigPatient(
+            secondPatientFirstName, secondPatientLastName, secondPatientBirthDate, DEFAULT_ORG_ID);
+    List<InitialSetupProperties.ConfigPatient> patients = List.of(firstPatient, secondPatient);
+    _organizationInitializingService.createPatients(patients);
+
+    List<Person> patientsLookup = _personRepository.findAll();
+    assertEquals(2, patientsLookup.size());
+
+    Person expectedFirstPatient =
+        firstPatient.makePatient(
+            _org, firstPatientFirstName, firstPatientLastName, firstPatientBirthDate);
+    Person expectedSecondPatient =
+        secondPatient.makePatient(
+            _org, secondPatientFirstName, secondPatientLastName, secondPatientBirthDate);
+    List<Person> expectedPatients = List.of(expectedFirstPatient, expectedSecondPatient);
+
+    for (int i = 0; i < patientsLookup.size(); i++) {
+      Person actualPatient = patientsLookup.get(i);
+      Person expectedPatient = expectedPatients.get(i);
+      assertEquals(actualPatient.getNameInfo(), expectedPatient.getNameInfo());
+      assertEquals(actualPatient.getBirthDate(), expectedPatient.getBirthDate());
+      assertEquals(actualPatient.getRace(), expectedPatient.getRace());
+      assertEquals(actualPatient.getRole(), expectedPatient.getRole());
+      assertEquals(actualPatient.getAddress(), expectedPatient.getAddress());
+      assertEquals(
+          actualPatient.getEmployedInHealthcare(), expectedPatient.getEmployedInHealthcare());
+      assertEquals(
+          actualPatient.getResidentCongregateSetting(),
+          expectedPatient.getResidentCongregateSetting());
+      assertEquals(actualPatient.getEmail(), expectedPatient.getEmail());
+      assertEquals(actualPatient.getTestResultDelivery(), expectedPatient.getTestResultDelivery());
+      assertEquals(actualPatient.getGender(), expectedPatient.getGender());
+      assertEquals(actualPatient.getGenderIdentity(), expectedPatient.getGenderIdentity());
+    }
+  }
+
+  @Test
+  void createPatients_doesNotAddDuplicatePatient() {
+    String firstName = "John";
+    String lastName = "Doe";
+    String birthDate = "03/03/2020";
+
+    InitialSetupProperties.ConfigPatient patient =
+        new InitialSetupProperties.ConfigPatient(firstName, lastName, birthDate, DEFAULT_ORG_ID);
+    List<InitialSetupProperties.ConfigPatient> patients = List.of(patient, patient);
+    _organizationInitializingService.createPatients(patients);
+    List<Person> patientLookup = _personRepository.findAll();
+    assertEquals(1, patientLookup.size());
+  }
+
+  @Test
+  void createPatients_withInvalidOrgExternalId_doesNotAddPatient() {
+    String firstName = "John";
+    String lastName = "Doe";
+    String birthDate = "03/03/2020";
+
+    InitialSetupProperties.ConfigPatient patient =
+        new InitialSetupProperties.ConfigPatient(
+            firstName, lastName, birthDate, "NONEXISTENT_ORG_EXTERNAL_ID");
+    _organizationInitializingService.createPatients(List.of(patient));
+    List<Person> patientLookup = _personRepository.findAll();
+    assertEquals(0, patientLookup.size());
+  }
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7157 

## Changes Proposed
- When I boot the app with the `create-sample-data` profile active, the app should generate sample patient data if it doesn't already exist.

## Additional Information
- N/A

## Testing
- Start the backend and ensure your `DIS_ORG` org gets 2 patients created
- Restart the backend again and ensure, those 2 patients do not get created again

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
