### PR TITLE
Use bulk upload supported diseases const

### DIFF
--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -7,6 +7,7 @@ import "./CsvSchemaDocumentation.scss";
 import { getAppInsights } from "../../TelemetryService";
 import ScrollToTopOnMount from "../../commonComponents/ScrollToTopOnMount";
 import { getFacilityIdFromUrl } from "../../utils/url";
+import { BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT } from "../../../config/constants";
 
 import { CsvSchema } from "./specificSchemaBuilder";
 
@@ -200,7 +201,7 @@ const CsvSchemaDocumentation: React.FC<CsvSchemaDocumentationProps> = ({
         <section id="anchor-top">
           <p className="text-base sub-header">
             How to format and upload a CSV file to report test results in bulk
-            for COVID-19, Flu A and B, and RSV through SimpleReport.
+            for {BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT} through SimpleReport.
           </p>
           <p>
             SimpleReport’s bulk results uploader lets you report multiple test

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -20,8 +20,8 @@ const DiseaseSpecificUploadContainer = () => {
             Organizations sending results to the California Department of Public
             Health (CDPH) can now use the bulk results upload feature to report
             positive flu and RSV tests. Report{" "}
-            {BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT}
-            results all from a single spreadsheet.{" "}
+            {BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT} results all from a single
+            spreadsheet.{" "}
             <a
               href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"
               onClick={() => {

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { FileUploadService } from "../../../fileUploadService/FileUploadService";
 import { getAppInsights } from "../../TelemetryService";
+import { BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT } from "../../../config/constants";
 
 import UploadForm from "./UploadForm";
 
@@ -18,7 +19,8 @@ const DiseaseSpecificUploadContainer = () => {
           <p>
             Organizations sending results to the California Department of Public
             Health (CDPH) can now use the bulk results upload feature to report
-            positive flu and RSV tests. Report COVID-19, flu A and B, and RSV
+            positive flu and RSV tests. Report{" "}
+            {BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT}
             results all from a single spreadsheet.{" "}
             <a
               href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 1`
         <p
           class="text-base sub-header"
         >
-          How to format and upload a CSV file to report test results in bulk for COVID-19, Flu A and B, and RSV through SimpleReport.
+          How to format and upload a CSV file to report test results in bulk for 
+          COVID-19, Flu A and B, and RSV
+           through SimpleReport.
         </p>
         <p>
           SimpleReport’s bulk results uploader lets you report multiple test results at once using a CSV file. When you submit your results, the uploader tool verifies the data, then sends your results to the relevant state and/or local health department(s).

--- a/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
@@ -34,7 +34,9 @@ exports[`Disease specific upload container test passes axe tests 1`] = `
               class="usa-alert__text"
             >
               <p>
-                Organizations sending results to the California Department of Public Health (CDPH) can now use the bulk results upload feature to report positive flu and RSV tests. Report COVID-19, flu A and B, and RSV results all from a single spreadsheet.
+                Organizations sending results to the California Department of Public Health (CDPH) can now use the bulk results upload feature to report positive flu and RSV tests. Report 
+                COVID-19, Flu A and B, and RSV
+                results all from a single spreadsheet.
                  
                 <a
                   href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"

--- a/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
@@ -34,9 +34,10 @@ exports[`Disease specific upload container test passes axe tests 1`] = `
               class="usa-alert__text"
             >
               <p>
-                Organizations sending results to the California Department of Public Health (CDPH) can now use the bulk results upload feature to report positive flu and RSV tests. Report 
+                Organizations sending results to the California Department of Public Health (CDPH) can now use the bulk results upload feature to report positive flu and RSV tests. Report
+                 
                 COVID-19, Flu A and B, and RSV
-                results all from a single spreadsheet.
+                 results all from a single spreadsheet.
                  
                 <a
                   href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Follow up to #7371 

## Changes Proposed

- Update copy text to use a constant for the reference to the supported diseases for bulk uploader. [See this comment](https://github.com/CDCgov/prime-simplereport/pull/7371#discussion_r1516271241)

## Testing

- Deployed on dev6

## Screenshots / Demos

This capitalizes Flu in this component
![Screenshot 2024-03-07 124510](https://github.com/CDCgov/prime-simplereport/assets/23287037/a4dd2088-95e5-4fe5-9104-6ddf7e049155)

Unchanged in this component, but references the constant
![Screenshot 2024-03-07 124536](https://github.com/CDCgov/prime-simplereport/assets/23287037/0dbe7075-9941-4a37-8a0d-2d7c52b9e966)