### PR TITLE
Modify WaitlistRequest template to include disease interest

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/WaitlistRequest.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/accountrequest/WaitlistRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import gov.cdc.usds.simplereport.api.model.TemplateVariablesProvider;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
@@ -16,6 +17,9 @@ public class WaitlistRequest implements TemplateVariablesProvider {
   @NotNull private String phone;
   @NotNull private String state;
   @NotNull private String organization;
+
+  private List<String> diseaseInterest;
+  private String additionalConditions;
   private String referral;
 
   @Override
@@ -32,6 +36,8 @@ public class WaitlistRequest implements TemplateVariablesProvider {
     variableMap.put("phone", phone);
     variableMap.put("state", state);
     variableMap.put("organization", organization);
+    variableMap.put("diseaseInterest", getDiseaseInterest());
+    variableMap.put("additionalConditions", additionalConditions);
     variableMap.put("referral", referral);
 
     return variableMap;
@@ -75,6 +81,17 @@ public class WaitlistRequest implements TemplateVariablesProvider {
 
   public void setOrganization(String organization) {
     this.organization = organization;
+  }
+
+  public String getDiseaseInterest() {
+    if (!diseaseInterest.isEmpty()) {
+      return diseaseInterest.toString();
+    }
+    return "";
+  }
+
+  public void setAdditionalConditions(String additionalConditions) {
+    this.additionalConditions = additionalConditions;
   }
 
   public String getReferral() {

--- a/backend/src/main/resources/templates/waitlist-request.html
+++ b/backend/src/main/resources/templates/waitlist-request.html
@@ -5,4 +5,6 @@ A new SimpleReport waitlist request has been submitted with the following detail
 <b>Phone number: </b>[[${phone}]]<br>
 <b>State: </b>[[${state}]]<br>
 <b>Organization: </b>[[${organization}]]<br>
+<b>Disease interest:</b> [[${diseaseInterest}]]<br>
+<b>Additional conditions:</b> [[${additionalConditions}]]<br>
 <b>Referral: </b>[[${referral}]]


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7465 
- Accompanying [static site PR](https://github.com/CDCgov/prime-simplereport-site/pull/679)

## Changes Proposed
- Adds a "Disease interest" and "Additional conditions" to the waitlist request email template

## Additional Information
N/A

## Testing
- enable mailhog locally
- using an API testing tool of your choice make a HTTP POST request to the following endpoint: `http://localhost:8080/account-request/waitlist` with a "Body" of

optional fields provided:
```
{
    "name": "Username",
    "email": "fake@example.com",
    "phone": "(401) 238-9222",
    "state": "AL",
    "organization": "org",
    "additional-conditions": "yes additional conditions",
    "referral": "from a friend",
    "disease-interest": [
        "Flu A",
        "Flu B"
    ]
}
```
OR

optional fields empty
```
{
    "name": "Username",
    "email": "fake@example.com",
    "phone": "(401) 238-9222",
    "state": "AL",
    "organization": "org",
    "additional-conditions": "",
    "referral": "",
    "disease-interest": []
}
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
