### PR TITLE
upgrade cypress to version 13

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -5,7 +5,6 @@ module.exports = {
   viewportHeight: 800,
   defaultCommandTimeout: 10000,
   video: true,
-  videoUploadOnPasses: false,
   videoCompression: false,
   retries: {
     runMode: 1,

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -87,6 +87,18 @@ module.exports = {
 
         return launchOptions;
       });
+      on("after:spec", (spec, results) => {
+        if (results && results.video) {
+          // Do we have failures for any retry attempts?
+          const failures = results.tests.some((test) =>
+            test.attempts.some((attempt) => attempt.state === "failed"),
+          );
+          if (!failures) {
+            // delete the video if the spec passed and no tests retried
+            fs.unlinkSync(results.video);
+          }
+        }
+      });
     },
     baseUrl: "http://localhost.simplereport.gov",
   },

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,4 +1,5 @@
 global.specRunVersions = new Map();
+const fs = require("fs");
 
 module.exports = {
   viewportWidth: 1200,

--- a/cypress/e2e/01-organization_sign_up.cy.js
+++ b/cypress/e2e/01-organization_sign_up.cy.js
@@ -10,7 +10,6 @@ const organization = generateOrganization();
 const user = generateUser();
 
 describe("Organization sign up", () => {
-  loginHooks();
   it("navigates to the sign up form", () => {
     cy.visit("/sign-up");
     cy.injectSRAxe();
@@ -39,6 +38,7 @@ describe("Organization sign up", () => {
   });
 
   it("navigates to the support pending org table and verifies the org", () => {
+    loginHooks();
     cy.removeOrganizationAccess();
     cy.visit("/admin");
 
@@ -64,6 +64,7 @@ describe("Organization sign up", () => {
     });
   });
   it("spoofs into the org", () => {
+    loginHooks();
     cy.visit("/admin");
 
     cy.contains("Access organization account").click();
@@ -81,6 +82,8 @@ describe("Organization sign up", () => {
     cy.contains("Support admin");
   });
   it("navigates to the manage facilities page", () => {
+    loginHooks();
+
     cy.visit("/admin");
     cy.contains("Support admin");
     cy.get("#desktop-settings-button").click();
@@ -120,6 +123,7 @@ describe("Organization sign up", () => {
   });
 
   it("enables adding patients", () => {
+    loginHooks();
     cy.visit("/");
     cy.get("#desktop-patient-nav-link").click();
     cy.contains("No results");

--- a/cypress/e2e/02a-bulk_upload_patient.cy.js
+++ b/cypress/e2e/02a-bulk_upload_patient.cy.js
@@ -14,9 +14,9 @@ const patientToCsv = (patient) => {
 };
 
 describe("Bulk upload patients", () => {
-  loginHooks();
-
   before("setup data", () => {
+    loginHooks();
+
     cy.task("getSpecRunVersionName", specRunName)
       .then((prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {
@@ -38,6 +38,10 @@ describe("Bulk upload patients", () => {
 
   after(() => {
     cleanUpRunOktaOrgs(currentSpecRunVersionName);
+  });
+
+  beforeEach(() => {
+    loginHooks();
   });
 
   it("navigates to the bulk upload page", () => {

--- a/cypress/e2e/02b-add_patient.cy.js
+++ b/cypress/e2e/02b-add_patient.cy.js
@@ -10,8 +10,9 @@ const specRunName = "spec02b";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 describe("Adding a single patient", () => {
-  loginHooks();
   before("store patient info", () => {
+    loginHooks();
+
     // TODO: clean up after no tests rely on this patient
     cy.task("setPatientName", patient.fullName);
     cy.task("setPatientDOB", patient.dobForPatientLink);
@@ -37,6 +38,10 @@ describe("Adding a single patient", () => {
 
   after(() => {
     cleanUpRunOktaOrgs(currentSpecRunVersionName);
+  });
+
+  beforeEach(() => {
+    loginHooks();
   });
 
   it("navigates to and fills out add patient form", () => {

--- a/cypress/e2e/03-add_devices.cy.js
+++ b/cypress/e2e/03-add_devices.cy.js
@@ -1,7 +1,8 @@
 import {
   generateCovidOnlyDevice,
   generateMultiplexDevice,
-  loginHooks, testNumber,
+  loginHooks,
+  testNumber,
 } from "../support/e2e";
 import { graphqlURL } from "../utils/request-utils";
 import { aliasGraphqlOperations } from "../utils/graphql-test-utils";
@@ -9,7 +10,7 @@ import {
   accessOrganizationByName,
   cleanUpPreviousRunSetupData,
   cleanUpRunOktaOrgs,
-  setupRunData
+  setupRunData,
 } from "../utils/setup-utils";
 
 const specRunName = "spec03";
@@ -18,25 +19,29 @@ const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 describe("Adding testing devices", () => {
   const covidOnlyDevice = generateCovidOnlyDevice();
   const multiplexDevice = generateMultiplexDevice();
-  loginHooks();
 
   before("setup spec data", () => {
-    cy.task("getSpecRunVersionName", specRunName)
-      .then((prevSpecRunVersionName) => {
+    loginHooks();
+
+    cy.task("getSpecRunVersionName", specRunName).then(
+      (prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {
           cleanUpPreviousRunSetupData(prevSpecRunVersionName);
           cleanUpRunOktaOrgs(prevSpecRunVersionName);
         }
         let data = {
           specRunName: specRunName,
-          versionName: currentSpecRunVersionName
+          versionName: currentSpecRunVersionName,
         };
-        cy.task("setSpecRunVersionName", data)
+        cy.task("setSpecRunVersionName", data);
         setupRunData(currentSpecRunVersionName);
-      })
+      },
+    );
   });
 
   beforeEach("alias graphql operations", () => {
+    loginHooks();
+
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });

--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -182,7 +182,9 @@ describe("Conducting a COVID test from:", () => {
     cy.wait("@GetPatientsByFacility");
     cy.get('[data-cy="manage-patients-page"]').contains(patientName);
 
-    cy.contains("tr", patientName).find(".sr-actions-menu").click();
+    cy.contains("tr", `${lastName}, ${patient.firstName}`)
+      .contains("More actions")
+      .click();
     cy.contains("Start test").click({ force: true });
 
     cy.wait("@GetFacilityQueue", { timeout: 20000 });

--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -23,9 +23,10 @@ describe("Conducting a COVID test from:", () => {
   const lastName = patient.lastName;
   const covidOnlyDevice = generateCovidOnlyDevice();
   const queueCard = "[data-cy=prime-queue-item]:last-of-type";
-  loginHooks();
 
   before("setup spec data", () => {
+    loginHooks();
+
     cy.task("getSpecRunVersionName", specRunName).then(
       (prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {
@@ -46,6 +47,8 @@ describe("Conducting a COVID test from:", () => {
   });
 
   beforeEach(() => {
+    loginHooks();
+
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });

--- a/cypress/e2e/05-get_result_from_patient_link.cy.js
+++ b/cypress/e2e/05-get_result_from_patient_link.cy.js
@@ -19,7 +19,6 @@ const {
 const specRunName = "spec05";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
-loginHooks();
 describe("Getting a test result from a patient link", () => {
   const patient = generatePatient();
   const covidOnlyDevice = generateCovidOnlyDevice();
@@ -29,6 +28,8 @@ describe("Getting a test result from a patient link", () => {
   let patientLink;
 
   before("setup spec data", () => {
+    loginHooks();
+
     cy.task("getSpecRunVersionName", specRunName).then(
       (prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {

--- a/cypress/e2e/06-self_registration.cy.js
+++ b/cypress/e2e/06-self_registration.cy.js
@@ -10,8 +10,9 @@ const specRunName = "spec06";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 describe("Patient self registration", () => {
-  loginHooks();
   before("store patient info", () => {
+    loginHooks();
+
     cy.task("setPatientName", patient.fullName);
     cy.task("setPatientDOB", patient.dobForPatientLink);
     cy.task("setPatientPhone", patient.phone);

--- a/cypress/e2e/07-organization_settings.cy.js
+++ b/cypress/e2e/07-organization_settings.cy.js
@@ -11,9 +11,9 @@ const specRunName = "spec07";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
 describe("Updating organization settings", () => {
-  loginHooks();
-
   before("setup run data", () => {
+    loginHooks();
+
     cy.task("getSpecRunVersionName", specRunName).then(
       (prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {
@@ -32,6 +32,8 @@ describe("Updating organization settings", () => {
   });
 
   beforeEach(() => {
+    loginHooks();
+
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });

--- a/cypress/e2e/08-account_creation.cy.js
+++ b/cypress/e2e/08-account_creation.cy.js
@@ -1,6 +1,3 @@
-// Selector constants
-import { loginHooks } from "../support/e2e";
-
 const mfaRadios = {
   sms: 'input[value="SMS"]+label',
   okta: 'input[value="Okta"]+label',

--- a/cypress/e2e/08-account_creation.cy.js
+++ b/cypress/e2e/08-account_creation.cy.js
@@ -1,4 +1,6 @@
 // Selector constants
+import { loginHooks } from "../support/e2e";
+
 const mfaRadios = {
   sms: 'input[value="SMS"]+label',
   okta: 'input[value="Okta"]+label',
@@ -62,162 +64,63 @@ Cypress.Commands.add("verifySecurityCode", (code) => {
   cy.get(submitButton).first().click();
 });
 
-describe("Okta account creation", () => {
+describe("Checks each of the account creation MFA options", () => {
   beforeEach(() => {
-    // Cypress clears cookies by default, but for these tests
-    // we want to preserve the Spring session cookie
-    Cypress.Cookies.preserveOnce("SESSION");
-  });
-  describe("Account creation w/ SMS MFA", () => {
-    before(() => {
-      cy.clearCookies();
-      cy.resetWiremock();
-    });
-    it("navigates to the activation link", () => {
-      cy.visit("/uac/?activationToken=h971awbXda7y7jGaxN8f");
-      cy.contains("Create your password");
-      cy.injectSRAxe();
-      cy.checkAccessibility();
-    });
-    it("sets a password", () => {
-      cy.setPassword();
-    });
-    it("sets a security question", () => {
-      cy.setSecurityQuestion();
-    });
-    it("selects SMS MFA", () => {
-      cy.mfaSelect("sms");
-    });
-    it("enters a phone number", () => {
-      cy.enterPhoneNumber();
-    });
-    it("enters a verification code", () => {
-      cy.verifySecurityCode("033457");
-    });
-    it("displays a success message", () => {
-      cy.contains("Account set up complete");
-      cy.checkAccessibility();
-    });
+    cy.clearCookies();
+    cy.resetWiremock();
+
+    cy.visit("/uac/?activationToken=NOr20VqF5M6m8AnwcSUJ");
+    cy.contains("Create your password");
+    cy.injectSRAxe();
+
+    // activation page
+    cy.checkAccessibility();
+
+    cy.setPassword();
+    // set password page
+    cy.checkAccessibility();
+
+    cy.setSecurityQuestion();
+    // MFA page
+    cy.checkAccessibility();
   });
 
-  describe("Account creation w/ Okta Verify MFA", () => {
-    before(() => {
-      cy.clearCookies();
-      cy.resetWiremock();
-    });
-    it("navigates to the activation link", () => {
-      cy.visit("/uac/?activationToken=NOr20VqF5M6m8AnwcSUJ");
-      cy.contains("Create your password");
-      cy.injectSRAxe();
-    });
-    it("sets a password", () => {
-      cy.setPassword();
-    });
-    it("sets a security question", () => {
-      cy.setSecurityQuestion();
-    });
-    it("selects Okta Verify MFA", () => {
-      cy.mfaSelect("okta");
-    });
-    it("'scans' a QR code", () => {
-      cy.scanQrCode();
-    });
-    it("enters a verification code", () => {
-      cy.verifySecurityCode("543663");
-    });
-    it("displays a success message", () => {
-      cy.contains("Account set up complete");
-      cy.checkAccessibility();
-    });
+  it("Account creation w/ SMS MFA", () => {
+    cy.mfaSelect("sms");
+    cy.enterPhoneNumber();
+    cy.verifySecurityCode("033457");
+
+    cy.contains("Account set up complete");
   });
 
-  describe("Account creation w/ Google Authenticator MFA", () => {
-    before(() => {
-      cy.clearCookies();
-      cy.resetWiremock();
-    });
-    it("navigates to the activation link", () => {
-      cy.visit("/uac/?activationToken=gqYPzH1FlPzVr0U3tQ7H");
-      cy.contains("Create your password");
-      cy.injectSRAxe();
-    });
-    it("sets a password", () => {
-      cy.setPassword();
-    });
-    it("sets a security question", () => {
-      cy.setSecurityQuestion();
-    });
-    it("selects Google Authenticator MFA", () => {
-      cy.mfaSelect("google");
-    });
-    it("'scans' a QR code", () => {
-      cy.scanQrCode();
-    });
-    it("enters a verification code", () => {
-      cy.verifySecurityCode("985721");
-    });
-    it("displays a success message", () => {
-      cy.contains("Account set up complete");
-      cy.checkAccessibility();
-    });
+  it("Account creation w/ Okta Verify MFA", () => {
+    cy.mfaSelect("okta");
+    cy.scanQrCode();
+    cy.verifySecurityCode("543663");
+    cy.contains("Account set up complete");
+    cy.checkAccessibility();
   });
+  it("Account creation w/ Google Authenticator MFA", () => {
+    cy.mfaSelect("google");
+    cy.scanQrCode();
+    cy.verifySecurityCode("985721");
 
-  describe("Account creation w/ Voice Call MFA", () => {
-    before(() => {
-      cy.clearCookies();
-      cy.resetWiremock();
-    });
-    it("navigates to the activation link", () => {
-      cy.visit("/uac/?activationToken=wN5mR-8SXao1TP2PLaFe");
-      cy.contains("Create your password");
-      cy.injectSRAxe();
-    });
-    it("sets a password", () => {
-      cy.setPassword();
-    });
-    it("sets a security question", () => {
-      cy.setSecurityQuestion();
-    });
-    it("selects voice call MFA", () => {
-      cy.mfaSelect("voice");
-    });
-    it("enters a phone number", () => {
-      cy.enterPhoneNumber();
-    });
-    it("enters a verification code", () => {
-      cy.verifySecurityCode("30835");
-    });
-    it("displays a success message", () => {
-      cy.contains("Account set up complete");
-      cy.checkAccessibility();
-    });
+    cy.contains("Account set up complete");
+    cy.checkAccessibility();
   });
+  it("Account creation w/ Voice Call MFA", () => {
+    cy.mfaSelect("voice");
+    cy.enterPhoneNumber();
+    cy.verifySecurityCode("30835");
 
-  describe("Account creation w/ Email MFA", () => {
-    before(() => {
-      cy.clearCookies();
-      cy.resetWiremock();
-    });
-    it("navigates to the activation link", () => {
-      cy.visit("/uac/?activationToken=4OVwdVhc6M1I-UwvLrNX");
-      cy.contains("Create your password");
-      cy.injectSRAxe();
-    });
-    it("sets a password", () => {
-      cy.setPassword();
-    });
-    it("sets a security question", () => {
-      cy.setSecurityQuestion();
-    });
-    it("selects email MFA", () => {
-      cy.mfaSelect("email");
-    });
-    it("enters a verification code", () => {
-      cy.verifySecurityCode("007781");
-    });
-    it("displays a success message", () => {
-      cy.contains("Account set up complete");
-      cy.checkAccessibility();
-    });
+    cy.contains("Account set up complete");
+    cy.checkAccessibility();
+  });
+  it("Account creation w/ Email MFA", () => {
+    cy.mfaSelect("email");
+
+    cy.verifySecurityCode("007781");
+    cy.contains("Account set up complete");
+    cy.checkAccessibility();
   });
 });

--- a/cypress/e2e/09-multiplex_testing.cy.js
+++ b/cypress/e2e/09-multiplex_testing.cy.js
@@ -17,13 +17,14 @@ import {
 const specRunName = "spec09";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
-loginHooks();
 describe("Testing with multiplex devices", () => {
   let facilityId, patientId;
   const patient = generatePatient();
   const multiplexDevice = generateMultiplexDevice();
 
   before(() => {
+    loginHooks();
+
     cy.task("getSpecRunVersionName", specRunName).then(
       (prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {
@@ -48,6 +49,8 @@ describe("Testing with multiplex devices", () => {
   });
 
   beforeEach(() => {
+    loginHooks();
+
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });
@@ -62,6 +65,11 @@ describe("Testing with multiplex devices", () => {
   });
 
   after("clean up spec data", () => {
+    // for some reason for this test in particular, the cleanup hooks
+    // lose access to the session they need to do the cleanup and error out,
+    // causing the test to fail. Repopulating the session into the cache seems to fix it???
+    loginHooks();
+
     cleanUpPreviousRunSetupData(currentSpecRunVersionName);
     cleanUpRunOktaOrgs(currentSpecRunVersionName);
   });

--- a/cypress/e2e/10-support-manage-facility.cy.js
+++ b/cypress/e2e/10-support-manage-facility.cy.js
@@ -12,13 +12,14 @@ import {
 const specRunName = "spec10";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
-loginHooks();
 describe("Support admin: manage facility", () => {
   const organizationName = createOrgName(currentSpecRunVersionName);
   const facilityName = createFacilityName(currentSpecRunVersionName);
   let facilityId = "";
 
   before("setup run data", () => {
+    loginHooks();
+
     cy.task("getSpecRunVersionName", specRunName).then(
       (prevSpecRunVersionName) => {
         if (prevSpecRunVersionName) {
@@ -39,6 +40,8 @@ describe("Support admin: manage facility", () => {
   });
 
   beforeEach(() => {
+    loginHooks();
+
     cy.intercept("POST", graphqlURL, (req) => {
       aliasGraphqlOperations(req);
     });

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
-    "cypress": "^11.0.0",
+    "cypress": "^13.6.6",
     "cypress-localstorage-commands": "^2.2.5",
     "dayjs": "^1.11.10",
     "eslint": "^8.57.0",

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,8 +30,8 @@ import { addOrgToQueueURL, graphqlURL } from "../utils/request-utils";
 
 // read environment variables
 
-const username = Cypress.env("OKTA_USERNAME") || "ruby@example.com";
-const password = Cypress.env("OKTA_PASSWORD") || "notapassword";
+const username = Cypress.env("OKTA_USERNAME");
+const password = Cypress.env("OKTA_PASSWORD");
 const secret = Cypress.env("OKTA_SECRET");
 const scope = Cypress.env("OKTA_SCOPE") || "simple_report_dev";
 const clientId = Cypress.env("OKTA_CLIENT_ID") || "0oa1k0163nAwfVxNW1d7";

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -49,45 +49,46 @@ Cypress.Commands.add("login", () => {
       cy.saveLocalStorage();
       return;
     } else {
-      cy.request("POST", "https://hhs-prime.oktapreview.com/api/v1/authn", {
-        username,
-        password,
-        options: {
-          multiOptionalFactorEnroll: true,
-          warnBeforePasswordExpired: true,
-        },
-      }).then((response) => {
-        const stateToken = response.body.stateToken;
-        const factorId = response.body._embedded.factors[0].id;
-        const passCode = authenticator.generate(secret);
-        cy.request(
-          "POST",
-          `https://hhs-prime.oktapreview.com/api/v1/authn/factors/${factorId}/verify`,
-          {
-            passCode,
-            stateToken,
+      cy.session([username, password], () => {
+        cy.request("POST", "https://hhs-prime.oktapreview.com/api/v1/authn", {
+          username,
+          password,
+          options: {
+            multiOptionalFactorEnroll: true,
+            warnBeforePasswordExpired: true,
           },
-        ).then((response) => {
-          const sessionToken = response.body.sessionToken;
+        }).then((response) => {
+          const stateToken = response.body.stateToken;
+          const factorId = response.body._embedded.factors[0].id;
+          const passCode = authenticator.generate(secret);
           cy.request(
-            "GET",
-            `https://hhs-prime.oktapreview.com/oauth2/default/v1/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=token%20id_token&scope=openid%20simple_report%20${scope}&nonce=thisisnotsafe&state=thisisbogus&sessionToken=${sessionToken}`,
+            "POST",
+            `https://hhs-prime.oktapreview.com/api/v1/authn/factors/${factorId}/verify`,
+            {
+              passCode,
+              stateToken,
+            },
           ).then((response) => {
-            const redirect = response.redirects[0];
-            const idTokenRegex = new RegExp(
-              "(?:id_token=)((.[\\s\\S]*))(?:&access_token=)",
-              "ig",
-            );
-            const accessTokenRegex = new RegExp(
-              "(?:access_token=)((.[\\s\\S]*))(?:&token_type=Bearer)",
-              "ig",
-            );
-            const id_token = idTokenRegex.exec(redirect)[1];
-            const access_token = accessTokenRegex.exec(redirect)[1];
-            cy.task("setAuth", { id_token, access_token });
-            cy.setLocalStorage("id_token", id_token);
-            cy.setLocalStorage("access_token", access_token);
-            cy.saveLocalStorage();
+            const sessionToken = response.body.sessionToken;
+            cy.request(
+              "GET",
+              `https://hhs-prime.oktapreview.com/oauth2/default/v1/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=token%20id_token&scope=openid%20simple_report%20${scope}&nonce=thisisnotsafe&state=thisisbogus&sessionToken=${sessionToken}`,
+            ).then((response) => {
+              const redirect = response.redirects[0];
+              const idTokenRegex = new RegExp(
+                "(?:id_token=)((.[\\s\\S]*))(?:&access_token=)",
+                "ig",
+              );
+              const accessTokenRegex = new RegExp(
+                "(?:access_token=)((.[\\s\\S]*))(?:&token_type=Bearer)",
+                "ig",
+              );
+              const id_token = idTokenRegex.exec(redirect)[1];
+              const access_token = accessTokenRegex.exec(redirect)[1];
+              cy.task("setAuth", { id_token, access_token });
+              window.localStorage.setItem("id_token", id_token);
+              window.localStorage.setItem("access_token", access_token);
+            });
           });
         });
       });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,11 +30,13 @@ import { addOrgToQueueURL, graphqlURL } from "../utils/request-utils";
 
 // read environment variables
 
-const username = Cypress.env("OKTA_USERNAME");
-const password = Cypress.env("OKTA_PASSWORD");
+const username = Cypress.env("OKTA_USERNAME") || "ruby@example.com";
+const password = Cypress.env("OKTA_PASSWORD") || "notapassword";
 const secret = Cypress.env("OKTA_SECRET");
 const scope = Cypress.env("OKTA_SCOPE") || "simple_report_dev";
 const clientId = Cypress.env("OKTA_CLIENT_ID") || "0oa1k0163nAwfVxNW1d7";
+const skipOkta = Cypress.env("SKIP_OKTA");
+
 const redirectUri =
   Cypress.env("OKTA_REDIRECT_URI") ||
   "https%3A%2F%2Flocalhost.simplereport.gov%2F";
@@ -48,7 +50,7 @@ Cypress.Commands.add("login", () => {
       cy.setLocalStorage("access_token", access_token);
       cy.saveLocalStorage();
       return;
-    } else {
+    } else if (!skipOkta) {
       cy.session([username, password], () => {
         cy.request("POST", "https://hhs-prime.oktapreview.com/api/v1/authn", {
           username,

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -92,22 +92,5 @@ Cypress.on("uncaught:exception", (err, _runnable) => {
 });
 
 export const loginHooks = () => {
-  // Global before for logging in to Okta
-  before(() => {
-    // Clear any leftover data from previous tests
-    cy.clearCookies();
-    cy.clearLocalStorageSnapshot();
-    // Login to Okta to get an access token
-    !Cypress.env("SKIP_OKTA") && cy.login();
-  });
-  beforeEach(() => {
-    // Cypress clears cookies by default, but for these tests
-    // we want to preserve the Spring session cookie
-    Cypress.Cookies.preserveOnce("SESSION");
-    // It also clears local storage, so restore before each test
-    cy.restoreLocalStorage();
-  });
-  afterEach(() => {
-    cy.saveLocalStorage();
-  });
+  cy.session("SESSION", cy.login, { cacheAcrossSpecs: true });
 };

--- a/cypress/utils/request-utils.js
+++ b/cypress/utils/request-utils.js
@@ -1,5 +1,6 @@
 export const frontendURL = `${
-  Cypress.env("REACT_APP_BASE_URL") || "https://localhost.simplereport.gov/app"
+  "http://localhost:3000"
+  // Cypress.env("REACT_APP_BASE_URL") || "https://localhost.simplereport.gov/app"
 }/`;
 const backendURL = Cypress.env("BACKEND_URL") || "http://localhost:8080";
 export const graphqlURL = `${backendURL}/graphql`;

--- a/cypress/utils/request-utils.js
+++ b/cypress/utils/request-utils.js
@@ -1,6 +1,5 @@
 export const frontendURL = `${
-  "http://localhost:3000"
-  // Cypress.env("REACT_APP_BASE_URL") || "https://localhost.simplereport.gov/app"
+  Cypress.env("REACT_APP_BASE_URL") || "https://localhost.simplereport.gov/app"
 }/`;
 const backendURL = Cypress.env("BACKEND_URL") || "http://localhost:8080";
 export const graphqlURL = `${backendURL}/graphql`;

--- a/cypress/utils/setup-utils.js
+++ b/cypress/utils/setup-utils.js
@@ -35,7 +35,7 @@ const createAndVerifyOrganization = (orgName) => {
 const archivePatientsForFacility = (facilityId) => {
   return getPatientsByFacilityId(facilityId).then((res) => {
     let patients = res.body.data.patients;
-    if (patients.length > 0) {
+    if (patients && patients.length > 0) {
       patients.map((patient) => markPatientAsDeleted(patient.internalId, true));
     }
   });
@@ -45,10 +45,10 @@ export const cleanUpPreviousRunSetupData = (specRunVersionName) => {
   let orgName = createOrgName(specRunVersionName);
   getOrganizationsByName(orgName).then((res) => {
     let orgs = res.body.data.organizationsByName;
-    let org = orgs.length > 0 ? orgs[0] : null;
+    let org = orgs && orgs.length > 0 ? orgs[0] : null;
     if (org) {
       let facilities = org.facilities;
-      if (facilities.length > 0) {
+      if (facilities && facilities.length > 0) {
         facilities.map((facility) => archivePatientsForFacility(facility.id));
       }
       markOrganizationAsDeleted(org.id, true);
@@ -63,14 +63,14 @@ export const cleanUpRunOktaOrgs = (specRunVersionName) => {
   // orgs so that the order of app vs okta deletion doesn't matter
   getOrganizationsByName(orgName, true).then((res) => {
     let orgs = res.body.data.organizationsByName;
-    let org = orgs.length > 0 ? orgs[0] : null;
+    let org = orgs && orgs.length > 0 ? orgs[0] : null;
     if (org) {
       deleteOktaOrgs(org.externalId);
     }
   });
   getOrganizationsByName(orgName).then((res) => {
     let orgs = res.body.data.organizationsByName;
-    let org = orgs.length > 0 ? orgs[0] : null;
+    let org = orgs && orgs.length > 0 ? orgs[0] : null;
     if (org) {
       deleteOktaOrgs(org.externalId);
     }
@@ -92,10 +92,10 @@ export const getCreatedFacility = (specRunVersionName) => {
   let orgName = createOrgName(specRunVersionName);
   return getOrganizationsByName(orgName).then((res) => {
     let orgs = res.body.data.organizationsByName;
-    let org = orgs.length > 0 ? orgs[0] : null;
+    let org = orgs && orgs.length > 0 ? orgs[0] : null;
     if (org) {
       let facilities = org.facilities;
-      return facilities.length > 0 ? facilities[0] : null;
+      return facilities && facilities.length > 0 ? facilities[0] : null;
     }
   });
 };
@@ -131,7 +131,9 @@ export const setupDevice = (
     .then((result) => {
       const specimenTypes = result.body.data.specimenTypes;
       specimenTypeId =
-        specimenTypes.length > 0 ? specimenTypes[0].internalId : null;
+        specimenTypes && specimenTypes.length > 0
+          ? specimenTypes[0].internalId
+          : null;
     })
     .then(() =>
       createDeviceType({
@@ -199,7 +201,9 @@ export const setupCovidOnlyDevice = (specRunVersionName, covidOnlyDevice) => {
     .then((result) => {
       const supportedDiseases = result.body.data.supportedDiseases;
       supportedDiseaseId =
-        supportedDiseases.length > 0 ? supportedDiseases[0].internalId : null;
+        supportedDiseases && supportedDiseases.length > 0
+          ? supportedDiseases[0].internalId
+          : null;
     })
     .then(() =>
       setupDevice(
@@ -246,7 +250,7 @@ export const setupTestOrder = (
 };
 
 export const accessOrganizationByName = (orgName) => {
-  return getOrganizationsByName(orgName)
-    .then((res) =>
-      accessOrganization(res.body.data.organizationsByName[0].externalId));
+  return getOrganizationsByName(orgName).then((res) =>
+    accessOrganization(res.body.data.organizationsByName[0].externalId),
+  );
 };

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@cypress/request@^2.88.10":
-  version "2.88.10"
-  resolved "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz"
-  integrity sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==
+"@cypress/request@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.1.tgz#72d7d5425236a2413bd3d8bb66d02d9dc3168960"
+  integrity sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -25,9 +25,9 @@
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "~6.5.2"
+    qs "6.10.4"
     safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
+    tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
@@ -158,11 +158,6 @@
   version "17.0.22"
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.22.tgz"
   integrity sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==
-
-"@types/node@^14.14.31":
-  version "14.18.12"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz"
-  integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
 
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
@@ -335,9 +330,9 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
-buffer@^5.6.0:
+buffer@^5.7.1:
   version "5.7.1"
-  resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
   dependencies:
     base64-js "^1.3.1"
@@ -347,6 +342,17 @@ cachedir@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz"
   integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
+
+call-bind@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
+  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.1"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -434,10 +440,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 common-tags@^1.8.0:
   version "1.8.2"
@@ -473,29 +479,28 @@ cypress-localstorage-commands@^2.2.5:
   resolved "https://registry.yarnpkg.com/cypress-localstorage-commands/-/cypress-localstorage-commands-2.2.5.tgz#81c8f53a06e2ed93c1e068c1101da85f80f27f61"
   integrity sha512-07zpwzWdY+uPi1NEHFhWQNylIJqRxR78Ile05L6WT8h1Gz0OaxgBSZRuzp+pqUni/3Pk4d2ieq/cSh++ZmujEA==
 
-cypress@^11.0.0:
-  version "11.2.0"
-  resolved "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz"
-  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
+cypress@^13.6.6:
+  version "13.6.6"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.6.tgz#5133f231ed1c6e57dc8dcbf60aade220bcd6884b"
+  integrity sha512-S+2S9S94611hXimH9a3EAYt81QM913ZVA03pUmGDfLTFa5gyp85NJ8dJGSlEAEmyRsYkioS1TtnWtbv/Fzt11A==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
     blob-util "^2.0.2"
     bluebird "^3.7.2"
-    buffer "^5.6.0"
+    buffer "^5.7.1"
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
-    commander "^5.1.0"
+    commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "^4.3.2"
+    debug "^4.3.4"
     enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
@@ -504,18 +509,19 @@ cypress@^11.0.0:
     figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
-    is-ci "^3.0.0"
+    is-ci "^3.0.1"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -540,7 +546,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -551,6 +557,15 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -590,6 +605,18 @@ enquirer@^2.3.6:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+es-define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
+  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
+  dependencies:
+    get-intrinsic "^1.2.4"
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -845,6 +872,22 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
+  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    hasown "^2.0.0"
+
 get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz"
@@ -899,6 +942,13 @@ globals@^13.19.0, globals@^13.20.0:
   dependencies:
     type-fest "^0.20.2"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.9"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz"
@@ -913,6 +963,30 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  dependencies:
+    es-define-property "^1.0.0"
+
+has-proto@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.3.tgz#b31ddfe9b0e6e9914536a6ab286426d0214f77fd"
+  integrity sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+hasown@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
 
 http-signature@~1.3.6:
   version "1.3.6"
@@ -974,9 +1048,9 @@ ini@2.0.0:
   resolved "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
-is-ci@^3.0.0:
+is-ci@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
     ci-info "^3.2.0"
@@ -1202,9 +1276,9 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.6:
+minimist@^1.2.8:
   version "1.2.8"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 ms@2.1.2:
@@ -1228,6 +1302,11 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-inspect@^1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
+  integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1342,15 +1421,20 @@ pretty-bytes@^5.6.0:
   resolved "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
-psl@^1.1.28:
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -1365,10 +1449,17 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+qs@6.10.4:
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.4.tgz#6a3003755add91c0ec9eacdc5f878b034e73f9e7"
+  integrity sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==
+  dependencies:
+    side-channel "^1.0.4"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -1381,6 +1472,11 @@ request-progress@^3.0.0:
   integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
   dependencies:
     throttleit "^1.0.0"
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -1436,12 +1532,24 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^7.3.2:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+semver@^7.5.3:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+set-function-length@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -1454,6 +1562,16 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+side-channel@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
+  integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
+  dependencies:
+    call-bind "^1.0.7"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.4"
+    object-inspect "^1.13.1"
 
 signal-exit@^3.0.2:
   version "3.0.7"
@@ -1560,13 +1678,15 @@ tmp@~0.2.1:
   dependencies:
     rimraf "^3.0.0"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+tough-cookie@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
-    psl "^1.1.28"
+    psl "^1.1.33"
     punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
 
 tslib@^2.1.0:
   version "2.3.1"
@@ -1602,6 +1722,11 @@ type-fest@^0.21.3:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz"
@@ -1618,6 +1743,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Fixes #4938 by upgrading us two major versions into 13.6!
- See parts [one](https://github.com/CDCgov/prime-simplereport/pull/7397) and [two](https://github.com/CDCgov/prime-simplereport/pull/7404) for more context

## Changes Proposed

- Refactor login hook to use the new `cy.session` methods / deprecating old more manual cookie caching
    - Move those login hooks within the tests to work as needed
-  Refactor test logic to accomodate the new test isolation features introduced in 12
- Added a flag to skip the session caching setup for a local w/o Okta run.
    - shoutout to @emyl3 for showing me how to get that running! Added a snippet to the wiki to reflect what we found
- Fixes a couple of minor debt things we found in local testing 

![Screenshot 2024-03-20 at 12 23 22 PM](https://github.com/CDCgov/prime-simplereport/assets/29645040/fa29a5f0-9944-4e62-87a6-1eea5536e36c)

## Testing

- Make sure we don't have any e2e regressions locally / in CI
    - double check that things are working locally with and w/o Okta! 

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---
