### PR TITLE
Make cypress e2e spec 7 rerunnable

### DIFF
--- a/cypress/e2e/07-organization_settings.cy.js
+++ b/cypress/e2e/07-organization_settings.cy.js
@@ -1,13 +1,45 @@
-import { loginHooks } from "../support/e2e";
+import { loginHooks, testNumber } from "../support/e2e";
 import { graphqlURL } from "../utils/request-utils";
 import { aliasGraphqlOperations } from "../utils/graphql-test-utils";
+import {
+  cleanUpPreviousRunSetupData,
+  cleanUpRunOktaOrgs,
+  setupRunData,
+} from "../utils/setup-utils";
+
+const specRunName = "spec07";
+const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 describe("Updating organization settings", () => {
   loginHooks();
+
+  before("setup run data", () => {
+    cy.task("getSpecRunVersionName", specRunName).then(
+      (prevSpecRunVersionName) => {
+        if (prevSpecRunVersionName) {
+          cleanUpPreviousRunSetupData(prevSpecRunVersionName);
+          cleanUpRunOktaOrgs(prevSpecRunVersionName);
+        }
+        let data = {
+          specRunName: specRunName,
+          versionName: currentSpecRunVersionName,
+        };
+        cy.task("setSpecRunVersionName", data);
+
+        setupRunData(currentSpecRunVersionName);
+      },
+    );
+  });
+
   beforeEach(() => {
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });
+  });
+
+  after("clean up run data", () => {
+    cleanUpRunOktaOrgs(currentSpecRunVersionName);
+    cleanUpPreviousRunSetupData(currentSpecRunVersionName);
   });
 
   it("navigates to the org settings page", () => {


### PR DESCRIPTION
# E2E PULL REQUEST

## Related Issue

- Resolves #7010 

## Changes Proposed

- Makes spec 7 independently rerunnable by setting up required data before each spec run

## Testing

- Run Cypress e2e tests locally