### PR TITLE
Elisa/7462 okta rate limit

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -1,7 +1,5 @@
 package gov.cdc.usds.simplereport.api.organization;
 
-import static gov.cdc.usds.simplereport.api.Translators.STATE_CODES;
-
 import gov.cdc.usds.simplereport.api.model.ApiFacility;
 import gov.cdc.usds.simplereport.api.model.ApiOrganization;
 import gov.cdc.usds.simplereport.api.model.ApiPendingOrganization;
@@ -18,7 +16,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
@@ -134,30 +131,5 @@ public class OrganizationResolver {
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public List<UUID> getOrgAdminUserIds(@Argument UUID orgId) {
     return _organizationService.getOrgAdminUserIds(orgId);
-  }
-
-  /**
-   * Used for outreach purposes - emails a CSV of org admin emails for the following type: 1.
-   * "facilities" - orgs that have facilities in the state 2. "patients" - orgs outside the state
-   * that have test results for patients whose address is in the state
-   *
-   * <p>The generated CSV is sent to the outreachMailingListRecipient email
-   *
-   * @param type "facilities" or "patients"
-   * @param state State abbreviation e.g. "NJ", "MN"
-   */
-  @MutationMapping
-  @AuthorizationConfiguration.RequireGlobalAdminUser
-  public Integer sendOrgAdminEmailCSV(@Argument String type, @Argument String state) {
-    Set<String> acceptableStates = STATE_CODES;
-    List<String> acceptableTypes = List.of("facilities", "patients");
-
-    if (!acceptableStates.contains(state.toUpperCase())) {
-      throw new IllegalGraphqlArgumentException("Not a valid state");
-    }
-    if (!acceptableTypes.contains(type.toLowerCase())) {
-      throw new IllegalGraphqlArgumentException("type can be \"facilities\" or \"patients\"");
-    }
-    return _organizationService.sendOrgAdminEmailCSV(type, state);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -17,6 +17,16 @@ import java.util.Set;
  * <p>Handles all user/organization management in Okta
  */
 public interface OktaRepository {
+  Integer OKTA_ORGS_LIMIT = 200;
+  Integer OKTA_RATE_LIMIT_SLEEP_MS = 60000;
+
+  default Integer getOktaOrgsLimit() {
+    return OKTA_ORGS_LIMIT;
+  }
+
+  default Integer getOktaRateLimitSleepMs() {
+    return OKTA_RATE_LIMIT_SLEEP_MS;
+  }
 
   Optional<OrganizationRoleClaims> createUser(
       IdentityAttributes userIdentity,

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -66,5 +66,5 @@ extend type Mutation {
     role: Role!): User!
   updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag
   deleteE2EOktaOrganizations(orgExternalId: String!): Organization
-  sendOrgAdminEmailCSV(type: String!, state: String!): Int
+  sendOrgAdminEmailCSV(type: String!, state: String!): Boolean
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolverTest.java
@@ -1,8 +1,6 @@
 package gov.cdc.usds.simplereport.api.organization;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -115,39 +113,5 @@ class OrganizationResolverTest {
 
     verify(organizationService).getOrganizationsByName(orgName, true);
     verify(organizationService).getFacilities(org);
-  }
-
-  @Test
-  void sendOrgAdminEmailCSV_success() {
-    String type = "patients";
-    String state = "NJ";
-    organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
-    verify(organizationService).sendOrgAdminEmailCSV(type, state);
-  }
-
-  @Test
-  void sendOrgAdminEmailCSV_unsupportedType_throwsException() {
-    String type = "unsupportedType";
-    String state = "NJ";
-    IllegalGraphqlArgumentException caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class,
-            () -> {
-              organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
-            });
-    assertEquals("type can be \"facilities\" or \"patients\"", caught.getMessage());
-  }
-
-  @Test
-  void sendOrgAdminEmailCSV_unsupportedState_throwsException() {
-    String type = "patients";
-    String state = "ZW";
-    IllegalGraphqlArgumentException caught =
-        assertThrows(
-            IllegalGraphqlArgumentException.class,
-            () -> {
-              organizationMutationResolver.sendOrgAdminEmailCSV(type, state);
-            });
-    assertEquals("Not a valid state", caught.getMessage());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,14 +53,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.access.AccessDeniedException;
 
+@EnableAsync
 class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Autowired private TestDataFactory testDataFactory;
   @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
   @Autowired @SpyBean private FacilityRepository facilityRepository;
-  @Autowired private OrganizationRepository organizationRepository;
+  @Autowired @SpyBean private OrganizationRepository organizationRepository;
   @Autowired private DeviceTypeRepository deviceTypeRepository;
   @Autowired @SpyBean private OktaRepository oktaRepository;
   @Autowired @SpyBean private PersonRepository personRepository;
@@ -510,6 +513,38 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   }
 
   @Test
+  @WithSimpleReportSiteAdminUser
+  void sendOrgAdminEmailCSVAsync_success() throws ExecutionException, InterruptedException {
+    setupDataByFacility();
+    String type = "facilities";
+    when(oktaRepository.getOktaRateLimitSleepMs()).thenReturn(0);
+    when(oktaRepository.getOktaOrgsLimit()).thenReturn(1);
+
+    String mnExternalId = "747e341d-0467-45b8-b92f-a638da2bf1ee";
+    UUID mnId = organizationRepository.findByExternalId(mnExternalId).get().getInternalId();
+    List<String> mnEmails = _service.sendOrgAdminEmailCSVAsync(List.of(mnId), type, "MN").get();
+    List<String> expectedMnEmails =
+        List.of("mn-orgBadmin1@example.com", "mn-orgBadmin2@example.com");
+    verify(emailService, times(1)).sendWithCSVAttachment(expectedMnEmails, "MN", type);
+    assertThat(mnEmails).isEqualTo(expectedMnEmails);
+    reset(emailService);
+
+    String njExternalId = "d6b3951b-6698-4ee7-9d63-aaadee85bac0";
+    UUID njId = organizationRepository.findByExternalId(njExternalId).get().getInternalId();
+    List<String> njEmails = _service.sendOrgAdminEmailCSVAsync(List.of(njId), type, "NJ").get();
+    List<String> expectedNjEmails = List.of("nj-orgAadmin1@example.com");
+    verify(emailService, times(1)).sendWithCSVAttachment(expectedNjEmails, "NJ", type);
+    assertThat(njEmails).isEqualTo(expectedNjEmails);
+    reset(emailService);
+
+    List<String> nonExistentOrgEmails =
+        _service.sendOrgAdminEmailCSVAsync(List.of(), type, "PA").get();
+    verify(emailService, times(1)).sendWithCSVAttachment(nonExistentOrgEmails, "PA", type);
+    assertThat(nonExistentOrgEmails).isEmpty();
+    reset(emailService);
+  }
+
+  @Test
   @WithSimpleReportStandardUser
   void sendOrgAdminEmailCSV_accessDeniedException() {
     assertThrows(
@@ -523,59 +558,45 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @WithSimpleReportSiteAdminUser
   void sendOrgAdminEmailCSV_byFacilities_success() {
     setupDataByFacility();
-    String type = "facilities";
+    when(oktaRepository.getOktaRateLimitSleepMs()).thenReturn(0);
+    when(oktaRepository.getOktaOrgsLimit()).thenReturn(1);
 
-    Integer mnCount = _service.sendOrgAdminEmailCSV(type, "MN");
+    boolean mnEmailSent = _service.sendOrgAdminEmailCSV("facilities", "MN");
     verify(facilityRepository, times(1)).findByFacilityState("MN");
-    verify(emailService, times(1))
-        .sendWithCSVAttachment(
-            List.of("mn-orgBadmin1@example.com", "mn-orgBadmin2@example.com"), "MN", type);
-    assertThat(mnCount).isEqualTo(2);
-    reset(emailService);
+    assertThat(mnEmailSent).isTrue();
 
-    Integer njCount = _service.sendOrgAdminEmailCSV(type, "nj");
-    verify(facilityRepository, times(1)).findByFacilityState("nj");
-    verify(emailService, times(1))
-        .sendWithCSVAttachment(List.of("nj-orgAadmin1@example.com"), "nj", type);
-    assertThat(njCount).isEqualTo(1);
-    reset(emailService);
-
-    Integer paCount = _service.sendOrgAdminEmailCSV(type, "PA");
-    verify(facilityRepository, times(1)).findByFacilityState("PA");
-    verify(emailService, times(1)).sendWithCSVAttachment(List.of(), "PA", type);
-    assertThat(paCount).isZero();
+    boolean njEmailSent = _service.sendOrgAdminEmailCSV("faCilities", "NJ");
+    verify(facilityRepository, times(1)).findByFacilityState("NJ");
+    assertThat(njEmailSent).isTrue();
   }
 
   @Test
   @WithSimpleReportSiteAdminUser
   void sendOrgAdminEmailCSV_byPatients_success() {
     setupDataByPatient();
-    String type = "patients";
+    when(oktaRepository.getOktaRateLimitSleepMs()).thenReturn(0);
+    when(oktaRepository.getOktaOrgsLimit()).thenReturn(1);
 
-    Integer caCount = _service.sendOrgAdminEmailCSV(type, "CA");
-    verify(emailService, times(1))
-        .sendWithCSVAttachment(List.of("mn-orgBadmin1@example.com"), "CA", type);
-    assertThat(caCount).isEqualTo(1);
-    reset(emailService);
+    boolean caEmailSent = _service.sendOrgAdminEmailCSV("patients", "CA");
+    verify(organizationRepository, times(1)).findAllByPatientStateWithTestEvents("CA");
+    assertThat(caEmailSent).isTrue();
 
-    Integer njCount = _service.sendOrgAdminEmailCSV(type, "nj");
-    verify(emailService, times(1))
-        .sendWithCSVAttachment(List.of("ca-orgAadmin1@example.com"), "nj", type);
-    assertThat(njCount).isEqualTo(1);
-    reset(emailService);
-
-    Integer mnCount = _service.sendOrgAdminEmailCSV(type, "MN");
-    verify(emailService, times(1)).sendWithCSVAttachment(List.of(), "MN", type);
-    assertThat(mnCount).isZero();
+    boolean njEmailSent = _service.sendOrgAdminEmailCSV("PATIENTS", "NJ");
+    verify(organizationRepository, times(1)).findAllByPatientStateWithTestEvents("NJ");
+    assertThat(njEmailSent).isTrue();
   }
 
   @Test
   @WithSimpleReportSiteAdminUser
   void sendOrgAdminEmailCSV_byUnsupportedType_success() {
-    String type = "unsupportedType";
+    setupDataByPatient();
+    when(oktaRepository.getOktaRateLimitSleepMs()).thenReturn(0);
+    when(oktaRepository.getOktaOrgsLimit()).thenReturn(1);
 
-    Integer caCount = _service.sendOrgAdminEmailCSV(type, "CA");
-    assertThat(caCount).isZero();
+    boolean unsupportedTypeEmailSent = _service.sendOrgAdminEmailCSV("Unsuported", "CA");
+    verify(organizationRepository, times(0)).findAllByPatientStateWithTestEvents("CA");
+    verify(facilityRepository, times(0)).findByFacilityState("CA");
+    assertThat(unsupportedTypeEmailSent).isTrue();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -517,6 +517,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   void sendOrgAdminEmailCSVAsync_success() throws ExecutionException, InterruptedException {
     setupDataByFacility();
     String type = "facilities";
+    reset(emailService);
     when(oktaRepository.getOktaRateLimitSleepMs()).thenReturn(0);
     when(oktaRepository.getOktaOrgsLimit()).thenReturn(1);
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -216,7 +216,7 @@ export type Mutation = {
   resendToReportStream?: Maybe<Scalars["Boolean"]["output"]>;
   resetUserMfa?: Maybe<User>;
   resetUserPassword?: Maybe<User>;
-  sendOrgAdminEmailCSV?: Maybe<Scalars["Int"]["output"]>;
+  sendOrgAdminEmailCSV?: Maybe<Scalars["Boolean"]["output"]>;
   sendPatientLinkEmail?: Maybe<Scalars["Boolean"]["output"]>;
   sendPatientLinkEmailByTestEventId?: Maybe<Scalars["Boolean"]["output"]>;
   sendPatientLinkSms?: Maybe<Scalars["Boolean"]["output"]>;


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Resolves #7462 

## Changes Proposed
- Workaround for Okta's rate limiting that we run into when fetching org admin emails
    - new async method `sendOrgAdminEmailCSVAsync` now fetches org (200 orgs at a time) admin emails before sleeping for 1 min and then resuming
- Move existing `sendOrgAdminEmailCSV` method from the `OrganizationResolver.java` file to the `OrganizationMutationResolver.java` file
- `sendOrgAdminEmailCSV` mutation now returns a `boolean` instead of an `Integer` 

## Additional Information
Chromatic jobs keep failing and I have no idea why 😵 

## Testing
- a modified branch [`elisa/7462-test-dev2-okta-rate-limit`](https://github.com/CDCgov/prime-simplereport/compare/elisa/7462-test-dev2-okta-rate-limit?expand=1) is available for testing
- use the following mutation to send an email with a CSV of org admin emails
```
mutation ($state: String!, $type: String!, $email: String!) {
  sendOrgAdminEmailCSV(
    type: $type,
    state: $state,
    email: $email,
  )
}
```
⚠️ SENDGRID IS ENABLED ON DEV2 SO PLEASE USE YOUR EMAIL ADDRESS ⚠️ 

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
