### PR TITLE
Add selectable diseases for analytics dashboard

### DIFF
--- a/frontend/src/app/ReportingApp.test.tsx
+++ b/frontend/src/app/ReportingApp.test.tsx
@@ -145,6 +145,7 @@ const getAnalyticsQueryMock = () => ({
       facilityId: "",
       startDate: getStartDateFromDaysAgo(7),
       endDate: getEndDateFromDaysAgo(0),
+      disease: "COVID-19",
     },
   },
   result: {
@@ -211,7 +212,7 @@ describe("App", () => {
 
     await user.click(screen.getAllByText("Testing Site", { exact: false })[0]);
     expect(
-      await screen.findByText("COVID-19 testing data")
+      await screen.findByText("COVID-19 testing data", { exact: false })
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -4,6 +4,7 @@ import { MockedProvider } from "@apollo/client/testing";
 import createMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import MockDate from "mockdate";
+import * as flaggedMock from "flagged";
 
 import { GetTopLevelDashboardMetricsNewDocument } from "../../generated/graphql";
 import { PATIENT_TERM_PLURAL } from "../../config/constants";
@@ -41,6 +42,7 @@ const getMocks = () => [
         facilityId: "",
         startDate: getStartDateFromDaysAgo(7),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -59,6 +61,7 @@ const getMocks = () => [
         facilityId: "",
         startDate: getStartDateFromDaysAgo(1),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -77,6 +80,7 @@ const getMocks = () => [
         facilityId: "",
         startDate: getStartDateFromDaysAgo(30),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -95,6 +99,7 @@ const getMocks = () => [
         facilityId: "1",
         startDate: getStartDateFromDaysAgo(7),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -113,6 +118,7 @@ const getMocks = () => [
         facilityId: "2",
         startDate: getStartDateFromDaysAgo(7),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -131,6 +137,7 @@ const getMocks = () => [
         facilityId: "",
         startDate: setStartTimeForDateRange(new Date("07/01/2021")),
         endDate: setEndTimeForDateRange(new Date("07/31/2021")),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -149,6 +156,7 @@ const getMocks = () => [
         facilityId: "",
         startDate: setStartTimeForDateRange(new Date("07/01/2021")),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -167,6 +175,7 @@ const getMocks = () => [
         facilityId: "3",
         startDate: getStartDateFromDaysAgo(7),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -185,6 +194,7 @@ const getMocks = () => [
         facilityId: "3",
         startDate: getStartDateFromDaysAgo(30),
         endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
       },
     },
     result: {
@@ -192,6 +202,44 @@ const getMocks = () => [
         topLevelDashboardMetrics: {
           totalTestCount: 5,
           positiveTestCount: 0,
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: GetTopLevelDashboardMetricsNewDocument,
+      variables: {
+        facilityId: "3",
+        startDate: getStartDateFromDaysAgo(7),
+        endDate: getEndDateFromDaysAgo(0),
+        disease: "COVID-19",
+      },
+    },
+    result: {
+      data: {
+        topLevelDashboardMetrics: {
+          totalTestCount: 5,
+          positiveTestCount: 0,
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: GetTopLevelDashboardMetricsNewDocument,
+      variables: {
+        facilityId: "",
+        startDate: getStartDateFromDaysAgo(7),
+        endDate: getEndDateFromDaysAgo(0),
+        disease: "Flu A",
+      },
+    },
+    result: {
+      data: {
+        topLevelDashboardMetrics: {
+          totalTestCount: 736,
+          positiveTestCount: 289,
         },
       },
     },
@@ -220,7 +268,7 @@ describe("Analytics", () => {
   it("renders", async () => {
     renderWithUser();
     expect(
-      await screen.findByText("COVID-19 testing data")
+      await screen.findByText("Central Schools - COVID-19 testing data")
     ).toBeInTheDocument();
   });
   it("shows the total test count", async () => {
@@ -241,7 +289,7 @@ describe("Analytics", () => {
   });
   it("allows filtering by Lincoln Middle School", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Testing facility"), [
       "Lincoln Middle School",
@@ -253,7 +301,7 @@ describe("Analytics", () => {
   });
   it("allows filtering by Rosa Parks High School", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Testing facility"), [
       "Rosa Parks High School",
@@ -265,7 +313,7 @@ describe("Analytics", () => {
   });
   it("allows filtering by last day", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Date range"), [
       "Last day (24 hours)",
@@ -278,7 +326,7 @@ describe("Analytics", () => {
   });
   it("allows filtering by last week", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Date range"), [
       "Last week (7 days)",
@@ -288,7 +336,7 @@ describe("Analytics", () => {
   });
   it("allows filtering by last month", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Date range"), [
       "Last month (30 days)",
@@ -301,13 +349,13 @@ describe("Analytics", () => {
   });
   it("allows filtering by a custom date range", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Date range"), [
       "Custom date range",
     ]);
 
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
     const startDate = screen.getByTestId("startDate") as HTMLInputElement;
     const endDate = screen.getByTestId("endDate") as HTMLInputElement;
 
@@ -327,7 +375,7 @@ describe("Analytics", () => {
   });
   it("shows N/A for positivity rate at Empty School", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Testing facility"), [
       "Empty School",
@@ -337,18 +385,37 @@ describe("Analytics", () => {
   });
   it("shows 0% for positivity rate at Empty School over last month", async () => {
     const { user } = renderWithUser();
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Central Schools - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Testing facility"), [
       "Empty School",
     ]);
 
-    await screen.findByText("COVID-19 testing data");
+    await screen.findByText("Empty School - COVID-19 testing data");
 
     await user.selectOptions(screen.getByLabelText("Date range"), [
       "Last month (30 days)",
     ]);
 
     expect(await screen.findByText("0.0%")).toBeInTheDocument();
+  });
+  it("allows selection of a different disease", async () => {
+    const { user } = renderWithUser();
+    await user.selectOptions(screen.getByLabelText("Condition"), ["Flu A"]);
+    await screen.findByText("Central Schools - Flu A testing data");
+
+    expect(await screen.findByText("736")).toBeInTheDocument();
+    expect(await screen.findByText("289")).toBeInTheDocument();
+    expect(await screen.findByText("447")).toBeInTheDocument();
+    expect(await screen.findByText("39.3%")).toBeInTheDocument();
+  });
+  it("filters out selection of disabled diseases", async () => {
+    const flagSpy = jest.spyOn(flaggedMock, "useFeature");
+    flagSpy.mockImplementation((flagName) => {
+      return flagName !== "hivEnabled";
+    });
+    const { user } = renderWithUser();
+    const hivElement = screen.queryByText("HIV");
+    expect(hivElement).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -414,7 +414,7 @@ describe("Analytics", () => {
     flagSpy.mockImplementation((flagName) => {
       return flagName !== "hivEnabled";
     });
-    const { user } = renderWithUser();
+    renderWithUser();
     const hivElement = screen.queryByText("HIV");
     expect(hivElement).not.toBeInTheDocument();
   });

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -9,6 +9,8 @@ import "./Analytics.scss";
 import { formatDate } from "../utils/date";
 import { PATIENT_TERM_PLURAL } from "../../config/constants";
 import { useDocumentTitle } from "../utils/hooks";
+import { MULTIPLEX_DISEASES } from "../testResults/constants";
+import { useSupportedDiseaseList } from "../utils/disease";
 
 const getDateFromDaysAgo = (daysAgo: number): Date => {
   const date = new Date();
@@ -56,7 +58,7 @@ interface Props {
 }
 
 export const Analytics = (props: Props) => {
-  useDocumentTitle("COVID-19 testing data dashboard");
+  useDocumentTitle("Testing data dashboard");
 
   const organization = useSelector(
     (state) => (state as any).organization as Organization
@@ -66,6 +68,9 @@ export const Analytics = (props: Props) => {
   );
   const [facilityId, setFacilityId] = useState<string>("");
   const [facilityName, setFacilityName] = useState<string>(organization.name);
+  const [selectedCondition, setSelectedCondition] = useState<string>(
+    MULTIPLEX_DISEASES.COVID_19
+  );
   const [dateRange, setDateRange] = useState<string>("week");
   const [startDate, setStartDate] = useState<string>(
     props.startDate || getStartDateStringFromDaysAgo(7)
@@ -74,6 +79,8 @@ export const Analytics = (props: Props) => {
     props.endDate || getEndDateStringFromDaysAgo(0)
   );
 
+  const supportedDiseaseList = useSupportedDiseaseList();
+
   const updateFacility = ({
     target: { value },
   }: ChangeEvent<HTMLSelectElement>) => {
@@ -81,6 +88,12 @@ export const Analytics = (props: Props) => {
       facilities.find((f) => f.id === value)?.name || "All facilities";
     setFacilityId(value);
     setFacilityName(facilityName);
+  };
+
+  const updateSelectedCondition = ({
+    target: { value },
+  }: ChangeEvent<HTMLSelectElement>) => {
+    setSelectedCondition(value);
   };
 
   const updateDateRange = ({
@@ -113,6 +126,7 @@ export const Analytics = (props: Props) => {
         getStartDateFromDaysAgo(7),
       endDate:
         setEndTimeForDateRange(new Date(endDate)) || getEndDateFromDaysAgo(0),
+      disease: selectedCondition,
     },
     fetchPolicy: "no-cache",
   });
@@ -136,7 +150,7 @@ export const Analytics = (props: Props) => {
       <div className="grid-container">
         <div className="prime-container card-container margin-top-2">
           <div className="usa-card__header">
-            <h1 className="font-sans-lg">COVID-19 testing data</h1>
+            <h1 className="font-sans-xl">Dashboard</h1>
           </div>
           <div id="analytics-page">
             <div className="prime-container padding-3">
@@ -159,6 +173,19 @@ export const Analytics = (props: Props) => {
                   />
                 </div>
                 {/* TODO: filter by patient role */}
+                <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
+                  <Dropdown
+                    label="Condition"
+                    options={supportedDiseaseList.map((disease: string) => {
+                      return {
+                        label: disease,
+                        value: disease,
+                      };
+                    })}
+                    onChange={updateSelectedCondition}
+                    selectedValue={selectedCondition}
+                  />
+                </div>
                 <div className="desktop:grid-col-4 tablet:grid-col-4 mobile:grid-col-1">
                   <Dropdown
                     label="Date range"
@@ -236,7 +263,9 @@ export const Analytics = (props: Props) => {
                 <p>Loading...</p>
               ) : (
                 <>
-                  <h2>{facilityName}</h2>
+                  <h2>
+                    {facilityName} - {selectedCondition} testing data
+                  </h2>
                   <p className="margin-bottom-0">
                     All {PATIENT_TERM_PLURAL} tested
                   </p>

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -1,0 +1,12 @@
+import { useFeature } from "flagged";
+
+import { MULTIPLEX_DISEASES } from "../testResults/constants";
+
+export const useSupportedDiseaseList = () => {
+  let allDiseases = Object.values(MULTIPLEX_DISEASES);
+  const hivEnabled = Boolean(useFeature("hivEnabled"));
+  if (!hivEnabled) {
+    allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.HIV);
+  }
+  return allDiseases;
+};


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7211 

## Changes Proposed

- Adds a new dropdown field on the analytics dashboard for selecting a specific condition you'd like analytics for
- Updates some of the copy on the page to reflect moving away from COVID-19 exclusive functionality

## Additional Information

- Backend changes added in #7394 

## Testing

- Deploying on dev6
- Submit some tests and confirm that the dashboard reflects accurately updated values

## Screenshots / Demos

Default state of dashboard showing COVID-19 data
![Screenshot 2024-03-13 152537](https://github.com/CDCgov/prime-simplereport/assets/23287037/7dc93285-987f-4698-a358-8ac4eef5a2d3)

Option list of diseases (currently excludes HIV if the feature flag is off)
![Screenshot 2024-03-13 152759](https://github.com/CDCgov/prime-simplereport/assets/23287037/b0b07e77-67f5-43b3-a420-b1c33a7934c4)

Dashboard showing Flu B results
![Screenshot 2024-03-13 152817](https://github.com/CDCgov/prime-simplereport/assets/23287037/baf521c7-4901-47a3-90c8-f90026b0311e)

Dashboard showing no results for RSV as an empty state
![Screenshot 2024-03-13 152810](https://github.com/CDCgov/prime-simplereport/assets/23287037/3737b762-59f9-46e2-b45e-9db6d5642b26)

Page title used for the browser tab updated
![Screenshot 2024-03-13 152904](https://github.com/CDCgov/prime-simplereport/assets/23287037/58f93b42-bd20-4008-b56f-cd475290317e)
