### PR TITLE
revert spec 6 cypress flakage fix

### DIFF
--- a/cypress/e2e/06-self_registration.cy.js
+++ b/cypress/e2e/06-self_registration.cy.js
@@ -36,10 +36,8 @@ describe("Patient self registration", () => {
     // gets the self registration link and navigates to it
 
     cy.visit("/settings");
-    // breaking apart contains.as --> click() because chaining it together was  
-    // creating race conditions / causing flakage in CI 
-    cy.contains("Patient self-registration").as("selfRegNav");
-    cy.get("@selfRegNav").click();
+
+    cy.contains("Patient self-registration").click();
     cy.contains("Patients can now register themselves online");
 
     // Test a11y on the Patient self registration page


### PR DESCRIPTION
undoes the tweak added to spec 6 since it hasn't seemed to fix the problem :( 

Made a ticket to look into [Cypress cloud monitoring tool](https://github.com/CDCgov/prime-simplereport/issues/7534) to try and debug this issue with proper insights rather than spending more time on debugging it blindly.