### PR TITLE
Update postgres base image to alpine3.17

### DIFF
--- a/backend/db-setup/Dockerfile
+++ b/backend/db-setup/Dockerfile
@@ -1,8 +1,6 @@
 FROM postgres:14-alpine3.17
 
 RUN apk add py3-pip postgresql-libs gcc musl-dev postgresql-dev make
-# RUN pip3 install pgxnclient
-# RUN pgxn install postgresql_anonymizer
 COPY ./requirements.txt /usr/local/lib/requirements.txt
 COPY ./generate_db_data.py /usr/local/lib/generate_db_data.py
 RUN pip3 install -r /usr/local/lib/requirements.txt

--- a/backend/db-setup/Dockerfile
+++ b/backend/db-setup/Dockerfile
@@ -1,8 +1,8 @@
 FROM postgres:14-alpine3.17
 
 RUN apk add py3-pip postgresql-libs gcc musl-dev postgresql-dev make
-RUN pip3 install pgxnclient
-RUN pgxn install postgresql_anonymizer
+# RUN pip3 install pgxnclient
+# RUN pgxn install postgresql_anonymizer
 COPY ./requirements.txt /usr/local/lib/requirements.txt
 COPY ./generate_db_data.py /usr/local/lib/generate_db_data.py
 RUN pip3 install -r /usr/local/lib/requirements.txt

--- a/backend/db-setup/Dockerfile
+++ b/backend/db-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14-alpine3.16
+FROM postgres:14-alpine3.17
 
 RUN apk add py3-pip postgresql-libs gcc musl-dev postgresql-dev make
 RUN pip3 install pgxnclient


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolve #5680 

## Changes Proposed

- Update alpine
- remove `postgresql_anonymizer` (which was causing the build error)

## Additional Information

- `postgresql_anonymizer` is a tool for anonymizing databases. We haven't used this since I developed the feature. I am confident that we can remove this package without disrupting business as usual.
- It would still be possible to use ``postgresql_anonymizer` by utilizing a different base image. 
- We use Alpine to keep the image small.

## Testing

- This image is being used in several Github Action jobs when running tests on this PR
- For anybody running docker, feel free to pull the image and run it

## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README