### PR TITLE
Seed OraQuick HIV device

### DIFF
--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -73,6 +73,8 @@ simple-report-initialization:
       collection-location-code: "71836000"
     - name: Venous blood specimen
       type-code: "122555007"
+    - name: Oral fluid specimen
+      type-code: "441620008"
   device-types:
     - name: Abbott Alinity M
       manufacturer: Abbott
@@ -170,6 +172,14 @@ simple-report-initialization:
         - test-performed-loinc-code: "80387-4"
           supported-disease: "HIV"
           testkit-name-id: "bioLytical Laboratories_INSTI HIV-1/HIV-2 Antibody Test"
+    - name: "OraQuick In-Home HIV Test"
+      manufacturer: "OraQuick"
+      model: "In-Home HIV Test"
+      specimen-types:
+        - "441620008"
+      test-performed-loincs:
+        - test-performed-loinc-code: "49580-4"
+          supported-disease: "HIV"
   patient-registration-links:
     - link: dis-org
       organization-external-id: DIS_ORG


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Resolves #7494 

## Changes Proposed

There seems to be no easy way to manually add the OraQuick HIV device to our demo and training environments. As Bob predicted, the endpoints require the global admin role but we don't have auth through Okta enabled in these environments. This change adds the OraQuick device and swab type to the sample data that gets generated on boot for `demo` and `training`.

## Additional Information

This will impact any environments that have the `create-sample-data` profile, currently `demo`, `training`, and local dev.

The ticket calls for the loinc long names to be populated but I don't think that's necessary because these envs aren't sending data to RS and demo users don't see those values. I think that's just there because the ticket is a copy of our ticket to add the devices to production.

## Testing

Pull the changes locally, boot up your backend, and verify the device and swab type has been added to your DB tables.