### PR TITLE
remove within-spec state reliance

### DIFF
--- a/cypress/e2e/01-organization_sign_up.cy.js
+++ b/cypress/e2e/01-organization_sign_up.cy.js
@@ -19,11 +19,11 @@ describe("Organization sign up", () => {
     cy.contains("Sign up for SimpleReport");
     cy.contains("My organization is new to SimpleReport").click();
     cy.contains("Continue").click();
-  });
-  it("fills out the org info form", () => {
+
     cy.contains("Sign up for SimpleReport in three steps");
     cy.checkAccessibility(); // Sign up form
 
+    // fills out the org info form
     cy.get('input[name="name"]').type(organization.name);
     cy.get('select[name="state"]').select("CA");
     cy.get('select[name="type"]').select("Camp");
@@ -31,12 +31,13 @@ describe("Organization sign up", () => {
     cy.get('input[name="lastName"]').type("McTester");
     cy.get('input[name="email"]').type(user.email);
     cy.get('input[name="workPhoneNumber"]').type("5308675309");
-  });
-  it("submits successfully", () => {
+
+    // submits successfully
     cy.get("button.submit-button").click();
     cy.contains("Identity verification consent");
     cy.checkAccessibility(); // Identity verification page
   });
+
   it("navigates to the support pending org table and verifies the org", () => {
     cy.removeOrganizationAccess();
     cy.visit("/admin");
@@ -95,8 +96,8 @@ describe("Organization sign up", () => {
 
     // Test a11y on New Facility page
     cy.checkAccessibility();
-  });
-  it("fills out the form for a new facility", () => {
+
+    // fills out the form for a new facility
     cy.get('input[name="facility.name"]').type(facility.name);
     cy.get('input[name="facility.phone"]').first().type("5308675309");
     cy.get('input[name="facility.street"]').first().type("123 Beach Way");
@@ -117,6 +118,7 @@ describe("Organization sign up", () => {
     cy.get(".modal__container #save-confirmed-address").click();
     cy.contains("+ New facility");
   });
+
   it("enables adding patients", () => {
     cy.visit("/");
     cy.get("#desktop-patient-nav-link").click();

--- a/cypress/e2e/02a-bulk_upload_patient.cy.js
+++ b/cypress/e2e/02a-bulk_upload_patient.cy.js
@@ -50,8 +50,8 @@ describe("Bulk upload patients", () => {
     cy.get(".prime-edit-patient").contains("Set up your spreadsheet");
     cy.injectSRAxe();
     cy.checkAccessibility(); // Bulk upload patient form
-  });
-  it("uploads csv file of patients", () => {
+
+    // uploads csv file of patients
     const csvFileContent =
       "last_name,first_name,middle_name,suffix,race,date_of_birth,biological_sex,ethnicity,street,street2,city,county,state,zip_code,country,phone_number,phone_number_type,employed_in_healthcare,resident_congregate_setting,role,email\n" +
       `${patientToCsv(patients[0])}\n` +
@@ -70,6 +70,7 @@ describe("Bulk upload patients", () => {
     cy.get(".usa-button").contains("Upload CSV file").click();
     cy.get(".prime-edit-patient").contains("Success: Data confirmed");
   });
+
   it("patients should appear in the patients list", () => {
     cy.visit("/");
     cy.get(".usa-nav-container");

--- a/cypress/e2e/05-get_result_from_patient_link.cy.js
+++ b/cypress/e2e/05-get_result_from_patient_link.cy.js
@@ -82,18 +82,17 @@ describe("Getting a test result from a patient link", () => {
 
   it("successfully navigates to the patient link", () => {
     cy.visit(patientLink);
-  });
-  it("contains no accessibility issues", () => {
+    // contains no accessibility issues
     cy.injectSRAxe();
     cy.checkAccessibility(); // PXP page
-  });
-  it("accepts the terms of service", () => {
+
+    // accepts the terms of service
     cy.contains("Terms of service");
     cy.contains("I agree").click();
-  });
-  it("enters the date of birth and submits", () => {
+
     cy.contains("Access your COVID-19 test result");
 
+    // enters the date of birth and submits
     // This sentence is broken into multiple lines due to how the i18n
     // library interpolates the patient name variable
     cy.contains("Enter ");
@@ -111,8 +110,8 @@ describe("Getting a test result from a patient link", () => {
     cy.get('input[name="day"]').type(birthDay);
     cy.get('input[name="year"]').type(birthYear);
     cy.get("#dob-submit-button").click();
-  });
-  it("shows the test result", () => {
+
+    // shows the test result
     cy.contains("Test result");
     cy.contains("Test date");
     cy.contains("Test device");

--- a/cypress/e2e/07-organization_settings.cy.js
+++ b/cypress/e2e/07-organization_settings.cy.js
@@ -50,23 +50,23 @@ describe("Updating organization settings", () => {
     // Test a11y on the Manage organization page
     cy.injectSRAxe();
     cy.checkAccessibility();
-  });
-  it("attempts an empty selection for organization type", () => {
+
+    // attempts an empty selection for organization type
     cy.get('select[name="type"]')
       .find("option:selected")
       .should("have.text", "Camp");
     cy.get('select[name="type"]').select("- Select -");
     cy.contains("Save settings").should("be.enabled").click();
-  });
-  it("displays a validation toast", () => {
+
+    // displays a validation toast
     cy.contains("An organization type must be selected");
-  });
-  it("attempts a valid selection for organization type", () => {
+
+    // attempts a valid selection for organization type
     cy.get('select[name="type"]').select("Nursing home");
     cy.contains("Save settings").should("be.enabled").click();
     cy.wait("@AdminSetOrganization");
-  });
-  it("displays a success toast", () => {
+
+    // displays a success toast
     cy.get(".Toastify").contains("Updated organization");
   });
 });

--- a/cypress/e2e/10-support-manage-facility.cy.js
+++ b/cypress/e2e/10-support-manage-facility.cy.js
@@ -84,9 +84,8 @@ describe("Support admin: manage facility", () => {
     cy.checkAccessibility();
     cy.get("button").contains("No, go back").click();
     cy.contains(`Delete ${facilityName}`).should("not.exist");
-  });
 
-  it("Deletes a facility", () => {
+    // Deletes a facility
     cy.get("button").contains("Delete facility").click();
     cy.get("button").contains("Yes, delete facility").click();
     cy.get(".Toastify").contains(


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Part 1 of #4938 
- Cypress 12 introduced some [test isolation features ](https://docs.cypress.io/guides/references/migration-guide#Test-Isolation)that resets state between different tests in the same file, causing some of our test logic to fail. Smushing those things together here prior to the upgrade for ease of review
- Cypress recommends grouping tests [in larger user-flow centered blocks as part of best practice](https://docs.cypress.io/guides/references/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion) anyways, so this is in line with that as well. Elected not to touch anything that wasn't immediately necessary for the refactor (since anything that doesn't rely on previous `it()`'s / can run independently are arguably a distinct block of interaction), but if folks want can go back and rework those as well.

## Testing

- Run the changed tests locally / notice them passing in CI 

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---
