### PR TITLE
feat: Update GHCR cleanup script to delete tagged versions, keep 100

### DIFF
--- a/.github/workflows/ghcrCleanup.yml
+++ b/.github/workflows/ghcrCleanup.yml
@@ -2,71 +2,78 @@ name: Delete old container images
 
 on:
   schedule:
-    - cron: "0 * * * *" # every hour
+    - cron: "0 0 * * *" # every day
 
 jobs:
   clean_ghcr:
-    name: Delete untagged container images
+    name: Delete container images
     runs-on: ubuntu-latest
     steps:
       # backend, cypress, database, frontend, frontend-lighthouse, nginx
-      - uses: actions/delete-package-versions@v4
+      - name: Delete backend container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/backend'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'
       - name: Sleep for 45 seconds because of secondary rate limit
         run: sleep 45
         shell: bash
-      - uses: actions/delete-package-versions@v4
+      - name: Delete cypress container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/cypress'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'
       - name: Sleep for 45 seconds because of secondary rate limit
         run: sleep 45
         shell: bash
-      - uses: actions/delete-package-versions@v4
+      - name: Delete database container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/database'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'
       - name: Sleep for 45 seconds because of secondary rate limit
         run: sleep 45
         shell: bash
-      - uses: actions/delete-package-versions@v4
+      - name: Delete db container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/db'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'
       - name: Sleep for 45 seconds because of secondary rate limit
         run: sleep 45
         shell: bash
-      - uses: actions/delete-package-versions@v4
+      - name: Delete frontend container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/frontend'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'
       - name: Sleep for 45 seconds because of secondary rate limit
         run: sleep 45
         shell: bash
-      - uses: actions/delete-package-versions@v4
+      - name: Delete frontend-lighthouse container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/frontend-lighthouse'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'
       - name: Sleep for 45 seconds because of secondary rate limit
         run: sleep 45
         shell: bash
-      - uses: actions/delete-package-versions@v4
+      - name: Delete nginx container images
+        uses: actions/delete-package-versions@v4
         with:
           package-name: 'prime-simplereport/nginx'
           package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'false'


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #6024 

## Changes Proposed

- Update to delete tagged images because we have around 600 images still for the backend, mostly from PR builds.
- Set to keep 100 images, which is two pages of images. That would go back ~3 months for the backend image.
- Change back to running once per day

## Additional Information

- Just more cleanup

## Testing

- :shrug: [This is an example of the job.](https://github.com/CDCgov/prime-simplereport/actions/runs/7820677904/job/21335919274?pr=7249)