### PR TITLE
add UNAVAILABLE_DISEASE to results error table

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/ResultUploadErrorType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/ResultUploadErrorType.java
@@ -1,8 +1,8 @@
 package gov.cdc.usds.simplereport.db.model.auxiliary;
 
 public enum ResultUploadErrorType {
-    MISSING_HEADER,
-    INVALID_DATA,
-    MISSING_DATA,
-    UNAVAILABLE_DISEASE
+  MISSING_HEADER,
+  INVALID_DATA,
+  MISSING_DATA,
+  UNAVAILABLE_DISEASE
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/ResultUploadErrorType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/ResultUploadErrorType.java
@@ -4,4 +4,5 @@ public enum ResultUploadErrorType {
   MISSING_HEADER,
   INVALID_DATA,
   MISSING_DATA,
+  INCLUDES_NON_AVAILABLE_DISEASE
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/ResultUploadErrorType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/ResultUploadErrorType.java
@@ -1,8 +1,8 @@
 package gov.cdc.usds.simplereport.db.model.auxiliary;
 
 public enum ResultUploadErrorType {
-  MISSING_HEADER,
-  INVALID_DATA,
-  MISSING_DATA,
-  INCLUDES_NON_AVAILABLE_DISEASE
+    MISSING_HEADER,
+    INVALID_DATA,
+    MISSING_DATA,
+    UNAVAILABLE_DISEASE
 }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5236,13 +5236,13 @@ databaseChangeLog:
                   type: text
                   remarks: testOrderedLoincLongName from LIVD API
   - changeSet:
-      id: add-includes-non-available-disease-to-test_result_upload_error
+      id: add-unavailable-disease-to-test_result_upload_error
       author: bob@skylight.digital
-      comment: add INCLUDES_NON_AVAILABLE_DISEASE to test_result_upload_error
+      comment: add UNAVAILABLE_DISEASE to test_result_upload_error
       changes:
         - tagDatabase:
-            tag: add-includes-non-available-disease-to-test_result_upload_error
+            tag: add-unavailable-disease-to-test_result_upload_error
         - sql:
             sql: |
-              ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'INCLUDES_NON_AVAILABLE_DISEASE';
+              ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'UNAVAILABLE_DISEASE';
       rollback: ""

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5235,3 +5235,12 @@ databaseChangeLog:
                   name: test_ordered_loinc_long_name
                   type: text
                   remarks: testOrderedLoincLongName from LIVD API
+  - changeSet:
+      id: add-includes-non-available-disease-to-test_result_upload_error
+      author: bob@skylight.digital
+      comment: add INCLUDES_NON_AVAILABLE_DISEASE to test_result_upload_error
+      changes:
+        - sql:
+            sql: |
+              ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'INCLUDES_NON_AVAILABLE_DISEASE';
+      rollback: ""

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5240,6 +5240,8 @@ databaseChangeLog:
       author: bob@skylight.digital
       comment: add INCLUDES_NON_AVAILABLE_DISEASE to test_result_upload_error
       changes:
+        - tagDatabase:
+            tag: add-includes-non-available-disease-to-test_result_upload_error
         - sql:
             sql: |
               ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'INCLUDES_NON_AVAILABLE_DISEASE';


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- setup for #7207 

## Changes Proposed

- Add a new error type to the results error table denoting "user is trying to upload a disease (HIV) in a env w/o the feature flag being turned on"

## Additional Information

- Splitting out this db change for scope / ease of review

## Testing

- Ensure DB spins up fine
- It is [not possible to remove a value from an enum](https://www.postgresql.org/docs/current/datatype-enum.html#id-1.5.7.15.8:~:text=Existing%20values%20cannot%20be%20removed%20from%20an,An), so roll back is just [empty string](https://docs.liquibase.com/workflows/liquibase-community/using-rollback.html). See a [this similar PR](https://github.com/CDCgov/prime-simplereport/pull/6356) for further discussion
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->

---