### PR TITLE
Add and initialize syphilis feature flag

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -24,6 +24,7 @@ public class FeatureFlagsConfig {
   @Setter(AccessLevel.NONE)
   private final FeatureFlagRepository _repo;
 
+  private boolean syphilisEnabled;
   private boolean hivBulkUploadEnabled;
   private boolean hivEnabled;
   private boolean agnosticEnabled;
@@ -37,6 +38,7 @@ public class FeatureFlagsConfig {
 
   private void flagMapping(String flagName, Boolean flagValue) {
     switch (flagName) {
+      case "syphilisEnabled" -> setSyphilisEnabled(flagValue);
       case "hivBulkUploadEnabled" -> setHivBulkUploadEnabled(flagValue);
       case "hivEnabled" -> setHivEnabled(flagValue);
       case "agnosticEnabled" -> setAgnosticEnabled(flagValue);

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -21,6 +21,7 @@ twilio:
   enabled: true
   from-number: "+14045312484"
 features:
+  syphilisEnabled: false
   hivBulkUploadEnabled: false
   hivEnabled: false
   agnosticEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -168,6 +168,7 @@ datahub:
   csv-upload-api-client: "simple_report.csvuploader"
   csv-upload-api-fhir-client: "simple_report.fullelr"
 features:
+  syphilisEnabled: true
   hivBulkUploadEnabled: true
   hivEnabled: true
   agnosticEnabled: true


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

part of [#7421 ](https://github.com/orgs/CDCgov/projects/15/views/1?pane=issue&itemId=56815922)

## Additional Information

- Adding a flag for syphilis that can be used to keep it from populating the dashboard unless the flag is turned on. This flag will also be used for gating all other parts of the syphilis feature until it is ready to be rolled out to prod.

## Testing

- Tests will be included in the following PR that adds syphilis to the dashboard. That PR is currently out as a draft here: https://github.com/CDCgov/prime-simplereport/pull/7514
