### PR TITLE
Add ability to send org admin emails as CSV for outreach

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -156,7 +156,7 @@ public class OrganizationResolver {
       throw new IllegalGraphqlArgumentException("Not a valid state");
     }
 
-    if (acceptableTypes.contains(type.toLowerCase())) {
+    if (!acceptableTypes.contains(type.toLowerCase())) {
       return _organizationService.sendOrgAdminEmailCSV(type, state);
     } else {
       throw new IllegalGraphqlArgumentException("type can be \"facilities\" or \"patients\"");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.api.organization;
 
+import static gov.cdc.usds.simplereport.api.Translators.STATE_CODES;
+
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.api.model.ApiOrganization;
 import gov.cdc.usds.simplereport.api.model.ApiPendingOrganization;
@@ -147,7 +149,13 @@ public class OrganizationResolver {
   @MutationMapping
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public Integer sendOrgAdminEmailCSV(@Argument String type, @Argument String state) {
+    Set<String> acceptableStates = STATE_CODES;
     List<String> acceptableTypes = List.of("facilities", "patients");
+
+    if (!acceptableStates.contains(state.toUpperCase())) {
+      throw new IllegalGraphqlArgumentException("Not a valid state");
+    }
+
     if (acceptableTypes.contains(type.toLowerCase())) {
       return _organizationService.sendOrgAdminEmailCSV(type, state);
     } else {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -155,11 +155,9 @@ public class OrganizationResolver {
     if (!acceptableStates.contains(state.toUpperCase())) {
       throw new IllegalGraphqlArgumentException("Not a valid state");
     }
-
     if (!acceptableTypes.contains(type.toLowerCase())) {
-      return _organizationService.sendOrgAdminEmailCSV(type, state);
-    } else {
       throw new IllegalGraphqlArgumentException("type can be \"facilities\" or \"patients\"");
     }
+    return _organizationService.sendOrgAdminEmailCSV(type, state);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
@@ -131,5 +132,26 @@ public class OrganizationResolver {
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public List<UUID> getOrgAdminUserIds(@Argument UUID orgId) {
     return _organizationService.getOrgAdminUserIds(orgId);
+  }
+
+  /**
+   * Used for outreach purposes - emails a CSV of org admin emails for the following type: 1.
+   * "facilities" - orgs that have facilities in the state 2. "patients" - orgs outside the state
+   * that have test results for patients whose address is in the state
+   *
+   * <p>The generated CSV is sent to the outreachMailingListRecipient email
+   *
+   * @param type "facilities" or "patients"
+   * @param state State abbreviation e.g. "NJ", "MN"
+   */
+  @MutationMapping
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public Integer sendOrgAdminEmailCSV(@Argument String type, @Argument String state) {
+    List<String> acceptableTypes = List.of("facilities", "patients");
+    if (acceptableTypes.contains(type.toLowerCase())) {
+      return _organizationService.sendOrgAdminEmailCSV(type, state);
+    } else {
+      throw new IllegalGraphqlArgumentException("type can be \"facilities\" or \"patients\"");
+    }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -40,4 +40,7 @@ public interface FacilityRepository extends EternalAuditedEntityRepository<Facil
 
   @Query("from Facility e where :deviceType member of e.configuredDeviceTypes")
   Set<Facility> findByDeviceType(DeviceType deviceType);
+
+  @Query(EternalAuditedEntityRepository.BASE_QUERY + " and lower(e.address.state) = lower(:state)")
+  List<Facility> findByFacilityState(String state);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepository.java
@@ -31,4 +31,13 @@ public interface OrganizationRepository extends EternalAuditedEntityRepository<O
       EternalAuditedEntityRepository.BASE_ALLOW_DELETED_QUERY
           + " UPPER(e.organizationName) = UPPER(:name) and e.isDeleted = :isDeleted")
   List<Organization> findAllByNameAndDeleted(String name, Boolean isDeleted);
+
+  @Query(
+      value =
+          "from #{#entityName} o"
+              + " LEFT JOIN TestEvent te ON te.organization.internalId = o.internalId"
+              + " LEFT JOIN Person p ON p.internalId = te.patient.internalId"
+              + " WHERE lower(p.address.state) = lower(:state) AND lower(o.externalId) NOT LIKE lower(concat('%', :state,'%'))"
+              + " GROUP BY o.internalId")
+  List<Organization> findAllByPatientStateWithTestEvents(String state);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -295,6 +295,7 @@ public class DemoOktaRepository implements OktaRepository {
     Set<Entry<String, OrganizationRoleClaims>> admins =
         usernameOrgRolesMap.entrySet().stream()
             .filter(e -> e.getValue().getGrantedRoles().contains(OrganizationRole.ADMIN))
+            .filter(e -> e.getValue().getOrganizationExternalId().equals(org.getExternalId()))
             .collect(Collectors.toSet());
     return admins.stream().map(Entry::getKey).collect(Collectors.toList());
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -594,7 +594,7 @@ public class LiveOktaRepository implements OktaRepository {
       List<User> admins = getOrgAdminUsers(org);
       return admins.stream().map(u -> u.getProfile().getLogin()).toList();
     } catch (IllegalGraphqlArgumentException e) {
-      log.error(String.format("Error fetchAdminUserEmail:", e));
+      log.error(String.format("Error fetchAdminUserEmail: %s", e));
       return List.of();
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -594,7 +594,7 @@ public class LiveOktaRepository implements OktaRepository {
       List<User> admins = getOrgAdminUsers(org);
       return admins.stream().map(u -> u.getProfile().getLogin()).toList();
     } catch (IllegalGraphqlArgumentException e) {
-      log.error(String.format("Error fetchAdminUserEmail: %s", e));
+      log.error("error fetching admin by email from Okta API");
       return List.of();
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -590,8 +590,13 @@ public class LiveOktaRepository implements OktaRepository {
 
   @Override
   public List<String> fetchAdminUserEmail(Organization org) {
-    var admins = getOrgAdminUsers(org);
-    return admins.stream().map(u -> u.getProfile().getLogin()).toList();
+    try {
+      List<User> admins = getOrgAdminUsers(org);
+      return admins.stream().map(u -> u.getProfile().getLogin()).toList();
+    } catch (IllegalGraphqlArgumentException e) {
+      log.error(String.format("Error fetchAdminUserEmail:", e));
+      return List.of();
+    }
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/properties/SendGridProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/properties/SendGridProperties.java
@@ -3,35 +3,20 @@ package gov.cdc.usds.simplereport.properties;
 import gov.cdc.usds.simplereport.service.email.EmailProviderTemplate;
 import java.util.List;
 import java.util.Map;
+import lombok.Builder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Builder
 @ConfigurationProperties(prefix = "simple-report.sendgrid")
 public final class SendGridProperties {
-
   private final boolean enabled;
   private final String apiKey;
   private final String fromEmail;
   private final String fromDisplayName;
   private final List<String> accountRequestRecipient;
   private final List<String> waitlistRecipient;
+  private final List<String> outreachMailingListRecipient;
   private final Map<EmailProviderTemplate, String> dynamicTemplates;
-
-  public SendGridProperties(
-      boolean enabled,
-      String apiKey,
-      String fromEmail,
-      String fromDisplayName,
-      List<String> accountRequestRecipient,
-      List<String> waitlistRecipient,
-      Map<EmailProviderTemplate, String> dynamicTemplates) {
-    this.enabled = enabled;
-    this.apiKey = apiKey;
-    this.fromEmail = fromEmail;
-    this.fromDisplayName = fromDisplayName;
-    this.accountRequestRecipient = accountRequestRecipient;
-    this.waitlistRecipient = waitlistRecipient;
-    this.dynamicTemplates = dynamicTemplates;
-  }
 
   public boolean getEnabled() {
     return enabled;
@@ -55,6 +40,10 @@ public final class SendGridProperties {
 
   public List<String> getWaitlistRecipient() {
     return waitlistRecipient;
+  }
+
+  public List<String> getOutreachMailingListRecipient() {
+    return outreachMailingListRecipient;
   }
 
   public String getDynamicTemplateGuid(final EmailProviderTemplate templateName) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -22,6 +22,7 @@ import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.service.model.OrganizationRoles;
 import gov.cdc.usds.simplereport.validators.OrderingProviderRequiredValidator;
 import java.util.ArrayList;
@@ -56,6 +57,8 @@ public class OrganizationService {
   private final OrderingProviderRequiredValidator orderingProviderValidator;
   private final PatientSelfRegistrationLinkService patientSelfRegistrationLinkService;
   private final DeviceTypeRepository deviceTypeRepository;
+
+  private final EmailService _emailService;
 
   public void resetOrganizationRolesContext() {
     organizationRolesContext.reset();
@@ -476,26 +479,76 @@ public class OrganizationService {
     return orgId != null ? orgId : getCurrentOrganization().getInternalId();
   }
 
-  @AuthorizationConfiguration.RequireGlobalAdminUser
-  public List<UUID> getOrgAdminUserIds(UUID orgId) {
+  private List<ApiUser> getOrgAdminUsers(UUID orgId) {
     Organization org =
         organizationRepository.findById(orgId).orElseThrow(NonexistentOrgException::new);
-    List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(org);
+    try {
+      List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(org);
+      return adminUserEmails.stream()
+          .map(
+              adminUserEmail -> {
+                Optional<ApiUser> foundUser = apiUserRepository.findByLoginEmail(adminUserEmail);
+                if (foundUser.isEmpty()) {
+                  log.warn(
+                      "Query for admin users in organization "
+                          + org.getInternalId()
+                          + " found a user in Okta but not in the database. Skipping...");
+                }
+                return foundUser.orElse(null);
+              })
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+    } catch (IllegalGraphqlArgumentException e) {
+      return List.of();
+    }
+  }
 
-    return adminUserEmails.stream()
-        .map(
-            email -> {
-              Optional<ApiUser> foundUser = apiUserRepository.findByLoginEmail(email);
-              if (foundUser.isEmpty()) {
-                log.warn(
-                    "Query for admin users in organization "
-                        + orgId
-                        + " found a user in Okta but not in the database. Skipping...");
-              }
-              return foundUser.map(user -> user.getInternalId()).orElse(null);
-            })
-        .filter(Objects::nonNull)
+  private List<String> getOrgAdminUserEmails(UUID orgId) {
+    return getOrgAdminUsers(orgId).stream()
+        .map(ApiUser::getLoginEmail)
         .collect(Collectors.toList());
+  }
+
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public List<UUID> getOrgAdminUserIds(UUID orgId) {
+    return getOrgAdminUsers(orgId).stream()
+        .map(ApiUser::getInternalId)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> getOrgAdminEmailsByFacilityState(String state) {
+    List<Facility> facilitiesInState = facilityRepository.findByFacilityState(state);
+    return facilitiesInState.stream()
+        .map(f -> f.getOrganization().getInternalId())
+        .distinct()
+        .map(this::getOrgAdminUserEmails)
+        .flatMap(List::stream)
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  private List<String> getOrgAdminEmailsByPatientState(String state) {
+    List<Organization> orgs = organizationRepository.findAllByPatientStateWithTestEvents(state);
+    return orgs.stream()
+        .map(o -> o.getInternalId())
+        .map(this::getOrgAdminUserEmails)
+        .flatMap(List::stream)
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public Integer sendOrgAdminEmailCSV(String type, String state) {
+    List<String> emailsByState;
+    if ("facilities".equalsIgnoreCase(type)) {
+      emailsByState = getOrgAdminEmailsByFacilityState(state);
+    } else if ("patients".equalsIgnoreCase(type)) {
+      emailsByState = getOrgAdminEmailsByPatientState(state);
+    } else {
+      return 0;
+    }
+    _emailService.sendWithCSVAttachment(emailsByState, state, type);
+    return emailsByState.size();
   }
 
   /**

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/CSVGeneratorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/CSVGeneratorUtils.java
@@ -1,0 +1,21 @@
+package gov.cdc.usds.simplereport.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CSVGeneratorUtils {
+  private CSVGeneratorUtils() {
+    throw new IllegalStateException("CSVGeneratorUtils is a utility class");
+  }
+
+  private static final String EMAIL_CSV_HEADER = "email\n";
+
+  public static byte[] generateEmailCSVInBytes(List<String> emails) {
+    StringBuilder csvContent = new StringBuilder();
+    csvContent.append(EMAIL_CSV_HEADER);
+    for (String email : emails) {
+      csvContent.append(email).append("\n");
+    }
+    return csvContent.toString().getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
@@ -133,4 +133,10 @@ public class DateTimeUtils {
     }
     return localDateTime;
   }
+
+  public static String getCurrentDatestamp(LocalDateTime time) {
+    ZonedDateTime zonedDateTime = time.atZone(easternTimeZoneId);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+    return formatter.format(zonedDateTime);
+  }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -109,7 +109,7 @@ simple-report:
     waitlist-recipient:
       - support@simplereport.gov
     outreach-mailing-list-recipient:
-      - support@simplereport.gov
+      - tof4@cdc.gov
     dynamic-templates:
       # The templates are added and edited at: https://mc.sendgrid.com/dynamic-templates
       # The keys in this map should match (but don't have to) the names of SendGrid Dynamic Templates that

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -108,6 +108,8 @@ simple-report:
       - support@simplereport.gov
     waitlist-recipient:
       - support@simplereport.gov
+    outreach-mailing-list-recipient:
+      - support@simplereport.gov
     dynamic-templates:
       # The templates are added and edited at: https://mc.sendgrid.com/dynamic-templates
       # The keys in this map should match (but don't have to) the names of SendGrid Dynamic Templates that

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -66,4 +66,5 @@ extend type Mutation {
     role: Role!): User!
   updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag
   deleteE2EOktaOrganizations(orgExternalId: String!): Organization
+  sendOrgAdminEmailCSV(type: String!, state: String!): Int
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -1,6 +1,8 @@
 package gov.cdc.usds.simplereport.api.organization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -113,5 +115,26 @@ class OrganizationResolverTest {
 
     verify(organizationService).getOrganizationsByName(orgName, true);
     verify(organizationService).getFacilities(org);
+  }
+
+  @Test
+  void sendOrgAdminEmailCSV_success() {
+    String type = "patients";
+    String state = "NJ";
+    organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
+    verify(organizationService).sendOrgAdminEmailCSV(type, state);
+  }
+
+  @Test
+  void sendOrgAdminEmailCSV_exception() {
+    String type = "unsupportedType";
+    String state = "NJ";
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            () -> {
+              organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
+            });
+    assertEquals("type can be \"facilities\" or \"patients\"", caught.getMessage());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -126,7 +126,7 @@ class OrganizationResolverTest {
   }
 
   @Test
-  void sendOrgAdminEmailCSV_exception() {
+  void sendOrgAdminEmailCSV_unsupportedType_throwsException() {
     String type = "unsupportedType";
     String state = "NJ";
     IllegalGraphqlArgumentException caught =
@@ -136,5 +136,18 @@ class OrganizationResolverTest {
               organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
             });
     assertEquals("type can be \"facilities\" or \"patients\"", caught.getMessage());
+  }
+
+  @Test
+  void sendOrgAdminEmailCSV_unsupportedState_throwsException() {
+    String type = "patients";
+    String state = "ZW";
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            () -> {
+              organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
+            });
+    assertEquals("Not a valid state", caught.getMessage());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 /**
  * A base test for Spring Data repository tests. Comes pre-wired with a standard API user to attach
@@ -22,7 +23,12 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({SliceTestConfiguration.class, DbTruncator.class, DataSourceConfiguration.class})
+@Import({
+  SliceTestConfiguration.class,
+  DbTruncator.class,
+  DataSourceConfiguration.class,
+  SpringTemplateEngine.class
+})
 @WithSimpleReportStandardUser
 // this allows us to have a non-static @BeforeAll method, at the cost of having slightly less
 // isolation between test cases (data could be passed between tests using instance variables). Don't

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -20,6 +20,7 @@ import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -469,6 +470,22 @@ class DemoOktaRepositoryTest {
         true);
 
     assertThat(_repo.fetchAdminUserEmail(ABC)).contains("dianek@gmail.com");
+  }
+
+  @Test
+  void fetchAdminUserEmail_differentOrgs_successful() {
+    Set<OrganizationRole> adminRoles = Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.ADMIN);
+    Organization orgA = new Organization("Org A", "k12", "Org A", true);
+    _repo.createOrganization(orgA);
+    Facility orgAFacility = getFacility(UUID.randomUUID(), orgA);
+    _repo.createFacility(orgAFacility);
+    _repo.createUser(AMOS, ABC, Set.of(ABC_1), adminRoles, true);
+    _repo.createUser(BRAD, orgA, Set.of(orgAFacility), adminRoles, true);
+
+    List<String> actualABCAdminEmails = _repo.fetchAdminUserEmail(ABC);
+    assertThat(actualABCAdminEmails).hasSize(1).contains(AMOS.getUsername());
+    List<String> actualOrgAAdminEmails = _repo.fetchAdminUserEmail(orgA);
+    assertThat(actualOrgAAdminEmails).hasSize(1).contains(BRAD.getUsername());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -575,7 +575,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     String type = "unsupportedType";
 
     Integer caCount = _service.sendOrgAdminEmailCSV(type, "CA");
-    assertThat(caCount).isEqualTo(0);
+    assertThat(caCount).isZero();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -10,11 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.api.model.FacilityStats;
+import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentOrgException;
 import gov.cdc.usds.simplereport.api.model.errors.OrderingProviderRequiredException;
@@ -23,15 +25,19 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientSelfRegistrationLink;
+import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PatientRegistrationLinkRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
+import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportSiteAdminUser;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
@@ -58,8 +64,10 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Autowired private DeviceTypeRepository deviceTypeRepository;
   @Autowired @SpyBean private OktaRepository oktaRepository;
   @Autowired @SpyBean private PersonRepository personRepository;
+  @Autowired @SpyBean private ProviderRepository providerRepository;
   @Autowired ApiUserRepository _apiUserRepo;
   @Autowired private DemoUserConfiguration userConfiguration;
+  @Autowired @SpyBean private EmailService emailService;
 
   @BeforeEach
   void setupData() {
@@ -502,6 +510,66 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   }
 
   @Test
+  @WithSimpleReportStandardUser
+  void sendOrgAdminEmailCSV_accessDeniedException() {
+    assertThrows(
+        AccessDeniedException.class,
+        () -> {
+          _service.sendOrgAdminEmailCSV("facilities", "NM");
+        });
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void sendOrgAdminEmailCSV_byFacilities_success() {
+    setupDataByFacility();
+    String type = "facilities";
+
+    Integer mnCount = _service.sendOrgAdminEmailCSV(type, "MN");
+    verify(facilityRepository, times(1)).findByFacilityState("MN");
+    verify(emailService, times(1))
+        .sendWithCSVAttachment(
+            List.of("mn-orgBadmin1@example.com", "mn-orgBadmin2@example.com"), "MN", type);
+    assertThat(mnCount).isEqualTo(2);
+    reset(emailService);
+
+    Integer njCount = _service.sendOrgAdminEmailCSV(type, "nj");
+    verify(facilityRepository, times(1)).findByFacilityState("nj");
+    verify(emailService, times(1))
+        .sendWithCSVAttachment(List.of("nj-orgAadmin1@example.com"), "nj", type);
+    assertThat(njCount).isEqualTo(1);
+    reset(emailService);
+
+    Integer paCount = _service.sendOrgAdminEmailCSV(type, "PA");
+    verify(facilityRepository, times(1)).findByFacilityState("PA");
+    verify(emailService, times(1)).sendWithCSVAttachment(List.of(), "PA", type);
+    assertThat(paCount).isZero();
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void sendOrgAdminEmailCSV_byPatients_success() {
+    setupDataByPatient();
+    String type = "patients";
+
+    Integer caCount = _service.sendOrgAdminEmailCSV(type, "CA");
+    verify(emailService, times(1))
+        .sendWithCSVAttachment(List.of("mn-orgBadmin1@example.com"), "CA", type);
+    assertThat(caCount).isEqualTo(1);
+    reset(emailService);
+
+    Integer njCount = _service.sendOrgAdminEmailCSV(type, "nj");
+    verify(emailService, times(1))
+        .sendWithCSVAttachment(List.of("ca-orgAadmin1@example.com"), "nj", type);
+    assertThat(njCount).isEqualTo(1);
+    reset(emailService);
+
+    Integer mnCount = _service.sendOrgAdminEmailCSV(type, "MN");
+    verify(emailService, times(1)).sendWithCSVAttachment(List.of(), "MN", type);
+    assertThat(mnCount).isZero();
+  }
+
+  @Test
   @WithSimpleReportSiteAdminUser
   void deleteE2EOktaOrganization_succeeds() {
     Organization createdOrg = _dataFactory.saveValidOrganization();
@@ -509,5 +577,63 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
     assertThat(deletedOrg).isEqualTo(createdOrg);
     verify(oktaRepository, times(1)).deleteOrganization(createdOrg);
+  }
+
+  private void setupDataByFacility() {
+    StreetAddress orgAStreetAddress =
+        new StreetAddress("123 Main Street", null, "Hackensack", "NJ", "07601", "Bergen");
+    Organization orgA =
+        _dataFactory.saveOrganization(
+            new Organization("Org A", "k12", "d6b3951b-6698-4ee7-9d63-aaadee85bac0", true));
+    _dataFactory.createValidFacility(orgA, "Org A Facility 1", orgAStreetAddress);
+    _dataFactory.createValidFacility(orgA, "Org A Facility 2", orgAStreetAddress);
+    testDataFactory.createValidApiUser("nj-orgAadmin1@example.com", orgA, Role.ADMIN);
+
+    StreetAddress orgBStreetAddress =
+        new StreetAddress("234 Red Street", null, "Minneapolis", "MN", "55407", "Hennepin");
+    Organization orgB =
+        _dataFactory.saveOrganization(
+            new Organization("Org B", "airport", "747e341d-0467-45b8-b92f-a638da2bf1ee", true));
+    _dataFactory.createValidFacility(orgB, "Org B Facility 1", orgBStreetAddress);
+    testDataFactory.createValidApiUser("mn-orgBadmin1@example.com", orgB, Role.ADMIN);
+    testDataFactory.createValidApiUser("mn-orgBadmin2@example.com", orgB, Role.ADMIN);
+  }
+
+  private void setupDataByPatient() {
+    StreetAddress njStreetAddress =
+        new StreetAddress("123 Main Street", null, "Hackensack", "NJ", "07601", "Bergen");
+    StreetAddress caStreetAddress =
+        new StreetAddress("456 Red Street", null, "Sunnyvale", "CA", "94086", "Santa Clara");
+    StreetAddress mnStreetAddress =
+        new StreetAddress("234 Red Street", null, "Minneapolis", "MN", "55407", "Hennepin");
+    Organization orgA =
+        _dataFactory.saveOrganization(
+            new Organization(
+                "Org A", "k12", "CA-org-a-5359aa13-93b2-4680-802c-9c90acb5d251", true));
+    testDataFactory.createValidApiUser("ca-orgAadmin1@example.com", orgA, Role.ADMIN);
+    Facility orgAFacility =
+        _dataFactory.createValidFacility(orgA, "Org A Facility 1", caStreetAddress);
+
+    // create patient in NJ with a test event for Org A
+    Person orgAPatient1 =
+        _dataFactory.createFullPersonWithAddress(orgA, njStreetAddress, "Joe", "Moe");
+    _dataFactory.createTestEvent(orgAPatient1, orgAFacility, TestResult.POSITIVE);
+
+    Organization orgB =
+        _dataFactory.saveOrganization(
+            new Organization(
+                "Org B", "airport", "MN-org-b-3dddkv89-8981-421b-bd61-f293723284", true));
+    testDataFactory.createValidApiUser("mn-orgBadmin1@example.com", orgB, Role.ADMIN);
+    testDataFactory.createValidApiUser("mn-orgBuser@example.com", orgB, Role.USER);
+    Facility orgBFacility =
+        _dataFactory.createValidFacility(orgB, "Org B Facility 1", mnStreetAddress);
+    // create patient in CA with a test event for Org A
+    Person orgAPatient2 =
+        _dataFactory.createFullPersonWithAddress(orgA, caStreetAddress, "Ed", "Eaves");
+    _dataFactory.createTestEvent(orgAPatient2, orgBFacility, TestResult.UNDETERMINED);
+    // create patient in CA with a test event for Org B
+    Person orgBPatient1 =
+        _dataFactory.createFullPersonWithAddress(orgB, caStreetAddress, "Mary", "Meade");
+    _dataFactory.createTestEvent(orgBPatient1, orgBFacility, TestResult.NEGATIVE);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -571,6 +571,15 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   @WithSimpleReportSiteAdminUser
+  void sendOrgAdminEmailCSV_byUnsupportedType_success() {
+    String type = "unsupportedType";
+
+    Integer caCount = _service.sendOrgAdminEmailCSV(type, "CA");
+    assertThat(caCount).isEqualTo(0);
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
   void deleteE2EOktaOrganization_succeeds() {
     Organization createdOrg = _dataFactory.saveValidOrganization();
     Organization deletedOrg = _service.deleteE2EOktaOrganization(createdOrg.getExternalId());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.api.model.FacilityStats;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
-import gov.cdc.usds.simplereport.api.model.errors.NonexistentOrgException;
 import gov.cdc.usds.simplereport.api.model.errors.OrderingProviderRequiredException;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
@@ -486,9 +485,10 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   @WithSimpleReportSiteAdminUser
-  void getOrgAdminUserIds_throws_forNonExistentOrg() {
+  void getOrgAdminUserIds_returnsEmptyList_forNonExistentOrg() {
     UUID mismatchedUUID = UUID.fromString("5ebf893a-bb57-48ca-8fc2-1ef6b25e465b");
-    assertThrows(NonexistentOrgException.class, () -> _service.getOrgAdminUserIds(mismatchedUUID));
+    List<UUID> adminIds = _service.getOrgAdminUserIds(mismatchedUUID);
+    assertThat(adminIds).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/email/EmailServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/email/EmailServiceTest.java
@@ -7,11 +7,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Attachments;
 import com.sendgrid.helpers.mail.objects.Personalization;
 import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +36,16 @@ class EmailServiceTest extends BaseServiceTest<EmailService> {
   SpringTemplateEngine _templateEngine;
 
   private static final SendGridProperties FAKE_PROPERTIES =
-      new SendGridProperties(
-          true, null, "me@example.com", "My Display Name", List.of(), List.of(), Map.of());
+      SendGridProperties.builder()
+          .enabled(true)
+          .apiKey(null)
+          .fromEmail("me@example.com")
+          .fromDisplayName("My Display Name")
+          .accountRequestRecipient(List.of())
+          .waitlistRecipient(List.of())
+          .outreachMailingListRecipient(List.of("support-test@simplereport.gov"))
+          .dynamicTemplates(Map.of())
+          .build();
 
   @Mock EmailProvider mockSendGrid;
   @Captor ArgumentCaptor<Mail> mail;
@@ -239,5 +250,34 @@ class EmailServiceTest extends BaseServiceTest<EmailService> {
     assertThat(sentMail.getFrom().getEmail()).isEqualTo("me@example.com");
     assertEquals(personalization.getTos().get(0).getEmail(), toEmail);
     assertThat(personalization.getDynamicTemplateData()).isEqualTo(dynamicTemplateData);
+  }
+
+  @Test
+  void sendWithCSVAttachment_success() throws IOException {
+    // GIVEN
+    List<String> emails = List.of("test-1@example.com", "test-2@example.com");
+
+    // WHEN
+    _service.sendWithCSVAttachment(emails, "NJ", "facilities");
+
+    // THEN
+    verify(mockSendGrid, times(1)).send(mail.capture());
+    Mail sentMail = mail.getValue();
+    String emailSubject = sentMail.getSubject();
+    String emailBody = sentMail.getContent().get(0).getValue();
+    Attachments attachment = sentMail.getAttachments().get(0);
+    String filename = attachment.getFilename();
+    String type = attachment.getType();
+    byte[] bytes = Base64.getDecoder().decode(attachment.getContent());
+    String attachmentString = new String(bytes, StandardCharsets.UTF_8);
+    Personalization personalization = sentMail.getPersonalization().get(0);
+
+    assertThat(sentMail.getFrom().getEmail()).isEqualTo("me@example.com");
+    assertEquals("support-test@simplereport.gov", personalization.getTos().get(0).getEmail());
+    assertThat(emailSubject).isEqualTo("Org admin email CSVs for outreach - facilities in NJ");
+    assertThat(emailBody).isEqualTo("Org admin email CSVs for outreach - facilities in NJ");
+    assertThat(filename).contains("-facilities_NJ-org_admin_emails.csv");
+    assertThat(type).isEqualTo("text/csv");
+    assertThat(attachmentString).isEqualTo("email\ntest-1@example.com\ntest-2@example.com\n");
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.api.pxp.CurrentPatientContextHolder;
 import gov.cdc.usds.simplereport.config.AuditingConfig;
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
+import gov.cdc.usds.simplereport.config.SendGridDisabledConfiguration;
 import gov.cdc.usds.simplereport.config.authorization.DemoAuthenticationConfiguration;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationExtractor;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
@@ -27,6 +28,7 @@ import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.PatientSelfRegistrationLinkService;
 import gov.cdc.usds.simplereport.service.ResultService;
 import gov.cdc.usds.simplereport.service.TenantDataAccessService;
+import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 import gov.cdc.usds.simplereport.validators.OrderingProviderRequiredValidator;
 import java.lang.annotation.ElementType;
@@ -102,7 +104,9 @@ import org.springframework.security.test.context.support.WithMockUser;
   WebhookContextHolder.class,
   TenantDataAccessService.class,
   PatientSelfRegistrationLinkService.class,
-  BackendAndDatabaseHealthIndicator.class
+  BackendAndDatabaseHealthIndicator.class,
+  EmailService.class,
+  SendGridDisabledConfiguration.class,
 })
 @EnableConfigurationProperties({InitialSetupProperties.class, AuthorizationProperties.class})
 public class SliceTestConfiguration {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -149,9 +149,13 @@ public class TestDataFactory {
   }
 
   public UserInfo createValidApiUser(String username, Organization org) {
+    return createValidApiUser(username, org, Role.USER);
+  }
+
+  public UserInfo createValidApiUser(String username, Organization org, Role role) {
     PersonName name = new PersonName("John", null, "June", null);
     return apiUserService.createUser(
-        username, name, org.getExternalId(), Role.USER, false, Collections.emptySet());
+        username, name, org.getExternalId(), role, false, Collections.emptySet());
   }
 
   public OrganizationQueueItem saveOrganizationQueueItem(
@@ -177,6 +181,11 @@ public class TestDataFactory {
   }
 
   public Facility createValidFacility(Organization org, String facilityName) {
+    return createValidFacility(org, facilityName, getAddress());
+  }
+
+  public Facility createValidFacility(
+      Organization org, String facilityName, StreetAddress facilityStreetAddress) {
     DeviceType defaultDevice = getGenericDevice();
     SpecimenType defaultSpecimen = genericSpecimenType;
 
@@ -191,7 +200,7 @@ public class TestDataFactory {
                 .org(org)
                 .facilityName(facilityName)
                 .cliaNumber("123456")
-                .facilityAddress(getAddress())
+                .facilityAddress(facilityStreetAddress)
                 .phone("555-867-5309")
                 .email("facility@test.com")
                 .orderingProvider(doc)
@@ -379,6 +388,35 @@ public class TestDataFactory {
             "English",
             TestResultDeliveryPreference.SMS,
             "Nashville-born spacefarer");
+    return personRepository.save(p);
+  }
+
+  @Transactional
+  public Person createFullPersonWithAddress(
+      Organization org, StreetAddress address, String firstName, String lastName) {
+    Person p =
+        new Person(
+            org,
+            "123",
+            firstName,
+            "",
+            lastName,
+            null,
+            DEFAULT_BDAY,
+            address,
+            "USA",
+            PersonRole.RESIDENT,
+            null,
+            "white",
+            "not_hispanic",
+            null,
+            "male",
+            "male",
+            false,
+            false,
+            "English",
+            TestResultDeliveryPreference.SMS,
+            "");
     return personRepository.save(p);
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/CSVGeneratorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/CSVGeneratorUtilsTest.java
@@ -1,0 +1,30 @@
+package gov.cdc.usds.simplereport.utils;
+
+import static gov.cdc.usds.simplereport.utils.CSVGeneratorUtils.generateEmailCSVInBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CSVGeneratorUtilsTest {
+  @Test
+  void generateEmailCSVInBytes_withEmails() {
+    List<String> emails =
+        List.of("fake-1@example.com", "fake.2@example.com", "fake.THREE+3@example.com");
+    byte[] emailsBytes = generateEmailCSVInBytes(emails);
+    String bytesToString = new String(emailsBytes, StandardCharsets.UTF_8);
+    String expectedString =
+        "email\nfake-1@example.com\nfake.2@example.com\nfake.THREE+3@example.com\n";
+    assertThat(bytesToString).isEqualTo(expectedString);
+  }
+
+  @Test
+  void generateEmailCSVInBytes_withNoEmails() {
+    List<String> emails = List.of();
+    byte[] emailsBytes = generateEmailCSVInBytes(emails);
+    String bytesToString = new String(emailsBytes, StandardCharsets.UTF_8);
+    String expectedString = "email\n";
+    assertThat(bytesToString).isEqualTo(expectedString);
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/DateTimeUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/DateTimeUtilsTest.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.utils;
 
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.DATE_TIME_FORMATTER;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.convertToZonedDateTime;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.getCurrentDatestamp;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.parseLocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -94,5 +95,11 @@ public class DateTimeUtilsTest {
     String dateTimeString = "07/13/2023";
     LocalDateTime expectedDateTime = LocalDateTime.of(2023, 7, 13, 12, 0);
     test_parseLocalDateTime(dateTimeString, expectedDateTime);
+  }
+
+  @Test
+  void getCurrentDatestamp_returnDateString() {
+    LocalDateTime expectedDateTime = LocalDateTime.of(2023, 7, 13, 12, 0);
+    assertThat(getCurrentDatestamp(expectedDateTime)).isEqualTo("20230713");
   }
 }

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -65,7 +65,7 @@ simple-report:
     waitlist-recipient:
       - support@simplereport.gov
     outreach-mailing-list-recipient:
-      - support@simplereport.gov
+      - tof4@cdc.gov
   azure-reporting-queue:
     exception-webhook-enabled: true
     exception-webhook-token: WATERMELON

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -64,6 +64,8 @@ simple-report:
       - support@simplereport.gov
     waitlist-recipient:
       - support@simplereport.gov
+    outreach-mailing-list-recipient:
+      - support@simplereport.gov
   azure-reporting-queue:
     exception-webhook-enabled: true
     exception-webhook-token: WATERMELON

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -216,6 +216,7 @@ export type Mutation = {
   resendToReportStream?: Maybe<Scalars["Boolean"]["output"]>;
   resetUserMfa?: Maybe<User>;
   resetUserPassword?: Maybe<User>;
+  sendOrgAdminEmailCSV?: Maybe<Scalars["Int"]["output"]>;
   sendPatientLinkEmail?: Maybe<Scalars["Boolean"]["output"]>;
   sendPatientLinkEmailByTestEventId?: Maybe<Scalars["Boolean"]["output"]>;
   sendPatientLinkSms?: Maybe<Scalars["Boolean"]["output"]>;
@@ -406,6 +407,11 @@ export type MutationResetUserMfaArgs = {
 
 export type MutationResetUserPasswordArgs = {
   id: Scalars["ID"]["input"];
+};
+
+export type MutationSendOrgAdminEmailCsvArgs = {
+  state: Scalars["String"]["input"];
+  type: Scalars["String"]["input"];
 };
 
 export type MutationSendPatientLinkEmailArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7318

## Changes Proposed
- Supports ability to generate a CSV that will be sent to the `outreach-mailing-list-recipient` (support inbox)
- CSVs of org admin emails generated are for the following scenarios:
  - facilities: orgs that have facilities in the state indicated
  - patients: orgs outside the state indicated that have test results for patients whose address is in the state
- expose `support admin`-only endpoint to email the CSVs

## Additional Information


## Testing
- a [modified branch](https://github.com/CDCgov/prime-simplereport/compare/elisa/7318-outreach-admin-emails...elisa/7318-testing-branch?expand=1) has been deployed to dev2

- with an API testing tool of your choice, test the following mutation on dev2 with **YOUR EMAIL ADDRESS** 
- ⚠️ SendGrid is enabled on dev2 ⚠️ so the email will actually be sent
```
mutation ($state: String!, $type: String!, $email: String!) {
  sendOrgAdminEmailCSV(
    type: $type,
    state: $state,
    email: $email,
  ) 
}
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
