### PR TITLE
Update SMS message copy to be generic

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryService.java
@@ -77,7 +77,7 @@ public class TestResultsDeliveryService {
   public boolean smsTestResults(PatientLink patientLink) {
     String message =
         format(
-            "Your COVID-19 test result is ready to view. This link will expire after {0}: {1}",
+            "Your test result is ready to view. This link will expire after {0}: {1}",
             getExpirationDuration(patientLink), patientLinkUrl + patientLink.getInternalId());
     List<SmsAPICallResult> smsSendResults = smsService.sendToPatientLink(patientLink, message);
     return smsSendResults.stream().allMatch(SmsAPICallResult::isSuccessful);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestResultsDeliveryServiceTest.java
@@ -173,7 +173,7 @@ class TestResultsDeliveryServiceTest {
     // THEN
     assertThat(success).isTrue();
     String message =
-        "Your COVID-19 test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
+        "Your test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
             + patientLinkId;
     verify(smsService).sendToPatientLink(patientLink, message);
   }
@@ -193,7 +193,7 @@ class TestResultsDeliveryServiceTest {
     // THEN
     assertThat(success).isTrue();
     String message =
-        "Your COVID-19 test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
+        "Your test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
             + uuid;
     verify(smsService).sendToPatientLink(patientLink, message);
   }
@@ -216,7 +216,7 @@ class TestResultsDeliveryServiceTest {
     // THEN
     assertThat(success).isFalse();
     String message =
-        "Your COVID-19 test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
+        "Your test result is ready to view. This link will expire after 2 days: https://simplereport.gov/pxp?plid="
             + uuid;
     verify(smsService).sendToPatientLink(patientLink, message);
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Resolves #7396 

## Changes Proposed

-Update the string in the text that we compose to be disease generic.
-Update the corresponding tests to have the new string 

## Additional Information

In the ticket Jayna asked about the feasibility of making the message be disease specific. From the digging that I did through our Twilio and SMS class configuration there did not seem to be a straight forward way to make this happen. 

ie at no point in the flow of control for sending a text did I find a place where an object that contained the information of the specific type of disease that was being tested for was present. If there is an easy way to add this information please let me know! If not, Jayna gave me the ok today at eng sync to precede with the generic "Your test result is ready to view" message.

## Testing

- Pull down this branch and run `TestResultsDeliveryServiceTest.java` locally.


