### PR TITLE
Use testing lab if ordering facility values blank in UP

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -299,36 +299,7 @@ public class BulkUploadResultsToFhir {
             testingLabAddr,
             DEFAULT_COUNTRY);
 
-    Organization orderingFacility = null;
-    if (StringUtils.isNotEmpty(row.getOrderingFacilityStreet().getValue())
-        || StringUtils.isNotEmpty(row.getOrderingFacilityStreet2().getValue())
-        || StringUtils.isNotEmpty(row.getOrderingFacilityCity().getValue())
-        || StringUtils.isNotEmpty(row.getOrderingFacilityState().getValue())
-        || StringUtils.isNotEmpty(row.getOrderingFacilityZipCode().getValue())
-        || StringUtils.isNotEmpty(row.getOrderingFacilityName().getValue())
-        || StringUtils.isNotEmpty(row.getOrderingFacilityPhoneNumber().getValue())) {
-      var orderingFacilityAddr =
-          new StreetAddress(
-              row.getOrderingFacilityStreet().getValue(),
-              row.getOrderingFacilityStreet2().getValue(),
-              row.getOrderingFacilityCity().getValue(),
-              row.getOrderingFacilityState().getValue(),
-              row.getOrderingFacilityZipCode().getValue(),
-              null);
-      orderingFacility =
-          fhirConverter.convertToOrganization(
-              uuidGenerator.randomUUID().toString(),
-              row.getOrderingFacilityName().getValue(),
-              row.getTestingLabClia().getValue(),
-              row.getOrderingFacilityPhoneNumber().getValue(),
-              null,
-              orderingFacilityAddr,
-              DEFAULT_COUNTRY);
-    }
-
-    if (orderingFacility == null) {
-      orderingFacility = testingLabOrg;
-    }
+    Organization orderingFacility = getOrderingFacilityOrgResource(row);
 
     var practitioner =
         fhirConverter.convertToPractitioner(
@@ -710,5 +681,54 @@ public class BulkUploadResultsToFhir {
     }
 
     return Optional.ofNullable(diseaseSpecificLoincMap.get(testPerformedCode));
+  }
+
+  private String getOrderingFacilityValOrDefault(
+      String orderingFacilityVal, String testingLabDefaultVal) {
+    return StringUtils.isNotEmpty(orderingFacilityVal) ? orderingFacilityVal : testingLabDefaultVal;
+  }
+
+  private Organization getOrderingFacilityOrgResource(TestResultRow row) {
+    String orderingFacilityStreet =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityStreet().getValue(), row.getTestingLabStreet().getValue());
+    String orderingFacilityStreet2 =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityStreet2().getValue(), row.getTestingLabStreet2().getValue());
+    String orderingFacilityCity =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityCity().getValue(), row.getTestingLabCity().getValue());
+    String orderingFacilityState =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityState().getValue(), row.getTestingLabState().getValue());
+    String orderingFacilityZipCode =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityZipCode().getValue(), row.getTestingLabZipCode().getValue());
+
+    StreetAddress orderingFacilityAddr =
+        new StreetAddress(
+            orderingFacilityStreet,
+            orderingFacilityStreet2,
+            orderingFacilityCity,
+            orderingFacilityState,
+            orderingFacilityZipCode,
+            null);
+
+    String orderingFacilityName =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityName().getValue(), row.getTestingLabName().getValue());
+    String orderingFacilityPhoneNumber =
+        getOrderingFacilityValOrDefault(
+            row.getOrderingFacilityPhoneNumber().getValue(),
+            row.getTestingLabPhoneNumber().getValue());
+
+    return fhirConverter.convertToOrganization(
+        uuidGenerator.randomUUID().toString(),
+        orderingFacilityName,
+        row.getTestingLabClia().getValue(),
+        orderingFacilityPhoneNumber,
+        null,
+        orderingFacilityAddr,
+        DEFAULT_COUNTRY);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7253 

## Changes Proposed

- This PR aligns the behavior of the bulk upload test result to the Universal Pipeline with the bulk upload guidance `/app/results/upload/submit/guide#ordering-facility` -- If any ordering facility value is left blank, the testing lab value is used instead)
- Previously, if any ordering provider value was provided it would create an incomplete Organization FHIR resource

## Additional Information
- Bug first discovered while working on similar ticket but for COVID pipeline: https://github.com/CDCgov/prime-simplereport/issues/7230

## Testing
- deployed [a version of this branch](https://github.com/CDCgov/prime-simplereport/compare/elisa/7253-up-testing-lab-default-add-log?expand=1) on dev3 with a log statement that can be checked in the dev3's app insights (transaction search for `CONVERTED BUNDLE:`)
- upload a spreadsheet with some or all ordering facility related values blank and ensure the equivalent testing lab values are used instead

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
