### PR TITLE
add device lookup filtering

### DIFF
--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookup.test.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookup.test.tsx
@@ -7,8 +7,10 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import * as flaggedMock from "flagged";
 
 import mockSupportedDiseaseTestPerformedCovid from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedCovid";
+import mockSupportedDiseaseTestPerformedHIV from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHIV";
 
 import DeviceLookup from "./DeviceLookup";
 
@@ -49,6 +51,15 @@ const devices = [
     testLength: 15,
     swabTypes: [{ internalId: "123", name: "nose", typeCode: "nose-code" }],
     supportedDiseaseTestPerformed: mockSupportedDiseaseTestPerformedCovid,
+  },
+  {
+    internalId: "abc2",
+    name: "Acme HIV Device (RT-PCR)",
+    model: "Model A",
+    manufacturer: "Celoxitin",
+    testLength: 15,
+    swabTypes: [{ internalId: "123", name: "nose", typeCode: "n123" }],
+    supportedDiseaseTestPerformed: mockSupportedDiseaseTestPerformedHIV,
   },
 ];
 
@@ -117,6 +128,26 @@ describe("Device lookup", () => {
     const specimenType = screen.getByLabelText("Specimen type");
     expect(within(specimenType).getByText("nose")).toBeInTheDocument();
     expect(within(specimenType).getByText("n123")).toBeInTheDocument();
+  });
+
+  it("hiv devices are filtered out if feature flag is off", async () => {
+    jest.spyOn(flaggedMock, "useFeature").mockReturnValue(false);
+
+    const { user } = renderWithUser();
+    await user.type(screen.getByLabelText("Select device"), "HIV");
+    await waitForElementToBeRemoved(() => screen.queryByText("Searching..."));
+    expect(
+      screen.getByText("No device found matching", { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("hiv devices show up if feature flag is on", async () => {
+    jest.spyOn(flaggedMock, "useFeature").mockReturnValue(true);
+
+    const { user } = renderWithUser();
+    await user.type(screen.getByLabelText("Select device"), "HIV");
+    await waitForElementToBeRemoved(() => screen.queryByText("Searching..."));
+    expect(screen.getByText("Model A")).toBeInTheDocument();
   });
 
   it("copy button displays when device selected", async () => {

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookup.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookup.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import "./DeviceLookup.scss";
 import { uniq } from "lodash";
+import { useFeature } from "flagged";
 
 import SearchInput from "../../testQueue/addToQueue/SearchInput";
 import { useDebounce } from "../../testQueue/addToQueue/useDebounce";
@@ -45,6 +46,19 @@ export const searchDevices = (
 };
 
 const DeviceLookup = (props: Props) => {
+  const hivBulkUploadEnabled = useFeature("hivBulkUploadEnabled") as boolean;
+
+  let deviceDisplayOptions = props.deviceOptions;
+  if (!hivBulkUploadEnabled) {
+    deviceDisplayOptions = deviceDisplayOptions.filter(
+      (d) =>
+        !d.supportedDiseaseTestPerformed
+          .map((s) => s.supportedDisease)
+          .map((sup) => sup.name)
+          .includes("HIV")
+    );
+  }
+
   const [queryString, debounced, setDebounced] = useDebounce("", {
     debounceTime: SEARCH_DEBOUNCE_TIME,
     runIf: (q) => q.length >= MIN_SEARCH_CHARACTER_COUNT,
@@ -122,7 +136,7 @@ const DeviceLookup = (props: Props) => {
             showSubmitButton={false}
           />
           <DeviceSearchResults
-            items={searchDevices(props.deviceOptions, queryString)}
+            items={searchDevices(deviceDisplayOptions, queryString)}
             setSelectedItem={setSelectedDevice}
             shouldShowSuggestions={showDropdown}
             loading={debounced !== queryString}


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixes #7207 by adding frontend-filtering for HIV devices
- Part three of the ticket (part one #7299 and part two #7293)

## Changes Proposed
- Adds a filtering function / test to the device code lookup tool

## Additional Information

- Thought briefly about filtering this on the backend but didn't want to assume that we will never need device data in an API call in other cases when the feature flag is off.

## Testing

- Verify filtering works on / off with the feature flag turning on and off

## Screenshots / Demos

Filtering on with the feature flag
https://github.com/CDCgov/prime-simplereport/assets/29645040/b02e47a9-92fd-4cec-b8b5-5f1cf901121d

Filtering off with the feature flag
https://github.com/CDCgov/prime-simplereport/assets/29645040/605e4407-e15c-4ce9-b48c-19b4b9ba5c42

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
