### PR TITLE
feat(dependabot): add grouping for frontend npm package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,7 +100,7 @@ updates:
     reviewers:
       - "cdcgov/simplereport-devsecops"
       - "cdcgov/simplereport-engineeringreviews"
-      
+
   - package-ecosystem: "npm"
     directory: "/frontend"
     open-pull-requests-limit: 2
@@ -110,7 +110,28 @@ updates:
     reviewers:
       - "cdcgov/simplereport-devsecops"
       - "cdcgov/simplereport-engineeringreviews"
-      
+    groups:
+      eslint:
+        patterns:
+        - "eslint*"
+      graphql:
+        patterns:
+        - "@graphql*"
+      jest:
+        patterns:
+        - "jest*"
+      storybook:
+        patterns:
+        - "@storybook*"
+        - "storybook*"
+        - "msw-storybook-addon"
+      types:
+        patterns:
+        - "@types/*"
+      typescript-eslint:
+        patterns:
+        - "@typescript-eslint*"
+
   - package-ecosystem: "npm"
     directory: "/cypress"
     open-pull-requests-limit: 2


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- resolves #7117 

## Changes Proposed

- Create groups of dependencies that can be upgraded together

## Additional Information

- If this works well, I have other dependencies for other project parts that would work well grouped.

## Testing

- To test this, I've forked SR, enabled dependabot on my fork, and triggered a scan. [Here is the list of open PRs.](https://github.com/alismx/prime-simplereport/pulls) [Here is an example of a grouped PR.](https://github.com/alismx/prime-simplereport/pull/23)

## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
