### PR TITLE
Add syphilis support on results page

### DIFF
--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -42,6 +42,10 @@ const setDiseaseResultKey = (diseaseName: MultiplexDisease, isPxp: boolean) => {
       return isPxp
         ? "constants.diseaseResultTitle.RSV"
         : "constants.disease.RSV";
+    case MULTIPLEX_DISEASES.SYPHILIS:
+      return isPxp
+        ? "constants.diseaseResultTitle.SYPHILIS"
+        : "constants.disease.SYPHILIS";
     default:
       return null;
   }

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -4,6 +4,7 @@ export enum MULTIPLEX_DISEASES {
   FLU_B = "Flu B",
   RSV = "RSV",
   HIV = "HIV",
+  SYPHILIS = "Syphilis",
 }
 
 export enum TEST_RESULTS {

--- a/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
@@ -4,15 +4,15 @@ import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CSVLink } from "react-csv";
 import { ApolloError } from "@apollo/client";
-import { useFeature } from "flagged";
 
 import { showError } from "../../utils/srToast";
-import { parseDataForCSV } from "../../utils/testResultCSV";
 import Button from "../../commonComponents/Button/Button";
 import {
   useGetFacilityResultsForCsvWithCountLazyQuery,
   GetFacilityResultsForCsvWithCountQuery,
 } from "../../../generated/graphql";
+import { parseDataForCSV } from "../../utils/testResultCSV";
+import { useDisabledFeatureDiseaseList } from "../../utils/disease";
 
 import { ALL_FACILITIES_ID, ResultsQueryVariables } from "./TestResultsList";
 
@@ -38,7 +38,7 @@ export const DownloadResultsCsvModal = ({
   >(null);
   // Disable downloads because backend will hang on over 20k results (#3953)
   const disableDownload = totalEntries > rowsMaxLimit;
-  const hivEnabled = Boolean(useFeature("hivEnabled"));
+  const disabledFeatureDiseaseList = useDisabledFeatureDiseaseList();
 
   const filtersPresent = Object.entries(filterParams).some(([key, val]) => {
     // active facility in the facility filter is the default
@@ -70,8 +70,8 @@ export const DownloadResultsCsvModal = ({
   const handleComplete = (data: GetFacilityResultsForCsvWithCountQuery) => {
     if (data?.testResultsPage?.content) {
       const csvResults = parseDataForCSV(
-        hivEnabled,
-        data.testResultsPage.content
+        data.testResultsPage.content,
+        disabledFeatureDiseaseList
       );
       setResults(csvResults);
     } else {

--- a/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
@@ -8,7 +8,6 @@ import React, {
 } from "react";
 import moment from "moment/moment";
 import { useLazyQuery } from "@apollo/client";
-import { useFeature } from "flagged";
 
 import SearchInput from "../../testQueue/addToQueue/SearchInput";
 import SearchResults from "../../testQueue/addToQueue/SearchResults";
@@ -94,7 +93,6 @@ const TestResultsFilters: React.FC<TestResultsFiltersProps> = ({
     useAppSelector((state) => state.user.permissions),
     appPermissions.settings.canView
   );
-  const hivEnabled = useFeature("hivEnabled");
 
   /**
    * Patient search

--- a/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
@@ -13,7 +13,6 @@ import { useFeature } from "flagged";
 import SearchInput from "../../testQueue/addToQueue/SearchInput";
 import SearchResults from "../../testQueue/addToQueue/SearchResults";
 import Select from "../../commonComponents/Select";
-import { MULTIPLEX_DISEASES } from "../constants";
 import {
   COVID_RESULTS,
   ROLE_VALUES,
@@ -39,6 +38,7 @@ import {
   SEARCH_DEBOUNCE_TIME,
 } from "../../testQueue/constants";
 import useComponentVisible from "../../commonComponents/ComponentVisible";
+import { useSupportedDiseaseOptionList } from "../../utils/disease";
 
 import { ALL_FACILITIES_ID, DateRangeFilter } from "./TestResultsList";
 import { getTodaysDate } from "./utils";
@@ -271,31 +271,7 @@ const TestResultsFilters: React.FC<TestResultsFiltersProps> = ({
   /**
    * Disease select
    */
-  const diseaseOptions = [
-    {
-      value: MULTIPLEX_DISEASES.COVID_19,
-      label: MULTIPLEX_DISEASES.COVID_19,
-    },
-    {
-      value: MULTIPLEX_DISEASES.FLU_A,
-      label: MULTIPLEX_DISEASES.FLU_A,
-    },
-    {
-      value: MULTIPLEX_DISEASES.FLU_B,
-      label: MULTIPLEX_DISEASES.FLU_B,
-    },
-    {
-      value: MULTIPLEX_DISEASES.RSV,
-      label: MULTIPLEX_DISEASES.RSV,
-    },
-  ];
-  if (hivEnabled) {
-    diseaseOptions.push({
-      value: MULTIPLEX_DISEASES.HIV,
-      label: MULTIPLEX_DISEASES.HIV,
-    });
-  }
-  diseaseOptions.sort((a, b) => (a.label > b.label ? 1 : -1));
+  const diseaseOptions = useSupportedDiseaseOptionList();
 
   useEffect(() => {
     if (data) {

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -10,3 +10,15 @@ export const useSupportedDiseaseList = () => {
   }
   return allDiseases;
 };
+
+export const useSupportedDiseaseOptionList = () => {
+  const supportedDiseases = useSupportedDiseaseList();
+  const options = supportedDiseases.map((disease) => {
+    return {
+      value: disease,
+      label: disease,
+    };
+  });
+  options.sort((a, b) => (a.label > b.label ? 1 : -1));
+  return options;
+};

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -18,7 +18,7 @@ export const useSupportedDiseaseList = () => {
 export const useDisabledFeatureDiseaseList = () => {
   const allDiseases = Object.values(MULTIPLEX_DISEASES);
   const supportedDiseases = useSupportedDiseaseList();
-  return allDiseases.filter((d) => supportedDiseases.includes(d));
+  return allDiseases.filter((d) => !supportedDiseases.includes(d));
 };
 
 export const useSupportedDiseaseOptionList = () => {

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -8,6 +8,10 @@ export const useSupportedDiseaseList = () => {
   if (!hivEnabled) {
     allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.HIV);
   }
+  const syphilisEnabled = Boolean(useFeature("syphilisEnabled"));
+  if (!syphilisEnabled) {
+    allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.SYPHILIS);
+  }
   return allDiseases;
 };
 

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -15,6 +15,12 @@ export const useSupportedDiseaseList = () => {
   return allDiseases;
 };
 
+export const useDisabledFeatureDiseaseList = () => {
+  const allDiseases = Object.values(MULTIPLEX_DISEASES);
+  const supportedDiseases = useSupportedDiseaseList();
+  return allDiseases.filter((d) => supportedDiseases.includes(d));
+};
+
 export const useSupportedDiseaseOptionList = () => {
   const supportedDiseases = useSupportedDiseaseList();
   const options = supportedDiseases.map((disease) => {

--- a/frontend/src/app/utils/testResultCSV.test.ts
+++ b/frontend/src/app/utils/testResultCSV.test.ts
@@ -1,3 +1,5 @@
+import { MULTIPLEX_DISEASES } from "../testResults/constants";
+
 import { parseDataForCSV } from "./testResultCSV";
 
 const data = [
@@ -36,6 +38,12 @@ const data = [
       {
         disease: {
           name: "HIV",
+        },
+        testResult: "POSITIVE",
+      },
+      {
+        disease: {
+          name: "Syphilis",
         },
         testResult: "POSITIVE",
       },
@@ -86,7 +94,7 @@ const data = [
   },
 ] as TestResult[];
 
-const resultNoHIV = [
+const resultNoSTD = [
   {
     "COVID-19 result": "Negative",
     "Device manufacturer": "Access Bio, Inc.",
@@ -131,28 +139,34 @@ const resultNoHIV = [
   },
 ];
 
-const result = [
+const resultAllDiseases = [
   {
-    ...resultNoHIV[0],
+    ...resultNoSTD[0],
     "HIV result": "Positive",
+    "Syphilis result": "Positive",
   },
 ];
 
 describe("parseDataForCSV", () => {
   it("parses multiplex data", () => {
-    expect(parseDataForCSV(true, data)).toEqual(result);
+    expect(parseDataForCSV(data)).toEqual(resultAllDiseases);
   });
   it("parse data does not fail if tribalAffiliation is null", () => {
     expect(
-      parseDataForCSV(true, [
+      parseDataForCSV([
         {
           ...data[0],
           patient: { ...data[0].patient, tribalAffiliation: null },
         },
       ])
-    ).toEqual(result);
+    ).toEqual(resultAllDiseases);
   });
-  it("doesn't include HIV if includeHIV are false", () => {
-    expect(parseDataForCSV(false, data)).toEqual(resultNoHIV);
+  it("doesn't include STD data if feature flags are false", () => {
+    expect(
+      parseDataForCSV(data, [
+        MULTIPLEX_DISEASES.HIV,
+        MULTIPLEX_DISEASES.SYPHILIS,
+      ])
+    ).toEqual(resultNoSTD);
   });
 });

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -7,12 +7,15 @@ import {
 import { TEST_RESULT_DESCRIPTIONS } from "../constants";
 import { MULTIPLEX_DISEASES } from "../testResults/constants";
 
-import { symptomsStringToArray, hasSymptomsForView } from "./symptoms";
+import { hasSymptomsForView, symptomsStringToArray } from "./symptoms";
 import { getResultByDiseaseName } from "./testResults";
 
 import { displayFullName, facilityDisplayName } from "./index";
 
-export function parseDataForCSV(includeHIV: boolean, data: TestResult[]) {
+export function parseDataForCSV(
+  data: TestResult[],
+  excludedDiseases: MULTIPLEX_DISEASES[] = []
+) {
   return data.sort(byDateTested).map((r: any) => {
     const symptomList = r.symptoms ? symptomsStringToArray(r.symptoms) : [];
 
@@ -85,18 +88,27 @@ export function parseDataForCSV(includeHIV: boolean, data: TestResult[]) {
 
     return {
       ...csvData1,
-      ...(includeHIV && {
-        "HIV result":
-          TEST_RESULT_DESCRIPTIONS[
-            getResultByDiseaseName(r.results, MULTIPLEX_DISEASES.HIV) as Results
-          ],
-      }),
       ...{
         "RSV result":
           TEST_RESULT_DESCRIPTIONS[
             getResultByDiseaseName(r.results, MULTIPLEX_DISEASES.RSV) as Results
           ],
       },
+      ...(!excludedDiseases.includes(MULTIPLEX_DISEASES.HIV) && {
+        "HIV result":
+          TEST_RESULT_DESCRIPTIONS[
+            getResultByDiseaseName(r.results, MULTIPLEX_DISEASES.HIV) as Results
+          ],
+      }),
+      ...(!excludedDiseases.includes(MULTIPLEX_DISEASES.SYPHILIS) && {
+        "Syphilis result":
+          TEST_RESULT_DESCRIPTIONS[
+            getResultByDiseaseName(
+              r.results,
+              MULTIPLEX_DISEASES.SYPHILIS
+            ) as Results
+          ],
+      }),
       ...csvData2,
     };
   });

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -38,6 +38,7 @@ export const en = {
         FLUB: "Flu B",
         RSV: "RSV",
         HIV: "HIV",
+        SYPHILIS: "Syphilis",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 result",
@@ -45,6 +46,7 @@ export const en = {
         FLUB: "Flu B result",
         RSV: "RSV result",
         HIV: "HIV result",
+        SYPHILIS: "Syphilis result",
       },
       role: {
         STAFF: "Staff",
@@ -405,6 +407,12 @@ export const en = {
           p1: "<0>Visit the CDC website to learn more about a positive HIV result</0> (cdc.gov/hiv/basics/hiv-testing/positive-hiv-results.html)",
           positiveHivLink:
             "https://www.cdc.gov/hiv/basics/hiv-testing/positive-hiv-results.html",
+        },
+      },
+      syphilisNotes: {
+        h1: "For Syphilis:",
+        all: {
+          p0: "Syphilis notes need to be added here",
         },
       },
       tos: {

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -41,6 +41,7 @@ export const es: LanguageConfig = {
         FLUB: "Flu B",
         RSV: "VRS",
         HIV: "VIH",
+        SYPHILIS: "Sífilis",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 resultado",
@@ -48,6 +49,7 @@ export const es: LanguageConfig = {
         FLUB: "Flu B resultado",
         RSV: "RSV resultado",
         HIV: "Resultado de la prueba del VIH",
+        SYPHILIS: "Sífilis resultado",
       },
       role: {
         STAFF: "Personal",
@@ -428,6 +430,12 @@ export const es: LanguageConfig = {
           p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo en la prueba del VIH.</0> (cdc.gov/hiv/spanish/basics/hiv-testing/positive-hiv-results.html)",
           positiveHivLink:
             "https://www.cdc.gov/hiv/spanish/basics/hiv-testing/positive-hiv-results.html",
+        },
+      },
+      syphilisNotes: {
+        h1: "Para Sífilis:",
+        all: {
+          p0: "Sífilis",
         },
       },
       tos: {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7440 

## Changes Proposed

- Adds support for syphilis on results page

## Additional Information

- Result guidance copy is still needed for syphilis so placeholder text is used for now

## Testing

- Deployed on [dev5](https://dev5.simplereport.gov/app/) which has a new syphilis device configured for "Big Organization"

## Screenshots / Demos
Syphilis selected on condition filter (if feature flag is enabled)
![Screenshot 2024-04-10 084256](https://github.com/CDCgov/prime-simplereport/assets/23287037/cbdcf49e-7b0c-49b3-9afe-6a236a48d1ae)

View Details modal
![Screenshot 2024-04-10 084201](https://github.com/CDCgov/prime-simplereport/assets/23287037/ce653579-e909-4dc7-a1b0-33e613012bde)

Print Details modal
![Screenshot 2024-04-13 004609](https://github.com/CDCgov/prime-simplereport/assets/23287037/0cbadb52-567f-4d3a-88b3-2cbd1bcb87fc)

Print Details modal (partial Spanish translation)
![Screenshot 2024-04-13 004841](https://github.com/CDCgov/prime-simplereport/assets/23287037/1d4fb8ab-a610-4d50-a5f3-10232324cd05)

Result accessible to patient via email/text 
![Screenshot 2024-04-11 191101](https://github.com/CDCgov/prime-simplereport/assets/23287037/adb13aff-5171-4a04-8829-8b8eb646684f)

Result accessible to patient via email/text (Spanish)
![Screenshot 2024-04-11 191112](https://github.com/CDCgov/prime-simplereport/assets/23287037/87597cee-1c80-40d1-9872-1453be37ec51)

Syphilis column added to the results CSV
![image](https://github.com/CDCgov/prime-simplereport/assets/23287037/bf644f95-60b7-4bd1-8bda-4e0196f1d967)


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
