### PR TITLE
Require HIV AOE values for positive HIV bulk upload result rows

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -15,6 +15,7 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateEma
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateEthnicity;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateGendersOfSexualPartners;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveHIVRequiredAOEFields;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateRace;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateResidence;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateSpecimenType;
@@ -475,6 +476,14 @@ public class TestResultRow implements FileRow {
     return emptyList();
   }
 
+  private boolean isHivResult() {
+    return resultsUploaderCachingService
+        .getHivEquipmentModelAndTestPerformedCodeSet()
+        .contains(
+            ResultsUploaderCachingService.getKey(
+                equipmentModelName.getValue(), testPerformedCode.getValue()));
+  }
+
   private List<FeedbackMessage> generateInvalidDataErrorMessages() {
     String errorMessage =
         "Invalid " + EQUIPMENT_MODEL_NAME + " and " + TEST_PERFORMED_CODE + " combination";
@@ -584,6 +593,11 @@ public class TestResultRow implements FileRow {
             equipmentModelName.getValue(), testPerformedCode.getValue()));
 
     errors.addAll(validateGendersOfSexualPartners(gendersOfSexualPartners));
+
+    if (isHivResult()) {
+      errors.addAll(
+          validatePositiveHIVRequiredAOEFields(testResult, gendersOfSexualPartners, pregnant));
+    }
 
     return errors;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -477,6 +477,9 @@ public class TestResultRow implements FileRow {
   }
 
   private boolean isHivResult() {
+    if (equipmentModelName.getValue() == null || testPerformedCode.getValue() == null) {
+      return false;
+    }
     return resultsUploaderCachingService
         .getHivEquipmentModelAndTestPerformedCodeSet()
         .contains(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
@@ -12,6 +12,8 @@ public class CachingConfig {
 
   public static final String COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "covidEquipmentModelAndTestPerformedCodeSet";
+  public static final String HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
+      "hivEquipmentModelAndTestPerformedCodeSet";
   public static final String DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP =
       "deviceModelAndTestPerformedCodeMap";
   public static final String SPECIMEN_NAME_TO_SNOMED_MAP = "specimenTypeNameSNOMEDMap";

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
@@ -25,6 +25,7 @@ public class CachingConfig {
   public CacheManager cacheManager() {
     return new ConcurrentMapCacheManager(
         COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+        HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP,
         SPECIMEN_NAME_TO_SNOMED_MAP,
         SNOMED_TO_SPECIMEN_NAME_MAP,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -169,7 +169,7 @@ public class ResultsUploaderCachingService {
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
   @Caching(
       evict = {
-        @CacheEvict(value = COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET, allEntries = true)
+        @CacheEvict(value = HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET, allEntries = true)
       })
   public void cacheHivEquipmentModelAndTestPerformedCodeSet() {
     log.info("clear and generate hivEquipmentModelAndTestPerformedCodeSet cache");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -147,13 +147,13 @@ public class ResultsUploaderCachingService {
   @Cacheable(HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
   public Set<String> getHivEquipmentModelAndTestPerformedCodeSet() {
     log.info("generating hivEquipmentModelAndTestPerformedCodeSet cache");
-    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet("HIV");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.HIV_NAME);
   }
 
   @Cacheable(COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
   public Set<String> getCovidEquipmentModelAndTestPerformedCodeSet() {
     log.info("generating covidEquipmentModelAndTestPerformedCodeSet cache");
-    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet("COVID-19");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.COVID19_NAME);
   }
 
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.service;
 import static gov.cdc.usds.simplereport.config.CachingConfig.ADDRESS_TIMEZONE_LOOKUP_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP;
+import static gov.cdc.usds.simplereport.config.CachingConfig.HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SNOMED_TO_SPECIMEN_NAME_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SPECIMEN_NAME_TO_SNOMED_MAP;
 
@@ -117,10 +118,7 @@ public class ResultsUploaderCachingService {
     getModelAndTestPerformedCodeToDeviceMap();
   }
 
-  @Cacheable(COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
-  public Set<String> getCovidEquipmentModelAndTestPerformedCodeSet() {
-    log.info("generating covidEquipmentModelAndTestPerformedCodeSet cache");
-
+  private Set<String> getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(String diseaseName) {
     Set<String> resultSet = new HashSet<>();
 
     deviceTypeRepository
@@ -134,7 +132,7 @@ public class ResultsUploaderCachingService {
                           if (deviceTypeDisease
                               .getSupportedDisease()
                               .getName()
-                              .equals("COVID-19")) {
+                              .equals(diseaseName)) {
                             String model = deviceType.getModel();
                             String testPerformedCode =
                                 deviceTypeDisease.getTestPerformedLoincCode();
@@ -143,8 +141,19 @@ public class ResultsUploaderCachingService {
                             }
                           }
                         }));
-
     return resultSet;
+  }
+
+  @Cacheable(HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
+  public Set<String> getHivEquipmentModelAndTestPerformedCodeSet() {
+    log.info("generating hivEquipmentModelAndTestPerformedCodeSet cache");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet("HIV");
+  }
+
+  @Cacheable(COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
+  public Set<String> getCovidEquipmentModelAndTestPerformedCodeSet() {
+    log.info("generating covidEquipmentModelAndTestPerformedCodeSet cache");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet("COVID-19");
   }
 
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
@@ -155,6 +164,16 @@ public class ResultsUploaderCachingService {
   public void cacheCovidEquipmentModelAndTestPerformedCodeSet() {
     log.info("clear and generate covidEquipmentModelAndTestPerformedCodeSet cache");
     getCovidEquipmentModelAndTestPerformedCodeSet();
+  }
+
+  @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
+  @Caching(
+      evict = {
+        @CacheEvict(value = COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET, allEntries = true)
+      })
+  public void cacheHivEquipmentModelAndTestPerformedCodeSet() {
+    log.info("clear and generate hivEquipmentModelAndTestPerformedCodeSet cache");
+    getHivEquipmentModelAndTestPerformedCodeSet();
   }
 
   @Cacheable(SNOMED_TO_SPECIMEN_NAME_MAP)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -254,6 +254,12 @@ public class CsvValidatorUtils {
     return "File is missing data in the " + columnName + " column.";
   }
 
+  private static String getRequiredHivAoeValuesErrorMessage(String columnName) {
+    return "File is missing data in the "
+        + columnName
+        + " column. This is required because the row contains a positive HIV test result.";
+  }
+
   public static List<FeedbackMessage> validateTestResult(ValueOrError input) {
     return validateSpecificValueOrSNOMED(input, TEST_RESULT_VALUES);
   }
@@ -626,6 +632,41 @@ public class CsvValidatorUtils {
               .message(getInvalidValueErrorMessage(input.getValue(), input.getHeader()))
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(input.isRequired())
+              .build());
+    }
+    return errors;
+  }
+
+  public static List<FeedbackMessage> validatePositiveHIVRequiredAOEFields(
+      ValueOrError testResult, ValueOrError gendersOfSexualPartners, ValueOrError pregnant) {
+    List<FeedbackMessage> errors = new ArrayList<>();
+    Set<String> positiveTestResultValues = Set.of("positive", "detected");
+    if (!positiveTestResultValues.contains(testResult.getValue().toLowerCase())) {
+      return errors;
+    }
+
+    if (gendersOfSexualPartners.getValue() == null
+        || gendersOfSexualPartners.getValue().isBlank()) {
+      errors.add(
+          FeedbackMessage.builder()
+              .scope(ITEM_SCOPE)
+              .fieldHeader(gendersOfSexualPartners.getHeader())
+              .source(ResultUploadErrorSource.SIMPLE_REPORT)
+              .message(getRequiredHivAoeValuesErrorMessage(gendersOfSexualPartners.getHeader()))
+              .errorType(ResultUploadErrorType.MISSING_DATA)
+              .fieldRequired(gendersOfSexualPartners.isRequired())
+              .build());
+    }
+
+    if (pregnant.getValue() == null || pregnant.getValue().isBlank()) {
+      errors.add(
+          FeedbackMessage.builder()
+              .scope(ITEM_SCOPE)
+              .fieldHeader(pregnant.getHeader())
+              .source(ResultUploadErrorSource.SIMPLE_REPORT)
+              .message(getRequiredHivAoeValuesErrorMessage(pregnant.getHeader()))
+              .errorType(ResultUploadErrorType.MISSING_DATA)
+              .fieldRequired(pregnant.isRequired())
               .build());
     }
     return errors;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -640,7 +640,8 @@ public class CsvValidatorUtils {
   public static List<FeedbackMessage> validatePositiveHIVRequiredAOEFields(
       ValueOrError testResult, ValueOrError gendersOfSexualPartners, ValueOrError pregnant) {
     List<FeedbackMessage> errors = new ArrayList<>();
-    Set<String> positiveTestResultValues = Set.of("positive", "detected");
+    // includes SNOMED values for positive and detected
+    Set<String> positiveTestResultValues = Set.of("positive", "detected", "260373001", "10828004");
     if (!positiveTestResultValues.contains(testResult.getValue().toLowerCase())) {
       return errors;
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -11,6 +11,7 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateFle
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateGendersOfSexualPartners;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePartialUnkAddress;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveHIVRequiredAOEFields;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateSpecimenType;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateZipCode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -285,5 +286,29 @@ class CsvValidatorUtilsTest {
   void invalidGendersOfSexualPartners() {
     ValueOrError genders = new ValueOrError("m, f, t, n", "genders_of_sexual_partners");
     assertThat(validateGendersOfSexualPartners(genders)).hasSize(1);
+  }
+
+  @Test
+  void validNegativeHIVNoRequiredAOEFields() {
+    ValueOrError testResult = new ValueOrError("negative", "test_result");
+    ValueOrError genders = new ValueOrError("", "genders_of_sexual_partners");
+    ValueOrError pregnant = new ValueOrError("", "pregnant");
+    assertThat(validatePositiveHIVRequiredAOEFields(testResult, genders, pregnant)).isEmpty();
+  }
+
+  @Test
+  void validPositiveHIVRequiredAOEFields() {
+    ValueOrError testResult = new ValueOrError("positive", "test_result");
+    ValueOrError genders = new ValueOrError("m, f, tm, tw", "genders_of_sexual_partners");
+    ValueOrError pregnant = new ValueOrError("n", "pregnant");
+    assertThat(validatePositiveHIVRequiredAOEFields(testResult, genders, pregnant)).isEmpty();
+  }
+
+  @Test
+  void invalidPositiveHIVRequiredAOEFields() {
+    ValueOrError testResult = new ValueOrError("positive", "test_result");
+    ValueOrError genders = new ValueOrError("", "genders_of_sexual_partners");
+    ValueOrError pregnant = new ValueOrError("", "pregnant");
+    assertThat(validatePositiveHIVRequiredAOEFields(testResult, genders, pregnant)).hasSize(2);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of #7455

## Changes Proposed

- Adds conditional validation for positive HIV result rows in which the `genders_of_sexual_partners` column and `pregnant` column become required values

## Additional Information

- Following PR will add `patient_gender_identity` column
- Ticket for updating the user guidance is #7461 

## Testing

- Deployed on dev6