### PR TITLE
Mike/7211 dashboard specific condition

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -106,8 +106,11 @@ public class TestResultResolver {
 
   @QueryMapping
   public TopLevelDashboardMetrics topLevelDashboardMetrics(
-      @Argument UUID facilityId, @Argument Date startDate, @Argument Date endDate) {
-    return tos.getTopLevelDashboardMetrics(facilityId, startDate, endDate);
+      @Argument UUID facilityId,
+      @Argument Date startDate,
+      @Argument Date endDate,
+      @Argument String disease) {
+    return tos.getTopLevelDashboardMetrics(facilityId, startDate, endDate, disease);
   }
 
   @QueryMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -67,10 +67,10 @@ public interface TestEventRepository
               + "         LEFT JOIN Result res ON res.testEvent = te "
               + "         LEFT JOIN SupportedDisease disease ON res.disease = disease "
               + "WHERE te.facility.internalId IN :facilityIds AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
-              + "    te.correctionStatus <> 'REMOVED' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = '96741-4' "
+              + "    te.correctionStatus <> 'REMOVED' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = :diseaseLoinc "
               + "GROUP BY res.testResult")
   List<TestResultWithCount> countByResultByFacility(
-      Collection<UUID> facilityIds, Date startDate, Date endDate);
+      Collection<UUID> facilityIds, Date startDate, Date endDate, String diseaseLoinc);
 
   @Query(
       value =
@@ -80,9 +80,10 @@ public interface TestEventRepository
               + "         LEFT JOIN Result res ON res.testEvent = te "
               + "         LEFT JOIN SupportedDisease disease ON res.disease = disease "
               + "WHERE te.facility.internalId = :facilityId AND COALESCE(te.dateTestedBackdate, te.createdAt) BETWEEN :startDate AND :endDate AND "
-              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = '96741-4' "
+              + "    te.correctionStatus = 'ORIGINAL' AND corrected_te.priorCorrectedTestEventId IS NULL AND disease.loinc = :diseaseLoinc "
               + "GROUP BY res.testResult")
-  List<TestResultWithCount> countByResultForFacility(UUID facilityId, Date startDate, Date endDate);
+  List<TestResultWithCount> countByResultForFacility(
+      UUID facilityId, Date startDate, Date endDate, String diseaseLoinc);
 
   boolean existsByPatient(Person person);
 }

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -524,6 +524,7 @@ type Query {
     facilityId: ID
     startDate: DateTime
     endDate: DateTime
+    disease: String
   ): TopLevelDashboardMetrics @requiredPermissions(allOf: ["EDIT_ORGANIZATION"])
   users: [ApiUser] @requiredPermissions(allOf: ["MANAGE_USERS"])
   usersWithStatus: [ApiUserWithStatus!]

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -164,7 +164,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Facility place = createTestEventsForMetricsTests(org);
 
     List<TestResultWithCount> results =
-        _repo.countByResultForFacility(place.getInternalId(), d1, DATE_1MIN_FUTURE);
+        _repo.countByResultForFacility(place.getInternalId(), d1, DATE_1MIN_FUTURE, "96741-4");
 
     assertEquals(2, results.size());
 
@@ -186,7 +186,8 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
     Facility place = createTestEventsForMetricsTests(org);
 
     List<TestResultWithCount> results =
-        _repo.countByResultByFacility(Set.of(place.getInternalId()), d1, DATE_1MIN_FUTURE);
+        _repo.countByResultByFacility(
+            Set.of(place.getInternalId()), d1, DATE_1MIN_FUTURE, "96741-4");
 
     assertEquals(2, results.size());
 
@@ -211,7 +212,8 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
         p, place, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.UNDETERMINED, false);
 
     List<TestResultWithCount> results =
-        _repo.countByResultByFacility(Set.of(place.getInternalId()), d1, DATE_1MIN_FUTURE);
+        _repo.countByResultByFacility(
+            Set.of(place.getInternalId()), d1, DATE_1MIN_FUTURE, "96741-4");
 
     assertEquals(2, results.size());
 
@@ -239,7 +241,7 @@ class TestEventRepositoryTest extends BaseRepositoryTest {
             .collect(Collectors.toSet());
 
     List<TestResultWithCount> results =
-        _repo.countByResultByFacility(facilityIds, d1, DATE_1MIN_FUTURE);
+        _repo.countByResultByFacility(facilityIds, d1, DATE_1MIN_FUTURE, "96741-4");
 
     assertEquals(3, results.size());
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2103,7 +2103,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
 
     TopLevelDashboardMetrics metrics =
-        _service.getTopLevelDashboardMetrics(null, startDate, endDate);
+        _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19");
     assertEquals(3, metrics.getPositiveTestCount());
     assertEquals(12, metrics.getTotalTestCount());
   }
@@ -2117,7 +2117,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     assertThrows(
         AccessDeniedException.class,
-        () -> _service.getTopLevelDashboardMetrics(null, startDate, endDate));
+        () -> _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19"));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -480,10 +480,16 @@ public class TestDataFactory {
   }
 
   public TestEvent createTestEvent(Person p, Facility f, AskOnEntrySurvey s, TestResult r, Date d) {
+    SupportedDisease defaultDisease = diseaseService.covid();
+    return createTestEvent(p, f, s, r, d, defaultDisease);
+  }
+
+  public TestEvent createTestEvent(
+      Person p, Facility f, AskOnEntrySurvey s, TestResult r, Date d, SupportedDisease disease) {
     TestOrder o = createTestOrder(p, f, s);
     o.setDateTestedBackdate(d);
 
-    Result orderResult = new Result(diseaseService.covid(), r);
+    Result orderResult = new Result(disease, r);
     resultService.addResultsToTestOrder(o, List.of(orderResult));
 
     TestEvent e = new TestEvent(o, false);

--- a/frontend/src/app/analytics/operations.graphql
+++ b/frontend/src/app/analytics/operations.graphql
@@ -2,11 +2,13 @@ query GetTopLevelDashboardMetricsNew(
   $facilityId: ID
   $startDate: DateTime
   $endDate: DateTime
+  $disease: String
 ) {
   topLevelDashboardMetrics(
     facilityId: $facilityId
     startDate: $startDate
     endDate: $endDate
+    disease: $disease
   ) {
     positiveTestCount
     totalTestCount

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -866,6 +866,7 @@ export type QueryTestResultsPageArgs = {
 };
 
 export type QueryTopLevelDashboardMetricsArgs = {
+  disease?: InputMaybe<Scalars["String"]["input"]>;
   endDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   facilityId?: InputMaybe<Scalars["ID"]["input"]>;
   startDate?: InputMaybe<Scalars["DateTime"]["input"]>;
@@ -1523,6 +1524,7 @@ export type GetTopLevelDashboardMetricsNewQueryVariables = Exact<{
   facilityId?: InputMaybe<Scalars["ID"]["input"]>;
   startDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   endDate?: InputMaybe<Scalars["DateTime"]["input"]>;
+  disease?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type GetTopLevelDashboardMetricsNewQuery = {
@@ -4277,11 +4279,13 @@ export const GetTopLevelDashboardMetricsNewDocument = gql`
     $facilityId: ID
     $startDate: DateTime
     $endDate: DateTime
+    $disease: String
   ) {
     topLevelDashboardMetrics(
       facilityId: $facilityId
       startDate: $startDate
       endDate: $endDate
+      disease: $disease
     ) {
       positiveTestCount
       totalTestCount
@@ -4304,6 +4308,7 @@ export const GetTopLevelDashboardMetricsNewDocument = gql`
  *      facilityId: // value for 'facilityId'
  *      startDate: // value for 'startDate'
  *      endDate: // value for 'endDate'
+ *      disease: // value for 'disease'
  *   },
  * });
  */


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Backend changes for #7211 

## Changes Proposed

- Updates the dashboard metrics query to support a disease parameter and use COVID-19 by default

## Additional Information

- Frontend changes for selecting the condition in the dashboard will come in a following PR

## Testing

- How should reviewers verify this PR?