### PR TITLE
Change encoder for org admin emails csv

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/email/EmailService.java
@@ -177,7 +177,7 @@ public class EmailService {
     attachments.setFilename(filename);
     attachments.setType("text/csv");
     attachments.setDisposition("attachment");
-    String attachmentContent = Base64.getMimeEncoder().encodeToString(emailsCSVBytes);
+    String attachmentContent = Base64.getEncoder().encodeToString(emailsCSVBytes);
     attachments.setContent(attachmentContent);
     String emailSubject =
         String.format("Org admin email CSVs for outreach - %s in %s", type, state);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Continuation of #7318 and #7462

## Changes Proposed
- While debugging on dev3 noticed CSVs not being sent for admin emails with a "+" symbol in the email
- Realized I should be using `Base64.getEncoder()` instead of `Base64.getMimeEncoder()` because mime encoder does the following:
> Each line of the output is no longer than 76 characters. Also, it ends with a carriage return followed by a linefeed (\r\n):
[Source](https://www.baeldung.com/java-base64-encode-and-decode) 


SendGrid throws a `400` when the attachment has those characters

## Additional Information
- Using `type: "patients"` and `state: "MN"`
- Before fix: Failed [sendgrid POST request](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%2C%22ResourceGroup%22%3A%22prime-simple-report-dev%22%2C%22Name%22%3A%22prime-simple-report-dev3-insights%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F7d1e3999-6577-4cd5-b296-f518e5c8e677%252FresourceGroups%252Fprime-simple-report-dev%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fprime-simple-report-dev3-insights%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%22d609bfd9-f11b-11ee-8f96-000d3a54385e%22%2C%22timestamp%22%3A%222024-04-02T18%3A06%3A47.186Z%22%2C%22cacheId%22%3A%2251b2ea99-c040-4382-a447-f19a680cda94%22%2C%22eventTable%22%3A%22traces%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A259200000%2C%22endTime%22%3A%222024-04-03T17%3A31%3A19.628Z%22%7D%7D) on original branch due to email with a "+" symbol

- After fix: Successful [sendgrid POST request](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%2C%22ResourceGroup%22%3A%22prime-simple-report-dev%22%2C%22Name%22%3A%22prime-simple-report-dev3-insights%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F7d1e3999-6577-4cd5-b296-f518e5c8e677%252FresourceGroups%252Fprime-simple-report-dev%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fprime-simple-report-dev3-insights%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%22619dd170-f1e0-11ee-8f96-000d3a1138a5%22%2C%22timestamp%22%3A%222024-04-03T17%3A33%3A39.098Z%22%2C%22cacheId%22%3A%22491f441c-7102-4a2c-87c6-de9034b3b063%22%2C%22eventTable%22%3A%22traces%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%2C%22endTime%22%3A%222024-04-03T17%3A36%3A54.814Z%22%7D%7D)

## Testing
- a modified branch [`elisa/dev3-fix-admin-email-csv-try2`](https://github.com/CDCgov/prime-simplereport/tree/elisa/dev3-fix-admin-email-csv-try2) has been deployed on `dev3`
- use the following mutation to send an email with a CSV of org admin emails
```
mutation ($state: String!, $type: String!, $email: String!) {
  sendOrgAdminEmailCSV(
    type: $type,
    state: $state,
    email: $email,
  )
}
```
⚠️ SENDGRID IS ENABLED ON DEV3 SO PLEASE USE YOUR EMAIL ADDRESS ⚠️

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->