### PR TITLE
Make e2e spec 4 and 5 rerunnable

### DIFF
--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -1,26 +1,59 @@
-import { generatePatient, loginHooks } from "../support/e2e";
+import {
+  generateCovidOnlyDevice,
+  generatePatient,
+  loginHooks,
+  testNumber,
+} from "../support/e2e";
 import { graphqlURL } from "../utils/request-utils";
 import { aliasGraphqlOperations } from "../utils/graphql-test-utils";
+import {
+  cleanUpPreviousRunSetupData,
+  cleanUpRunOktaOrgs,
+  setupCovidOnlyDevice,
+  setupRunData,
+  setupPatient,
+} from "../utils/setup-utils";
+
+const specRunName = "spec04";
+const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 describe("Conducting a COVID test from:", () => {
-  let patientName, lastName, covidOnlyDeviceName;
+  const patient = generatePatient();
+  const patientName = patient.fullName;
+  const lastName = patient.lastName;
+  const covidOnlyDevice = generateCovidOnlyDevice();
   const queueCard = "[data-cy=prime-queue-item]:last-of-type";
   loginHooks();
 
-  before("retrieve the patient name and covid device name", () => {
-    cy.task("getPatientName").then((name) => {
-      patientName = name;
-      lastName = patientName.split(",")[0];
-    });
-    cy.task("getCovidOnlyDeviceName").then((name) => {
-      covidOnlyDeviceName = name;
-    });
+  before("setup spec data", () => {
+    cy.task("getSpecRunVersionName", specRunName).then(
+      (prevSpecRunVersionName) => {
+        if (prevSpecRunVersionName) {
+          cleanUpPreviousRunSetupData(prevSpecRunVersionName);
+          cleanUpRunOktaOrgs(prevSpecRunVersionName);
+        }
+        let data = {
+          specRunName: specRunName,
+          versionName: currentSpecRunVersionName,
+        };
+        cy.task("setSpecRunVersionName", data);
+
+        setupRunData(currentSpecRunVersionName);
+        setupPatient(currentSpecRunVersionName, patient);
+        setupCovidOnlyDevice(currentSpecRunVersionName, covidOnlyDevice);
+      },
+    );
   });
 
   beforeEach(() => {
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });
+  });
+
+  after("clean up spec data", () => {
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
+    cleanUpRunOktaOrgs(currentSpecRunVersionName);
   });
 
   it("conducts a test from the result page", () => {
@@ -48,10 +81,10 @@ describe("Conducting a COVID test from:", () => {
     cy.get(queueCard).contains("COVID-19 result");
 
     cy.get(queueCard).within(() => {
-      cy.get('select[name="testDevice"]').select(covidOnlyDeviceName);
+      cy.get('select[name="testDevice"]').select(covidOnlyDevice.name);
       cy.get('select[name="testDevice"]')
         .find("option:selected")
-        .should("have.text", covidOnlyDeviceName);
+        .should("have.text", covidOnlyDevice.name);
     });
 
     // We cant wait on EditQueueItem after selecting as device

--- a/cypress/e2e/05-get_result_from_patient_link.cy.js
+++ b/cypress/e2e/05-get_result_from_patient_link.cy.js
@@ -1,28 +1,85 @@
 const dayjs = require("dayjs");
 const { getPatientLinkByTestEventId } = require("../utils/testing-data-utils");
-const { loginHooks } = require("../support/e2e");
+const {
+  loginHooks,
+  testNumber,
+  generatePatient,
+  generateCovidOnlyDevice,
+} = require("../support/e2e");
 const { frontendURL } = require("../utils/request-utils");
+const {
+  cleanUpPreviousRunSetupData,
+  setupRunData,
+  setupPatient,
+  setupCovidOnlyDevice,
+  cleanUpRunOktaOrgs,
+  setupTestOrder,
+} = require("../utils/setup-utils");
+
+const specRunName = "spec05";
+const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 loginHooks();
 describe("Getting a test result from a patient link", () => {
-  let patientLink, patientDOB, patientObfuscatedName;
-  before("retrieve the patient link and dob", () => {
-    cy.task("getTestEventId").then((testEventId) => {
-      getPatientLinkByTestEventId(testEventId).then((res) => {
-        const patientLinkId = res.body.data.testResult.patientLink.internalId;
+  const patient = generatePatient();
+  const covidOnlyDevice = generateCovidOnlyDevice();
+  const patientDOB = patient.dobForPatientLink;
+  const patientObfuscatedName =
+    patient.firstName + " " + patient.lastName[0] + ".";
+  let patientLink;
 
-        patientLink = `${frontendURL}pxp?plid=${patientLinkId}`;
-      });
-    });
+  before("setup spec data", () => {
+    cy.task("getSpecRunVersionName", specRunName).then(
+      (prevSpecRunVersionName) => {
+        if (prevSpecRunVersionName) {
+          cleanUpPreviousRunSetupData(prevSpecRunVersionName);
+          cleanUpRunOktaOrgs(prevSpecRunVersionName);
+        }
+        let data = {
+          specRunName: specRunName,
+          versionName: currentSpecRunVersionName,
+        };
+        cy.task("setSpecRunVersionName", data);
+        let patientId, createdDeviceId, specimenTypeId, testEventId;
+        setupRunData(currentSpecRunVersionName)
+          .then(() => setupPatient(currentSpecRunVersionName, patient))
+          .then((result) => {
+            patientId = result.internalId;
+          })
+          .then(() =>
+            setupCovidOnlyDevice(currentSpecRunVersionName, covidOnlyDevice),
+          )
+          .then((result) => {
+            createdDeviceId = result.createdDeviceId;
+            specimenTypeId = result.specimenTypeId;
+          })
+          .then(() =>
+            setupTestOrder(
+              currentSpecRunVersionName,
+              patientId,
+              createdDeviceId,
+              specimenTypeId,
+            ),
+          )
+          .then((result) => {
+            testEventId = result.body.data.submitQueueItem.testEventId;
+          })
+          .then(() => getPatientLinkByTestEventId(testEventId))
+          .then((result) => {
+            const patientLinkId =
+              result.body.data.testResult.patientLink.internalId;
 
-    cy.task("getPatientDOB").then((dob) => {
-      patientDOB = dob;
-    });
-    cy.task("getPatientName").then((name) => {
-      const [lastName, firstName] = name.split(",");
-      patientObfuscatedName = firstName + " " + lastName[0] + ".";
-    });
+            patientLink = `${frontendURL}pxp?plid=${patientLinkId}`;
+          });
+      },
+    );
   });
+
+  after("clean up spec data", () => {
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
+    cleanUpRunOktaOrgs(currentSpecRunVersionName);
+  });
+
   it("successfully navigates to the patient link", () => {
     cy.visit(patientLink);
   });

--- a/cypress/utils/setup-utils.js
+++ b/cypress/utils/setup-utils.js
@@ -202,7 +202,19 @@ export const setupCovidOnlyDevice = (specRunVersionName, covidOnlyDevice) => {
         supportedDiseases.length > 0 ? supportedDiseases[0].internalId : null;
     })
     .then(() =>
-      setupDevice(covidOnlyDevice, [supportedDiseaseId], specRunVersionName),
+      setupDevice(
+        covidOnlyDevice,
+        [
+          {
+            supportedDisease: supportedDiseaseId,
+            testPerformedLoincCode: `96741-1`,
+            equipmentUid: `equipment-uid-${specRunVersionName}`,
+            testkitNameId: `testkit-name-id-${specRunVersionName}`,
+            testOrderedLoincCode: `96741-1`,
+          },
+        ],
+        specRunVersionName,
+      ),
     );
 };
 


### PR DESCRIPTION
# E2E PULL REQUEST

## Related Issue

- Resolves #7007 

## Changes Proposed

- Makes spec 4 and 5 independently rerunnable by setting up required data before each spec run

## Additional Information

- To get spec 5 to run locally, you *might* need to update your local environment so that it can load the patient link correctly. Not sure if this was only because of my individual local environment setup or if this is a common issue that others come across as well. If it is I'd be happy to look into modifying [request-utils](https://github.com/CDCgov/prime-simplereport/blob/main/cypress/utils/request-utils.js) to make it easier to run locally.
- In `request-utils.js` the frontendURL variable points to either the `REACT_APP_BASE_URL` via Cypress.env or if that is empty then a hardcoded https://localhost.simplereport.gov/app. At least on my machine Cypress doesn't seem to actually pick up that `REACT_APP_BASE_URL` which may be an issue with how we are using Cypress.env to try reading the variable since [Cypress environment variables are not necessarily the same as OS environment variables](https://docs.cypress.io/guides/guides/environment-variables). If others run into this, we could either decide to fix it in this PR or in a follow-up.
- If you run into the same issue, then you can resolve this either by editing your hosts file with localhost.simplereport.gov by following this guidance or by temporarily editing the value in request-utils.js.

```
export const frontendURL = `${
  Cypress.env("REACT_APP_BASE_URL") || "https://localhost:3000/app"
}/`;
```

## Testing

- Run cypress tests locally