### PR TITLE
feat: Refactor container cleaning workflow and include delay for dele…

### DIFF
--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  clean_ghcr_backend:
+  clean_ghcr:
     name: Delete untagged container images
     runs-on: ubuntu-latest
     steps:
@@ -19,10 +19,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-  clean_ghcr_cypress:
-    name: Delete untagged container images
-    runs-on: ubuntu-latest
-    steps:
       - name: Sleep for 65 seconds
         run: sleep 65
         shell: bash
@@ -32,10 +28,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-  clean_ghcr_database:
-    name: Delete untagged container images
-    runs-on: ubuntu-latest
-    steps:
       - name: Sleep for 65 seconds
         run: sleep 65
         shell: bash
@@ -45,10 +37,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-  clean_ghcr_db:
-    name: Delete untagged container images
-    runs-on: ubuntu-latest
-    steps:
       - name: Sleep for 65 seconds
         run: sleep 65
         shell: bash
@@ -58,10 +46,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-  clean_ghcr_frontend:
-    name: Delete untagged container images
-    runs-on: ubuntu-latest
-    steps:
       - name: Sleep for 65 seconds
         run: sleep 65
         shell: bash
@@ -71,10 +55,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-  clean_ghcr_frontend_lighthouse:
-    name: Delete untagged container images
-    runs-on: ubuntu-latest
-    steps:
       - name: Sleep for 65 seconds
         run: sleep 65
         shell: bash
@@ -84,10 +64,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-  clean_ghcr_nginx:
-    name: Delete untagged container images
-    runs-on: ubuntu-latest
-    steps:
       - name: Sleep for 65 seconds
         run: sleep 65
         shell: bash

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -1,11 +1,8 @@
 name: Delete old container images
 
 on:
-  push:
-    branches:
-      - alis/ghcr-cleanup-sleep
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *" # every hour
 
 jobs:
   clean_ghcr:

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -19,14 +19,17 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+      - name: Sleep for 45 seconds because of secondary rate limit
+        run: sleep 45
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/cypress'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-      - name: Sleep for 65 seconds
-        run: sleep 65
+      - name: Sleep for 45 seconds because of secondary rate limit
+        run: sleep 45
         shell: bash
       - uses: actions/delete-package-versions@v4
         with:
@@ -34,14 +37,17 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+      - name: Sleep for 45 seconds because of secondary rate limit
+        run: sleep 45
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/db'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-      - name: Sleep for 65 seconds
-        run: sleep 65
+      - name: Sleep for 45 seconds because of secondary rate limit
+        run: sleep 45
         shell: bash
       - uses: actions/delete-package-versions@v4
         with:
@@ -49,14 +55,17 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+      - name: Sleep for 45 seconds because of secondary rate limit
+        run: sleep 45
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/frontend-lighthouse'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-      - name: Sleep for 65 seconds
-        run: sleep 65
+      - name: Sleep for 45 seconds because of secondary rate limit
+        run: sleep 45
         shell: bash
       - uses: actions/delete-package-versions@v4
         with:

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -1,11 +1,14 @@
 name: Delete old container images
 
 on:
+  push:
+    branches:
+      - alis/ghcr-cleanup-sleep
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
-  clean_ghcr:
+  clean_ghcr_backend:
     name: Delete untagged container images
     runs-on: ubuntu-latest
     steps:
@@ -16,36 +19,78 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+  clean_ghcr_cypress:
+    name: Delete untagged container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 65 seconds
+        run: sleep 65
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/cypress'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+  clean_ghcr_database:
+    name: Delete untagged container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 65 seconds
+        run: sleep 65
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/database'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+  clean_ghcr_db:
+    name: Delete untagged container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 65 seconds
+        run: sleep 65
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/db'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+  clean_ghcr_frontend:
+    name: Delete untagged container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 65 seconds
+        run: sleep 65
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/frontend'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+  clean_ghcr_frontend_lighthouse:
+    name: Delete untagged container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 65 seconds
+        run: sleep 65
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/frontend-lighthouse'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+  clean_ghcr_nginx:
+    name: Delete untagged container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 65 seconds
+        run: sleep 65
+        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/nginx'

--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -19,9 +19,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-      - name: Sleep for 65 seconds
-        run: sleep 65
-        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/cypress'
@@ -37,9 +34,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-      - name: Sleep for 65 seconds
-        run: sleep 65
-        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/db'
@@ -55,9 +49,6 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
-      - name: Sleep for 65 seconds
-        run: sleep 65
-        shell: bash
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/frontend-lighthouse'


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #6024 

## Changes Proposed

- Update to run more often
- Add sleep to get around a secondary rate limit

## Additional Information

- This job was somewhat working, except we hit a secondary rate limit after the first 200 images were deleted. We still have hundreds of pages of untagged images to get through, so I thought increasing the frequency would help us burn through it.
- This job will need to be revised after we delete the bulk of untagged images.
- I'm open to other solutions.

## Testing

- :shrug: [This is an example of the job](https://github.com/CDCgov/prime-simplereport/actions/runs/7735453085/job/21120333591) working with the sleeps in place.