### PR TITLE
Add Syphilis to dashboard

### DIFF
--- a/backend/src/main/resources/application-azure-dev4.yaml
+++ b/backend/src/main/resources/application-azure-dev4.yaml
@@ -15,6 +15,3 @@ simple-report:
       - https://dev4.simplereport.gov
 twilio:
   enabled: true
-  features:
-    syphilisEnabled: true
-

--- a/backend/src/main/resources/application-azure-dev4.yaml
+++ b/backend/src/main/resources/application-azure-dev4.yaml
@@ -17,5 +17,4 @@ twilio:
   enabled: true
   features:
     syphilisEnabled: true
-    hivEnabled: true
 

--- a/backend/src/main/resources/application-azure-dev4.yaml
+++ b/backend/src/main/resources/application-azure-dev4.yaml
@@ -15,3 +15,7 @@ simple-report:
       - https://dev4.simplereport.gov
 twilio:
   enabled: true
+  features:
+    syphilisEnabled: true
+    hivEnabled: true
+

--- a/frontend/src/app/analytics/Analytics.test.tsx
+++ b/frontend/src/app/analytics/Analytics.test.tsx
@@ -409,7 +409,7 @@ describe("Analytics", () => {
     expect(await screen.findByText("447")).toBeInTheDocument();
     expect(await screen.findByText("39.3%")).toBeInTheDocument();
   });
-  it("filters out selection of disabled diseases", async () => {
+  it("filters out HIV form dropdown", async () => {
     const flagSpy = jest.spyOn(flaggedMock, "useFeature");
     flagSpy.mockImplementation((flagName) => {
       return flagName !== "hivEnabled";
@@ -417,5 +417,15 @@ describe("Analytics", () => {
     renderWithUser();
     const hivElement = screen.queryByText("HIV");
     expect(hivElement).not.toBeInTheDocument();
+  });
+  it("filters out syphilis from dropdown", async () => {
+    const flagSpy = jest.spyOn(flaggedMock, "useFeature");
+    flagSpy.mockImplementation((flagName) => {
+      return flagName !== "syphilisEnabled";
+    });
+
+    renderWithUser();
+    const syphilisElement = screen.queryByText("syphilis");
+    expect(syphilisElement).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -91,7 +91,6 @@ export const displayGuidance = (results: MultiplexResults) => {
     hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.COVID_19) ||
     hasPositiveFluResults(results) ||
     hasPositiveRsvResults(results) ||
-    hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.HIV) ||
-    hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.SYPHILIS)
+    hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.HIV)
   );
 };

--- a/frontend/src/app/utils/testResults.ts
+++ b/frontend/src/app/utils/testResults.ts
@@ -91,6 +91,7 @@ export const displayGuidance = (results: MultiplexResults) => {
     hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.COVID_19) ||
     hasPositiveFluResults(results) ||
     hasPositiveRsvResults(results) ||
-    hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.HIV)
+    hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.HIV) ||
+    hasDiseaseSpecificResults(results, MULTIPLEX_DISEASES.SYPHILIS)
   );
 };


### PR DESCRIPTION
# FRONT END PULL REQUEST

## Related Issue

- part of #7421 

## Changes Proposed

- Add Syphilis to disease constants so that it will be an option in dashboard drop down
- Add logic that only populates dropdown with Syphilis as an option if feature flag is set to true

## Testing
- Configure the `syphilisEnabled` flag to true in your `application.yaml` file and the dashboard dropdown should Include Syphilis as an option. The opposite logic can be tested with setting the flag to false.


