### PR TITLE
Remove unused feature flags from DB

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5246,3 +5246,15 @@ databaseChangeLog:
             sql: |
               ALTER TYPE ${database.defaultSchemaName}.TEST_RESULT_UPLOAD_ERROR ADD VALUE 'UNAVAILABLE_DISEASE';
       rollback: ""
+  - changeSet:
+      id: remove-unused-feature-flags
+      author: ttu8@cdc.gov
+      comment: remove rsvEnabled, testCardRefactorEnabled, and singleEntryRsvEnabled
+      changes:
+        - tagDatabase:
+            tag: remove-unused-feature-flags
+        - delete:
+            schemaName: ${database.defaultSchemaName}
+            tableName: feature_flag
+            where: name in ('rsvEnabled', 'testCardRefactorEnabled', 'singleEntryRsvEnabled')
+      rollback: ""


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- Final part (3 of 3) to resolve #7056 

## Changes Proposed
- Removes `rsvEnabled`, `testCardRefactorEnabled`, `singleEntryRsvEnabled` from the DB

## Additional Information
- Might be nice in the future to create an endpoint to remove these from our DB and not just create them

## Testing
- Create the following feature flags locally: `rsvEnabled`, `testCardRefactorEnabled`, `singleEntryRsvEnabled` via the `updateFeatureFlag` mutation
- Create other ones as well if desired
- Start the backend and see that only those 3 feature flags are removed

<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->
