### PR TITLE
Gender identity from patient extension to aoe observation

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -13,6 +13,8 @@ public class FhirConstants {
   public static final String SNOMED_CODE_SYSTEM = "http://snomed.info/sct";
   public static final String LOINC_CODE_SYSTEM = "http://loinc.org";
   public static final String YESNO_CODE_SYSTEM = "http://terminology.hl7.org/ValueSet/v2-0136";
+  public static final String DATA_ABSENT_REASON_CODE_SYSTEM =
+      "http://terminology.hl7.org/5.0.0/CodeSystem-data-absent-reason.html";
 
   public static final String RACE_EXTENSION_URL =
       "http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd";
@@ -57,6 +59,7 @@ public class FhirConstants {
   public static final String LOINC_AOE_ICU = "95420-6";
   public static final String LOINC_AOE_RESIDENT_CONGREGATE_SETTING = "95421-4";
   public static final String LOINC_AOE_RESIDENCE_TYPE = "75617-1";
+  public static final String LOINC_GENDER_IDENTITY = "76691-5";
 
   public static final String PROCESSING_ID_SYSTEM = "http://terminology.hl7.org/CodeSystem/v2-0103";
   public static final Map<String, String> PROCESSING_ID_DISPLAY =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -512,7 +512,6 @@ public class FhirConverter {
             .build());
   }
 
-  // no bulk upload changes, it doesnt pass gender id atm
   public Patient convertToPatient(ConvertToPatientProps props) {
     var patient =
         new Patient()
@@ -922,22 +921,24 @@ public class FhirConverter {
       observations.add(convertToAOEPregnancyObservation(surveyData.getPregnancy()));
     }
 
-    if (patientData.getEmployedInHealthcare() != null) {
-      observations.add(
-          convertToAOEYesNoUnkObservation(
-              patientData.getEmployedInHealthcare(),
-              LOINC_AOE_EMPLOYED_IN_HEALTHCARE,
-              AOE_EMPLOYED_IN_HEALTHCARE_DISPLAY));
-    }
+    if (patientData != null) {
+      if (patientData.getEmployedInHealthcare() != null) {
+        observations.add(
+            convertToAOEYesNoUnkObservation(
+                patientData.getEmployedInHealthcare(),
+                LOINC_AOE_EMPLOYED_IN_HEALTHCARE,
+                AOE_EMPLOYED_IN_HEALTHCARE_DISPLAY));
+      }
 
-    if (patientData.getResidentCongregateSetting() != null) {
-      observations.addAll(
-          convertToAOEResidenceObservation(patientData.getResidentCongregateSetting(), null));
-    }
+      if (patientData.getResidentCongregateSetting() != null) {
+        observations.addAll(
+            convertToAOEResidenceObservation(patientData.getResidentCongregateSetting(), null));
+      }
 
-    if (StringUtils.isNotBlank(patientData.getGenderIdentity())) {
-      observations.addAll(
-          convertToAOEGenderIdentityObservation(eventId, patientData.getGenderIdentity()));
+      if (StringUtils.isNotBlank(patientData.getGenderIdentity())) {
+        observations.addAll(
+            convertToAOEGenderIdentityObservation(eventId, patientData.getGenderIdentity()));
+      }
     }
 
     return observations;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -867,12 +867,10 @@ public class FhirConverter {
     Set<Observation> observations = new LinkedHashSet<>();
     if (StringUtils.isNotBlank(genderIdentity)
         && GENDER_IDENTITIES.contains(genderIdentity.toLowerCase())) {
-      CodeableConcept genderIdentityLoincConcept =
-          createLoincConcept(LOINC_GENDER_IDENTITY, "Gender identity", "Gender identity");
 
       String valueCode;
       String valueDisplay;
-      String codeSystem = null;
+      String codeSystem;
 
       switch (genderIdentity.toLowerCase()) {
         case OTHER -> {
@@ -884,20 +882,29 @@ public class FhirConverter {
         case FEMALE, MALE, NON_BINARY, TRANS_MAN, TRANS_WOMAN -> {
           codeSystem = SNOMED_CODE_SYSTEM;
         }
+        default -> {
+          codeSystem = null;
+        }
       }
-      valueDisplay = genderIdentityDisplaySet.get(genderIdentity.toLowerCase());
-      valueCode = genderIdentitySnomedSet.get(genderIdentity.toLowerCase());
 
-      CodeableConcept valueCodeableConcept = new CodeableConcept();
-      valueCodeableConcept
-          .addCoding()
-          .setSystem(codeSystem)
-          .setCode(valueCode)
-          .setDisplay(valueDisplay);
+      if (codeSystem != null) {
+        CodeableConcept genderIdentityLoincConcept =
+            createLoincConcept(LOINC_GENDER_IDENTITY, "Gender identity", "Gender identity");
 
-      observations.add(
-          createAOEObservation(
-              eventId + LOINC_GENDER_IDENTITY, genderIdentityLoincConcept, valueCodeableConcept));
+        valueDisplay = genderIdentityDisplaySet.get(genderIdentity.toLowerCase());
+        valueCode = genderIdentitySnomedSet.get(genderIdentity.toLowerCase());
+
+        CodeableConcept valueCodeableConcept = new CodeableConcept();
+        valueCodeableConcept
+            .addCoding()
+            .setSystem(codeSystem)
+            .setCode(valueCode)
+            .setDisplay(valueDisplay);
+
+        observations.add(
+            createAOEObservation(
+                eventId + LOINC_GENDER_IDENTITY, genderIdentityLoincConcept, valueCodeableConcept));
+      }
     }
     return observations;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.api.converter;
 
 import static gov.cdc.usds.simplereport.api.Translators.DETECTED_SNOMED_CONCEPT;
 import static gov.cdc.usds.simplereport.api.Translators.FEMALE;
+import static gov.cdc.usds.simplereport.api.Translators.GENDER_IDENTITIES;
 import static gov.cdc.usds.simplereport.api.Translators.MALE;
 import static gov.cdc.usds.simplereport.api.Translators.NON_BINARY;
 import static gov.cdc.usds.simplereport.api.Translators.OTHER;
@@ -12,6 +13,7 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLA
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAG_ABNORMAL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAG_NORMAL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.AOE_EMPLOYED_IN_HEALTHCARE_DISPLAY;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.DATA_ABSENT_REASON_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.DATA_ABSENT_REASON_EXTENSION_URL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.DEFAULT_COUNTRY;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.DIAGNOSTIC_CODE_SYSTEM;
@@ -20,8 +22,6 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ETHNICITY_EX
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EVENT_TYPE_CODE;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EVENT_TYPE_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.EVENT_TYPE_DISPLAY;
-import static gov.cdc.usds.simplereport.api.converter.FhirConstants.GENDER_IDENTITY_EXTENSION_CODE_SYSTEM;
-import static gov.cdc.usds.simplereport.api.converter.FhirConstants.GENDER_IDENTITY_EXTENSION_URL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LABORATORY_STRING_LITERAL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LAB_STRING_LITERAL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_EMPLOYED_IN_HEALTHCARE;
@@ -32,6 +32,7 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_RE
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_SYMPTOMATIC;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_SYMPTOM_ONSET;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_CODE_SYSTEM;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_GENDER_IDENTITY;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_CODING_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_CODING_SYSTEM_CODE;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_CODING_SYSTEM_CODE_INDEX_EXTENSION_URL;
@@ -62,6 +63,8 @@ import static gov.cdc.usds.simplereport.api.model.TestEventExport.DEFAULT_LOCATI
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.DEFAULT_LOCATION_NAME;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.FALLBACK_DEFAULT_TEST_MINUTES;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.UNKNOWN_ADDRESS_INDICATOR;
+import static gov.cdc.usds.simplereport.db.model.PersonUtils.genderIdentityDisplaySet;
+import static gov.cdc.usds.simplereport.db.model.PersonUtils.genderIdentitySnomedSet;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.getResidenceTypeMap;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.pregnancyStatusDisplayMap;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.pregnancyStatusSnomedMap;
@@ -105,7 +108,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -510,6 +512,7 @@ public class FhirConverter {
             .build());
   }
 
+  // no bulk upload changes, it doesnt pass gender id atm
   public Patient convertToPatient(ConvertToPatientProps props) {
     var patient =
         new Patient()
@@ -523,8 +526,6 @@ public class FhirConverter {
     patient.addExtension(
         convertToTribalAffiliationExtension(props.getTribalAffiliations()).orElse(null));
 
-    patient.addExtension(convertToGenderIdentityExtension(props.getGenderIdentity()));
-
     patient.setId(props.getId());
     patient.addIdentifier().setValue(props.getId());
 
@@ -537,43 +538,6 @@ public class FhirConverter {
           .forEach(patient::addTelecom);
     }
     return patient;
-  }
-
-  private Extension convertToGenderIdentityExtension(String genderIdentity) {
-    if (StringUtils.isNotBlank(genderIdentity)) {
-
-      Map<String, String> extensionValueSet =
-          Map.of(
-              FEMALE, "female",
-              MALE, "male",
-              NON_BINARY, "non-binary",
-              TRANS_MAN, "transgender male",
-              TRANS_WOMAN, "transgender female",
-              OTHER, "other",
-              REFUSED, "non-disclose");
-
-      Map<String, String> extensionDisplaySet =
-          Map.of(
-              FEMALE, "female",
-              MALE, "male",
-              NON_BINARY, "non-binary",
-              TRANS_MAN, "transgender male",
-              TRANS_WOMAN, "transgender female",
-              OTHER, "other",
-              REFUSED, "does not wish to disclose");
-
-      String genderIdentityKey = genderIdentity.toLowerCase();
-
-      var codeableConcept =
-          new CodeableConcept()
-              .addCoding()
-              .setSystem(GENDER_IDENTITY_EXTENSION_CODE_SYSTEM)
-              .setCode(extensionValueSet.get(genderIdentityKey))
-              .setDisplay(extensionDisplaySet.get(genderIdentityKey));
-
-      return new Extension().setUrl(GENDER_IDENTITY_EXTENSION_URL).setValue(codeableConcept);
-    }
-    return null;
   }
 
   public Device convertToDevice(
@@ -899,11 +863,48 @@ public class FhirConverter {
     return observations;
   }
 
+  public Set<Observation> convertToAOEGenderIdentityObservation(
+      String eventId, String genderIdentity) {
+    Set<Observation> observations = new LinkedHashSet<>();
+    if (StringUtils.isNotBlank(genderIdentity)
+        && GENDER_IDENTITIES.contains(genderIdentity.toLowerCase())) {
+      CodeableConcept genderIdentityLoincConcept =
+          createLoincConcept(LOINC_GENDER_IDENTITY, "Gender identity", "Gender identity");
+
+      String valueCode;
+      String valueDisplay;
+      String codeSystem = null;
+
+      switch (genderIdentity.toLowerCase()) {
+        case OTHER -> {
+          codeSystem = NULL_CODE_SYSTEM;
+        }
+        case REFUSED -> {
+          codeSystem = DATA_ABSENT_REASON_CODE_SYSTEM;
+        }
+        case FEMALE, MALE, NON_BINARY, TRANS_MAN, TRANS_WOMAN -> {
+          codeSystem = SNOMED_CODE_SYSTEM;
+        }
+      }
+      valueDisplay = genderIdentityDisplaySet.get(genderIdentity.toLowerCase());
+      valueCode = genderIdentitySnomedSet.get(genderIdentity.toLowerCase());
+
+      CodeableConcept valueCodeableConcept = new CodeableConcept();
+      valueCodeableConcept
+          .addCoding()
+          .setSystem(codeSystem)
+          .setCode(valueCode)
+          .setDisplay(valueDisplay);
+
+      observations.add(
+          createAOEObservation(
+              eventId + LOINC_GENDER_IDENTITY, genderIdentityLoincConcept, valueCodeableConcept));
+    }
+    return observations;
+  }
+
   public Set<Observation> convertToAOEObservations(
-      String eventId,
-      AskOnEntrySurvey surveyData,
-      Boolean employedInHealthcare,
-      Boolean residesInCongregateSetting) {
+      String eventId, AskOnEntrySurvey surveyData, Person patientData) {
     HashSet<Observation> observations = new LinkedHashSet<>();
     Boolean symptomatic = null;
     if (Boolean.TRUE.equals(surveyData.getNoSymptoms())) {
@@ -921,16 +922,22 @@ public class FhirConverter {
       observations.add(convertToAOEPregnancyObservation(surveyData.getPregnancy()));
     }
 
-    if (employedInHealthcare != null) {
+    if (patientData.getEmployedInHealthcare() != null) {
       observations.add(
           convertToAOEYesNoUnkObservation(
-              employedInHealthcare,
+              patientData.getEmployedInHealthcare(),
               LOINC_AOE_EMPLOYED_IN_HEALTHCARE,
               AOE_EMPLOYED_IN_HEALTHCARE_DISPLAY));
     }
 
-    if (residesInCongregateSetting != null) {
-      observations.addAll(convertToAOEResidenceObservation(residesInCongregateSetting, null));
+    if (patientData.getResidentCongregateSetting() != null) {
+      observations.addAll(
+          convertToAOEResidenceObservation(patientData.getResidentCongregateSetting(), null));
+    }
+
+    if (StringUtils.isNotBlank(patientData.getGenderIdentity())) {
+      observations.addAll(
+          convertToAOEGenderIdentityObservation(eventId, patientData.getGenderIdentity()));
     }
 
     return observations;
@@ -1240,8 +1247,7 @@ public class FhirConverter {
                 convertToAOEObservations(
                     testEvent.getInternalId().toString(),
                     testEvent.getSurveyData(),
-                    testEvent.getPatientData().getEmployedInHealthcare(),
-                    testEvent.getPatientData().getResidentCongregateSetting()))
+                    testEvent.getPatientData()))
             .serviceRequest(convertToServiceRequest(testEvent.getOrder(), dateTested))
             .diagnosticReport(convertToDiagnosticReport(testEvent, currentDate))
             .currentDate(currentDate)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
@@ -1,5 +1,13 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import static gov.cdc.usds.simplereport.api.Translators.FEMALE;
+import static gov.cdc.usds.simplereport.api.Translators.MALE;
+import static gov.cdc.usds.simplereport.api.Translators.NON_BINARY;
+import static gov.cdc.usds.simplereport.api.Translators.OTHER;
+import static gov.cdc.usds.simplereport.api.Translators.REFUSED;
+import static gov.cdc.usds.simplereport.api.Translators.TRANS_MAN;
+import static gov.cdc.usds.simplereport.api.Translators.TRANS_WOMAN;
+
 import gov.cdc.usds.simplereport.api.MappingConstants;
 import java.util.HashMap;
 import java.util.List;
@@ -801,4 +809,24 @@ public class PersonUtils {
           PREGNANT_SNOMED, "Pregnant",
           NOT_PREGNANT_SNOMED, "Not pregnant",
           PREGNANT_UNKNOWN_SNOMED, "Unknown");
+
+  public static final Map<String, String> genderIdentitySnomedSet =
+      Map.of(
+          FEMALE, "446141000124107",
+          MALE, "446151000124109",
+          NON_BINARY, "446131000124102",
+          TRANS_MAN, "446151000124109",
+          TRANS_WOMAN, "446141000124107",
+          OTHER, MappingConstants.UNK_CODE,
+          REFUSED, "asked-declined");
+
+  public static final Map<String, String> genderIdentityDisplaySet =
+      Map.of(
+          FEMALE, "Female gender identity",
+          MALE, "Male gender identity",
+          NON_BINARY, "non-binary",
+          TRANS_MAN, "Male gender identity",
+          TRANS_WOMAN, "Female gender identity",
+          OTHER, "Non-binary gender identity",
+          REFUSED, "Asked But Declined");
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1021,7 +1021,9 @@ class FhirConverterTest {
     var answers = new AskOnEntrySurvey(null, Map.of("fake", false), true, null, null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, null, null);
+    var actual =
+        fhirConverter.convertToAOEObservations(
+            testId, answers, new Person("first", "last", "middle", "suffix", null));
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
@@ -1039,7 +1041,9 @@ class FhirConverterTest {
         new AskOnEntrySurvey(null, Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, null, null);
+    var actual =
+        fhirConverter.convertToAOEObservations(
+            testId, answers, new Person("first", "last", "middle", "suffix", null));
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
@@ -1058,7 +1062,32 @@ class FhirConverterTest {
     var answers = new AskOnEntrySurvey(null, Map.of("fake", false), null, null, null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, true, null);
+    var birthDate = LocalDate.of(2022, 12, 13);
+    var person =
+        new Person(
+            null,
+            null,
+            null,
+            "Austin",
+            "Wingate",
+            "Curtis",
+            "Jr",
+            birthDate,
+            new StreetAddress(
+                List.of("501 Virginia St E", "#1"), "Charleston", "WV", "25301", "Kanawha"),
+            "USA",
+            null,
+            List.of("email1", "email2"),
+            "black",
+            "hispanic",
+            List.of("123"),
+            "Male",
+            null,
+            true,
+            "English",
+            null);
+
+    var actual = fhirConverter.convertToAOEObservations(testId, answers, person);
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
@@ -1077,7 +1106,32 @@ class FhirConverterTest {
     var answers = new AskOnEntrySurvey(null, Map.of("fake", false), null, null, null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, null, true);
+    var birthDate = LocalDate.of(2022, 12, 13);
+    var person =
+        new Person(
+            null,
+            null,
+            null,
+            "Austin",
+            "Wingate",
+            "Curtis",
+            "Jr",
+            birthDate,
+            new StreetAddress(
+                List.of("501 Virginia St E", "#1"), "Charleston", "WV", "25301", "Kanawha"),
+            "USA",
+            null,
+            List.of("email1", "email2"),
+            "black",
+            "hispanic",
+            List.of("123"),
+            "Male",
+            true,
+            null,
+            "English",
+            null);
+
+    var actual = fhirConverter.convertToAOEObservations(testId, answers, person);
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
@@ -1096,7 +1150,9 @@ class FhirConverterTest {
     var answers = new AskOnEntrySurvey("77386006", Map.of("fake", false), null, null, null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, null, null);
+    var actual =
+        fhirConverter.convertToAOEObservations(
+            testId, answers, new Person("first", "last", "middle", "suffix", null));
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
@@ -1117,7 +1173,32 @@ class FhirConverterTest {
             "102874004", Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, false, false);
+    var birthDate = LocalDate.of(2022, 12, 13);
+    var person =
+        new Person(
+            null,
+            null,
+            null,
+            "Austin",
+            "Wingate",
+            "Curtis",
+            "Jr",
+            birthDate,
+            new StreetAddress(
+                List.of("501 Virginia St E", "#1"), "Charleston", "WV", "25301", "Kanawha"),
+            "USA",
+            null,
+            List.of("email1", "email2"),
+            "black",
+            "hispanic",
+            List.of("123"),
+            "Male",
+            false,
+            false,
+            "English",
+            null);
+
+    var actual = fhirConverter.convertToAOEObservations(testId, answers, person);
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
@@ -1134,7 +1215,9 @@ class FhirConverterTest {
     var answers = new AskOnEntrySurvey(null, Map.of("fake", false), false, null, null);
     String testId = "fakeId";
 
-    var actual = fhirConverter.convertToAOEObservations(testId, answers, null, null);
+    var actual =
+        fhirConverter.convertToAOEObservations(
+            testId, answers, new Person("first", "last", "middle", "suffix", null));
 
     String actualSerialized =
         actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();

--- a/backend/src/test/resources/fhir/bundle-integration-testing.json
+++ b/backend/src/test/resources/fhir/bundle-integration-testing.json
@@ -166,14 +166,6 @@
               ],
               "text": "Not Hispanic or Latino"
             }
-          },
-          {
-            "url": "https://hl7.org/fhir/R4/extension-patient-genderidentity.html",
-            "valueCoding": {
-              "system": "https://hl7.org/fhir/R4/valueset-gender-identity.html",
-              "code": "male",
-              "display": "male"
-            }
           }
         ],
         "identifier": [
@@ -386,6 +378,9 @@
           },
           {
             "reference": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          },
+          {
+            "reference": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
           }
         ],
         "note": [
@@ -523,6 +518,64 @@
         "code": {
           "coding": [
             {
+              "system": "http://loinc.org"
+            }
+          ],
+          "text": "Flu A"
+        },
+        "subject": {
+          "reference": "Patient/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        },
+        "issued": "2021-09-01T10:31:30.001Z",
+        "performer": [
+          {
+            "reference": "Organization/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260415000",
+              "display": "Not detected"
+            }
+          ]
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+                "code": "N",
+                "display": "Normal"
+              }
+            ]
+          }
+        ],
+        "method": {
+          "coding": [
+            {
+              "display": "LumiraDx SARS-CoV-2 Ag Test*"
+            }
+          ]
+        },
+        "specimen": {
+          "reference": "Specimen/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        },
+        "device": {
+          "reference": "Device/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        }
+      }
+    },
+    {
+      "fullUrl": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "status": "final",
+        "code": {
+          "coding": [
+            {
               "system": "http://loinc.org",
               "code": "95209-3"
             }
@@ -567,64 +620,6 @@
               }
             }
           ],
-          "coding": [
-            {
-              "display": "LumiraDx SARS-CoV-2 Ag Test*"
-            }
-          ]
-        },
-        "specimen": {
-          "reference": "Specimen/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        },
-        "device": {
-          "reference": "Device/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        }
-      }
-    },
-    {
-      "fullUrl": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org"
-            }
-          ],
-          "text": "Flu A"
-        },
-        "subject": {
-          "reference": "Patient/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        },
-        "issued": "2021-09-01T10:31:30.001Z",
-        "performer": [
-          {
-            "reference": "Organization/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-          }
-        ],
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "260415000",
-              "display": "Not detected"
-            }
-          ]
-        },
-        "interpretation": [
-          {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
-                "code": "N",
-                "display": "Normal"
-              }
-            ]
-          }
-        ],
-        "method": {
           "coding": [
             {
               "display": "LumiraDx SARS-CoV-2 Ag Test*"
@@ -846,6 +841,50 @@
               "system": "http://terminology.hl7.org/ValueSet/v2-0136",
               "code": "N",
               "display": "No"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "identifier": [
+          {
+            "use": "official",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "81959-9",
+                  "display": "Public health laboratory ask at order entry panel"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "76691-5",
+              "display": "Gender identity"
+            }
+          ],
+          "text": "Gender identity"
+        },
+        "subject": {
+          "reference": "Patient/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "446151000124109",
+              "display": "Male gender identity"
             }
           ]
         }

--- a/backend/src/test/resources/fhir/bundle.json
+++ b/backend/src/test/resources/fhir/bundle.json
@@ -126,13 +126,13 @@
         ],
         "result": [
           {
+            "reference": "Observation/6db25889-09cb-4127-9330-cc7e7459c1cd"
+          },
+          {
             "reference": "Observation/f7184a68-c54e-4209-8cc6-5bf5b253e4bd"
           },
           {
             "reference": "Observation/4163abc1-0a54-4aff-badb-87bb96a89470"
-          },
-          {
-            "reference": "Observation/6db25889-09cb-4127-9330-cc7e7459c1cd"
           }
         ]
       }
@@ -166,14 +166,6 @@
                 }
               ],
               "text": "unknown"
-            }
-          },
-          {
-            "url": "https://hl7.org/fhir/R4/extension-patient-genderidentity.html",
-            "valueCoding": {
-              "system": "https://hl7.org/fhir/R4/valueset-gender-identity.html",
-              "code": "male",
-              "display": "male"
             }
           }
         ],
@@ -322,6 +314,7 @@
         },
         "receivedTime": "2023-07-14T15:45:34+00:00",
         "collection": {
+          "collectedDateTime": "2023-07-14T15:45:34+00:00",
           "bodySite": {
             "coding": [
               {
@@ -330,8 +323,7 @@
               }
             ],
             "text": "Topography unknown (body structure)"
-          },
-          "collectedDateTime": "2023-07-14T15:45:34+00:00"
+          }
         }
       }
     },
@@ -387,6 +379,9 @@
           },
           {
             "reference": "Observation/585761a1-2d41-3688-b5c7-9ae8535b4a67"
+          },
+          {
+            "reference": "Observation/cbfd183e-7784-32df-8473-1c33f19f2e6f"
           }
         ],
         "note": [
@@ -450,6 +445,74 @@
         "resourceType": "Organization",
         "id": "07640c5d-87cd-488b-9343-a226c5166539",
         "name": "SimpleReport"
+      }
+    },
+    {
+      "fullUrl": "Observation/6db25889-09cb-4127-9330-cc7e7459c1cd",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6db25889-09cb-4127-9330-cc7e7459c1cd",
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "92141-1",
+              "display": "Influenza virus B RNA [Presence] in Respiratory specimen by NAA with probe detection"
+            }
+          ],
+          "text": "FLU B"
+        },
+        "subject": {
+          "reference": "Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
+        },
+        "issued": "2023-07-14T15:52:34.540Z",
+        "performer": [
+          {
+            "reference": "Organization/1c3d14b9-e222-4a16-9fb2-d9f173034a6a"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "455371000124106",
+              "display": "Invalid result"
+            }
+          ]
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
+                "code": "N",
+                "display": "Normal"
+              }
+            ]
+          }
+        ],
+        "method": {
+          "extension": [
+            {
+              "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
+              "valueCoding": {
+                "code": "testkitNameId3"
+              }
+            }
+          ],
+          "coding": [
+            {
+              "display": "model"
+            }
+          ]
+        },
+        "specimen": {
+          "reference": "Specimen/725252ea-50ef-46bd-ae79-c70e1d04b949"
+        },
+        "device": {
+          "reference": "Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
+        }
       }
     },
     {
@@ -571,74 +634,6 @@
               "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
               "valueCoding": {
                 "code": "testkitNameId1"
-              }
-            }
-          ],
-          "coding": [
-            {
-              "display": "model"
-            }
-          ]
-        },
-        "specimen": {
-          "reference": "Specimen/725252ea-50ef-46bd-ae79-c70e1d04b949"
-        },
-        "device": {
-          "reference": "Device/48aabd5f-a591-4e0e-9fa2-301d3d5a6df4"
-        }
-      }
-    },
-    {
-      "fullUrl": "Observation/6db25889-09cb-4127-9330-cc7e7459c1cd",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "6db25889-09cb-4127-9330-cc7e7459c1cd",
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "92141-1",
-              "display": "Influenza virus B RNA [Presence] in Respiratory specimen by NAA with probe detection"
-            }
-          ],
-          "text": "FLU B"
-        },
-        "subject": {
-          "reference": "Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
-        },
-        "issued": "2023-07-14T15:52:34.540Z",
-        "performer": [
-          {
-            "reference": "Organization/1c3d14b9-e222-4a16-9fb2-d9f173034a6a"
-          }
-        ],
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "455371000124106",
-              "display": "Invalid result"
-            }
-          ]
-        },
-        "interpretation": [
-          {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/v2-0078",
-                "code": "N",
-                "display": "Normal"
-              }
-            ]
-          }
-        ],
-        "method": {
-          "extension": [
-            {
-              "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/testkit-name-id",
-              "valueCoding": {
-                "code": "testkitNameId3"
               }
             }
           ],
@@ -783,6 +778,50 @@
               "system": "http://terminology.hl7.org/ValueSet/v2-0136",
               "code": "N",
               "display": "No"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "Observation/cbfd183e-7784-32df-8473-1c33f19f2e6f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cbfd183e-7784-32df-8473-1c33f19f2e6f",
+        "identifier": [
+          {
+            "use": "official",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "81959-9",
+                  "display": "Public health laboratory ask at order entry panel"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "76691-5",
+              "display": "Gender identity"
+            }
+          ],
+          "text": "Gender identity"
+        },
+        "subject": {
+          "reference": "Patient/55c53ed2-add5-47fb-884e-b4542ee64589"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "446151000124109",
+              "display": "Male gender identity"
             }
           ]
         }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #7232 

## Changes Proposed

- Remove the gender identity extension from the patient
- Add an additional AOE observation containing the gender identity information (different mapping / code system)

## Additional Information

## Testing

- Easiest way to verify the fhir mapping code is to debug locally.
- Regression testing in lower envs

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
