### PR TITLE
Update local Github Actions

### DIFF
--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to ACR
       shell: bash
       run: docker login ${{ inputs.acr_registry }} -u ${{ inputs.acr_username }} -p ${{ inputs.acr_password }}

--- a/.github/actions/build-db-client-container/action.yml
+++ b/.github/actions/build-db-client-container/action.yml
@@ -7,9 +7,9 @@ runs:
       run:
         working-directory: ./ops/services/container_instances/db_client/image
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to ACR
         run: docker login ${{ secrets.ACR_REPO_URL }} -u ${{ secrets.ACR_ADMIN_USERNAME }} -p ${{ secrets.ACR_ADMIN_PASWORD }}
       - name: Build and push Docker images

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -31,11 +31,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3.8.1
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Use cache for node_modules
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4
       with:
         path: |
           ./frontend/node_modules
@@ -94,7 +94,7 @@ runs:
         tar -C ./frontend/build -czf ${{ inputs.client_tarball }} .
         echo "::endgroup::"
     - name: Save compiled frontend application
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: frontend-tarball

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -98,5 +98,5 @@ runs:
       if: success()
       with:
         name: frontend-tarball
-        path: client.tgz
+        path: ${{ inputs.client_tarball }}
         retention-days: 1

--- a/.github/actions/db-actions/action.yml
+++ b/.github/actions/db-actions/action.yml
@@ -74,7 +74,7 @@ runs:
           --yes || echo "No ${{ inputs.action }} image to delete"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push Docker images
       shell: bash

--- a/.github/actions/deploy-application/action.yml
+++ b/.github/actions/deploy-application/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         creds: ${{ inputs.azure_creds }}
     - name: Retrieve frontend build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: frontend-tarball
     - name: Unpack client

--- a/.github/actions/docker-buildx/action.yml
+++ b/.github/actions/docker-buildx/action.yml
@@ -38,16 +38,16 @@ runs:
   steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Log in to the GH Container registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         password: ${{ inputs.gh_token }}
         registry: ${{ inputs.gh_registry }}
@@ -55,7 +55,7 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ${{ inputs.gh_registry }}/${{ github.repository }}/${{ inputs.image_name }}
@@ -65,7 +65,7 @@ runs:
           type=ref,event=pr
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}

--- a/.github/actions/slack-message/action.yml
+++ b/.github/actions/slack-message/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set vars
       id: vars
       shell: bash

--- a/.github/workflows/checkGraphql.yml
+++ b/.github/workflows/checkGraphql.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: ${{env.NODE_VERSION}}
       - name: Cache yarn
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{env.NODE_VERSION}}
       - name: Cache npm local files
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ./frontend/node_modules
@@ -47,7 +47,7 @@ jobs:
           java-version: ${{env.JAVA_VERSION}}
           distribution: ${{env.JAVA_DISTRIBUTION}}
       - name: Cache Java Dependencies
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/smokeTestDeployProd.yml
+++ b/.github/workflows/smokeTestDeployProd.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: ${{env.NODE_VERSION}}
       - name: Cache yarn
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Cache Java Dependencies
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -59,7 +59,7 @@ jobs:
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
         run: ./gradlew jacocoTestReport -PtestDbPort=5432
       - name: Cache backend coverage results
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: backend/build/**
           key: ${{ runner.os }}-backend-coverage-${{ github.run_id }}-${{ github.run_attempt }}
@@ -79,7 +79,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache yarn
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./frontend
         run: yarn test:ci
       - name: Cache frontend coverage results
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             frontend/coverage/**
@@ -106,7 +106,7 @@ jobs:
         working-directory: ./ops/services/app_functions/report_stream_batched_publisher/functions
         run: yarn coverage
       - name: Cache function coverage results
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ops/services/app_functions/report_stream_batched_publisher/functions/coverage/**
@@ -128,21 +128,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
       - name: Restore backend cache
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             backend/build/**
           key: ${{ runner.os }}-backend-coverage-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Restore frontend cache
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             frontend/coverage/**
           key: ${{ runner.os }}-frontend-coverage-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Restore functions cache
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ops/services/app_functions/report_stream_batched_publisher/functions/coverage/**
@@ -168,7 +168,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Cache Java dependencies
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -186,7 +186,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Cache Java dependencies
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -203,7 +203,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache yarn
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolve #7289

## Changes Proposed

Updates  for:
- actions/cache
- actions/checkout
- actions/setup-node
- actions/upload-artifact
- docker/build-push-action
- docker/login-action
- docker/metadata-action
- docker/setup-buildx-action
- docker/setup-qemu-action

## Additional Information

- Our Dependabot configuration is missing our local GitHub actions in its GitHub action updates. These major version bumps are all due to the actions using node 20. Our GitHub runners are prepared for this upgrade and we haven't had any issues on previous PRs.

## Testing

- Check the output of the jobs to ensure they're using the new versions and passing as expected.

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README