### PR TITLE
switch cleanup method in cypress cleanup hook

### DIFF
--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -52,8 +52,8 @@ describe("Conducting a COVID test from:", () => {
   });
 
   after("clean up spec data", () => {
-    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
     cleanUpRunOktaOrgs(currentSpecRunVersionName);
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
   });
 
   it("conducts a test from the result page", () => {

--- a/cypress/e2e/05-get_result_from_patient_link.cy.js
+++ b/cypress/e2e/05-get_result_from_patient_link.cy.js
@@ -76,8 +76,8 @@ describe("Getting a test result from a patient link", () => {
   });
 
   after("clean up spec data", () => {
-    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
     cleanUpRunOktaOrgs(currentSpecRunVersionName);
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
   });
 
   it("successfully navigates to the patient link", () => {


### PR DESCRIPTION
cleanup for after hook /cleanup issue causing flaking when running tests locally.

See [this comment thread for more context](https://github.com/CDCgov/prime-simplereport/pull/7251#discussion_r1484489967)