### PR TITLE
syphilis test card support backend

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/ApiTestOrderDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/ApiTestOrderDataResolver.java
@@ -65,6 +65,14 @@ public class ApiTestOrderDataResolver {
         .thenApply(patientAnswers -> patientAnswers.getSurvey().getPregnancy());
   }
 
+  @SchemaMapping(typeName = "TestOrder", field = "syphilisHistory")
+  public CompletableFuture<String> syphilisHistory(
+      ApiTestOrder apiTestOrder, DataLoader<UUID, PatientAnswers> loader) {
+    return loader
+        .load(apiTestOrder.getWrapped().getPatientAnswersId())
+        .thenApply(patientAnswers -> patientAnswers.getSurvey().getSyphilisHistory());
+  }
+
   @SchemaMapping(typeName = "TestOrder", field = "noSymptoms")
   public CompletableFuture<Boolean> noSymptoms(
       ApiTestOrder apiTestOrder, DataLoader<UUID, PatientAnswers> loader) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -56,6 +56,7 @@ public class QueueMutationResolver {
       @Argument UUID facilityId,
       @Argument UUID patientId,
       @Argument String pregnancy,
+      @Argument String syphilisHistory,
       @Argument String symptoms,
       @Argument LocalDate symptomOnset,
       @Argument Boolean noSymptoms,
@@ -69,6 +70,7 @@ public class QueueMutationResolver {
             facilityId,
             personService.getPatientNoPermissionsCheck(patientId),
             pregnancy,
+            syphilisHistory,
             symptomsMap,
             symptomOnset,
             noSymptoms);
@@ -90,6 +92,7 @@ public class QueueMutationResolver {
   public void updateTimeOfTestQuestions(
       @Argument UUID patientId,
       @Argument String pregnancy,
+      @Argument String syphilisHistory,
       @Argument String symptoms,
       @Argument LocalDate symptomOnset,
       @Argument Boolean noSymptoms,
@@ -99,7 +102,13 @@ public class QueueMutationResolver {
     Map<String, Boolean> symptomsMap = parseSymptoms(symptoms);
 
     testOrderService.updateTimeOfTestQuestions(
-        patientId, pregnancy, symptomsMap, symptomOnset, noSymptoms, genderOfSexualPartners);
+        patientId,
+        pregnancy,
+        syphilisHistory,
+        symptomsMap,
+        symptomOnset,
+        noSymptoms,
+        genderOfSexualPartners);
 
     if (testResultDelivery != null) {
       personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
@@ -9,851 +9,850 @@ import static gov.cdc.usds.simplereport.api.Translators.TRANS_MAN;
 import static gov.cdc.usds.simplereport.api.Translators.TRANS_WOMAN;
 
 import gov.cdc.usds.simplereport.api.MappingConstants;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class PersonUtils {
-    private PersonUtils() {
-        throw new IllegalStateException("Utility class");
-    }
+  private PersonUtils() {
+    throw new IllegalStateException("Utility class");
+  }
 
-    public static Map<String, String> tribalMap() {
-        var tribeCodes = new HashMap<String, String>();
-        tribeCodes.put("1", "Absentee-Shawnee Tribe of Indians of Oklahoma");
-        tribeCodes.put(
-                "2",
-                "Agua Caliente Band of Cahuilla Indians of the Agua Caliente Indian Reservation, California");
-        tribeCodes.put("3", "Ak-Chin Indian Community");
-        tribeCodes.put("4", "Alabama-Coushatta Tribe of Texas");
-        tribeCodes.put("5", "Alabama-Quassarte Tribal Town");
-        tribeCodes.put("6", "Alturas Indian Rancheria, California");
-        tribeCodes.put("7", "Apache Tribe of Oklahoma");
-        tribeCodes.put("8", "Northern Arapaho Tribe of the Wind River Reservation, Wyoming");
-        tribeCodes.put("9", "Mi'kmaq Nation");
-        tribeCodes.put(
-                "10", "Assiniboine and Sioux Tribes of the Fort Peck Indian Reservation, Montana");
-        tribeCodes.put("11", "Augustine Band of Cahuilla Indians, California");
-        tribeCodes.put(
-                "12",
-                "Bad River Band of the Lake Superior Tribe of Chippewa Indians of the Bad River Reservation, Wisconsin");
-        tribeCodes.put("33", "Barona Group of Capitan Grande Band of Mission Ind");
-        tribeCodes.put("13", "Bay Mills Indian Community, Michigan");
-        tribeCodes.put("14", "Bear River Band of the Rohnerville Rancheria, California");
-        tribeCodes.put("15", "Berry Creek Rancheria of Maidu Indians of California");
-        tribeCodes.put("16", "Big Lagoon Rancheria, California");
-        tribeCodes.put("17", "Big Pine Paiute Tribe of the Owens Valley");
-        tribeCodes.put("18", "Big Sandy Rancheria of Western Mono Indians of California");
-        tribeCodes.put("19", "Big Valley Band of Pomo Indians of the Big Valley Rancheria, California");
-        tribeCodes.put("20", "Blackfeet Tribe of the Blackfeet Indian Reservation of Montana");
-        tribeCodes.put("21", "Blue Lake Rancheria, California");
-        tribeCodes.put("22", "Bridgeport Indian Colony");
-        tribeCodes.put("23", "Buena Vista Rancheria of Me-Wuk Indians of California");
-        tribeCodes.put("24", "Burns Paiute Tribe");
-        tribeCodes.put("25", "Cabazon Band of Mission Indians, California");
-        tribeCodes.put(
-                "26",
-                "Cachil DeHe Band of Wintun Indians of the Colusa Indian Community of the Colusa Rancheria, California");
-        tribeCodes.put("27", "Caddo Nation of Oklahoma");
-        tribeCodes.put("29", "Cahto Tribe of the Laytonville Rancheria");
-        tribeCodes.put("28", "Cahuilla Band of Indians");
-        tribeCodes.put("30", "California Valley Miwok Tribe, California");
-        tribeCodes.put(
-                "31", "Campo Band of Diegueno Mission Indians of the Campo Indian Reservation, California");
-        tribeCodes.put("32", "Capitan Grande Band of Diegueno Mission Indians of California");
-        tribeCodes.put("35", "Catawba Indian Nation");
-        tribeCodes.put("36", "Cayuga Nation");
-        tribeCodes.put("37", "Cedarville Rancheria, California");
-        tribeCodes.put("38", "Chemehuevi Indian Tribe of the Chemehuevi Reservation, California");
-        tribeCodes.put("39", "Cher-Ae Heights Indian Community of the Trinidad Rancheria, California");
-        tribeCodes.put("40", "Cherokee Nation");
-        tribeCodes.put(
-                "42", "Cheyenne River Sioux Tribe of the Cheyenne River Reservation, South Dakota");
-        tribeCodes.put("41", "Cheyenne and Arapaho Tribes, Oklahoma");
-        tribeCodes.put("43", "The Chickasaw Nation");
-        tribeCodes.put("44", "Chicken Ranch Rancheria of Me-Wuk Indians of California");
-        tribeCodes.put("45", "Chippewa Cree Indians of the Rocky Boy's Reservation, Montana");
-        tribeCodes.put("46", "Chitimacha Tribe of Louisiana");
-        tribeCodes.put("47", "The Choctaw Nation of Oklahoma");
-        tribeCodes.put("48", "Citizen Potawatomi Nation, Oklahoma");
-        tribeCodes.put("49", "Cloverdale Rancheria of Pomo Indians of California");
-        tribeCodes.put("50", "Cocopah Tribe of Arizona");
-        tribeCodes.put("51", "Coeur D'Alene Tribe");
-        tribeCodes.put("52", "Cold Springs Rancheria of Mono Indians of California");
-        tribeCodes.put(
-                "53",
-                "Colorado River Indian Tribes of the Colorado River Indian Reservation, Arizona and California");
-        tribeCodes.put("54", "Comanche Nation, Oklahoma");
-        tribeCodes.put("55", "Confederated Salish and Kootenai Tribes of the Flathead Reservation");
-        tribeCodes.put("64", "Confederated Tribes and Bands of the Yakama Nation");
-        tribeCodes.put("56", "Confederated Tribes of the Chehalis Reservation");
-        tribeCodes.put("57", "Confederated Tribes of the Colville Reservation");
-        tribeCodes.put("58", "Confederated Tribes of the Coos, Lower Umpqua and Siuslaw Indians");
-        tribeCodes.put("59", "Confederated Tribes of the Goshute Reservation, Nevada and Utah");
-        tribeCodes.put("60", "Confederated Tribes of the Grand Ronde Community of Oregon");
-        tribeCodes.put("61", "Confederated Tribes of Siletz Indians of Oregon");
-        tribeCodes.put("62", "Confederated Tribes of the Umatilla Indian Reservation");
-        tribeCodes.put("63", "Confederated Tribes of the Warm Springs Reservation of Oregon");
-        tribeCodes.put("65", "Coquille Indian Tribe");
-        tribeCodes.put("66", "Kletsel Dehe Band of Wintun Indians");
-        tribeCodes.put("67", "Coushatta Tribe of Louisiana");
-        tribeCodes.put("68", "Cow Creek Band of Umpqua Tribe of Indians");
-        tribeCodes.put("69", "Coyote Valley Band of Pomo Indians of California");
-        tribeCodes.put("71", "Crow Creek Sioux Tribe of the Crow Creek Reservation, South Dakota");
-        tribeCodes.put("70", "Crow Tribe of Montana");
-        tribeCodes.put("72", "Ewiiaapaayp Band of Kumeyaay Indians, California");
-        tribeCodes.put("73", "Timbisha Shoshone Tribe");
-        tribeCodes.put("74", "Delaware Nation, Oklahoma");
-        tribeCodes.put("75", "Delaware Tribe of Indians");
-        tribeCodes.put("76", "Dry Creek Rancheria Band of Pomo Indians, California");
-        tribeCodes.put("77", "Duckwater Shoshone Tribe of the Duckwater Reservation, Nevada");
-        tribeCodes.put("78", "Eastern Band of Cherokee Indians");
-        tribeCodes.put("79", "Eastern Shawnee Tribe of Oklahoma");
-        tribeCodes.put(
-                "80", "Elem Indian Colony of Pomo Indians of the Sulphur Bank Rancheria, California");
-        tribeCodes.put("81", "Elk Valley Rancheria, California");
-        tribeCodes.put("82", "Ely Shoshone Tribe of Nevada");
-        tribeCodes.put("83", "Enterprise Rancheria of Maidu Indians of California");
-        tribeCodes.put("84", "Flandreau Santee Sioux Tribe of South Dakota");
-        tribeCodes.put("85", "Forest County Potawatomi Community, Wisconsin");
-        tribeCodes.put(
-                "86", "Fort Belknap Indian Community of the Fort Belknap Reservation of Montana");
-        tribeCodes.put(
-                "87", "Fort Bidwell Indian Community of the Fort Bidwell Reservation of California");
-        tribeCodes.put(
-                "88",
-                "Fort Independence Indian Community of Paiute Indians of the Fort Independence Reservation, California");
-        tribeCodes.put(
-                "89",
-                "Fort McDermitt Paiute and Shoshone Tribes of the Fort McDermitt Indian Reservation, Nevada and Oregon");
-        tribeCodes.put("90", "Fort McDowell Yavapai Nation, Arizona");
-        tribeCodes.put("91", "Fort Mojave Indian Tribe of Arizona, California & Nevada");
-        tribeCodes.put("92", "Fort Sill Apache Tribe of Oklahoma");
-        tribeCodes.put(
-                "93", "Gila River Indian Community of the Gila River Indian Reservation, Arizona");
-        tribeCodes.put("94", "Grand Traverse Band of Ottawa and Chippewa Indians, Michigan");
-        tribeCodes.put("95", "Federated Indians of Graton Rancheria, California");
-        tribeCodes.put("96", "Greenville Rancheria");
-        tribeCodes.put("97", "Grindstone Indian Rancheria of Wintun-Wailaki Indians of California");
-        tribeCodes.put("98", "Guidiville Rancheria of California");
-        tribeCodes.put("99", "Hannahville Indian Community, Michigan");
-        tribeCodes.put("100", "Havasupai Tribe of the Havasupai Reservation, Arizona");
-        tribeCodes.put("101", "Ho-Chunk Nation of Wisconsin");
-        tribeCodes.put("102", "Hoh Indian Tribe");
-        tribeCodes.put("103", "Hoopa Valley Tribe, California");
-        tribeCodes.put("104", "Hopi Tribe of Arizona");
-        tribeCodes.put("105", "Hopland Band of Pomo Indians, California");
-        tribeCodes.put("106", "Houlton Band of Maliseet Indians");
-        tribeCodes.put("107", "Hualapai Indian Tribe of the Hualapai Indian Reservation, Arizona");
-        tribeCodes.put("108", "Nottawaseppi Huron Band of the Potawatomi, Michigan");
-        tribeCodes.put(
-                "109",
-                "Inaja Band of Diegueno Mission Indians of the Inaja and Cosmit Reservation, California");
-        tribeCodes.put("110", "Ione Band of Miwok Indians of California");
-        tribeCodes.put("111", "Iowa Tribe of Kansas and Nebraska");
-        tribeCodes.put("112", "Iowa Tribe of Oklahoma");
-        tribeCodes.put("113", "Jackson Band of Miwuk Indians");
-        tribeCodes.put("114", "Jamestown S'Klallam Tribe");
-        tribeCodes.put("115", "Jamul Indian Village of California");
-        tribeCodes.put("116", "Jena Band of Choctaw Indians");
-        tribeCodes.put("117", "Jicarilla Apache Nation, New Mexico");
-        tribeCodes.put(
-                "118", "Kaibab Band of Paiute Indians of the Kaibab Indian Reservation, Arizona");
-        tribeCodes.put("119", "Kalispel Indian Community of the Kalispel Reservation");
-        tribeCodes.put("120", "Karuk Tribe");
-        tribeCodes.put(
-                "121", "Kashia Band of Pomo Indians of the Stewarts Point Rancheria, California");
-        tribeCodes.put("122", "Kaw Nation, Oklahoma");
-        tribeCodes.put("123", "Keweenaw Bay Indian Community, Michigan");
-        tribeCodes.put("124", "Kialegee Tribal Town");
-        tribeCodes.put("127", "Kickapoo Traditional Tribe of Texas");
-        tribeCodes.put("125", "Kickapoo Tribe of Indians of the Kickapoo Reservation in Kansas");
-        tribeCodes.put("126", "Kickapoo Tribe of Oklahoma");
-        tribeCodes.put("128", "Kiowa Indian Tribe of Oklahoma");
-        tribeCodes.put("129", "Klamath Tribes");
-        tribeCodes.put("130", "Kootenai Tribe of Idaho");
-        tribeCodes.put("131", "La Jolla Band of Luiseno Indians, California");
-        tribeCodes.put(
-                "132",
-                "La Posta Band of Diegueno Mission Indians of the La Posta Indian Reservation, California");
-        tribeCodes.put(
-                "133", "Lac Courte Oreilles Band of Lake Superior Chippewa Indians of Wisconsin");
-        tribeCodes.put(
-                "134",
-                "Lac du Flambeau Band of Lake Superior Chippewa Indians of the Lac du Flambeau Reservation of Wisconsin");
-        tribeCodes.put("135", "Lac Vieux Desert Band of Lake Superior Chippewa Indians of Michigan");
-        tribeCodes.put(
-                "136", "Las Vegas Tribe of Paiute Indians of the Las Vegas Indian Colony, Nevada");
-        tribeCodes.put("137", "Little River Band of Ottawa Indians, Michigan");
-        tribeCodes.put("138", "Little Traverse Bay Bands of Odawa Indians, Michigan");
-        tribeCodes.put("140", "Los Coyotes Band of Cahuilla and Cupeno Indians, California");
-        tribeCodes.put("141", "Lovelock Paiute Tribe of the Lovelock Indian Colony, Nevada");
-        tribeCodes.put("142", "Lower Brule Sioux Tribe of the Lower Brule Reservation, South Dakota");
-        tribeCodes.put("143", "Lower Elwha Tribal Community");
-        tribeCodes.put("139", "Koi Nation of Northern California");
-        tribeCodes.put("144", "Lower Sioux Indian Community in the State of Minnesota");
-        tribeCodes.put("145", "Lummi Tribe of the Lummi Reservation");
-        tribeCodes.put("146", "Lytton Rancheria of California");
-        tribeCodes.put("147", "Makah Indian Tribe of the Makah Indian Reservation");
-        tribeCodes.put(
-                "148", "Manchester Band of Pomo Indians of the Manchester Rancheria, California");
-        tribeCodes.put(
-                "149",
-                "Manzanita Band of Diegueno Mission Indians of the Manzanita Reservation, California");
-        tribeCodes.put("150", "Mashantucket Pequot Indian Tribe");
-        tribeCodes.put("151", "Match-e-be-nash-she-wish Band of Pottawatomi Indians of Michigan");
-        tribeCodes.put("152", "Mechoopda Indian Tribe of Chico Rancheria, California");
-        tribeCodes.put("153", "Menominee Indian Tribe of Wisconsin");
-        tribeCodes.put(
-                "154",
-                "Mesa Grande Band of Diegueno Mission Indians of the Mesa Grande Reservation, California");
-        tribeCodes.put("155", "Mescalero Apache Tribe of the Mescalero Reservation, New Mexico");
-        tribeCodes.put("156", "Miami Tribe of Oklahoma");
-        tribeCodes.put("157", "Miccosukee Tribe of Indians");
-        tribeCodes.put("158", "Middletown Rancheria of Pomo Indians of California");
-        tribeCodes.put(
-                "159",
-                "Minnesota Chippewa Tribe, Minnesota (Six component reservations: Bois Forte Band (Nett Lake); Fond du Lac Band; Grand Portage Band; Leech Lake Band; Mille Lacs Band; White Earth Band)");
-        tribeCodes.put("160", "Bois Forte Band (Nett Lake); Fond du Lac Band; Gra");
-        tribeCodes.put("161", "Mississippi Band of Choctaw Indians");
-        tribeCodes.put(
-                "162", "Moapa Band of Paiute Indians of the Moapa River Indian Reservation, Nevada");
-        tribeCodes.put("163", "Modoc Nation");
-        tribeCodes.put("164", "Mohegan Tribe of Indians of Connecticut");
-        tribeCodes.put("165", "Mooretown Rancheria of Maidu Indians of California");
-        tribeCodes.put("166", "Morongo Band of Mission Indians, California");
-        tribeCodes.put("167", "Muckleshoot Indian Tribe");
-        tribeCodes.put("168", "The Muscogee (Creek) Nation");
-        tribeCodes.put("169", "Narragansett Indian Tribe");
-        tribeCodes.put("170", "Navajo Nation, Arizona, New Mexico, & Utah");
-        tribeCodes.put("171", "Nez Perce Tribe");
-        tribeCodes.put("172", "Nisqually Indian Tribe of the Nisqually Reservatio");
-        tribeCodes.put("173", "Nooksack Indian Tribe");
-        tribeCodes.put(
-                "174", "Northern Cheyenne Tribe of the Northern Cheyenne Indian Reservation, Montana");
-        tribeCodes.put("175", "Northfork Rancheria of Mono Indians of California");
-        tribeCodes.put("176", "Northwestern Band of the Shoshone Nation");
-        tribeCodes.put("177", "Oglala Sioux Tribe");
-        tribeCodes.put("178", "Omaha Tribe of Nebraska");
-        tribeCodes.put("179", "Oneida Indian Nation");
-        tribeCodes.put("180", "Oneida Nation");
-        tribeCodes.put("181", "Onondaga Nation");
-        tribeCodes.put("182", "The Osage Nation");
-        tribeCodes.put("184", "Otoe-Missouria Tribe of Indians, Oklahoma");
-        tribeCodes.put("183", "Ottawa Tribe of Oklahoma");
-        tribeCodes.put(
-                "185",
-                "Paiute Indian Tribe of Utah (Cedar Band of Paiutes, Kanosh Band of Paiutes, Koosharem Band of Paiutes, Indian Peaks Band of Paiutes, and Shivwits Band of Paiutes)");
-        tribeCodes.put("186", "Bishop Paiute Tribe");
-        tribeCodes.put("188", "Lone Pine Paiute-Shoshone Tribe");
-        tribeCodes.put("187", "Paiute-Shoshone Tribe of the Fallon Reservation and Colony, Nevada");
-        tribeCodes.put("189", "Pala Band of Mission Indians");
-        tribeCodes.put("190", "Pascua Yaqui Tribe of Arizona");
-        tribeCodes.put("191", "Paskenta Band of Nomlaki Indians of California");
-        tribeCodes.put("192", "Passamaquoddy Tribe");
-        tribeCodes.put(
-                "193",
-                "Pauma Band of Luiseno Mission Indians of the Pauma & Yuima Reservation, California");
-        tribeCodes.put("194", "Pawnee Nation of Oklahoma");
-        tribeCodes.put("195", "Pechanga Band of Indians");
-        tribeCodes.put("196", "Penobscot Nation");
-        tribeCodes.put("197", "Peoria Tribe of Indians of Oklahoma");
-        tribeCodes.put("198", "Picayune Rancheria of Chukchansi Indians of California");
-        tribeCodes.put("199", "Pinoleville Pomo Nation, California");
-        tribeCodes.put(
-                "200",
-                "Pit River Tribe, California (includes XL Ranch, Big Bend, Likely, Lookout, Montgomery Creek, and Roaring Creek Rancherias)");
-        tribeCodes.put("201", "Poarch Band of Creek Indians");
-        tribeCodes.put("202", "Pokagon Band of Potawatomi Indians, Michigan and Indiana");
-        tribeCodes.put("203", "Ponca Tribe of Indians of Oklahoma");
-        tribeCodes.put("204", "Ponca Tribe of Nebraska");
-        tribeCodes.put("205", "Port Gamble S'Klallam Tribe");
-        tribeCodes.put("206", "Potter Valley Tribe, California");
-        tribeCodes.put("207", "Prairie Band Potawatomi Nation");
-        tribeCodes.put("208", "Prairie Island Indian Community in the State of Minnesota");
-        tribeCodes.put("209", "Pueblo of Acoma, New Mexico");
-        tribeCodes.put("210", "Pueblo of Cochiti, New Mexico");
-        tribeCodes.put("212", "Pueblo of Isleta, New Mexico");
-        tribeCodes.put("211", "Pueblo of Jemez, New Mexico");
-        tribeCodes.put("213", "Pueblo of Laguna, New Mexico");
-        tribeCodes.put("214", "Pueblo of Nambe, New Mexico");
-        tribeCodes.put("215", "Pueblo of Picuris, New Mexico");
-        tribeCodes.put("216", "Pueblo of Pojoaque, New Mexico");
-        tribeCodes.put("217", "Pueblo of San Felipe, New Mexico");
-        tribeCodes.put("219", "Pueblo of San Ildefonso, New Mexico");
-        tribeCodes.put("218", "Ohkay Owingeh, New Mexico");
-        tribeCodes.put("220", "Pueblo of Sandia, New Mexico");
-        tribeCodes.put("221", "Pueblo of Santa Ana, New Mexico");
-        tribeCodes.put("222", "Pueblo of Santa Clara, New Mexico");
-        tribeCodes.put("223", "Santo Domingo Pueblo");
-        tribeCodes.put("224", "Pueblo of Taos, New Mexico");
-        tribeCodes.put("225", "Pueblo of Tesuque, New Mexico");
-        tribeCodes.put("226", "Pueblo of Zia, New Mexico");
-        tribeCodes.put("227", "Puyallup Tribe of the Puyallup Reservation");
-        tribeCodes.put("228", "Pyramid Lake Paiute Tribe of the Pyramid Lake Reservation, Nevada");
-        tribeCodes.put("229", "Quapaw Nation");
-        tribeCodes.put(
-                "230", "Quartz Valley Indian Community of the Quartz Valley Reservation of California");
-        tribeCodes.put(
-                "231", "Quechan Tribe of the Fort Yuma Indian Reservation, California & Arizona");
-        tribeCodes.put("232", "Quileute Tribe of the Quileute Reservation");
-        tribeCodes.put("233", "Quinault Indian Nation");
-        tribeCodes.put("234", "Ramona Band of Cahuilla, California");
-        tribeCodes.put("235", "Red Cliff Band of Lake Superior Chippewa Indians of Wisconsin");
-        tribeCodes.put("236", "Red Lake Band of Chippewa Indians, Minnesota");
-        tribeCodes.put("237", "Redding Rancheria, California");
-        tribeCodes.put(
-                "238",
-                "Redwood Valley or Little River Band of Pomo Indians of the Redwood Valley Rancheria California");
-        tribeCodes.put("239", "Reno-Sparks Indian Colony, Nevada");
-        tribeCodes.put("240", "Resighini Rancheria, California");
-        tribeCodes.put(
-                "241", "Rincon Band of Luiseno Mission Indians of Rincon Reservation, California");
-        tribeCodes.put("242", "Robinson Rancheria");
-        tribeCodes.put("243", "Rosebud Sioux Tribe of the Rosebud Indian Reservation, South Dakota");
-        tribeCodes.put("244", "Round Valley Indian Tribes, Round Valley Reservation, California");
-        tribeCodes.put("245", "Yocha Dehe Wintun Nation, California");
-        tribeCodes.put("247", "Sac & Fox Nation of Missouri in Kansas and Nebraska");
-        tribeCodes.put("248", "Sac & Fox Nation, Oklahoma");
-        tribeCodes.put("246", "Sac & Fox Tribe of the Mississippi in Iowa");
-        tribeCodes.put("249", "Saginaw Chippewa Indian Tribe of Michigan");
-        tribeCodes.put(
-                "250", "Salt River Pima-Maricopa Indian Community of the Salt River Reservation, Arizona");
-        tribeCodes.put("251", "Samish Indian Nation");
-        tribeCodes.put("252", "San Carlos Apache Tribe of the San Carlos Reservation, Arizona");
-        tribeCodes.put("253", "San Juan Southern Paiute Tribe of Arizona");
-        tribeCodes.put("254", "Yuhaaviatam of San Manuel Nation");
-        tribeCodes.put("255", "San Pasqual Band of Diegueno Mission Indians of California");
-        tribeCodes.put("257", "Santa Rosa Band of Cahuilla Indians, California");
-        tribeCodes.put("256", "Santa Rosa Indian Community of the Santa Rosa Rancheria, California");
-        tribeCodes.put(
-                "258",
-                "Santa Ynez Band of Chumash Mission Indians of the Santa Ynez Reservation, California");
-        tribeCodes.put("259", "Iipay Nation of Santa Ysabel, California");
-        tribeCodes.put("260", "Santee Sioux Nation, Nebraska");
-        tribeCodes.put("261", "Sauk-Suiattle Indian Tribe");
-        tribeCodes.put("262", "Sault Ste. Marie Tribe of Chippewa Indians, Michigan");
-        tribeCodes.put("263", "Scotts Valley Band of Pomo Indians of California");
-        tribeCodes.put("264", "The Seminole Nation of Oklahoma");
-        tribeCodes.put("265", "Seminole Tribe of Florida");
-        tribeCodes.put("266", "Seneca Nation of Indians");
-        tribeCodes.put("267", "Seneca-Cayuga Nation");
-        tribeCodes.put("268", "Shakopee Mdewakanton Sioux Community of Minnesota");
-        tribeCodes.put("269", "Shawnee Tribe");
-        tribeCodes.put("270", "Sherwood Valley Rancheria of Pomo Indians of California");
-        tribeCodes.put(
-                "271",
-                "Shingle Springs Band of Miwok Indians, Shingle Springs Rancheria (Verona Tract), California");
-        tribeCodes.put("272", "Shoalwater Bay Indian Tribe of the Shoalwater Bay Indian Reservation");
-        tribeCodes.put("273", "Eastern Shoshone Tribe of the Wind River Reservation, Wyoming");
-        tribeCodes.put("274", "Shoshone-Bannock Tribes of the Fort Hall Reservation");
-        tribeCodes.put("275", "Shoshone-Paiute Tribes of the Duck Valley Reservation, Nevada");
-        tribeCodes.put("276", "Sisseton-Wahpeton Oyate of the Lake Traverse Reservation, South Dakota");
-        tribeCodes.put("277", "Skokomish Indian Tribe");
-        tribeCodes.put("278", "Skull Valley Band of Goshute Indians of Utah");
-        tribeCodes.put("279", "Tolowa Dee-ni' Nation");
-        tribeCodes.put("280", "Snoqualmie Indian Tribe");
-        tribeCodes.put("281", "Soboba Band of Luiseno Indians, California");
-        tribeCodes.put("282", "Sokaogon Chippewa Community, Wisconsin");
-        tribeCodes.put("283", "Southern Ute Indian Tribe of the Southern Ute Reservation, Colorado");
-        tribeCodes.put("284", "Spirit Lake Tribe, North Dakota");
-        tribeCodes.put("285", "Spokane Tribe of the Spokane Reservation");
-        tribeCodes.put("286", "Squaxin Island Tribe of the Squaxin Island Reservation");
-        tribeCodes.put("287", "St. Croix Chippewa Indians of Wisconsin");
-        tribeCodes.put("288", "Saint Regis Mohawk Tribe");
-        tribeCodes.put("289", "Standing Rock Sioux Tribe of North & South Dakota");
-        tribeCodes.put("291", "Stillaguamish Tribe of Indians of Washington");
-        tribeCodes.put("290", "Stockbridge Munsee Community, Wisconsin");
-        tribeCodes.put("292", "Summit Lake Paiute Tribe of Nevada");
-        tribeCodes.put("293", "Suquamish Indian Tribe of the Port Madison Reservation");
-        tribeCodes.put("294", "Susanville Indian Rancheria, California");
-        tribeCodes.put("295", "Swinomish Indian Tribal Community");
-        tribeCodes.put("296", "Sycuan Band of the Kumeyaay Nation");
-        tribeCodes.put("297", "Wiyot Tribe, California");
-        tribeCodes.put("298", "Table Mountain Rancheria");
-        tribeCodes.put(
-                "299",
-                "Te-Moak Tribe of Western Shoshone Indians of Nevada (Four constituent bands: Battle Mountain Band; Elko Band; South Fork Band; and Wells Band)");
-        tribeCodes.put("300", "Thlopthlocco Tribal Town");
-        tribeCodes.put("301", "Three Affiliated Tribes of the Fort Berthold Reservation, North Dakota");
-        tribeCodes.put("302", "Tohono O'odham Nation of Arizona");
-        tribeCodes.put("303", "Tonawanda Band of Seneca");
-        tribeCodes.put("304", "Tonkawa Tribe of Indians of Oklahoma");
-        tribeCodes.put("305", "Tonto Apache Tribe of Arizona");
-        tribeCodes.put("306", "Torres Martinez Desert Cahuilla Indians, California");
-        tribeCodes.put("308", "Tulalip Tribes of Washington");
-        tribeCodes.put("307", "Tule River Indian Tribe of the Tule River Reservation, California");
-        tribeCodes.put("309", "Tunica-Biloxi Indian Tribe");
-        tribeCodes.put(
-                "310", "Tuolumne Band of Me-Wuk Indians of the Tuolumne Rancheria of California");
-        tribeCodes.put("311", "Turtle Mountain Band of Chippewa Indians of North Dakota");
-        tribeCodes.put("312", "Tuscarora Nation");
-        tribeCodes.put("313", "Twenty-Nine Palms Band of Mission Indians of California");
-        tribeCodes.put("314", "United Auburn Indian Community of the Auburn Rancheria of California");
-        tribeCodes.put("315", "United Keetoowah Band of Cherokee Indians in Oklahoma");
-        tribeCodes.put("316", "Habematolel Pomo of Upper Lake, California");
-        tribeCodes.put("317", "Upper Sioux Community, Minnesota");
-        tribeCodes.put("318", "Upper Skagit Indian Tribe");
-        tribeCodes.put("319", "Ute Indian Tribe of the Uintah & Ouray Reservation, Utah");
-        tribeCodes.put("320", "Ute Mountain Ute Tribe");
-        tribeCodes.put(
-                "321", "Utu Utu Gwaitu Paiute Tribe of the Benton Paiute Reservation, California");
-        tribeCodes.put("34", "Viejas (Baron Long) Group of Capitan Grande Band o");
-        tribeCodes.put("322", "Walker River Paiute Tribe of the Walker River Reservation, Nevada");
-        tribeCodes.put("323", "Wampanoag Tribe of Gay Head (Aquinnah)");
-        tribeCodes.put(
-                "324",
-                "Washoe Tribe of Nevada & California (Carson Colony, Dresslerville Colony, Woodfords Community, Stewart Community, & Washoe Ranches)");
-        tribeCodes.put("325", "White Mountain Apache Tribe of the Fort Apache Reservation, Arizona");
-        tribeCodes.put(
-                "326", "Wichita and Affiliated Tribes (Wichita, Keechi, Waco, & Tawakonie), Oklahoma");
-        tribeCodes.put("327", "Winnebago Tribe of Nebraska");
-        tribeCodes.put("328", "Winnemucca Indian Colony of Nevada");
-        tribeCodes.put("329", "Wyandotte Nation");
-        tribeCodes.put("330", "Yankton Sioux Tribe of South Dakota");
-        tribeCodes.put("331", "Yavapai-Apache Nation of the Camp Verde Indian Reservation, Arizona");
-        tribeCodes.put("332", "Yavapai-Prescott Indian Tribe");
-        tribeCodes.put(
-                "333", "Yerington Paiute Tribe of the Yerington Colony & Campbell Ranch, Nevada");
-        tribeCodes.put("334", "Yomba Shoshone Tribe of the Yomba Reservation, Nevada");
-        tribeCodes.put("335", "Ysleta del Sur Pueblo");
-        tribeCodes.put("336", "Yurok Tribe of the Yurok Reservation, California");
-        tribeCodes.put("337", "Zuni Tribe of the Zuni Reservation, New Mexico");
-        tribeCodes.put("338", "Native Village of Afognak");
-        tribeCodes.put("339", "Agdaagux Tribe of King Cove");
-        tribeCodes.put("340", "Native Village of Akhiok");
-        tribeCodes.put("341", "Akiachak Native Community");
-        tribeCodes.put("342", "Akiak Native Community");
-        tribeCodes.put("343", "Native Village of Akutan");
-        tribeCodes.put("344", "Village of Alakanuk");
-        tribeCodes.put("345", "Alatna Village");
-        tribeCodes.put("346", "Native Village of Aleknagik");
-        tribeCodes.put("347", "Algaaciq Native Village (St. Mary's)");
-        tribeCodes.put("348", "Allakaket Village");
-        tribeCodes.put("349", "Native Village of Ambler");
-        tribeCodes.put("350", "Village of Anaktuvuk Pass");
-        tribeCodes.put("351", "Yupiit of Andreafski");
-        tribeCodes.put("352", "Angoon Community Association");
-        tribeCodes.put("353", "Village of Aniak");
-        tribeCodes.put("354", "Anvik Village");
-        tribeCodes.put("355", "Arctic Village");
-        tribeCodes.put("356", "Asa'carsarmiut Tribe");
-        tribeCodes.put("357", "Native Village of Atka");
-        tribeCodes.put("358", "Village of Atmautluak");
-        tribeCodes.put("359", "Native Village of Atqasuk");
-        tribeCodes.put("360", "Native Village of Barrow Inupiat Traditional Government");
-        tribeCodes.put("361", "Beaver Village");
-        tribeCodes.put("362", "Native Village of Belkofski");
-        tribeCodes.put("363", "Village of Bill Moore's Slough");
-        tribeCodes.put("364", "Birch Creek Tribe");
-        tribeCodes.put("365", "Native Village of Brevig Mission");
-        tribeCodes.put("366", "Native Village of Buckland");
-        tribeCodes.put("367", "Native Village of Cantwell");
-        tribeCodes.put("368", "Native Village of Chenega (aka Chanega)");
-        tribeCodes.put("369", "Chalkyitsik Village");
-        tribeCodes.put("370", "Village of Chefornak");
-        tribeCodes.put("371", "Chevak Native Village");
-        tribeCodes.put("372", "Chickaloon Native Village");
-        tribeCodes.put("373", "Chignik Bay Tribal Council");
-        tribeCodes.put("374", "Native Village of Chignik Lagoon");
-        tribeCodes.put("375", "Chignik Lake Village");
-        tribeCodes.put("376", "Chilkat Indian Village (Klukwan)");
-        tribeCodes.put("377", "Chilkoot Indian Association (Haines)");
-        tribeCodes.put("378", "Chinik Eskimo Community (Golovin)");
-        tribeCodes.put("379", "Cheesh-Na Tribe");
-        tribeCodes.put("380", "Native Village of Chitina");
-        tribeCodes.put("381", "Native Village of Chuathbaluk (Russian Mission, Kuskokwim)");
-        tribeCodes.put("382", "Chuloonawick Native Village");
-        tribeCodes.put("383", "Circle Native Community");
-        tribeCodes.put("384", "Village of Clarks Point");
-        tribeCodes.put("385", "Native Village of Council");
-        tribeCodes.put("386", "Craig Tribal Association");
-        tribeCodes.put("387", "Village of Crooked Creek");
-        tribeCodes.put("388", "Curyung Tribal Council");
-        tribeCodes.put("389", "Native Village of Deering");
-        tribeCodes.put("390", "Native Village of Diomede (aka Inalik)");
-        tribeCodes.put("391", "Village of Dot Lake");
-        tribeCodes.put("392", "Douglas Indian Association");
-        tribeCodes.put("393", "Native Village of Eagle");
-        tribeCodes.put("394", "Native Village of Eek");
-        tribeCodes.put("395", "Egegik Village");
-        tribeCodes.put("396", "Eklutna Native Village");
-        tribeCodes.put("397", "Native Village of Ekuk");
-        tribeCodes.put("398", "Native Village of Ekwok");
-        tribeCodes.put("399", "Native Village of Elim");
-        tribeCodes.put("400", "Emmonak Village");
-        tribeCodes.put("401", "Evansville Village (aka Bettles Field)");
-        tribeCodes.put("402", "Native Village of Eyak (Cordova)");
-        tribeCodes.put("403", "Native Village of False Pass");
-        tribeCodes.put("404", "Native Village of Fort Yukon");
-        tribeCodes.put("405", "Native Village of Gakona");
-        tribeCodes.put("406", "Galena Village (aka Louden Village)");
-        tribeCodes.put("407", "Native Village of Gambell");
-        tribeCodes.put("408", "Native Village of Georgetown");
-        tribeCodes.put("409", "Native Village of Goodnews Bay");
-        tribeCodes.put("410", "Organized Village of Grayling (aka Holikachuk)");
-        tribeCodes.put("411", "Gulkana Village Council");
-        tribeCodes.put("412", "Native Village of Hamilton");
-        tribeCodes.put("413", "Healy Lake Village");
-        tribeCodes.put("414", "Holy Cross Tribe");
-        tribeCodes.put("415", "Hoonah Indian Association");
-        tribeCodes.put("416", "Native Village of Hooper Bay");
-        tribeCodes.put("417", "Hughes Village");
-        tribeCodes.put("418", "Huslia Village");
-        tribeCodes.put("419", "Hydaburg Cooperative Association");
-        tribeCodes.put("420", "Igiugig Village");
-        tribeCodes.put("421", "Village of Iliamna");
-        tribeCodes.put("422", "Inupiat Community of the Arctic Slope");
-        tribeCodes.put("423", "Iqugmiut Traditional Council");
-        tribeCodes.put("424", "Ivanof Bay Tribe");
-        tribeCodes.put("425", "Kaguyak Village");
-        tribeCodes.put("426", "Organized Village of Kake");
-        tribeCodes.put("427", "Kaktovik Village (aka Barter Island)");
-        tribeCodes.put("428", "Village of Kalskag");
-        tribeCodes.put("429", "Village of Kaltag");
-        tribeCodes.put("430", "Native Village of Kanatak");
-        tribeCodes.put("431", "Native Village of Karluk");
-        tribeCodes.put("432", "Organized Village of Kasaan");
-        tribeCodes.put("433", "Kasigluk Traditional Elders Council");
-        tribeCodes.put("434", "Kenaitze Indian Tribe");
-        tribeCodes.put("435", "Ketchikan Indian Community");
-        tribeCodes.put("436", "Native Village of Kiana");
-        tribeCodes.put("437", "King Island Native Community");
-        tribeCodes.put("438", "King Salmon Tribe");
-        tribeCodes.put("439", "Native Village of Kipnuk");
-        tribeCodes.put("440", "Native Village of Kivalina");
-        tribeCodes.put("441", "Klawock Cooperative Association");
-        tribeCodes.put("442", "Native Village of Kluti Kaah (aka Copper Center)");
-        tribeCodes.put("443", "Knik Tribe");
-        tribeCodes.put("444", "Native Village of Kobuk");
-        tribeCodes.put("445", "Kokhanok Village");
-        tribeCodes.put("446", "Native Village of Kongiganak");
-        tribeCodes.put("447", "Village of Kotlik");
-        tribeCodes.put("448", "Native Village of Kotzebue");
-        tribeCodes.put("449", "Native Village of Koyuk");
-        tribeCodes.put("450", "Koyukuk Native Village");
-        tribeCodes.put("451", "Organized Village of Kwethluk");
-        tribeCodes.put("452", "Native Village of Kwigillingok");
-        tribeCodes.put("453", "Native Village of Kwinhagak (aka Quinhagak)");
-        tribeCodes.put("454", "Native Village of Larsen Bay");
-        tribeCodes.put("455", "Levelock Village");
-        tribeCodes.put("456", "Tangirnaq Native Village");
-        tribeCodes.put("457", "Lime Village");
-        tribeCodes.put("458", "Village of Lower Kalskag");
-        tribeCodes.put("459", "Manley Hot Springs Village");
-        tribeCodes.put("460", "Manokotak Village");
-        tribeCodes.put("461", "Native Village of Marshall (aka Fortuna Ledge)");
-        tribeCodes.put("462", "Native Village of Mary's Igloo");
-        tribeCodes.put("463", "McGrath Native Village");
-        tribeCodes.put("464", "Native Village of Mekoryuk");
-        tribeCodes.put("465", "Mentasta Traditional Council");
-        tribeCodes.put("466", "Metlakatla Indian Community, Annette Island Reserve");
-        tribeCodes.put("467", "Native Village of Minto");
-        tribeCodes.put("468", "Naknek Native Village");
-        tribeCodes.put("469", "Native Village of Nanwalek (aka English Bay)");
-        tribeCodes.put("470", "Native Village of Napaimute");
-        tribeCodes.put("471", "Native Village of Napakiak");
-        tribeCodes.put("472", "Native Village of Napaskiak");
-        tribeCodes.put("473", "Native Village of Nelson Lagoon");
-        tribeCodes.put("474", "Nenana Native Association");
-        tribeCodes.put("475", "New Koliganek Village Council");
-        tribeCodes.put("476", "New Stuyahok Village");
-        tribeCodes.put("477", "Newhalen Village");
-        tribeCodes.put("478", "Newtok Village");
-        tribeCodes.put("479", "Native Village of Nightmute");
-        tribeCodes.put("480", "Nikolai Village");
-        tribeCodes.put("481", "Native Village of Nikolski");
-        tribeCodes.put("482", "Ninilchik Village");
-        tribeCodes.put("483", "Native Village of Noatak");
-        tribeCodes.put("484", "Nome Eskimo Community");
-        tribeCodes.put("485", "Nondalton Village");
-        tribeCodes.put("486", "Noorvik Native Community");
-        tribeCodes.put("487", "Northway Village");
-        tribeCodes.put("488", "Native Village of Nuiqsut (aka Nooiksut)");
-        tribeCodes.put("489", "Nulato Village");
-        tribeCodes.put("490", "Nunakauyarmiut Tribe");
-        tribeCodes.put("491", "Native Village of Nunapitchuk");
-        tribeCodes.put("492", "Village of Ohogamiut");
-        tribeCodes.put("493", "Alutiiq Tribe of Old Harbor");
-        tribeCodes.put("494", "Orutsararmiut Traditional Native Council");
-        tribeCodes.put("495", "Oscarville Traditional Village");
-        tribeCodes.put("496", "Native Village of Ouzinkie");
-        tribeCodes.put("497", "Native Village of Paimiut");
-        tribeCodes.put("498", "Pauloff Harbor Village");
-        tribeCodes.put("499", "Pedro Bay Village");
-        tribeCodes.put("500", "Native Village of Perryville");
-        tribeCodes.put("501", "Petersburg Indian Association");
-        tribeCodes.put("502", "Native Village of Pilot Point");
-        tribeCodes.put("503", "Pilot Station Traditional Village");
-        tribeCodes.put("504", "Pitka's Point Traditional Council");
-        tribeCodes.put("505", "Platinum Traditional Village");
-        tribeCodes.put("506", "Native Village of Point Hope");
-        tribeCodes.put("507", "Native Village of Point Lay");
-        tribeCodes.put("508", "Native Village of Port Graham");
-        tribeCodes.put("509", "Native Village of Port Heiden");
-        tribeCodes.put("510", "Native Village of Port Lions");
-        tribeCodes.put("511", "Portage Creek Village (aka Ohgsenakale)");
-        tribeCodes.put(
-                "512",
-                "Pribilof Islands Aleut Communities of St. Paul & St. George Islands (Saint George Island and Saint Paul Island)");
-        tribeCodes.put("513", "Qagan Tayagungin Tribe of Sand Point");
-        tribeCodes.put("514", "Qawalangin Tribe of Unalaska");
-        tribeCodes.put("515", "Rampart Village");
-        tribeCodes.put("516", "Village of Red Devil");
-        tribeCodes.put("517", "Native Village of Ruby");
-        tribeCodes.put("518", "Saint George Island");
-        tribeCodes.put("519", "Native Village of Saint Michael");
-        tribeCodes.put("520", "Saint Paul Island");
-        tribeCodes.put("521", "Salamatof Tribe");
-        tribeCodes.put("522", "Native Village of Savoonga");
-        tribeCodes.put("523", "Organized Village of Saxman");
-        tribeCodes.put("524", "Native Village of Scammon Bay");
-        tribeCodes.put("525", "Native Village of Selawik");
-        tribeCodes.put("526", "Seldovia Village Tribe");
-        tribeCodes.put("527", "Shageluk Native Village");
-        tribeCodes.put("528", "Native Village of Shaktoolik");
-        tribeCodes.put("529", "Native Village of Nunam Iqua");
-        tribeCodes.put("530", "Native Village of Shishmaref");
-        tribeCodes.put("531", "Sun'aq Tribe of Kodiak");
-        tribeCodes.put("532", "Native Village of Shungnak");
-        tribeCodes.put("533", "Sitka Tribe of Alaska");
-        tribeCodes.put("534", "Skagway Village");
-        tribeCodes.put("535", "Village of Sleetmute");
-        tribeCodes.put("536", "Village of Solomon");
-        tribeCodes.put("537", "South Naknek Village");
-        tribeCodes.put("538", "Stebbins Community Association");
-        tribeCodes.put("539", "Native Village of Stevens");
-        tribeCodes.put("540", "Village of Stony River");
-        tribeCodes.put("541", "Takotna Village");
-        tribeCodes.put("542", "Native Village of Tanacross");
-        tribeCodes.put("543", "Native Village of Tanana");
-        tribeCodes.put("544", "Native Village of Tatitlek");
-        tribeCodes.put("545", "Native Village of Tazlina");
-        tribeCodes.put("546", "Telida Village");
-        tribeCodes.put("547", "Native Village of Teller");
-        tribeCodes.put("548", "Native Village of Tetlin");
-        tribeCodes.put("549", "Central Council of the Tlingit & Haida Indian Tribes");
-        tribeCodes.put("550", "Traditional Village of Togiak");
-        tribeCodes.put("551", "Tuluksak Native Community");
-        tribeCodes.put("552", "Native Village of Tuntutuliak");
-        tribeCodes.put("553", "Native Village of Tununak");
-        tribeCodes.put("554", "Twin Hills Village");
-        tribeCodes.put("555", "Native Village of Tyonek");
-        tribeCodes.put("556", "Ugashik Village");
-        tribeCodes.put("557", "Umkumiut Native Village");
-        tribeCodes.put("558", "Native Village of Unalakleet");
-        tribeCodes.put("559", "Native Village of Unga");
-        tribeCodes.put("560", "Village of Venetie");
-        tribeCodes.put(
-                "561",
-                "Native Village of Venetie Tribal Government (Arctic Village and Village of Venetie)");
-        tribeCodes.put("562", "Village of Wainwright");
-        tribeCodes.put("563", "Native Village of Wales");
-        tribeCodes.put("564", "Native Village of White Mountain");
-        tribeCodes.put("565", "Wrangell Cooperative Association");
-        tribeCodes.put("566", "Yakutat Tlingit Tribe");
-        tribeCodes.put("567", "Chickahominy Indian Tribe");
-        tribeCodes.put("568", "Chickahominy Indian Tribe—Eastern Division");
-        tribeCodes.put("569", "Monacan Indian Nation");
-        tribeCodes.put("570", "Nansemond Indian Nation");
-        tribeCodes.put("571", "Rappahannock Tribe, Inc.");
-        tribeCodes.put("572", "Upper Mattaponi Tribe");
-        tribeCodes.put("573", "Cowlitz Indian Tribe");
-        tribeCodes.put("574", "Little Shell Tribe of Chippewa Indians of Montana");
-        tribeCodes.put("575", "Mashpee Wampanoag Tribe");
-        tribeCodes.put("576", "Pamunkey Indian Tribe");
-        tribeCodes.put("577", "Shinnecock Indian Nation");
-        tribeCodes.put("578", "Wilton Rancheria, California");
-        tribeCodes.put("579", "Tejon Indian Tribe");
-        return tribeCodes;
-    }
+  public static Map<String, String> tribalMap() {
+    var tribeCodes = new HashMap<String, String>();
+    tribeCodes.put("1", "Absentee-Shawnee Tribe of Indians of Oklahoma");
+    tribeCodes.put(
+        "2",
+        "Agua Caliente Band of Cahuilla Indians of the Agua Caliente Indian Reservation, California");
+    tribeCodes.put("3", "Ak-Chin Indian Community");
+    tribeCodes.put("4", "Alabama-Coushatta Tribe of Texas");
+    tribeCodes.put("5", "Alabama-Quassarte Tribal Town");
+    tribeCodes.put("6", "Alturas Indian Rancheria, California");
+    tribeCodes.put("7", "Apache Tribe of Oklahoma");
+    tribeCodes.put("8", "Northern Arapaho Tribe of the Wind River Reservation, Wyoming");
+    tribeCodes.put("9", "Mi'kmaq Nation");
+    tribeCodes.put(
+        "10", "Assiniboine and Sioux Tribes of the Fort Peck Indian Reservation, Montana");
+    tribeCodes.put("11", "Augustine Band of Cahuilla Indians, California");
+    tribeCodes.put(
+        "12",
+        "Bad River Band of the Lake Superior Tribe of Chippewa Indians of the Bad River Reservation, Wisconsin");
+    tribeCodes.put("33", "Barona Group of Capitan Grande Band of Mission Ind");
+    tribeCodes.put("13", "Bay Mills Indian Community, Michigan");
+    tribeCodes.put("14", "Bear River Band of the Rohnerville Rancheria, California");
+    tribeCodes.put("15", "Berry Creek Rancheria of Maidu Indians of California");
+    tribeCodes.put("16", "Big Lagoon Rancheria, California");
+    tribeCodes.put("17", "Big Pine Paiute Tribe of the Owens Valley");
+    tribeCodes.put("18", "Big Sandy Rancheria of Western Mono Indians of California");
+    tribeCodes.put("19", "Big Valley Band of Pomo Indians of the Big Valley Rancheria, California");
+    tribeCodes.put("20", "Blackfeet Tribe of the Blackfeet Indian Reservation of Montana");
+    tribeCodes.put("21", "Blue Lake Rancheria, California");
+    tribeCodes.put("22", "Bridgeport Indian Colony");
+    tribeCodes.put("23", "Buena Vista Rancheria of Me-Wuk Indians of California");
+    tribeCodes.put("24", "Burns Paiute Tribe");
+    tribeCodes.put("25", "Cabazon Band of Mission Indians, California");
+    tribeCodes.put(
+        "26",
+        "Cachil DeHe Band of Wintun Indians of the Colusa Indian Community of the Colusa Rancheria, California");
+    tribeCodes.put("27", "Caddo Nation of Oklahoma");
+    tribeCodes.put("29", "Cahto Tribe of the Laytonville Rancheria");
+    tribeCodes.put("28", "Cahuilla Band of Indians");
+    tribeCodes.put("30", "California Valley Miwok Tribe, California");
+    tribeCodes.put(
+        "31", "Campo Band of Diegueno Mission Indians of the Campo Indian Reservation, California");
+    tribeCodes.put("32", "Capitan Grande Band of Diegueno Mission Indians of California");
+    tribeCodes.put("35", "Catawba Indian Nation");
+    tribeCodes.put("36", "Cayuga Nation");
+    tribeCodes.put("37", "Cedarville Rancheria, California");
+    tribeCodes.put("38", "Chemehuevi Indian Tribe of the Chemehuevi Reservation, California");
+    tribeCodes.put("39", "Cher-Ae Heights Indian Community of the Trinidad Rancheria, California");
+    tribeCodes.put("40", "Cherokee Nation");
+    tribeCodes.put(
+        "42", "Cheyenne River Sioux Tribe of the Cheyenne River Reservation, South Dakota");
+    tribeCodes.put("41", "Cheyenne and Arapaho Tribes, Oklahoma");
+    tribeCodes.put("43", "The Chickasaw Nation");
+    tribeCodes.put("44", "Chicken Ranch Rancheria of Me-Wuk Indians of California");
+    tribeCodes.put("45", "Chippewa Cree Indians of the Rocky Boy's Reservation, Montana");
+    tribeCodes.put("46", "Chitimacha Tribe of Louisiana");
+    tribeCodes.put("47", "The Choctaw Nation of Oklahoma");
+    tribeCodes.put("48", "Citizen Potawatomi Nation, Oklahoma");
+    tribeCodes.put("49", "Cloverdale Rancheria of Pomo Indians of California");
+    tribeCodes.put("50", "Cocopah Tribe of Arizona");
+    tribeCodes.put("51", "Coeur D'Alene Tribe");
+    tribeCodes.put("52", "Cold Springs Rancheria of Mono Indians of California");
+    tribeCodes.put(
+        "53",
+        "Colorado River Indian Tribes of the Colorado River Indian Reservation, Arizona and California");
+    tribeCodes.put("54", "Comanche Nation, Oklahoma");
+    tribeCodes.put("55", "Confederated Salish and Kootenai Tribes of the Flathead Reservation");
+    tribeCodes.put("64", "Confederated Tribes and Bands of the Yakama Nation");
+    tribeCodes.put("56", "Confederated Tribes of the Chehalis Reservation");
+    tribeCodes.put("57", "Confederated Tribes of the Colville Reservation");
+    tribeCodes.put("58", "Confederated Tribes of the Coos, Lower Umpqua and Siuslaw Indians");
+    tribeCodes.put("59", "Confederated Tribes of the Goshute Reservation, Nevada and Utah");
+    tribeCodes.put("60", "Confederated Tribes of the Grand Ronde Community of Oregon");
+    tribeCodes.put("61", "Confederated Tribes of Siletz Indians of Oregon");
+    tribeCodes.put("62", "Confederated Tribes of the Umatilla Indian Reservation");
+    tribeCodes.put("63", "Confederated Tribes of the Warm Springs Reservation of Oregon");
+    tribeCodes.put("65", "Coquille Indian Tribe");
+    tribeCodes.put("66", "Kletsel Dehe Band of Wintun Indians");
+    tribeCodes.put("67", "Coushatta Tribe of Louisiana");
+    tribeCodes.put("68", "Cow Creek Band of Umpqua Tribe of Indians");
+    tribeCodes.put("69", "Coyote Valley Band of Pomo Indians of California");
+    tribeCodes.put("71", "Crow Creek Sioux Tribe of the Crow Creek Reservation, South Dakota");
+    tribeCodes.put("70", "Crow Tribe of Montana");
+    tribeCodes.put("72", "Ewiiaapaayp Band of Kumeyaay Indians, California");
+    tribeCodes.put("73", "Timbisha Shoshone Tribe");
+    tribeCodes.put("74", "Delaware Nation, Oklahoma");
+    tribeCodes.put("75", "Delaware Tribe of Indians");
+    tribeCodes.put("76", "Dry Creek Rancheria Band of Pomo Indians, California");
+    tribeCodes.put("77", "Duckwater Shoshone Tribe of the Duckwater Reservation, Nevada");
+    tribeCodes.put("78", "Eastern Band of Cherokee Indians");
+    tribeCodes.put("79", "Eastern Shawnee Tribe of Oklahoma");
+    tribeCodes.put(
+        "80", "Elem Indian Colony of Pomo Indians of the Sulphur Bank Rancheria, California");
+    tribeCodes.put("81", "Elk Valley Rancheria, California");
+    tribeCodes.put("82", "Ely Shoshone Tribe of Nevada");
+    tribeCodes.put("83", "Enterprise Rancheria of Maidu Indians of California");
+    tribeCodes.put("84", "Flandreau Santee Sioux Tribe of South Dakota");
+    tribeCodes.put("85", "Forest County Potawatomi Community, Wisconsin");
+    tribeCodes.put(
+        "86", "Fort Belknap Indian Community of the Fort Belknap Reservation of Montana");
+    tribeCodes.put(
+        "87", "Fort Bidwell Indian Community of the Fort Bidwell Reservation of California");
+    tribeCodes.put(
+        "88",
+        "Fort Independence Indian Community of Paiute Indians of the Fort Independence Reservation, California");
+    tribeCodes.put(
+        "89",
+        "Fort McDermitt Paiute and Shoshone Tribes of the Fort McDermitt Indian Reservation, Nevada and Oregon");
+    tribeCodes.put("90", "Fort McDowell Yavapai Nation, Arizona");
+    tribeCodes.put("91", "Fort Mojave Indian Tribe of Arizona, California & Nevada");
+    tribeCodes.put("92", "Fort Sill Apache Tribe of Oklahoma");
+    tribeCodes.put(
+        "93", "Gila River Indian Community of the Gila River Indian Reservation, Arizona");
+    tribeCodes.put("94", "Grand Traverse Band of Ottawa and Chippewa Indians, Michigan");
+    tribeCodes.put("95", "Federated Indians of Graton Rancheria, California");
+    tribeCodes.put("96", "Greenville Rancheria");
+    tribeCodes.put("97", "Grindstone Indian Rancheria of Wintun-Wailaki Indians of California");
+    tribeCodes.put("98", "Guidiville Rancheria of California");
+    tribeCodes.put("99", "Hannahville Indian Community, Michigan");
+    tribeCodes.put("100", "Havasupai Tribe of the Havasupai Reservation, Arizona");
+    tribeCodes.put("101", "Ho-Chunk Nation of Wisconsin");
+    tribeCodes.put("102", "Hoh Indian Tribe");
+    tribeCodes.put("103", "Hoopa Valley Tribe, California");
+    tribeCodes.put("104", "Hopi Tribe of Arizona");
+    tribeCodes.put("105", "Hopland Band of Pomo Indians, California");
+    tribeCodes.put("106", "Houlton Band of Maliseet Indians");
+    tribeCodes.put("107", "Hualapai Indian Tribe of the Hualapai Indian Reservation, Arizona");
+    tribeCodes.put("108", "Nottawaseppi Huron Band of the Potawatomi, Michigan");
+    tribeCodes.put(
+        "109",
+        "Inaja Band of Diegueno Mission Indians of the Inaja and Cosmit Reservation, California");
+    tribeCodes.put("110", "Ione Band of Miwok Indians of California");
+    tribeCodes.put("111", "Iowa Tribe of Kansas and Nebraska");
+    tribeCodes.put("112", "Iowa Tribe of Oklahoma");
+    tribeCodes.put("113", "Jackson Band of Miwuk Indians");
+    tribeCodes.put("114", "Jamestown S'Klallam Tribe");
+    tribeCodes.put("115", "Jamul Indian Village of California");
+    tribeCodes.put("116", "Jena Band of Choctaw Indians");
+    tribeCodes.put("117", "Jicarilla Apache Nation, New Mexico");
+    tribeCodes.put(
+        "118", "Kaibab Band of Paiute Indians of the Kaibab Indian Reservation, Arizona");
+    tribeCodes.put("119", "Kalispel Indian Community of the Kalispel Reservation");
+    tribeCodes.put("120", "Karuk Tribe");
+    tribeCodes.put(
+        "121", "Kashia Band of Pomo Indians of the Stewarts Point Rancheria, California");
+    tribeCodes.put("122", "Kaw Nation, Oklahoma");
+    tribeCodes.put("123", "Keweenaw Bay Indian Community, Michigan");
+    tribeCodes.put("124", "Kialegee Tribal Town");
+    tribeCodes.put("127", "Kickapoo Traditional Tribe of Texas");
+    tribeCodes.put("125", "Kickapoo Tribe of Indians of the Kickapoo Reservation in Kansas");
+    tribeCodes.put("126", "Kickapoo Tribe of Oklahoma");
+    tribeCodes.put("128", "Kiowa Indian Tribe of Oklahoma");
+    tribeCodes.put("129", "Klamath Tribes");
+    tribeCodes.put("130", "Kootenai Tribe of Idaho");
+    tribeCodes.put("131", "La Jolla Band of Luiseno Indians, California");
+    tribeCodes.put(
+        "132",
+        "La Posta Band of Diegueno Mission Indians of the La Posta Indian Reservation, California");
+    tribeCodes.put(
+        "133", "Lac Courte Oreilles Band of Lake Superior Chippewa Indians of Wisconsin");
+    tribeCodes.put(
+        "134",
+        "Lac du Flambeau Band of Lake Superior Chippewa Indians of the Lac du Flambeau Reservation of Wisconsin");
+    tribeCodes.put("135", "Lac Vieux Desert Band of Lake Superior Chippewa Indians of Michigan");
+    tribeCodes.put(
+        "136", "Las Vegas Tribe of Paiute Indians of the Las Vegas Indian Colony, Nevada");
+    tribeCodes.put("137", "Little River Band of Ottawa Indians, Michigan");
+    tribeCodes.put("138", "Little Traverse Bay Bands of Odawa Indians, Michigan");
+    tribeCodes.put("140", "Los Coyotes Band of Cahuilla and Cupeno Indians, California");
+    tribeCodes.put("141", "Lovelock Paiute Tribe of the Lovelock Indian Colony, Nevada");
+    tribeCodes.put("142", "Lower Brule Sioux Tribe of the Lower Brule Reservation, South Dakota");
+    tribeCodes.put("143", "Lower Elwha Tribal Community");
+    tribeCodes.put("139", "Koi Nation of Northern California");
+    tribeCodes.put("144", "Lower Sioux Indian Community in the State of Minnesota");
+    tribeCodes.put("145", "Lummi Tribe of the Lummi Reservation");
+    tribeCodes.put("146", "Lytton Rancheria of California");
+    tribeCodes.put("147", "Makah Indian Tribe of the Makah Indian Reservation");
+    tribeCodes.put(
+        "148", "Manchester Band of Pomo Indians of the Manchester Rancheria, California");
+    tribeCodes.put(
+        "149",
+        "Manzanita Band of Diegueno Mission Indians of the Manzanita Reservation, California");
+    tribeCodes.put("150", "Mashantucket Pequot Indian Tribe");
+    tribeCodes.put("151", "Match-e-be-nash-she-wish Band of Pottawatomi Indians of Michigan");
+    tribeCodes.put("152", "Mechoopda Indian Tribe of Chico Rancheria, California");
+    tribeCodes.put("153", "Menominee Indian Tribe of Wisconsin");
+    tribeCodes.put(
+        "154",
+        "Mesa Grande Band of Diegueno Mission Indians of the Mesa Grande Reservation, California");
+    tribeCodes.put("155", "Mescalero Apache Tribe of the Mescalero Reservation, New Mexico");
+    tribeCodes.put("156", "Miami Tribe of Oklahoma");
+    tribeCodes.put("157", "Miccosukee Tribe of Indians");
+    tribeCodes.put("158", "Middletown Rancheria of Pomo Indians of California");
+    tribeCodes.put(
+        "159",
+        "Minnesota Chippewa Tribe, Minnesota (Six component reservations: Bois Forte Band (Nett Lake); Fond du Lac Band; Grand Portage Band; Leech Lake Band; Mille Lacs Band; White Earth Band)");
+    tribeCodes.put("160", "Bois Forte Band (Nett Lake); Fond du Lac Band; Gra");
+    tribeCodes.put("161", "Mississippi Band of Choctaw Indians");
+    tribeCodes.put(
+        "162", "Moapa Band of Paiute Indians of the Moapa River Indian Reservation, Nevada");
+    tribeCodes.put("163", "Modoc Nation");
+    tribeCodes.put("164", "Mohegan Tribe of Indians of Connecticut");
+    tribeCodes.put("165", "Mooretown Rancheria of Maidu Indians of California");
+    tribeCodes.put("166", "Morongo Band of Mission Indians, California");
+    tribeCodes.put("167", "Muckleshoot Indian Tribe");
+    tribeCodes.put("168", "The Muscogee (Creek) Nation");
+    tribeCodes.put("169", "Narragansett Indian Tribe");
+    tribeCodes.put("170", "Navajo Nation, Arizona, New Mexico, & Utah");
+    tribeCodes.put("171", "Nez Perce Tribe");
+    tribeCodes.put("172", "Nisqually Indian Tribe of the Nisqually Reservatio");
+    tribeCodes.put("173", "Nooksack Indian Tribe");
+    tribeCodes.put(
+        "174", "Northern Cheyenne Tribe of the Northern Cheyenne Indian Reservation, Montana");
+    tribeCodes.put("175", "Northfork Rancheria of Mono Indians of California");
+    tribeCodes.put("176", "Northwestern Band of the Shoshone Nation");
+    tribeCodes.put("177", "Oglala Sioux Tribe");
+    tribeCodes.put("178", "Omaha Tribe of Nebraska");
+    tribeCodes.put("179", "Oneida Indian Nation");
+    tribeCodes.put("180", "Oneida Nation");
+    tribeCodes.put("181", "Onondaga Nation");
+    tribeCodes.put("182", "The Osage Nation");
+    tribeCodes.put("184", "Otoe-Missouria Tribe of Indians, Oklahoma");
+    tribeCodes.put("183", "Ottawa Tribe of Oklahoma");
+    tribeCodes.put(
+        "185",
+        "Paiute Indian Tribe of Utah (Cedar Band of Paiutes, Kanosh Band of Paiutes, Koosharem Band of Paiutes, Indian Peaks Band of Paiutes, and Shivwits Band of Paiutes)");
+    tribeCodes.put("186", "Bishop Paiute Tribe");
+    tribeCodes.put("188", "Lone Pine Paiute-Shoshone Tribe");
+    tribeCodes.put("187", "Paiute-Shoshone Tribe of the Fallon Reservation and Colony, Nevada");
+    tribeCodes.put("189", "Pala Band of Mission Indians");
+    tribeCodes.put("190", "Pascua Yaqui Tribe of Arizona");
+    tribeCodes.put("191", "Paskenta Band of Nomlaki Indians of California");
+    tribeCodes.put("192", "Passamaquoddy Tribe");
+    tribeCodes.put(
+        "193",
+        "Pauma Band of Luiseno Mission Indians of the Pauma & Yuima Reservation, California");
+    tribeCodes.put("194", "Pawnee Nation of Oklahoma");
+    tribeCodes.put("195", "Pechanga Band of Indians");
+    tribeCodes.put("196", "Penobscot Nation");
+    tribeCodes.put("197", "Peoria Tribe of Indians of Oklahoma");
+    tribeCodes.put("198", "Picayune Rancheria of Chukchansi Indians of California");
+    tribeCodes.put("199", "Pinoleville Pomo Nation, California");
+    tribeCodes.put(
+        "200",
+        "Pit River Tribe, California (includes XL Ranch, Big Bend, Likely, Lookout, Montgomery Creek, and Roaring Creek Rancherias)");
+    tribeCodes.put("201", "Poarch Band of Creek Indians");
+    tribeCodes.put("202", "Pokagon Band of Potawatomi Indians, Michigan and Indiana");
+    tribeCodes.put("203", "Ponca Tribe of Indians of Oklahoma");
+    tribeCodes.put("204", "Ponca Tribe of Nebraska");
+    tribeCodes.put("205", "Port Gamble S'Klallam Tribe");
+    tribeCodes.put("206", "Potter Valley Tribe, California");
+    tribeCodes.put("207", "Prairie Band Potawatomi Nation");
+    tribeCodes.put("208", "Prairie Island Indian Community in the State of Minnesota");
+    tribeCodes.put("209", "Pueblo of Acoma, New Mexico");
+    tribeCodes.put("210", "Pueblo of Cochiti, New Mexico");
+    tribeCodes.put("212", "Pueblo of Isleta, New Mexico");
+    tribeCodes.put("211", "Pueblo of Jemez, New Mexico");
+    tribeCodes.put("213", "Pueblo of Laguna, New Mexico");
+    tribeCodes.put("214", "Pueblo of Nambe, New Mexico");
+    tribeCodes.put("215", "Pueblo of Picuris, New Mexico");
+    tribeCodes.put("216", "Pueblo of Pojoaque, New Mexico");
+    tribeCodes.put("217", "Pueblo of San Felipe, New Mexico");
+    tribeCodes.put("219", "Pueblo of San Ildefonso, New Mexico");
+    tribeCodes.put("218", "Ohkay Owingeh, New Mexico");
+    tribeCodes.put("220", "Pueblo of Sandia, New Mexico");
+    tribeCodes.put("221", "Pueblo of Santa Ana, New Mexico");
+    tribeCodes.put("222", "Pueblo of Santa Clara, New Mexico");
+    tribeCodes.put("223", "Santo Domingo Pueblo");
+    tribeCodes.put("224", "Pueblo of Taos, New Mexico");
+    tribeCodes.put("225", "Pueblo of Tesuque, New Mexico");
+    tribeCodes.put("226", "Pueblo of Zia, New Mexico");
+    tribeCodes.put("227", "Puyallup Tribe of the Puyallup Reservation");
+    tribeCodes.put("228", "Pyramid Lake Paiute Tribe of the Pyramid Lake Reservation, Nevada");
+    tribeCodes.put("229", "Quapaw Nation");
+    tribeCodes.put(
+        "230", "Quartz Valley Indian Community of the Quartz Valley Reservation of California");
+    tribeCodes.put(
+        "231", "Quechan Tribe of the Fort Yuma Indian Reservation, California & Arizona");
+    tribeCodes.put("232", "Quileute Tribe of the Quileute Reservation");
+    tribeCodes.put("233", "Quinault Indian Nation");
+    tribeCodes.put("234", "Ramona Band of Cahuilla, California");
+    tribeCodes.put("235", "Red Cliff Band of Lake Superior Chippewa Indians of Wisconsin");
+    tribeCodes.put("236", "Red Lake Band of Chippewa Indians, Minnesota");
+    tribeCodes.put("237", "Redding Rancheria, California");
+    tribeCodes.put(
+        "238",
+        "Redwood Valley or Little River Band of Pomo Indians of the Redwood Valley Rancheria California");
+    tribeCodes.put("239", "Reno-Sparks Indian Colony, Nevada");
+    tribeCodes.put("240", "Resighini Rancheria, California");
+    tribeCodes.put(
+        "241", "Rincon Band of Luiseno Mission Indians of Rincon Reservation, California");
+    tribeCodes.put("242", "Robinson Rancheria");
+    tribeCodes.put("243", "Rosebud Sioux Tribe of the Rosebud Indian Reservation, South Dakota");
+    tribeCodes.put("244", "Round Valley Indian Tribes, Round Valley Reservation, California");
+    tribeCodes.put("245", "Yocha Dehe Wintun Nation, California");
+    tribeCodes.put("247", "Sac & Fox Nation of Missouri in Kansas and Nebraska");
+    tribeCodes.put("248", "Sac & Fox Nation, Oklahoma");
+    tribeCodes.put("246", "Sac & Fox Tribe of the Mississippi in Iowa");
+    tribeCodes.put("249", "Saginaw Chippewa Indian Tribe of Michigan");
+    tribeCodes.put(
+        "250", "Salt River Pima-Maricopa Indian Community of the Salt River Reservation, Arizona");
+    tribeCodes.put("251", "Samish Indian Nation");
+    tribeCodes.put("252", "San Carlos Apache Tribe of the San Carlos Reservation, Arizona");
+    tribeCodes.put("253", "San Juan Southern Paiute Tribe of Arizona");
+    tribeCodes.put("254", "Yuhaaviatam of San Manuel Nation");
+    tribeCodes.put("255", "San Pasqual Band of Diegueno Mission Indians of California");
+    tribeCodes.put("257", "Santa Rosa Band of Cahuilla Indians, California");
+    tribeCodes.put("256", "Santa Rosa Indian Community of the Santa Rosa Rancheria, California");
+    tribeCodes.put(
+        "258",
+        "Santa Ynez Band of Chumash Mission Indians of the Santa Ynez Reservation, California");
+    tribeCodes.put("259", "Iipay Nation of Santa Ysabel, California");
+    tribeCodes.put("260", "Santee Sioux Nation, Nebraska");
+    tribeCodes.put("261", "Sauk-Suiattle Indian Tribe");
+    tribeCodes.put("262", "Sault Ste. Marie Tribe of Chippewa Indians, Michigan");
+    tribeCodes.put("263", "Scotts Valley Band of Pomo Indians of California");
+    tribeCodes.put("264", "The Seminole Nation of Oklahoma");
+    tribeCodes.put("265", "Seminole Tribe of Florida");
+    tribeCodes.put("266", "Seneca Nation of Indians");
+    tribeCodes.put("267", "Seneca-Cayuga Nation");
+    tribeCodes.put("268", "Shakopee Mdewakanton Sioux Community of Minnesota");
+    tribeCodes.put("269", "Shawnee Tribe");
+    tribeCodes.put("270", "Sherwood Valley Rancheria of Pomo Indians of California");
+    tribeCodes.put(
+        "271",
+        "Shingle Springs Band of Miwok Indians, Shingle Springs Rancheria (Verona Tract), California");
+    tribeCodes.put("272", "Shoalwater Bay Indian Tribe of the Shoalwater Bay Indian Reservation");
+    tribeCodes.put("273", "Eastern Shoshone Tribe of the Wind River Reservation, Wyoming");
+    tribeCodes.put("274", "Shoshone-Bannock Tribes of the Fort Hall Reservation");
+    tribeCodes.put("275", "Shoshone-Paiute Tribes of the Duck Valley Reservation, Nevada");
+    tribeCodes.put("276", "Sisseton-Wahpeton Oyate of the Lake Traverse Reservation, South Dakota");
+    tribeCodes.put("277", "Skokomish Indian Tribe");
+    tribeCodes.put("278", "Skull Valley Band of Goshute Indians of Utah");
+    tribeCodes.put("279", "Tolowa Dee-ni' Nation");
+    tribeCodes.put("280", "Snoqualmie Indian Tribe");
+    tribeCodes.put("281", "Soboba Band of Luiseno Indians, California");
+    tribeCodes.put("282", "Sokaogon Chippewa Community, Wisconsin");
+    tribeCodes.put("283", "Southern Ute Indian Tribe of the Southern Ute Reservation, Colorado");
+    tribeCodes.put("284", "Spirit Lake Tribe, North Dakota");
+    tribeCodes.put("285", "Spokane Tribe of the Spokane Reservation");
+    tribeCodes.put("286", "Squaxin Island Tribe of the Squaxin Island Reservation");
+    tribeCodes.put("287", "St. Croix Chippewa Indians of Wisconsin");
+    tribeCodes.put("288", "Saint Regis Mohawk Tribe");
+    tribeCodes.put("289", "Standing Rock Sioux Tribe of North & South Dakota");
+    tribeCodes.put("291", "Stillaguamish Tribe of Indians of Washington");
+    tribeCodes.put("290", "Stockbridge Munsee Community, Wisconsin");
+    tribeCodes.put("292", "Summit Lake Paiute Tribe of Nevada");
+    tribeCodes.put("293", "Suquamish Indian Tribe of the Port Madison Reservation");
+    tribeCodes.put("294", "Susanville Indian Rancheria, California");
+    tribeCodes.put("295", "Swinomish Indian Tribal Community");
+    tribeCodes.put("296", "Sycuan Band of the Kumeyaay Nation");
+    tribeCodes.put("297", "Wiyot Tribe, California");
+    tribeCodes.put("298", "Table Mountain Rancheria");
+    tribeCodes.put(
+        "299",
+        "Te-Moak Tribe of Western Shoshone Indians of Nevada (Four constituent bands: Battle Mountain Band; Elko Band; South Fork Band; and Wells Band)");
+    tribeCodes.put("300", "Thlopthlocco Tribal Town");
+    tribeCodes.put("301", "Three Affiliated Tribes of the Fort Berthold Reservation, North Dakota");
+    tribeCodes.put("302", "Tohono O'odham Nation of Arizona");
+    tribeCodes.put("303", "Tonawanda Band of Seneca");
+    tribeCodes.put("304", "Tonkawa Tribe of Indians of Oklahoma");
+    tribeCodes.put("305", "Tonto Apache Tribe of Arizona");
+    tribeCodes.put("306", "Torres Martinez Desert Cahuilla Indians, California");
+    tribeCodes.put("308", "Tulalip Tribes of Washington");
+    tribeCodes.put("307", "Tule River Indian Tribe of the Tule River Reservation, California");
+    tribeCodes.put("309", "Tunica-Biloxi Indian Tribe");
+    tribeCodes.put(
+        "310", "Tuolumne Band of Me-Wuk Indians of the Tuolumne Rancheria of California");
+    tribeCodes.put("311", "Turtle Mountain Band of Chippewa Indians of North Dakota");
+    tribeCodes.put("312", "Tuscarora Nation");
+    tribeCodes.put("313", "Twenty-Nine Palms Band of Mission Indians of California");
+    tribeCodes.put("314", "United Auburn Indian Community of the Auburn Rancheria of California");
+    tribeCodes.put("315", "United Keetoowah Band of Cherokee Indians in Oklahoma");
+    tribeCodes.put("316", "Habematolel Pomo of Upper Lake, California");
+    tribeCodes.put("317", "Upper Sioux Community, Minnesota");
+    tribeCodes.put("318", "Upper Skagit Indian Tribe");
+    tribeCodes.put("319", "Ute Indian Tribe of the Uintah & Ouray Reservation, Utah");
+    tribeCodes.put("320", "Ute Mountain Ute Tribe");
+    tribeCodes.put(
+        "321", "Utu Utu Gwaitu Paiute Tribe of the Benton Paiute Reservation, California");
+    tribeCodes.put("34", "Viejas (Baron Long) Group of Capitan Grande Band o");
+    tribeCodes.put("322", "Walker River Paiute Tribe of the Walker River Reservation, Nevada");
+    tribeCodes.put("323", "Wampanoag Tribe of Gay Head (Aquinnah)");
+    tribeCodes.put(
+        "324",
+        "Washoe Tribe of Nevada & California (Carson Colony, Dresslerville Colony, Woodfords Community, Stewart Community, & Washoe Ranches)");
+    tribeCodes.put("325", "White Mountain Apache Tribe of the Fort Apache Reservation, Arizona");
+    tribeCodes.put(
+        "326", "Wichita and Affiliated Tribes (Wichita, Keechi, Waco, & Tawakonie), Oklahoma");
+    tribeCodes.put("327", "Winnebago Tribe of Nebraska");
+    tribeCodes.put("328", "Winnemucca Indian Colony of Nevada");
+    tribeCodes.put("329", "Wyandotte Nation");
+    tribeCodes.put("330", "Yankton Sioux Tribe of South Dakota");
+    tribeCodes.put("331", "Yavapai-Apache Nation of the Camp Verde Indian Reservation, Arizona");
+    tribeCodes.put("332", "Yavapai-Prescott Indian Tribe");
+    tribeCodes.put(
+        "333", "Yerington Paiute Tribe of the Yerington Colony & Campbell Ranch, Nevada");
+    tribeCodes.put("334", "Yomba Shoshone Tribe of the Yomba Reservation, Nevada");
+    tribeCodes.put("335", "Ysleta del Sur Pueblo");
+    tribeCodes.put("336", "Yurok Tribe of the Yurok Reservation, California");
+    tribeCodes.put("337", "Zuni Tribe of the Zuni Reservation, New Mexico");
+    tribeCodes.put("338", "Native Village of Afognak");
+    tribeCodes.put("339", "Agdaagux Tribe of King Cove");
+    tribeCodes.put("340", "Native Village of Akhiok");
+    tribeCodes.put("341", "Akiachak Native Community");
+    tribeCodes.put("342", "Akiak Native Community");
+    tribeCodes.put("343", "Native Village of Akutan");
+    tribeCodes.put("344", "Village of Alakanuk");
+    tribeCodes.put("345", "Alatna Village");
+    tribeCodes.put("346", "Native Village of Aleknagik");
+    tribeCodes.put("347", "Algaaciq Native Village (St. Mary's)");
+    tribeCodes.put("348", "Allakaket Village");
+    tribeCodes.put("349", "Native Village of Ambler");
+    tribeCodes.put("350", "Village of Anaktuvuk Pass");
+    tribeCodes.put("351", "Yupiit of Andreafski");
+    tribeCodes.put("352", "Angoon Community Association");
+    tribeCodes.put("353", "Village of Aniak");
+    tribeCodes.put("354", "Anvik Village");
+    tribeCodes.put("355", "Arctic Village");
+    tribeCodes.put("356", "Asa'carsarmiut Tribe");
+    tribeCodes.put("357", "Native Village of Atka");
+    tribeCodes.put("358", "Village of Atmautluak");
+    tribeCodes.put("359", "Native Village of Atqasuk");
+    tribeCodes.put("360", "Native Village of Barrow Inupiat Traditional Government");
+    tribeCodes.put("361", "Beaver Village");
+    tribeCodes.put("362", "Native Village of Belkofski");
+    tribeCodes.put("363", "Village of Bill Moore's Slough");
+    tribeCodes.put("364", "Birch Creek Tribe");
+    tribeCodes.put("365", "Native Village of Brevig Mission");
+    tribeCodes.put("366", "Native Village of Buckland");
+    tribeCodes.put("367", "Native Village of Cantwell");
+    tribeCodes.put("368", "Native Village of Chenega (aka Chanega)");
+    tribeCodes.put("369", "Chalkyitsik Village");
+    tribeCodes.put("370", "Village of Chefornak");
+    tribeCodes.put("371", "Chevak Native Village");
+    tribeCodes.put("372", "Chickaloon Native Village");
+    tribeCodes.put("373", "Chignik Bay Tribal Council");
+    tribeCodes.put("374", "Native Village of Chignik Lagoon");
+    tribeCodes.put("375", "Chignik Lake Village");
+    tribeCodes.put("376", "Chilkat Indian Village (Klukwan)");
+    tribeCodes.put("377", "Chilkoot Indian Association (Haines)");
+    tribeCodes.put("378", "Chinik Eskimo Community (Golovin)");
+    tribeCodes.put("379", "Cheesh-Na Tribe");
+    tribeCodes.put("380", "Native Village of Chitina");
+    tribeCodes.put("381", "Native Village of Chuathbaluk (Russian Mission, Kuskokwim)");
+    tribeCodes.put("382", "Chuloonawick Native Village");
+    tribeCodes.put("383", "Circle Native Community");
+    tribeCodes.put("384", "Village of Clarks Point");
+    tribeCodes.put("385", "Native Village of Council");
+    tribeCodes.put("386", "Craig Tribal Association");
+    tribeCodes.put("387", "Village of Crooked Creek");
+    tribeCodes.put("388", "Curyung Tribal Council");
+    tribeCodes.put("389", "Native Village of Deering");
+    tribeCodes.put("390", "Native Village of Diomede (aka Inalik)");
+    tribeCodes.put("391", "Village of Dot Lake");
+    tribeCodes.put("392", "Douglas Indian Association");
+    tribeCodes.put("393", "Native Village of Eagle");
+    tribeCodes.put("394", "Native Village of Eek");
+    tribeCodes.put("395", "Egegik Village");
+    tribeCodes.put("396", "Eklutna Native Village");
+    tribeCodes.put("397", "Native Village of Ekuk");
+    tribeCodes.put("398", "Native Village of Ekwok");
+    tribeCodes.put("399", "Native Village of Elim");
+    tribeCodes.put("400", "Emmonak Village");
+    tribeCodes.put("401", "Evansville Village (aka Bettles Field)");
+    tribeCodes.put("402", "Native Village of Eyak (Cordova)");
+    tribeCodes.put("403", "Native Village of False Pass");
+    tribeCodes.put("404", "Native Village of Fort Yukon");
+    tribeCodes.put("405", "Native Village of Gakona");
+    tribeCodes.put("406", "Galena Village (aka Louden Village)");
+    tribeCodes.put("407", "Native Village of Gambell");
+    tribeCodes.put("408", "Native Village of Georgetown");
+    tribeCodes.put("409", "Native Village of Goodnews Bay");
+    tribeCodes.put("410", "Organized Village of Grayling (aka Holikachuk)");
+    tribeCodes.put("411", "Gulkana Village Council");
+    tribeCodes.put("412", "Native Village of Hamilton");
+    tribeCodes.put("413", "Healy Lake Village");
+    tribeCodes.put("414", "Holy Cross Tribe");
+    tribeCodes.put("415", "Hoonah Indian Association");
+    tribeCodes.put("416", "Native Village of Hooper Bay");
+    tribeCodes.put("417", "Hughes Village");
+    tribeCodes.put("418", "Huslia Village");
+    tribeCodes.put("419", "Hydaburg Cooperative Association");
+    tribeCodes.put("420", "Igiugig Village");
+    tribeCodes.put("421", "Village of Iliamna");
+    tribeCodes.put("422", "Inupiat Community of the Arctic Slope");
+    tribeCodes.put("423", "Iqugmiut Traditional Council");
+    tribeCodes.put("424", "Ivanof Bay Tribe");
+    tribeCodes.put("425", "Kaguyak Village");
+    tribeCodes.put("426", "Organized Village of Kake");
+    tribeCodes.put("427", "Kaktovik Village (aka Barter Island)");
+    tribeCodes.put("428", "Village of Kalskag");
+    tribeCodes.put("429", "Village of Kaltag");
+    tribeCodes.put("430", "Native Village of Kanatak");
+    tribeCodes.put("431", "Native Village of Karluk");
+    tribeCodes.put("432", "Organized Village of Kasaan");
+    tribeCodes.put("433", "Kasigluk Traditional Elders Council");
+    tribeCodes.put("434", "Kenaitze Indian Tribe");
+    tribeCodes.put("435", "Ketchikan Indian Community");
+    tribeCodes.put("436", "Native Village of Kiana");
+    tribeCodes.put("437", "King Island Native Community");
+    tribeCodes.put("438", "King Salmon Tribe");
+    tribeCodes.put("439", "Native Village of Kipnuk");
+    tribeCodes.put("440", "Native Village of Kivalina");
+    tribeCodes.put("441", "Klawock Cooperative Association");
+    tribeCodes.put("442", "Native Village of Kluti Kaah (aka Copper Center)");
+    tribeCodes.put("443", "Knik Tribe");
+    tribeCodes.put("444", "Native Village of Kobuk");
+    tribeCodes.put("445", "Kokhanok Village");
+    tribeCodes.put("446", "Native Village of Kongiganak");
+    tribeCodes.put("447", "Village of Kotlik");
+    tribeCodes.put("448", "Native Village of Kotzebue");
+    tribeCodes.put("449", "Native Village of Koyuk");
+    tribeCodes.put("450", "Koyukuk Native Village");
+    tribeCodes.put("451", "Organized Village of Kwethluk");
+    tribeCodes.put("452", "Native Village of Kwigillingok");
+    tribeCodes.put("453", "Native Village of Kwinhagak (aka Quinhagak)");
+    tribeCodes.put("454", "Native Village of Larsen Bay");
+    tribeCodes.put("455", "Levelock Village");
+    tribeCodes.put("456", "Tangirnaq Native Village");
+    tribeCodes.put("457", "Lime Village");
+    tribeCodes.put("458", "Village of Lower Kalskag");
+    tribeCodes.put("459", "Manley Hot Springs Village");
+    tribeCodes.put("460", "Manokotak Village");
+    tribeCodes.put("461", "Native Village of Marshall (aka Fortuna Ledge)");
+    tribeCodes.put("462", "Native Village of Mary's Igloo");
+    tribeCodes.put("463", "McGrath Native Village");
+    tribeCodes.put("464", "Native Village of Mekoryuk");
+    tribeCodes.put("465", "Mentasta Traditional Council");
+    tribeCodes.put("466", "Metlakatla Indian Community, Annette Island Reserve");
+    tribeCodes.put("467", "Native Village of Minto");
+    tribeCodes.put("468", "Naknek Native Village");
+    tribeCodes.put("469", "Native Village of Nanwalek (aka English Bay)");
+    tribeCodes.put("470", "Native Village of Napaimute");
+    tribeCodes.put("471", "Native Village of Napakiak");
+    tribeCodes.put("472", "Native Village of Napaskiak");
+    tribeCodes.put("473", "Native Village of Nelson Lagoon");
+    tribeCodes.put("474", "Nenana Native Association");
+    tribeCodes.put("475", "New Koliganek Village Council");
+    tribeCodes.put("476", "New Stuyahok Village");
+    tribeCodes.put("477", "Newhalen Village");
+    tribeCodes.put("478", "Newtok Village");
+    tribeCodes.put("479", "Native Village of Nightmute");
+    tribeCodes.put("480", "Nikolai Village");
+    tribeCodes.put("481", "Native Village of Nikolski");
+    tribeCodes.put("482", "Ninilchik Village");
+    tribeCodes.put("483", "Native Village of Noatak");
+    tribeCodes.put("484", "Nome Eskimo Community");
+    tribeCodes.put("485", "Nondalton Village");
+    tribeCodes.put("486", "Noorvik Native Community");
+    tribeCodes.put("487", "Northway Village");
+    tribeCodes.put("488", "Native Village of Nuiqsut (aka Nooiksut)");
+    tribeCodes.put("489", "Nulato Village");
+    tribeCodes.put("490", "Nunakauyarmiut Tribe");
+    tribeCodes.put("491", "Native Village of Nunapitchuk");
+    tribeCodes.put("492", "Village of Ohogamiut");
+    tribeCodes.put("493", "Alutiiq Tribe of Old Harbor");
+    tribeCodes.put("494", "Orutsararmiut Traditional Native Council");
+    tribeCodes.put("495", "Oscarville Traditional Village");
+    tribeCodes.put("496", "Native Village of Ouzinkie");
+    tribeCodes.put("497", "Native Village of Paimiut");
+    tribeCodes.put("498", "Pauloff Harbor Village");
+    tribeCodes.put("499", "Pedro Bay Village");
+    tribeCodes.put("500", "Native Village of Perryville");
+    tribeCodes.put("501", "Petersburg Indian Association");
+    tribeCodes.put("502", "Native Village of Pilot Point");
+    tribeCodes.put("503", "Pilot Station Traditional Village");
+    tribeCodes.put("504", "Pitka's Point Traditional Council");
+    tribeCodes.put("505", "Platinum Traditional Village");
+    tribeCodes.put("506", "Native Village of Point Hope");
+    tribeCodes.put("507", "Native Village of Point Lay");
+    tribeCodes.put("508", "Native Village of Port Graham");
+    tribeCodes.put("509", "Native Village of Port Heiden");
+    tribeCodes.put("510", "Native Village of Port Lions");
+    tribeCodes.put("511", "Portage Creek Village (aka Ohgsenakale)");
+    tribeCodes.put(
+        "512",
+        "Pribilof Islands Aleut Communities of St. Paul & St. George Islands (Saint George Island and Saint Paul Island)");
+    tribeCodes.put("513", "Qagan Tayagungin Tribe of Sand Point");
+    tribeCodes.put("514", "Qawalangin Tribe of Unalaska");
+    tribeCodes.put("515", "Rampart Village");
+    tribeCodes.put("516", "Village of Red Devil");
+    tribeCodes.put("517", "Native Village of Ruby");
+    tribeCodes.put("518", "Saint George Island");
+    tribeCodes.put("519", "Native Village of Saint Michael");
+    tribeCodes.put("520", "Saint Paul Island");
+    tribeCodes.put("521", "Salamatof Tribe");
+    tribeCodes.put("522", "Native Village of Savoonga");
+    tribeCodes.put("523", "Organized Village of Saxman");
+    tribeCodes.put("524", "Native Village of Scammon Bay");
+    tribeCodes.put("525", "Native Village of Selawik");
+    tribeCodes.put("526", "Seldovia Village Tribe");
+    tribeCodes.put("527", "Shageluk Native Village");
+    tribeCodes.put("528", "Native Village of Shaktoolik");
+    tribeCodes.put("529", "Native Village of Nunam Iqua");
+    tribeCodes.put("530", "Native Village of Shishmaref");
+    tribeCodes.put("531", "Sun'aq Tribe of Kodiak");
+    tribeCodes.put("532", "Native Village of Shungnak");
+    tribeCodes.put("533", "Sitka Tribe of Alaska");
+    tribeCodes.put("534", "Skagway Village");
+    tribeCodes.put("535", "Village of Sleetmute");
+    tribeCodes.put("536", "Village of Solomon");
+    tribeCodes.put("537", "South Naknek Village");
+    tribeCodes.put("538", "Stebbins Community Association");
+    tribeCodes.put("539", "Native Village of Stevens");
+    tribeCodes.put("540", "Village of Stony River");
+    tribeCodes.put("541", "Takotna Village");
+    tribeCodes.put("542", "Native Village of Tanacross");
+    tribeCodes.put("543", "Native Village of Tanana");
+    tribeCodes.put("544", "Native Village of Tatitlek");
+    tribeCodes.put("545", "Native Village of Tazlina");
+    tribeCodes.put("546", "Telida Village");
+    tribeCodes.put("547", "Native Village of Teller");
+    tribeCodes.put("548", "Native Village of Tetlin");
+    tribeCodes.put("549", "Central Council of the Tlingit & Haida Indian Tribes");
+    tribeCodes.put("550", "Traditional Village of Togiak");
+    tribeCodes.put("551", "Tuluksak Native Community");
+    tribeCodes.put("552", "Native Village of Tuntutuliak");
+    tribeCodes.put("553", "Native Village of Tununak");
+    tribeCodes.put("554", "Twin Hills Village");
+    tribeCodes.put("555", "Native Village of Tyonek");
+    tribeCodes.put("556", "Ugashik Village");
+    tribeCodes.put("557", "Umkumiut Native Village");
+    tribeCodes.put("558", "Native Village of Unalakleet");
+    tribeCodes.put("559", "Native Village of Unga");
+    tribeCodes.put("560", "Village of Venetie");
+    tribeCodes.put(
+        "561",
+        "Native Village of Venetie Tribal Government (Arctic Village and Village of Venetie)");
+    tribeCodes.put("562", "Village of Wainwright");
+    tribeCodes.put("563", "Native Village of Wales");
+    tribeCodes.put("564", "Native Village of White Mountain");
+    tribeCodes.put("565", "Wrangell Cooperative Association");
+    tribeCodes.put("566", "Yakutat Tlingit Tribe");
+    tribeCodes.put("567", "Chickahominy Indian Tribe");
+    tribeCodes.put("568", "Chickahominy Indian Tribe—Eastern Division");
+    tribeCodes.put("569", "Monacan Indian Nation");
+    tribeCodes.put("570", "Nansemond Indian Nation");
+    tribeCodes.put("571", "Rappahannock Tribe, Inc.");
+    tribeCodes.put("572", "Upper Mattaponi Tribe");
+    tribeCodes.put("573", "Cowlitz Indian Tribe");
+    tribeCodes.put("574", "Little Shell Tribe of Chippewa Indians of Montana");
+    tribeCodes.put("575", "Mashpee Wampanoag Tribe");
+    tribeCodes.put("576", "Pamunkey Indian Tribe");
+    tribeCodes.put("577", "Shinnecock Indian Nation");
+    tribeCodes.put("578", "Wilton Rancheria, California");
+    tribeCodes.put("579", "Tejon Indian Tribe");
+    return tribeCodes;
+  }
 
-    public static final Map<String, String> raceMap = new HashMap<>();
-    private static final String NATIVE_CODE = "1002-5";
-    private static final String ASIAN_CODE = "2028-9";
-    private static final String BLACK_CODE = "2054-5";
-    private static final String PACIFIC_CODE = "2076-8";
-    private static final String WHITE_CODE = "2106-3";
-    private static final String OTHER_CODE = "2131-1";
+  public static final Map<String, String> raceMap = new HashMap<>();
+  private static final String NATIVE_CODE = "1002-5";
+  private static final String ASIAN_CODE = "2028-9";
+  private static final String BLACK_CODE = "2054-5";
+  private static final String PACIFIC_CODE = "2076-8";
+  private static final String WHITE_CODE = "2106-3";
+  private static final String OTHER_CODE = "2131-1";
 
-    static {
-        raceMap.put("native", NATIVE_CODE);
-        raceMap.put(NATIVE_CODE, "native");
-        raceMap.put("american indian or alaska native", NATIVE_CODE);
-        raceMap.put("asian", ASIAN_CODE);
-        raceMap.put(ASIAN_CODE, "asian");
-        raceMap.put("black", BLACK_CODE);
-        raceMap.put(BLACK_CODE, "black");
-        raceMap.put("black or african american", BLACK_CODE);
-        raceMap.put("pacific", PACIFIC_CODE);
-        raceMap.put(PACIFIC_CODE, "pacific");
-        raceMap.put("native hawaiian or other pacific islander", PACIFIC_CODE);
-        raceMap.put("white", WHITE_CODE);
-        raceMap.put(WHITE_CODE, "white");
-        raceMap.put("other", OTHER_CODE);
-        raceMap.put(OTHER_CODE, "other");
-        raceMap.put("unknown", MappingConstants.UNK_CODE);
-        raceMap.put("unk", MappingConstants.UNK_CODE);
-        raceMap.put("refused", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
-        raceMap.put("ask, but unknown", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
-        raceMap.put("asku", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
-    }
+  static {
+    raceMap.put("native", NATIVE_CODE);
+    raceMap.put(NATIVE_CODE, "native");
+    raceMap.put("american indian or alaska native", NATIVE_CODE);
+    raceMap.put("asian", ASIAN_CODE);
+    raceMap.put(ASIAN_CODE, "asian");
+    raceMap.put("black", BLACK_CODE);
+    raceMap.put(BLACK_CODE, "black");
+    raceMap.put("black or african american", BLACK_CODE);
+    raceMap.put("pacific", PACIFIC_CODE);
+    raceMap.put(PACIFIC_CODE, "pacific");
+    raceMap.put("native hawaiian or other pacific islander", PACIFIC_CODE);
+    raceMap.put("white", WHITE_CODE);
+    raceMap.put(WHITE_CODE, "white");
+    raceMap.put("other", OTHER_CODE);
+    raceMap.put(OTHER_CODE, "other");
+    raceMap.put("unknown", MappingConstants.UNK_CODE);
+    raceMap.put("unk", MappingConstants.UNK_CODE);
+    raceMap.put("refused", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
+    raceMap.put("ask, but unknown", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
+    raceMap.put("asku", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
+  }
 
-    private static final List<String> hispanic = List.of("H", "Hispanic or Latino");
-    private static final List<String> not_hispanic = List.of("N", "Not Hispanic or Latino");
-    public static final Map<String, List<String>> ETHNICITY_MAP =
-            Map.of(
-                    "hispanic", hispanic,
-                    "hispanic or latino", hispanic,
-                    "2135-2", hispanic,
-                    "not_hispanic", not_hispanic,
-                    "not hispanic or latino", not_hispanic,
-                    "2186-5", not_hispanic,
-                    "refused", List.of("U", "unknown"));
+  private static final List<String> hispanic = List.of("H", "Hispanic or Latino");
+  private static final List<String> not_hispanic = List.of("N", "Not Hispanic or Latino");
+  public static final Map<String, List<String>> ETHNICITY_MAP =
+      Map.of(
+          "hispanic", hispanic,
+          "hispanic or latino", hispanic,
+          "2135-2", hispanic,
+          "not_hispanic", not_hispanic,
+          "not hispanic or latino", not_hispanic,
+          "2186-5", not_hispanic,
+          "refused", List.of("U", "unknown"));
 
-    public static final String HOSPITAL_LITERAL = "hospital";
-    public static final String HOSPITAL_SNOMED = "22232009";
-    public static final String HOSPITAL_SHIP_LITERAL = "hospital ship";
-    public static final String HOSPITAL_SHIP_SNOMED = "2081004";
-    public static final String LONG_TERM_HOSPITAL_LITERAL = "long term care hospital";
-    public static final String LONG_TERM_HOSPITAL_SNOMED = "32074000";
-    public static final String SECURE_HOSPITAL_LITERAL = "secure hospital";
-    public static final String SECURE_HOSPITAL_SNOMED = "224929004";
-    public static final String NURSING_HOME_LITERAL = "nursing home";
-    public static final String NURSING_HOME_SNOMED = "42665001";
-    public static final String RETIREMENT_HOME_LITERAL = "retirement home";
-    public static final String RETIREMENT_HOME_SNOMED = "30629002";
-    public static final String ORPHANAGE_LITERAL = "orphanage";
-    public static final String ORPHANAGE_SNOMED = "74056004";
-    public static final String PRISON_BASED_CARE_LITERAL = "prison-based care site";
-    public static final String PRISON_BASED_CARE_SNOMED = "722173008";
-    public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL =
-            "substance abuse treatment center";
-    public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED = "20078004";
-    public static final String BOARDING_HOUSE_LITERAL = "boarding house";
-    public static final String BOARDING_HOUSE_SNOMED = "257573002";
-    public static final String MILITARY_ACCOMMODATION_LITERAL = "military accommodation";
-    public static final String MILITARY_ACCOMMODATION_SNOMED = "224683003";
-    public static final String HOSPICE_LITERAL = "hospice";
-    public static final String HOSPICE_SNOMED = "284546000";
-    public static final String HOSTEL_LITERAL = "hostel";
-    public static final String HOSTEL_SNOMED = "257628001";
-    public static final String SHELTERED_HOUSING_LITERAL = "sheltered housing";
-    public static final String SHELTERED_HOUSING_SNOMED = "310207003";
-    public static final String PENAL_INSTITUTION_LITERAL = "penal institution";
-    public static final String PENAL_INSTITUTION_SNOMED = "57656006";
-    public static final String RELIGIOUS_RESIDENCE_LITERAL = "religious institutional residence";
-    public static final String RELIGIOUS_RESIDENCE_SNOMED = "285113009";
-    public static final String WORK_ENVIRONMENT_LITERAL = "work (environment)";
-    public static final String WORK_ENVIRONMENT_SNOMED = "285141008";
-    public static final String HOMELESS_LITERAL = "homeless";
-    public static final String HOMELESS_SNOMED = "32911000";
+  public static final String HOSPITAL_LITERAL = "hospital";
+  public static final String HOSPITAL_SNOMED = "22232009";
+  public static final String HOSPITAL_SHIP_LITERAL = "hospital ship";
+  public static final String HOSPITAL_SHIP_SNOMED = "2081004";
+  public static final String LONG_TERM_HOSPITAL_LITERAL = "long term care hospital";
+  public static final String LONG_TERM_HOSPITAL_SNOMED = "32074000";
+  public static final String SECURE_HOSPITAL_LITERAL = "secure hospital";
+  public static final String SECURE_HOSPITAL_SNOMED = "224929004";
+  public static final String NURSING_HOME_LITERAL = "nursing home";
+  public static final String NURSING_HOME_SNOMED = "42665001";
+  public static final String RETIREMENT_HOME_LITERAL = "retirement home";
+  public static final String RETIREMENT_HOME_SNOMED = "30629002";
+  public static final String ORPHANAGE_LITERAL = "orphanage";
+  public static final String ORPHANAGE_SNOMED = "74056004";
+  public static final String PRISON_BASED_CARE_LITERAL = "prison-based care site";
+  public static final String PRISON_BASED_CARE_SNOMED = "722173008";
+  public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL =
+      "substance abuse treatment center";
+  public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED = "20078004";
+  public static final String BOARDING_HOUSE_LITERAL = "boarding house";
+  public static final String BOARDING_HOUSE_SNOMED = "257573002";
+  public static final String MILITARY_ACCOMMODATION_LITERAL = "military accommodation";
+  public static final String MILITARY_ACCOMMODATION_SNOMED = "224683003";
+  public static final String HOSPICE_LITERAL = "hospice";
+  public static final String HOSPICE_SNOMED = "284546000";
+  public static final String HOSTEL_LITERAL = "hostel";
+  public static final String HOSTEL_SNOMED = "257628001";
+  public static final String SHELTERED_HOUSING_LITERAL = "sheltered housing";
+  public static final String SHELTERED_HOUSING_SNOMED = "310207003";
+  public static final String PENAL_INSTITUTION_LITERAL = "penal institution";
+  public static final String PENAL_INSTITUTION_SNOMED = "57656006";
+  public static final String RELIGIOUS_RESIDENCE_LITERAL = "religious institutional residence";
+  public static final String RELIGIOUS_RESIDENCE_SNOMED = "285113009";
+  public static final String WORK_ENVIRONMENT_LITERAL = "work (environment)";
+  public static final String WORK_ENVIRONMENT_SNOMED = "285141008";
+  public static final String HOMELESS_LITERAL = "homeless";
+  public static final String HOMELESS_SNOMED = "32911000";
 
-    public static final Map<String, String> getResidenceTypeMap() {
-        Map<String, String> residenceTypeMap = new HashMap<>();
-        residenceTypeMap.put(HOSPITAL_SNOMED, HOSPITAL_LITERAL);
-        residenceTypeMap.put(HOSPITAL_LITERAL, HOSPITAL_SNOMED);
-        residenceTypeMap.put(HOSPITAL_SHIP_SNOMED, HOSPITAL_SHIP_LITERAL);
-        residenceTypeMap.put(HOSPITAL_SHIP_LITERAL, HOSPITAL_SHIP_SNOMED);
-        residenceTypeMap.put(LONG_TERM_HOSPITAL_SNOMED, LONG_TERM_HOSPITAL_LITERAL);
-        residenceTypeMap.put(LONG_TERM_HOSPITAL_LITERAL, LONG_TERM_HOSPITAL_SNOMED);
-        residenceTypeMap.put(SECURE_HOSPITAL_SNOMED, SECURE_HOSPITAL_LITERAL);
-        residenceTypeMap.put(SECURE_HOSPITAL_LITERAL, SECURE_HOSPITAL_SNOMED);
-        residenceTypeMap.put(NURSING_HOME_SNOMED, NURSING_HOME_LITERAL);
-        residenceTypeMap.put(NURSING_HOME_LITERAL, NURSING_HOME_SNOMED);
-        residenceTypeMap.put(RETIREMENT_HOME_SNOMED, RETIREMENT_HOME_LITERAL);
-        residenceTypeMap.put(RETIREMENT_HOME_LITERAL, RETIREMENT_HOME_SNOMED);
-        residenceTypeMap.put(ORPHANAGE_SNOMED, ORPHANAGE_LITERAL);
-        residenceTypeMap.put(ORPHANAGE_LITERAL, ORPHANAGE_SNOMED);
-        residenceTypeMap.put(PRISON_BASED_CARE_SNOMED, PRISON_BASED_CARE_LITERAL);
-        residenceTypeMap.put(PRISON_BASED_CARE_LITERAL, PRISON_BASED_CARE_SNOMED);
-        residenceTypeMap.put(
-                SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED, SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL);
-        residenceTypeMap.put(
-                SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL, SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED);
-        residenceTypeMap.put(BOARDING_HOUSE_SNOMED, BOARDING_HOUSE_LITERAL);
-        residenceTypeMap.put(BOARDING_HOUSE_LITERAL, BOARDING_HOUSE_SNOMED);
-        residenceTypeMap.put(MILITARY_ACCOMMODATION_SNOMED, MILITARY_ACCOMMODATION_LITERAL);
-        residenceTypeMap.put(MILITARY_ACCOMMODATION_LITERAL, MILITARY_ACCOMMODATION_SNOMED);
-        residenceTypeMap.put(HOSPICE_SNOMED, HOSPICE_LITERAL);
-        residenceTypeMap.put(HOSPICE_LITERAL, HOSPICE_SNOMED);
-        residenceTypeMap.put(HOSTEL_SNOMED, HOSTEL_LITERAL);
-        residenceTypeMap.put(HOSTEL_LITERAL, HOSTEL_SNOMED);
-        residenceTypeMap.put(SHELTERED_HOUSING_SNOMED, SHELTERED_HOUSING_LITERAL);
-        residenceTypeMap.put(SHELTERED_HOUSING_LITERAL, SHELTERED_HOUSING_SNOMED);
-        residenceTypeMap.put(PENAL_INSTITUTION_SNOMED, PENAL_INSTITUTION_LITERAL);
-        residenceTypeMap.put(PENAL_INSTITUTION_LITERAL, PENAL_INSTITUTION_SNOMED);
-        residenceTypeMap.put(RELIGIOUS_RESIDENCE_SNOMED, RELIGIOUS_RESIDENCE_LITERAL);
-        residenceTypeMap.put(RELIGIOUS_RESIDENCE_LITERAL, RELIGIOUS_RESIDENCE_SNOMED);
-        residenceTypeMap.put(WORK_ENVIRONMENT_SNOMED, WORK_ENVIRONMENT_LITERAL);
-        residenceTypeMap.put(WORK_ENVIRONMENT_LITERAL, WORK_ENVIRONMENT_SNOMED);
-        residenceTypeMap.put(HOMELESS_SNOMED, HOMELESS_LITERAL);
-        residenceTypeMap.put(HOMELESS_LITERAL, HOMELESS_SNOMED);
-        return residenceTypeMap;
-    }
+  public static final Map<String, String> getResidenceTypeMap() {
+    Map<String, String> residenceTypeMap = new HashMap<>();
+    residenceTypeMap.put(HOSPITAL_SNOMED, HOSPITAL_LITERAL);
+    residenceTypeMap.put(HOSPITAL_LITERAL, HOSPITAL_SNOMED);
+    residenceTypeMap.put(HOSPITAL_SHIP_SNOMED, HOSPITAL_SHIP_LITERAL);
+    residenceTypeMap.put(HOSPITAL_SHIP_LITERAL, HOSPITAL_SHIP_SNOMED);
+    residenceTypeMap.put(LONG_TERM_HOSPITAL_SNOMED, LONG_TERM_HOSPITAL_LITERAL);
+    residenceTypeMap.put(LONG_TERM_HOSPITAL_LITERAL, LONG_TERM_HOSPITAL_SNOMED);
+    residenceTypeMap.put(SECURE_HOSPITAL_SNOMED, SECURE_HOSPITAL_LITERAL);
+    residenceTypeMap.put(SECURE_HOSPITAL_LITERAL, SECURE_HOSPITAL_SNOMED);
+    residenceTypeMap.put(NURSING_HOME_SNOMED, NURSING_HOME_LITERAL);
+    residenceTypeMap.put(NURSING_HOME_LITERAL, NURSING_HOME_SNOMED);
+    residenceTypeMap.put(RETIREMENT_HOME_SNOMED, RETIREMENT_HOME_LITERAL);
+    residenceTypeMap.put(RETIREMENT_HOME_LITERAL, RETIREMENT_HOME_SNOMED);
+    residenceTypeMap.put(ORPHANAGE_SNOMED, ORPHANAGE_LITERAL);
+    residenceTypeMap.put(ORPHANAGE_LITERAL, ORPHANAGE_SNOMED);
+    residenceTypeMap.put(PRISON_BASED_CARE_SNOMED, PRISON_BASED_CARE_LITERAL);
+    residenceTypeMap.put(PRISON_BASED_CARE_LITERAL, PRISON_BASED_CARE_SNOMED);
+    residenceTypeMap.put(
+        SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED, SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL);
+    residenceTypeMap.put(
+        SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL, SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED);
+    residenceTypeMap.put(BOARDING_HOUSE_SNOMED, BOARDING_HOUSE_LITERAL);
+    residenceTypeMap.put(BOARDING_HOUSE_LITERAL, BOARDING_HOUSE_SNOMED);
+    residenceTypeMap.put(MILITARY_ACCOMMODATION_SNOMED, MILITARY_ACCOMMODATION_LITERAL);
+    residenceTypeMap.put(MILITARY_ACCOMMODATION_LITERAL, MILITARY_ACCOMMODATION_SNOMED);
+    residenceTypeMap.put(HOSPICE_SNOMED, HOSPICE_LITERAL);
+    residenceTypeMap.put(HOSPICE_LITERAL, HOSPICE_SNOMED);
+    residenceTypeMap.put(HOSTEL_SNOMED, HOSTEL_LITERAL);
+    residenceTypeMap.put(HOSTEL_LITERAL, HOSTEL_SNOMED);
+    residenceTypeMap.put(SHELTERED_HOUSING_SNOMED, SHELTERED_HOUSING_LITERAL);
+    residenceTypeMap.put(SHELTERED_HOUSING_LITERAL, SHELTERED_HOUSING_SNOMED);
+    residenceTypeMap.put(PENAL_INSTITUTION_SNOMED, PENAL_INSTITUTION_LITERAL);
+    residenceTypeMap.put(PENAL_INSTITUTION_LITERAL, PENAL_INSTITUTION_SNOMED);
+    residenceTypeMap.put(RELIGIOUS_RESIDENCE_SNOMED, RELIGIOUS_RESIDENCE_LITERAL);
+    residenceTypeMap.put(RELIGIOUS_RESIDENCE_LITERAL, RELIGIOUS_RESIDENCE_SNOMED);
+    residenceTypeMap.put(WORK_ENVIRONMENT_SNOMED, WORK_ENVIRONMENT_LITERAL);
+    residenceTypeMap.put(WORK_ENVIRONMENT_LITERAL, WORK_ENVIRONMENT_SNOMED);
+    residenceTypeMap.put(HOMELESS_SNOMED, HOMELESS_LITERAL);
+    residenceTypeMap.put(HOMELESS_LITERAL, HOMELESS_SNOMED);
+    return residenceTypeMap;
+  }
 
-    private static final String PREGNANT_SNOMED = "77386006";
-    private static final String NOT_PREGNANT_SNOMED = "60001007";
-    private static final String PREGNANT_UNKNOWN_SNOMED = "102874004";
+  private static final String PREGNANT_SNOMED = "77386006";
+  private static final String NOT_PREGNANT_SNOMED = "60001007";
+  private static final String PREGNANT_UNKNOWN_SNOMED = "102874004";
 
-    public static final String YES_SYPHILIS_HISTORY_SNOMED = "1087151000119108";
-    public static final String NO_SYPHILIS_HISTORY_SNOMED = "14732006";
-    public static final String UNKNOWN_SYPHILIS_HISTORY_SNOMED = "261665006";
+  public static final String YES_SYPHILIS_HISTORY_SNOMED = "1087151000119108";
+  public static final String NO_SYPHILIS_HISTORY_SNOMED = "14732006";
+  public static final String UNKNOWN_SYPHILIS_HISTORY_SNOMED = "261665006";
 
-    public static final Map<String, String> pregnancyStatusSnomedMap =
-            Map.of(
-                    "YES".toLowerCase(), PREGNANT_SNOMED,
-                    "Y".toLowerCase(), PREGNANT_SNOMED,
-                    "NO".toLowerCase(), NOT_PREGNANT_SNOMED,
-                    "N".toLowerCase(), NOT_PREGNANT_SNOMED,
-                    "UNK".toLowerCase(), PREGNANT_UNKNOWN_SNOMED,
-                    "U".toLowerCase(), PREGNANT_UNKNOWN_SNOMED);
+  public static final Map<String, String> pregnancyStatusSnomedMap =
+      Map.of(
+          "YES".toLowerCase(), PREGNANT_SNOMED,
+          "Y".toLowerCase(), PREGNANT_SNOMED,
+          "NO".toLowerCase(), NOT_PREGNANT_SNOMED,
+          "N".toLowerCase(), NOT_PREGNANT_SNOMED,
+          "UNK".toLowerCase(), PREGNANT_UNKNOWN_SNOMED,
+          "U".toLowerCase(), PREGNANT_UNKNOWN_SNOMED);
 
-    public static final Map<String, String> pregnancyStatusDisplayMap =
-            Map.of(
-                    PREGNANT_SNOMED, "Pregnant",
-                    NOT_PREGNANT_SNOMED, "Not pregnant",
-                    PREGNANT_UNKNOWN_SNOMED, "Unknown");
+  public static final Map<String, String> pregnancyStatusDisplayMap =
+      Map.of(
+          PREGNANT_SNOMED, "Pregnant",
+          NOT_PREGNANT_SNOMED, "Not pregnant",
+          PREGNANT_UNKNOWN_SNOMED, "Unknown");
 
-    public static final Map<String, String> genderIdentitySnomedSet =
-            Map.of(
-                    FEMALE, "446141000124107",
-                    MALE, "446151000124109",
-                    NON_BINARY, "446131000124102",
-                    TRANS_MAN, "446151000124109",
-                    TRANS_WOMAN, "446141000124107",
-                    OTHER, MappingConstants.UNK_CODE,
-                    REFUSED, "asked-declined");
+  public static final Map<String, String> genderIdentitySnomedSet =
+      Map.of(
+          FEMALE, "446141000124107",
+          MALE, "446151000124109",
+          NON_BINARY, "446131000124102",
+          TRANS_MAN, "446151000124109",
+          TRANS_WOMAN, "446141000124107",
+          OTHER, MappingConstants.UNK_CODE,
+          REFUSED, "asked-declined");
 
-    public static final Map<String, String> genderIdentityDisplaySet =
-            Map.of(
-                    FEMALE, "Female gender identity",
-                    MALE, "Male gender identity",
-                    NON_BINARY, "Non-binary gender identity",
-                    TRANS_MAN, "Male gender identity",
-                    TRANS_WOMAN, "Female gender identity",
-                    OTHER, "Non-binary gender identity",
-                    REFUSED, "Asked But Declined");
+  public static final Map<String, String> genderIdentityDisplaySet =
+      Map.of(
+          FEMALE, "Female gender identity",
+          MALE, "Male gender identity",
+          NON_BINARY, "Non-binary gender identity",
+          TRANS_MAN, "Male gender identity",
+          TRANS_WOMAN, "Female gender identity",
+          OTHER, "Non-binary gender identity",
+          REFUSED, "Asked But Declined");
 
-    public static Map<String, String> getGenderIdentityAbbreviationMap() {
-        Map<String, String> genderMap = new HashMap<>();
+  public static Map<String, String> getGenderIdentityAbbreviationMap() {
+    Map<String, String> genderMap = new HashMap<>();
 
-        genderMap.put("F", FEMALE);
-        genderMap.put("FEMALE", FEMALE);
-        genderMap.put("M", MALE);
-        genderMap.put("MALE", MALE);
-        genderMap.put("NB", NON_BINARY);
-        genderMap.put("NONBINARY", NON_BINARY);
-        genderMap.put("TM", TRANS_MAN);
-        genderMap.put("TRANS MAN", TRANS_MAN);
-        genderMap.put("TW", TRANS_WOMAN);
-        genderMap.put("TRANS WOMAN", TRANS_WOMAN);
-        genderMap.put("O", OTHER);
-        genderMap.put("OTHER", OTHER);
-        genderMap.put("R", REFUSED);
-        genderMap.put("REFUSED", REFUSED);
+    genderMap.put("F", FEMALE);
+    genderMap.put("FEMALE", FEMALE);
+    genderMap.put("M", MALE);
+    genderMap.put("MALE", MALE);
+    genderMap.put("NB", NON_BINARY);
+    genderMap.put("NONBINARY", NON_BINARY);
+    genderMap.put("TM", TRANS_MAN);
+    genderMap.put("TRANS MAN", TRANS_MAN);
+    genderMap.put("TW", TRANS_WOMAN);
+    genderMap.put("TRANS WOMAN", TRANS_WOMAN);
+    genderMap.put("O", OTHER);
+    genderMap.put("OTHER", OTHER);
+    genderMap.put("R", REFUSED);
+    genderMap.put("REFUSED", REFUSED);
 
-        return genderMap;
-    }
+    return genderMap;
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
@@ -9,845 +9,851 @@ import static gov.cdc.usds.simplereport.api.Translators.TRANS_MAN;
 import static gov.cdc.usds.simplereport.api.Translators.TRANS_WOMAN;
 
 import gov.cdc.usds.simplereport.api.MappingConstants;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class PersonUtils {
-  private PersonUtils() {
-    throw new IllegalStateException("Utility class");
-  }
+    private PersonUtils() {
+        throw new IllegalStateException("Utility class");
+    }
 
-  public static Map<String, String> tribalMap() {
-    var tribeCodes = new HashMap<String, String>();
-    tribeCodes.put("1", "Absentee-Shawnee Tribe of Indians of Oklahoma");
-    tribeCodes.put(
-        "2",
-        "Agua Caliente Band of Cahuilla Indians of the Agua Caliente Indian Reservation, California");
-    tribeCodes.put("3", "Ak-Chin Indian Community");
-    tribeCodes.put("4", "Alabama-Coushatta Tribe of Texas");
-    tribeCodes.put("5", "Alabama-Quassarte Tribal Town");
-    tribeCodes.put("6", "Alturas Indian Rancheria, California");
-    tribeCodes.put("7", "Apache Tribe of Oklahoma");
-    tribeCodes.put("8", "Northern Arapaho Tribe of the Wind River Reservation, Wyoming");
-    tribeCodes.put("9", "Mi'kmaq Nation");
-    tribeCodes.put(
-        "10", "Assiniboine and Sioux Tribes of the Fort Peck Indian Reservation, Montana");
-    tribeCodes.put("11", "Augustine Band of Cahuilla Indians, California");
-    tribeCodes.put(
-        "12",
-        "Bad River Band of the Lake Superior Tribe of Chippewa Indians of the Bad River Reservation, Wisconsin");
-    tribeCodes.put("33", "Barona Group of Capitan Grande Band of Mission Ind");
-    tribeCodes.put("13", "Bay Mills Indian Community, Michigan");
-    tribeCodes.put("14", "Bear River Band of the Rohnerville Rancheria, California");
-    tribeCodes.put("15", "Berry Creek Rancheria of Maidu Indians of California");
-    tribeCodes.put("16", "Big Lagoon Rancheria, California");
-    tribeCodes.put("17", "Big Pine Paiute Tribe of the Owens Valley");
-    tribeCodes.put("18", "Big Sandy Rancheria of Western Mono Indians of California");
-    tribeCodes.put("19", "Big Valley Band of Pomo Indians of the Big Valley Rancheria, California");
-    tribeCodes.put("20", "Blackfeet Tribe of the Blackfeet Indian Reservation of Montana");
-    tribeCodes.put("21", "Blue Lake Rancheria, California");
-    tribeCodes.put("22", "Bridgeport Indian Colony");
-    tribeCodes.put("23", "Buena Vista Rancheria of Me-Wuk Indians of California");
-    tribeCodes.put("24", "Burns Paiute Tribe");
-    tribeCodes.put("25", "Cabazon Band of Mission Indians, California");
-    tribeCodes.put(
-        "26",
-        "Cachil DeHe Band of Wintun Indians of the Colusa Indian Community of the Colusa Rancheria, California");
-    tribeCodes.put("27", "Caddo Nation of Oklahoma");
-    tribeCodes.put("29", "Cahto Tribe of the Laytonville Rancheria");
-    tribeCodes.put("28", "Cahuilla Band of Indians");
-    tribeCodes.put("30", "California Valley Miwok Tribe, California");
-    tribeCodes.put(
-        "31", "Campo Band of Diegueno Mission Indians of the Campo Indian Reservation, California");
-    tribeCodes.put("32", "Capitan Grande Band of Diegueno Mission Indians of California");
-    tribeCodes.put("35", "Catawba Indian Nation");
-    tribeCodes.put("36", "Cayuga Nation");
-    tribeCodes.put("37", "Cedarville Rancheria, California");
-    tribeCodes.put("38", "Chemehuevi Indian Tribe of the Chemehuevi Reservation, California");
-    tribeCodes.put("39", "Cher-Ae Heights Indian Community of the Trinidad Rancheria, California");
-    tribeCodes.put("40", "Cherokee Nation");
-    tribeCodes.put(
-        "42", "Cheyenne River Sioux Tribe of the Cheyenne River Reservation, South Dakota");
-    tribeCodes.put("41", "Cheyenne and Arapaho Tribes, Oklahoma");
-    tribeCodes.put("43", "The Chickasaw Nation");
-    tribeCodes.put("44", "Chicken Ranch Rancheria of Me-Wuk Indians of California");
-    tribeCodes.put("45", "Chippewa Cree Indians of the Rocky Boy's Reservation, Montana");
-    tribeCodes.put("46", "Chitimacha Tribe of Louisiana");
-    tribeCodes.put("47", "The Choctaw Nation of Oklahoma");
-    tribeCodes.put("48", "Citizen Potawatomi Nation, Oklahoma");
-    tribeCodes.put("49", "Cloverdale Rancheria of Pomo Indians of California");
-    tribeCodes.put("50", "Cocopah Tribe of Arizona");
-    tribeCodes.put("51", "Coeur D'Alene Tribe");
-    tribeCodes.put("52", "Cold Springs Rancheria of Mono Indians of California");
-    tribeCodes.put(
-        "53",
-        "Colorado River Indian Tribes of the Colorado River Indian Reservation, Arizona and California");
-    tribeCodes.put("54", "Comanche Nation, Oklahoma");
-    tribeCodes.put("55", "Confederated Salish and Kootenai Tribes of the Flathead Reservation");
-    tribeCodes.put("64", "Confederated Tribes and Bands of the Yakama Nation");
-    tribeCodes.put("56", "Confederated Tribes of the Chehalis Reservation");
-    tribeCodes.put("57", "Confederated Tribes of the Colville Reservation");
-    tribeCodes.put("58", "Confederated Tribes of the Coos, Lower Umpqua and Siuslaw Indians");
-    tribeCodes.put("59", "Confederated Tribes of the Goshute Reservation, Nevada and Utah");
-    tribeCodes.put("60", "Confederated Tribes of the Grand Ronde Community of Oregon");
-    tribeCodes.put("61", "Confederated Tribes of Siletz Indians of Oregon");
-    tribeCodes.put("62", "Confederated Tribes of the Umatilla Indian Reservation");
-    tribeCodes.put("63", "Confederated Tribes of the Warm Springs Reservation of Oregon");
-    tribeCodes.put("65", "Coquille Indian Tribe");
-    tribeCodes.put("66", "Kletsel Dehe Band of Wintun Indians");
-    tribeCodes.put("67", "Coushatta Tribe of Louisiana");
-    tribeCodes.put("68", "Cow Creek Band of Umpqua Tribe of Indians");
-    tribeCodes.put("69", "Coyote Valley Band of Pomo Indians of California");
-    tribeCodes.put("71", "Crow Creek Sioux Tribe of the Crow Creek Reservation, South Dakota");
-    tribeCodes.put("70", "Crow Tribe of Montana");
-    tribeCodes.put("72", "Ewiiaapaayp Band of Kumeyaay Indians, California");
-    tribeCodes.put("73", "Timbisha Shoshone Tribe");
-    tribeCodes.put("74", "Delaware Nation, Oklahoma");
-    tribeCodes.put("75", "Delaware Tribe of Indians");
-    tribeCodes.put("76", "Dry Creek Rancheria Band of Pomo Indians, California");
-    tribeCodes.put("77", "Duckwater Shoshone Tribe of the Duckwater Reservation, Nevada");
-    tribeCodes.put("78", "Eastern Band of Cherokee Indians");
-    tribeCodes.put("79", "Eastern Shawnee Tribe of Oklahoma");
-    tribeCodes.put(
-        "80", "Elem Indian Colony of Pomo Indians of the Sulphur Bank Rancheria, California");
-    tribeCodes.put("81", "Elk Valley Rancheria, California");
-    tribeCodes.put("82", "Ely Shoshone Tribe of Nevada");
-    tribeCodes.put("83", "Enterprise Rancheria of Maidu Indians of California");
-    tribeCodes.put("84", "Flandreau Santee Sioux Tribe of South Dakota");
-    tribeCodes.put("85", "Forest County Potawatomi Community, Wisconsin");
-    tribeCodes.put(
-        "86", "Fort Belknap Indian Community of the Fort Belknap Reservation of Montana");
-    tribeCodes.put(
-        "87", "Fort Bidwell Indian Community of the Fort Bidwell Reservation of California");
-    tribeCodes.put(
-        "88",
-        "Fort Independence Indian Community of Paiute Indians of the Fort Independence Reservation, California");
-    tribeCodes.put(
-        "89",
-        "Fort McDermitt Paiute and Shoshone Tribes of the Fort McDermitt Indian Reservation, Nevada and Oregon");
-    tribeCodes.put("90", "Fort McDowell Yavapai Nation, Arizona");
-    tribeCodes.put("91", "Fort Mojave Indian Tribe of Arizona, California & Nevada");
-    tribeCodes.put("92", "Fort Sill Apache Tribe of Oklahoma");
-    tribeCodes.put(
-        "93", "Gila River Indian Community of the Gila River Indian Reservation, Arizona");
-    tribeCodes.put("94", "Grand Traverse Band of Ottawa and Chippewa Indians, Michigan");
-    tribeCodes.put("95", "Federated Indians of Graton Rancheria, California");
-    tribeCodes.put("96", "Greenville Rancheria");
-    tribeCodes.put("97", "Grindstone Indian Rancheria of Wintun-Wailaki Indians of California");
-    tribeCodes.put("98", "Guidiville Rancheria of California");
-    tribeCodes.put("99", "Hannahville Indian Community, Michigan");
-    tribeCodes.put("100", "Havasupai Tribe of the Havasupai Reservation, Arizona");
-    tribeCodes.put("101", "Ho-Chunk Nation of Wisconsin");
-    tribeCodes.put("102", "Hoh Indian Tribe");
-    tribeCodes.put("103", "Hoopa Valley Tribe, California");
-    tribeCodes.put("104", "Hopi Tribe of Arizona");
-    tribeCodes.put("105", "Hopland Band of Pomo Indians, California");
-    tribeCodes.put("106", "Houlton Band of Maliseet Indians");
-    tribeCodes.put("107", "Hualapai Indian Tribe of the Hualapai Indian Reservation, Arizona");
-    tribeCodes.put("108", "Nottawaseppi Huron Band of the Potawatomi, Michigan");
-    tribeCodes.put(
-        "109",
-        "Inaja Band of Diegueno Mission Indians of the Inaja and Cosmit Reservation, California");
-    tribeCodes.put("110", "Ione Band of Miwok Indians of California");
-    tribeCodes.put("111", "Iowa Tribe of Kansas and Nebraska");
-    tribeCodes.put("112", "Iowa Tribe of Oklahoma");
-    tribeCodes.put("113", "Jackson Band of Miwuk Indians");
-    tribeCodes.put("114", "Jamestown S'Klallam Tribe");
-    tribeCodes.put("115", "Jamul Indian Village of California");
-    tribeCodes.put("116", "Jena Band of Choctaw Indians");
-    tribeCodes.put("117", "Jicarilla Apache Nation, New Mexico");
-    tribeCodes.put(
-        "118", "Kaibab Band of Paiute Indians of the Kaibab Indian Reservation, Arizona");
-    tribeCodes.put("119", "Kalispel Indian Community of the Kalispel Reservation");
-    tribeCodes.put("120", "Karuk Tribe");
-    tribeCodes.put(
-        "121", "Kashia Band of Pomo Indians of the Stewarts Point Rancheria, California");
-    tribeCodes.put("122", "Kaw Nation, Oklahoma");
-    tribeCodes.put("123", "Keweenaw Bay Indian Community, Michigan");
-    tribeCodes.put("124", "Kialegee Tribal Town");
-    tribeCodes.put("127", "Kickapoo Traditional Tribe of Texas");
-    tribeCodes.put("125", "Kickapoo Tribe of Indians of the Kickapoo Reservation in Kansas");
-    tribeCodes.put("126", "Kickapoo Tribe of Oklahoma");
-    tribeCodes.put("128", "Kiowa Indian Tribe of Oklahoma");
-    tribeCodes.put("129", "Klamath Tribes");
-    tribeCodes.put("130", "Kootenai Tribe of Idaho");
-    tribeCodes.put("131", "La Jolla Band of Luiseno Indians, California");
-    tribeCodes.put(
-        "132",
-        "La Posta Band of Diegueno Mission Indians of the La Posta Indian Reservation, California");
-    tribeCodes.put(
-        "133", "Lac Courte Oreilles Band of Lake Superior Chippewa Indians of Wisconsin");
-    tribeCodes.put(
-        "134",
-        "Lac du Flambeau Band of Lake Superior Chippewa Indians of the Lac du Flambeau Reservation of Wisconsin");
-    tribeCodes.put("135", "Lac Vieux Desert Band of Lake Superior Chippewa Indians of Michigan");
-    tribeCodes.put(
-        "136", "Las Vegas Tribe of Paiute Indians of the Las Vegas Indian Colony, Nevada");
-    tribeCodes.put("137", "Little River Band of Ottawa Indians, Michigan");
-    tribeCodes.put("138", "Little Traverse Bay Bands of Odawa Indians, Michigan");
-    tribeCodes.put("140", "Los Coyotes Band of Cahuilla and Cupeno Indians, California");
-    tribeCodes.put("141", "Lovelock Paiute Tribe of the Lovelock Indian Colony, Nevada");
-    tribeCodes.put("142", "Lower Brule Sioux Tribe of the Lower Brule Reservation, South Dakota");
-    tribeCodes.put("143", "Lower Elwha Tribal Community");
-    tribeCodes.put("139", "Koi Nation of Northern California");
-    tribeCodes.put("144", "Lower Sioux Indian Community in the State of Minnesota");
-    tribeCodes.put("145", "Lummi Tribe of the Lummi Reservation");
-    tribeCodes.put("146", "Lytton Rancheria of California");
-    tribeCodes.put("147", "Makah Indian Tribe of the Makah Indian Reservation");
-    tribeCodes.put(
-        "148", "Manchester Band of Pomo Indians of the Manchester Rancheria, California");
-    tribeCodes.put(
-        "149",
-        "Manzanita Band of Diegueno Mission Indians of the Manzanita Reservation, California");
-    tribeCodes.put("150", "Mashantucket Pequot Indian Tribe");
-    tribeCodes.put("151", "Match-e-be-nash-she-wish Band of Pottawatomi Indians of Michigan");
-    tribeCodes.put("152", "Mechoopda Indian Tribe of Chico Rancheria, California");
-    tribeCodes.put("153", "Menominee Indian Tribe of Wisconsin");
-    tribeCodes.put(
-        "154",
-        "Mesa Grande Band of Diegueno Mission Indians of the Mesa Grande Reservation, California");
-    tribeCodes.put("155", "Mescalero Apache Tribe of the Mescalero Reservation, New Mexico");
-    tribeCodes.put("156", "Miami Tribe of Oklahoma");
-    tribeCodes.put("157", "Miccosukee Tribe of Indians");
-    tribeCodes.put("158", "Middletown Rancheria of Pomo Indians of California");
-    tribeCodes.put(
-        "159",
-        "Minnesota Chippewa Tribe, Minnesota (Six component reservations: Bois Forte Band (Nett Lake); Fond du Lac Band; Grand Portage Band; Leech Lake Band; Mille Lacs Band; White Earth Band)");
-    tribeCodes.put("160", "Bois Forte Band (Nett Lake); Fond du Lac Band; Gra");
-    tribeCodes.put("161", "Mississippi Band of Choctaw Indians");
-    tribeCodes.put(
-        "162", "Moapa Band of Paiute Indians of the Moapa River Indian Reservation, Nevada");
-    tribeCodes.put("163", "Modoc Nation");
-    tribeCodes.put("164", "Mohegan Tribe of Indians of Connecticut");
-    tribeCodes.put("165", "Mooretown Rancheria of Maidu Indians of California");
-    tribeCodes.put("166", "Morongo Band of Mission Indians, California");
-    tribeCodes.put("167", "Muckleshoot Indian Tribe");
-    tribeCodes.put("168", "The Muscogee (Creek) Nation");
-    tribeCodes.put("169", "Narragansett Indian Tribe");
-    tribeCodes.put("170", "Navajo Nation, Arizona, New Mexico, & Utah");
-    tribeCodes.put("171", "Nez Perce Tribe");
-    tribeCodes.put("172", "Nisqually Indian Tribe of the Nisqually Reservatio");
-    tribeCodes.put("173", "Nooksack Indian Tribe");
-    tribeCodes.put(
-        "174", "Northern Cheyenne Tribe of the Northern Cheyenne Indian Reservation, Montana");
-    tribeCodes.put("175", "Northfork Rancheria of Mono Indians of California");
-    tribeCodes.put("176", "Northwestern Band of the Shoshone Nation");
-    tribeCodes.put("177", "Oglala Sioux Tribe");
-    tribeCodes.put("178", "Omaha Tribe of Nebraska");
-    tribeCodes.put("179", "Oneida Indian Nation");
-    tribeCodes.put("180", "Oneida Nation");
-    tribeCodes.put("181", "Onondaga Nation");
-    tribeCodes.put("182", "The Osage Nation");
-    tribeCodes.put("184", "Otoe-Missouria Tribe of Indians, Oklahoma");
-    tribeCodes.put("183", "Ottawa Tribe of Oklahoma");
-    tribeCodes.put(
-        "185",
-        "Paiute Indian Tribe of Utah (Cedar Band of Paiutes, Kanosh Band of Paiutes, Koosharem Band of Paiutes, Indian Peaks Band of Paiutes, and Shivwits Band of Paiutes)");
-    tribeCodes.put("186", "Bishop Paiute Tribe");
-    tribeCodes.put("188", "Lone Pine Paiute-Shoshone Tribe");
-    tribeCodes.put("187", "Paiute-Shoshone Tribe of the Fallon Reservation and Colony, Nevada");
-    tribeCodes.put("189", "Pala Band of Mission Indians");
-    tribeCodes.put("190", "Pascua Yaqui Tribe of Arizona");
-    tribeCodes.put("191", "Paskenta Band of Nomlaki Indians of California");
-    tribeCodes.put("192", "Passamaquoddy Tribe");
-    tribeCodes.put(
-        "193",
-        "Pauma Band of Luiseno Mission Indians of the Pauma & Yuima Reservation, California");
-    tribeCodes.put("194", "Pawnee Nation of Oklahoma");
-    tribeCodes.put("195", "Pechanga Band of Indians");
-    tribeCodes.put("196", "Penobscot Nation");
-    tribeCodes.put("197", "Peoria Tribe of Indians of Oklahoma");
-    tribeCodes.put("198", "Picayune Rancheria of Chukchansi Indians of California");
-    tribeCodes.put("199", "Pinoleville Pomo Nation, California");
-    tribeCodes.put(
-        "200",
-        "Pit River Tribe, California (includes XL Ranch, Big Bend, Likely, Lookout, Montgomery Creek, and Roaring Creek Rancherias)");
-    tribeCodes.put("201", "Poarch Band of Creek Indians");
-    tribeCodes.put("202", "Pokagon Band of Potawatomi Indians, Michigan and Indiana");
-    tribeCodes.put("203", "Ponca Tribe of Indians of Oklahoma");
-    tribeCodes.put("204", "Ponca Tribe of Nebraska");
-    tribeCodes.put("205", "Port Gamble S'Klallam Tribe");
-    tribeCodes.put("206", "Potter Valley Tribe, California");
-    tribeCodes.put("207", "Prairie Band Potawatomi Nation");
-    tribeCodes.put("208", "Prairie Island Indian Community in the State of Minnesota");
-    tribeCodes.put("209", "Pueblo of Acoma, New Mexico");
-    tribeCodes.put("210", "Pueblo of Cochiti, New Mexico");
-    tribeCodes.put("212", "Pueblo of Isleta, New Mexico");
-    tribeCodes.put("211", "Pueblo of Jemez, New Mexico");
-    tribeCodes.put("213", "Pueblo of Laguna, New Mexico");
-    tribeCodes.put("214", "Pueblo of Nambe, New Mexico");
-    tribeCodes.put("215", "Pueblo of Picuris, New Mexico");
-    tribeCodes.put("216", "Pueblo of Pojoaque, New Mexico");
-    tribeCodes.put("217", "Pueblo of San Felipe, New Mexico");
-    tribeCodes.put("219", "Pueblo of San Ildefonso, New Mexico");
-    tribeCodes.put("218", "Ohkay Owingeh, New Mexico");
-    tribeCodes.put("220", "Pueblo of Sandia, New Mexico");
-    tribeCodes.put("221", "Pueblo of Santa Ana, New Mexico");
-    tribeCodes.put("222", "Pueblo of Santa Clara, New Mexico");
-    tribeCodes.put("223", "Santo Domingo Pueblo");
-    tribeCodes.put("224", "Pueblo of Taos, New Mexico");
-    tribeCodes.put("225", "Pueblo of Tesuque, New Mexico");
-    tribeCodes.put("226", "Pueblo of Zia, New Mexico");
-    tribeCodes.put("227", "Puyallup Tribe of the Puyallup Reservation");
-    tribeCodes.put("228", "Pyramid Lake Paiute Tribe of the Pyramid Lake Reservation, Nevada");
-    tribeCodes.put("229", "Quapaw Nation");
-    tribeCodes.put(
-        "230", "Quartz Valley Indian Community of the Quartz Valley Reservation of California");
-    tribeCodes.put(
-        "231", "Quechan Tribe of the Fort Yuma Indian Reservation, California & Arizona");
-    tribeCodes.put("232", "Quileute Tribe of the Quileute Reservation");
-    tribeCodes.put("233", "Quinault Indian Nation");
-    tribeCodes.put("234", "Ramona Band of Cahuilla, California");
-    tribeCodes.put("235", "Red Cliff Band of Lake Superior Chippewa Indians of Wisconsin");
-    tribeCodes.put("236", "Red Lake Band of Chippewa Indians, Minnesota");
-    tribeCodes.put("237", "Redding Rancheria, California");
-    tribeCodes.put(
-        "238",
-        "Redwood Valley or Little River Band of Pomo Indians of the Redwood Valley Rancheria California");
-    tribeCodes.put("239", "Reno-Sparks Indian Colony, Nevada");
-    tribeCodes.put("240", "Resighini Rancheria, California");
-    tribeCodes.put(
-        "241", "Rincon Band of Luiseno Mission Indians of Rincon Reservation, California");
-    tribeCodes.put("242", "Robinson Rancheria");
-    tribeCodes.put("243", "Rosebud Sioux Tribe of the Rosebud Indian Reservation, South Dakota");
-    tribeCodes.put("244", "Round Valley Indian Tribes, Round Valley Reservation, California");
-    tribeCodes.put("245", "Yocha Dehe Wintun Nation, California");
-    tribeCodes.put("247", "Sac & Fox Nation of Missouri in Kansas and Nebraska");
-    tribeCodes.put("248", "Sac & Fox Nation, Oklahoma");
-    tribeCodes.put("246", "Sac & Fox Tribe of the Mississippi in Iowa");
-    tribeCodes.put("249", "Saginaw Chippewa Indian Tribe of Michigan");
-    tribeCodes.put(
-        "250", "Salt River Pima-Maricopa Indian Community of the Salt River Reservation, Arizona");
-    tribeCodes.put("251", "Samish Indian Nation");
-    tribeCodes.put("252", "San Carlos Apache Tribe of the San Carlos Reservation, Arizona");
-    tribeCodes.put("253", "San Juan Southern Paiute Tribe of Arizona");
-    tribeCodes.put("254", "Yuhaaviatam of San Manuel Nation");
-    tribeCodes.put("255", "San Pasqual Band of Diegueno Mission Indians of California");
-    tribeCodes.put("257", "Santa Rosa Band of Cahuilla Indians, California");
-    tribeCodes.put("256", "Santa Rosa Indian Community of the Santa Rosa Rancheria, California");
-    tribeCodes.put(
-        "258",
-        "Santa Ynez Band of Chumash Mission Indians of the Santa Ynez Reservation, California");
-    tribeCodes.put("259", "Iipay Nation of Santa Ysabel, California");
-    tribeCodes.put("260", "Santee Sioux Nation, Nebraska");
-    tribeCodes.put("261", "Sauk-Suiattle Indian Tribe");
-    tribeCodes.put("262", "Sault Ste. Marie Tribe of Chippewa Indians, Michigan");
-    tribeCodes.put("263", "Scotts Valley Band of Pomo Indians of California");
-    tribeCodes.put("264", "The Seminole Nation of Oklahoma");
-    tribeCodes.put("265", "Seminole Tribe of Florida");
-    tribeCodes.put("266", "Seneca Nation of Indians");
-    tribeCodes.put("267", "Seneca-Cayuga Nation");
-    tribeCodes.put("268", "Shakopee Mdewakanton Sioux Community of Minnesota");
-    tribeCodes.put("269", "Shawnee Tribe");
-    tribeCodes.put("270", "Sherwood Valley Rancheria of Pomo Indians of California");
-    tribeCodes.put(
-        "271",
-        "Shingle Springs Band of Miwok Indians, Shingle Springs Rancheria (Verona Tract), California");
-    tribeCodes.put("272", "Shoalwater Bay Indian Tribe of the Shoalwater Bay Indian Reservation");
-    tribeCodes.put("273", "Eastern Shoshone Tribe of the Wind River Reservation, Wyoming");
-    tribeCodes.put("274", "Shoshone-Bannock Tribes of the Fort Hall Reservation");
-    tribeCodes.put("275", "Shoshone-Paiute Tribes of the Duck Valley Reservation, Nevada");
-    tribeCodes.put("276", "Sisseton-Wahpeton Oyate of the Lake Traverse Reservation, South Dakota");
-    tribeCodes.put("277", "Skokomish Indian Tribe");
-    tribeCodes.put("278", "Skull Valley Band of Goshute Indians of Utah");
-    tribeCodes.put("279", "Tolowa Dee-ni' Nation");
-    tribeCodes.put("280", "Snoqualmie Indian Tribe");
-    tribeCodes.put("281", "Soboba Band of Luiseno Indians, California");
-    tribeCodes.put("282", "Sokaogon Chippewa Community, Wisconsin");
-    tribeCodes.put("283", "Southern Ute Indian Tribe of the Southern Ute Reservation, Colorado");
-    tribeCodes.put("284", "Spirit Lake Tribe, North Dakota");
-    tribeCodes.put("285", "Spokane Tribe of the Spokane Reservation");
-    tribeCodes.put("286", "Squaxin Island Tribe of the Squaxin Island Reservation");
-    tribeCodes.put("287", "St. Croix Chippewa Indians of Wisconsin");
-    tribeCodes.put("288", "Saint Regis Mohawk Tribe");
-    tribeCodes.put("289", "Standing Rock Sioux Tribe of North & South Dakota");
-    tribeCodes.put("291", "Stillaguamish Tribe of Indians of Washington");
-    tribeCodes.put("290", "Stockbridge Munsee Community, Wisconsin");
-    tribeCodes.put("292", "Summit Lake Paiute Tribe of Nevada");
-    tribeCodes.put("293", "Suquamish Indian Tribe of the Port Madison Reservation");
-    tribeCodes.put("294", "Susanville Indian Rancheria, California");
-    tribeCodes.put("295", "Swinomish Indian Tribal Community");
-    tribeCodes.put("296", "Sycuan Band of the Kumeyaay Nation");
-    tribeCodes.put("297", "Wiyot Tribe, California");
-    tribeCodes.put("298", "Table Mountain Rancheria");
-    tribeCodes.put(
-        "299",
-        "Te-Moak Tribe of Western Shoshone Indians of Nevada (Four constituent bands: Battle Mountain Band; Elko Band; South Fork Band; and Wells Band)");
-    tribeCodes.put("300", "Thlopthlocco Tribal Town");
-    tribeCodes.put("301", "Three Affiliated Tribes of the Fort Berthold Reservation, North Dakota");
-    tribeCodes.put("302", "Tohono O'odham Nation of Arizona");
-    tribeCodes.put("303", "Tonawanda Band of Seneca");
-    tribeCodes.put("304", "Tonkawa Tribe of Indians of Oklahoma");
-    tribeCodes.put("305", "Tonto Apache Tribe of Arizona");
-    tribeCodes.put("306", "Torres Martinez Desert Cahuilla Indians, California");
-    tribeCodes.put("308", "Tulalip Tribes of Washington");
-    tribeCodes.put("307", "Tule River Indian Tribe of the Tule River Reservation, California");
-    tribeCodes.put("309", "Tunica-Biloxi Indian Tribe");
-    tribeCodes.put(
-        "310", "Tuolumne Band of Me-Wuk Indians of the Tuolumne Rancheria of California");
-    tribeCodes.put("311", "Turtle Mountain Band of Chippewa Indians of North Dakota");
-    tribeCodes.put("312", "Tuscarora Nation");
-    tribeCodes.put("313", "Twenty-Nine Palms Band of Mission Indians of California");
-    tribeCodes.put("314", "United Auburn Indian Community of the Auburn Rancheria of California");
-    tribeCodes.put("315", "United Keetoowah Band of Cherokee Indians in Oklahoma");
-    tribeCodes.put("316", "Habematolel Pomo of Upper Lake, California");
-    tribeCodes.put("317", "Upper Sioux Community, Minnesota");
-    tribeCodes.put("318", "Upper Skagit Indian Tribe");
-    tribeCodes.put("319", "Ute Indian Tribe of the Uintah & Ouray Reservation, Utah");
-    tribeCodes.put("320", "Ute Mountain Ute Tribe");
-    tribeCodes.put(
-        "321", "Utu Utu Gwaitu Paiute Tribe of the Benton Paiute Reservation, California");
-    tribeCodes.put("34", "Viejas (Baron Long) Group of Capitan Grande Band o");
-    tribeCodes.put("322", "Walker River Paiute Tribe of the Walker River Reservation, Nevada");
-    tribeCodes.put("323", "Wampanoag Tribe of Gay Head (Aquinnah)");
-    tribeCodes.put(
-        "324",
-        "Washoe Tribe of Nevada & California (Carson Colony, Dresslerville Colony, Woodfords Community, Stewart Community, & Washoe Ranches)");
-    tribeCodes.put("325", "White Mountain Apache Tribe of the Fort Apache Reservation, Arizona");
-    tribeCodes.put(
-        "326", "Wichita and Affiliated Tribes (Wichita, Keechi, Waco, & Tawakonie), Oklahoma");
-    tribeCodes.put("327", "Winnebago Tribe of Nebraska");
-    tribeCodes.put("328", "Winnemucca Indian Colony of Nevada");
-    tribeCodes.put("329", "Wyandotte Nation");
-    tribeCodes.put("330", "Yankton Sioux Tribe of South Dakota");
-    tribeCodes.put("331", "Yavapai-Apache Nation of the Camp Verde Indian Reservation, Arizona");
-    tribeCodes.put("332", "Yavapai-Prescott Indian Tribe");
-    tribeCodes.put(
-        "333", "Yerington Paiute Tribe of the Yerington Colony & Campbell Ranch, Nevada");
-    tribeCodes.put("334", "Yomba Shoshone Tribe of the Yomba Reservation, Nevada");
-    tribeCodes.put("335", "Ysleta del Sur Pueblo");
-    tribeCodes.put("336", "Yurok Tribe of the Yurok Reservation, California");
-    tribeCodes.put("337", "Zuni Tribe of the Zuni Reservation, New Mexico");
-    tribeCodes.put("338", "Native Village of Afognak");
-    tribeCodes.put("339", "Agdaagux Tribe of King Cove");
-    tribeCodes.put("340", "Native Village of Akhiok");
-    tribeCodes.put("341", "Akiachak Native Community");
-    tribeCodes.put("342", "Akiak Native Community");
-    tribeCodes.put("343", "Native Village of Akutan");
-    tribeCodes.put("344", "Village of Alakanuk");
-    tribeCodes.put("345", "Alatna Village");
-    tribeCodes.put("346", "Native Village of Aleknagik");
-    tribeCodes.put("347", "Algaaciq Native Village (St. Mary's)");
-    tribeCodes.put("348", "Allakaket Village");
-    tribeCodes.put("349", "Native Village of Ambler");
-    tribeCodes.put("350", "Village of Anaktuvuk Pass");
-    tribeCodes.put("351", "Yupiit of Andreafski");
-    tribeCodes.put("352", "Angoon Community Association");
-    tribeCodes.put("353", "Village of Aniak");
-    tribeCodes.put("354", "Anvik Village");
-    tribeCodes.put("355", "Arctic Village");
-    tribeCodes.put("356", "Asa'carsarmiut Tribe");
-    tribeCodes.put("357", "Native Village of Atka");
-    tribeCodes.put("358", "Village of Atmautluak");
-    tribeCodes.put("359", "Native Village of Atqasuk");
-    tribeCodes.put("360", "Native Village of Barrow Inupiat Traditional Government");
-    tribeCodes.put("361", "Beaver Village");
-    tribeCodes.put("362", "Native Village of Belkofski");
-    tribeCodes.put("363", "Village of Bill Moore's Slough");
-    tribeCodes.put("364", "Birch Creek Tribe");
-    tribeCodes.put("365", "Native Village of Brevig Mission");
-    tribeCodes.put("366", "Native Village of Buckland");
-    tribeCodes.put("367", "Native Village of Cantwell");
-    tribeCodes.put("368", "Native Village of Chenega (aka Chanega)");
-    tribeCodes.put("369", "Chalkyitsik Village");
-    tribeCodes.put("370", "Village of Chefornak");
-    tribeCodes.put("371", "Chevak Native Village");
-    tribeCodes.put("372", "Chickaloon Native Village");
-    tribeCodes.put("373", "Chignik Bay Tribal Council");
-    tribeCodes.put("374", "Native Village of Chignik Lagoon");
-    tribeCodes.put("375", "Chignik Lake Village");
-    tribeCodes.put("376", "Chilkat Indian Village (Klukwan)");
-    tribeCodes.put("377", "Chilkoot Indian Association (Haines)");
-    tribeCodes.put("378", "Chinik Eskimo Community (Golovin)");
-    tribeCodes.put("379", "Cheesh-Na Tribe");
-    tribeCodes.put("380", "Native Village of Chitina");
-    tribeCodes.put("381", "Native Village of Chuathbaluk (Russian Mission, Kuskokwim)");
-    tribeCodes.put("382", "Chuloonawick Native Village");
-    tribeCodes.put("383", "Circle Native Community");
-    tribeCodes.put("384", "Village of Clarks Point");
-    tribeCodes.put("385", "Native Village of Council");
-    tribeCodes.put("386", "Craig Tribal Association");
-    tribeCodes.put("387", "Village of Crooked Creek");
-    tribeCodes.put("388", "Curyung Tribal Council");
-    tribeCodes.put("389", "Native Village of Deering");
-    tribeCodes.put("390", "Native Village of Diomede (aka Inalik)");
-    tribeCodes.put("391", "Village of Dot Lake");
-    tribeCodes.put("392", "Douglas Indian Association");
-    tribeCodes.put("393", "Native Village of Eagle");
-    tribeCodes.put("394", "Native Village of Eek");
-    tribeCodes.put("395", "Egegik Village");
-    tribeCodes.put("396", "Eklutna Native Village");
-    tribeCodes.put("397", "Native Village of Ekuk");
-    tribeCodes.put("398", "Native Village of Ekwok");
-    tribeCodes.put("399", "Native Village of Elim");
-    tribeCodes.put("400", "Emmonak Village");
-    tribeCodes.put("401", "Evansville Village (aka Bettles Field)");
-    tribeCodes.put("402", "Native Village of Eyak (Cordova)");
-    tribeCodes.put("403", "Native Village of False Pass");
-    tribeCodes.put("404", "Native Village of Fort Yukon");
-    tribeCodes.put("405", "Native Village of Gakona");
-    tribeCodes.put("406", "Galena Village (aka Louden Village)");
-    tribeCodes.put("407", "Native Village of Gambell");
-    tribeCodes.put("408", "Native Village of Georgetown");
-    tribeCodes.put("409", "Native Village of Goodnews Bay");
-    tribeCodes.put("410", "Organized Village of Grayling (aka Holikachuk)");
-    tribeCodes.put("411", "Gulkana Village Council");
-    tribeCodes.put("412", "Native Village of Hamilton");
-    tribeCodes.put("413", "Healy Lake Village");
-    tribeCodes.put("414", "Holy Cross Tribe");
-    tribeCodes.put("415", "Hoonah Indian Association");
-    tribeCodes.put("416", "Native Village of Hooper Bay");
-    tribeCodes.put("417", "Hughes Village");
-    tribeCodes.put("418", "Huslia Village");
-    tribeCodes.put("419", "Hydaburg Cooperative Association");
-    tribeCodes.put("420", "Igiugig Village");
-    tribeCodes.put("421", "Village of Iliamna");
-    tribeCodes.put("422", "Inupiat Community of the Arctic Slope");
-    tribeCodes.put("423", "Iqugmiut Traditional Council");
-    tribeCodes.put("424", "Ivanof Bay Tribe");
-    tribeCodes.put("425", "Kaguyak Village");
-    tribeCodes.put("426", "Organized Village of Kake");
-    tribeCodes.put("427", "Kaktovik Village (aka Barter Island)");
-    tribeCodes.put("428", "Village of Kalskag");
-    tribeCodes.put("429", "Village of Kaltag");
-    tribeCodes.put("430", "Native Village of Kanatak");
-    tribeCodes.put("431", "Native Village of Karluk");
-    tribeCodes.put("432", "Organized Village of Kasaan");
-    tribeCodes.put("433", "Kasigluk Traditional Elders Council");
-    tribeCodes.put("434", "Kenaitze Indian Tribe");
-    tribeCodes.put("435", "Ketchikan Indian Community");
-    tribeCodes.put("436", "Native Village of Kiana");
-    tribeCodes.put("437", "King Island Native Community");
-    tribeCodes.put("438", "King Salmon Tribe");
-    tribeCodes.put("439", "Native Village of Kipnuk");
-    tribeCodes.put("440", "Native Village of Kivalina");
-    tribeCodes.put("441", "Klawock Cooperative Association");
-    tribeCodes.put("442", "Native Village of Kluti Kaah (aka Copper Center)");
-    tribeCodes.put("443", "Knik Tribe");
-    tribeCodes.put("444", "Native Village of Kobuk");
-    tribeCodes.put("445", "Kokhanok Village");
-    tribeCodes.put("446", "Native Village of Kongiganak");
-    tribeCodes.put("447", "Village of Kotlik");
-    tribeCodes.put("448", "Native Village of Kotzebue");
-    tribeCodes.put("449", "Native Village of Koyuk");
-    tribeCodes.put("450", "Koyukuk Native Village");
-    tribeCodes.put("451", "Organized Village of Kwethluk");
-    tribeCodes.put("452", "Native Village of Kwigillingok");
-    tribeCodes.put("453", "Native Village of Kwinhagak (aka Quinhagak)");
-    tribeCodes.put("454", "Native Village of Larsen Bay");
-    tribeCodes.put("455", "Levelock Village");
-    tribeCodes.put("456", "Tangirnaq Native Village");
-    tribeCodes.put("457", "Lime Village");
-    tribeCodes.put("458", "Village of Lower Kalskag");
-    tribeCodes.put("459", "Manley Hot Springs Village");
-    tribeCodes.put("460", "Manokotak Village");
-    tribeCodes.put("461", "Native Village of Marshall (aka Fortuna Ledge)");
-    tribeCodes.put("462", "Native Village of Mary's Igloo");
-    tribeCodes.put("463", "McGrath Native Village");
-    tribeCodes.put("464", "Native Village of Mekoryuk");
-    tribeCodes.put("465", "Mentasta Traditional Council");
-    tribeCodes.put("466", "Metlakatla Indian Community, Annette Island Reserve");
-    tribeCodes.put("467", "Native Village of Minto");
-    tribeCodes.put("468", "Naknek Native Village");
-    tribeCodes.put("469", "Native Village of Nanwalek (aka English Bay)");
-    tribeCodes.put("470", "Native Village of Napaimute");
-    tribeCodes.put("471", "Native Village of Napakiak");
-    tribeCodes.put("472", "Native Village of Napaskiak");
-    tribeCodes.put("473", "Native Village of Nelson Lagoon");
-    tribeCodes.put("474", "Nenana Native Association");
-    tribeCodes.put("475", "New Koliganek Village Council");
-    tribeCodes.put("476", "New Stuyahok Village");
-    tribeCodes.put("477", "Newhalen Village");
-    tribeCodes.put("478", "Newtok Village");
-    tribeCodes.put("479", "Native Village of Nightmute");
-    tribeCodes.put("480", "Nikolai Village");
-    tribeCodes.put("481", "Native Village of Nikolski");
-    tribeCodes.put("482", "Ninilchik Village");
-    tribeCodes.put("483", "Native Village of Noatak");
-    tribeCodes.put("484", "Nome Eskimo Community");
-    tribeCodes.put("485", "Nondalton Village");
-    tribeCodes.put("486", "Noorvik Native Community");
-    tribeCodes.put("487", "Northway Village");
-    tribeCodes.put("488", "Native Village of Nuiqsut (aka Nooiksut)");
-    tribeCodes.put("489", "Nulato Village");
-    tribeCodes.put("490", "Nunakauyarmiut Tribe");
-    tribeCodes.put("491", "Native Village of Nunapitchuk");
-    tribeCodes.put("492", "Village of Ohogamiut");
-    tribeCodes.put("493", "Alutiiq Tribe of Old Harbor");
-    tribeCodes.put("494", "Orutsararmiut Traditional Native Council");
-    tribeCodes.put("495", "Oscarville Traditional Village");
-    tribeCodes.put("496", "Native Village of Ouzinkie");
-    tribeCodes.put("497", "Native Village of Paimiut");
-    tribeCodes.put("498", "Pauloff Harbor Village");
-    tribeCodes.put("499", "Pedro Bay Village");
-    tribeCodes.put("500", "Native Village of Perryville");
-    tribeCodes.put("501", "Petersburg Indian Association");
-    tribeCodes.put("502", "Native Village of Pilot Point");
-    tribeCodes.put("503", "Pilot Station Traditional Village");
-    tribeCodes.put("504", "Pitka's Point Traditional Council");
-    tribeCodes.put("505", "Platinum Traditional Village");
-    tribeCodes.put("506", "Native Village of Point Hope");
-    tribeCodes.put("507", "Native Village of Point Lay");
-    tribeCodes.put("508", "Native Village of Port Graham");
-    tribeCodes.put("509", "Native Village of Port Heiden");
-    tribeCodes.put("510", "Native Village of Port Lions");
-    tribeCodes.put("511", "Portage Creek Village (aka Ohgsenakale)");
-    tribeCodes.put(
-        "512",
-        "Pribilof Islands Aleut Communities of St. Paul & St. George Islands (Saint George Island and Saint Paul Island)");
-    tribeCodes.put("513", "Qagan Tayagungin Tribe of Sand Point");
-    tribeCodes.put("514", "Qawalangin Tribe of Unalaska");
-    tribeCodes.put("515", "Rampart Village");
-    tribeCodes.put("516", "Village of Red Devil");
-    tribeCodes.put("517", "Native Village of Ruby");
-    tribeCodes.put("518", "Saint George Island");
-    tribeCodes.put("519", "Native Village of Saint Michael");
-    tribeCodes.put("520", "Saint Paul Island");
-    tribeCodes.put("521", "Salamatof Tribe");
-    tribeCodes.put("522", "Native Village of Savoonga");
-    tribeCodes.put("523", "Organized Village of Saxman");
-    tribeCodes.put("524", "Native Village of Scammon Bay");
-    tribeCodes.put("525", "Native Village of Selawik");
-    tribeCodes.put("526", "Seldovia Village Tribe");
-    tribeCodes.put("527", "Shageluk Native Village");
-    tribeCodes.put("528", "Native Village of Shaktoolik");
-    tribeCodes.put("529", "Native Village of Nunam Iqua");
-    tribeCodes.put("530", "Native Village of Shishmaref");
-    tribeCodes.put("531", "Sun'aq Tribe of Kodiak");
-    tribeCodes.put("532", "Native Village of Shungnak");
-    tribeCodes.put("533", "Sitka Tribe of Alaska");
-    tribeCodes.put("534", "Skagway Village");
-    tribeCodes.put("535", "Village of Sleetmute");
-    tribeCodes.put("536", "Village of Solomon");
-    tribeCodes.put("537", "South Naknek Village");
-    tribeCodes.put("538", "Stebbins Community Association");
-    tribeCodes.put("539", "Native Village of Stevens");
-    tribeCodes.put("540", "Village of Stony River");
-    tribeCodes.put("541", "Takotna Village");
-    tribeCodes.put("542", "Native Village of Tanacross");
-    tribeCodes.put("543", "Native Village of Tanana");
-    tribeCodes.put("544", "Native Village of Tatitlek");
-    tribeCodes.put("545", "Native Village of Tazlina");
-    tribeCodes.put("546", "Telida Village");
-    tribeCodes.put("547", "Native Village of Teller");
-    tribeCodes.put("548", "Native Village of Tetlin");
-    tribeCodes.put("549", "Central Council of the Tlingit & Haida Indian Tribes");
-    tribeCodes.put("550", "Traditional Village of Togiak");
-    tribeCodes.put("551", "Tuluksak Native Community");
-    tribeCodes.put("552", "Native Village of Tuntutuliak");
-    tribeCodes.put("553", "Native Village of Tununak");
-    tribeCodes.put("554", "Twin Hills Village");
-    tribeCodes.put("555", "Native Village of Tyonek");
-    tribeCodes.put("556", "Ugashik Village");
-    tribeCodes.put("557", "Umkumiut Native Village");
-    tribeCodes.put("558", "Native Village of Unalakleet");
-    tribeCodes.put("559", "Native Village of Unga");
-    tribeCodes.put("560", "Village of Venetie");
-    tribeCodes.put(
-        "561",
-        "Native Village of Venetie Tribal Government (Arctic Village and Village of Venetie)");
-    tribeCodes.put("562", "Village of Wainwright");
-    tribeCodes.put("563", "Native Village of Wales");
-    tribeCodes.put("564", "Native Village of White Mountain");
-    tribeCodes.put("565", "Wrangell Cooperative Association");
-    tribeCodes.put("566", "Yakutat Tlingit Tribe");
-    tribeCodes.put("567", "Chickahominy Indian Tribe");
-    tribeCodes.put("568", "Chickahominy Indian Tribe—Eastern Division");
-    tribeCodes.put("569", "Monacan Indian Nation");
-    tribeCodes.put("570", "Nansemond Indian Nation");
-    tribeCodes.put("571", "Rappahannock Tribe, Inc.");
-    tribeCodes.put("572", "Upper Mattaponi Tribe");
-    tribeCodes.put("573", "Cowlitz Indian Tribe");
-    tribeCodes.put("574", "Little Shell Tribe of Chippewa Indians of Montana");
-    tribeCodes.put("575", "Mashpee Wampanoag Tribe");
-    tribeCodes.put("576", "Pamunkey Indian Tribe");
-    tribeCodes.put("577", "Shinnecock Indian Nation");
-    tribeCodes.put("578", "Wilton Rancheria, California");
-    tribeCodes.put("579", "Tejon Indian Tribe");
-    return tribeCodes;
-  }
+    public static Map<String, String> tribalMap() {
+        var tribeCodes = new HashMap<String, String>();
+        tribeCodes.put("1", "Absentee-Shawnee Tribe of Indians of Oklahoma");
+        tribeCodes.put(
+                "2",
+                "Agua Caliente Band of Cahuilla Indians of the Agua Caliente Indian Reservation, California");
+        tribeCodes.put("3", "Ak-Chin Indian Community");
+        tribeCodes.put("4", "Alabama-Coushatta Tribe of Texas");
+        tribeCodes.put("5", "Alabama-Quassarte Tribal Town");
+        tribeCodes.put("6", "Alturas Indian Rancheria, California");
+        tribeCodes.put("7", "Apache Tribe of Oklahoma");
+        tribeCodes.put("8", "Northern Arapaho Tribe of the Wind River Reservation, Wyoming");
+        tribeCodes.put("9", "Mi'kmaq Nation");
+        tribeCodes.put(
+                "10", "Assiniboine and Sioux Tribes of the Fort Peck Indian Reservation, Montana");
+        tribeCodes.put("11", "Augustine Band of Cahuilla Indians, California");
+        tribeCodes.put(
+                "12",
+                "Bad River Band of the Lake Superior Tribe of Chippewa Indians of the Bad River Reservation, Wisconsin");
+        tribeCodes.put("33", "Barona Group of Capitan Grande Band of Mission Ind");
+        tribeCodes.put("13", "Bay Mills Indian Community, Michigan");
+        tribeCodes.put("14", "Bear River Band of the Rohnerville Rancheria, California");
+        tribeCodes.put("15", "Berry Creek Rancheria of Maidu Indians of California");
+        tribeCodes.put("16", "Big Lagoon Rancheria, California");
+        tribeCodes.put("17", "Big Pine Paiute Tribe of the Owens Valley");
+        tribeCodes.put("18", "Big Sandy Rancheria of Western Mono Indians of California");
+        tribeCodes.put("19", "Big Valley Band of Pomo Indians of the Big Valley Rancheria, California");
+        tribeCodes.put("20", "Blackfeet Tribe of the Blackfeet Indian Reservation of Montana");
+        tribeCodes.put("21", "Blue Lake Rancheria, California");
+        tribeCodes.put("22", "Bridgeport Indian Colony");
+        tribeCodes.put("23", "Buena Vista Rancheria of Me-Wuk Indians of California");
+        tribeCodes.put("24", "Burns Paiute Tribe");
+        tribeCodes.put("25", "Cabazon Band of Mission Indians, California");
+        tribeCodes.put(
+                "26",
+                "Cachil DeHe Band of Wintun Indians of the Colusa Indian Community of the Colusa Rancheria, California");
+        tribeCodes.put("27", "Caddo Nation of Oklahoma");
+        tribeCodes.put("29", "Cahto Tribe of the Laytonville Rancheria");
+        tribeCodes.put("28", "Cahuilla Band of Indians");
+        tribeCodes.put("30", "California Valley Miwok Tribe, California");
+        tribeCodes.put(
+                "31", "Campo Band of Diegueno Mission Indians of the Campo Indian Reservation, California");
+        tribeCodes.put("32", "Capitan Grande Band of Diegueno Mission Indians of California");
+        tribeCodes.put("35", "Catawba Indian Nation");
+        tribeCodes.put("36", "Cayuga Nation");
+        tribeCodes.put("37", "Cedarville Rancheria, California");
+        tribeCodes.put("38", "Chemehuevi Indian Tribe of the Chemehuevi Reservation, California");
+        tribeCodes.put("39", "Cher-Ae Heights Indian Community of the Trinidad Rancheria, California");
+        tribeCodes.put("40", "Cherokee Nation");
+        tribeCodes.put(
+                "42", "Cheyenne River Sioux Tribe of the Cheyenne River Reservation, South Dakota");
+        tribeCodes.put("41", "Cheyenne and Arapaho Tribes, Oklahoma");
+        tribeCodes.put("43", "The Chickasaw Nation");
+        tribeCodes.put("44", "Chicken Ranch Rancheria of Me-Wuk Indians of California");
+        tribeCodes.put("45", "Chippewa Cree Indians of the Rocky Boy's Reservation, Montana");
+        tribeCodes.put("46", "Chitimacha Tribe of Louisiana");
+        tribeCodes.put("47", "The Choctaw Nation of Oklahoma");
+        tribeCodes.put("48", "Citizen Potawatomi Nation, Oklahoma");
+        tribeCodes.put("49", "Cloverdale Rancheria of Pomo Indians of California");
+        tribeCodes.put("50", "Cocopah Tribe of Arizona");
+        tribeCodes.put("51", "Coeur D'Alene Tribe");
+        tribeCodes.put("52", "Cold Springs Rancheria of Mono Indians of California");
+        tribeCodes.put(
+                "53",
+                "Colorado River Indian Tribes of the Colorado River Indian Reservation, Arizona and California");
+        tribeCodes.put("54", "Comanche Nation, Oklahoma");
+        tribeCodes.put("55", "Confederated Salish and Kootenai Tribes of the Flathead Reservation");
+        tribeCodes.put("64", "Confederated Tribes and Bands of the Yakama Nation");
+        tribeCodes.put("56", "Confederated Tribes of the Chehalis Reservation");
+        tribeCodes.put("57", "Confederated Tribes of the Colville Reservation");
+        tribeCodes.put("58", "Confederated Tribes of the Coos, Lower Umpqua and Siuslaw Indians");
+        tribeCodes.put("59", "Confederated Tribes of the Goshute Reservation, Nevada and Utah");
+        tribeCodes.put("60", "Confederated Tribes of the Grand Ronde Community of Oregon");
+        tribeCodes.put("61", "Confederated Tribes of Siletz Indians of Oregon");
+        tribeCodes.put("62", "Confederated Tribes of the Umatilla Indian Reservation");
+        tribeCodes.put("63", "Confederated Tribes of the Warm Springs Reservation of Oregon");
+        tribeCodes.put("65", "Coquille Indian Tribe");
+        tribeCodes.put("66", "Kletsel Dehe Band of Wintun Indians");
+        tribeCodes.put("67", "Coushatta Tribe of Louisiana");
+        tribeCodes.put("68", "Cow Creek Band of Umpqua Tribe of Indians");
+        tribeCodes.put("69", "Coyote Valley Band of Pomo Indians of California");
+        tribeCodes.put("71", "Crow Creek Sioux Tribe of the Crow Creek Reservation, South Dakota");
+        tribeCodes.put("70", "Crow Tribe of Montana");
+        tribeCodes.put("72", "Ewiiaapaayp Band of Kumeyaay Indians, California");
+        tribeCodes.put("73", "Timbisha Shoshone Tribe");
+        tribeCodes.put("74", "Delaware Nation, Oklahoma");
+        tribeCodes.put("75", "Delaware Tribe of Indians");
+        tribeCodes.put("76", "Dry Creek Rancheria Band of Pomo Indians, California");
+        tribeCodes.put("77", "Duckwater Shoshone Tribe of the Duckwater Reservation, Nevada");
+        tribeCodes.put("78", "Eastern Band of Cherokee Indians");
+        tribeCodes.put("79", "Eastern Shawnee Tribe of Oklahoma");
+        tribeCodes.put(
+                "80", "Elem Indian Colony of Pomo Indians of the Sulphur Bank Rancheria, California");
+        tribeCodes.put("81", "Elk Valley Rancheria, California");
+        tribeCodes.put("82", "Ely Shoshone Tribe of Nevada");
+        tribeCodes.put("83", "Enterprise Rancheria of Maidu Indians of California");
+        tribeCodes.put("84", "Flandreau Santee Sioux Tribe of South Dakota");
+        tribeCodes.put("85", "Forest County Potawatomi Community, Wisconsin");
+        tribeCodes.put(
+                "86", "Fort Belknap Indian Community of the Fort Belknap Reservation of Montana");
+        tribeCodes.put(
+                "87", "Fort Bidwell Indian Community of the Fort Bidwell Reservation of California");
+        tribeCodes.put(
+                "88",
+                "Fort Independence Indian Community of Paiute Indians of the Fort Independence Reservation, California");
+        tribeCodes.put(
+                "89",
+                "Fort McDermitt Paiute and Shoshone Tribes of the Fort McDermitt Indian Reservation, Nevada and Oregon");
+        tribeCodes.put("90", "Fort McDowell Yavapai Nation, Arizona");
+        tribeCodes.put("91", "Fort Mojave Indian Tribe of Arizona, California & Nevada");
+        tribeCodes.put("92", "Fort Sill Apache Tribe of Oklahoma");
+        tribeCodes.put(
+                "93", "Gila River Indian Community of the Gila River Indian Reservation, Arizona");
+        tribeCodes.put("94", "Grand Traverse Band of Ottawa and Chippewa Indians, Michigan");
+        tribeCodes.put("95", "Federated Indians of Graton Rancheria, California");
+        tribeCodes.put("96", "Greenville Rancheria");
+        tribeCodes.put("97", "Grindstone Indian Rancheria of Wintun-Wailaki Indians of California");
+        tribeCodes.put("98", "Guidiville Rancheria of California");
+        tribeCodes.put("99", "Hannahville Indian Community, Michigan");
+        tribeCodes.put("100", "Havasupai Tribe of the Havasupai Reservation, Arizona");
+        tribeCodes.put("101", "Ho-Chunk Nation of Wisconsin");
+        tribeCodes.put("102", "Hoh Indian Tribe");
+        tribeCodes.put("103", "Hoopa Valley Tribe, California");
+        tribeCodes.put("104", "Hopi Tribe of Arizona");
+        tribeCodes.put("105", "Hopland Band of Pomo Indians, California");
+        tribeCodes.put("106", "Houlton Band of Maliseet Indians");
+        tribeCodes.put("107", "Hualapai Indian Tribe of the Hualapai Indian Reservation, Arizona");
+        tribeCodes.put("108", "Nottawaseppi Huron Band of the Potawatomi, Michigan");
+        tribeCodes.put(
+                "109",
+                "Inaja Band of Diegueno Mission Indians of the Inaja and Cosmit Reservation, California");
+        tribeCodes.put("110", "Ione Band of Miwok Indians of California");
+        tribeCodes.put("111", "Iowa Tribe of Kansas and Nebraska");
+        tribeCodes.put("112", "Iowa Tribe of Oklahoma");
+        tribeCodes.put("113", "Jackson Band of Miwuk Indians");
+        tribeCodes.put("114", "Jamestown S'Klallam Tribe");
+        tribeCodes.put("115", "Jamul Indian Village of California");
+        tribeCodes.put("116", "Jena Band of Choctaw Indians");
+        tribeCodes.put("117", "Jicarilla Apache Nation, New Mexico");
+        tribeCodes.put(
+                "118", "Kaibab Band of Paiute Indians of the Kaibab Indian Reservation, Arizona");
+        tribeCodes.put("119", "Kalispel Indian Community of the Kalispel Reservation");
+        tribeCodes.put("120", "Karuk Tribe");
+        tribeCodes.put(
+                "121", "Kashia Band of Pomo Indians of the Stewarts Point Rancheria, California");
+        tribeCodes.put("122", "Kaw Nation, Oklahoma");
+        tribeCodes.put("123", "Keweenaw Bay Indian Community, Michigan");
+        tribeCodes.put("124", "Kialegee Tribal Town");
+        tribeCodes.put("127", "Kickapoo Traditional Tribe of Texas");
+        tribeCodes.put("125", "Kickapoo Tribe of Indians of the Kickapoo Reservation in Kansas");
+        tribeCodes.put("126", "Kickapoo Tribe of Oklahoma");
+        tribeCodes.put("128", "Kiowa Indian Tribe of Oklahoma");
+        tribeCodes.put("129", "Klamath Tribes");
+        tribeCodes.put("130", "Kootenai Tribe of Idaho");
+        tribeCodes.put("131", "La Jolla Band of Luiseno Indians, California");
+        tribeCodes.put(
+                "132",
+                "La Posta Band of Diegueno Mission Indians of the La Posta Indian Reservation, California");
+        tribeCodes.put(
+                "133", "Lac Courte Oreilles Band of Lake Superior Chippewa Indians of Wisconsin");
+        tribeCodes.put(
+                "134",
+                "Lac du Flambeau Band of Lake Superior Chippewa Indians of the Lac du Flambeau Reservation of Wisconsin");
+        tribeCodes.put("135", "Lac Vieux Desert Band of Lake Superior Chippewa Indians of Michigan");
+        tribeCodes.put(
+                "136", "Las Vegas Tribe of Paiute Indians of the Las Vegas Indian Colony, Nevada");
+        tribeCodes.put("137", "Little River Band of Ottawa Indians, Michigan");
+        tribeCodes.put("138", "Little Traverse Bay Bands of Odawa Indians, Michigan");
+        tribeCodes.put("140", "Los Coyotes Band of Cahuilla and Cupeno Indians, California");
+        tribeCodes.put("141", "Lovelock Paiute Tribe of the Lovelock Indian Colony, Nevada");
+        tribeCodes.put("142", "Lower Brule Sioux Tribe of the Lower Brule Reservation, South Dakota");
+        tribeCodes.put("143", "Lower Elwha Tribal Community");
+        tribeCodes.put("139", "Koi Nation of Northern California");
+        tribeCodes.put("144", "Lower Sioux Indian Community in the State of Minnesota");
+        tribeCodes.put("145", "Lummi Tribe of the Lummi Reservation");
+        tribeCodes.put("146", "Lytton Rancheria of California");
+        tribeCodes.put("147", "Makah Indian Tribe of the Makah Indian Reservation");
+        tribeCodes.put(
+                "148", "Manchester Band of Pomo Indians of the Manchester Rancheria, California");
+        tribeCodes.put(
+                "149",
+                "Manzanita Band of Diegueno Mission Indians of the Manzanita Reservation, California");
+        tribeCodes.put("150", "Mashantucket Pequot Indian Tribe");
+        tribeCodes.put("151", "Match-e-be-nash-she-wish Band of Pottawatomi Indians of Michigan");
+        tribeCodes.put("152", "Mechoopda Indian Tribe of Chico Rancheria, California");
+        tribeCodes.put("153", "Menominee Indian Tribe of Wisconsin");
+        tribeCodes.put(
+                "154",
+                "Mesa Grande Band of Diegueno Mission Indians of the Mesa Grande Reservation, California");
+        tribeCodes.put("155", "Mescalero Apache Tribe of the Mescalero Reservation, New Mexico");
+        tribeCodes.put("156", "Miami Tribe of Oklahoma");
+        tribeCodes.put("157", "Miccosukee Tribe of Indians");
+        tribeCodes.put("158", "Middletown Rancheria of Pomo Indians of California");
+        tribeCodes.put(
+                "159",
+                "Minnesota Chippewa Tribe, Minnesota (Six component reservations: Bois Forte Band (Nett Lake); Fond du Lac Band; Grand Portage Band; Leech Lake Band; Mille Lacs Band; White Earth Band)");
+        tribeCodes.put("160", "Bois Forte Band (Nett Lake); Fond du Lac Band; Gra");
+        tribeCodes.put("161", "Mississippi Band of Choctaw Indians");
+        tribeCodes.put(
+                "162", "Moapa Band of Paiute Indians of the Moapa River Indian Reservation, Nevada");
+        tribeCodes.put("163", "Modoc Nation");
+        tribeCodes.put("164", "Mohegan Tribe of Indians of Connecticut");
+        tribeCodes.put("165", "Mooretown Rancheria of Maidu Indians of California");
+        tribeCodes.put("166", "Morongo Band of Mission Indians, California");
+        tribeCodes.put("167", "Muckleshoot Indian Tribe");
+        tribeCodes.put("168", "The Muscogee (Creek) Nation");
+        tribeCodes.put("169", "Narragansett Indian Tribe");
+        tribeCodes.put("170", "Navajo Nation, Arizona, New Mexico, & Utah");
+        tribeCodes.put("171", "Nez Perce Tribe");
+        tribeCodes.put("172", "Nisqually Indian Tribe of the Nisqually Reservatio");
+        tribeCodes.put("173", "Nooksack Indian Tribe");
+        tribeCodes.put(
+                "174", "Northern Cheyenne Tribe of the Northern Cheyenne Indian Reservation, Montana");
+        tribeCodes.put("175", "Northfork Rancheria of Mono Indians of California");
+        tribeCodes.put("176", "Northwestern Band of the Shoshone Nation");
+        tribeCodes.put("177", "Oglala Sioux Tribe");
+        tribeCodes.put("178", "Omaha Tribe of Nebraska");
+        tribeCodes.put("179", "Oneida Indian Nation");
+        tribeCodes.put("180", "Oneida Nation");
+        tribeCodes.put("181", "Onondaga Nation");
+        tribeCodes.put("182", "The Osage Nation");
+        tribeCodes.put("184", "Otoe-Missouria Tribe of Indians, Oklahoma");
+        tribeCodes.put("183", "Ottawa Tribe of Oklahoma");
+        tribeCodes.put(
+                "185",
+                "Paiute Indian Tribe of Utah (Cedar Band of Paiutes, Kanosh Band of Paiutes, Koosharem Band of Paiutes, Indian Peaks Band of Paiutes, and Shivwits Band of Paiutes)");
+        tribeCodes.put("186", "Bishop Paiute Tribe");
+        tribeCodes.put("188", "Lone Pine Paiute-Shoshone Tribe");
+        tribeCodes.put("187", "Paiute-Shoshone Tribe of the Fallon Reservation and Colony, Nevada");
+        tribeCodes.put("189", "Pala Band of Mission Indians");
+        tribeCodes.put("190", "Pascua Yaqui Tribe of Arizona");
+        tribeCodes.put("191", "Paskenta Band of Nomlaki Indians of California");
+        tribeCodes.put("192", "Passamaquoddy Tribe");
+        tribeCodes.put(
+                "193",
+                "Pauma Band of Luiseno Mission Indians of the Pauma & Yuima Reservation, California");
+        tribeCodes.put("194", "Pawnee Nation of Oklahoma");
+        tribeCodes.put("195", "Pechanga Band of Indians");
+        tribeCodes.put("196", "Penobscot Nation");
+        tribeCodes.put("197", "Peoria Tribe of Indians of Oklahoma");
+        tribeCodes.put("198", "Picayune Rancheria of Chukchansi Indians of California");
+        tribeCodes.put("199", "Pinoleville Pomo Nation, California");
+        tribeCodes.put(
+                "200",
+                "Pit River Tribe, California (includes XL Ranch, Big Bend, Likely, Lookout, Montgomery Creek, and Roaring Creek Rancherias)");
+        tribeCodes.put("201", "Poarch Band of Creek Indians");
+        tribeCodes.put("202", "Pokagon Band of Potawatomi Indians, Michigan and Indiana");
+        tribeCodes.put("203", "Ponca Tribe of Indians of Oklahoma");
+        tribeCodes.put("204", "Ponca Tribe of Nebraska");
+        tribeCodes.put("205", "Port Gamble S'Klallam Tribe");
+        tribeCodes.put("206", "Potter Valley Tribe, California");
+        tribeCodes.put("207", "Prairie Band Potawatomi Nation");
+        tribeCodes.put("208", "Prairie Island Indian Community in the State of Minnesota");
+        tribeCodes.put("209", "Pueblo of Acoma, New Mexico");
+        tribeCodes.put("210", "Pueblo of Cochiti, New Mexico");
+        tribeCodes.put("212", "Pueblo of Isleta, New Mexico");
+        tribeCodes.put("211", "Pueblo of Jemez, New Mexico");
+        tribeCodes.put("213", "Pueblo of Laguna, New Mexico");
+        tribeCodes.put("214", "Pueblo of Nambe, New Mexico");
+        tribeCodes.put("215", "Pueblo of Picuris, New Mexico");
+        tribeCodes.put("216", "Pueblo of Pojoaque, New Mexico");
+        tribeCodes.put("217", "Pueblo of San Felipe, New Mexico");
+        tribeCodes.put("219", "Pueblo of San Ildefonso, New Mexico");
+        tribeCodes.put("218", "Ohkay Owingeh, New Mexico");
+        tribeCodes.put("220", "Pueblo of Sandia, New Mexico");
+        tribeCodes.put("221", "Pueblo of Santa Ana, New Mexico");
+        tribeCodes.put("222", "Pueblo of Santa Clara, New Mexico");
+        tribeCodes.put("223", "Santo Domingo Pueblo");
+        tribeCodes.put("224", "Pueblo of Taos, New Mexico");
+        tribeCodes.put("225", "Pueblo of Tesuque, New Mexico");
+        tribeCodes.put("226", "Pueblo of Zia, New Mexico");
+        tribeCodes.put("227", "Puyallup Tribe of the Puyallup Reservation");
+        tribeCodes.put("228", "Pyramid Lake Paiute Tribe of the Pyramid Lake Reservation, Nevada");
+        tribeCodes.put("229", "Quapaw Nation");
+        tribeCodes.put(
+                "230", "Quartz Valley Indian Community of the Quartz Valley Reservation of California");
+        tribeCodes.put(
+                "231", "Quechan Tribe of the Fort Yuma Indian Reservation, California & Arizona");
+        tribeCodes.put("232", "Quileute Tribe of the Quileute Reservation");
+        tribeCodes.put("233", "Quinault Indian Nation");
+        tribeCodes.put("234", "Ramona Band of Cahuilla, California");
+        tribeCodes.put("235", "Red Cliff Band of Lake Superior Chippewa Indians of Wisconsin");
+        tribeCodes.put("236", "Red Lake Band of Chippewa Indians, Minnesota");
+        tribeCodes.put("237", "Redding Rancheria, California");
+        tribeCodes.put(
+                "238",
+                "Redwood Valley or Little River Band of Pomo Indians of the Redwood Valley Rancheria California");
+        tribeCodes.put("239", "Reno-Sparks Indian Colony, Nevada");
+        tribeCodes.put("240", "Resighini Rancheria, California");
+        tribeCodes.put(
+                "241", "Rincon Band of Luiseno Mission Indians of Rincon Reservation, California");
+        tribeCodes.put("242", "Robinson Rancheria");
+        tribeCodes.put("243", "Rosebud Sioux Tribe of the Rosebud Indian Reservation, South Dakota");
+        tribeCodes.put("244", "Round Valley Indian Tribes, Round Valley Reservation, California");
+        tribeCodes.put("245", "Yocha Dehe Wintun Nation, California");
+        tribeCodes.put("247", "Sac & Fox Nation of Missouri in Kansas and Nebraska");
+        tribeCodes.put("248", "Sac & Fox Nation, Oklahoma");
+        tribeCodes.put("246", "Sac & Fox Tribe of the Mississippi in Iowa");
+        tribeCodes.put("249", "Saginaw Chippewa Indian Tribe of Michigan");
+        tribeCodes.put(
+                "250", "Salt River Pima-Maricopa Indian Community of the Salt River Reservation, Arizona");
+        tribeCodes.put("251", "Samish Indian Nation");
+        tribeCodes.put("252", "San Carlos Apache Tribe of the San Carlos Reservation, Arizona");
+        tribeCodes.put("253", "San Juan Southern Paiute Tribe of Arizona");
+        tribeCodes.put("254", "Yuhaaviatam of San Manuel Nation");
+        tribeCodes.put("255", "San Pasqual Band of Diegueno Mission Indians of California");
+        tribeCodes.put("257", "Santa Rosa Band of Cahuilla Indians, California");
+        tribeCodes.put("256", "Santa Rosa Indian Community of the Santa Rosa Rancheria, California");
+        tribeCodes.put(
+                "258",
+                "Santa Ynez Band of Chumash Mission Indians of the Santa Ynez Reservation, California");
+        tribeCodes.put("259", "Iipay Nation of Santa Ysabel, California");
+        tribeCodes.put("260", "Santee Sioux Nation, Nebraska");
+        tribeCodes.put("261", "Sauk-Suiattle Indian Tribe");
+        tribeCodes.put("262", "Sault Ste. Marie Tribe of Chippewa Indians, Michigan");
+        tribeCodes.put("263", "Scotts Valley Band of Pomo Indians of California");
+        tribeCodes.put("264", "The Seminole Nation of Oklahoma");
+        tribeCodes.put("265", "Seminole Tribe of Florida");
+        tribeCodes.put("266", "Seneca Nation of Indians");
+        tribeCodes.put("267", "Seneca-Cayuga Nation");
+        tribeCodes.put("268", "Shakopee Mdewakanton Sioux Community of Minnesota");
+        tribeCodes.put("269", "Shawnee Tribe");
+        tribeCodes.put("270", "Sherwood Valley Rancheria of Pomo Indians of California");
+        tribeCodes.put(
+                "271",
+                "Shingle Springs Band of Miwok Indians, Shingle Springs Rancheria (Verona Tract), California");
+        tribeCodes.put("272", "Shoalwater Bay Indian Tribe of the Shoalwater Bay Indian Reservation");
+        tribeCodes.put("273", "Eastern Shoshone Tribe of the Wind River Reservation, Wyoming");
+        tribeCodes.put("274", "Shoshone-Bannock Tribes of the Fort Hall Reservation");
+        tribeCodes.put("275", "Shoshone-Paiute Tribes of the Duck Valley Reservation, Nevada");
+        tribeCodes.put("276", "Sisseton-Wahpeton Oyate of the Lake Traverse Reservation, South Dakota");
+        tribeCodes.put("277", "Skokomish Indian Tribe");
+        tribeCodes.put("278", "Skull Valley Band of Goshute Indians of Utah");
+        tribeCodes.put("279", "Tolowa Dee-ni' Nation");
+        tribeCodes.put("280", "Snoqualmie Indian Tribe");
+        tribeCodes.put("281", "Soboba Band of Luiseno Indians, California");
+        tribeCodes.put("282", "Sokaogon Chippewa Community, Wisconsin");
+        tribeCodes.put("283", "Southern Ute Indian Tribe of the Southern Ute Reservation, Colorado");
+        tribeCodes.put("284", "Spirit Lake Tribe, North Dakota");
+        tribeCodes.put("285", "Spokane Tribe of the Spokane Reservation");
+        tribeCodes.put("286", "Squaxin Island Tribe of the Squaxin Island Reservation");
+        tribeCodes.put("287", "St. Croix Chippewa Indians of Wisconsin");
+        tribeCodes.put("288", "Saint Regis Mohawk Tribe");
+        tribeCodes.put("289", "Standing Rock Sioux Tribe of North & South Dakota");
+        tribeCodes.put("291", "Stillaguamish Tribe of Indians of Washington");
+        tribeCodes.put("290", "Stockbridge Munsee Community, Wisconsin");
+        tribeCodes.put("292", "Summit Lake Paiute Tribe of Nevada");
+        tribeCodes.put("293", "Suquamish Indian Tribe of the Port Madison Reservation");
+        tribeCodes.put("294", "Susanville Indian Rancheria, California");
+        tribeCodes.put("295", "Swinomish Indian Tribal Community");
+        tribeCodes.put("296", "Sycuan Band of the Kumeyaay Nation");
+        tribeCodes.put("297", "Wiyot Tribe, California");
+        tribeCodes.put("298", "Table Mountain Rancheria");
+        tribeCodes.put(
+                "299",
+                "Te-Moak Tribe of Western Shoshone Indians of Nevada (Four constituent bands: Battle Mountain Band; Elko Band; South Fork Band; and Wells Band)");
+        tribeCodes.put("300", "Thlopthlocco Tribal Town");
+        tribeCodes.put("301", "Three Affiliated Tribes of the Fort Berthold Reservation, North Dakota");
+        tribeCodes.put("302", "Tohono O'odham Nation of Arizona");
+        tribeCodes.put("303", "Tonawanda Band of Seneca");
+        tribeCodes.put("304", "Tonkawa Tribe of Indians of Oklahoma");
+        tribeCodes.put("305", "Tonto Apache Tribe of Arizona");
+        tribeCodes.put("306", "Torres Martinez Desert Cahuilla Indians, California");
+        tribeCodes.put("308", "Tulalip Tribes of Washington");
+        tribeCodes.put("307", "Tule River Indian Tribe of the Tule River Reservation, California");
+        tribeCodes.put("309", "Tunica-Biloxi Indian Tribe");
+        tribeCodes.put(
+                "310", "Tuolumne Band of Me-Wuk Indians of the Tuolumne Rancheria of California");
+        tribeCodes.put("311", "Turtle Mountain Band of Chippewa Indians of North Dakota");
+        tribeCodes.put("312", "Tuscarora Nation");
+        tribeCodes.put("313", "Twenty-Nine Palms Band of Mission Indians of California");
+        tribeCodes.put("314", "United Auburn Indian Community of the Auburn Rancheria of California");
+        tribeCodes.put("315", "United Keetoowah Band of Cherokee Indians in Oklahoma");
+        tribeCodes.put("316", "Habematolel Pomo of Upper Lake, California");
+        tribeCodes.put("317", "Upper Sioux Community, Minnesota");
+        tribeCodes.put("318", "Upper Skagit Indian Tribe");
+        tribeCodes.put("319", "Ute Indian Tribe of the Uintah & Ouray Reservation, Utah");
+        tribeCodes.put("320", "Ute Mountain Ute Tribe");
+        tribeCodes.put(
+                "321", "Utu Utu Gwaitu Paiute Tribe of the Benton Paiute Reservation, California");
+        tribeCodes.put("34", "Viejas (Baron Long) Group of Capitan Grande Band o");
+        tribeCodes.put("322", "Walker River Paiute Tribe of the Walker River Reservation, Nevada");
+        tribeCodes.put("323", "Wampanoag Tribe of Gay Head (Aquinnah)");
+        tribeCodes.put(
+                "324",
+                "Washoe Tribe of Nevada & California (Carson Colony, Dresslerville Colony, Woodfords Community, Stewart Community, & Washoe Ranches)");
+        tribeCodes.put("325", "White Mountain Apache Tribe of the Fort Apache Reservation, Arizona");
+        tribeCodes.put(
+                "326", "Wichita and Affiliated Tribes (Wichita, Keechi, Waco, & Tawakonie), Oklahoma");
+        tribeCodes.put("327", "Winnebago Tribe of Nebraska");
+        tribeCodes.put("328", "Winnemucca Indian Colony of Nevada");
+        tribeCodes.put("329", "Wyandotte Nation");
+        tribeCodes.put("330", "Yankton Sioux Tribe of South Dakota");
+        tribeCodes.put("331", "Yavapai-Apache Nation of the Camp Verde Indian Reservation, Arizona");
+        tribeCodes.put("332", "Yavapai-Prescott Indian Tribe");
+        tribeCodes.put(
+                "333", "Yerington Paiute Tribe of the Yerington Colony & Campbell Ranch, Nevada");
+        tribeCodes.put("334", "Yomba Shoshone Tribe of the Yomba Reservation, Nevada");
+        tribeCodes.put("335", "Ysleta del Sur Pueblo");
+        tribeCodes.put("336", "Yurok Tribe of the Yurok Reservation, California");
+        tribeCodes.put("337", "Zuni Tribe of the Zuni Reservation, New Mexico");
+        tribeCodes.put("338", "Native Village of Afognak");
+        tribeCodes.put("339", "Agdaagux Tribe of King Cove");
+        tribeCodes.put("340", "Native Village of Akhiok");
+        tribeCodes.put("341", "Akiachak Native Community");
+        tribeCodes.put("342", "Akiak Native Community");
+        tribeCodes.put("343", "Native Village of Akutan");
+        tribeCodes.put("344", "Village of Alakanuk");
+        tribeCodes.put("345", "Alatna Village");
+        tribeCodes.put("346", "Native Village of Aleknagik");
+        tribeCodes.put("347", "Algaaciq Native Village (St. Mary's)");
+        tribeCodes.put("348", "Allakaket Village");
+        tribeCodes.put("349", "Native Village of Ambler");
+        tribeCodes.put("350", "Village of Anaktuvuk Pass");
+        tribeCodes.put("351", "Yupiit of Andreafski");
+        tribeCodes.put("352", "Angoon Community Association");
+        tribeCodes.put("353", "Village of Aniak");
+        tribeCodes.put("354", "Anvik Village");
+        tribeCodes.put("355", "Arctic Village");
+        tribeCodes.put("356", "Asa'carsarmiut Tribe");
+        tribeCodes.put("357", "Native Village of Atka");
+        tribeCodes.put("358", "Village of Atmautluak");
+        tribeCodes.put("359", "Native Village of Atqasuk");
+        tribeCodes.put("360", "Native Village of Barrow Inupiat Traditional Government");
+        tribeCodes.put("361", "Beaver Village");
+        tribeCodes.put("362", "Native Village of Belkofski");
+        tribeCodes.put("363", "Village of Bill Moore's Slough");
+        tribeCodes.put("364", "Birch Creek Tribe");
+        tribeCodes.put("365", "Native Village of Brevig Mission");
+        tribeCodes.put("366", "Native Village of Buckland");
+        tribeCodes.put("367", "Native Village of Cantwell");
+        tribeCodes.put("368", "Native Village of Chenega (aka Chanega)");
+        tribeCodes.put("369", "Chalkyitsik Village");
+        tribeCodes.put("370", "Village of Chefornak");
+        tribeCodes.put("371", "Chevak Native Village");
+        tribeCodes.put("372", "Chickaloon Native Village");
+        tribeCodes.put("373", "Chignik Bay Tribal Council");
+        tribeCodes.put("374", "Native Village of Chignik Lagoon");
+        tribeCodes.put("375", "Chignik Lake Village");
+        tribeCodes.put("376", "Chilkat Indian Village (Klukwan)");
+        tribeCodes.put("377", "Chilkoot Indian Association (Haines)");
+        tribeCodes.put("378", "Chinik Eskimo Community (Golovin)");
+        tribeCodes.put("379", "Cheesh-Na Tribe");
+        tribeCodes.put("380", "Native Village of Chitina");
+        tribeCodes.put("381", "Native Village of Chuathbaluk (Russian Mission, Kuskokwim)");
+        tribeCodes.put("382", "Chuloonawick Native Village");
+        tribeCodes.put("383", "Circle Native Community");
+        tribeCodes.put("384", "Village of Clarks Point");
+        tribeCodes.put("385", "Native Village of Council");
+        tribeCodes.put("386", "Craig Tribal Association");
+        tribeCodes.put("387", "Village of Crooked Creek");
+        tribeCodes.put("388", "Curyung Tribal Council");
+        tribeCodes.put("389", "Native Village of Deering");
+        tribeCodes.put("390", "Native Village of Diomede (aka Inalik)");
+        tribeCodes.put("391", "Village of Dot Lake");
+        tribeCodes.put("392", "Douglas Indian Association");
+        tribeCodes.put("393", "Native Village of Eagle");
+        tribeCodes.put("394", "Native Village of Eek");
+        tribeCodes.put("395", "Egegik Village");
+        tribeCodes.put("396", "Eklutna Native Village");
+        tribeCodes.put("397", "Native Village of Ekuk");
+        tribeCodes.put("398", "Native Village of Ekwok");
+        tribeCodes.put("399", "Native Village of Elim");
+        tribeCodes.put("400", "Emmonak Village");
+        tribeCodes.put("401", "Evansville Village (aka Bettles Field)");
+        tribeCodes.put("402", "Native Village of Eyak (Cordova)");
+        tribeCodes.put("403", "Native Village of False Pass");
+        tribeCodes.put("404", "Native Village of Fort Yukon");
+        tribeCodes.put("405", "Native Village of Gakona");
+        tribeCodes.put("406", "Galena Village (aka Louden Village)");
+        tribeCodes.put("407", "Native Village of Gambell");
+        tribeCodes.put("408", "Native Village of Georgetown");
+        tribeCodes.put("409", "Native Village of Goodnews Bay");
+        tribeCodes.put("410", "Organized Village of Grayling (aka Holikachuk)");
+        tribeCodes.put("411", "Gulkana Village Council");
+        tribeCodes.put("412", "Native Village of Hamilton");
+        tribeCodes.put("413", "Healy Lake Village");
+        tribeCodes.put("414", "Holy Cross Tribe");
+        tribeCodes.put("415", "Hoonah Indian Association");
+        tribeCodes.put("416", "Native Village of Hooper Bay");
+        tribeCodes.put("417", "Hughes Village");
+        tribeCodes.put("418", "Huslia Village");
+        tribeCodes.put("419", "Hydaburg Cooperative Association");
+        tribeCodes.put("420", "Igiugig Village");
+        tribeCodes.put("421", "Village of Iliamna");
+        tribeCodes.put("422", "Inupiat Community of the Arctic Slope");
+        tribeCodes.put("423", "Iqugmiut Traditional Council");
+        tribeCodes.put("424", "Ivanof Bay Tribe");
+        tribeCodes.put("425", "Kaguyak Village");
+        tribeCodes.put("426", "Organized Village of Kake");
+        tribeCodes.put("427", "Kaktovik Village (aka Barter Island)");
+        tribeCodes.put("428", "Village of Kalskag");
+        tribeCodes.put("429", "Village of Kaltag");
+        tribeCodes.put("430", "Native Village of Kanatak");
+        tribeCodes.put("431", "Native Village of Karluk");
+        tribeCodes.put("432", "Organized Village of Kasaan");
+        tribeCodes.put("433", "Kasigluk Traditional Elders Council");
+        tribeCodes.put("434", "Kenaitze Indian Tribe");
+        tribeCodes.put("435", "Ketchikan Indian Community");
+        tribeCodes.put("436", "Native Village of Kiana");
+        tribeCodes.put("437", "King Island Native Community");
+        tribeCodes.put("438", "King Salmon Tribe");
+        tribeCodes.put("439", "Native Village of Kipnuk");
+        tribeCodes.put("440", "Native Village of Kivalina");
+        tribeCodes.put("441", "Klawock Cooperative Association");
+        tribeCodes.put("442", "Native Village of Kluti Kaah (aka Copper Center)");
+        tribeCodes.put("443", "Knik Tribe");
+        tribeCodes.put("444", "Native Village of Kobuk");
+        tribeCodes.put("445", "Kokhanok Village");
+        tribeCodes.put("446", "Native Village of Kongiganak");
+        tribeCodes.put("447", "Village of Kotlik");
+        tribeCodes.put("448", "Native Village of Kotzebue");
+        tribeCodes.put("449", "Native Village of Koyuk");
+        tribeCodes.put("450", "Koyukuk Native Village");
+        tribeCodes.put("451", "Organized Village of Kwethluk");
+        tribeCodes.put("452", "Native Village of Kwigillingok");
+        tribeCodes.put("453", "Native Village of Kwinhagak (aka Quinhagak)");
+        tribeCodes.put("454", "Native Village of Larsen Bay");
+        tribeCodes.put("455", "Levelock Village");
+        tribeCodes.put("456", "Tangirnaq Native Village");
+        tribeCodes.put("457", "Lime Village");
+        tribeCodes.put("458", "Village of Lower Kalskag");
+        tribeCodes.put("459", "Manley Hot Springs Village");
+        tribeCodes.put("460", "Manokotak Village");
+        tribeCodes.put("461", "Native Village of Marshall (aka Fortuna Ledge)");
+        tribeCodes.put("462", "Native Village of Mary's Igloo");
+        tribeCodes.put("463", "McGrath Native Village");
+        tribeCodes.put("464", "Native Village of Mekoryuk");
+        tribeCodes.put("465", "Mentasta Traditional Council");
+        tribeCodes.put("466", "Metlakatla Indian Community, Annette Island Reserve");
+        tribeCodes.put("467", "Native Village of Minto");
+        tribeCodes.put("468", "Naknek Native Village");
+        tribeCodes.put("469", "Native Village of Nanwalek (aka English Bay)");
+        tribeCodes.put("470", "Native Village of Napaimute");
+        tribeCodes.put("471", "Native Village of Napakiak");
+        tribeCodes.put("472", "Native Village of Napaskiak");
+        tribeCodes.put("473", "Native Village of Nelson Lagoon");
+        tribeCodes.put("474", "Nenana Native Association");
+        tribeCodes.put("475", "New Koliganek Village Council");
+        tribeCodes.put("476", "New Stuyahok Village");
+        tribeCodes.put("477", "Newhalen Village");
+        tribeCodes.put("478", "Newtok Village");
+        tribeCodes.put("479", "Native Village of Nightmute");
+        tribeCodes.put("480", "Nikolai Village");
+        tribeCodes.put("481", "Native Village of Nikolski");
+        tribeCodes.put("482", "Ninilchik Village");
+        tribeCodes.put("483", "Native Village of Noatak");
+        tribeCodes.put("484", "Nome Eskimo Community");
+        tribeCodes.put("485", "Nondalton Village");
+        tribeCodes.put("486", "Noorvik Native Community");
+        tribeCodes.put("487", "Northway Village");
+        tribeCodes.put("488", "Native Village of Nuiqsut (aka Nooiksut)");
+        tribeCodes.put("489", "Nulato Village");
+        tribeCodes.put("490", "Nunakauyarmiut Tribe");
+        tribeCodes.put("491", "Native Village of Nunapitchuk");
+        tribeCodes.put("492", "Village of Ohogamiut");
+        tribeCodes.put("493", "Alutiiq Tribe of Old Harbor");
+        tribeCodes.put("494", "Orutsararmiut Traditional Native Council");
+        tribeCodes.put("495", "Oscarville Traditional Village");
+        tribeCodes.put("496", "Native Village of Ouzinkie");
+        tribeCodes.put("497", "Native Village of Paimiut");
+        tribeCodes.put("498", "Pauloff Harbor Village");
+        tribeCodes.put("499", "Pedro Bay Village");
+        tribeCodes.put("500", "Native Village of Perryville");
+        tribeCodes.put("501", "Petersburg Indian Association");
+        tribeCodes.put("502", "Native Village of Pilot Point");
+        tribeCodes.put("503", "Pilot Station Traditional Village");
+        tribeCodes.put("504", "Pitka's Point Traditional Council");
+        tribeCodes.put("505", "Platinum Traditional Village");
+        tribeCodes.put("506", "Native Village of Point Hope");
+        tribeCodes.put("507", "Native Village of Point Lay");
+        tribeCodes.put("508", "Native Village of Port Graham");
+        tribeCodes.put("509", "Native Village of Port Heiden");
+        tribeCodes.put("510", "Native Village of Port Lions");
+        tribeCodes.put("511", "Portage Creek Village (aka Ohgsenakale)");
+        tribeCodes.put(
+                "512",
+                "Pribilof Islands Aleut Communities of St. Paul & St. George Islands (Saint George Island and Saint Paul Island)");
+        tribeCodes.put("513", "Qagan Tayagungin Tribe of Sand Point");
+        tribeCodes.put("514", "Qawalangin Tribe of Unalaska");
+        tribeCodes.put("515", "Rampart Village");
+        tribeCodes.put("516", "Village of Red Devil");
+        tribeCodes.put("517", "Native Village of Ruby");
+        tribeCodes.put("518", "Saint George Island");
+        tribeCodes.put("519", "Native Village of Saint Michael");
+        tribeCodes.put("520", "Saint Paul Island");
+        tribeCodes.put("521", "Salamatof Tribe");
+        tribeCodes.put("522", "Native Village of Savoonga");
+        tribeCodes.put("523", "Organized Village of Saxman");
+        tribeCodes.put("524", "Native Village of Scammon Bay");
+        tribeCodes.put("525", "Native Village of Selawik");
+        tribeCodes.put("526", "Seldovia Village Tribe");
+        tribeCodes.put("527", "Shageluk Native Village");
+        tribeCodes.put("528", "Native Village of Shaktoolik");
+        tribeCodes.put("529", "Native Village of Nunam Iqua");
+        tribeCodes.put("530", "Native Village of Shishmaref");
+        tribeCodes.put("531", "Sun'aq Tribe of Kodiak");
+        tribeCodes.put("532", "Native Village of Shungnak");
+        tribeCodes.put("533", "Sitka Tribe of Alaska");
+        tribeCodes.put("534", "Skagway Village");
+        tribeCodes.put("535", "Village of Sleetmute");
+        tribeCodes.put("536", "Village of Solomon");
+        tribeCodes.put("537", "South Naknek Village");
+        tribeCodes.put("538", "Stebbins Community Association");
+        tribeCodes.put("539", "Native Village of Stevens");
+        tribeCodes.put("540", "Village of Stony River");
+        tribeCodes.put("541", "Takotna Village");
+        tribeCodes.put("542", "Native Village of Tanacross");
+        tribeCodes.put("543", "Native Village of Tanana");
+        tribeCodes.put("544", "Native Village of Tatitlek");
+        tribeCodes.put("545", "Native Village of Tazlina");
+        tribeCodes.put("546", "Telida Village");
+        tribeCodes.put("547", "Native Village of Teller");
+        tribeCodes.put("548", "Native Village of Tetlin");
+        tribeCodes.put("549", "Central Council of the Tlingit & Haida Indian Tribes");
+        tribeCodes.put("550", "Traditional Village of Togiak");
+        tribeCodes.put("551", "Tuluksak Native Community");
+        tribeCodes.put("552", "Native Village of Tuntutuliak");
+        tribeCodes.put("553", "Native Village of Tununak");
+        tribeCodes.put("554", "Twin Hills Village");
+        tribeCodes.put("555", "Native Village of Tyonek");
+        tribeCodes.put("556", "Ugashik Village");
+        tribeCodes.put("557", "Umkumiut Native Village");
+        tribeCodes.put("558", "Native Village of Unalakleet");
+        tribeCodes.put("559", "Native Village of Unga");
+        tribeCodes.put("560", "Village of Venetie");
+        tribeCodes.put(
+                "561",
+                "Native Village of Venetie Tribal Government (Arctic Village and Village of Venetie)");
+        tribeCodes.put("562", "Village of Wainwright");
+        tribeCodes.put("563", "Native Village of Wales");
+        tribeCodes.put("564", "Native Village of White Mountain");
+        tribeCodes.put("565", "Wrangell Cooperative Association");
+        tribeCodes.put("566", "Yakutat Tlingit Tribe");
+        tribeCodes.put("567", "Chickahominy Indian Tribe");
+        tribeCodes.put("568", "Chickahominy Indian Tribe—Eastern Division");
+        tribeCodes.put("569", "Monacan Indian Nation");
+        tribeCodes.put("570", "Nansemond Indian Nation");
+        tribeCodes.put("571", "Rappahannock Tribe, Inc.");
+        tribeCodes.put("572", "Upper Mattaponi Tribe");
+        tribeCodes.put("573", "Cowlitz Indian Tribe");
+        tribeCodes.put("574", "Little Shell Tribe of Chippewa Indians of Montana");
+        tribeCodes.put("575", "Mashpee Wampanoag Tribe");
+        tribeCodes.put("576", "Pamunkey Indian Tribe");
+        tribeCodes.put("577", "Shinnecock Indian Nation");
+        tribeCodes.put("578", "Wilton Rancheria, California");
+        tribeCodes.put("579", "Tejon Indian Tribe");
+        return tribeCodes;
+    }
 
-  public static final Map<String, String> raceMap = new HashMap<>();
-  private static final String NATIVE_CODE = "1002-5";
-  private static final String ASIAN_CODE = "2028-9";
-  private static final String BLACK_CODE = "2054-5";
-  private static final String PACIFIC_CODE = "2076-8";
-  private static final String WHITE_CODE = "2106-3";
-  private static final String OTHER_CODE = "2131-1";
+    public static final Map<String, String> raceMap = new HashMap<>();
+    private static final String NATIVE_CODE = "1002-5";
+    private static final String ASIAN_CODE = "2028-9";
+    private static final String BLACK_CODE = "2054-5";
+    private static final String PACIFIC_CODE = "2076-8";
+    private static final String WHITE_CODE = "2106-3";
+    private static final String OTHER_CODE = "2131-1";
 
-  static {
-    raceMap.put("native", NATIVE_CODE);
-    raceMap.put(NATIVE_CODE, "native");
-    raceMap.put("american indian or alaska native", NATIVE_CODE);
-    raceMap.put("asian", ASIAN_CODE);
-    raceMap.put(ASIAN_CODE, "asian");
-    raceMap.put("black", BLACK_CODE);
-    raceMap.put(BLACK_CODE, "black");
-    raceMap.put("black or african american", BLACK_CODE);
-    raceMap.put("pacific", PACIFIC_CODE);
-    raceMap.put(PACIFIC_CODE, "pacific");
-    raceMap.put("native hawaiian or other pacific islander", PACIFIC_CODE);
-    raceMap.put("white", WHITE_CODE);
-    raceMap.put(WHITE_CODE, "white");
-    raceMap.put("other", OTHER_CODE);
-    raceMap.put(OTHER_CODE, "other");
-    raceMap.put("unknown", MappingConstants.UNK_CODE);
-    raceMap.put("unk", MappingConstants.UNK_CODE);
-    raceMap.put("refused", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
-    raceMap.put("ask, but unknown", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
-    raceMap.put("asku", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
-  }
+    static {
+        raceMap.put("native", NATIVE_CODE);
+        raceMap.put(NATIVE_CODE, "native");
+        raceMap.put("american indian or alaska native", NATIVE_CODE);
+        raceMap.put("asian", ASIAN_CODE);
+        raceMap.put(ASIAN_CODE, "asian");
+        raceMap.put("black", BLACK_CODE);
+        raceMap.put(BLACK_CODE, "black");
+        raceMap.put("black or african american", BLACK_CODE);
+        raceMap.put("pacific", PACIFIC_CODE);
+        raceMap.put(PACIFIC_CODE, "pacific");
+        raceMap.put("native hawaiian or other pacific islander", PACIFIC_CODE);
+        raceMap.put("white", WHITE_CODE);
+        raceMap.put(WHITE_CODE, "white");
+        raceMap.put("other", OTHER_CODE);
+        raceMap.put(OTHER_CODE, "other");
+        raceMap.put("unknown", MappingConstants.UNK_CODE);
+        raceMap.put("unk", MappingConstants.UNK_CODE);
+        raceMap.put("refused", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
+        raceMap.put("ask, but unknown", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
+        raceMap.put("asku", MappingConstants.ASKED_BUT_UNKNOWN_CODE); // Asked, but unknown
+    }
 
-  private static final List<String> hispanic = List.of("H", "Hispanic or Latino");
-  private static final List<String> not_hispanic = List.of("N", "Not Hispanic or Latino");
-  public static final Map<String, List<String>> ETHNICITY_MAP =
-      Map.of(
-          "hispanic", hispanic,
-          "hispanic or latino", hispanic,
-          "2135-2", hispanic,
-          "not_hispanic", not_hispanic,
-          "not hispanic or latino", not_hispanic,
-          "2186-5", not_hispanic,
-          "refused", List.of("U", "unknown"));
+    private static final List<String> hispanic = List.of("H", "Hispanic or Latino");
+    private static final List<String> not_hispanic = List.of("N", "Not Hispanic or Latino");
+    public static final Map<String, List<String>> ETHNICITY_MAP =
+            Map.of(
+                    "hispanic", hispanic,
+                    "hispanic or latino", hispanic,
+                    "2135-2", hispanic,
+                    "not_hispanic", not_hispanic,
+                    "not hispanic or latino", not_hispanic,
+                    "2186-5", not_hispanic,
+                    "refused", List.of("U", "unknown"));
 
-  public static final String HOSPITAL_LITERAL = "hospital";
-  public static final String HOSPITAL_SNOMED = "22232009";
-  public static final String HOSPITAL_SHIP_LITERAL = "hospital ship";
-  public static final String HOSPITAL_SHIP_SNOMED = "2081004";
-  public static final String LONG_TERM_HOSPITAL_LITERAL = "long term care hospital";
-  public static final String LONG_TERM_HOSPITAL_SNOMED = "32074000";
-  public static final String SECURE_HOSPITAL_LITERAL = "secure hospital";
-  public static final String SECURE_HOSPITAL_SNOMED = "224929004";
-  public static final String NURSING_HOME_LITERAL = "nursing home";
-  public static final String NURSING_HOME_SNOMED = "42665001";
-  public static final String RETIREMENT_HOME_LITERAL = "retirement home";
-  public static final String RETIREMENT_HOME_SNOMED = "30629002";
-  public static final String ORPHANAGE_LITERAL = "orphanage";
-  public static final String ORPHANAGE_SNOMED = "74056004";
-  public static final String PRISON_BASED_CARE_LITERAL = "prison-based care site";
-  public static final String PRISON_BASED_CARE_SNOMED = "722173008";
-  public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL =
-      "substance abuse treatment center";
-  public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED = "20078004";
-  public static final String BOARDING_HOUSE_LITERAL = "boarding house";
-  public static final String BOARDING_HOUSE_SNOMED = "257573002";
-  public static final String MILITARY_ACCOMMODATION_LITERAL = "military accommodation";
-  public static final String MILITARY_ACCOMMODATION_SNOMED = "224683003";
-  public static final String HOSPICE_LITERAL = "hospice";
-  public static final String HOSPICE_SNOMED = "284546000";
-  public static final String HOSTEL_LITERAL = "hostel";
-  public static final String HOSTEL_SNOMED = "257628001";
-  public static final String SHELTERED_HOUSING_LITERAL = "sheltered housing";
-  public static final String SHELTERED_HOUSING_SNOMED = "310207003";
-  public static final String PENAL_INSTITUTION_LITERAL = "penal institution";
-  public static final String PENAL_INSTITUTION_SNOMED = "57656006";
-  public static final String RELIGIOUS_RESIDENCE_LITERAL = "religious institutional residence";
-  public static final String RELIGIOUS_RESIDENCE_SNOMED = "285113009";
-  public static final String WORK_ENVIRONMENT_LITERAL = "work (environment)";
-  public static final String WORK_ENVIRONMENT_SNOMED = "285141008";
-  public static final String HOMELESS_LITERAL = "homeless";
-  public static final String HOMELESS_SNOMED = "32911000";
+    public static final String HOSPITAL_LITERAL = "hospital";
+    public static final String HOSPITAL_SNOMED = "22232009";
+    public static final String HOSPITAL_SHIP_LITERAL = "hospital ship";
+    public static final String HOSPITAL_SHIP_SNOMED = "2081004";
+    public static final String LONG_TERM_HOSPITAL_LITERAL = "long term care hospital";
+    public static final String LONG_TERM_HOSPITAL_SNOMED = "32074000";
+    public static final String SECURE_HOSPITAL_LITERAL = "secure hospital";
+    public static final String SECURE_HOSPITAL_SNOMED = "224929004";
+    public static final String NURSING_HOME_LITERAL = "nursing home";
+    public static final String NURSING_HOME_SNOMED = "42665001";
+    public static final String RETIREMENT_HOME_LITERAL = "retirement home";
+    public static final String RETIREMENT_HOME_SNOMED = "30629002";
+    public static final String ORPHANAGE_LITERAL = "orphanage";
+    public static final String ORPHANAGE_SNOMED = "74056004";
+    public static final String PRISON_BASED_CARE_LITERAL = "prison-based care site";
+    public static final String PRISON_BASED_CARE_SNOMED = "722173008";
+    public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL =
+            "substance abuse treatment center";
+    public static final String SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED = "20078004";
+    public static final String BOARDING_HOUSE_LITERAL = "boarding house";
+    public static final String BOARDING_HOUSE_SNOMED = "257573002";
+    public static final String MILITARY_ACCOMMODATION_LITERAL = "military accommodation";
+    public static final String MILITARY_ACCOMMODATION_SNOMED = "224683003";
+    public static final String HOSPICE_LITERAL = "hospice";
+    public static final String HOSPICE_SNOMED = "284546000";
+    public static final String HOSTEL_LITERAL = "hostel";
+    public static final String HOSTEL_SNOMED = "257628001";
+    public static final String SHELTERED_HOUSING_LITERAL = "sheltered housing";
+    public static final String SHELTERED_HOUSING_SNOMED = "310207003";
+    public static final String PENAL_INSTITUTION_LITERAL = "penal institution";
+    public static final String PENAL_INSTITUTION_SNOMED = "57656006";
+    public static final String RELIGIOUS_RESIDENCE_LITERAL = "religious institutional residence";
+    public static final String RELIGIOUS_RESIDENCE_SNOMED = "285113009";
+    public static final String WORK_ENVIRONMENT_LITERAL = "work (environment)";
+    public static final String WORK_ENVIRONMENT_SNOMED = "285141008";
+    public static final String HOMELESS_LITERAL = "homeless";
+    public static final String HOMELESS_SNOMED = "32911000";
 
-  public static final Map<String, String> getResidenceTypeMap() {
-    Map<String, String> residenceTypeMap = new HashMap<>();
-    residenceTypeMap.put(HOSPITAL_SNOMED, HOSPITAL_LITERAL);
-    residenceTypeMap.put(HOSPITAL_LITERAL, HOSPITAL_SNOMED);
-    residenceTypeMap.put(HOSPITAL_SHIP_SNOMED, HOSPITAL_SHIP_LITERAL);
-    residenceTypeMap.put(HOSPITAL_SHIP_LITERAL, HOSPITAL_SHIP_SNOMED);
-    residenceTypeMap.put(LONG_TERM_HOSPITAL_SNOMED, LONG_TERM_HOSPITAL_LITERAL);
-    residenceTypeMap.put(LONG_TERM_HOSPITAL_LITERAL, LONG_TERM_HOSPITAL_SNOMED);
-    residenceTypeMap.put(SECURE_HOSPITAL_SNOMED, SECURE_HOSPITAL_LITERAL);
-    residenceTypeMap.put(SECURE_HOSPITAL_LITERAL, SECURE_HOSPITAL_SNOMED);
-    residenceTypeMap.put(NURSING_HOME_SNOMED, NURSING_HOME_LITERAL);
-    residenceTypeMap.put(NURSING_HOME_LITERAL, NURSING_HOME_SNOMED);
-    residenceTypeMap.put(RETIREMENT_HOME_SNOMED, RETIREMENT_HOME_LITERAL);
-    residenceTypeMap.put(RETIREMENT_HOME_LITERAL, RETIREMENT_HOME_SNOMED);
-    residenceTypeMap.put(ORPHANAGE_SNOMED, ORPHANAGE_LITERAL);
-    residenceTypeMap.put(ORPHANAGE_LITERAL, ORPHANAGE_SNOMED);
-    residenceTypeMap.put(PRISON_BASED_CARE_SNOMED, PRISON_BASED_CARE_LITERAL);
-    residenceTypeMap.put(PRISON_BASED_CARE_LITERAL, PRISON_BASED_CARE_SNOMED);
-    residenceTypeMap.put(
-        SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED, SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL);
-    residenceTypeMap.put(
-        SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL, SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED);
-    residenceTypeMap.put(BOARDING_HOUSE_SNOMED, BOARDING_HOUSE_LITERAL);
-    residenceTypeMap.put(BOARDING_HOUSE_LITERAL, BOARDING_HOUSE_SNOMED);
-    residenceTypeMap.put(MILITARY_ACCOMMODATION_SNOMED, MILITARY_ACCOMMODATION_LITERAL);
-    residenceTypeMap.put(MILITARY_ACCOMMODATION_LITERAL, MILITARY_ACCOMMODATION_SNOMED);
-    residenceTypeMap.put(HOSPICE_SNOMED, HOSPICE_LITERAL);
-    residenceTypeMap.put(HOSPICE_LITERAL, HOSPICE_SNOMED);
-    residenceTypeMap.put(HOSTEL_SNOMED, HOSTEL_LITERAL);
-    residenceTypeMap.put(HOSTEL_LITERAL, HOSTEL_SNOMED);
-    residenceTypeMap.put(SHELTERED_HOUSING_SNOMED, SHELTERED_HOUSING_LITERAL);
-    residenceTypeMap.put(SHELTERED_HOUSING_LITERAL, SHELTERED_HOUSING_SNOMED);
-    residenceTypeMap.put(PENAL_INSTITUTION_SNOMED, PENAL_INSTITUTION_LITERAL);
-    residenceTypeMap.put(PENAL_INSTITUTION_LITERAL, PENAL_INSTITUTION_SNOMED);
-    residenceTypeMap.put(RELIGIOUS_RESIDENCE_SNOMED, RELIGIOUS_RESIDENCE_LITERAL);
-    residenceTypeMap.put(RELIGIOUS_RESIDENCE_LITERAL, RELIGIOUS_RESIDENCE_SNOMED);
-    residenceTypeMap.put(WORK_ENVIRONMENT_SNOMED, WORK_ENVIRONMENT_LITERAL);
-    residenceTypeMap.put(WORK_ENVIRONMENT_LITERAL, WORK_ENVIRONMENT_SNOMED);
-    residenceTypeMap.put(HOMELESS_SNOMED, HOMELESS_LITERAL);
-    residenceTypeMap.put(HOMELESS_LITERAL, HOMELESS_SNOMED);
-    return residenceTypeMap;
-  }
+    public static final Map<String, String> getResidenceTypeMap() {
+        Map<String, String> residenceTypeMap = new HashMap<>();
+        residenceTypeMap.put(HOSPITAL_SNOMED, HOSPITAL_LITERAL);
+        residenceTypeMap.put(HOSPITAL_LITERAL, HOSPITAL_SNOMED);
+        residenceTypeMap.put(HOSPITAL_SHIP_SNOMED, HOSPITAL_SHIP_LITERAL);
+        residenceTypeMap.put(HOSPITAL_SHIP_LITERAL, HOSPITAL_SHIP_SNOMED);
+        residenceTypeMap.put(LONG_TERM_HOSPITAL_SNOMED, LONG_TERM_HOSPITAL_LITERAL);
+        residenceTypeMap.put(LONG_TERM_HOSPITAL_LITERAL, LONG_TERM_HOSPITAL_SNOMED);
+        residenceTypeMap.put(SECURE_HOSPITAL_SNOMED, SECURE_HOSPITAL_LITERAL);
+        residenceTypeMap.put(SECURE_HOSPITAL_LITERAL, SECURE_HOSPITAL_SNOMED);
+        residenceTypeMap.put(NURSING_HOME_SNOMED, NURSING_HOME_LITERAL);
+        residenceTypeMap.put(NURSING_HOME_LITERAL, NURSING_HOME_SNOMED);
+        residenceTypeMap.put(RETIREMENT_HOME_SNOMED, RETIREMENT_HOME_LITERAL);
+        residenceTypeMap.put(RETIREMENT_HOME_LITERAL, RETIREMENT_HOME_SNOMED);
+        residenceTypeMap.put(ORPHANAGE_SNOMED, ORPHANAGE_LITERAL);
+        residenceTypeMap.put(ORPHANAGE_LITERAL, ORPHANAGE_SNOMED);
+        residenceTypeMap.put(PRISON_BASED_CARE_SNOMED, PRISON_BASED_CARE_LITERAL);
+        residenceTypeMap.put(PRISON_BASED_CARE_LITERAL, PRISON_BASED_CARE_SNOMED);
+        residenceTypeMap.put(
+                SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED, SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL);
+        residenceTypeMap.put(
+                SUBSTANCE_ABUSE_TREATMENT_CENTER_LITERAL, SUBSTANCE_ABUSE_TREATMENT_CENTER_SNOMED);
+        residenceTypeMap.put(BOARDING_HOUSE_SNOMED, BOARDING_HOUSE_LITERAL);
+        residenceTypeMap.put(BOARDING_HOUSE_LITERAL, BOARDING_HOUSE_SNOMED);
+        residenceTypeMap.put(MILITARY_ACCOMMODATION_SNOMED, MILITARY_ACCOMMODATION_LITERAL);
+        residenceTypeMap.put(MILITARY_ACCOMMODATION_LITERAL, MILITARY_ACCOMMODATION_SNOMED);
+        residenceTypeMap.put(HOSPICE_SNOMED, HOSPICE_LITERAL);
+        residenceTypeMap.put(HOSPICE_LITERAL, HOSPICE_SNOMED);
+        residenceTypeMap.put(HOSTEL_SNOMED, HOSTEL_LITERAL);
+        residenceTypeMap.put(HOSTEL_LITERAL, HOSTEL_SNOMED);
+        residenceTypeMap.put(SHELTERED_HOUSING_SNOMED, SHELTERED_HOUSING_LITERAL);
+        residenceTypeMap.put(SHELTERED_HOUSING_LITERAL, SHELTERED_HOUSING_SNOMED);
+        residenceTypeMap.put(PENAL_INSTITUTION_SNOMED, PENAL_INSTITUTION_LITERAL);
+        residenceTypeMap.put(PENAL_INSTITUTION_LITERAL, PENAL_INSTITUTION_SNOMED);
+        residenceTypeMap.put(RELIGIOUS_RESIDENCE_SNOMED, RELIGIOUS_RESIDENCE_LITERAL);
+        residenceTypeMap.put(RELIGIOUS_RESIDENCE_LITERAL, RELIGIOUS_RESIDENCE_SNOMED);
+        residenceTypeMap.put(WORK_ENVIRONMENT_SNOMED, WORK_ENVIRONMENT_LITERAL);
+        residenceTypeMap.put(WORK_ENVIRONMENT_LITERAL, WORK_ENVIRONMENT_SNOMED);
+        residenceTypeMap.put(HOMELESS_SNOMED, HOMELESS_LITERAL);
+        residenceTypeMap.put(HOMELESS_LITERAL, HOMELESS_SNOMED);
+        return residenceTypeMap;
+    }
 
-  private static final String PREGNANT_SNOMED = "77386006";
-  private static final String NOT_PREGNANT_SNOMED = "60001007";
-  private static final String PREGNANT_UNKNOWN_SNOMED = "102874004";
-  public static final Map<String, String> pregnancyStatusSnomedMap =
-      Map.of(
-          "YES".toLowerCase(), PREGNANT_SNOMED,
-          "Y".toLowerCase(), PREGNANT_SNOMED,
-          "NO".toLowerCase(), NOT_PREGNANT_SNOMED,
-          "N".toLowerCase(), NOT_PREGNANT_SNOMED,
-          "UNK".toLowerCase(), PREGNANT_UNKNOWN_SNOMED,
-          "U".toLowerCase(), PREGNANT_UNKNOWN_SNOMED);
+    private static final String PREGNANT_SNOMED = "77386006";
+    private static final String NOT_PREGNANT_SNOMED = "60001007";
+    private static final String PREGNANT_UNKNOWN_SNOMED = "102874004";
 
-  public static final Map<String, String> pregnancyStatusDisplayMap =
-      Map.of(
-          PREGNANT_SNOMED, "Pregnant",
-          NOT_PREGNANT_SNOMED, "Not pregnant",
-          PREGNANT_UNKNOWN_SNOMED, "Unknown");
+    public static final String YES_SYPHILIS_HISTORY_SNOMED = "1087151000119108";
+    public static final String NO_SYPHILIS_HISTORY_SNOMED = "14732006";
+    public static final String UNKNOWN_SYPHILIS_HISTORY_SNOMED = "261665006";
 
-  public static final Map<String, String> genderIdentitySnomedSet =
-      Map.of(
-          FEMALE, "446141000124107",
-          MALE, "446151000124109",
-          NON_BINARY, "446131000124102",
-          TRANS_MAN, "446151000124109",
-          TRANS_WOMAN, "446141000124107",
-          OTHER, MappingConstants.UNK_CODE,
-          REFUSED, "asked-declined");
+    public static final Map<String, String> pregnancyStatusSnomedMap =
+            Map.of(
+                    "YES".toLowerCase(), PREGNANT_SNOMED,
+                    "Y".toLowerCase(), PREGNANT_SNOMED,
+                    "NO".toLowerCase(), NOT_PREGNANT_SNOMED,
+                    "N".toLowerCase(), NOT_PREGNANT_SNOMED,
+                    "UNK".toLowerCase(), PREGNANT_UNKNOWN_SNOMED,
+                    "U".toLowerCase(), PREGNANT_UNKNOWN_SNOMED);
 
-  public static final Map<String, String> genderIdentityDisplaySet =
-      Map.of(
-          FEMALE, "Female gender identity",
-          MALE, "Male gender identity",
-          NON_BINARY, "Non-binary gender identity",
-          TRANS_MAN, "Male gender identity",
-          TRANS_WOMAN, "Female gender identity",
-          OTHER, "Non-binary gender identity",
-          REFUSED, "Asked But Declined");
+    public static final Map<String, String> pregnancyStatusDisplayMap =
+            Map.of(
+                    PREGNANT_SNOMED, "Pregnant",
+                    NOT_PREGNANT_SNOMED, "Not pregnant",
+                    PREGNANT_UNKNOWN_SNOMED, "Unknown");
 
-  public static Map<String, String> getGenderIdentityAbbreviationMap() {
-    Map<String, String> genderMap = new HashMap<>();
+    public static final Map<String, String> genderIdentitySnomedSet =
+            Map.of(
+                    FEMALE, "446141000124107",
+                    MALE, "446151000124109",
+                    NON_BINARY, "446131000124102",
+                    TRANS_MAN, "446151000124109",
+                    TRANS_WOMAN, "446141000124107",
+                    OTHER, MappingConstants.UNK_CODE,
+                    REFUSED, "asked-declined");
 
-    genderMap.put("F", FEMALE);
-    genderMap.put("FEMALE", FEMALE);
-    genderMap.put("M", MALE);
-    genderMap.put("MALE", MALE);
-    genderMap.put("NB", NON_BINARY);
-    genderMap.put("NONBINARY", NON_BINARY);
-    genderMap.put("TM", TRANS_MAN);
-    genderMap.put("TRANS MAN", TRANS_MAN);
-    genderMap.put("TW", TRANS_WOMAN);
-    genderMap.put("TRANS WOMAN", TRANS_WOMAN);
-    genderMap.put("O", OTHER);
-    genderMap.put("OTHER", OTHER);
-    genderMap.put("R", REFUSED);
-    genderMap.put("REFUSED", REFUSED);
+    public static final Map<String, String> genderIdentityDisplaySet =
+            Map.of(
+                    FEMALE, "Female gender identity",
+                    MALE, "Male gender identity",
+                    NON_BINARY, "Non-binary gender identity",
+                    TRANS_MAN, "Male gender identity",
+                    TRANS_WOMAN, "Female gender identity",
+                    OTHER, "Non-binary gender identity",
+                    REFUSED, "Asked But Declined");
 
-    return genderMap;
-  }
+    public static Map<String, String> getGenderIdentityAbbreviationMap() {
+        Map<String, String> genderMap = new HashMap<>();
+
+        genderMap.put("F", FEMALE);
+        genderMap.put("FEMALE", FEMALE);
+        genderMap.put("M", MALE);
+        genderMap.put("MALE", MALE);
+        genderMap.put("NB", NON_BINARY);
+        genderMap.put("NONBINARY", NON_BINARY);
+        genderMap.put("TM", TRANS_MAN);
+        genderMap.put("TRANS MAN", TRANS_MAN);
+        genderMap.put("TW", TRANS_WOMAN);
+        genderMap.put("TRANS WOMAN", TRANS_WOMAN);
+        genderMap.put("O", OTHER);
+        genderMap.put("OTHER", OTHER);
+        genderMap.put("R", REFUSED);
+        genderMap.put("REFUSED", REFUSED);
+
+        return genderMap;
+    }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
@@ -792,9 +792,9 @@ public class PersonUtils {
     return residenceTypeMap;
   }
 
-  private static final String PREGNANT_SNOMED = "77386006";
-  private static final String NOT_PREGNANT_SNOMED = "60001007";
-  private static final String PREGNANT_UNKNOWN_SNOMED = "102874004";
+  public static final String PREGNANT_SNOMED = "77386006";
+  public static final String NOT_PREGNANT_SNOMED = "60001007";
+  public static final String PREGNANT_UNKNOWN_SNOMED = "102874004";
 
   public static final String YES_SYPHILIS_HISTORY_SNOMED = "1087151000119108";
   public static final String NO_SYPHILIS_HISTORY_SNOMED = "14732006";

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -56,7 +56,8 @@ public class TestOrder extends BaseTestInfo {
   private Set<Result> results = new HashSet<>();
 
   protected TestOrder() {
-    /* for hibernate */ }
+    /* for hibernate */
+  }
 
   public TestOrder(Person patient, Facility facility) {
     super(patient, facility, facility.getDefaultDeviceType(), facility.getDefaultSpecimenType());
@@ -108,6 +109,10 @@ public class TestOrder extends BaseTestInfo {
 
   public String getPregnancy() {
     return askOnEntrySurvey.getSurvey().getPregnancy();
+  }
+
+  public String getSyphilisHistory() {
+    return askOnEntrySurvey.getSurvey().getSyphilisHistory();
   }
 
   public String getSymptoms() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -111,10 +111,6 @@ public class TestOrder extends BaseTestInfo {
     return askOnEntrySurvey.getSurvey().getPregnancy();
   }
 
-  public String getSyphilisHistory() {
-    return askOnEntrySurvey.getSurvey().getSyphilisHistory();
-  }
-
   public String getSymptoms() {
     return askOnEntrySurvey.getSurvey().getSymptomsJSON();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/AskOnEntrySurvey.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/AskOnEntrySurvey.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 public class AskOnEntrySurvey {
 
   private String pregnancy;
+  private String syphilisHistory;
   private Map<String, Boolean> symptoms;
   private Boolean noSymptoms;
   private LocalDate symptomOnsetDate;
@@ -30,6 +31,7 @@ public class AskOnEntrySurvey {
 
   public AskOnEntrySurvey(
       String pregnancy,
+      String syphilisHistory,
       Map<String, Boolean> symptoms,
       Boolean noSymptoms,
       LocalDate symptomOnsetDate,
@@ -39,6 +41,7 @@ public class AskOnEntrySurvey {
     this.noSymptoms = noSymptoms;
     this.symptomOnsetDate = symptomOnsetDate;
     this.genderOfSexualPartners = genderOfSexualPartners;
+    this.syphilisHistory = syphilisHistory;
   }
 
   @JsonIgnore

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -402,6 +402,7 @@ public class TestOrderService {
       UUID facilityId,
       Person patient,
       String pregnancy,
+      String syphilisHistory,
       Map<String, Boolean> symptoms,
       LocalDate symptomOnsetDate,
       Boolean noSymptoms) {
@@ -442,6 +443,7 @@ public class TestOrderService {
     AskOnEntrySurvey survey =
         AskOnEntrySurvey.builder()
             .pregnancy(pregnancy)
+            .syphilisHistory(syphilisHistory)
             .symptoms(symptoms)
             .noSymptoms(noSymptoms)
             .symptomOnsetDate(symptomOnsetDate)
@@ -456,6 +458,7 @@ public class TestOrderService {
   public void updateTimeOfTestQuestions(
       UUID patientId,
       String pregnancy,
+      String syphilisHistory,
       Map<String, Boolean> symptoms,
       LocalDate symptomOnsetDate,
       Boolean noSymptoms,
@@ -465,6 +468,7 @@ public class TestOrderService {
     PatientAnswers answers = order.getAskOnEntrySurvey();
     AskOnEntrySurvey survey = answers.getSurvey();
     survey.setPregnancy(pregnancy);
+    survey.setSyphilisHistory(syphilisHistory);
     survey.setSymptoms(symptoms);
     survey.setNoSymptoms(noSymptoms);
     survey.setSymptomOnsetDate(symptomOnsetDate);

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -268,6 +268,7 @@ type TestOrder {
   dateAdded: String!
   dateUpdated: DateTime
   pregnancy: String
+  syphilisHistory: String
   noSymptoms: Boolean
   symptoms: String
   symptomOnset: LocalDate
@@ -287,6 +288,7 @@ type TestResult {
   dateAdded: String
   dateUpdated: DateTime
   pregnancy: String
+  syphilisHistory: String
   noSymptoms: Boolean
   symptoms: String
   symptomOnset: LocalDate
@@ -674,6 +676,7 @@ type Mutation {
     facilityId: ID!
     patientId: ID!
     pregnancy: String
+    syphilisHistory: String
     symptoms: String @Size(min: 0, max: 1024)
     symptomOnset: LocalDate
     noSymptoms: Boolean
@@ -684,6 +687,7 @@ type Mutation {
   updateTimeOfTestQuestions(
     patientId: ID!
     pregnancy: String
+    syphilisHistory: String
     symptoms: String @Size(min: 0, max: 1024)
     symptomOnset: LocalDate
     noSymptoms: Boolean

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1018,7 +1018,8 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_noSymptoms_matchesJson() throws IOException {
-    var answers = new AskOnEntrySurvey(null, Map.of("fake", false), true, null, null);
+    AskOnEntrySurvey answers =
+        new AskOnEntrySurvey(null, null, Map.of("fake", false), true, null, null);
     String testId = "fakeId";
 
     var actual =
@@ -1037,8 +1038,9 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_symptomatic_matchesJson() throws IOException {
-    var answers =
-        new AskOnEntrySurvey(null, Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
+    AskOnEntrySurvey answers =
+        new AskOnEntrySurvey(
+            null, null, Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
     String testId = "fakeId";
 
     var actual =
@@ -1059,7 +1061,8 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_employedInHealthcare_matchesJson() throws IOException {
-    var answers = new AskOnEntrySurvey(null, Map.of("fake", false), null, null, null);
+    AskOnEntrySurvey answers =
+        new AskOnEntrySurvey(null, null, Map.of("fake", false), null, null, null);
     String testId = "fakeId";
 
     var birthDate = LocalDate.of(2022, 12, 13);
@@ -1103,7 +1106,8 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_residesInCongregateSetting_matchesJson() throws IOException {
-    var answers = new AskOnEntrySurvey(null, Map.of("fake", false), null, null, null);
+    AskOnEntrySurvey answers =
+        new AskOnEntrySurvey(null, "", Map.of("fake", false), null, null, null);
     String testId = "fakeId";
 
     var birthDate = LocalDate.of(2022, 12, 13);
@@ -1147,7 +1151,8 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_pregnancyStatus_matchesJson() throws IOException {
-    var answers = new AskOnEntrySurvey("77386006", Map.of("fake", false), null, null, null);
+    AskOnEntrySurvey answers =
+        new AskOnEntrySurvey("77386006", "", Map.of("fake", false), null, null, null);
     String testId = "fakeId";
 
     var actual =
@@ -1170,7 +1175,7 @@ class FhirConverterTest {
   void convertToAoeObservation_genderOfSexualPartners_matchesJson() throws IOException {
     List<String> sexualPartners = List.of("transwoman", "transman", "nonbinary");
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(null, Map.of("fake", false), null, null, sexualPartners);
+        new AskOnEntrySurvey(null, null, Map.of("fake", false), null, null, sexualPartners);
     String testId = "fakeId";
 
     var actual =
@@ -1190,9 +1195,9 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_allAOE_matchesJson() throws IOException {
-    var answers =
+    AskOnEntrySurvey answers =
         new AskOnEntrySurvey(
-            "102874004", Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
+            "102874004", "", Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
     String testId = "fakeId";
 
     var birthDate = LocalDate.of(2022, 12, 13);
@@ -1234,7 +1239,7 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_noAnswer_matchesJson() throws IOException {
-    var answers = new AskOnEntrySurvey(null, Map.of("fake", false), false, null, null);
+    var answers = new AskOnEntrySurvey(null, null, Map.of("fake", false), false, null, null);
     String testId = "fakeId";
 
     var actual =
@@ -1817,8 +1822,9 @@ class FhirConverterTest {
             null,
             "Adventurer of the cosmos");
     var testOrder = new TestOrder(person, facility);
-    var answers =
-        new PatientAnswers(new AskOnEntrySurvey(null, Map.of("fake", false), false, null, null));
+    PatientAnswers answers =
+        new PatientAnswers(
+            new AskOnEntrySurvey(null, null, Map.of("fake", false), false, null, null));
     testOrder.setAskOnEntrySurvey(answers);
 
     var covidResult =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -5,6 +5,7 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NULL_CODE_SY
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.DEFAULT_LOCATION_CODE;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.DEFAULT_LOCATION_NAME;
 import static gov.cdc.usds.simplereport.api.model.TestEventExport.UNKNOWN_ADDRESS_INDICATOR;
+import static gov.cdc.usds.simplereport.db.model.PersonUtils.PREGNANT_UNKNOWN_SNOMED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -1019,7 +1020,14 @@ class FhirConverterTest {
   @Test
   void convertToAoeObservation_noSymptoms_matchesJson() throws IOException {
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(null, null, Map.of("fake", false), true, null, null);
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", false))
+            .noSymptoms(true)
+            .symptomOnsetDate(null)
+            .genderOfSexualPartners(null)
+            .build();
     String testId = "fakeId";
 
     var actual =
@@ -1039,8 +1047,15 @@ class FhirConverterTest {
   @Test
   void convertToAoeObservation_symptomatic_matchesJson() throws IOException {
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(
-            null, null, Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", true))
+            .symptomOnsetDate(LocalDate.of(2023, 3, 4))
+            .genderOfSexualPartners(null)
+            .noSymptoms(false)
+            .build();
+
     String testId = "fakeId";
 
     var actual =
@@ -1062,7 +1077,14 @@ class FhirConverterTest {
   @Test
   void convertToAoeObservation_employedInHealthcare_matchesJson() throws IOException {
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(null, null, Map.of("fake", false), null, null, null);
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", false))
+            .genderOfSexualPartners(null)
+            .noSymptoms(null)
+            .build();
+
     String testId = "fakeId";
 
     var birthDate = LocalDate.of(2022, 12, 13);
@@ -1107,7 +1129,14 @@ class FhirConverterTest {
   @Test
   void convertToAoeObservation_residesInCongregateSetting_matchesJson() throws IOException {
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(null, "", Map.of("fake", false), null, null, null);
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", false))
+            .genderOfSexualPartners(null)
+            .noSymptoms(null)
+            .build();
+
     String testId = "fakeId";
 
     var birthDate = LocalDate.of(2022, 12, 13);
@@ -1152,7 +1181,15 @@ class FhirConverterTest {
   @Test
   void convertToAoeObservation_pregnancyStatus_matchesJson() throws IOException {
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey("77386006", "", Map.of("fake", false), null, null, null);
+        AskOnEntrySurvey.builder()
+            .pregnancy("77386006")
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", false))
+            .genderOfSexualPartners(null)
+            .symptomOnsetDate(null)
+            .noSymptoms(null)
+            .build();
+
     String testId = "fakeId";
 
     var actual =
@@ -1175,7 +1212,14 @@ class FhirConverterTest {
   void convertToAoeObservation_genderOfSexualPartners_matchesJson() throws IOException {
     List<String> sexualPartners = List.of("transwoman", "transman", "nonbinary");
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(null, null, Map.of("fake", false), null, null, sexualPartners);
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", false))
+            .genderOfSexualPartners(sexualPartners)
+            .noSymptoms(null)
+            .build();
+
     String testId = "fakeId";
 
     var actual =
@@ -1196,8 +1240,15 @@ class FhirConverterTest {
   @Test
   void convertToAoeObservation_allAOE_matchesJson() throws IOException {
     AskOnEntrySurvey answers =
-        new AskOnEntrySurvey(
-            "102874004", "", Map.of("fake", true), false, LocalDate.of(2023, 3, 4), null);
+        AskOnEntrySurvey.builder()
+            .pregnancy(PREGNANT_UNKNOWN_SNOMED)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", true))
+            .symptomOnsetDate(LocalDate.of(2023, 3, 4))
+            .genderOfSexualPartners(null)
+            .noSymptoms(false)
+            .build();
+
     String testId = "fakeId";
 
     var birthDate = LocalDate.of(2022, 12, 13);
@@ -1239,7 +1290,16 @@ class FhirConverterTest {
 
   @Test
   void convertToAoeObservation_noAnswer_matchesJson() throws IOException {
-    var answers = new AskOnEntrySurvey(null, null, Map.of("fake", false), false, null, null);
+    AskOnEntrySurvey answers =
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(Map.of("fake", false))
+            .symptomOnsetDate(null)
+            .genderOfSexualPartners(null)
+            .noSymptoms(false)
+            .build();
+
     String testId = "fakeId";
 
     var actual =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1884,7 +1884,15 @@ class FhirConverterTest {
     var testOrder = new TestOrder(person, facility);
     PatientAnswers answers =
         new PatientAnswers(
-            new AskOnEntrySurvey(null, null, Map.of("fake", false), false, null, null));
+            AskOnEntrySurvey.builder()
+                .pregnancy(null)
+                .syphilisHistory(null)
+                .symptoms(Map.of("fake", false))
+                .symptomOnsetDate(null)
+                .genderOfSexualPartners(null)
+                .noSymptoms(false)
+                .build());
+
     testOrder.setAskOnEntrySurvey(answers);
 
     var covidResult =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
+import static gov.cdc.usds.simplereport.db.model.PersonUtils.NO_SYPHILIS_HISTORY_SNOMED;
+import static gov.cdc.usds.simplereport.db.model.PersonUtils.YES_SYPHILIS_HISTORY_SNOMED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,6 +24,7 @@ import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.sms.SmsService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -33,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,462 +45,466 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @WithSimpleReportStandardUser // hackedy hack
 class TestResultTest extends BaseGraphqlTest {
 
-  @Autowired private TestDataFactory _dataFactory;
-  @Autowired private OrganizationService _orgService;
-  @MockBean private SmsService _smsService;
-  @MockBean private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
+    @Autowired
+    private TestDataFactory _dataFactory;
+    @Autowired
+    private OrganizationService _orgService;
+    @MockBean
+    private SmsService _smsService;
+    @MockBean
+    private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
 
-  private Organization _org;
-  private Facility _site;
-  private Facility _secondSite;
-  private List<MultiplexResultInput> positiveCovidResult;
-  private List<MultiplexResultInput> negativeCovidResult;
+    private Organization _org;
+    private Facility _site;
+    private Facility _secondSite;
+    private List<MultiplexResultInput> positiveCovidResult;
+    private List<MultiplexResultInput> negativeCovidResult;
 
-  @BeforeEach
-  public void init() {
-    _org = _orgService.getCurrentOrganizationNoCache();
-    _site = _orgService.getFacilities(_org).get(0);
-    _secondSite = _orgService.getFacilities(_org).get(1);
+    @BeforeEach
+    public void init() {
+        _org = _orgService.getCurrentOrganizationNoCache();
+        _site = _orgService.getFacilities(_org).get(0);
+        _secondSite = _orgService.getFacilities(_org).get(1);
 
-    positiveCovidResult =
-        List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
-    negativeCovidResult =
-        List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
-  }
+        positiveCovidResult =
+                List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
+        negativeCovidResult =
+                List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
+    }
 
-  @Test
-  void fetchTestResults() {
-    Person p = _dataFactory.createFullPerson(_org);
-    _dataFactory.createTestEvent(p, _site);
-    _dataFactory.createTestEvent(p, _site);
-    _dataFactory.createTestEvent(p, _site);
+    @Test
+    void fetchTestResults() {
+        Person p = _dataFactory.createFullPerson(_org);
+        _dataFactory.createTestEvent(p, _site);
+        _dataFactory.createTestEvent(p, _site);
+        _dataFactory.createTestEvent(p, _site);
 
-    HashMap<String, Object> variables = getFacilityScopedArguments();
-    ArrayNode testResults = fetchTestResults(variables);
+        HashMap<String, Object> variables = getFacilityScopedArguments();
+        ArrayNode testResults = fetchTestResults(variables);
 
-    assertEquals(3, testResults.size());
-    assertNotNull(testResults.get(0).get("patientLink"));
-  }
+        assertEquals(3, testResults.size());
+        assertNotNull(testResults.get(0).get("patientLink"));
+    }
 
-  @Test
-  void fetchOrganizationTestResults_adminUser() {
-    useOrgAdmin();
+    @Test
+    void fetchOrganizationTestResults_adminUser() {
+        useOrgAdmin();
 
-    Person p = _dataFactory.createFullPerson(_org);
-    _dataFactory.createTestEvent(p, _site);
-    _dataFactory.createTestEvent(p, _site);
-    _dataFactory.createTestEvent(p, _site);
+        Person p = _dataFactory.createFullPerson(_org);
+        _dataFactory.createTestEvent(p, _site);
+        _dataFactory.createTestEvent(p, _site);
+        _dataFactory.createTestEvent(p, _site);
 
-    HashMap<String, Object> variables = getFacilityScopedArguments();
-    variables.put("facilityId", null);
-    ArrayNode testResults = fetchTestResults(variables);
+        HashMap<String, Object> variables = getFacilityScopedArguments();
+        variables.put("facilityId", null);
+        ArrayNode testResults = fetchTestResults(variables);
 
-    testResults = fetchTestResults(variables);
-    assertEquals(3, testResults.size());
-  }
+        testResults = fetchTestResults(variables);
+        assertEquals(3, testResults.size());
+    }
 
-  @Test
-  void fetchOrganizationTestResults__orgUser_failure() {
-    HashMap<String, Object> variables = getFacilityScopedArguments();
-    variables.put("facilityId", null);
-    fetchTestResultsWithError(variables, ACCESS_ERROR);
-  }
+    @Test
+    void fetchOrganizationTestResults__orgUser_failure() {
+        HashMap<String, Object> variables = getFacilityScopedArguments();
+        variables.put("facilityId", null);
+        fetchTestResultsWithError(variables, ACCESS_ERROR);
+    }
 
-  @Test
-  void submitTestResult() {
-    Person p = _dataFactory.createFullPerson(_org);
-    DeviceType d = _site.getDefaultDeviceType();
-    SpecimenType s = _site.getDefaultSpecimenType();
-    _dataFactory.createTestOrder(p, _site);
-    String dateTested = "2020-12-31T14:30:30.001Z";
+    @Test
+    void submitTestResult() {
+        Person p = _dataFactory.createFullPerson(_org);
+        DeviceType d = _site.getDefaultDeviceType();
+        SpecimenType s = _site.getDefaultSpecimenType();
+        _dataFactory.createTestOrder(p, _site);
+        String dateTested = "2020-12-31T14:30:30.001Z";
 
-    Map<String, Object> variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
-    submitQueueItem(variables, Optional.empty());
+        Map<String, Object> variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
+        submitQueueItem(variables, Optional.empty());
 
-    ArrayNode testResults = fetchTestResults(getFacilityScopedArguments());
+        ArrayNode testResults = fetchTestResults(getFacilityScopedArguments());
 
-    assertTrue(testResults.has(0), "Has at least one submitted test result=");
-    assertEquals(testResults.get(0).get("dateTested").asText(), dateTested);
-  }
+        assertTrue(testResults.has(0), "Has at least one submitted test result=");
+        assertEquals(testResults.get(0).get("dateTested").asText(), dateTested);
+    }
 
-  @Test
-  void submitAndFetchMultiplexResult() {
-    Person p = _dataFactory.createFullPerson(_org);
-    DeviceType d = _site.getDefaultDeviceType();
-    SpecimenType s = _site.getDefaultSpecimenType();
-    Map<String, Boolean> symptoms = Map.of("25064002", true);
-    LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
-    _dataFactory.createTestOrder(
-        p,
-        _site,
-        new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate, List.of("male")));
-    String dateTested = "2020-12-31T14:30:30.001Z";
+    @Test
+    void submitAndFetchMultiplexResult() {
+        Person p = _dataFactory.createFullPerson(_org);
+        DeviceType d = _site.getDefaultDeviceType();
+        SpecimenType s = _site.getDefaultSpecimenType();
+        Map<String, Boolean> symptoms = Map.of("25064002", true);
+        LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
+        _dataFactory.createTestOrder(
+                p,
+                _site,
+                new AskOnEntrySurvey("77386006", YES_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, List.of("male")));
+        String dateTested = "2020-12-31T14:30:30.001Z";
 
-    List<MultiplexResultInput> results = new ArrayList<>();
-    results.add(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
-    results.add(new MultiplexResultInput(_diseaseService.fluA().getName(), TestResult.POSITIVE));
-    results.add(
-        new MultiplexResultInput(_diseaseService.fluB().getName(), TestResult.UNDETERMINED));
+        List<MultiplexResultInput> results = new ArrayList<>();
+        results.add(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
+        results.add(new MultiplexResultInput(_diseaseService.fluA().getName(), TestResult.POSITIVE));
+        results.add(
+                new MultiplexResultInput(_diseaseService.fluB().getName(), TestResult.UNDETERMINED));
 
-    Map<String, Object> variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p.getInternalId().toString(),
-            "results",
-            results,
-            "dateTested",
-            dateTested);
-    submitQueueItem(variables, Optional.empty());
+        Map<String, Object> variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p.getInternalId().toString(),
+                        "results",
+                        results,
+                        "dateTested",
+                        dateTested);
+        submitQueueItem(variables, Optional.empty());
 
-    ArrayNode testResults = fetchTestResultsMultiplex(getFacilityScopedArguments());
+        ArrayNode testResults = fetchTestResultsMultiplex(getFacilityScopedArguments());
 
-    assertTrue(testResults.has(0), "Has at least one submitted test result=");
-    assertEquals(dateTested, testResults.get(0).get("dateTested").asText());
-    assertEquals("{\"25064002\":\"true\"}", testResults.get(0).get("symptoms").asText());
-    assertEquals("false", testResults.get(0).get("noSymptoms").asText());
-    assertEquals("77386006", testResults.get(0).get("pregnancy").asText());
-    assertEquals("2020-09-15", testResults.get(0).get("symptomOnset").asText());
-    assertEquals("[\"male\"]", testResults.get(0).get("genderOfSexualPartners").toString());
-    testResults
-        .get(0)
-        .get("results")
-        .elements()
-        .forEachRemaining(
-            r -> {
-              switch (r.get("disease").get("name").asText()) {
-                case "COVID-19":
-                  assertEquals(TestResult.NEGATIVE.toString(), r.get("testResult").asText());
-                  break;
-                case "Flu A":
-                  assertEquals(TestResult.POSITIVE.toString(), r.get("testResult").asText());
-                  break;
-                case "Flu B":
-                  assertEquals(TestResult.UNDETERMINED.toString(), r.get("testResult").asText());
-                  break;
-                default:
-                  fail("Unexpected disease=" + r.get("disease").get("name").asText());
-              }
-            });
-  }
+        assertTrue(testResults.has(0), "Has at least one submitted test result=");
+        assertEquals(dateTested, testResults.get(0).get("dateTested").asText());
+        assertEquals("{\"25064002\":\"true\"}", testResults.get(0).get("symptoms").asText());
+        assertEquals("false", testResults.get(0).get("noSymptoms").asText());
+        assertEquals("77386006", testResults.get(0).get("pregnancy").asText());
+        assertEquals("2020-09-15", testResults.get(0).get("symptomOnset").asText());
+        assertEquals("[\"male\"]", testResults.get(0).get("genderOfSexualPartners").toString());
+        testResults
+                .get(0)
+                .get("results")
+                .elements()
+                .forEachRemaining(
+                        r -> {
+                            switch (r.get("disease").get("name").asText()) {
+                                case "COVID-19":
+                                    assertEquals(TestResult.NEGATIVE.toString(), r.get("testResult").asText());
+                                    break;
+                                case "Flu A":
+                                    assertEquals(TestResult.POSITIVE.toString(), r.get("testResult").asText());
+                                    break;
+                                case "Flu B":
+                                    assertEquals(TestResult.UNDETERMINED.toString(), r.get("testResult").asText());
+                                    break;
+                                default:
+                                    fail("Unexpected disease=" + r.get("disease").get("name").asText());
+                            }
+                        });
+    }
 
-  @Test
-  void testResultOperations_standardUser_successDependsOnFacilityAccess() {
-    Person p1 = _dataFactory.createFullPerson(_org);
-    Person p2 = _dataFactory.createMinimalPerson(_org, _site);
-    DeviceType d = _site.getDefaultDeviceType();
-    SpecimenType s = _site.getDefaultSpecimenType();
-    Map<String, Boolean> symptoms = Map.of("25064002", true);
-    LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
+    @Test
+    void testResultOperations_standardUser_successDependsOnFacilityAccess() {
+        Person p1 = _dataFactory.createFullPerson(_org);
+        Person p2 = _dataFactory.createMinimalPerson(_org, _site);
+        DeviceType d = _site.getDefaultDeviceType();
+        SpecimenType s = _site.getDefaultSpecimenType();
+        Map<String, Boolean> symptoms = Map.of("25064002", true);
+        LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
 
-    _dataFactory.createTestOrder(
-        p1, _site, new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate, null));
-    _dataFactory.createTestOrder(
-        p2, _site, new AskOnEntrySurvey("77386006", symptoms, false, symptomOnsetDate, null));
-    String dateTested = "2020-12-31T14:30:30.001Z";
+        _dataFactory.createTestOrder(
+                p1, _site, new AskOnEntrySurvey("77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
+        _dataFactory.createTestOrder(
+                p2, _site, new AskOnEntrySurvey("77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
+        String dateTested = "2020-12-31T14:30:30.001Z";
 
-    // The test default standard user is configured to access _site by default,
-    // so we need to remove access to establish a baseline in this test
-    updateSelfPrivileges(Role.USER, false, Set.of());
-    Map<String, Object> submitP1Variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p1.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
-    Map<String, Object> submitP2Variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p2.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
+        // The test default standard user is configured to access _site by default,
+        // so we need to remove access to establish a baseline in this test
+        updateSelfPrivileges(Role.USER, false, Set.of());
+        Map<String, Object> submitP1Variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p1.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
+        Map<String, Object> submitP2Variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p2.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
 
-    submitQueueItem(submitP1Variables, Optional.of(ACCESS_ERROR));
-    submitQueueItem(submitP2Variables, Optional.of(ACCESS_ERROR));
+        submitQueueItem(submitP1Variables, Optional.of(ACCESS_ERROR));
+        submitQueueItem(submitP2Variables, Optional.of(ACCESS_ERROR));
 
-    updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-    submitQueueItem(submitP1Variables, Optional.empty());
-    submitQueueItem(submitP2Variables, Optional.empty());
+        updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
+        submitQueueItem(submitP1Variables, Optional.empty());
+        submitQueueItem(submitP2Variables, Optional.empty());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
-    Map<String, Object> fetchVariables = getFacilityScopedArguments();
-    fetchTestResultsWithError(fetchVariables, ACCESS_ERROR);
+        updateSelfPrivileges(Role.USER, false, Set.of());
+        Map<String, Object> fetchVariables = getFacilityScopedArguments();
+        fetchTestResultsWithError(fetchVariables, ACCESS_ERROR);
 
-    updateSelfPrivileges(Role.USER, true, Set.of());
-    ArrayNode testResults = fetchTestResults(fetchVariables);
-    assertEquals(2, testResults.size());
-    UUID t1Id = UUID.fromString(testResults.get(0).get("internalId").asText());
-    UUID t2Id = UUID.fromString(testResults.get(1).get("internalId").asText());
+        updateSelfPrivileges(Role.USER, true, Set.of());
+        ArrayNode testResults = fetchTestResults(fetchVariables);
+        assertEquals(2, testResults.size());
+        UUID t1Id = UUID.fromString(testResults.get(0).get("internalId").asText());
+        UUID t2Id = UUID.fromString(testResults.get(1).get("internalId").asText());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
+        updateSelfPrivileges(Role.USER, false, Set.of());
 
-    Map<String, Object> correctT1Variables =
-        Map.of("id", t1Id.toString(), "reason", "nobody's perfect");
+        Map<String, Object> correctT1Variables =
+                Map.of("id", t1Id.toString(), "reason", "nobody's perfect");
 
-    Map<String, Object> correctT2Variables =
-        Map.of("id", t2Id.toString(), "reason", "nobody's perfect");
+        Map<String, Object> correctT2Variables =
+                Map.of("id", t2Id.toString(), "reason", "nobody's perfect");
 
-    correctTest(correctT1Variables, Optional.of(ACCESS_ERROR));
-    correctTest(correctT2Variables, Optional.of(ACCESS_ERROR));
+        correctTest(correctT1Variables, Optional.of(ACCESS_ERROR));
+        correctTest(correctT2Variables, Optional.of(ACCESS_ERROR));
 
-    updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-    correctTest(correctT1Variables, Optional.empty());
-    correctTest(correctT2Variables, Optional.empty());
+        updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
+        correctTest(correctT1Variables, Optional.empty());
+        correctTest(correctT2Variables, Optional.empty());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
-    Map<String, Object> fetchT1Variables = Map.of("id", t1Id.toString());
-    Map<String, Object> fetchT2Variables = Map.of("id", t2Id.toString());
+        updateSelfPrivileges(Role.USER, false, Set.of());
+        Map<String, Object> fetchT1Variables = Map.of("id", t1Id.toString());
+        Map<String, Object> fetchT2Variables = Map.of("id", t2Id.toString());
 
-    fetchTestResult(fetchT1Variables, Optional.of(ACCESS_ERROR));
-    fetchTestResult(fetchT2Variables, Optional.of(ACCESS_ERROR));
+        fetchTestResult(fetchT1Variables, Optional.of(ACCESS_ERROR));
+        fetchTestResult(fetchT2Variables, Optional.of(ACCESS_ERROR));
 
-    updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-    fetchTestResult(fetchT1Variables, Optional.empty());
-    fetchTestResult(fetchT2Variables, Optional.empty());
-  }
+        updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
+        fetchTestResult(fetchT1Variables, Optional.empty());
+        fetchTestResult(fetchT2Variables, Optional.empty());
+    }
 
-  @Test
-  void getOrganizationLevelDashboardMetrics_orgAdmin_success() {
-    useOrgAdmin();
+    @Test
+    void getOrganizationLevelDashboardMetrics_orgAdmin_success() {
+        useOrgAdmin();
 
-    Person p1 = _dataFactory.createFullPerson(_org);
-    Person p2 = _dataFactory.createMinimalPerson(_org, _site);
-    Person p3 = _dataFactory.createMinimalPerson(_org, _secondSite, "Carl", "A", "Scheffer", "");
-    Person p4 =
-        _dataFactory.createMinimalPerson(_org, _secondSite, "Lindsay", "L", "Wasserman", "");
+        Person p1 = _dataFactory.createFullPerson(_org);
+        Person p2 = _dataFactory.createMinimalPerson(_org, _site);
+        Person p3 = _dataFactory.createMinimalPerson(_org, _secondSite, "Carl", "A", "Scheffer", "");
+        Person p4 =
+                _dataFactory.createMinimalPerson(_org, _secondSite, "Lindsay", "L", "Wasserman", "");
 
-    DeviceType d = _site.getDefaultDeviceType();
-    SpecimenType s = _site.getDefaultSpecimenType();
+        DeviceType d = _site.getDefaultDeviceType();
+        SpecimenType s = _site.getDefaultSpecimenType();
 
-    DeviceType secondSiteDevice = _secondSite.getDefaultDeviceType();
-    SpecimenType secondSiteSpecimen = _secondSite.getDefaultSpecimenType();
+        DeviceType secondSiteDevice = _secondSite.getDefaultDeviceType();
+        SpecimenType secondSiteSpecimen = _secondSite.getDefaultSpecimenType();
 
-    _dataFactory.createTestOrder(p1, _site);
-    _dataFactory.createTestOrder(p2, _site);
-    _dataFactory.createTestOrder(p3, _secondSite);
-    _dataFactory.createTestOrder(p4, _secondSite);
-    String dateTested = "2020-12-31T14:30:30.001Z";
+        _dataFactory.createTestOrder(p1, _site);
+        _dataFactory.createTestOrder(p2, _site);
+        _dataFactory.createTestOrder(p3, _secondSite);
+        _dataFactory.createTestOrder(p4, _secondSite);
+        String dateTested = "2020-12-31T14:30:30.001Z";
 
-    Map<String, Object> submitP1Variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p1.getInternalId().toString(),
-            "results",
-            positiveCovidResult,
-            "dateTested",
-            dateTested);
-    Map<String, Object> submitP2Variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p2.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
-    Map<String, Object> submitP3Variables =
-        Map.of(
-            "deviceId",
-            secondSiteDevice.getInternalId().toString(),
-            "specimenId",
-            secondSiteSpecimen.getInternalId().toString(),
-            "patientId",
-            p3.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
-    Map<String, Object> submitP4Variables =
-        Map.of(
-            "deviceId",
-            secondSiteDevice.getInternalId().toString(),
-            "specimenId",
-            secondSiteSpecimen.getInternalId().toString(),
-            "patientId",
-            p4.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
-    submitQueueItem(submitP1Variables, Optional.empty());
-    submitQueueItem(submitP2Variables, Optional.empty());
-    submitQueueItem(submitP3Variables, Optional.empty());
-    submitQueueItem(submitP4Variables, Optional.empty());
+        Map<String, Object> submitP1Variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p1.getInternalId().toString(),
+                        "results",
+                        positiveCovidResult,
+                        "dateTested",
+                        dateTested);
+        Map<String, Object> submitP2Variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p2.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
+        Map<String, Object> submitP3Variables =
+                Map.of(
+                        "deviceId",
+                        secondSiteDevice.getInternalId().toString(),
+                        "specimenId",
+                        secondSiteSpecimen.getInternalId().toString(),
+                        "patientId",
+                        p3.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
+        Map<String, Object> submitP4Variables =
+                Map.of(
+                        "deviceId",
+                        secondSiteDevice.getInternalId().toString(),
+                        "specimenId",
+                        secondSiteSpecimen.getInternalId().toString(),
+                        "patientId",
+                        p4.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
+        submitQueueItem(submitP1Variables, Optional.empty());
+        submitQueueItem(submitP2Variables, Optional.empty());
+        submitQueueItem(submitP3Variables, Optional.empty());
+        submitQueueItem(submitP4Variables, Optional.empty());
 
-    String startDate = "2020-01-01";
-    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+        String startDate = "2020-01-01";
+        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-    Map<String, Object> variables =
-        Map.of(
-            "startDate", startDate,
-            "endDate", endDate);
+        Map<String, Object> variables =
+                Map.of(
+                        "startDate", startDate,
+                        "endDate", endDate);
 
-    ObjectNode result =
+        ObjectNode result =
+                runQuery(
+                        "organization-level-metrics", "GetOrganizationLevelDashboardMetrics", variables, null);
+
+        JsonNode metrics = result.get("organizationLevelDashboardMetrics");
+        assertEquals(1L, metrics.get("organizationPositiveTestCount").asLong());
+        assertEquals(3L, metrics.get("organizationNegativeTestCount").asLong());
+        assertEquals(4L, metrics.get("organizationTotalTestCount").asLong());
+        assertEquals(2, metrics.get("facilityMetrics").size());
+    }
+
+    @Test
+    void getOrganizationLevelDashboardMetrics_orgUser_failure() {
+        String startDate = "2020-01-01";
+        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+
+        Map<String, Object> variables =
+                Map.of(
+                        "startDate", startDate,
+                        "endDate", endDate);
+        useOrgUser();
+
         runQuery(
-            "organization-level-metrics", "GetOrganizationLevelDashboardMetrics", variables, null);
+                "organization-level-metrics",
+                "GetOrganizationLevelDashboardMetrics",
+                variables,
+                "Current user does not have permission to request [/organizationLevelDashboardMetrics]");
+    }
 
-    JsonNode metrics = result.get("organizationLevelDashboardMetrics");
-    assertEquals(1L, metrics.get("organizationPositiveTestCount").asLong());
-    assertEquals(3L, metrics.get("organizationNegativeTestCount").asLong());
-    assertEquals(4L, metrics.get("organizationTotalTestCount").asLong());
-    assertEquals(2, metrics.get("facilityMetrics").size());
-  }
+    @Test
+    void getTopLevelDashboardMetrics_orgAdmin_success() {
+        Person p1 = _dataFactory.createFullPerson(_org);
+        Person p2 = _dataFactory.createMinimalPerson(_org, _site);
+        DeviceType d = _site.getDefaultDeviceType();
+        SpecimenType s = _site.getDefaultSpecimenType();
+        _dataFactory.createTestOrder(p1, _site);
+        _dataFactory.createTestOrder(p2, _site);
+        String dateTested = "2020-12-31T14:30:30.001Z";
 
-  @Test
-  void getOrganizationLevelDashboardMetrics_orgUser_failure() {
-    String startDate = "2020-01-01";
-    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+        Map<String, Object> submitP1Variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p1.getInternalId().toString(),
+                        "results",
+                        positiveCovidResult,
+                        "dateTested",
+                        dateTested);
+        Map<String, Object> submitP2Variables =
+                Map.of(
+                        "deviceId",
+                        d.getInternalId().toString(),
+                        "specimenId",
+                        s.getInternalId().toString(),
+                        "patientId",
+                        p2.getInternalId().toString(),
+                        "results",
+                        negativeCovidResult,
+                        "dateTested",
+                        dateTested);
+        submitQueueItem(submitP1Variables, Optional.empty());
+        submitQueueItem(submitP2Variables, Optional.empty());
 
-    Map<String, Object> variables =
-        Map.of(
-            "startDate", startDate,
-            "endDate", endDate);
-    useOrgUser();
+        String startDate = "2020-01-01";
+        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-    runQuery(
-        "organization-level-metrics",
-        "GetOrganizationLevelDashboardMetrics",
-        variables,
-        "Current user does not have permission to request [/organizationLevelDashboardMetrics]");
-  }
+        useOrgAdmin();
 
-  @Test
-  void getTopLevelDashboardMetrics_orgAdmin_success() {
-    Person p1 = _dataFactory.createFullPerson(_org);
-    Person p2 = _dataFactory.createMinimalPerson(_org, _site);
-    DeviceType d = _site.getDefaultDeviceType();
-    SpecimenType s = _site.getDefaultSpecimenType();
-    _dataFactory.createTestOrder(p1, _site);
-    _dataFactory.createTestOrder(p2, _site);
-    String dateTested = "2020-12-31T14:30:30.001Z";
+        Map<String, Object> variables =
+                Map.of(
+                        "startDate", startDate,
+                        "endDate", endDate);
 
-    Map<String, Object> submitP1Variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p1.getInternalId().toString(),
-            "results",
-            positiveCovidResult,
-            "dateTested",
-            dateTested);
-    Map<String, Object> submitP2Variables =
-        Map.of(
-            "deviceId",
-            d.getInternalId().toString(),
-            "specimenId",
-            s.getInternalId().toString(),
-            "patientId",
-            p2.getInternalId().toString(),
-            "results",
-            negativeCovidResult,
-            "dateTested",
-            dateTested);
-    submitQueueItem(submitP1Variables, Optional.empty());
-    submitQueueItem(submitP2Variables, Optional.empty());
+        ObjectNode result =
+                runQuery("dashboard-metrics", "GetTopLevelDashboardMetrics", variables, null);
 
-    String startDate = "2020-01-01";
-    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+        JsonNode metrics = result.get("topLevelDashboardMetrics");
+        assertEquals(1L, metrics.get("positiveTestCount").asLong());
+        assertEquals(2L, metrics.get("totalTestCount").asLong());
+    }
 
-    useOrgAdmin();
+    @Test
+    void getTopLevelDashboardMetrics_orgUser_failure() {
+        String startDate = "2020-01-01";
+        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-    Map<String, Object> variables =
-        Map.of(
-            "startDate", startDate,
-            "endDate", endDate);
+        Map<String, Object> variables =
+                Map.of(
+                        "startDate", startDate,
+                        "endDate", endDate);
 
-    ObjectNode result =
-        runQuery("dashboard-metrics", "GetTopLevelDashboardMetrics", variables, null);
+        useOrgUser();
 
-    JsonNode metrics = result.get("topLevelDashboardMetrics");
-    assertEquals(1L, metrics.get("positiveTestCount").asLong());
-    assertEquals(2L, metrics.get("totalTestCount").asLong());
-  }
+        runQuery(
+                "dashboard-metrics",
+                "GetTopLevelDashboardMetrics",
+                variables,
+                "Current user does not have permission to request [/topLevelDashboardMetrics]");
+    }
 
-  @Test
-  void getTopLevelDashboardMetrics_orgUser_failure() {
-    String startDate = "2020-01-01";
-    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+    private HashMap<String, Object> getFacilityScopedArguments() {
+        return new HashMap<>(Map.of("facilityId", _site.getInternalId().toString()));
+    }
 
-    Map<String, Object> variables =
-        Map.of(
-            "startDate", startDate,
-            "endDate", endDate);
+    private ObjectNode submitQueueItem(
+            Map<String, Object> variables, Optional<String> expectedError) {
+        return runQuery("submit-queue-item", variables, expectedError.orElse(null));
+    }
 
-    useOrgUser();
+    private ArrayNode fetchTestResults(Map<String, Object> variables) {
+        return (ArrayNode)
+                runQuery("test-results-with-count-query", variables).get("testResultsPage").get("content");
+    }
 
-    runQuery(
-        "dashboard-metrics",
-        "GetTopLevelDashboardMetrics",
-        variables,
-        "Current user does not have permission to request [/topLevelDashboardMetrics]");
-  }
+    private ArrayNode fetchTestResultsMultiplex(Map<String, Object> variables) {
+        return (ArrayNode)
+                runQuery("test-results-with-count-multiplex-query", variables)
+                        .get("testResultsPage")
+                        .get("content");
+    }
 
-  private HashMap<String, Object> getFacilityScopedArguments() {
-    return new HashMap<>(Map.of("facilityId", _site.getInternalId().toString()));
-  }
+    private void fetchTestResultsWithError(Map<String, Object> variables, String expectedError) {
+        runQuery("test-results-with-count-query", variables, expectedError);
+    }
 
-  private ObjectNode submitQueueItem(
-      Map<String, Object> variables, Optional<String> expectedError) {
-    return runQuery("submit-queue-item", variables, expectedError.orElse(null));
-  }
+    private void fetchTestResult(Map<String, Object> variables, Optional<String> expectedError) {
+        runQuery("test-result-query", variables, expectedError.orElse(null));
+    }
 
-  private ArrayNode fetchTestResults(Map<String, Object> variables) {
-    return (ArrayNode)
-        runQuery("test-results-with-count-query", variables).get("testResultsPage").get("content");
-  }
-
-  private ArrayNode fetchTestResultsMultiplex(Map<String, Object> variables) {
-    return (ArrayNode)
-        runQuery("test-results-with-count-multiplex-query", variables)
-            .get("testResultsPage")
-            .get("content");
-  }
-
-  private void fetchTestResultsWithError(Map<String, Object> variables, String expectedError) {
-    runQuery("test-results-with-count-query", variables, expectedError);
-  }
-
-  private void fetchTestResult(Map<String, Object> variables, Optional<String> expectedError) {
-    runQuery("test-result-query", variables, expectedError.orElse(null));
-  }
-
-  private ObjectNode correctTest(Map<String, Object> variables, Optional<String> expectedError) {
-    return runQuery("correct-test-result-mutation", variables, expectedError.orElse(null));
-  }
+    private ObjectNode correctTest(Map<String, Object> variables, Optional<String> expectedError) {
+        return runQuery("correct-test-result-mutation", variables, expectedError.orElse(null));
+    }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.api.graphql;
 
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.NO_SYPHILIS_HISTORY_SNOMED;
+import static gov.cdc.usds.simplereport.db.model.PersonUtils.PREGNANT_SNOMED;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.YES_SYPHILIS_HISTORY_SNOMED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -142,13 +143,14 @@ class TestResultTest extends BaseGraphqlTest {
     _dataFactory.createTestOrder(
         p,
         _site,
-        new AskOnEntrySurvey(
-            "77386006",
-            YES_SYPHILIS_HISTORY_SNOMED,
-            symptoms,
-            false,
-            symptomOnsetDate,
-            List.of("male")));
+        AskOnEntrySurvey.builder()
+            .pregnancy(PREGNANT_SNOMED)
+            .syphilisHistory(YES_SYPHILIS_HISTORY_SNOMED)
+            .symptoms(symptoms)
+            .symptomOnsetDate(symptomOnsetDate)
+            .genderOfSexualPartners(List.of("male"))
+            .noSymptoms(false)
+            .build());
     String dateTested = "2020-12-31T14:30:30.001Z";
 
     List<MultiplexResultInput> results = new ArrayList<>();
@@ -214,13 +216,25 @@ class TestResultTest extends BaseGraphqlTest {
     _dataFactory.createTestOrder(
         p1,
         _site,
-        new AskOnEntrySurvey(
-            "77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
+        AskOnEntrySurvey.builder()
+            .pregnancy(PREGNANT_SNOMED)
+            .syphilisHistory(NO_SYPHILIS_HISTORY_SNOMED)
+            .symptoms(symptoms)
+            .symptomOnsetDate(symptomOnsetDate)
+            .genderOfSexualPartners(null)
+            .noSymptoms(false)
+            .build());
     _dataFactory.createTestOrder(
         p2,
         _site,
-        new AskOnEntrySurvey(
-            "77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
+        AskOnEntrySurvey.builder()
+            .pregnancy(PREGNANT_SNOMED)
+            .syphilisHistory(NO_SYPHILIS_HISTORY_SNOMED)
+            .symptoms(symptoms)
+            .symptomOnsetDate(symptomOnsetDate)
+            .genderOfSexualPartners(null)
+            .noSymptoms(false)
+            .build());
     String dateTested = "2020-12-31T14:30:30.001Z";
 
     // The test default standard user is configured to access _site by default,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -24,7 +24,6 @@ import gov.cdc.usds.simplereport.service.OrganizationService;
 import gov.cdc.usds.simplereport.service.sms.SmsService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
-
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -36,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,466 +43,474 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @WithSimpleReportStandardUser // hackedy hack
 class TestResultTest extends BaseGraphqlTest {
 
-    @Autowired
-    private TestDataFactory _dataFactory;
-    @Autowired
-    private OrganizationService _orgService;
-    @MockBean
-    private SmsService _smsService;
-    @MockBean
-    private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
+  @Autowired private TestDataFactory _dataFactory;
+  @Autowired private OrganizationService _orgService;
+  @MockBean private SmsService _smsService;
+  @MockBean private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
 
-    private Organization _org;
-    private Facility _site;
-    private Facility _secondSite;
-    private List<MultiplexResultInput> positiveCovidResult;
-    private List<MultiplexResultInput> negativeCovidResult;
+  private Organization _org;
+  private Facility _site;
+  private Facility _secondSite;
+  private List<MultiplexResultInput> positiveCovidResult;
+  private List<MultiplexResultInput> negativeCovidResult;
 
-    @BeforeEach
-    public void init() {
-        _org = _orgService.getCurrentOrganizationNoCache();
-        _site = _orgService.getFacilities(_org).get(0);
-        _secondSite = _orgService.getFacilities(_org).get(1);
+  @BeforeEach
+  public void init() {
+    _org = _orgService.getCurrentOrganizationNoCache();
+    _site = _orgService.getFacilities(_org).get(0);
+    _secondSite = _orgService.getFacilities(_org).get(1);
 
-        positiveCovidResult =
-                List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
-        negativeCovidResult =
-                List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
-    }
+    positiveCovidResult =
+        List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.POSITIVE));
+    negativeCovidResult =
+        List.of(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
+  }
 
-    @Test
-    void fetchTestResults() {
-        Person p = _dataFactory.createFullPerson(_org);
-        _dataFactory.createTestEvent(p, _site);
-        _dataFactory.createTestEvent(p, _site);
-        _dataFactory.createTestEvent(p, _site);
+  @Test
+  void fetchTestResults() {
+    Person p = _dataFactory.createFullPerson(_org);
+    _dataFactory.createTestEvent(p, _site);
+    _dataFactory.createTestEvent(p, _site);
+    _dataFactory.createTestEvent(p, _site);
 
-        HashMap<String, Object> variables = getFacilityScopedArguments();
-        ArrayNode testResults = fetchTestResults(variables);
+    HashMap<String, Object> variables = getFacilityScopedArguments();
+    ArrayNode testResults = fetchTestResults(variables);
 
-        assertEquals(3, testResults.size());
-        assertNotNull(testResults.get(0).get("patientLink"));
-    }
+    assertEquals(3, testResults.size());
+    assertNotNull(testResults.get(0).get("patientLink"));
+  }
 
-    @Test
-    void fetchOrganizationTestResults_adminUser() {
-        useOrgAdmin();
+  @Test
+  void fetchOrganizationTestResults_adminUser() {
+    useOrgAdmin();
 
-        Person p = _dataFactory.createFullPerson(_org);
-        _dataFactory.createTestEvent(p, _site);
-        _dataFactory.createTestEvent(p, _site);
-        _dataFactory.createTestEvent(p, _site);
+    Person p = _dataFactory.createFullPerson(_org);
+    _dataFactory.createTestEvent(p, _site);
+    _dataFactory.createTestEvent(p, _site);
+    _dataFactory.createTestEvent(p, _site);
 
-        HashMap<String, Object> variables = getFacilityScopedArguments();
-        variables.put("facilityId", null);
-        ArrayNode testResults = fetchTestResults(variables);
+    HashMap<String, Object> variables = getFacilityScopedArguments();
+    variables.put("facilityId", null);
+    ArrayNode testResults = fetchTestResults(variables);
 
-        testResults = fetchTestResults(variables);
-        assertEquals(3, testResults.size());
-    }
+    testResults = fetchTestResults(variables);
+    assertEquals(3, testResults.size());
+  }
 
-    @Test
-    void fetchOrganizationTestResults__orgUser_failure() {
-        HashMap<String, Object> variables = getFacilityScopedArguments();
-        variables.put("facilityId", null);
-        fetchTestResultsWithError(variables, ACCESS_ERROR);
-    }
+  @Test
+  void fetchOrganizationTestResults__orgUser_failure() {
+    HashMap<String, Object> variables = getFacilityScopedArguments();
+    variables.put("facilityId", null);
+    fetchTestResultsWithError(variables, ACCESS_ERROR);
+  }
 
-    @Test
-    void submitTestResult() {
-        Person p = _dataFactory.createFullPerson(_org);
-        DeviceType d = _site.getDefaultDeviceType();
-        SpecimenType s = _site.getDefaultSpecimenType();
-        _dataFactory.createTestOrder(p, _site);
-        String dateTested = "2020-12-31T14:30:30.001Z";
+  @Test
+  void submitTestResult() {
+    Person p = _dataFactory.createFullPerson(_org);
+    DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
+    _dataFactory.createTestOrder(p, _site);
+    String dateTested = "2020-12-31T14:30:30.001Z";
 
-        Map<String, Object> variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
-        submitQueueItem(variables, Optional.empty());
+    Map<String, Object> variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
+    submitQueueItem(variables, Optional.empty());
 
-        ArrayNode testResults = fetchTestResults(getFacilityScopedArguments());
+    ArrayNode testResults = fetchTestResults(getFacilityScopedArguments());
 
-        assertTrue(testResults.has(0), "Has at least one submitted test result=");
-        assertEquals(testResults.get(0).get("dateTested").asText(), dateTested);
-    }
+    assertTrue(testResults.has(0), "Has at least one submitted test result=");
+    assertEquals(testResults.get(0).get("dateTested").asText(), dateTested);
+  }
 
-    @Test
-    void submitAndFetchMultiplexResult() {
-        Person p = _dataFactory.createFullPerson(_org);
-        DeviceType d = _site.getDefaultDeviceType();
-        SpecimenType s = _site.getDefaultSpecimenType();
-        Map<String, Boolean> symptoms = Map.of("25064002", true);
-        LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
-        _dataFactory.createTestOrder(
-                p,
-                _site,
-                new AskOnEntrySurvey("77386006", YES_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, List.of("male")));
-        String dateTested = "2020-12-31T14:30:30.001Z";
+  @Test
+  void submitAndFetchMultiplexResult() {
+    Person p = _dataFactory.createFullPerson(_org);
+    DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
+    Map<String, Boolean> symptoms = Map.of("25064002", true);
+    LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
+    _dataFactory.createTestOrder(
+        p,
+        _site,
+        new AskOnEntrySurvey(
+            "77386006",
+            YES_SYPHILIS_HISTORY_SNOMED,
+            symptoms,
+            false,
+            symptomOnsetDate,
+            List.of("male")));
+    String dateTested = "2020-12-31T14:30:30.001Z";
 
-        List<MultiplexResultInput> results = new ArrayList<>();
-        results.add(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
-        results.add(new MultiplexResultInput(_diseaseService.fluA().getName(), TestResult.POSITIVE));
-        results.add(
-                new MultiplexResultInput(_diseaseService.fluB().getName(), TestResult.UNDETERMINED));
+    List<MultiplexResultInput> results = new ArrayList<>();
+    results.add(new MultiplexResultInput(_diseaseService.covid().getName(), TestResult.NEGATIVE));
+    results.add(new MultiplexResultInput(_diseaseService.fluA().getName(), TestResult.POSITIVE));
+    results.add(
+        new MultiplexResultInput(_diseaseService.fluB().getName(), TestResult.UNDETERMINED));
 
-        Map<String, Object> variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p.getInternalId().toString(),
-                        "results",
-                        results,
-                        "dateTested",
-                        dateTested);
-        submitQueueItem(variables, Optional.empty());
+    Map<String, Object> variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p.getInternalId().toString(),
+            "results",
+            results,
+            "dateTested",
+            dateTested);
+    submitQueueItem(variables, Optional.empty());
 
-        ArrayNode testResults = fetchTestResultsMultiplex(getFacilityScopedArguments());
+    ArrayNode testResults = fetchTestResultsMultiplex(getFacilityScopedArguments());
 
-        assertTrue(testResults.has(0), "Has at least one submitted test result=");
-        assertEquals(dateTested, testResults.get(0).get("dateTested").asText());
-        assertEquals("{\"25064002\":\"true\"}", testResults.get(0).get("symptoms").asText());
-        assertEquals("false", testResults.get(0).get("noSymptoms").asText());
-        assertEquals("77386006", testResults.get(0).get("pregnancy").asText());
-        assertEquals("2020-09-15", testResults.get(0).get("symptomOnset").asText());
-        assertEquals("[\"male\"]", testResults.get(0).get("genderOfSexualPartners").toString());
-        testResults
-                .get(0)
-                .get("results")
-                .elements()
-                .forEachRemaining(
-                        r -> {
-                            switch (r.get("disease").get("name").asText()) {
-                                case "COVID-19":
-                                    assertEquals(TestResult.NEGATIVE.toString(), r.get("testResult").asText());
-                                    break;
-                                case "Flu A":
-                                    assertEquals(TestResult.POSITIVE.toString(), r.get("testResult").asText());
-                                    break;
-                                case "Flu B":
-                                    assertEquals(TestResult.UNDETERMINED.toString(), r.get("testResult").asText());
-                                    break;
-                                default:
-                                    fail("Unexpected disease=" + r.get("disease").get("name").asText());
-                            }
-                        });
-    }
+    assertTrue(testResults.has(0), "Has at least one submitted test result=");
+    assertEquals(dateTested, testResults.get(0).get("dateTested").asText());
+    assertEquals("{\"25064002\":\"true\"}", testResults.get(0).get("symptoms").asText());
+    assertEquals("false", testResults.get(0).get("noSymptoms").asText());
+    assertEquals("77386006", testResults.get(0).get("pregnancy").asText());
+    assertEquals("2020-09-15", testResults.get(0).get("symptomOnset").asText());
+    assertEquals("[\"male\"]", testResults.get(0).get("genderOfSexualPartners").toString());
+    testResults
+        .get(0)
+        .get("results")
+        .elements()
+        .forEachRemaining(
+            r -> {
+              switch (r.get("disease").get("name").asText()) {
+                case "COVID-19":
+                  assertEquals(TestResult.NEGATIVE.toString(), r.get("testResult").asText());
+                  break;
+                case "Flu A":
+                  assertEquals(TestResult.POSITIVE.toString(), r.get("testResult").asText());
+                  break;
+                case "Flu B":
+                  assertEquals(TestResult.UNDETERMINED.toString(), r.get("testResult").asText());
+                  break;
+                default:
+                  fail("Unexpected disease=" + r.get("disease").get("name").asText());
+              }
+            });
+  }
 
-    @Test
-    void testResultOperations_standardUser_successDependsOnFacilityAccess() {
-        Person p1 = _dataFactory.createFullPerson(_org);
-        Person p2 = _dataFactory.createMinimalPerson(_org, _site);
-        DeviceType d = _site.getDefaultDeviceType();
-        SpecimenType s = _site.getDefaultSpecimenType();
-        Map<String, Boolean> symptoms = Map.of("25064002", true);
-        LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
+  @Test
+  void testResultOperations_standardUser_successDependsOnFacilityAccess() {
+    Person p1 = _dataFactory.createFullPerson(_org);
+    Person p2 = _dataFactory.createMinimalPerson(_org, _site);
+    DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
+    Map<String, Boolean> symptoms = Map.of("25064002", true);
+    LocalDate symptomOnsetDate = LocalDate.of(2020, 9, 15);
 
-        _dataFactory.createTestOrder(
-                p1, _site, new AskOnEntrySurvey("77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
-        _dataFactory.createTestOrder(
-                p2, _site, new AskOnEntrySurvey("77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
-        String dateTested = "2020-12-31T14:30:30.001Z";
+    _dataFactory.createTestOrder(
+        p1,
+        _site,
+        new AskOnEntrySurvey(
+            "77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
+    _dataFactory.createTestOrder(
+        p2,
+        _site,
+        new AskOnEntrySurvey(
+            "77386006", NO_SYPHILIS_HISTORY_SNOMED, symptoms, false, symptomOnsetDate, null));
+    String dateTested = "2020-12-31T14:30:30.001Z";
 
-        // The test default standard user is configured to access _site by default,
-        // so we need to remove access to establish a baseline in this test
-        updateSelfPrivileges(Role.USER, false, Set.of());
-        Map<String, Object> submitP1Variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p1.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
-        Map<String, Object> submitP2Variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p2.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
+    // The test default standard user is configured to access _site by default,
+    // so we need to remove access to establish a baseline in this test
+    updateSelfPrivileges(Role.USER, false, Set.of());
+    Map<String, Object> submitP1Variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p1.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
+    Map<String, Object> submitP2Variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p2.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
 
-        submitQueueItem(submitP1Variables, Optional.of(ACCESS_ERROR));
-        submitQueueItem(submitP2Variables, Optional.of(ACCESS_ERROR));
+    submitQueueItem(submitP1Variables, Optional.of(ACCESS_ERROR));
+    submitQueueItem(submitP2Variables, Optional.of(ACCESS_ERROR));
 
-        updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-        submitQueueItem(submitP1Variables, Optional.empty());
-        submitQueueItem(submitP2Variables, Optional.empty());
+    updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
+    submitQueueItem(submitP1Variables, Optional.empty());
+    submitQueueItem(submitP2Variables, Optional.empty());
 
-        updateSelfPrivileges(Role.USER, false, Set.of());
-        Map<String, Object> fetchVariables = getFacilityScopedArguments();
-        fetchTestResultsWithError(fetchVariables, ACCESS_ERROR);
+    updateSelfPrivileges(Role.USER, false, Set.of());
+    Map<String, Object> fetchVariables = getFacilityScopedArguments();
+    fetchTestResultsWithError(fetchVariables, ACCESS_ERROR);
 
-        updateSelfPrivileges(Role.USER, true, Set.of());
-        ArrayNode testResults = fetchTestResults(fetchVariables);
-        assertEquals(2, testResults.size());
-        UUID t1Id = UUID.fromString(testResults.get(0).get("internalId").asText());
-        UUID t2Id = UUID.fromString(testResults.get(1).get("internalId").asText());
+    updateSelfPrivileges(Role.USER, true, Set.of());
+    ArrayNode testResults = fetchTestResults(fetchVariables);
+    assertEquals(2, testResults.size());
+    UUID t1Id = UUID.fromString(testResults.get(0).get("internalId").asText());
+    UUID t2Id = UUID.fromString(testResults.get(1).get("internalId").asText());
 
-        updateSelfPrivileges(Role.USER, false, Set.of());
+    updateSelfPrivileges(Role.USER, false, Set.of());
 
-        Map<String, Object> correctT1Variables =
-                Map.of("id", t1Id.toString(), "reason", "nobody's perfect");
+    Map<String, Object> correctT1Variables =
+        Map.of("id", t1Id.toString(), "reason", "nobody's perfect");
 
-        Map<String, Object> correctT2Variables =
-                Map.of("id", t2Id.toString(), "reason", "nobody's perfect");
+    Map<String, Object> correctT2Variables =
+        Map.of("id", t2Id.toString(), "reason", "nobody's perfect");
 
-        correctTest(correctT1Variables, Optional.of(ACCESS_ERROR));
-        correctTest(correctT2Variables, Optional.of(ACCESS_ERROR));
+    correctTest(correctT1Variables, Optional.of(ACCESS_ERROR));
+    correctTest(correctT2Variables, Optional.of(ACCESS_ERROR));
 
-        updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-        correctTest(correctT1Variables, Optional.empty());
-        correctTest(correctT2Variables, Optional.empty());
+    updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
+    correctTest(correctT1Variables, Optional.empty());
+    correctTest(correctT2Variables, Optional.empty());
 
-        updateSelfPrivileges(Role.USER, false, Set.of());
-        Map<String, Object> fetchT1Variables = Map.of("id", t1Id.toString());
-        Map<String, Object> fetchT2Variables = Map.of("id", t2Id.toString());
+    updateSelfPrivileges(Role.USER, false, Set.of());
+    Map<String, Object> fetchT1Variables = Map.of("id", t1Id.toString());
+    Map<String, Object> fetchT2Variables = Map.of("id", t2Id.toString());
 
-        fetchTestResult(fetchT1Variables, Optional.of(ACCESS_ERROR));
-        fetchTestResult(fetchT2Variables, Optional.of(ACCESS_ERROR));
+    fetchTestResult(fetchT1Variables, Optional.of(ACCESS_ERROR));
+    fetchTestResult(fetchT2Variables, Optional.of(ACCESS_ERROR));
 
-        updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
-        fetchTestResult(fetchT1Variables, Optional.empty());
-        fetchTestResult(fetchT2Variables, Optional.empty());
-    }
+    updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));
+    fetchTestResult(fetchT1Variables, Optional.empty());
+    fetchTestResult(fetchT2Variables, Optional.empty());
+  }
 
-    @Test
-    void getOrganizationLevelDashboardMetrics_orgAdmin_success() {
-        useOrgAdmin();
+  @Test
+  void getOrganizationLevelDashboardMetrics_orgAdmin_success() {
+    useOrgAdmin();
 
-        Person p1 = _dataFactory.createFullPerson(_org);
-        Person p2 = _dataFactory.createMinimalPerson(_org, _site);
-        Person p3 = _dataFactory.createMinimalPerson(_org, _secondSite, "Carl", "A", "Scheffer", "");
-        Person p4 =
-                _dataFactory.createMinimalPerson(_org, _secondSite, "Lindsay", "L", "Wasserman", "");
+    Person p1 = _dataFactory.createFullPerson(_org);
+    Person p2 = _dataFactory.createMinimalPerson(_org, _site);
+    Person p3 = _dataFactory.createMinimalPerson(_org, _secondSite, "Carl", "A", "Scheffer", "");
+    Person p4 =
+        _dataFactory.createMinimalPerson(_org, _secondSite, "Lindsay", "L", "Wasserman", "");
 
-        DeviceType d = _site.getDefaultDeviceType();
-        SpecimenType s = _site.getDefaultSpecimenType();
+    DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
 
-        DeviceType secondSiteDevice = _secondSite.getDefaultDeviceType();
-        SpecimenType secondSiteSpecimen = _secondSite.getDefaultSpecimenType();
+    DeviceType secondSiteDevice = _secondSite.getDefaultDeviceType();
+    SpecimenType secondSiteSpecimen = _secondSite.getDefaultSpecimenType();
 
-        _dataFactory.createTestOrder(p1, _site);
-        _dataFactory.createTestOrder(p2, _site);
-        _dataFactory.createTestOrder(p3, _secondSite);
-        _dataFactory.createTestOrder(p4, _secondSite);
-        String dateTested = "2020-12-31T14:30:30.001Z";
+    _dataFactory.createTestOrder(p1, _site);
+    _dataFactory.createTestOrder(p2, _site);
+    _dataFactory.createTestOrder(p3, _secondSite);
+    _dataFactory.createTestOrder(p4, _secondSite);
+    String dateTested = "2020-12-31T14:30:30.001Z";
 
-        Map<String, Object> submitP1Variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p1.getInternalId().toString(),
-                        "results",
-                        positiveCovidResult,
-                        "dateTested",
-                        dateTested);
-        Map<String, Object> submitP2Variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p2.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
-        Map<String, Object> submitP3Variables =
-                Map.of(
-                        "deviceId",
-                        secondSiteDevice.getInternalId().toString(),
-                        "specimenId",
-                        secondSiteSpecimen.getInternalId().toString(),
-                        "patientId",
-                        p3.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
-        Map<String, Object> submitP4Variables =
-                Map.of(
-                        "deviceId",
-                        secondSiteDevice.getInternalId().toString(),
-                        "specimenId",
-                        secondSiteSpecimen.getInternalId().toString(),
-                        "patientId",
-                        p4.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
-        submitQueueItem(submitP1Variables, Optional.empty());
-        submitQueueItem(submitP2Variables, Optional.empty());
-        submitQueueItem(submitP3Variables, Optional.empty());
-        submitQueueItem(submitP4Variables, Optional.empty());
+    Map<String, Object> submitP1Variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p1.getInternalId().toString(),
+            "results",
+            positiveCovidResult,
+            "dateTested",
+            dateTested);
+    Map<String, Object> submitP2Variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p2.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
+    Map<String, Object> submitP3Variables =
+        Map.of(
+            "deviceId",
+            secondSiteDevice.getInternalId().toString(),
+            "specimenId",
+            secondSiteSpecimen.getInternalId().toString(),
+            "patientId",
+            p3.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
+    Map<String, Object> submitP4Variables =
+        Map.of(
+            "deviceId",
+            secondSiteDevice.getInternalId().toString(),
+            "specimenId",
+            secondSiteSpecimen.getInternalId().toString(),
+            "patientId",
+            p4.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
+    submitQueueItem(submitP1Variables, Optional.empty());
+    submitQueueItem(submitP2Variables, Optional.empty());
+    submitQueueItem(submitP3Variables, Optional.empty());
+    submitQueueItem(submitP4Variables, Optional.empty());
 
-        String startDate = "2020-01-01";
-        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+    String startDate = "2020-01-01";
+    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-        Map<String, Object> variables =
-                Map.of(
-                        "startDate", startDate,
-                        "endDate", endDate);
+    Map<String, Object> variables =
+        Map.of(
+            "startDate", startDate,
+            "endDate", endDate);
 
-        ObjectNode result =
-                runQuery(
-                        "organization-level-metrics", "GetOrganizationLevelDashboardMetrics", variables, null);
-
-        JsonNode metrics = result.get("organizationLevelDashboardMetrics");
-        assertEquals(1L, metrics.get("organizationPositiveTestCount").asLong());
-        assertEquals(3L, metrics.get("organizationNegativeTestCount").asLong());
-        assertEquals(4L, metrics.get("organizationTotalTestCount").asLong());
-        assertEquals(2, metrics.get("facilityMetrics").size());
-    }
-
-    @Test
-    void getOrganizationLevelDashboardMetrics_orgUser_failure() {
-        String startDate = "2020-01-01";
-        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
-
-        Map<String, Object> variables =
-                Map.of(
-                        "startDate", startDate,
-                        "endDate", endDate);
-        useOrgUser();
-
+    ObjectNode result =
         runQuery(
-                "organization-level-metrics",
-                "GetOrganizationLevelDashboardMetrics",
-                variables,
-                "Current user does not have permission to request [/organizationLevelDashboardMetrics]");
-    }
+            "organization-level-metrics", "GetOrganizationLevelDashboardMetrics", variables, null);
 
-    @Test
-    void getTopLevelDashboardMetrics_orgAdmin_success() {
-        Person p1 = _dataFactory.createFullPerson(_org);
-        Person p2 = _dataFactory.createMinimalPerson(_org, _site);
-        DeviceType d = _site.getDefaultDeviceType();
-        SpecimenType s = _site.getDefaultSpecimenType();
-        _dataFactory.createTestOrder(p1, _site);
-        _dataFactory.createTestOrder(p2, _site);
-        String dateTested = "2020-12-31T14:30:30.001Z";
+    JsonNode metrics = result.get("organizationLevelDashboardMetrics");
+    assertEquals(1L, metrics.get("organizationPositiveTestCount").asLong());
+    assertEquals(3L, metrics.get("organizationNegativeTestCount").asLong());
+    assertEquals(4L, metrics.get("organizationTotalTestCount").asLong());
+    assertEquals(2, metrics.get("facilityMetrics").size());
+  }
 
-        Map<String, Object> submitP1Variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p1.getInternalId().toString(),
-                        "results",
-                        positiveCovidResult,
-                        "dateTested",
-                        dateTested);
-        Map<String, Object> submitP2Variables =
-                Map.of(
-                        "deviceId",
-                        d.getInternalId().toString(),
-                        "specimenId",
-                        s.getInternalId().toString(),
-                        "patientId",
-                        p2.getInternalId().toString(),
-                        "results",
-                        negativeCovidResult,
-                        "dateTested",
-                        dateTested);
-        submitQueueItem(submitP1Variables, Optional.empty());
-        submitQueueItem(submitP2Variables, Optional.empty());
+  @Test
+  void getOrganizationLevelDashboardMetrics_orgUser_failure() {
+    String startDate = "2020-01-01";
+    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-        String startDate = "2020-01-01";
-        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+    Map<String, Object> variables =
+        Map.of(
+            "startDate", startDate,
+            "endDate", endDate);
+    useOrgUser();
 
-        useOrgAdmin();
+    runQuery(
+        "organization-level-metrics",
+        "GetOrganizationLevelDashboardMetrics",
+        variables,
+        "Current user does not have permission to request [/organizationLevelDashboardMetrics]");
+  }
 
-        Map<String, Object> variables =
-                Map.of(
-                        "startDate", startDate,
-                        "endDate", endDate);
+  @Test
+  void getTopLevelDashboardMetrics_orgAdmin_success() {
+    Person p1 = _dataFactory.createFullPerson(_org);
+    Person p2 = _dataFactory.createMinimalPerson(_org, _site);
+    DeviceType d = _site.getDefaultDeviceType();
+    SpecimenType s = _site.getDefaultSpecimenType();
+    _dataFactory.createTestOrder(p1, _site);
+    _dataFactory.createTestOrder(p2, _site);
+    String dateTested = "2020-12-31T14:30:30.001Z";
 
-        ObjectNode result =
-                runQuery("dashboard-metrics", "GetTopLevelDashboardMetrics", variables, null);
+    Map<String, Object> submitP1Variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p1.getInternalId().toString(),
+            "results",
+            positiveCovidResult,
+            "dateTested",
+            dateTested);
+    Map<String, Object> submitP2Variables =
+        Map.of(
+            "deviceId",
+            d.getInternalId().toString(),
+            "specimenId",
+            s.getInternalId().toString(),
+            "patientId",
+            p2.getInternalId().toString(),
+            "results",
+            negativeCovidResult,
+            "dateTested",
+            dateTested);
+    submitQueueItem(submitP1Variables, Optional.empty());
+    submitQueueItem(submitP2Variables, Optional.empty());
 
-        JsonNode metrics = result.get("topLevelDashboardMetrics");
-        assertEquals(1L, metrics.get("positiveTestCount").asLong());
-        assertEquals(2L, metrics.get("totalTestCount").asLong());
-    }
+    String startDate = "2020-01-01";
+    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-    @Test
-    void getTopLevelDashboardMetrics_orgUser_failure() {
-        String startDate = "2020-01-01";
-        String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
+    useOrgAdmin();
 
-        Map<String, Object> variables =
-                Map.of(
-                        "startDate", startDate,
-                        "endDate", endDate);
+    Map<String, Object> variables =
+        Map.of(
+            "startDate", startDate,
+            "endDate", endDate);
 
-        useOrgUser();
+    ObjectNode result =
+        runQuery("dashboard-metrics", "GetTopLevelDashboardMetrics", variables, null);
 
-        runQuery(
-                "dashboard-metrics",
-                "GetTopLevelDashboardMetrics",
-                variables,
-                "Current user does not have permission to request [/topLevelDashboardMetrics]");
-    }
+    JsonNode metrics = result.get("topLevelDashboardMetrics");
+    assertEquals(1L, metrics.get("positiveTestCount").asLong());
+    assertEquals(2L, metrics.get("totalTestCount").asLong());
+  }
 
-    private HashMap<String, Object> getFacilityScopedArguments() {
-        return new HashMap<>(Map.of("facilityId", _site.getInternalId().toString()));
-    }
+  @Test
+  void getTopLevelDashboardMetrics_orgUser_failure() {
+    String startDate = "2020-01-01";
+    String endDate = new SimpleDateFormat("yyyy-MM-dd").format(Date.from(Instant.now()));
 
-    private ObjectNode submitQueueItem(
-            Map<String, Object> variables, Optional<String> expectedError) {
-        return runQuery("submit-queue-item", variables, expectedError.orElse(null));
-    }
+    Map<String, Object> variables =
+        Map.of(
+            "startDate", startDate,
+            "endDate", endDate);
 
-    private ArrayNode fetchTestResults(Map<String, Object> variables) {
-        return (ArrayNode)
-                runQuery("test-results-with-count-query", variables).get("testResultsPage").get("content");
-    }
+    useOrgUser();
 
-    private ArrayNode fetchTestResultsMultiplex(Map<String, Object> variables) {
-        return (ArrayNode)
-                runQuery("test-results-with-count-multiplex-query", variables)
-                        .get("testResultsPage")
-                        .get("content");
-    }
+    runQuery(
+        "dashboard-metrics",
+        "GetTopLevelDashboardMetrics",
+        variables,
+        "Current user does not have permission to request [/topLevelDashboardMetrics]");
+  }
 
-    private void fetchTestResultsWithError(Map<String, Object> variables, String expectedError) {
-        runQuery("test-results-with-count-query", variables, expectedError);
-    }
+  private HashMap<String, Object> getFacilityScopedArguments() {
+    return new HashMap<>(Map.of("facilityId", _site.getInternalId().toString()));
+  }
 
-    private void fetchTestResult(Map<String, Object> variables, Optional<String> expectedError) {
-        runQuery("test-result-query", variables, expectedError.orElse(null));
-    }
+  private ObjectNode submitQueueItem(
+      Map<String, Object> variables, Optional<String> expectedError) {
+    return runQuery("submit-queue-item", variables, expectedError.orElse(null));
+  }
 
-    private ObjectNode correctTest(Map<String, Object> variables, Optional<String> expectedError) {
-        return runQuery("correct-test-result-mutation", variables, expectedError.orElse(null));
-    }
+  private ArrayNode fetchTestResults(Map<String, Object> variables) {
+    return (ArrayNode)
+        runQuery("test-results-with-count-query", variables).get("testResultsPage").get("content");
+  }
+
+  private ArrayNode fetchTestResultsMultiplex(Map<String, Object> variables) {
+    return (ArrayNode)
+        runQuery("test-results-with-count-multiplex-query", variables)
+            .get("testResultsPage")
+            .get("content");
+  }
+
+  private void fetchTestResultsWithError(Map<String, Object> variables, String expectedError) {
+    runQuery("test-results-with-count-query", variables, expectedError);
+  }
+
+  private void fetchTestResult(Map<String, Object> variables, Optional<String> expectedError) {
+    runQuery("test-result-query", variables, expectedError.orElse(null));
+  }
+
+  private ObjectNode correctTest(Map<String, Object> variables, Optional<String> expectedError) {
+    return runQuery("correct-test-result-mutation", variables, expectedError.orElse(null));
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -157,6 +157,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(),
         patient,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
@@ -226,7 +227,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null);
 
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
 
     List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
     _service.addMultiplexResult(
@@ -245,7 +252,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
 
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1866, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1866, 12, 25),
+        false);
     _service.addMultiplexResult(
         _dataFactory.getGenericDevice().getInternalId(),
         _dataFactory.getGenericSpecimen().getInternalId(),
@@ -306,7 +319,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             "Space-faring maverick");
 
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
 
     List<TestOrder> queue = _service.getQueue(facility.getInternalId());
     assertEquals(1, queue.size());
@@ -348,11 +367,17 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     assertThrows(
         AccessDeniedException.class,
-        () -> _service.addPatientToQueue(facilityId, p, "", symptoms, symptomOnsetDate, false));
+        () -> _service.addPatientToQueue(facilityId, p, "", "", symptoms, symptomOnsetDate, false));
 
     TestUserIdentities.setFacilityAuthorities(facility);
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
     TestUserIdentities.setFacilityAuthorities();
 
     assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
@@ -394,7 +419,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _personService.updateTestResultDeliveryPreference(
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
 
     UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
     UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
@@ -442,7 +473,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null,
             null);
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
 
     UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
     UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
@@ -520,12 +557,14 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility1.getInternalId(),
         p1,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
     _service.addPatientToQueue(
         facility1.getInternalId(),
         p2,
+        "",
         "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
@@ -588,7 +627,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _personService.updateTestResultDeliveryPreference(
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
     DeviceType deviceType = _dataFactory.getGenericDevice();
     SpecimenType specimenType = _dataFactory.getGenericSpecimen();
     facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
@@ -615,7 +660,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _personService.updateTestResultDeliveryPreference(
         p.getInternalId(), TestResultDeliveryPreference.SMS);
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
     DeviceType deviceType = _dataFactory.getGenericDevice();
     SpecimenType specimenType = _dataFactory.getGenericSpecimen();
     facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
@@ -645,7 +696,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     Facility facility = _organizationService.getFacilities(org).get(0);
     Person p = _dataFactory.createFullPerson(org);
     _service.addPatientToQueue(
-        facility.getInternalId(), p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
     DeviceType deviceType = _dataFactory.getGenericDevice();
     SpecimenType specimenType = _dataFactory.getGenericSpecimen();
     facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
@@ -708,6 +765,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(),
         patient,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
@@ -750,6 +808,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(),
         patient,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
@@ -789,6 +848,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(),
         patient,
+        "",
         "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
@@ -833,6 +893,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(),
         patient,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
@@ -872,6 +933,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(),
         patient,
+        "",
         "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
@@ -914,6 +976,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(),
         patient,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
@@ -949,6 +1012,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _service.addPatientToQueue(
         facility.getInternalId(),
         patient,
+        "",
         "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
@@ -1368,7 +1432,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
             null);
 
     _service.addPatientToQueue(
-        facilityId, p1, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        facilityId, p1, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
 
     // get the first query count
     long startQueryCount = QueryCountService.get().getSelect();
@@ -1403,7 +1467,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
               null);
 
       _service.addPatientToQueue(
-          facilityId, p, "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+          facilityId, p, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     }
 
     startQueryCount = QueryCountService.get().getSelect();
@@ -2212,6 +2276,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         facility.getInternalId(),
         patient,
         "",
+        "",
         Collections.emptyMap(),
         LocalDate.of(1865, 12, 25),
         false);
@@ -2436,6 +2501,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         _service.addPatientToQueue(
             facility.getInternalId(),
             patient,
+            "",
             "",
             Collections.emptyMap(),
             LocalDate.of(2022, 6, 5),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -54,7 +54,6 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -69,7 +68,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -85,2445 +83,2433 @@ import org.springframework.test.context.TestPropertySource;
 @SuppressWarnings("checkstyle:MagicNumber")
 class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
-    @Autowired
-    @SpyBean
-    private OrganizationService _organizationService;
-    @Autowired
-    private PersonService _personService;
-    @Autowired
-    private TestEventRepository _testEventRepository;
-    @Autowired
-    @SpyBean
-    private TestOrderRepository _testOrderRepository;
-    @Autowired
-    private ResultRepository _resultRepository;
-    @Autowired
-    private TestDataFactory _dataFactory;
-    @SpyBean
-    private PatientLinkService patientLinkService;
-    @MockBean
-    private TestResultsDeliveryService testResultsDeliveryService;
+  @Autowired @SpyBean private OrganizationService _organizationService;
+  @Autowired private PersonService _personService;
+  @Autowired private TestEventRepository _testEventRepository;
+  @Autowired @SpyBean private TestOrderRepository _testOrderRepository;
+  @Autowired private ResultRepository _resultRepository;
+  @Autowired private TestDataFactory _dataFactory;
+  @SpyBean private PatientLinkService patientLinkService;
+  @MockBean private TestResultsDeliveryService testResultsDeliveryService;
 
-    @MockBean(name = "csvQueueReportingService")
-    TestEventReportingService testEventReportingService;
+  @MockBean(name = "csvQueueReportingService")
+  TestEventReportingService testEventReportingService;
 
-    @MockBean(name = "fhirQueueReportingService")
-    TestEventReportingService fhirQueueReportingService;
+  @MockBean(name = "fhirQueueReportingService")
+  TestEventReportingService fhirQueueReportingService;
 
-    @SpyBean
-    ReportTestEventToRSEventListener reportTestEventToRSEventListener;
+  @SpyBean ReportTestEventToRSEventListener reportTestEventToRSEventListener;
 
-    @Captor
-    ArgumentCaptor<TestEvent> testEventArgumentCaptor;
+  @Captor ArgumentCaptor<TestEvent> testEventArgumentCaptor;
 
-    private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
-    private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
-    private static final PersonName CHARLES = new PersonName("Charles", "Mathew", "Albemarle", "Sr.");
-    private static final PersonName DEXTER = new PersonName("Dexter", null, "Jones", null);
-    private static final PersonName ELIZABETH =
-            new PersonName("Elizabeth", "Martha", "Merriwether", null);
-    private static final PersonName FRANK = new PersonName("Frank", "Mathew", "Bones", "3");
-    private static final PersonName GALE = new PersonName("Gale", "Mary", "Vittorio", "PhD");
-    private static final PersonName HEINRICK = new PersonName("Heinrick", "Mark", "Silver", "III");
-    private static final PersonName IAN = new PersonName("Ian", "Brou", "Rutter", null);
-    private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
-    private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
-    private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
-    private Facility _site;
+  private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
+  private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
+  private static final PersonName CHARLES = new PersonName("Charles", "Mathew", "Albemarle", "Sr.");
+  private static final PersonName DEXTER = new PersonName("Dexter", null, "Jones", null);
+  private static final PersonName ELIZABETH =
+      new PersonName("Elizabeth", "Martha", "Merriwether", null);
+  private static final PersonName FRANK = new PersonName("Frank", "Mathew", "Bones", "3");
+  private static final PersonName GALE = new PersonName("Gale", "Mary", "Vittorio", "PhD");
+  private static final PersonName HEINRICK = new PersonName("Heinrick", "Mark", "Silver", "III");
+  private static final PersonName IAN = new PersonName("Ian", "Brou", "Rutter", null);
+  private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
+  private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
+  private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
+  private Facility _site;
 
-    @BeforeEach
-    void setupData() {
-        initSampleData();
-    }
+  @BeforeEach
+  void setupData() {
+    initSampleData();
+  }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void roundTrip() {
-        // GIVEN
-        Facility facility =
-                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-        Person patient =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "English",
-                        null,
-                        null);
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void roundTrip() {
+    // GIVEN
+    Facility facility =
+        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+    Person patient =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "English",
+            null,
+            null);
 
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
 
-        UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
-        UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
+    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(1, queue.size());
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(1, queue.size());
 
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    // WHEN
+    _service.addMultiplexResult(
+        defaultDeviceType,
+        defaultSpecimenType,
+        positiveCovidOnlyResult,
+        patient.getInternalId(),
+        null);
+
+    // THEN
+    queue = _service.getQueue(facility.getInternalId());
+    assertEquals(0, queue.size());
+
+    List<TestEvent> testEvents =
+        _testEventRepository.findAllByPatientAndFacilities(patient, List.of(facility));
+    assertThat(testEvents).hasSize(1);
+    assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+    verify(patientLinkService).createPatientLink(any());
+
+    // make sure the corrected event is sent to storage queue
+    verify(testEventReportingService).report(testEventArgumentCaptor.capture());
+    verify(fhirQueueReportingService).report(any());
+    TestEvent sentEvent = testEventArgumentCaptor.getValue();
+    TestResult testResult = sentEvent.getCovidTestResult().get();
+    assertThat(sentEvent.getPatient().getInternalId()).isEqualTo(patient.getInternalId());
+    assertThat(testResult).isEqualTo(TestResult.POSITIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_populateFirstTest() {
+    Facility facility =
+        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+    Person p =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "English",
+            null,
+            null);
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    _service.addMultiplexResult(
+        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericSpecimen().getInternalId(),
+        positiveCovidOnlyResult,
+        p.getInternalId(),
+        null);
+
+    verify(testEventReportingService).report(any());
+    verify(fhirQueueReportingService).report(any());
+
+    List<TestEvent> testEvents =
+        _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
+    assertThat(testEvents).hasSize(1);
+    assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1866, 12, 25),
+        false);
+    _service.addMultiplexResult(
+        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericSpecimen().getInternalId(),
+        positiveCovidOnlyResult,
+        p.getInternalId(),
+        null);
+
+    testEvents = _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
+    assertThat(testEvents).hasSize(2);
+    assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+    assertThat(testEvents.get(1).getPatientHasPriorTests()).isTrue();
+    verify(testEventReportingService, times(2)).report(any());
+    verify(fhirQueueReportingService, times(2)).report(any());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void getQueue_standardUser_successDependsOnFacilityAccess() {
+    Facility facility =
+        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+
+    UUID facilityId = facility.getInternalId();
+    assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
+
+    TestUserIdentities.setFacilityAuthorities(facility);
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(0, queue.size());
+  }
+
+  @Test
+  @WithSimpleReportStandardAllFacilitiesUser
+  void addPatientToQueue_standardUserAllFacilities_ok() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person p =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "Spanish",
+            null,
+            "Space-faring maverick");
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(1, queue.size());
+  }
+
+  @Test
+  void addPatientToQueue_standardUser_successDependsOnFacilityAccess() {
+    Facility facility =
+        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+
+    Person p =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "German",
+            null,
+            "success depends on Fred's access");
+
+    UUID facilityId = facility.getInternalId();
+    Map<String, Boolean> symptoms = Collections.emptyMap();
+    LocalDate symptomOnsetDate = LocalDate.of(1865, 12, 25);
+
+    assertThrows(
+        AccessDeniedException.class,
+        () -> _service.addPatientToQueue(facilityId, p, "", "", symptoms, symptomOnsetDate, false));
+
+    TestUserIdentities.setFacilityAuthorities(facility);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    TestUserIdentities.setFacilityAuthorities();
+
+    assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
+
+    TestUserIdentities.setFacilityAuthorities(facility);
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(1, queue.size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_orgAdmin_ok() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person p =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "French",
+            null,
+            null);
+    _personService.updateTestResultDeliveryPreference(
+        p.getInternalId(), TestResultDeliveryPreference.SMS);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+
+    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
+
+    List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
+
+    _service.addMultiplexResult(
+        defaultDeviceType, defaultSpecimenType, positiveCovidResult, p.getInternalId(), null);
+
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(0, queue.size());
+    verify(testEventReportingService).report(any());
+    verify(fhirQueueReportingService).report(any());
+  }
+
+  @Test
+  @WithSimpleReportStandardAllFacilitiesUser
+  void addTestResult_standardUserAllFacilities_ok() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person p =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "Spanish",
+            null,
+            null);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+
+    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
+
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+
+    _service.addMultiplexResult(
+        defaultDeviceType, defaultSpecimenType, positiveCovidOnlyResult, p.getInternalId(), null);
+
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(0, queue.size());
+    verify(testEventReportingService).report(any());
+    verify(fhirQueueReportingService).report(any());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void addTestResult_standardUser_successDependsOnFacilityAccess() {
+    Facility facility1 =
+        _dataFactory.createValidFacility(
+            _organizationService.getCurrentOrganization(), "First One");
+
+    TestUserIdentities.setFacilityAuthorities(facility1);
+
+    Person p1 =
+        _personService.addPatient(
+            (UUID) null,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "English",
+            null,
+            null);
+    Person p2 =
+        _personService.addPatient(
+            facility1.getInternalId(),
+            "BAR",
+            "Baz",
+            null,
+            "",
+            "Jr.",
+            LocalDate.of(1900, 1, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STUDENT,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "Spanish",
+            null,
+            null);
+
+    _service.addPatientToQueue(
+        facility1.getInternalId(),
+        p1,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    _service.addPatientToQueue(
+        facility1.getInternalId(),
+        p2,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+
+    TestUserIdentities.setFacilityAuthorities();
+
+    UUID deviceId = _dataFactory.getGenericDevice().getInternalId();
+    UUID specimenId = _dataFactory.getGenericSpecimen().getInternalId();
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    UUID patientTwoId = p2.getInternalId();
+
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            _service.addMultiplexResult(
+                deviceId, specimenId, positiveCovidOnlyResult, patientTwoId, null));
+
+    UUID patientOneId = p1.getInternalId();
+    // caller has access to the patient (whose facility is null)
+    // but cannot modify the test order which was created at a non-accessible facility
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            _service.addMultiplexResult(
+                deviceId, specimenId, positiveCovidOnlyResult, patientOneId, null));
+
+    // make sure the nothing was sent to storage queue
+    verifyNoInteractions(testEventReportingService);
+
+    TestUserIdentities.setFacilityAuthorities(facility1);
+    _service.addMultiplexResult(
+        deviceId, specimenId, positiveCovidOnlyResult, p1.getInternalId(), null);
+    List<TestOrder> queue = _service.getQueue(facility1.getInternalId());
+    assertEquals(1, queue.size());
+
+    // make sure the corrected event is sent to storage queue
+    verify(testEventReportingService).report(any());
+    verify(fhirQueueReportingService).report(any());
+
+    List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
+
+    _service.addMultiplexResult(
+        deviceId, specimenId, negativeCovidResult, p2.getInternalId(), null);
+
+    queue = _service.getQueue(facility1.getInternalId());
+    assertEquals(0, queue.size());
+
+    // make sure the second event is sent to storage queue
+    verify(testEventReportingService, times(2)).report(any());
+    verify(fhirQueueReportingService, times(2)).report(any());
+  }
+
+  @Test
+  @WithSimpleReportEntryOnlyAllFacilitiesUser
+  void addTestResult_entryOnlyUserAllFacilities_ok() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person p = _dataFactory.createFullPerson(org);
+    _personService.updateTestResultDeliveryPreference(
+        p.getInternalId(), TestResultDeliveryPreference.SMS);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    _service.addMultiplexResult(
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidOnlyResult,
+        p.getInternalId(),
+        null);
+
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+
+    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+    assertEquals(0, queue.size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_testAlreadySubmitted_failure() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person p = _dataFactory.createFullPerson(org);
+    _personService.updateTestResultDeliveryPreference(
+        p.getInternalId(), TestResultDeliveryPreference.SMS);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+    List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    _service.addMultiplexResult(
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidResult,
+        p.getInternalId(),
+        null);
+    UUID deviceId = deviceType.getInternalId();
+    UUID specimentId = specimenType.getInternalId();
+    UUID patientId = p.getInternalId();
+
+    assertThrows(
+        NonexistentQueueItemException.class,
+        () ->
+            _service.addMultiplexResult(
+                deviceId, specimentId, positiveCovidResult, patientId, null));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_correction() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person p = _dataFactory.createFullPerson(org);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        p,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+    // Create test event for a later correction
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    _service.addMultiplexResult(
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidOnlyResult,
+        p.getInternalId(),
+        null);
+    List<TestEvent> testEvents =
+        _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
+    assertEquals(1, testEvents.size());
+
+    // Mark existing test order as "corrected", re-open as "pending" order status
+    TestEvent originalTestEvent = testEvents.get(0);
+    _service.markAsCorrection(originalTestEvent.getInternalId(), "Cold feet");
+
+    // Issue test correction
+    List<MultiplexResultInput> negativeCovidOnlyResult = makeCovidOnlyResult(TestResult.NEGATIVE);
+    AddTestResultResponse response =
         _service.addMultiplexResult(
-                defaultDeviceType,
-                defaultSpecimenType,
-                positiveCovidOnlyResult,
-                patient.getInternalId(),
-                null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            negativeCovidOnlyResult,
+            p.getInternalId(),
+            null);
 
-        // THEN
-        queue = _service.getQueue(facility.getInternalId());
-        assertEquals(0, queue.size());
+    TestEvent correctionTestEvent = response.getTestOrder().getTestEvent();
 
-        List<TestEvent> testEvents =
-                _testEventRepository.findAllByPatientAndFacilities(patient, List.of(facility));
-        assertThat(testEvents).hasSize(1);
-        assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
-        verify(patientLinkService).createPatientLink(any());
+    assertEquals(
+        originalTestEvent.getInternalId(), correctionTestEvent.getPriorCorrectedTestEventId());
+    assertEquals(TestCorrectionStatus.CORRECTED, correctionTestEvent.getCorrectionStatus());
+    assertEquals("Cold feet", correctionTestEvent.getReasonForCorrection());
+    assertEquals(TestResult.NEGATIVE, correctionTestEvent.getCovidTestResult().get());
+    // Date of original test is overwritten by the new correction event
+    assertNotEquals(
+        LocalDate.of(1865, 12, 25),
+        LocalDate.ofInstant(
+            correctionTestEvent.getDateTested().toInstant(), ZoneId.systemDefault()));
+    assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(correctionTestEvent).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(originalTestEvent).size());
+  }
 
-        // make sure the corrected event is sent to storage queue
-        verify(testEventReportingService).report(testEventArgumentCaptor.capture());
-        verify(fhirQueueReportingService).report(any());
-        TestEvent sentEvent = testEventArgumentCaptor.getValue();
-        TestResult testResult = sentEvent.getCovidTestResult().get();
-        assertThat(sentEvent.getPatient().getInternalId()).isEqualTo(patient.getInternalId());
-        assertThat(testResult).isEqualTo(TestResult.POSITIVE);
-    }
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_smsDelivery() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_populateFirstTest() {
-        Facility facility =
-                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-        Person p =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "English",
-                        null,
-                        null);
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.SMS);
 
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+    when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
+    when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
 
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                _dataFactory.getGenericDevice().getInternalId(),
-                _dataFactory.getGenericSpecimen().getInternalId(),
-                positiveCovidOnlyResult,
-                p.getInternalId(),
-                null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
-        verify(testEventReportingService).report(any());
-        verify(fhirQueueReportingService).report(any());
+    // THEN
+    assertTrue(res.getDeliverySuccess());
+    ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
+    verify(testResultsDeliveryService).smsTestResults(patientLinkCaptor.capture());
+    assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
+        .isEqualTo(patient.getInternalId());
+  }
 
-        List<TestEvent> testEvents =
-                _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
-        assertThat(testEvents).hasSize(1);
-        assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_smsDelivery_failure() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1866, 12, 25),
-                false);
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.SMS);
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+    when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
+    when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
+
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                _dataFactory.getGenericDevice().getInternalId(),
-                _dataFactory.getGenericSpecimen().getInternalId(),
-                positiveCovidOnlyResult,
-                p.getInternalId(),
-                null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
-        testEvents = _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
-        assertThat(testEvents).hasSize(2);
-        assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
-        assertThat(testEvents.get(1).getPatientHasPriorTests()).isTrue();
-        verify(testEventReportingService, times(2)).report(any());
-        verify(fhirQueueReportingService, times(2)).report(any());
-    }
+    // THEN
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+    assertFalse(res.getDeliverySuccess());
+  }
 
-    @Test
-    @WithSimpleReportStandardUser
-    void getQueue_standardUser_successDependsOnFacilityAccess() {
-        Facility facility =
-                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_emailDelivery() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
-        UUID facilityId = facility.getInternalId();
-        assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
 
-        TestUserIdentities.setFacilityAuthorities(facility);
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(0, queue.size());
-    }
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
-    @Test
-    @WithSimpleReportStandardAllFacilitiesUser
-    void addPatientToQueue_standardUserAllFacilities_ok() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person p =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "Spanish",
-                        null,
-                        "Space-faring maverick");
+    when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
+    when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
 
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(1, queue.size());
-    }
-
-    @Test
-    void addPatientToQueue_standardUser_successDependsOnFacilityAccess() {
-        Facility facility =
-                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-
-        Person p =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "German",
-                        null,
-                        "success depends on Fred's access");
-
-        UUID facilityId = facility.getInternalId();
-        Map<String, Boolean> symptoms = Collections.emptyMap();
-        LocalDate symptomOnsetDate = LocalDate.of(1865, 12, 25);
-
-        assertThrows(
-                AccessDeniedException.class,
-                () -> _service.addPatientToQueue(facilityId, p, "", "", symptoms, symptomOnsetDate, false));
-
-        TestUserIdentities.setFacilityAuthorities(facility);
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        TestUserIdentities.setFacilityAuthorities();
-
-        assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
-
-        TestUserIdentities.setFacilityAuthorities(facility);
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(1, queue.size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_orgAdmin_ok() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person p =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "French",
-                        null,
-                        null);
-        _personService.updateTestResultDeliveryPreference(
-                p.getInternalId(), TestResultDeliveryPreference.SMS);
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-
-        UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
-        UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
-
-        List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
-
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                defaultDeviceType, defaultSpecimenType, positiveCovidResult, p.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
-        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+    // THEN
+    assertTrue(res.getDeliverySuccess());
+    ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
+    verify(testResultsDeliveryService).emailTestResults(patientLinkCaptor.capture());
+    assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
+        .isEqualTo(patient.getInternalId());
+  }
 
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(0, queue.size());
-        verify(testEventReportingService).report(any());
-        verify(fhirQueueReportingService).report(any());
-    }
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_emailDelivery_failure() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
-    @Test
-    @WithSimpleReportStandardAllFacilitiesUser
-    void addTestResult_standardUserAllFacilities_ok() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person p =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "Spanish",
-                        null,
-                        null);
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
 
-        UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
-        UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
 
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(false);
+    when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(false);
 
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                defaultDeviceType, defaultSpecimenType, positiveCovidOnlyResult, p.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(0, queue.size());
-        verify(testEventReportingService).report(any());
-        verify(fhirQueueReportingService).report(any());
-    }
+    // THEN
+    verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
+    assertFalse(res.getDeliverySuccess());
+  }
 
-    @Test
-    @WithSimpleReportStandardUser
-    void addTestResult_standardUser_successDependsOnFacilityAccess() {
-        Facility facility1 =
-                _dataFactory.createValidFacility(
-                        _organizationService.getCurrentOrganization(), "First One");
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_emailAndSmsDelivery() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
-        TestUserIdentities.setFacilityAuthorities(facility1);
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.ALL);
 
-        Person p1 =
-                _personService.addPatient(
-                        (UUID) null,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "English",
-                        null,
-                        null);
-        Person p2 =
-                _personService.addPatient(
-                        facility1.getInternalId(),
-                        "BAR",
-                        "Baz",
-                        null,
-                        "",
-                        "Jr.",
-                        LocalDate.of(1900, 1, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STUDENT,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "Spanish",
-                        null,
-                        null);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+    when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
+    when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
 
-        _service.addPatientToQueue(
-                facility1.getInternalId(),
-                p1,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        _service.addPatientToQueue(
-                facility1.getInternalId(),
-                p2,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
 
-        TestUserIdentities.setFacilityAuthorities();
-
-        UUID deviceId = _dataFactory.getGenericDevice().getInternalId();
-        UUID specimenId = _dataFactory.getGenericSpecimen().getInternalId();
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        UUID patientTwoId = p2.getInternalId();
-
-        assertThrows(
-                AccessDeniedException.class,
-                () ->
-                        _service.addMultiplexResult(
-                                deviceId, specimenId, positiveCovidOnlyResult, patientTwoId, null));
-
-        UUID patientOneId = p1.getInternalId();
-        // caller has access to the patient (whose facility is null)
-        // but cannot modify the test order which was created at a non-accessible facility
-        assertThrows(
-                AccessDeniedException.class,
-                () ->
-                        _service.addMultiplexResult(
-                                deviceId, specimenId, positiveCovidOnlyResult, patientOneId, null));
-
-        // make sure the nothing was sent to storage queue
-        verifyNoInteractions(testEventReportingService);
-
-        TestUserIdentities.setFacilityAuthorities(facility1);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                deviceId, specimenId, positiveCovidOnlyResult, p1.getInternalId(), null);
-        List<TestOrder> queue = _service.getQueue(facility1.getInternalId());
-        assertEquals(1, queue.size());
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
-        // make sure the corrected event is sent to storage queue
-        verify(testEventReportingService).report(any());
-        verify(fhirQueueReportingService).report(any());
+    // THEN
+    verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
+    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+    assertTrue(res.getDeliverySuccess());
+  }
 
-        List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_NoTestResultDelivery() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.NONE);
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                deviceId, specimenId, negativeCovidResult, p2.getInternalId(), null);
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
 
-        queue = _service.getQueue(facility1.getInternalId());
-        assertEquals(0, queue.size());
+    // THEN
+    assertTrue(res.getDeliverySuccess());
+    verifyNoInteractions(testResultsDeliveryService);
+    verify(testEventReportingService).report(any());
+    verify(fhirQueueReportingService).report(any());
+  }
 
-        // make sure the second event is sent to storage queue
-        verify(testEventReportingService, times(2)).report(any());
-        verify(fhirQueueReportingService, times(2)).report(any());
-    }
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_savesResults() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
 
-    @Test
-    @WithSimpleReportEntryOnlyAllFacilitiesUser
-    void addTestResult_entryOnlyUserAllFacilities_ok() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person p = _dataFactory.createFullPerson(org);
-        _personService.updateTestResultDeliveryPreference(
-                p.getInternalId(), TestResultDeliveryPreference.SMS);
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    AddTestResultResponse res =
         _service.addMultiplexResult(
-                deviceType.getInternalId(),
-                specimenType.getInternalId(),
-                positiveCovidOnlyResult,
-                p.getInternalId(),
-                null);
-
-        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-
-        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-        assertEquals(0, queue.size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_testAlreadySubmitted_failure() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person p = _dataFactory.createFullPerson(org);
-        _personService.updateTestResultDeliveryPreference(
-                p.getInternalId(), TestResultDeliveryPreference.SMS);
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        _service.addMultiplexResult(
-                deviceType.getInternalId(),
-                specimenType.getInternalId(),
-                positiveCovidResult,
-                p.getInternalId(),
-                null);
-        UUID deviceId = deviceType.getInternalId();
-        UUID specimentId = specimenType.getInternalId();
-        UUID patientId = p.getInternalId();
-
-        assertThrows(
-                NonexistentQueueItemException.class,
-                () ->
-                        _service.addMultiplexResult(
-                                deviceId, specimentId, positiveCovidResult, patientId, null));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_correction() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person p = _dataFactory.createFullPerson(org);
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                p,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        // Create test event for a later correction
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        _service.addMultiplexResult(
-                deviceType.getInternalId(),
-                specimenType.getInternalId(),
-                positiveCovidOnlyResult,
-                p.getInternalId(),
-                null);
-        List<TestEvent> testEvents =
-                _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
-        assertEquals(1, testEvents.size());
-
-        // Mark existing test order as "corrected", re-open as "pending" order status
-        TestEvent originalTestEvent = testEvents.get(0);
-        _service.markAsCorrection(originalTestEvent.getInternalId(), "Cold feet");
-
-        // Issue test correction
-        List<MultiplexResultInput> negativeCovidOnlyResult = makeCovidOnlyResult(TestResult.NEGATIVE);
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        negativeCovidOnlyResult,
-                        p.getInternalId(),
-                        null);
-
-        TestEvent correctionTestEvent = response.getTestOrder().getTestEvent();
-
-        assertEquals(
-                originalTestEvent.getInternalId(), correctionTestEvent.getPriorCorrectedTestEventId());
-        assertEquals(TestCorrectionStatus.CORRECTED, correctionTestEvent.getCorrectionStatus());
-        assertEquals("Cold feet", correctionTestEvent.getReasonForCorrection());
-        assertEquals(TestResult.NEGATIVE, correctionTestEvent.getCovidTestResult().get());
-        // Date of original test is overwritten by the new correction event
-        assertNotEquals(
-                LocalDate.of(1865, 12, 25),
-                LocalDate.ofInstant(
-                        correctionTestEvent.getDateTested().toInstant(), ZoneId.systemDefault()));
-        assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(correctionTestEvent).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(originalTestEvent).size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_smsDelivery() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.SMS);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-        when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
-        when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        assertTrue(res.getDeliverySuccess());
-        ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
-        verify(testResultsDeliveryService).smsTestResults(patientLinkCaptor.capture());
-        assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
-                .isEqualTo(patient.getInternalId());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_smsDelivery_failure() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.SMS);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
-        when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-        assertFalse(res.getDeliverySuccess());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_emailDelivery() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
-        when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        assertTrue(res.getDeliverySuccess());
-        ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
-        verify(testResultsDeliveryService).emailTestResults(patientLinkCaptor.capture());
-        assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
-                .isEqualTo(patient.getInternalId());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_emailDelivery_failure() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(false);
-        when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(false);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
-        assertFalse(res.getDeliverySuccess());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_emailAndSmsDelivery() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.ALL);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-        when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
-        when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
-        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-        assertTrue(res.getDeliverySuccess());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_NoTestResultDelivery() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.NONE);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        assertTrue(res.getDeliverySuccess());
-        verifyNoInteractions(testResultsDeliveryService);
-        verify(testEventReportingService).report(any());
-        verify(fhirQueueReportingService).report(any());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_savesResults() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-        AddTestResultResponse res =
-                _service.addMultiplexResult(
-                        deviceType.getInternalId(),
-                        specimenType.getInternalId(),
-                        positiveCovidOnlyResult,
-                        patient.getInternalId(),
-                        null);
-
-        // THEN
-        List<Result> testOrderResults = _resultRepository.findAllByTestOrder(res.getTestOrder());
-        List<Result> testEventResults =
-                _resultRepository.findAllByTestEvent(res.getTestOrder().getTestEvent());
-        assertEquals(1, testOrderResults.size());
-        assertEquals(1, testEventResults.size());
-
-        Result testOrderResult = testOrderResults.get(0);
-        Result testEventResult = testEventResults.get(0);
-
-        // we create two different results, 1 mutable for the testOrder, 1 immutable for the testEvent
-        assertThat(testOrderResult).isNotEqualTo(testEventResult);
-
-        // verify the testOrder Result
-        assertThat(testOrderResult.getTestOrder()).isNotNull();
-        assertThat(testOrderResult.getTestEvent()).isNull();
-        assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
-        assertThat(testOrderResult.getDisease()).isEqualTo(_diseaseService.covid());
-
-        // verify the testEvent Result
-        assertThat(testEventResult.getTestOrder()).isNull();
-        assertThat(testEventResult.getTestEvent()).isNotNull();
-        assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
-        assertThat(testEventResult.getDisease()).isEqualTo(_diseaseService.covid());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void editQueueItemMultiplexResult_worksWithSingleResult() {
-        TestOrder order = addTestToQueue();
-
-        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
-
-        TestOrder updatedOrder =
-                _service.editQueueItemMultiplexResult(
-                        order.getInternalId(),
-                        _dataFactory.getGenericDevice().getInternalId(),
-                        _dataFactory.getGenericSpecimen().getInternalId(),
-                        List.of(covidResult),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertEquals(1, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void editQueueItemMultiplexResult_worksWithMultipleResults() {
-        TestOrder order = addTestToQueue();
-
-        TestOrder updatedOrder =
-                _service.editQueueItemMultiplexResult(
-                        order.getInternalId(),
-                        _dataFactory.getGenericDevice().getInternalId(),
-                        _dataFactory.getGenericSpecimen().getInternalId(),
-                        makeMultiplexTestResult(TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void editQueueItemMultiplexResult_worksWithEmptyResults() {
-        TestOrder order = addTestToQueue();
-
-        TestOrder updatedOrder =
-                _service.editQueueItemMultiplexResult(
-                        order.getInternalId(),
-                        _dataFactory.getGenericDevice().getInternalId(),
-                        _dataFactory.getGenericSpecimen().getInternalId(),
-                        List.of(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertTrue(_service.getTestOrder(updatedOrder.getInternalId()).getResults().isEmpty());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addMultiplexResult_multipleEditsBeforeSubmissionSuccessful() {
-        TestOrder order = addTestToQueue();
-
-        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
-        MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", TestResult.NEGATIVE);
-        MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", TestResult.NEGATIVE);
-
+            deviceType.getInternalId(),
+            specimenType.getInternalId(),
+            positiveCovidOnlyResult,
+            patient.getInternalId(),
+            null);
+
+    // THEN
+    List<Result> testOrderResults = _resultRepository.findAllByTestOrder(res.getTestOrder());
+    List<Result> testEventResults =
+        _resultRepository.findAllByTestEvent(res.getTestOrder().getTestEvent());
+    assertEquals(1, testOrderResults.size());
+    assertEquals(1, testEventResults.size());
+
+    Result testOrderResult = testOrderResults.get(0);
+    Result testEventResult = testEventResults.get(0);
+
+    // we create two different results, 1 mutable for the testOrder, 1 immutable for the testEvent
+    assertThat(testOrderResult).isNotEqualTo(testEventResult);
+
+    // verify the testOrder Result
+    assertThat(testOrderResult.getTestOrder()).isNotNull();
+    assertThat(testOrderResult.getTestEvent()).isNull();
+    assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
+    assertThat(testOrderResult.getDisease()).isEqualTo(_diseaseService.covid());
+
+    // verify the testEvent Result
+    assertThat(testEventResult.getTestOrder()).isNull();
+    assertThat(testEventResult.getTestEvent()).isNotNull();
+    assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
+    assertThat(testEventResult.getDisease()).isEqualTo(_diseaseService.covid());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void editQueueItemMultiplexResult_worksWithSingleResult() {
+    TestOrder order = addTestToQueue();
+
+    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
+
+    TestOrder updatedOrder =
         _service.editQueueItemMultiplexResult(
-                order.getInternalId(),
-                _dataFactory.getGenericDevice().getInternalId(),
-                _dataFactory.getGenericSpecimen().getInternalId(),
-                List.of(covidResult, fluAResult, fluBResult),
-                convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        MultiplexResultInput updatedCovidResult =
-                new MultiplexResultInput("COVID-19", TestResult.NEGATIVE);
-        TestOrder updatedOrder =
-                _service.editQueueItemMultiplexResult(
-                        order.getInternalId(),
-                        _dataFactory.getGenericDevice().getInternalId(),
-                        _dataFactory.getGenericSpecimen().getInternalId(),
-                        List.of(updatedCovidResult, fluAResult, fluBResult),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
-
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        updatedOrder.getDeviceType().getInternalId(),
-                        updatedOrder.getSpecimenType().getInternalId(),
-                        List.of(updatedCovidResult, fluAResult, fluBResult),
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertEquals(3, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void multiplexResultMutations_covidOnlyCorrectionSuccessful() {
-        TestOrder order = addTestToQueue();
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        order.getDeviceType().getInternalId(),
-                        order.getSpecimenType().getInternalId(),
-                        List.of(new MultiplexResultInput("COVID-19", TestResult.POSITIVE)),
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-        _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
-
-        AddTestResultResponse correctedResponse =
-                _service.addMultiplexResult(
-                        order.getDeviceType().getInternalId(),
-                        order.getSpecimenType().getInternalId(),
-                        List.of(new MultiplexResultInput("COVID-19", TestResult.NEGATIVE)),
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertEquals(1, _resultRepository.findAllByTestOrder(order).size());
-        assertEquals(
-                1,
-                _resultRepository
-                        .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
-                        .size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void multiplexResultMutations_multiplexCorrectionSuccessful() {
-
-        List<MultiplexResultInput> originalResults =
-                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.POSITIVE);
-
-        TestOrder order = addTestToQueue();
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        order.getDeviceType().getInternalId(),
-                        order.getSpecimenType().getInternalId(),
-                        originalResults,
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-        _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
-
-        List<MultiplexResultInput> correctedResults =
-                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE);
-
-        AddTestResultResponse correctedResponse =
-                _service.addMultiplexResult(
-                        order.getDeviceType().getInternalId(),
-                        order.getSpecimenType().getInternalId(),
-                        correctedResults,
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
-        assertEquals(
-                3,
-                _resultRepository
-                        .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
-                        .size());
-        assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void multiplexResultMutations_removalSuccessful() {
-        List<MultiplexResultInput> originalResults =
-                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
-
-        TestOrder order = addTestToQueue();
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        order.getDeviceType().getInternalId(),
-                        order.getSpecimenType().getInternalId(),
-                        originalResults,
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-        TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-        TestEvent removedEvent = _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
-
-        assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
-        assertEquals(3, _resultRepository.findAllByTestEvent(removedEvent).size());
-        assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void fetchTestEventsResults_standardUser_successDependsOnFacilityAccess() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createValidFacility(org);
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createTestEvent(p, facility);
-        UUID facilityId = facility.getInternalId();
-
-        assertThrows(
-                AccessDeniedException.class,
-                () ->
-                        _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
-
-        TestUserIdentities.setFacilityAuthorities(facility);
-        _service.getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 10);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void fetchTestEventsAtArchivedFacility_orgAdminUser_ok() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createTestEvent(p, facility);
-
-        Page<TestEvent> testEventsByFacility =
-                _service.getFacilityTestEventsResults(
-                        facility.getInternalId(), null, null, null, null, null, 0, 10);
-        assertThat(testEventsByFacility.getTotalElements()).isEqualTo(1);
-        assertThat(testEventsByFacility.getTotalPages()).isEqualTo(1);
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void fetchTestEventsAtArchivedFacility_standardUser_failure() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createTestEvent(p, facility);
-        UUID facilityId = facility.getInternalId();
-
-        assertThrows(
-                AccessDeniedException.class,
-                () ->
-                        _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void fetchAllFacilityTestEventsResults_orgAdminUser_ok() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createValidFacility(org);
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createTestEvent(p, facility);
-
-        Page<TestEvent> testEventsByOrg =
-                _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
-        assertThat(testEventsByOrg.getTotalElements()).isEqualTo(1);
-        assertThat(testEventsByOrg.getTotalPages()).isEqualTo(1);
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void fetchAllFacilityTestEventsResults_standardUser_failure() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createValidFacility(org);
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createTestEvent(p, facility);
-
-        assertThrows(
-                AccessDeniedException.class,
-                () -> _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10));
-    }
-
-    @Test
-    @WithSimpleReportStandardUser
-    void fetchTestResults_standardUser_successDependsOnFacilityAccess() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility f1 = _dataFactory.createValidFacility(org, "First One");
-        Facility f2 = _dataFactory.createValidFacility(org, "Second One");
-        Person p1 = _dataFactory.createMinimalPerson(org, f1);
-        Person p2 = _dataFactory.createMinimalPerson(org);
-        _dataFactory.createTestEvent(p1, f1);
-        _dataFactory.createTestEvent(p2, f1);
-        _dataFactory.createTestEvent(p2, f2);
-
-        assertThrows(AccessDeniedException.class, () -> _service.getTestResults(p1));
-        // filters out all test results from inaccessible facilities, but we can still
-        // request test results for a patient whose own facility is null
-        assertEquals(0, _service.getTestResults(p2).size());
-
-        TestUserIdentities.setFacilityAuthorities(f1);
-        assertEquals(1, _service.getTestResults(p1).size());
-        // filters out all test results from inaccessible facilities
-        assertEquals(1, _service.getTestResults(p2).size());
-
-        TestUserIdentities.setFacilityAuthorities(f1, f2);
-        assertEquals(1, _service.getTestResults(p1).size());
-        assertEquals(2, _service.getTestResults(p2).size());
-    }
-
-    @Test
-    @WithSimpleReportEntryOnlyUser
-    void fetchTestResults_entryOnlyUser_error() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person p = _dataFactory.createFullPerson(org);
-        _dataFactory.createTestEvent(p, facility);
-
-        // https://github.com/CDCgov/prime-simplereport/issues/677
-        // assertSecurityError(() ->
-        // _service.getTestResults(facility.getInternalId()));
-        assertSecurityError(() -> _service.getTestResults(p));
-    }
-
-    // watch for N+1 queries
-    @Test
-    @WithSimpleReportStandardAllFacilitiesUser
-    void fetchTestEventsResults_getTestEventsResults_NPlusOne() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person p = _dataFactory.createFullPerson(org);
-
-        // add some initial data
-        _dataFactory.createTestEvent(p, facility);
-        _dataFactory.createTestEvent(p, facility);
-
-        // count queries
-        long startQueryCount = QueryCountService.get().getSelect();
-        _service.getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50);
-        long firstPassTotal = QueryCountService.get().getSelect() - startQueryCount;
-
-        // add more data
-        _dataFactory.createTestEvent(p, facility);
-        _dataFactory.createTestEvent(p, facility);
-        _dataFactory.createTestEvent(p, facility);
-        _dataFactory.createTestEvent(p, facility);
-        _dataFactory.createTestEvent(p, facility);
-
-        // count queries again and make sure queries made didn't increase
-        startQueryCount = QueryCountService.get().getSelect();
-        _service.getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50);
-        long secondPassTotal = QueryCountService.get().getSelect() - startQueryCount;
-        assertEquals(firstPassTotal, secondPassTotal);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void editTestResult_getQueue_NPlusOne() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        UUID facilityId = facility.getInternalId();
-
-        Person p1 =
-                _personService.addPatient(
-                        facilityId,
-                        "FOO",
-                        "Fred",
-                        null,
-                        "",
-                        "Sr.",
-                        LocalDate.of(1865, 12, 25),
-                        getAddress(),
-                        "USA",
-                        TestDataFactory.getListOfOnePhoneNumber(),
-                        PersonRole.STAFF,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        false,
-                        false,
-                        "Spanish",
-                        null,
-                        null);
-
-        _service.addPatientToQueue(
-                facilityId, p1, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-
-        // get the first query count
-        long startQueryCount = QueryCountService.get().getSelect();
-        _service.getQueue(facility.getInternalId());
-        long firstRunCount = QueryCountService.get().getSelect() - startQueryCount;
-
-        for (int ii = 0; ii < 2; ii++) {
-            // add more tests to the queue. (which needs more patients)
-            Person p =
-                    _personService.addPatient(
-                            facilityId,
-                            "FOO",
-                            "Fred",
-                            null,
-                            "",
-                            "Sr.",
-                            LocalDate.of(1865, 12, 25),
-                            getAddress(),
-                            "USA",
-                            TestDataFactory.getListOfOnePhoneNumber(),
-                            PersonRole.STAFF,
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            false,
-                            false,
-                            "French",
-                            null,
-                            null);
-
-            _service.addPatientToQueue(
-                    facilityId, p, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-        }
-
-        startQueryCount = QueryCountService.get().getSelect();
-        _service.getQueue(facility.getInternalId());
-        long secondRunCount = QueryCountService.get().getSelect() - startQueryCount;
-        assertEquals(firstRunCount, secondRunCount);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void markAsErrorTest() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person person = _dataFactory.createFullPerson(org);
-        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
-        assertNotNull(deleteMarkerEvent);
-
-        assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
-        assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
-
-        assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
-
-        List<TestEvent> events_before =
-                _service
-                        .getFacilityTestEventsResults(
-                                facility.getInternalId(), null, null, null, null, null, 0, 50)
-                        .toList();
-        assertEquals(1, events_before.size());
-
-        // verify the original order was updated
-        TestEvent refreshedTestResult = _service.getTestResult(testEvent.getInternalId());
-        TestOrder onlySavedOrder = refreshedTestResult.getTestOrder();
-        TestEvent mostRecentEvent = onlySavedOrder.getTestEvent();
-        assertEquals(reasonMsg, onlySavedOrder.getReasonForCorrection());
-        assertEquals(deleteMarkerEvent.getInternalId(), mostRecentEvent.getInternalId());
-        assertEquals(TestCorrectionStatus.REMOVED, onlySavedOrder.getCorrectionStatus());
-
-        // make sure the original item is removed from the result and ONLY the
-        // "corrected" removed one is shown
-        List<TestEvent> events_after =
-                _service
-                        .getFacilityTestEventsResults(
-                                facility.getInternalId(), null, null, null, null, null, 0, 50)
-                        .toList();
-        assertEquals(1, events_after.size());
-        assertEquals(
-                deleteMarkerEvent.getInternalId().toString(),
-                events_after.get(0).getInternalId().toString());
-
-        // verify that a Result object is created for the original and new TestEvent and one for the
-        // TestOrder
-        assertEquals(1, _resultRepository.findAllByTestOrder(onlySavedOrder).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(mostRecentEvent).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(deleteMarkerEvent).size());
-
-        // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
-        // to report stream
-        verify(testEventReportingService).report(deleteMarkerEvent);
-        verify(fhirQueueReportingService).report(any());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void markAsErrorTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        DeviceType device = _dataFactory.getGenericDevice();
-        SpecimenType specimen = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(device, specimen);
-        Person person = _dataFactory.createFullPerson(org);
-        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-        facility.getAddress().setState("ND");
-        _organizationService.updateFacility(
-                facility.getInternalId(),
-                facility.getFacilityName(),
-                facility.getCliaNumber(),
-                facility.getAddress(),
-                facility.getTelephone(),
-                facility.getEmail(),
-                facility.getOrderingProvider().getNameInfo(),
-                facility.getOrderingProvider().getAddress(),
-                facility.getOrderingProvider().getProviderId(),
-                facility.getOrderingProvider().getTelephone(),
-                facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
-
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        TestEvent deletedTest = _service.markAsError(testEvent.getInternalId(), reasonMsg);
-
-        assertEquals(deletedTest.getDeviceType().getInternalId(), device.getInternalId());
-        assertEquals(deletedTest.getSpecimenType().getInternalId(), specimen.getInternalId());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void correctionsTest() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person p = _dataFactory.createFullPerson(org);
-        TestEvent e = _dataFactory.createTestEvent(p, facility);
-
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-
-        // A test correction call just returns the original TestEvent...
-        TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
-
-        // ...but re-opens the original TestOrder and updates correction status
-        TestOrder updatedOrder = originalEvent.getTestOrder();
-        assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
-        assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
-        assertEquals(e.getInternalId(), updatedOrder.getTestEvent().getInternalId());
-        assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
-
-        // Unlike marking a test as deleted, which immediately creates a second TestEvent
-        // that represents the removal, a test correction does not result in another
-        // TestEvent being generated and saved
-        long testEventCount = _testEventRepository.count();
-        assertEquals(1, testEventCount);
-
-        // Does not report to ReportStream
-        verify(testEventReportingService, times(0)).report(e);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void markAsErrorTest_backwardCompatible() {
-        // GIVEN
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person person = _dataFactory.createFullPerson(org);
-        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-        // ensure the Result will have both testEvent and testOrder populated
-        _resultRepository.deleteAll(testEvent.getOrder().getResults());
-        Set<Result> results = testEvent.getResults();
-        results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
-        _resultRepository.saveAll(results);
-
-        // assert that we have the same Result object for both testEvent and testOrder
-        List<Result> allOldResultsByTestOrder =
-                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-        List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-        assertEquals(1, allOldResultsByTestEvent.size());
-        assertEquals(1, allOldResultsByTestOrder.size());
-        Result testOrderOldResult = allOldResultsByTestOrder.get(0);
-        Result testEventOldResult = allOldResultsByTestEvent.get(0);
-        assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
-
-        // WHEN
-        TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
-
-        // THEN
-        assertNotNull(deleteMarkerEvent);
-
-        assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
-        assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
-
-        assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
-
-        // assert that we have two Result objects for both testEvent and testOrder
-        List<Result> allResultsByTestOrder =
-                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-        List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-        assertEquals(1, allResultsByTestOrder.size());
-        assertEquals(1, allResultsByTestEvent.size());
-
-        Result testOrderResult = allResultsByTestOrder.get(0);
-        Result testEventResult = allResultsByTestEvent.get(0);
-        assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
-
-        assertThat(testEventResult.getTestOrder()).isNull();
-        assertThat(testEventResult.getTestEvent()).isNotNull();
-
-        assertThat(testOrderResult.getTestOrder()).isNotNull();
-        assertThat(testOrderResult.getTestEvent()).isNull();
-
-        assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-        assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void correctionsTest_backwardCompatible() {
-        // GIVEN
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person person = _dataFactory.createFullPerson(org);
-        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-        // ensure the Result will have both testEvent and testOrder populated
-        _resultRepository.deleteAll(testEvent.getOrder().getResults());
-        Set<Result> results = testEvent.getResults();
-        results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
-        _resultRepository.saveAll(results);
-
-        // assert that we have the same Result object for both testEvent and testOrder
-        List<Result> allOldResultsByTestOrder =
-                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-        List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-        assertEquals(1, allOldResultsByTestEvent.size());
-        assertEquals(1, allOldResultsByTestOrder.size());
-        Result testOrderOldResult = allOldResultsByTestOrder.get(0);
-        Result testEventOldResult = allOldResultsByTestEvent.get(0);
-        assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
-
-        // WHEN
-        TestEvent originalEvent = _service.markAsCorrection(testEvent.getInternalId(), reasonMsg);
-
-        // THEN
-        TestOrder updatedOrder = originalEvent.getTestOrder();
-        assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
-        assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
-        assertEquals(testEvent.getInternalId(), updatedOrder.getTestEvent().getInternalId());
-        assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
-
-        // assert that we have two Result objects for both testEvent and testOrder
-        List<Result> allResultsByTestOrder =
-                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-        List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-        assertEquals(1, allResultsByTestOrder.size());
-        assertEquals(1, allResultsByTestEvent.size());
-
-        Result testOrderResult = allResultsByTestOrder.get(0);
-        Result testEventResult = allResultsByTestEvent.get(0);
-        assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
-
-        assertThat(testEventResult.getTestOrder()).isNull();
-        assertThat(testEventResult.getTestEvent()).isNotNull();
-
-        assertThat(testOrderResult.getTestOrder()).isNotNull();
-        assertThat(testOrderResult.getTestEvent()).isNull();
-
-        assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-        assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void correctTest_backDatedFromCurrentDate() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person p = _dataFactory.createFullPerson(org);
-        TestEvent e = _dataFactory.createTestEvent(p, facility);
-
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-
-        assertNull(e.getTestOrder().getDateTestedBackdate());
-
-        // A test correction call just returns the original TestEvent...
-        TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
-
-        assertEquals(e.getDateTested(), originalEvent.getTestOrder().getDateTestedBackdate());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void correctTest_backdatePreserved() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-        Person p = _dataFactory.createFullPerson(org);
-
-        LocalDate localDate = LocalDate.of(2022, 1, 1);
-        Date dateTested = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
-        TestEvent e = _dataFactory.createTestEvent(p, facility, null, TestResult.POSITIVE, dateTested);
-
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-
-        TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
-        assertEquals(0, originalEvent.getTestOrder().getDateTestedBackdate().compareTo(dateTested));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void correctTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        DeviceType device = _dataFactory.getGenericDevice();
-        SpecimenType specimen = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(device, specimen);
-        Person p = _dataFactory.createFullPerson(org);
-        TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
-
-        facility.getAddress().setState("ND");
-        _organizationService.updateFacility(
-                facility.getInternalId(),
-                facility.getFacilityName(),
-                facility.getCliaNumber(),
-                facility.getAddress(),
-                facility.getTelephone(),
-                facility.getEmail(),
-                facility.getOrderingProvider().getNameInfo(),
-                facility.getOrderingProvider().getAddress(),
-                facility.getOrderingProvider().getProviderId(),
-                facility.getOrderingProvider().getTelephone(),
-                facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
-
-        // Re-open the original test as a correction
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
-
-        // Re-submit the corrected test
-        List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        device.getInternalId(),
-                        specimen.getInternalId(),
-                        correctedTestResult,
-                        p.getInternalId(),
-                        null);
-        TestEvent correctedEvent = response.getTestOrder().getTestEvent();
-        assertEquals(correctedEvent.getDeviceType().getInternalId(), device.getInternalId());
-        assertEquals(correctedEvent.getSpecimenType().getInternalId(), specimen.getInternalId());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void removeACorrectedTest_success() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        DeviceType device = _dataFactory.getGenericDevice();
-        SpecimenType specimen = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(device, specimen);
-        Person p = _dataFactory.createFullPerson(org);
-        TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
-
-        // Re-open the original test as a correction
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
-
-        // Re-submit the corrected test
-        List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        device.getInternalId(),
-                        specimen.getInternalId(),
-                        correctedTestResult,
-                        p.getInternalId(),
-                        null);
-        TestEvent correctedEvent = response.getTestOrder().getTestEvent();
-
-        assertEquals(
-                2, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
-        assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
-
-        // Now mark the corrected test as an error
-        String removalMsg = "I changed my mind, remove this test " + LocalDateTime.now();
-        TestEvent deleteCorrectedEvent =
-                _service.markAsError(correctedEvent.getInternalId(), removalMsg);
-
-        // There should only be a single TestOrder, but three TestEvents - the original, the corrected,
-        // and the removed
-        // There should also be exactly 4 Result objects, 1 for the order, and 1 per each TestEvent
-        assertEquals(
-                3, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
-        assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
-        assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(correctedEvent).size());
-        assertEquals(1, _resultRepository.findAllByTestEvent(deleteCorrectedEvent).size());
-
-        TestOrder order = deleteCorrectedEvent.getTestOrder();
-        assertEquals(TestCorrectionStatus.REMOVED, order.getCorrectionStatus());
-        assertEquals(removalMsg, order.getReasonForCorrection());
-        assertEquals(deleteCorrectedEvent.getInternalId(), order.getTestEvent().getInternalId());
-        assertEquals(OrderStatus.COMPLETED, order.getOrderStatus());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestEventsResults_pagination() {
-        List<TestEvent> testEvents = makedata();
-        List<TestEvent> results_page0 =
-                _service
-                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 0, 5)
-                        .toList();
-        List<TestEvent> results_page1 =
-                _service
-                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 1, 5)
-                        .toList();
-        List<TestEvent> results_page2 =
-                _service
-                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 2, 5)
-                        .toList();
-        List<TestEvent> results_page3 =
-                _service
-                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 3, 5)
-                        .toList();
-
-        Collections.reverse(testEvents);
-
-        assertTestResultsList(results_page0, testEvents.subList(0, 5));
-        assertTestResultsList(results_page1, testEvents.subList(5, 10));
-        assertTestResultsList(results_page2, testEvents.subList(10, 11));
-        assertEquals(0, results_page3.size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestEventsResults_filtering() {
-        List<TestEvent> testEvents = makedata();
-        List<TestEvent> positives =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(), null, TestResult.POSITIVE, null, null, null, 0, 10)
-                        .toList();
-        List<TestEvent> negatives =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10)
-                        .toList();
-        List<TestEvent> inconclusives =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(), null, TestResult.UNDETERMINED, null, null, null, 0, 10)
-                        .toList();
-        List<TestEvent> students =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(), null, null, PersonRole.STUDENT, null, null, 0, 10)
-                        .toList();
-        List<TestEvent> visitors =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(), null, null, PersonRole.VISITOR, null, null, 0, 10)
-                        .toList();
-        List<TestEvent> june1to3 =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(),
-                                null,
-                                null,
-                                null,
-                                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
-                                convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59)),
-                                0,
-                                10)
-                        .toList();
-        List<TestEvent> priorToJune2Noon =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(),
-                                null,
-                                null,
-                                null,
-                                null,
-                                convertDate(LocalDateTime.of(2021, 6, 2, 11, 59, 59)),
-                                0,
-                                10)
-                        .toList();
-        List<TestEvent> positivesAmos =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(),
-                                _dataFactory.getPersonByName(AMOS).getInternalId(),
-                                TestResult.POSITIVE,
-                                null,
-                                null,
-                                null,
-                                0,
-                                10)
-                        .toList();
-        List<TestEvent> negativesAmos =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(),
-                                _dataFactory.getPersonByName(AMOS).getInternalId(),
-                                TestResult.NEGATIVE,
-                                null,
-                                null,
-                                null,
-                                0,
-                                10)
-                        .toList();
-        List<TestEvent> allFilters =
-                _service
-                        .getFacilityTestEventsResults(
-                                _site.getInternalId(),
-                                _dataFactory.getPersonByName(CHARLES).getInternalId(),
-                                TestResult.POSITIVE,
-                                PersonRole.RESIDENT,
-                                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
-                                convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59)),
-                                0,
-                                10)
-                        .toList();
-
-        Collections.reverse(testEvents);
-
-        assertTestResultsList(
-                positives,
-                testEvents.stream()
-                        .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.POSITIVE)
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                negatives,
-                testEvents.stream()
-                        .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE)
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                inconclusives,
-                testEvents.stream()
-                        .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.UNDETERMINED)
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                students,
-                testEvents.stream()
-                        .filter(t -> t.getPatient().getRole() == PersonRole.STUDENT)
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                visitors,
-                testEvents.stream()
-                        .filter(t -> t.getPatient().getRole() == PersonRole.VISITOR)
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                june1to3,
-                testEvents.stream()
-                        .filter(
-                                t ->
-                                        !t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
-                                                && !t.getDateTested()
-                                                .after(convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59))))
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                priorToJune2Noon,
-                testEvents.stream()
-                        .filter(
-                                t -> t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0))))
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                positivesAmos,
-                testEvents.stream()
-                        .filter(
-                                t ->
-                                        t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
-                                                && t.getPatient().getNameInfo().equals(AMOS))
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                negativesAmos,
-                testEvents.stream()
-                        .filter(
-                                t ->
-                                        t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE
-                                                && t.getPatient().getNameInfo().equals(AMOS))
-                        .collect(Collectors.toList()));
-        assertTestResultsList(
-                allFilters,
-                testEvents.stream()
-                        .filter(
-                                t ->
-                                        t.getPatient().getNameInfo().equals(CHARLES)
-                                                && t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
-                                                && t.getPatient().getRole() == PersonRole.RESIDENT
-                                                && !t.getDateTested()
-                                                .before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
-                                                && !t.getDateTested()
-                                                .after(convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59))))
-                        .collect(Collectors.toList()));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestEventsResults_withMultiplex_returnsOnlyOneEvent() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createMultiplexTestEvent(
-                p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
-
-        var res =
-                _service
-                        .getFacilityTestEventsResults(
-                                facility.getInternalId(), null, null, null, null, null, 0, 10)
-                        .toList();
-        assertEquals(1, res.size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestEventsResults_withMultiplexAndCovid_returnsOnlyTwoEvent() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        _dataFactory.createTestEvent(p, facility);
-        _dataFactory.createMultiplexTestEvent(
-                p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
-
-        var res =
-                _service
-                        .getFacilityTestEventsResults(
-                                facility.getInternalId(), null, null, null, null, null, 0, 10)
-                        .toList();
-        assertEquals(2, res.size());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestEventsResults_withResultFilter_returnsFluAndCovidNegatives() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-        Person p = _dataFactory.createMinimalPerson(org, facility);
-        var notExpected_allPos =
-                _dataFactory.createMultiplexTestEvent(
-                        p, facility, TestResult.POSITIVE, TestResult.POSITIVE, TestResult.POSITIVE, false);
-        var expected_allNeg =
-                _dataFactory.createMultiplexTestEvent(
-                        p, facility, TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
-        var expected_covidPos =
-                _dataFactory.createMultiplexTestEvent(
-                        p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
-
-        var res =
-                _service.getFacilityTestEventsResults(
-                        facility.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10);
-
-        var expected = List.of(expected_allNeg.getInternalId(), expected_covidPos.getInternalId());
-        var actualInternalIds = res.stream().map(TestEvent::getInternalId).collect(Collectors.toList());
-        assertTrue(actualInternalIds.containsAll(expected));
-        assertEquals(expected.size(), actualInternalIds.size());
-        assertFalse(actualInternalIds.contains(notExpected_allPos.getInternalId()));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestResultsCount() {
-        makedata();
-        int size =
-                _service.getTestResultsCount(_site.getInternalId(), null, null, null, null, null, null);
-        assertEquals(11, size);
-    }
-
-    @Test
-    @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-    void getTestResultsCount_forOrganization() {
-        var testEvents = makeAdminData();
-        var orgId = testEvents.get(0).getOrganization().getInternalId();
-        int size = _service.getTestResultsCount(null, null, null, null, null, null, orgId);
-        assertEquals(4, size);
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTestResultsCount_forOrganization_failsForNonSiteAdmins() {
-        var otherOrgId = UUID.randomUUID();
-        assertThrows(
-                AccessDeniedException.class,
-                () -> _service.getTestResultsCount(null, null, null, null, null, null, otherOrgId));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getOrganizationLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
-        makedata();
-        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-        OrganizationLevelDashboardMetrics metrics =
-                _service.getOrganizationLevelDashboardMetrics(startDate, endDate);
-        assertEquals(3, metrics.getOrganizationPositiveTestCount());
-        assertEquals(12, metrics.getOrganizationTotalTestCount());
-        assertEquals(5, metrics.getOrganizationNegativeTestCount());
-        assertEquals(4, metrics.getFacilityMetrics().size());
-    }
-
-    @Test
-    @WithSimpleReportStandardAllFacilitiesUser
-    void getOrganizationLevelDashboardMetrics_inOrgWithStandardUser_failure() {
-        makedata();
-        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-        assertThrows(
-                AccessDeniedException.class,
-                () -> _service.getOrganizationLevelDashboardMetrics(startDate, endDate));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTopLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
-        makedata();
-        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-        TopLevelDashboardMetrics metrics =
-                _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19");
-        assertEquals(3, metrics.getPositiveTestCount());
-        assertEquals(12, metrics.getTotalTestCount());
-    }
-
-    @Test
-    @WithSimpleReportStandardAllFacilitiesUser
-    void getTopLevelDashboardMetrics_inOrgWithStandardUser_failure() {
-        makedata();
-        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-        assertThrows(
-                AccessDeniedException.class,
-                () -> _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19"));
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void getTopLevelDashboardMetrics_showsNonCovidResults() {
-        makedata();
-        makeSpecificDiseaseData(_diseaseService.fluA());
-        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-        TopLevelDashboardMetrics metrics =
-                _service.getTopLevelDashboardMetrics(null, startDate, endDate, "Flu A");
-        assertEquals(1, metrics.getPositiveTestCount());
-        assertEquals(2, metrics.getTotalTestCount());
-    }
-
-    @Test
-    void markAsErrorTest_successDependsOnFacilityAccess() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _dataFactory.createValidFacility(org);
-        Person p = _dataFactory.createFullPerson(org);
-        TestEvent _e = _dataFactory.createTestEvent(p, facility);
-
-        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-        UUID facilityId = facility.getInternalId();
-        UUID testEventId = _e.getInternalId();
-
-        assertThrows(AccessDeniedException.class, () -> _service.markAsError(testEventId, reasonMsg));
-        assertThrows(
-                AccessDeniedException.class,
-                () ->
-                        _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
-        assertThrows(AccessDeniedException.class, () -> _service.getTestResult(testEventId));
-
-        // make sure the corrected event is not sent to storage queue
-        verifyNoInteractions(testEventReportingService);
-        verifyNoInteractions(fhirQueueReportingService);
-
-        TestUserIdentities.setFacilityAuthorities(facility);
-        TestEvent correctedTestEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
-        _service.getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 10);
-        _service.getTestResult(_e.getInternalId()).getTestOrder();
-        // make sure the corrected event is sent to storage queue
-        verify(testEventReportingService).report(correctedTestEvent);
-        verify(fhirQueueReportingService).report(any());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void removeFromQueueByFacilityId_notAuthorizedError() {
-        UUID facilityId = UUID.randomUUID();
-        assertThrows(
-                AccessDeniedException.class, () -> _service.removeFromQueueByFacilityId(facilityId));
-    }
-
-    @Test
-    @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-    void removeFromQueueByFacilityId_facilityNotFoundError() {
-        UUID facilityId = UUID.randomUUID();
-        when(this._organizationService.getFacilityById(facilityId)).thenReturn(Optional.empty());
-        assertThrows(
-                IllegalGraphqlArgumentException.class,
-                () -> _service.removeFromQueueByFacilityId(facilityId));
-    }
-
-    @Test
-    @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-    void removeFromQueueByFacilityId_success() {
-        UUID facilityId = UUID.randomUUID();
-        Facility mockFacility = mock(Facility.class);
-        List<TestOrder> mockOrders = List.of();
-        doReturn(Optional.of(mockFacility)).when(this._organizationService).getFacilityById(facilityId);
-        doReturn(mockOrders).when(_testOrderRepository).fetchQueueItemsByFacilityId(mockFacility);
-        ArgumentCaptor<List<TestOrder>> ordersCaptor = ArgumentCaptor.forClass(List.class);
-        doReturn(null).when(_testOrderRepository).saveAll(ordersCaptor.capture());
-
-        _service.removeFromQueueByFacilityId(facilityId);
-        assertEquals(mockOrders, ordersCaptor.getValue());
-    }
-
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void addTestResult_sentToReportingService() {
-        // GIVEN
-        Organization org = _organizationService.getCurrentOrganization();
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        Person patient = _dataFactory.createFullPerson(org);
-
-        _service.addPatientToQueue(
-                facility.getInternalId(),
-                patient,
-                "",
-                "",
-                Collections.emptyMap(),
-                LocalDate.of(1865, 12, 25),
-                false);
-        DeviceType deviceType = _dataFactory.getGenericDevice();
-        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-        // WHEN
-        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+            order.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
+            List.of(covidResult),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    assertEquals(1, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void editQueueItemMultiplexResult_worksWithMultipleResults() {
+    TestOrder order = addTestToQueue();
+
+    TestOrder updatedOrder =
+        _service.editQueueItemMultiplexResult(
+            order.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
+            makeMultiplexTestResult(TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void editQueueItemMultiplexResult_worksWithEmptyResults() {
+    TestOrder order = addTestToQueue();
+
+    TestOrder updatedOrder =
+        _service.editQueueItemMultiplexResult(
+            order.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
+            List.of(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    assertTrue(_service.getTestOrder(updatedOrder.getInternalId()).getResults().isEmpty());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addMultiplexResult_multipleEditsBeforeSubmissionSuccessful() {
+    TestOrder order = addTestToQueue();
+
+    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
+    MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", TestResult.NEGATIVE);
+    MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", TestResult.NEGATIVE);
+
+    _service.editQueueItemMultiplexResult(
+        order.getInternalId(),
+        _dataFactory.getGenericDevice().getInternalId(),
+        _dataFactory.getGenericSpecimen().getInternalId(),
+        List.of(covidResult, fluAResult, fluBResult),
+        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    MultiplexResultInput updatedCovidResult =
+        new MultiplexResultInput("COVID-19", TestResult.NEGATIVE);
+    TestOrder updatedOrder =
+        _service.editQueueItemMultiplexResult(
+            order.getInternalId(),
+            _dataFactory.getGenericDevice().getInternalId(),
+            _dataFactory.getGenericSpecimen().getInternalId(),
+            List.of(updatedCovidResult, fluAResult, fluBResult),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
+
+    AddTestResultResponse response =
         _service.addMultiplexResult(
-                deviceType.getInternalId(),
-                specimenType.getInternalId(),
-                positiveCovidOnlyResult,
-                patient.getInternalId(),
-                null);
+            updatedOrder.getDeviceType().getInternalId(),
+            updatedOrder.getSpecimenType().getInternalId(),
+            List.of(updatedCovidResult, fluAResult, fluBResult),
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
 
-        // THEN
-        verify(reportTestEventToRSEventListener, times(1)).handleEvent(any());
-        verify(testEventReportingService, times(1)).report(any());
+    assertEquals(3, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void multiplexResultMutations_covidOnlyCorrectionSuccessful() {
+    TestOrder order = addTestToQueue();
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
+            List.of(new MultiplexResultInput("COVID-19", TestResult.POSITIVE)),
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+    _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
+
+    AddTestResultResponse correctedResponse =
+        _service.addMultiplexResult(
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
+            List.of(new MultiplexResultInput("COVID-19", TestResult.NEGATIVE)),
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    assertEquals(1, _resultRepository.findAllByTestOrder(order).size());
+    assertEquals(
+        1,
+        _resultRepository
+            .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
+            .size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void multiplexResultMutations_multiplexCorrectionSuccessful() {
+
+    List<MultiplexResultInput> originalResults =
+        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.POSITIVE);
+
+    TestOrder order = addTestToQueue();
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
+            originalResults,
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+    _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
+
+    List<MultiplexResultInput> correctedResults =
+        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE);
+
+    AddTestResultResponse correctedResponse =
+        _service.addMultiplexResult(
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
+            correctedResults,
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
+    assertEquals(
+        3,
+        _resultRepository
+            .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
+            .size());
+    assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void multiplexResultMutations_removalSuccessful() {
+    List<MultiplexResultInput> originalResults =
+        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
+
+    TestOrder order = addTestToQueue();
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
+            originalResults,
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+    TestEvent removedEvent = _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
+
+    assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
+    assertEquals(3, _resultRepository.findAllByTestEvent(removedEvent).size());
+    assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void fetchTestEventsResults_standardUser_successDependsOnFacilityAccess() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createValidFacility(org);
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createTestEvent(p, facility);
+    UUID facilityId = facility.getInternalId();
+
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+
+    TestUserIdentities.setFacilityAuthorities(facility);
+    _service.getFacilityTestEventsResults(
+        facility.getInternalId(), null, null, null, null, null, 0, 10);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void fetchTestEventsAtArchivedFacility_orgAdminUser_ok() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createTestEvent(p, facility);
+
+    Page<TestEvent> testEventsByFacility =
+        _service.getFacilityTestEventsResults(
+            facility.getInternalId(), null, null, null, null, null, 0, 10);
+    assertThat(testEventsByFacility.getTotalElements()).isEqualTo(1);
+    assertThat(testEventsByFacility.getTotalPages()).isEqualTo(1);
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void fetchTestEventsAtArchivedFacility_standardUser_failure() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createTestEvent(p, facility);
+    UUID facilityId = facility.getInternalId();
+
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void fetchAllFacilityTestEventsResults_orgAdminUser_ok() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createValidFacility(org);
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createTestEvent(p, facility);
+
+    Page<TestEvent> testEventsByOrg =
+        _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
+    assertThat(testEventsByOrg.getTotalElements()).isEqualTo(1);
+    assertThat(testEventsByOrg.getTotalPages()).isEqualTo(1);
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void fetchAllFacilityTestEventsResults_standardUser_failure() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createValidFacility(org);
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createTestEvent(p, facility);
+
+    assertThrows(
+        AccessDeniedException.class,
+        () -> _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10));
+  }
+
+  @Test
+  @WithSimpleReportStandardUser
+  void fetchTestResults_standardUser_successDependsOnFacilityAccess() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility f1 = _dataFactory.createValidFacility(org, "First One");
+    Facility f2 = _dataFactory.createValidFacility(org, "Second One");
+    Person p1 = _dataFactory.createMinimalPerson(org, f1);
+    Person p2 = _dataFactory.createMinimalPerson(org);
+    _dataFactory.createTestEvent(p1, f1);
+    _dataFactory.createTestEvent(p2, f1);
+    _dataFactory.createTestEvent(p2, f2);
+
+    assertThrows(AccessDeniedException.class, () -> _service.getTestResults(p1));
+    // filters out all test results from inaccessible facilities, but we can still
+    // request test results for a patient whose own facility is null
+    assertEquals(0, _service.getTestResults(p2).size());
+
+    TestUserIdentities.setFacilityAuthorities(f1);
+    assertEquals(1, _service.getTestResults(p1).size());
+    // filters out all test results from inaccessible facilities
+    assertEquals(1, _service.getTestResults(p2).size());
+
+    TestUserIdentities.setFacilityAuthorities(f1, f2);
+    assertEquals(1, _service.getTestResults(p1).size());
+    assertEquals(2, _service.getTestResults(p2).size());
+  }
+
+  @Test
+  @WithSimpleReportEntryOnlyUser
+  void fetchTestResults_entryOnlyUser_error() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person p = _dataFactory.createFullPerson(org);
+    _dataFactory.createTestEvent(p, facility);
+
+    // https://github.com/CDCgov/prime-simplereport/issues/677
+    // assertSecurityError(() ->
+    // _service.getTestResults(facility.getInternalId()));
+    assertSecurityError(() -> _service.getTestResults(p));
+  }
+
+  // watch for N+1 queries
+  @Test
+  @WithSimpleReportStandardAllFacilitiesUser
+  void fetchTestEventsResults_getTestEventsResults_NPlusOne() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person p = _dataFactory.createFullPerson(org);
+
+    // add some initial data
+    _dataFactory.createTestEvent(p, facility);
+    _dataFactory.createTestEvent(p, facility);
+
+    // count queries
+    long startQueryCount = QueryCountService.get().getSelect();
+    _service.getFacilityTestEventsResults(
+        facility.getInternalId(), null, null, null, null, null, 0, 50);
+    long firstPassTotal = QueryCountService.get().getSelect() - startQueryCount;
+
+    // add more data
+    _dataFactory.createTestEvent(p, facility);
+    _dataFactory.createTestEvent(p, facility);
+    _dataFactory.createTestEvent(p, facility);
+    _dataFactory.createTestEvent(p, facility);
+    _dataFactory.createTestEvent(p, facility);
+
+    // count queries again and make sure queries made didn't increase
+    startQueryCount = QueryCountService.get().getSelect();
+    _service.getFacilityTestEventsResults(
+        facility.getInternalId(), null, null, null, null, null, 0, 50);
+    long secondPassTotal = QueryCountService.get().getSelect() - startQueryCount;
+    assertEquals(firstPassTotal, secondPassTotal);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void editTestResult_getQueue_NPlusOne() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    UUID facilityId = facility.getInternalId();
+
+    Person p1 =
+        _personService.addPatient(
+            facilityId,
+            "FOO",
+            "Fred",
+            null,
+            "",
+            "Sr.",
+            LocalDate.of(1865, 12, 25),
+            getAddress(),
+            "USA",
+            TestDataFactory.getListOfOnePhoneNumber(),
+            PersonRole.STAFF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "Spanish",
+            null,
+            null);
+
+    _service.addPatientToQueue(
+        facilityId, p1, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+
+    // get the first query count
+    long startQueryCount = QueryCountService.get().getSelect();
+    _service.getQueue(facility.getInternalId());
+    long firstRunCount = QueryCountService.get().getSelect() - startQueryCount;
+
+    for (int ii = 0; ii < 2; ii++) {
+      // add more tests to the queue. (which needs more patients)
+      Person p =
+          _personService.addPatient(
+              facilityId,
+              "FOO",
+              "Fred",
+              null,
+              "",
+              "Sr.",
+              LocalDate.of(1865, 12, 25),
+              getAddress(),
+              "USA",
+              TestDataFactory.getListOfOnePhoneNumber(),
+              PersonRole.STAFF,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              false,
+              false,
+              "French",
+              null,
+              null);
+
+      _service.addPatientToQueue(
+          facilityId, p, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
     }
 
-    @Test
-    @WithSimpleReportOrgAdminUser
-    void removeTest_sentToReportingService() {
-        // GIVEN
-        List<MultiplexResultInput> originalResults =
-                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
+    startQueryCount = QueryCountService.get().getSelect();
+    _service.getQueue(facility.getInternalId());
+    long secondRunCount = QueryCountService.get().getSelect() - startQueryCount;
+    assertEquals(firstRunCount, secondRunCount);
+  }
 
-        TestOrder order = addTestToQueue();
-        AddTestResultResponse response =
-                _service.addMultiplexResult(
-                        order.getDeviceType().getInternalId(),
-                        order.getSpecimenType().getInternalId(),
-                        originalResults,
-                        order.getPatient().getInternalId(),
-                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void markAsErrorTest() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person person = _dataFactory.createFullPerson(org);
+    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
 
-        TestEvent originalEvent = response.getTestOrder().getTestEvent();
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+    assertNotNull(deleteMarkerEvent);
 
-        // WHEN
-        _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
+    assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
+    assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
 
-        // THEN
-        // Invoked once when result is added, invoked again when marked as error
-        verify(reportTestEventToRSEventListener, times(2)).handleEvent(any());
-        verify(testEventReportingService, times(2)).report(any());
+    assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
+
+    List<TestEvent> events_before =
+        _service
+            .getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 50)
+            .toList();
+    assertEquals(1, events_before.size());
+
+    // verify the original order was updated
+    TestEvent refreshedTestResult = _service.getTestResult(testEvent.getInternalId());
+    TestOrder onlySavedOrder = refreshedTestResult.getTestOrder();
+    TestEvent mostRecentEvent = onlySavedOrder.getTestEvent();
+    assertEquals(reasonMsg, onlySavedOrder.getReasonForCorrection());
+    assertEquals(deleteMarkerEvent.getInternalId(), mostRecentEvent.getInternalId());
+    assertEquals(TestCorrectionStatus.REMOVED, onlySavedOrder.getCorrectionStatus());
+
+    // make sure the original item is removed from the result and ONLY the
+    // "corrected" removed one is shown
+    List<TestEvent> events_after =
+        _service
+            .getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 50)
+            .toList();
+    assertEquals(1, events_after.size());
+    assertEquals(
+        deleteMarkerEvent.getInternalId().toString(),
+        events_after.get(0).getInternalId().toString());
+
+    // verify that a Result object is created for the original and new TestEvent and one for the
+    // TestOrder
+    assertEquals(1, _resultRepository.findAllByTestOrder(onlySavedOrder).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(mostRecentEvent).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(deleteMarkerEvent).size());
+
+    // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
+    // to report stream
+    verify(testEventReportingService).report(deleteMarkerEvent);
+    verify(fhirQueueReportingService).report(any());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void markAsErrorTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    DeviceType device = _dataFactory.getGenericDevice();
+    SpecimenType specimen = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+    Person person = _dataFactory.createFullPerson(org);
+    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+    facility.getAddress().setState("ND");
+    _organizationService.updateFacility(
+        facility.getInternalId(),
+        facility.getFacilityName(),
+        facility.getCliaNumber(),
+        facility.getAddress(),
+        facility.getTelephone(),
+        facility.getEmail(),
+        facility.getOrderingProvider().getNameInfo(),
+        facility.getOrderingProvider().getAddress(),
+        facility.getOrderingProvider().getProviderId(),
+        facility.getOrderingProvider().getTelephone(),
+        facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
+
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    TestEvent deletedTest = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+
+    assertEquals(deletedTest.getDeviceType().getInternalId(), device.getInternalId());
+    assertEquals(deletedTest.getSpecimenType().getInternalId(), specimen.getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void correctionsTest() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person p = _dataFactory.createFullPerson(org);
+    TestEvent e = _dataFactory.createTestEvent(p, facility);
+
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+
+    // A test correction call just returns the original TestEvent...
+    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
+
+    // ...but re-opens the original TestOrder and updates correction status
+    TestOrder updatedOrder = originalEvent.getTestOrder();
+    assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
+    assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
+    assertEquals(e.getInternalId(), updatedOrder.getTestEvent().getInternalId());
+    assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
+
+    // Unlike marking a test as deleted, which immediately creates a second TestEvent
+    // that represents the removal, a test correction does not result in another
+    // TestEvent being generated and saved
+    long testEventCount = _testEventRepository.count();
+    assertEquals(1, testEventCount);
+
+    // Does not report to ReportStream
+    verify(testEventReportingService, times(0)).report(e);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void markAsErrorTest_backwardCompatible() {
+    // GIVEN
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person person = _dataFactory.createFullPerson(org);
+    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+    // ensure the Result will have both testEvent and testOrder populated
+    _resultRepository.deleteAll(testEvent.getOrder().getResults());
+    Set<Result> results = testEvent.getResults();
+    results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
+    _resultRepository.saveAll(results);
+
+    // assert that we have the same Result object for both testEvent and testOrder
+    List<Result> allOldResultsByTestOrder =
+        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+    List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+    assertEquals(1, allOldResultsByTestEvent.size());
+    assertEquals(1, allOldResultsByTestOrder.size());
+    Result testOrderOldResult = allOldResultsByTestOrder.get(0);
+    Result testEventOldResult = allOldResultsByTestEvent.get(0);
+    assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
+
+    // WHEN
+    TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+
+    // THEN
+    assertNotNull(deleteMarkerEvent);
+
+    assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
+    assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
+
+    assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
+
+    // assert that we have two Result objects for both testEvent and testOrder
+    List<Result> allResultsByTestOrder =
+        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+    List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+    assertEquals(1, allResultsByTestOrder.size());
+    assertEquals(1, allResultsByTestEvent.size());
+
+    Result testOrderResult = allResultsByTestOrder.get(0);
+    Result testEventResult = allResultsByTestEvent.get(0);
+    assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
+
+    assertThat(testEventResult.getTestOrder()).isNull();
+    assertThat(testEventResult.getTestEvent()).isNotNull();
+
+    assertThat(testOrderResult.getTestOrder()).isNotNull();
+    assertThat(testOrderResult.getTestEvent()).isNull();
+
+    assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+    assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void correctionsTest_backwardCompatible() {
+    // GIVEN
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person person = _dataFactory.createFullPerson(org);
+    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+    // ensure the Result will have both testEvent and testOrder populated
+    _resultRepository.deleteAll(testEvent.getOrder().getResults());
+    Set<Result> results = testEvent.getResults();
+    results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
+    _resultRepository.saveAll(results);
+
+    // assert that we have the same Result object for both testEvent and testOrder
+    List<Result> allOldResultsByTestOrder =
+        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+    List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+    assertEquals(1, allOldResultsByTestEvent.size());
+    assertEquals(1, allOldResultsByTestOrder.size());
+    Result testOrderOldResult = allOldResultsByTestOrder.get(0);
+    Result testEventOldResult = allOldResultsByTestEvent.get(0);
+    assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
+
+    // WHEN
+    TestEvent originalEvent = _service.markAsCorrection(testEvent.getInternalId(), reasonMsg);
+
+    // THEN
+    TestOrder updatedOrder = originalEvent.getTestOrder();
+    assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
+    assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
+    assertEquals(testEvent.getInternalId(), updatedOrder.getTestEvent().getInternalId());
+    assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
+
+    // assert that we have two Result objects for both testEvent and testOrder
+    List<Result> allResultsByTestOrder =
+        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+    List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+    assertEquals(1, allResultsByTestOrder.size());
+    assertEquals(1, allResultsByTestEvent.size());
+
+    Result testOrderResult = allResultsByTestOrder.get(0);
+    Result testEventResult = allResultsByTestEvent.get(0);
+    assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
+
+    assertThat(testEventResult.getTestOrder()).isNull();
+    assertThat(testEventResult.getTestEvent()).isNotNull();
+
+    assertThat(testOrderResult.getTestOrder()).isNotNull();
+    assertThat(testOrderResult.getTestEvent()).isNull();
+
+    assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+    assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void correctTest_backDatedFromCurrentDate() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person p = _dataFactory.createFullPerson(org);
+    TestEvent e = _dataFactory.createTestEvent(p, facility);
+
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+
+    assertNull(e.getTestOrder().getDateTestedBackdate());
+
+    // A test correction call just returns the original TestEvent...
+    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
+
+    assertEquals(e.getDateTested(), originalEvent.getTestOrder().getDateTestedBackdate());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void correctTest_backdatePreserved() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+    Person p = _dataFactory.createFullPerson(org);
+
+    LocalDate localDate = LocalDate.of(2022, 1, 1);
+    Date dateTested = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    TestEvent e = _dataFactory.createTestEvent(p, facility, null, TestResult.POSITIVE, dateTested);
+
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+
+    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
+    assertEquals(0, originalEvent.getTestOrder().getDateTestedBackdate().compareTo(dateTested));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void correctTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    DeviceType device = _dataFactory.getGenericDevice();
+    SpecimenType specimen = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+    Person p = _dataFactory.createFullPerson(org);
+    TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
+
+    facility.getAddress().setState("ND");
+    _organizationService.updateFacility(
+        facility.getInternalId(),
+        facility.getFacilityName(),
+        facility.getCliaNumber(),
+        facility.getAddress(),
+        facility.getTelephone(),
+        facility.getEmail(),
+        facility.getOrderingProvider().getNameInfo(),
+        facility.getOrderingProvider().getAddress(),
+        facility.getOrderingProvider().getProviderId(),
+        facility.getOrderingProvider().getTelephone(),
+        facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
+
+    // Re-open the original test as a correction
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
+
+    // Re-submit the corrected test
+    List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            device.getInternalId(),
+            specimen.getInternalId(),
+            correctedTestResult,
+            p.getInternalId(),
+            null);
+    TestEvent correctedEvent = response.getTestOrder().getTestEvent();
+    assertEquals(correctedEvent.getDeviceType().getInternalId(), device.getInternalId());
+    assertEquals(correctedEvent.getSpecimenType().getInternalId(), specimen.getInternalId());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void removeACorrectedTest_success() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    DeviceType device = _dataFactory.getGenericDevice();
+    SpecimenType specimen = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+    Person p = _dataFactory.createFullPerson(org);
+    TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
+
+    // Re-open the original test as a correction
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
+
+    // Re-submit the corrected test
+    List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            device.getInternalId(),
+            specimen.getInternalId(),
+            correctedTestResult,
+            p.getInternalId(),
+            null);
+    TestEvent correctedEvent = response.getTestOrder().getTestEvent();
+
+    assertEquals(
+        2, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
+    assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
+
+    // Now mark the corrected test as an error
+    String removalMsg = "I changed my mind, remove this test " + LocalDateTime.now();
+    TestEvent deleteCorrectedEvent =
+        _service.markAsError(correctedEvent.getInternalId(), removalMsg);
+
+    // There should only be a single TestOrder, but three TestEvents - the original, the corrected,
+    // and the removed
+    // There should also be exactly 4 Result objects, 1 for the order, and 1 per each TestEvent
+    assertEquals(
+        3, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
+    assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
+    assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(correctedEvent).size());
+    assertEquals(1, _resultRepository.findAllByTestEvent(deleteCorrectedEvent).size());
+
+    TestOrder order = deleteCorrectedEvent.getTestOrder();
+    assertEquals(TestCorrectionStatus.REMOVED, order.getCorrectionStatus());
+    assertEquals(removalMsg, order.getReasonForCorrection());
+    assertEquals(deleteCorrectedEvent.getInternalId(), order.getTestEvent().getInternalId());
+    assertEquals(OrderStatus.COMPLETED, order.getOrderStatus());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestEventsResults_pagination() {
+    List<TestEvent> testEvents = makedata();
+    List<TestEvent> results_page0 =
+        _service
+            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 0, 5)
+            .toList();
+    List<TestEvent> results_page1 =
+        _service
+            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 1, 5)
+            .toList();
+    List<TestEvent> results_page2 =
+        _service
+            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 2, 5)
+            .toList();
+    List<TestEvent> results_page3 =
+        _service
+            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 3, 5)
+            .toList();
+
+    Collections.reverse(testEvents);
+
+    assertTestResultsList(results_page0, testEvents.subList(0, 5));
+    assertTestResultsList(results_page1, testEvents.subList(5, 10));
+    assertTestResultsList(results_page2, testEvents.subList(10, 11));
+    assertEquals(0, results_page3.size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestEventsResults_filtering() {
+    List<TestEvent> testEvents = makedata();
+    List<TestEvent> positives =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, TestResult.POSITIVE, null, null, null, 0, 10)
+            .toList();
+    List<TestEvent> negatives =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10)
+            .toList();
+    List<TestEvent> inconclusives =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, TestResult.UNDETERMINED, null, null, null, 0, 10)
+            .toList();
+    List<TestEvent> students =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, PersonRole.STUDENT, null, null, 0, 10)
+            .toList();
+    List<TestEvent> visitors =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, PersonRole.VISITOR, null, null, 0, 10)
+            .toList();
+    List<TestEvent> june1to3 =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(),
+                null,
+                null,
+                null,
+                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
+                convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59)),
+                0,
+                10)
+            .toList();
+    List<TestEvent> priorToJune2Noon =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(),
+                null,
+                null,
+                null,
+                null,
+                convertDate(LocalDateTime.of(2021, 6, 2, 11, 59, 59)),
+                0,
+                10)
+            .toList();
+    List<TestEvent> positivesAmos =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(),
+                _dataFactory.getPersonByName(AMOS).getInternalId(),
+                TestResult.POSITIVE,
+                null,
+                null,
+                null,
+                0,
+                10)
+            .toList();
+    List<TestEvent> negativesAmos =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(),
+                _dataFactory.getPersonByName(AMOS).getInternalId(),
+                TestResult.NEGATIVE,
+                null,
+                null,
+                null,
+                0,
+                10)
+            .toList();
+    List<TestEvent> allFilters =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(),
+                _dataFactory.getPersonByName(CHARLES).getInternalId(),
+                TestResult.POSITIVE,
+                PersonRole.RESIDENT,
+                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
+                convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59)),
+                0,
+                10)
+            .toList();
+
+    Collections.reverse(testEvents);
+
+    assertTestResultsList(
+        positives,
+        testEvents.stream()
+            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.POSITIVE)
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        negatives,
+        testEvents.stream()
+            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE)
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        inconclusives,
+        testEvents.stream()
+            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.UNDETERMINED)
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        students,
+        testEvents.stream()
+            .filter(t -> t.getPatient().getRole() == PersonRole.STUDENT)
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        visitors,
+        testEvents.stream()
+            .filter(t -> t.getPatient().getRole() == PersonRole.VISITOR)
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        june1to3,
+        testEvents.stream()
+            .filter(
+                t ->
+                    !t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
+                        && !t.getDateTested()
+                            .after(convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59))))
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        priorToJune2Noon,
+        testEvents.stream()
+            .filter(
+                t -> t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0))))
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        positivesAmos,
+        testEvents.stream()
+            .filter(
+                t ->
+                    t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
+                        && t.getPatient().getNameInfo().equals(AMOS))
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        negativesAmos,
+        testEvents.stream()
+            .filter(
+                t ->
+                    t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE
+                        && t.getPatient().getNameInfo().equals(AMOS))
+            .collect(Collectors.toList()));
+    assertTestResultsList(
+        allFilters,
+        testEvents.stream()
+            .filter(
+                t ->
+                    t.getPatient().getNameInfo().equals(CHARLES)
+                        && t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
+                        && t.getPatient().getRole() == PersonRole.RESIDENT
+                        && !t.getDateTested()
+                            .before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
+                        && !t.getDateTested()
+                            .after(convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59))))
+            .collect(Collectors.toList()));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestEventsResults_withMultiplex_returnsOnlyOneEvent() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createMultiplexTestEvent(
+        p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
+
+    var res =
+        _service
+            .getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 10)
+            .toList();
+    assertEquals(1, res.size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestEventsResults_withMultiplexAndCovid_returnsOnlyTwoEvent() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    _dataFactory.createTestEvent(p, facility);
+    _dataFactory.createMultiplexTestEvent(
+        p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
+
+    var res =
+        _service
+            .getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 10)
+            .toList();
+    assertEquals(2, res.size());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestEventsResults_withResultFilter_returnsFluAndCovidNegatives() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+    Person p = _dataFactory.createMinimalPerson(org, facility);
+    var notExpected_allPos =
+        _dataFactory.createMultiplexTestEvent(
+            p, facility, TestResult.POSITIVE, TestResult.POSITIVE, TestResult.POSITIVE, false);
+    var expected_allNeg =
+        _dataFactory.createMultiplexTestEvent(
+            p, facility, TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
+    var expected_covidPos =
+        _dataFactory.createMultiplexTestEvent(
+            p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
+
+    var res =
+        _service.getFacilityTestEventsResults(
+            facility.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10);
+
+    var expected = List.of(expected_allNeg.getInternalId(), expected_covidPos.getInternalId());
+    var actualInternalIds = res.stream().map(TestEvent::getInternalId).collect(Collectors.toList());
+    assertTrue(actualInternalIds.containsAll(expected));
+    assertEquals(expected.size(), actualInternalIds.size());
+    assertFalse(actualInternalIds.contains(notExpected_allPos.getInternalId()));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestResultsCount() {
+    makedata();
+    int size =
+        _service.getTestResultsCount(_site.getInternalId(), null, null, null, null, null, null);
+    assertEquals(11, size);
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void getTestResultsCount_forOrganization() {
+    var testEvents = makeAdminData();
+    var orgId = testEvents.get(0).getOrganization().getInternalId();
+    int size = _service.getTestResultsCount(null, null, null, null, null, null, orgId);
+    assertEquals(4, size);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTestResultsCount_forOrganization_failsForNonSiteAdmins() {
+    var otherOrgId = UUID.randomUUID();
+    assertThrows(
+        AccessDeniedException.class,
+        () -> _service.getTestResultsCount(null, null, null, null, null, null, otherOrgId));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getOrganizationLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
+    makedata();
+    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+    OrganizationLevelDashboardMetrics metrics =
+        _service.getOrganizationLevelDashboardMetrics(startDate, endDate);
+    assertEquals(3, metrics.getOrganizationPositiveTestCount());
+    assertEquals(12, metrics.getOrganizationTotalTestCount());
+    assertEquals(5, metrics.getOrganizationNegativeTestCount());
+    assertEquals(4, metrics.getFacilityMetrics().size());
+  }
+
+  @Test
+  @WithSimpleReportStandardAllFacilitiesUser
+  void getOrganizationLevelDashboardMetrics_inOrgWithStandardUser_failure() {
+    makedata();
+    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+    assertThrows(
+        AccessDeniedException.class,
+        () -> _service.getOrganizationLevelDashboardMetrics(startDate, endDate));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTopLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
+    makedata();
+    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+    TopLevelDashboardMetrics metrics =
+        _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19");
+    assertEquals(3, metrics.getPositiveTestCount());
+    assertEquals(12, metrics.getTotalTestCount());
+  }
+
+  @Test
+  @WithSimpleReportStandardAllFacilitiesUser
+  void getTopLevelDashboardMetrics_inOrgWithStandardUser_failure() {
+    makedata();
+    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+    assertThrows(
+        AccessDeniedException.class,
+        () -> _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19"));
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getTopLevelDashboardMetrics_showsNonCovidResults() {
+    makedata();
+    makeSpecificDiseaseData(_diseaseService.fluA());
+    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+    TopLevelDashboardMetrics metrics =
+        _service.getTopLevelDashboardMetrics(null, startDate, endDate, "Flu A");
+    assertEquals(1, metrics.getPositiveTestCount());
+    assertEquals(2, metrics.getTotalTestCount());
+  }
+
+  @Test
+  void markAsErrorTest_successDependsOnFacilityAccess() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _dataFactory.createValidFacility(org);
+    Person p = _dataFactory.createFullPerson(org);
+    TestEvent _e = _dataFactory.createTestEvent(p, facility);
+
+    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+    UUID facilityId = facility.getInternalId();
+    UUID testEventId = _e.getInternalId();
+
+    assertThrows(AccessDeniedException.class, () -> _service.markAsError(testEventId, reasonMsg));
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+    assertThrows(AccessDeniedException.class, () -> _service.getTestResult(testEventId));
+
+    // make sure the corrected event is not sent to storage queue
+    verifyNoInteractions(testEventReportingService);
+    verifyNoInteractions(fhirQueueReportingService);
+
+    TestUserIdentities.setFacilityAuthorities(facility);
+    TestEvent correctedTestEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
+    _service.getFacilityTestEventsResults(
+        facility.getInternalId(), null, null, null, null, null, 0, 10);
+    _service.getTestResult(_e.getInternalId()).getTestOrder();
+    // make sure the corrected event is sent to storage queue
+    verify(testEventReportingService).report(correctedTestEvent);
+    verify(fhirQueueReportingService).report(any());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void removeFromQueueByFacilityId_notAuthorizedError() {
+    UUID facilityId = UUID.randomUUID();
+    assertThrows(
+        AccessDeniedException.class, () -> _service.removeFromQueueByFacilityId(facilityId));
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void removeFromQueueByFacilityId_facilityNotFoundError() {
+    UUID facilityId = UUID.randomUUID();
+    when(this._organizationService.getFacilityById(facilityId)).thenReturn(Optional.empty());
+    assertThrows(
+        IllegalGraphqlArgumentException.class,
+        () -> _service.removeFromQueueByFacilityId(facilityId));
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void removeFromQueueByFacilityId_success() {
+    UUID facilityId = UUID.randomUUID();
+    Facility mockFacility = mock(Facility.class);
+    List<TestOrder> mockOrders = List.of();
+    doReturn(Optional.of(mockFacility)).when(this._organizationService).getFacilityById(facilityId);
+    doReturn(mockOrders).when(_testOrderRepository).fetchQueueItemsByFacilityId(mockFacility);
+    ArgumentCaptor<List<TestOrder>> ordersCaptor = ArgumentCaptor.forClass(List.class);
+    doReturn(null).when(_testOrderRepository).saveAll(ordersCaptor.capture());
+
+    _service.removeFromQueueByFacilityId(facilityId);
+    assertEquals(mockOrders, ordersCaptor.getValue());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void addTestResult_sentToReportingService() {
+    // GIVEN
+    Organization org = _organizationService.getCurrentOrganization();
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    Person patient = _dataFactory.createFullPerson(org);
+
+    _service.addPatientToQueue(
+        facility.getInternalId(),
+        patient,
+        "",
+        "",
+        Collections.emptyMap(),
+        LocalDate.of(1865, 12, 25),
+        false);
+    DeviceType deviceType = _dataFactory.getGenericDevice();
+    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+    // WHEN
+    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+    _service.addMultiplexResult(
+        deviceType.getInternalId(),
+        specimenType.getInternalId(),
+        positiveCovidOnlyResult,
+        patient.getInternalId(),
+        null);
+
+    // THEN
+    verify(reportTestEventToRSEventListener, times(1)).handleEvent(any());
+    verify(testEventReportingService, times(1)).report(any());
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void removeTest_sentToReportingService() {
+    // GIVEN
+    List<MultiplexResultInput> originalResults =
+        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
+
+    TestOrder order = addTestToQueue();
+    AddTestResultResponse response =
+        _service.addMultiplexResult(
+            order.getDeviceType().getInternalId(),
+            order.getSpecimenType().getInternalId(),
+            originalResults,
+            order.getPatient().getInternalId(),
+            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+    TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+    // WHEN
+    _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
+
+    // THEN
+    // Invoked once when result is added, invoked again when marked as error
+    verify(reportTestEventToRSEventListener, times(2)).handleEvent(any());
+    verify(testEventReportingService, times(2)).report(any());
+  }
+
+  private List<TestEvent> makeAdminData() {
+    var org = _organizationService.createOrganization("Da Org", "airport", "da-org-airport");
+    _organizationService.setIdentityVerified("da-org-airport", true);
+    var facility = _dataFactory.createValidFacility(org, "Da Facilitiy");
+    var person = _dataFactory.createMinimalPerson(org);
+    return List.of(
+        _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
+        _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
+        _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE),
+        _dataFactory.createTestEvent(person, facility, TestResult.UNDETERMINED));
+  }
+
+  private List<TestEvent> makedata() {
+    Organization org = _organizationService.getCurrentOrganization();
+    _site = _dataFactory.createValidFacility(org, "The Facility");
+    Map<PersonName, TestResult> patientsToResults = new HashMap<>();
+    patientsToResults.put(AMOS, TestResult.POSITIVE);
+    patientsToResults.put(CHARLES, TestResult.POSITIVE);
+    patientsToResults.put(DEXTER, TestResult.POSITIVE);
+    patientsToResults.put(ELIZABETH, TestResult.NEGATIVE);
+    patientsToResults.put(FRANK, TestResult.NEGATIVE);
+    patientsToResults.put(GALE, TestResult.NEGATIVE);
+    patientsToResults.put(HEINRICK, TestResult.NEGATIVE);
+    patientsToResults.put(IAN, TestResult.UNDETERMINED);
+    patientsToResults.put(JANNELLE, TestResult.UNDETERMINED);
+    patientsToResults.put(KACEY, TestResult.UNDETERMINED);
+    patientsToResults.put(LEELOO, TestResult.UNDETERMINED);
+
+    Map<PersonName, Date> patientsToDates = new HashMap<>();
+    patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
+    patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
+    patientsToDates.put(DEXTER, convertDate(LocalDateTime.of(2021, 6, 2, 0, 0, 0)));
+    patientsToDates.put(ELIZABETH, convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0)));
+    patientsToDates.put(FRANK, convertDate(LocalDateTime.of(2021, 6, 3, 0, 0, 0)));
+    patientsToDates.put(GALE, convertDate(LocalDateTime.of(2021, 6, 3, 12, 0, 0)));
+    patientsToDates.put(HEINRICK, convertDate(LocalDateTime.of(2021, 6, 4, 0, 0, 0)));
+    patientsToDates.put(IAN, convertDate(LocalDateTime.of(2021, 6, 4, 12, 0, 0)));
+    patientsToDates.put(JANNELLE, convertDate(LocalDateTime.of(2021, 6, 5, 0, 0, 0)));
+    patientsToDates.put(KACEY, convertDate(LocalDateTime.of(2021, 6, 5, 12, 0, 0)));
+    patientsToDates.put(LEELOO, convertDate(LocalDateTime.of(2021, 6, 6, 0, 0, 0)));
+
+    Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
+    patientsToRoles.put(AMOS, PersonRole.RESIDENT);
+    patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
+    patientsToRoles.put(DEXTER, PersonRole.STUDENT);
+    patientsToRoles.put(ELIZABETH, PersonRole.STUDENT);
+    patientsToRoles.put(FRANK, PersonRole.VISITOR);
+    patientsToRoles.put(GALE, PersonRole.VISITOR);
+    patientsToRoles.put(HEINRICK, PersonRole.STAFF);
+    patientsToRoles.put(IAN, PersonRole.STAFF);
+    patientsToRoles.put(JANNELLE, PersonRole.RESIDENT);
+    patientsToRoles.put(KACEY, PersonRole.RESIDENT);
+    patientsToRoles.put(LEELOO, PersonRole.STUDENT);
+
+    Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
+    patientsToSurveys.put(
+        AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+    patientsToSurveys.put(
+        CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+    patientsToSurveys.put(
+        DEXTER, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
+    patientsToSurveys.put(
+        ELIZABETH, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+    patientsToSurveys.put(
+        FRANK, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+    patientsToSurveys.put(
+        GALE, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
+    patientsToSurveys.put(
+        HEINRICK, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+    patientsToSurveys.put(
+        IAN, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+    patientsToSurveys.put(
+        JANNELLE, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
+    patientsToSurveys.put(
+        KACEY, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+    patientsToSurveys.put(
+        LEELOO, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+
+    List<TestEvent> testEvents =
+        patientsToResults.keySet().stream()
+            .map(
+                n -> {
+                  TestResult t = patientsToResults.get(n);
+                  PersonRole r = patientsToRoles.get(n);
+                  AskOnEntrySurvey s = patientsToSurveys.get(n);
+                  Date d = patientsToDates.get(n);
+
+                  Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
+                  return _dataFactory.createTestEvent(person, _site, s, t, d);
+                })
+            .collect(Collectors.toList());
+    // Make one result in another facility
+    Facility _otherSite = _dataFactory.createValidFacility(org, "The Other Facility");
+    _dataFactory.createTestEvent(
+        _dataFactory.createMinimalPerson(org, _otherSite, BRAD), _otherSite, TestResult.NEGATIVE);
+    return testEvents;
+  }
+
+  private List<TestEvent> makeSpecificDiseaseData(SupportedDisease disease) {
+    Organization org = _organizationService.getCurrentOrganization();
+    _site = _dataFactory.createValidFacility(org, "The Facility for " + disease.getName());
+    Map<PersonName, TestResult> patientsToResults = new HashMap<>();
+    patientsToResults.put(AMOS, TestResult.POSITIVE);
+    patientsToResults.put(CHARLES, TestResult.NEGATIVE);
+
+    Map<PersonName, Date> patientsToDates = new HashMap<>();
+    patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
+    patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
+
+    Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
+    patientsToRoles.put(AMOS, PersonRole.RESIDENT);
+    patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
+
+    Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
+    patientsToSurveys.put(
+        AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+    patientsToSurveys.put(
+        CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+
+    return patientsToResults.keySet().stream()
+        .map(
+            n -> {
+              TestResult t = patientsToResults.get(n);
+              PersonRole r = patientsToRoles.get(n);
+              AskOnEntrySurvey s = patientsToSurveys.get(n);
+              Date d = patientsToDates.get(n);
+
+              Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
+              return _dataFactory.createTestEvent(person, _site, s, t, d, disease);
+            })
+        .collect(Collectors.toList());
+  }
+
+  private List<MultiplexResultInput> makeCovidOnlyResult(TestResult covidTestResult) {
+    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
+    return List.of(covidResult);
+  }
+
+  private List<MultiplexResultInput> makeMultiplexTestResult(
+      TestResult covidTestResult, TestResult fluATestResult, TestResult fluBTestResult) {
+    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
+    MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", fluATestResult);
+    MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", fluBTestResult);
+    return List.of(covidResult, fluAResult, fluBResult);
+  }
+
+  private static void assertTestResultsList(List<TestEvent> found, List<TestEvent> expected) {
+    // check common elements first
+    for (int i = 0; i < expected.size() && i < found.size(); i++) {
+      assertEquals(expected.get(i).getInternalId(), found.get(i).getInternalId());
     }
-
-    private List<TestEvent> makeAdminData() {
-        var org = _organizationService.createOrganization("Da Org", "airport", "da-org-airport");
-        _organizationService.setIdentityVerified("da-org-airport", true);
-        var facility = _dataFactory.createValidFacility(org, "Da Facilitiy");
-        var person = _dataFactory.createMinimalPerson(org);
-        return List.of(
-                _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
-                _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
-                _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE),
-                _dataFactory.createTestEvent(person, facility, TestResult.UNDETERMINED));
+    // *then* check if there are extras
+    if (expected.size() != found.size()) {
+      fail("Expected " + expected.size() + " items but found " + found.size());
     }
+  }
 
-    private List<TestEvent> makedata() {
-        Organization org = _organizationService.getCurrentOrganization();
-        _site = _dataFactory.createValidFacility(org, "The Facility");
-        Map<PersonName, TestResult> patientsToResults = new HashMap<>();
-        patientsToResults.put(AMOS, TestResult.POSITIVE);
-        patientsToResults.put(CHARLES, TestResult.POSITIVE);
-        patientsToResults.put(DEXTER, TestResult.POSITIVE);
-        patientsToResults.put(ELIZABETH, TestResult.NEGATIVE);
-        patientsToResults.put(FRANK, TestResult.NEGATIVE);
-        patientsToResults.put(GALE, TestResult.NEGATIVE);
-        patientsToResults.put(HEINRICK, TestResult.NEGATIVE);
-        patientsToResults.put(IAN, TestResult.UNDETERMINED);
-        patientsToResults.put(JANNELLE, TestResult.UNDETERMINED);
-        patientsToResults.put(KACEY, TestResult.UNDETERMINED);
-        patientsToResults.put(LEELOO, TestResult.UNDETERMINED);
+  private static Date convertDate(LocalDateTime dateTime) {
+    return Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
+  }
 
-        Map<PersonName, Date> patientsToDates = new HashMap<>();
-        patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
-        patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
-        patientsToDates.put(DEXTER, convertDate(LocalDateTime.of(2021, 6, 2, 0, 0, 0)));
-        patientsToDates.put(ELIZABETH, convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0)));
-        patientsToDates.put(FRANK, convertDate(LocalDateTime.of(2021, 6, 3, 0, 0, 0)));
-        patientsToDates.put(GALE, convertDate(LocalDateTime.of(2021, 6, 3, 12, 0, 0)));
-        patientsToDates.put(HEINRICK, convertDate(LocalDateTime.of(2021, 6, 4, 0, 0, 0)));
-        patientsToDates.put(IAN, convertDate(LocalDateTime.of(2021, 6, 4, 12, 0, 0)));
-        patientsToDates.put(JANNELLE, convertDate(LocalDateTime.of(2021, 6, 5, 0, 0, 0)));
-        patientsToDates.put(KACEY, convertDate(LocalDateTime.of(2021, 6, 5, 12, 0, 0)));
-        patientsToDates.put(LEELOO, convertDate(LocalDateTime.of(2021, 6, 6, 0, 0, 0)));
+  private TestOrder addTestToQueue() {
+    Organization org = _organizationService.getCurrentOrganization();
+    Person patient = _dataFactory.createFullPerson(org);
+    return addTestToQueue(org, patient);
+  }
 
-        Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
-        patientsToRoles.put(AMOS, PersonRole.RESIDENT);
-        patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
-        patientsToRoles.put(DEXTER, PersonRole.STUDENT);
-        patientsToRoles.put(ELIZABETH, PersonRole.STUDENT);
-        patientsToRoles.put(FRANK, PersonRole.VISITOR);
-        patientsToRoles.put(GALE, PersonRole.VISITOR);
-        patientsToRoles.put(HEINRICK, PersonRole.STAFF);
-        patientsToRoles.put(IAN, PersonRole.STAFF);
-        patientsToRoles.put(JANNELLE, PersonRole.RESIDENT);
-        patientsToRoles.put(KACEY, PersonRole.RESIDENT);
-        patientsToRoles.put(LEELOO, PersonRole.STUDENT);
+  private TestOrder addTestToQueue(Organization org, Person patient) {
+    Facility facility = _organizationService.getFacilities(org).get(0);
+    _personService.updateTestResultDeliveryPreference(
+        patient.getInternalId(), TestResultDeliveryPreference.SMS);
 
-        Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
-        patientsToSurveys.put(
-                AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
-        patientsToSurveys.put(
-                CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
-        patientsToSurveys.put(
-                DEXTER, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
-        patientsToSurveys.put(
-                ELIZABETH, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
-        patientsToSurveys.put(
-                FRANK, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
-        patientsToSurveys.put(
-                GALE, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
-        patientsToSurveys.put(
-                HEINRICK, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
-        patientsToSurveys.put(
-                IAN, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
-        patientsToSurveys.put(
-                JANNELLE, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
-        patientsToSurveys.put(
-                KACEY, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
-        patientsToSurveys.put(
-                LEELOO, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+    TestOrder order =
+        _service.addPatientToQueue(
+            facility.getInternalId(),
+            patient,
+            "",
+            "",
+            Collections.emptyMap(),
+            LocalDate.of(2022, 6, 5),
+            false);
 
-        List<TestEvent> testEvents =
-                patientsToResults.keySet().stream()
-                        .map(
-                                n -> {
-                                    TestResult t = patientsToResults.get(n);
-                                    PersonRole r = patientsToRoles.get(n);
-                                    AskOnEntrySurvey s = patientsToSurveys.get(n);
-                                    Date d = patientsToDates.get(n);
+    facility.setDefaultDeviceTypeSpecimenType(
+        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
 
-                                    Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
-                                    return _dataFactory.createTestEvent(person, _site, s, t, d);
-                                })
-                        .collect(Collectors.toList());
-        // Make one result in another facility
-        Facility _otherSite = _dataFactory.createValidFacility(org, "The Other Facility");
-        _dataFactory.createTestEvent(
-                _dataFactory.createMinimalPerson(org, _otherSite, BRAD), _otherSite, TestResult.NEGATIVE);
-        return testEvents;
-    }
-
-    private List<TestEvent> makeSpecificDiseaseData(SupportedDisease disease) {
-        Organization org = _organizationService.getCurrentOrganization();
-        _site = _dataFactory.createValidFacility(org, "The Facility for " + disease.getName());
-        Map<PersonName, TestResult> patientsToResults = new HashMap<>();
-        patientsToResults.put(AMOS, TestResult.POSITIVE);
-        patientsToResults.put(CHARLES, TestResult.NEGATIVE);
-
-        Map<PersonName, Date> patientsToDates = new HashMap<>();
-        patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
-        patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
-
-        Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
-        patientsToRoles.put(AMOS, PersonRole.RESIDENT);
-        patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
-
-        Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
-        patientsToSurveys.put(
-                AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
-        patientsToSurveys.put(
-                CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
-
-        return patientsToResults.keySet().stream()
-                .map(
-                        n -> {
-                            TestResult t = patientsToResults.get(n);
-                            PersonRole r = patientsToRoles.get(n);
-                            AskOnEntrySurvey s = patientsToSurveys.get(n);
-                            Date d = patientsToDates.get(n);
-
-                            Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
-                            return _dataFactory.createTestEvent(person, _site, s, t, d, disease);
-                        })
-                .collect(Collectors.toList());
-    }
-
-    private List<MultiplexResultInput> makeCovidOnlyResult(TestResult covidTestResult) {
-        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
-        return List.of(covidResult);
-    }
-
-    private List<MultiplexResultInput> makeMultiplexTestResult(
-            TestResult covidTestResult, TestResult fluATestResult, TestResult fluBTestResult) {
-        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
-        MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", fluATestResult);
-        MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", fluBTestResult);
-        return List.of(covidResult, fluAResult, fluBResult);
-    }
-
-    private static void assertTestResultsList(List<TestEvent> found, List<TestEvent> expected) {
-        // check common elements first
-        for (int i = 0; i < expected.size() && i < found.size(); i++) {
-            assertEquals(expected.get(i).getInternalId(), found.get(i).getInternalId());
-        }
-        // *then* check if there are extras
-        if (expected.size() != found.size()) {
-            fail("Expected " + expected.size() + " items but found " + found.size());
-        }
-    }
-
-    private static Date convertDate(LocalDateTime dateTime) {
-        return Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
-    }
-
-    private TestOrder addTestToQueue() {
-        Organization org = _organizationService.getCurrentOrganization();
-        Person patient = _dataFactory.createFullPerson(org);
-        return addTestToQueue(org, patient);
-    }
-
-    private TestOrder addTestToQueue(Organization org, Person patient) {
-        Facility facility = _organizationService.getFacilities(org).get(0);
-        _personService.updateTestResultDeliveryPreference(
-                patient.getInternalId(), TestResultDeliveryPreference.SMS);
-
-        TestOrder order =
-                _service.addPatientToQueue(
-                        facility.getInternalId(),
-                        patient,
-                        "",
-                        "",
-                        Collections.emptyMap(),
-                        LocalDate.of(2022, 6, 5),
-                        false);
-
-        facility.setDefaultDeviceTypeSpecimenType(
-                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-
-        return order;
-    }
+    return order;
+  }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -54,6 +54,7 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleRepo
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportStandardUser;
 import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
+
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -68,6 +69,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -83,2433 +85,2445 @@ import org.springframework.test.context.TestPropertySource;
 @SuppressWarnings("checkstyle:MagicNumber")
 class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
-  @Autowired @SpyBean private OrganizationService _organizationService;
-  @Autowired private PersonService _personService;
-  @Autowired private TestEventRepository _testEventRepository;
-  @Autowired @SpyBean private TestOrderRepository _testOrderRepository;
-  @Autowired private ResultRepository _resultRepository;
-  @Autowired private TestDataFactory _dataFactory;
-  @SpyBean private PatientLinkService patientLinkService;
-  @MockBean private TestResultsDeliveryService testResultsDeliveryService;
-
-  @MockBean(name = "csvQueueReportingService")
-  TestEventReportingService testEventReportingService;
-
-  @MockBean(name = "fhirQueueReportingService")
-  TestEventReportingService fhirQueueReportingService;
-
-  @SpyBean ReportTestEventToRSEventListener reportTestEventToRSEventListener;
-
-  @Captor ArgumentCaptor<TestEvent> testEventArgumentCaptor;
-
-  private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
-  private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
-  private static final PersonName CHARLES = new PersonName("Charles", "Mathew", "Albemarle", "Sr.");
-  private static final PersonName DEXTER = new PersonName("Dexter", null, "Jones", null);
-  private static final PersonName ELIZABETH =
-      new PersonName("Elizabeth", "Martha", "Merriwether", null);
-  private static final PersonName FRANK = new PersonName("Frank", "Mathew", "Bones", "3");
-  private static final PersonName GALE = new PersonName("Gale", "Mary", "Vittorio", "PhD");
-  private static final PersonName HEINRICK = new PersonName("Heinrick", "Mark", "Silver", "III");
-  private static final PersonName IAN = new PersonName("Ian", "Brou", "Rutter", null);
-  private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
-  private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
-  private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
-  private Facility _site;
-
-  @BeforeEach
-  void setupData() {
-    initSampleData();
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void roundTrip() {
-    // GIVEN
-    Facility facility =
-        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-    Person patient =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "English",
-            null,
-            null);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-
-    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
-    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
-
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(1, queue.size());
-
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    // WHEN
-    _service.addMultiplexResult(
-        defaultDeviceType,
-        defaultSpecimenType,
-        positiveCovidOnlyResult,
-        patient.getInternalId(),
-        null);
-
-    // THEN
-    queue = _service.getQueue(facility.getInternalId());
-    assertEquals(0, queue.size());
-
-    List<TestEvent> testEvents =
-        _testEventRepository.findAllByPatientAndFacilities(patient, List.of(facility));
-    assertThat(testEvents).hasSize(1);
-    assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
-    verify(patientLinkService).createPatientLink(any());
-
-    // make sure the corrected event is sent to storage queue
-    verify(testEventReportingService).report(testEventArgumentCaptor.capture());
-    verify(fhirQueueReportingService).report(any());
-    TestEvent sentEvent = testEventArgumentCaptor.getValue();
-    TestResult testResult = sentEvent.getCovidTestResult().get();
-    assertThat(sentEvent.getPatient().getInternalId()).isEqualTo(patient.getInternalId());
-    assertThat(testResult).isEqualTo(TestResult.POSITIVE);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_populateFirstTest() {
-    Facility facility =
-        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-    Person p =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "English",
-            null,
-            null);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    _service.addMultiplexResult(
-        _dataFactory.getGenericDevice().getInternalId(),
-        _dataFactory.getGenericSpecimen().getInternalId(),
-        positiveCovidOnlyResult,
-        p.getInternalId(),
-        null);
-
-    verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
-
-    List<TestEvent> testEvents =
-        _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
-    assertThat(testEvents).hasSize(1);
-    assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1866, 12, 25),
-        false);
-    _service.addMultiplexResult(
-        _dataFactory.getGenericDevice().getInternalId(),
-        _dataFactory.getGenericSpecimen().getInternalId(),
-        positiveCovidOnlyResult,
-        p.getInternalId(),
-        null);
-
-    testEvents = _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
-    assertThat(testEvents).hasSize(2);
-    assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
-    assertThat(testEvents.get(1).getPatientHasPriorTests()).isTrue();
-    verify(testEventReportingService, times(2)).report(any());
-    verify(fhirQueueReportingService, times(2)).report(any());
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void getQueue_standardUser_successDependsOnFacilityAccess() {
-    Facility facility =
-        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-
-    UUID facilityId = facility.getInternalId();
-    assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
-
-    TestUserIdentities.setFacilityAuthorities(facility);
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(0, queue.size());
-  }
-
-  @Test
-  @WithSimpleReportStandardAllFacilitiesUser
-  void addPatientToQueue_standardUserAllFacilities_ok() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "Spanish",
-            null,
-            "Space-faring maverick");
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(1, queue.size());
-  }
-
-  @Test
-  void addPatientToQueue_standardUser_successDependsOnFacilityAccess() {
-    Facility facility =
-        _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
-
-    Person p =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "German",
-            null,
-            "success depends on Fred's access");
-
-    UUID facilityId = facility.getInternalId();
-    Map<String, Boolean> symptoms = Collections.emptyMap();
-    LocalDate symptomOnsetDate = LocalDate.of(1865, 12, 25);
-
-    assertThrows(
-        AccessDeniedException.class,
-        () -> _service.addPatientToQueue(facilityId, p, "", "", symptoms, symptomOnsetDate, false));
-
-    TestUserIdentities.setFacilityAuthorities(facility);
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    TestUserIdentities.setFacilityAuthorities();
-
-    assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
-
-    TestUserIdentities.setFacilityAuthorities(facility);
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(1, queue.size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_orgAdmin_ok() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "French",
-            null,
-            null);
-    _personService.updateTestResultDeliveryPreference(
-        p.getInternalId(), TestResultDeliveryPreference.SMS);
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-
-    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
-    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
-
-    List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
-
-    _service.addMultiplexResult(
-        defaultDeviceType, defaultSpecimenType, positiveCovidResult, p.getInternalId(), null);
-
-    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(0, queue.size());
-    verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
-  }
-
-  @Test
-  @WithSimpleReportStandardAllFacilitiesUser
-  void addTestResult_standardUserAllFacilities_ok() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "Spanish",
-            null,
-            null);
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-
-    UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
-    UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
-
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-
-    _service.addMultiplexResult(
-        defaultDeviceType, defaultSpecimenType, positiveCovidOnlyResult, p.getInternalId(), null);
-
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(0, queue.size());
-    verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void addTestResult_standardUser_successDependsOnFacilityAccess() {
-    Facility facility1 =
-        _dataFactory.createValidFacility(
-            _organizationService.getCurrentOrganization(), "First One");
-
-    TestUserIdentities.setFacilityAuthorities(facility1);
-
-    Person p1 =
-        _personService.addPatient(
-            (UUID) null,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "English",
-            null,
-            null);
-    Person p2 =
-        _personService.addPatient(
-            facility1.getInternalId(),
-            "BAR",
-            "Baz",
-            null,
-            "",
-            "Jr.",
-            LocalDate.of(1900, 1, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STUDENT,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "Spanish",
-            null,
-            null);
-
-    _service.addPatientToQueue(
-        facility1.getInternalId(),
-        p1,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    _service.addPatientToQueue(
-        facility1.getInternalId(),
-        p2,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-
-    TestUserIdentities.setFacilityAuthorities();
-
-    UUID deviceId = _dataFactory.getGenericDevice().getInternalId();
-    UUID specimenId = _dataFactory.getGenericSpecimen().getInternalId();
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    UUID patientTwoId = p2.getInternalId();
-
-    assertThrows(
-        AccessDeniedException.class,
-        () ->
-            _service.addMultiplexResult(
-                deviceId, specimenId, positiveCovidOnlyResult, patientTwoId, null));
-
-    UUID patientOneId = p1.getInternalId();
-    // caller has access to the patient (whose facility is null)
-    // but cannot modify the test order which was created at a non-accessible facility
-    assertThrows(
-        AccessDeniedException.class,
-        () ->
-            _service.addMultiplexResult(
-                deviceId, specimenId, positiveCovidOnlyResult, patientOneId, null));
-
-    // make sure the nothing was sent to storage queue
-    verifyNoInteractions(testEventReportingService);
-
-    TestUserIdentities.setFacilityAuthorities(facility1);
-    _service.addMultiplexResult(
-        deviceId, specimenId, positiveCovidOnlyResult, p1.getInternalId(), null);
-    List<TestOrder> queue = _service.getQueue(facility1.getInternalId());
-    assertEquals(1, queue.size());
-
-    // make sure the corrected event is sent to storage queue
-    verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
-
-    List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
-
-    _service.addMultiplexResult(
-        deviceId, specimenId, negativeCovidResult, p2.getInternalId(), null);
-
-    queue = _service.getQueue(facility1.getInternalId());
-    assertEquals(0, queue.size());
-
-    // make sure the second event is sent to storage queue
-    verify(testEventReportingService, times(2)).report(any());
-    verify(fhirQueueReportingService, times(2)).report(any());
-  }
-
-  @Test
-  @WithSimpleReportEntryOnlyAllFacilitiesUser
-  void addTestResult_entryOnlyUserAllFacilities_ok() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p = _dataFactory.createFullPerson(org);
-    _personService.updateTestResultDeliveryPreference(
-        p.getInternalId(), TestResultDeliveryPreference.SMS);
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    _service.addMultiplexResult(
-        deviceType.getInternalId(),
-        specimenType.getInternalId(),
-        positiveCovidOnlyResult,
-        p.getInternalId(),
-        null);
-
-    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-
-    List<TestOrder> queue = _service.getQueue(facility.getInternalId());
-    assertEquals(0, queue.size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_testAlreadySubmitted_failure() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p = _dataFactory.createFullPerson(org);
-    _personService.updateTestResultDeliveryPreference(
-        p.getInternalId(), TestResultDeliveryPreference.SMS);
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    _service.addMultiplexResult(
-        deviceType.getInternalId(),
-        specimenType.getInternalId(),
-        positiveCovidResult,
-        p.getInternalId(),
-        null);
-    UUID deviceId = deviceType.getInternalId();
-    UUID specimentId = specimenType.getInternalId();
-    UUID patientId = p.getInternalId();
-
-    assertThrows(
-        NonexistentQueueItemException.class,
-        () ->
-            _service.addMultiplexResult(
-                deviceId, specimentId, positiveCovidResult, patientId, null));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_correction() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person p = _dataFactory.createFullPerson(org);
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        p,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    // Create test event for a later correction
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    _service.addMultiplexResult(
-        deviceType.getInternalId(),
-        specimenType.getInternalId(),
-        positiveCovidOnlyResult,
-        p.getInternalId(),
-        null);
-    List<TestEvent> testEvents =
-        _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
-    assertEquals(1, testEvents.size());
-
-    // Mark existing test order as "corrected", re-open as "pending" order status
-    TestEvent originalTestEvent = testEvents.get(0);
-    _service.markAsCorrection(originalTestEvent.getInternalId(), "Cold feet");
-
-    // Issue test correction
-    List<MultiplexResultInput> negativeCovidOnlyResult = makeCovidOnlyResult(TestResult.NEGATIVE);
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            negativeCovidOnlyResult,
-            p.getInternalId(),
-            null);
-
-    TestEvent correctionTestEvent = response.getTestOrder().getTestEvent();
-
-    assertEquals(
-        originalTestEvent.getInternalId(), correctionTestEvent.getPriorCorrectedTestEventId());
-    assertEquals(TestCorrectionStatus.CORRECTED, correctionTestEvent.getCorrectionStatus());
-    assertEquals("Cold feet", correctionTestEvent.getReasonForCorrection());
-    assertEquals(TestResult.NEGATIVE, correctionTestEvent.getCovidTestResult().get());
-    // Date of original test is overwritten by the new correction event
-    assertNotEquals(
-        LocalDate.of(1865, 12, 25),
-        LocalDate.ofInstant(
-            correctionTestEvent.getDateTested().toInstant(), ZoneId.systemDefault()));
-    assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(correctionTestEvent).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(originalTestEvent).size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_smsDelivery() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.SMS);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-    when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
-    when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    assertTrue(res.getDeliverySuccess());
-    ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
-    verify(testResultsDeliveryService).smsTestResults(patientLinkCaptor.capture());
-    assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
-        .isEqualTo(patient.getInternalId());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_smsDelivery_failure() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.SMS);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
-    when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-    assertFalse(res.getDeliverySuccess());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_emailDelivery() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
-    when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    assertTrue(res.getDeliverySuccess());
-    ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
-    verify(testResultsDeliveryService).emailTestResults(patientLinkCaptor.capture());
-    assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
-        .isEqualTo(patient.getInternalId());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_emailDelivery_failure() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(false);
-    when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(false);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
-    assertFalse(res.getDeliverySuccess());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_emailAndSmsDelivery() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.ALL);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-    when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
-    when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
-    verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
-    assertTrue(res.getDeliverySuccess());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_NoTestResultDelivery() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.NONE);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    assertTrue(res.getDeliverySuccess());
-    verifyNoInteractions(testResultsDeliveryService);
-    verify(testEventReportingService).report(any());
-    verify(fhirQueueReportingService).report(any());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_savesResults() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    AddTestResultResponse res =
-        _service.addMultiplexResult(
-            deviceType.getInternalId(),
-            specimenType.getInternalId(),
-            positiveCovidOnlyResult,
-            patient.getInternalId(),
-            null);
-
-    // THEN
-    List<Result> testOrderResults = _resultRepository.findAllByTestOrder(res.getTestOrder());
-    List<Result> testEventResults =
-        _resultRepository.findAllByTestEvent(res.getTestOrder().getTestEvent());
-    assertEquals(1, testOrderResults.size());
-    assertEquals(1, testEventResults.size());
-
-    Result testOrderResult = testOrderResults.get(0);
-    Result testEventResult = testEventResults.get(0);
-
-    // we create two different results, 1 mutable for the testOrder, 1 immutable for the testEvent
-    assertThat(testOrderResult).isNotEqualTo(testEventResult);
-
-    // verify the testOrder Result
-    assertThat(testOrderResult.getTestOrder()).isNotNull();
-    assertThat(testOrderResult.getTestEvent()).isNull();
-    assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
-    assertThat(testOrderResult.getDisease()).isEqualTo(_diseaseService.covid());
-
-    // verify the testEvent Result
-    assertThat(testEventResult.getTestOrder()).isNull();
-    assertThat(testEventResult.getTestEvent()).isNotNull();
-    assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
-    assertThat(testEventResult.getDisease()).isEqualTo(_diseaseService.covid());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void editQueueItemMultiplexResult_worksWithSingleResult() {
-    TestOrder order = addTestToQueue();
-
-    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
-
-    TestOrder updatedOrder =
-        _service.editQueueItemMultiplexResult(
-            order.getInternalId(),
-            _dataFactory.getGenericDevice().getInternalId(),
-            _dataFactory.getGenericSpecimen().getInternalId(),
-            List.of(covidResult),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertEquals(1, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void editQueueItemMultiplexResult_worksWithMultipleResults() {
-    TestOrder order = addTestToQueue();
-
-    TestOrder updatedOrder =
-        _service.editQueueItemMultiplexResult(
-            order.getInternalId(),
-            _dataFactory.getGenericDevice().getInternalId(),
-            _dataFactory.getGenericSpecimen().getInternalId(),
-            makeMultiplexTestResult(TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void editQueueItemMultiplexResult_worksWithEmptyResults() {
-    TestOrder order = addTestToQueue();
-
-    TestOrder updatedOrder =
-        _service.editQueueItemMultiplexResult(
-            order.getInternalId(),
-            _dataFactory.getGenericDevice().getInternalId(),
-            _dataFactory.getGenericSpecimen().getInternalId(),
-            List.of(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertTrue(_service.getTestOrder(updatedOrder.getInternalId()).getResults().isEmpty());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addMultiplexResult_multipleEditsBeforeSubmissionSuccessful() {
-    TestOrder order = addTestToQueue();
-
-    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
-    MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", TestResult.NEGATIVE);
-    MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", TestResult.NEGATIVE);
-
-    _service.editQueueItemMultiplexResult(
-        order.getInternalId(),
-        _dataFactory.getGenericDevice().getInternalId(),
-        _dataFactory.getGenericSpecimen().getInternalId(),
-        List.of(covidResult, fluAResult, fluBResult),
-        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    MultiplexResultInput updatedCovidResult =
-        new MultiplexResultInput("COVID-19", TestResult.NEGATIVE);
-    TestOrder updatedOrder =
-        _service.editQueueItemMultiplexResult(
-            order.getInternalId(),
-            _dataFactory.getGenericDevice().getInternalId(),
-            _dataFactory.getGenericSpecimen().getInternalId(),
-            List.of(updatedCovidResult, fluAResult, fluBResult),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
-
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            updatedOrder.getDeviceType().getInternalId(),
-            updatedOrder.getSpecimenType().getInternalId(),
-            List.of(updatedCovidResult, fluAResult, fluBResult),
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertEquals(3, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void multiplexResultMutations_covidOnlyCorrectionSuccessful() {
-    TestOrder order = addTestToQueue();
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            order.getDeviceType().getInternalId(),
-            order.getSpecimenType().getInternalId(),
-            List.of(new MultiplexResultInput("COVID-19", TestResult.POSITIVE)),
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-    _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
-
-    AddTestResultResponse correctedResponse =
-        _service.addMultiplexResult(
-            order.getDeviceType().getInternalId(),
-            order.getSpecimenType().getInternalId(),
-            List.of(new MultiplexResultInput("COVID-19", TestResult.NEGATIVE)),
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertEquals(1, _resultRepository.findAllByTestOrder(order).size());
-    assertEquals(
-        1,
-        _resultRepository
-            .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
-            .size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void multiplexResultMutations_multiplexCorrectionSuccessful() {
-
-    List<MultiplexResultInput> originalResults =
-        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.POSITIVE);
-
-    TestOrder order = addTestToQueue();
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            order.getDeviceType().getInternalId(),
-            order.getSpecimenType().getInternalId(),
-            originalResults,
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-    _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
-
-    List<MultiplexResultInput> correctedResults =
-        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE);
-
-    AddTestResultResponse correctedResponse =
-        _service.addMultiplexResult(
-            order.getDeviceType().getInternalId(),
-            order.getSpecimenType().getInternalId(),
-            correctedResults,
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
-    assertEquals(
-        3,
-        _resultRepository
-            .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
-            .size());
-    assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void multiplexResultMutations_removalSuccessful() {
-    List<MultiplexResultInput> originalResults =
-        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
-
-    TestOrder order = addTestToQueue();
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            order.getDeviceType().getInternalId(),
-            order.getSpecimenType().getInternalId(),
-            originalResults,
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-    TestEvent removedEvent = _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
-
-    assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
-    assertEquals(3, _resultRepository.findAllByTestEvent(removedEvent).size());
-    assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void fetchTestEventsResults_standardUser_successDependsOnFacilityAccess() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createTestEvent(p, facility);
-    UUID facilityId = facility.getInternalId();
-
-    assertThrows(
-        AccessDeniedException.class,
-        () ->
-            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
-
-    TestUserIdentities.setFacilityAuthorities(facility);
-    _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 10);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void fetchTestEventsAtArchivedFacility_orgAdminUser_ok() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createTestEvent(p, facility);
-
-    Page<TestEvent> testEventsByFacility =
-        _service.getFacilityTestEventsResults(
-            facility.getInternalId(), null, null, null, null, null, 0, 10);
-    assertThat(testEventsByFacility.getTotalElements()).isEqualTo(1);
-    assertThat(testEventsByFacility.getTotalPages()).isEqualTo(1);
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void fetchTestEventsAtArchivedFacility_standardUser_failure() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createTestEvent(p, facility);
-    UUID facilityId = facility.getInternalId();
-
-    assertThrows(
-        AccessDeniedException.class,
-        () ->
-            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void fetchAllFacilityTestEventsResults_orgAdminUser_ok() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createTestEvent(p, facility);
-
-    Page<TestEvent> testEventsByOrg =
-        _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
-    assertThat(testEventsByOrg.getTotalElements()).isEqualTo(1);
-    assertThat(testEventsByOrg.getTotalPages()).isEqualTo(1);
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void fetchAllFacilityTestEventsResults_standardUser_failure() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createTestEvent(p, facility);
-
-    assertThrows(
-        AccessDeniedException.class,
-        () -> _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10));
-  }
-
-  @Test
-  @WithSimpleReportStandardUser
-  void fetchTestResults_standardUser_successDependsOnFacilityAccess() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility f1 = _dataFactory.createValidFacility(org, "First One");
-    Facility f2 = _dataFactory.createValidFacility(org, "Second One");
-    Person p1 = _dataFactory.createMinimalPerson(org, f1);
-    Person p2 = _dataFactory.createMinimalPerson(org);
-    _dataFactory.createTestEvent(p1, f1);
-    _dataFactory.createTestEvent(p2, f1);
-    _dataFactory.createTestEvent(p2, f2);
-
-    assertThrows(AccessDeniedException.class, () -> _service.getTestResults(p1));
-    // filters out all test results from inaccessible facilities, but we can still
-    // request test results for a patient whose own facility is null
-    assertEquals(0, _service.getTestResults(p2).size());
-
-    TestUserIdentities.setFacilityAuthorities(f1);
-    assertEquals(1, _service.getTestResults(p1).size());
-    // filters out all test results from inaccessible facilities
-    assertEquals(1, _service.getTestResults(p2).size());
-
-    TestUserIdentities.setFacilityAuthorities(f1, f2);
-    assertEquals(1, _service.getTestResults(p1).size());
-    assertEquals(2, _service.getTestResults(p2).size());
-  }
-
-  @Test
-  @WithSimpleReportEntryOnlyUser
-  void fetchTestResults_entryOnlyUser_error() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person p = _dataFactory.createFullPerson(org);
-    _dataFactory.createTestEvent(p, facility);
-
-    // https://github.com/CDCgov/prime-simplereport/issues/677
-    // assertSecurityError(() ->
-    // _service.getTestResults(facility.getInternalId()));
-    assertSecurityError(() -> _service.getTestResults(p));
-  }
-
-  // watch for N+1 queries
-  @Test
-  @WithSimpleReportStandardAllFacilitiesUser
-  void fetchTestEventsResults_getTestEventsResults_NPlusOne() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person p = _dataFactory.createFullPerson(org);
-
-    // add some initial data
-    _dataFactory.createTestEvent(p, facility);
-    _dataFactory.createTestEvent(p, facility);
-
-    // count queries
-    long startQueryCount = QueryCountService.get().getSelect();
-    _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 50);
-    long firstPassTotal = QueryCountService.get().getSelect() - startQueryCount;
-
-    // add more data
-    _dataFactory.createTestEvent(p, facility);
-    _dataFactory.createTestEvent(p, facility);
-    _dataFactory.createTestEvent(p, facility);
-    _dataFactory.createTestEvent(p, facility);
-    _dataFactory.createTestEvent(p, facility);
-
-    // count queries again and make sure queries made didn't increase
-    startQueryCount = QueryCountService.get().getSelect();
-    _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 50);
-    long secondPassTotal = QueryCountService.get().getSelect() - startQueryCount;
-    assertEquals(firstPassTotal, secondPassTotal);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void editTestResult_getQueue_NPlusOne() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    UUID facilityId = facility.getInternalId();
-
-    Person p1 =
-        _personService.addPatient(
-            facilityId,
-            "FOO",
-            "Fred",
-            null,
-            "",
-            "Sr.",
-            LocalDate.of(1865, 12, 25),
-            getAddress(),
-            "USA",
-            TestDataFactory.getListOfOnePhoneNumber(),
-            PersonRole.STAFF,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "Spanish",
-            null,
-            null);
-
-    _service.addPatientToQueue(
-        facilityId, p1, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
-
-    // get the first query count
-    long startQueryCount = QueryCountService.get().getSelect();
-    _service.getQueue(facility.getInternalId());
-    long firstRunCount = QueryCountService.get().getSelect() - startQueryCount;
-
-    for (int ii = 0; ii < 2; ii++) {
-      // add more tests to the queue. (which needs more patients)
-      Person p =
-          _personService.addPatient(
-              facilityId,
-              "FOO",
-              "Fred",
-              null,
-              "",
-              "Sr.",
-              LocalDate.of(1865, 12, 25),
-              getAddress(),
-              "USA",
-              TestDataFactory.getListOfOnePhoneNumber(),
-              PersonRole.STAFF,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              false,
-              false,
-              "French",
-              null,
-              null);
-
-      _service.addPatientToQueue(
-          facilityId, p, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+    @Autowired
+    @SpyBean
+    private OrganizationService _organizationService;
+    @Autowired
+    private PersonService _personService;
+    @Autowired
+    private TestEventRepository _testEventRepository;
+    @Autowired
+    @SpyBean
+    private TestOrderRepository _testOrderRepository;
+    @Autowired
+    private ResultRepository _resultRepository;
+    @Autowired
+    private TestDataFactory _dataFactory;
+    @SpyBean
+    private PatientLinkService patientLinkService;
+    @MockBean
+    private TestResultsDeliveryService testResultsDeliveryService;
+
+    @MockBean(name = "csvQueueReportingService")
+    TestEventReportingService testEventReportingService;
+
+    @MockBean(name = "fhirQueueReportingService")
+    TestEventReportingService fhirQueueReportingService;
+
+    @SpyBean
+    ReportTestEventToRSEventListener reportTestEventToRSEventListener;
+
+    @Captor
+    ArgumentCaptor<TestEvent> testEventArgumentCaptor;
+
+    private static final PersonName AMOS = new PersonName("Amos", null, "Quint", null);
+    private static final PersonName BRAD = new PersonName("Bradley", "Z.", "Jones", "Jr.");
+    private static final PersonName CHARLES = new PersonName("Charles", "Mathew", "Albemarle", "Sr.");
+    private static final PersonName DEXTER = new PersonName("Dexter", null, "Jones", null);
+    private static final PersonName ELIZABETH =
+            new PersonName("Elizabeth", "Martha", "Merriwether", null);
+    private static final PersonName FRANK = new PersonName("Frank", "Mathew", "Bones", "3");
+    private static final PersonName GALE = new PersonName("Gale", "Mary", "Vittorio", "PhD");
+    private static final PersonName HEINRICK = new PersonName("Heinrick", "Mark", "Silver", "III");
+    private static final PersonName IAN = new PersonName("Ian", "Brou", "Rutter", null);
+    private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
+    private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
+    private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
+    private Facility _site;
+
+    @BeforeEach
+    void setupData() {
+        initSampleData();
     }
 
-    startQueryCount = QueryCountService.get().getSelect();
-    _service.getQueue(facility.getInternalId());
-    long secondRunCount = QueryCountService.get().getSelect() - startQueryCount;
-    assertEquals(firstRunCount, secondRunCount);
-  }
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void roundTrip() {
+        // GIVEN
+        Facility facility =
+                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+        Person patient =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "English",
+                        null,
+                        null);
 
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void markAsErrorTest() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person person = _dataFactory.createFullPerson(org);
-    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
-    assertNotNull(deleteMarkerEvent);
-
-    assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
-    assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
-
-    assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
-
-    List<TestEvent> events_before =
-        _service
-            .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50)
-            .toList();
-    assertEquals(1, events_before.size());
-
-    // verify the original order was updated
-    TestEvent refreshedTestResult = _service.getTestResult(testEvent.getInternalId());
-    TestOrder onlySavedOrder = refreshedTestResult.getTestOrder();
-    TestEvent mostRecentEvent = onlySavedOrder.getTestEvent();
-    assertEquals(reasonMsg, onlySavedOrder.getReasonForCorrection());
-    assertEquals(deleteMarkerEvent.getInternalId(), mostRecentEvent.getInternalId());
-    assertEquals(TestCorrectionStatus.REMOVED, onlySavedOrder.getCorrectionStatus());
-
-    // make sure the original item is removed from the result and ONLY the
-    // "corrected" removed one is shown
-    List<TestEvent> events_after =
-        _service
-            .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50)
-            .toList();
-    assertEquals(1, events_after.size());
-    assertEquals(
-        deleteMarkerEvent.getInternalId().toString(),
-        events_after.get(0).getInternalId().toString());
-
-    // verify that a Result object is created for the original and new TestEvent and one for the
-    // TestOrder
-    assertEquals(1, _resultRepository.findAllByTestOrder(onlySavedOrder).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(mostRecentEvent).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(deleteMarkerEvent).size());
-
-    // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
-    // to report stream
-    verify(testEventReportingService).report(deleteMarkerEvent);
-    verify(fhirQueueReportingService).report(any());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void markAsErrorTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceType device = _dataFactory.getGenericDevice();
-    SpecimenType specimen = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
-    Person person = _dataFactory.createFullPerson(org);
-    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-    facility.getAddress().setState("ND");
-    _organizationService.updateFacility(
-        facility.getInternalId(),
-        facility.getFacilityName(),
-        facility.getCliaNumber(),
-        facility.getAddress(),
-        facility.getTelephone(),
-        facility.getEmail(),
-        facility.getOrderingProvider().getNameInfo(),
-        facility.getOrderingProvider().getAddress(),
-        facility.getOrderingProvider().getProviderId(),
-        facility.getOrderingProvider().getTelephone(),
-        facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
-
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    TestEvent deletedTest = _service.markAsError(testEvent.getInternalId(), reasonMsg);
-
-    assertEquals(deletedTest.getDeviceType().getInternalId(), device.getInternalId());
-    assertEquals(deletedTest.getSpecimenType().getInternalId(), specimen.getInternalId());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void correctionsTest() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person p = _dataFactory.createFullPerson(org);
-    TestEvent e = _dataFactory.createTestEvent(p, facility);
-
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-
-    // A test correction call just returns the original TestEvent...
-    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
-
-    // ...but re-opens the original TestOrder and updates correction status
-    TestOrder updatedOrder = originalEvent.getTestOrder();
-    assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
-    assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
-    assertEquals(e.getInternalId(), updatedOrder.getTestEvent().getInternalId());
-    assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
-
-    // Unlike marking a test as deleted, which immediately creates a second TestEvent
-    // that represents the removal, a test correction does not result in another
-    // TestEvent being generated and saved
-    long testEventCount = _testEventRepository.count();
-    assertEquals(1, testEventCount);
-
-    // Does not report to ReportStream
-    verify(testEventReportingService, times(0)).report(e);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void markAsErrorTest_backwardCompatible() {
-    // GIVEN
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person person = _dataFactory.createFullPerson(org);
-    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-    // ensure the Result will have both testEvent and testOrder populated
-    _resultRepository.deleteAll(testEvent.getOrder().getResults());
-    Set<Result> results = testEvent.getResults();
-    results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
-    _resultRepository.saveAll(results);
-
-    // assert that we have the same Result object for both testEvent and testOrder
-    List<Result> allOldResultsByTestOrder =
-        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-    List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-    assertEquals(1, allOldResultsByTestEvent.size());
-    assertEquals(1, allOldResultsByTestOrder.size());
-    Result testOrderOldResult = allOldResultsByTestOrder.get(0);
-    Result testEventOldResult = allOldResultsByTestEvent.get(0);
-    assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
-
-    // WHEN
-    TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
-
-    // THEN
-    assertNotNull(deleteMarkerEvent);
-
-    assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
-    assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
-
-    assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
-
-    // assert that we have two Result objects for both testEvent and testOrder
-    List<Result> allResultsByTestOrder =
-        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-    List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-    assertEquals(1, allResultsByTestOrder.size());
-    assertEquals(1, allResultsByTestEvent.size());
-
-    Result testOrderResult = allResultsByTestOrder.get(0);
-    Result testEventResult = allResultsByTestEvent.get(0);
-    assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
-
-    assertThat(testEventResult.getTestOrder()).isNull();
-    assertThat(testEventResult.getTestEvent()).isNotNull();
-
-    assertThat(testOrderResult.getTestOrder()).isNotNull();
-    assertThat(testOrderResult.getTestEvent()).isNull();
-
-    assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-    assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void correctionsTest_backwardCompatible() {
-    // GIVEN
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person person = _dataFactory.createFullPerson(org);
-    TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
-
-    // ensure the Result will have both testEvent and testOrder populated
-    _resultRepository.deleteAll(testEvent.getOrder().getResults());
-    Set<Result> results = testEvent.getResults();
-    results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
-    _resultRepository.saveAll(results);
-
-    // assert that we have the same Result object for both testEvent and testOrder
-    List<Result> allOldResultsByTestOrder =
-        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-    List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-    assertEquals(1, allOldResultsByTestEvent.size());
-    assertEquals(1, allOldResultsByTestOrder.size());
-    Result testOrderOldResult = allOldResultsByTestOrder.get(0);
-    Result testEventOldResult = allOldResultsByTestEvent.get(0);
-    assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
-
-    // WHEN
-    TestEvent originalEvent = _service.markAsCorrection(testEvent.getInternalId(), reasonMsg);
-
-    // THEN
-    TestOrder updatedOrder = originalEvent.getTestOrder();
-    assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
-    assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
-    assertEquals(testEvent.getInternalId(), updatedOrder.getTestEvent().getInternalId());
-    assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
-
-    // assert that we have two Result objects for both testEvent and testOrder
-    List<Result> allResultsByTestOrder =
-        _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
-    List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
-    assertEquals(1, allResultsByTestOrder.size());
-    assertEquals(1, allResultsByTestEvent.size());
-
-    Result testOrderResult = allResultsByTestOrder.get(0);
-    Result testEventResult = allResultsByTestEvent.get(0);
-    assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
-
-    assertThat(testEventResult.getTestOrder()).isNull();
-    assertThat(testEventResult.getTestEvent()).isNotNull();
-
-    assertThat(testOrderResult.getTestOrder()).isNotNull();
-    assertThat(testOrderResult.getTestEvent()).isNull();
-
-    assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-    assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void correctTest_backDatedFromCurrentDate() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person p = _dataFactory.createFullPerson(org);
-    TestEvent e = _dataFactory.createTestEvent(p, facility);
-
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-
-    assertNull(e.getTestOrder().getDateTestedBackdate());
-
-    // A test correction call just returns the original TestEvent...
-    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
-
-    assertEquals(e.getDateTested(), originalEvent.getTestOrder().getDateTestedBackdate());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void correctTest_backdatePreserved() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
-    Person p = _dataFactory.createFullPerson(org);
-
-    LocalDate localDate = LocalDate.of(2022, 1, 1);
-    Date dateTested = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
-    TestEvent e = _dataFactory.createTestEvent(p, facility, null, TestResult.POSITIVE, dateTested);
-
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-
-    TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
-    assertEquals(0, originalEvent.getTestOrder().getDateTestedBackdate().compareTo(dateTested));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void correctTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceType device = _dataFactory.getGenericDevice();
-    SpecimenType specimen = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
-    Person p = _dataFactory.createFullPerson(org);
-    TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
-
-    facility.getAddress().setState("ND");
-    _organizationService.updateFacility(
-        facility.getInternalId(),
-        facility.getFacilityName(),
-        facility.getCliaNumber(),
-        facility.getAddress(),
-        facility.getTelephone(),
-        facility.getEmail(),
-        facility.getOrderingProvider().getNameInfo(),
-        facility.getOrderingProvider().getAddress(),
-        facility.getOrderingProvider().getProviderId(),
-        facility.getOrderingProvider().getTelephone(),
-        facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
-
-    // Re-open the original test as a correction
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
-
-    // Re-submit the corrected test
-    List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            device.getInternalId(),
-            specimen.getInternalId(),
-            correctedTestResult,
-            p.getInternalId(),
-            null);
-    TestEvent correctedEvent = response.getTestOrder().getTestEvent();
-    assertEquals(correctedEvent.getDeviceType().getInternalId(), device.getInternalId());
-    assertEquals(correctedEvent.getSpecimenType().getInternalId(), specimen.getInternalId());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void removeACorrectedTest_success() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    DeviceType device = _dataFactory.getGenericDevice();
-    SpecimenType specimen = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(device, specimen);
-    Person p = _dataFactory.createFullPerson(org);
-    TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
-
-    // Re-open the original test as a correction
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
-
-    // Re-submit the corrected test
-    List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            device.getInternalId(),
-            specimen.getInternalId(),
-            correctedTestResult,
-            p.getInternalId(),
-            null);
-    TestEvent correctedEvent = response.getTestOrder().getTestEvent();
-
-    assertEquals(
-        2, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
-    assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
-
-    // Now mark the corrected test as an error
-    String removalMsg = "I changed my mind, remove this test " + LocalDateTime.now();
-    TestEvent deleteCorrectedEvent =
-        _service.markAsError(correctedEvent.getInternalId(), removalMsg);
-
-    // There should only be a single TestOrder, but three TestEvents - the original, the corrected,
-    // and the removed
-    // There should also be exactly 4 Result objects, 1 for the order, and 1 per each TestEvent
-    assertEquals(
-        3, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
-    assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
-    assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(correctedEvent).size());
-    assertEquals(1, _resultRepository.findAllByTestEvent(deleteCorrectedEvent).size());
-
-    TestOrder order = deleteCorrectedEvent.getTestOrder();
-    assertEquals(TestCorrectionStatus.REMOVED, order.getCorrectionStatus());
-    assertEquals(removalMsg, order.getReasonForCorrection());
-    assertEquals(deleteCorrectedEvent.getInternalId(), order.getTestEvent().getInternalId());
-    assertEquals(OrderStatus.COMPLETED, order.getOrderStatus());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestEventsResults_pagination() {
-    List<TestEvent> testEvents = makedata();
-    List<TestEvent> results_page0 =
-        _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 0, 5)
-            .toList();
-    List<TestEvent> results_page1 =
-        _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 1, 5)
-            .toList();
-    List<TestEvent> results_page2 =
-        _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 2, 5)
-            .toList();
-    List<TestEvent> results_page3 =
-        _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 3, 5)
-            .toList();
-
-    Collections.reverse(testEvents);
-
-    assertTestResultsList(results_page0, testEvents.subList(0, 5));
-    assertTestResultsList(results_page1, testEvents.subList(5, 10));
-    assertTestResultsList(results_page2, testEvents.subList(10, 11));
-    assertEquals(0, results_page3.size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestEventsResults_filtering() {
-    List<TestEvent> testEvents = makedata();
-    List<TestEvent> positives =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(), null, TestResult.POSITIVE, null, null, null, 0, 10)
-            .toList();
-    List<TestEvent> negatives =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10)
-            .toList();
-    List<TestEvent> inconclusives =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(), null, TestResult.UNDETERMINED, null, null, null, 0, 10)
-            .toList();
-    List<TestEvent> students =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(), null, null, PersonRole.STUDENT, null, null, 0, 10)
-            .toList();
-    List<TestEvent> visitors =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(), null, null, PersonRole.VISITOR, null, null, 0, 10)
-            .toList();
-    List<TestEvent> june1to3 =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(),
-                null,
-                null,
-                null,
-                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
-                convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59)),
-                0,
-                10)
-            .toList();
-    List<TestEvent> priorToJune2Noon =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(),
-                null,
-                null,
-                null,
-                null,
-                convertDate(LocalDateTime.of(2021, 6, 2, 11, 59, 59)),
-                0,
-                10)
-            .toList();
-    List<TestEvent> positivesAmos =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(),
-                _dataFactory.getPersonByName(AMOS).getInternalId(),
-                TestResult.POSITIVE,
-                null,
-                null,
-                null,
-                0,
-                10)
-            .toList();
-    List<TestEvent> negativesAmos =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(),
-                _dataFactory.getPersonByName(AMOS).getInternalId(),
-                TestResult.NEGATIVE,
-                null,
-                null,
-                null,
-                0,
-                10)
-            .toList();
-    List<TestEvent> allFilters =
-        _service
-            .getFacilityTestEventsResults(
-                _site.getInternalId(),
-                _dataFactory.getPersonByName(CHARLES).getInternalId(),
-                TestResult.POSITIVE,
-                PersonRole.RESIDENT,
-                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
-                convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59)),
-                0,
-                10)
-            .toList();
-
-    Collections.reverse(testEvents);
-
-    assertTestResultsList(
-        positives,
-        testEvents.stream()
-            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.POSITIVE)
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        negatives,
-        testEvents.stream()
-            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE)
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        inconclusives,
-        testEvents.stream()
-            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.UNDETERMINED)
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        students,
-        testEvents.stream()
-            .filter(t -> t.getPatient().getRole() == PersonRole.STUDENT)
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        visitors,
-        testEvents.stream()
-            .filter(t -> t.getPatient().getRole() == PersonRole.VISITOR)
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        june1to3,
-        testEvents.stream()
-            .filter(
-                t ->
-                    !t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
-                        && !t.getDateTested()
-                            .after(convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59))))
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        priorToJune2Noon,
-        testEvents.stream()
-            .filter(
-                t -> t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0))))
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        positivesAmos,
-        testEvents.stream()
-            .filter(
-                t ->
-                    t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
-                        && t.getPatient().getNameInfo().equals(AMOS))
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        negativesAmos,
-        testEvents.stream()
-            .filter(
-                t ->
-                    t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE
-                        && t.getPatient().getNameInfo().equals(AMOS))
-            .collect(Collectors.toList()));
-    assertTestResultsList(
-        allFilters,
-        testEvents.stream()
-            .filter(
-                t ->
-                    t.getPatient().getNameInfo().equals(CHARLES)
-                        && t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
-                        && t.getPatient().getRole() == PersonRole.RESIDENT
-                        && !t.getDateTested()
-                            .before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
-                        && !t.getDateTested()
-                            .after(convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59))))
-            .collect(Collectors.toList()));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestEventsResults_withMultiplex_returnsOnlyOneEvent() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createMultiplexTestEvent(
-        p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
-
-    var res =
-        _service
-            .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 10)
-            .toList();
-    assertEquals(1, res.size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestEventsResults_withMultiplexAndCovid_returnsOnlyTwoEvent() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    _dataFactory.createTestEvent(p, facility);
-    _dataFactory.createMultiplexTestEvent(
-        p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
-
-    var res =
-        _service
-            .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 10)
-            .toList();
-    assertEquals(2, res.size());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestEventsResults_withResultFilter_returnsFluAndCovidNegatives() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
-    Person p = _dataFactory.createMinimalPerson(org, facility);
-    var notExpected_allPos =
-        _dataFactory.createMultiplexTestEvent(
-            p, facility, TestResult.POSITIVE, TestResult.POSITIVE, TestResult.POSITIVE, false);
-    var expected_allNeg =
-        _dataFactory.createMultiplexTestEvent(
-            p, facility, TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
-    var expected_covidPos =
-        _dataFactory.createMultiplexTestEvent(
-            p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
-
-    var res =
-        _service.getFacilityTestEventsResults(
-            facility.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10);
-
-    var expected = List.of(expected_allNeg.getInternalId(), expected_covidPos.getInternalId());
-    var actualInternalIds = res.stream().map(TestEvent::getInternalId).collect(Collectors.toList());
-    assertTrue(actualInternalIds.containsAll(expected));
-    assertEquals(expected.size(), actualInternalIds.size());
-    assertFalse(actualInternalIds.contains(notExpected_allPos.getInternalId()));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestResultsCount() {
-    makedata();
-    int size =
-        _service.getTestResultsCount(_site.getInternalId(), null, null, null, null, null, null);
-    assertEquals(11, size);
-  }
-
-  @Test
-  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-  void getTestResultsCount_forOrganization() {
-    var testEvents = makeAdminData();
-    var orgId = testEvents.get(0).getOrganization().getInternalId();
-    int size = _service.getTestResultsCount(null, null, null, null, null, null, orgId);
-    assertEquals(4, size);
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTestResultsCount_forOrganization_failsForNonSiteAdmins() {
-    var otherOrgId = UUID.randomUUID();
-    assertThrows(
-        AccessDeniedException.class,
-        () -> _service.getTestResultsCount(null, null, null, null, null, null, otherOrgId));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getOrganizationLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
-    makedata();
-    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-    OrganizationLevelDashboardMetrics metrics =
-        _service.getOrganizationLevelDashboardMetrics(startDate, endDate);
-    assertEquals(3, metrics.getOrganizationPositiveTestCount());
-    assertEquals(12, metrics.getOrganizationTotalTestCount());
-    assertEquals(5, metrics.getOrganizationNegativeTestCount());
-    assertEquals(4, metrics.getFacilityMetrics().size());
-  }
-
-  @Test
-  @WithSimpleReportStandardAllFacilitiesUser
-  void getOrganizationLevelDashboardMetrics_inOrgWithStandardUser_failure() {
-    makedata();
-    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-    assertThrows(
-        AccessDeniedException.class,
-        () -> _service.getOrganizationLevelDashboardMetrics(startDate, endDate));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTopLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
-    makedata();
-    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-    TopLevelDashboardMetrics metrics =
-        _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19");
-    assertEquals(3, metrics.getPositiveTestCount());
-    assertEquals(12, metrics.getTotalTestCount());
-  }
-
-  @Test
-  @WithSimpleReportStandardAllFacilitiesUser
-  void getTopLevelDashboardMetrics_inOrgWithStandardUser_failure() {
-    makedata();
-    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-    assertThrows(
-        AccessDeniedException.class,
-        () -> _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19"));
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void getTopLevelDashboardMetrics_showsNonCovidResults() {
-    makedata();
-    makeSpecificDiseaseData(_diseaseService.fluA());
-    Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
-    Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
-
-    TopLevelDashboardMetrics metrics =
-        _service.getTopLevelDashboardMetrics(null, startDate, endDate, "Flu A");
-    assertEquals(1, metrics.getPositiveTestCount());
-    assertEquals(2, metrics.getTotalTestCount());
-  }
-
-  @Test
-  void markAsErrorTest_successDependsOnFacilityAccess() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _dataFactory.createValidFacility(org);
-    Person p = _dataFactory.createFullPerson(org);
-    TestEvent _e = _dataFactory.createTestEvent(p, facility);
-
-    String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
-    UUID facilityId = facility.getInternalId();
-    UUID testEventId = _e.getInternalId();
-
-    assertThrows(AccessDeniedException.class, () -> _service.markAsError(testEventId, reasonMsg));
-    assertThrows(
-        AccessDeniedException.class,
-        () ->
-            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
-    assertThrows(AccessDeniedException.class, () -> _service.getTestResult(testEventId));
-
-    // make sure the corrected event is not sent to storage queue
-    verifyNoInteractions(testEventReportingService);
-    verifyNoInteractions(fhirQueueReportingService);
-
-    TestUserIdentities.setFacilityAuthorities(facility);
-    TestEvent correctedTestEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
-    _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 10);
-    _service.getTestResult(_e.getInternalId()).getTestOrder();
-    // make sure the corrected event is sent to storage queue
-    verify(testEventReportingService).report(correctedTestEvent);
-    verify(fhirQueueReportingService).report(any());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void removeFromQueueByFacilityId_notAuthorizedError() {
-    UUID facilityId = UUID.randomUUID();
-    assertThrows(
-        AccessDeniedException.class, () -> _service.removeFromQueueByFacilityId(facilityId));
-  }
-
-  @Test
-  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-  void removeFromQueueByFacilityId_facilityNotFoundError() {
-    UUID facilityId = UUID.randomUUID();
-    when(this._organizationService.getFacilityById(facilityId)).thenReturn(Optional.empty());
-    assertThrows(
-        IllegalGraphqlArgumentException.class,
-        () -> _service.removeFromQueueByFacilityId(facilityId));
-  }
-
-  @Test
-  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-  void removeFromQueueByFacilityId_success() {
-    UUID facilityId = UUID.randomUUID();
-    Facility mockFacility = mock(Facility.class);
-    List<TestOrder> mockOrders = List.of();
-    doReturn(Optional.of(mockFacility)).when(this._organizationService).getFacilityById(facilityId);
-    doReturn(mockOrders).when(_testOrderRepository).fetchQueueItemsByFacilityId(mockFacility);
-    ArgumentCaptor<List<TestOrder>> ordersCaptor = ArgumentCaptor.forClass(List.class);
-    doReturn(null).when(_testOrderRepository).saveAll(ordersCaptor.capture());
-
-    _service.removeFromQueueByFacilityId(facilityId);
-    assertEquals(mockOrders, ordersCaptor.getValue());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void addTestResult_sentToReportingService() {
-    // GIVEN
-    Organization org = _organizationService.getCurrentOrganization();
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    Person patient = _dataFactory.createFullPerson(org);
-
-    _service.addPatientToQueue(
-        facility.getInternalId(),
-        patient,
-        "",
-        "",
-        Collections.emptyMap(),
-        LocalDate.of(1865, 12, 25),
-        false);
-    DeviceType deviceType = _dataFactory.getGenericDevice();
-    SpecimenType specimenType = _dataFactory.getGenericSpecimen();
-    facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
-
-    // WHEN
-    List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
-    _service.addMultiplexResult(
-        deviceType.getInternalId(),
-        specimenType.getInternalId(),
-        positiveCovidOnlyResult,
-        patient.getInternalId(),
-        null);
-
-    // THEN
-    verify(reportTestEventToRSEventListener, times(1)).handleEvent(any());
-    verify(testEventReportingService, times(1)).report(any());
-  }
-
-  @Test
-  @WithSimpleReportOrgAdminUser
-  void removeTest_sentToReportingService() {
-    // GIVEN
-    List<MultiplexResultInput> originalResults =
-        makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
-
-    TestOrder order = addTestToQueue();
-    AddTestResultResponse response =
-        _service.addMultiplexResult(
-            order.getDeviceType().getInternalId(),
-            order.getSpecimenType().getInternalId(),
-            originalResults,
-            order.getPatient().getInternalId(),
-            convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
-
-    TestEvent originalEvent = response.getTestOrder().getTestEvent();
-
-    // WHEN
-    _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
-
-    // THEN
-    // Invoked once when result is added, invoked again when marked as error
-    verify(reportTestEventToRSEventListener, times(2)).handleEvent(any());
-    verify(testEventReportingService, times(2)).report(any());
-  }
-
-  private List<TestEvent> makeAdminData() {
-    var org = _organizationService.createOrganization("Da Org", "airport", "da-org-airport");
-    _organizationService.setIdentityVerified("da-org-airport", true);
-    var facility = _dataFactory.createValidFacility(org, "Da Facilitiy");
-    var person = _dataFactory.createMinimalPerson(org);
-    return List.of(
-        _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
-        _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
-        _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE),
-        _dataFactory.createTestEvent(person, facility, TestResult.UNDETERMINED));
-  }
-
-  private List<TestEvent> makedata() {
-    Organization org = _organizationService.getCurrentOrganization();
-    _site = _dataFactory.createValidFacility(org, "The Facility");
-    Map<PersonName, TestResult> patientsToResults = new HashMap<>();
-    patientsToResults.put(AMOS, TestResult.POSITIVE);
-    patientsToResults.put(CHARLES, TestResult.POSITIVE);
-    patientsToResults.put(DEXTER, TestResult.POSITIVE);
-    patientsToResults.put(ELIZABETH, TestResult.NEGATIVE);
-    patientsToResults.put(FRANK, TestResult.NEGATIVE);
-    patientsToResults.put(GALE, TestResult.NEGATIVE);
-    patientsToResults.put(HEINRICK, TestResult.NEGATIVE);
-    patientsToResults.put(IAN, TestResult.UNDETERMINED);
-    patientsToResults.put(JANNELLE, TestResult.UNDETERMINED);
-    patientsToResults.put(KACEY, TestResult.UNDETERMINED);
-    patientsToResults.put(LEELOO, TestResult.UNDETERMINED);
-
-    Map<PersonName, Date> patientsToDates = new HashMap<>();
-    patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
-    patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
-    patientsToDates.put(DEXTER, convertDate(LocalDateTime.of(2021, 6, 2, 0, 0, 0)));
-    patientsToDates.put(ELIZABETH, convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0)));
-    patientsToDates.put(FRANK, convertDate(LocalDateTime.of(2021, 6, 3, 0, 0, 0)));
-    patientsToDates.put(GALE, convertDate(LocalDateTime.of(2021, 6, 3, 12, 0, 0)));
-    patientsToDates.put(HEINRICK, convertDate(LocalDateTime.of(2021, 6, 4, 0, 0, 0)));
-    patientsToDates.put(IAN, convertDate(LocalDateTime.of(2021, 6, 4, 12, 0, 0)));
-    patientsToDates.put(JANNELLE, convertDate(LocalDateTime.of(2021, 6, 5, 0, 0, 0)));
-    patientsToDates.put(KACEY, convertDate(LocalDateTime.of(2021, 6, 5, 12, 0, 0)));
-    patientsToDates.put(LEELOO, convertDate(LocalDateTime.of(2021, 6, 6, 0, 0, 0)));
-
-    Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
-    patientsToRoles.put(AMOS, PersonRole.RESIDENT);
-    patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
-    patientsToRoles.put(DEXTER, PersonRole.STUDENT);
-    patientsToRoles.put(ELIZABETH, PersonRole.STUDENT);
-    patientsToRoles.put(FRANK, PersonRole.VISITOR);
-    patientsToRoles.put(GALE, PersonRole.VISITOR);
-    patientsToRoles.put(HEINRICK, PersonRole.STAFF);
-    patientsToRoles.put(IAN, PersonRole.STAFF);
-    patientsToRoles.put(JANNELLE, PersonRole.RESIDENT);
-    patientsToRoles.put(KACEY, PersonRole.RESIDENT);
-    patientsToRoles.put(LEELOO, PersonRole.STUDENT);
-
-    Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
-    patientsToSurveys.put(
-        AMOS, new AskOnEntrySurvey(null, Map.of("fake", true), false, null, null));
-    patientsToSurveys.put(
-        CHARLES, new AskOnEntrySurvey(null, Collections.emptyMap(), false, null, null));
-    patientsToSurveys.put(
-        DEXTER, new AskOnEntrySurvey(null, Collections.emptyMap(), true, null, null));
-    patientsToSurveys.put(
-        ELIZABETH, new AskOnEntrySurvey(null, Map.of("fake", true), false, null, null));
-    patientsToSurveys.put(
-        FRANK, new AskOnEntrySurvey(null, Collections.emptyMap(), false, null, null));
-    patientsToSurveys.put(
-        GALE, new AskOnEntrySurvey(null, Collections.emptyMap(), true, null, null));
-    patientsToSurveys.put(
-        HEINRICK, new AskOnEntrySurvey(null, Map.of("fake", true), false, null, null));
-    patientsToSurveys.put(
-        IAN, new AskOnEntrySurvey(null, Collections.emptyMap(), false, null, null));
-    patientsToSurveys.put(
-        JANNELLE, new AskOnEntrySurvey(null, Collections.emptyMap(), true, null, null));
-    patientsToSurveys.put(
-        KACEY, new AskOnEntrySurvey(null, Map.of("fake", true), false, null, null));
-    patientsToSurveys.put(
-        LEELOO, new AskOnEntrySurvey(null, Collections.emptyMap(), false, null, null));
-
-    List<TestEvent> testEvents =
-        patientsToResults.keySet().stream()
-            .map(
-                n -> {
-                  TestResult t = patientsToResults.get(n);
-                  PersonRole r = patientsToRoles.get(n);
-                  AskOnEntrySurvey s = patientsToSurveys.get(n);
-                  Date d = patientsToDates.get(n);
-
-                  Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
-                  return _dataFactory.createTestEvent(person, _site, s, t, d);
-                })
-            .collect(Collectors.toList());
-    // Make one result in another facility
-    Facility _otherSite = _dataFactory.createValidFacility(org, "The Other Facility");
-    _dataFactory.createTestEvent(
-        _dataFactory.createMinimalPerson(org, _otherSite, BRAD), _otherSite, TestResult.NEGATIVE);
-    return testEvents;
-  }
-
-  private List<TestEvent> makeSpecificDiseaseData(SupportedDisease disease) {
-    Organization org = _organizationService.getCurrentOrganization();
-    _site = _dataFactory.createValidFacility(org, "The Facility for " + disease.getName());
-    Map<PersonName, TestResult> patientsToResults = new HashMap<>();
-    patientsToResults.put(AMOS, TestResult.POSITIVE);
-    patientsToResults.put(CHARLES, TestResult.NEGATIVE);
-
-    Map<PersonName, Date> patientsToDates = new HashMap<>();
-    patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
-    patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
-
-    Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
-    patientsToRoles.put(AMOS, PersonRole.RESIDENT);
-    patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
-
-    Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
-    patientsToSurveys.put(
-        AMOS, new AskOnEntrySurvey(null, Map.of("fake", true), false, null, null));
-    patientsToSurveys.put(
-        CHARLES, new AskOnEntrySurvey(null, Collections.emptyMap(), false, null, null));
-
-    return patientsToResults.keySet().stream()
-        .map(
-            n -> {
-              TestResult t = patientsToResults.get(n);
-              PersonRole r = patientsToRoles.get(n);
-              AskOnEntrySurvey s = patientsToSurveys.get(n);
-              Date d = patientsToDates.get(n);
-
-              Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
-              return _dataFactory.createTestEvent(person, _site, s, t, d, disease);
-            })
-        .collect(Collectors.toList());
-  }
-
-  private List<MultiplexResultInput> makeCovidOnlyResult(TestResult covidTestResult) {
-    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
-    return List.of(covidResult);
-  }
-
-  private List<MultiplexResultInput> makeMultiplexTestResult(
-      TestResult covidTestResult, TestResult fluATestResult, TestResult fluBTestResult) {
-    MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
-    MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", fluATestResult);
-    MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", fluBTestResult);
-    return List.of(covidResult, fluAResult, fluBResult);
-  }
-
-  private static void assertTestResultsList(List<TestEvent> found, List<TestEvent> expected) {
-    // check common elements first
-    for (int i = 0; i < expected.size() && i < found.size(); i++) {
-      assertEquals(expected.get(i).getInternalId(), found.get(i).getInternalId());
-    }
-    // *then* check if there are extras
-    if (expected.size() != found.size()) {
-      fail("Expected " + expected.size() + " items but found " + found.size());
-    }
-  }
-
-  private static Date convertDate(LocalDateTime dateTime) {
-    return Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
-  }
-
-  private TestOrder addTestToQueue() {
-    Organization org = _organizationService.getCurrentOrganization();
-    Person patient = _dataFactory.createFullPerson(org);
-    return addTestToQueue(org, patient);
-  }
-
-  private TestOrder addTestToQueue(Organization org, Person patient) {
-    Facility facility = _organizationService.getFacilities(org).get(0);
-    _personService.updateTestResultDeliveryPreference(
-        patient.getInternalId(), TestResultDeliveryPreference.SMS);
-
-    TestOrder order =
         _service.addPatientToQueue(
-            facility.getInternalId(),
-            patient,
-            "",
-            "",
-            Collections.emptyMap(),
-            LocalDate.of(2022, 6, 5),
-            false);
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
 
-    facility.setDefaultDeviceTypeSpecimenType(
-        _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+        UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
 
-    return order;
-  }
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(1, queue.size());
+
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        // WHEN
+        _service.addMultiplexResult(
+                defaultDeviceType,
+                defaultSpecimenType,
+                positiveCovidOnlyResult,
+                patient.getInternalId(),
+                null);
+
+        // THEN
+        queue = _service.getQueue(facility.getInternalId());
+        assertEquals(0, queue.size());
+
+        List<TestEvent> testEvents =
+                _testEventRepository.findAllByPatientAndFacilities(patient, List.of(facility));
+        assertThat(testEvents).hasSize(1);
+        assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+        verify(patientLinkService).createPatientLink(any());
+
+        // make sure the corrected event is sent to storage queue
+        verify(testEventReportingService).report(testEventArgumentCaptor.capture());
+        verify(fhirQueueReportingService).report(any());
+        TestEvent sentEvent = testEventArgumentCaptor.getValue();
+        TestResult testResult = sentEvent.getCovidTestResult().get();
+        assertThat(sentEvent.getPatient().getInternalId()).isEqualTo(patient.getInternalId());
+        assertThat(testResult).isEqualTo(TestResult.POSITIVE);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_populateFirstTest() {
+        Facility facility =
+                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+        Person p =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "English",
+                        null,
+                        null);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        _service.addMultiplexResult(
+                _dataFactory.getGenericDevice().getInternalId(),
+                _dataFactory.getGenericSpecimen().getInternalId(),
+                positiveCovidOnlyResult,
+                p.getInternalId(),
+                null);
+
+        verify(testEventReportingService).report(any());
+        verify(fhirQueueReportingService).report(any());
+
+        List<TestEvent> testEvents =
+                _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
+        assertThat(testEvents).hasSize(1);
+        assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1866, 12, 25),
+                false);
+        _service.addMultiplexResult(
+                _dataFactory.getGenericDevice().getInternalId(),
+                _dataFactory.getGenericSpecimen().getInternalId(),
+                positiveCovidOnlyResult,
+                p.getInternalId(),
+                null);
+
+        testEvents = _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
+        assertThat(testEvents).hasSize(2);
+        assertThat(testEvents.get(0).getPatientHasPriorTests()).isFalse();
+        assertThat(testEvents.get(1).getPatientHasPriorTests()).isTrue();
+        verify(testEventReportingService, times(2)).report(any());
+        verify(fhirQueueReportingService, times(2)).report(any());
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void getQueue_standardUser_successDependsOnFacilityAccess() {
+        Facility facility =
+                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+
+        UUID facilityId = facility.getInternalId();
+        assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
+
+        TestUserIdentities.setFacilityAuthorities(facility);
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    @WithSimpleReportStandardAllFacilitiesUser
+    void addPatientToQueue_standardUserAllFacilities_ok() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "Spanish",
+                        null,
+                        "Space-faring maverick");
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(1, queue.size());
+    }
+
+    @Test
+    void addPatientToQueue_standardUser_successDependsOnFacilityAccess() {
+        Facility facility =
+                _dataFactory.createValidFacility(_organizationService.getCurrentOrganization());
+
+        Person p =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "German",
+                        null,
+                        "success depends on Fred's access");
+
+        UUID facilityId = facility.getInternalId();
+        Map<String, Boolean> symptoms = Collections.emptyMap();
+        LocalDate symptomOnsetDate = LocalDate.of(1865, 12, 25);
+
+        assertThrows(
+                AccessDeniedException.class,
+                () -> _service.addPatientToQueue(facilityId, p, "", "", symptoms, symptomOnsetDate, false));
+
+        TestUserIdentities.setFacilityAuthorities(facility);
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        TestUserIdentities.setFacilityAuthorities();
+
+        assertThrows(AccessDeniedException.class, () -> _service.getQueue(facilityId));
+
+        TestUserIdentities.setFacilityAuthorities(facility);
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(1, queue.size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_orgAdmin_ok() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "French",
+                        null,
+                        null);
+        _personService.updateTestResultDeliveryPreference(
+                p.getInternalId(), TestResultDeliveryPreference.SMS);
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+
+        UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+        UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
+
+        List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
+
+        _service.addMultiplexResult(
+                defaultDeviceType, defaultSpecimenType, positiveCovidResult, p.getInternalId(), null);
+
+        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(0, queue.size());
+        verify(testEventReportingService).report(any());
+        verify(fhirQueueReportingService).report(any());
+    }
+
+    @Test
+    @WithSimpleReportStandardAllFacilitiesUser
+    void addTestResult_standardUserAllFacilities_ok() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "Spanish",
+                        null,
+                        null);
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+
+        UUID defaultDeviceType = facility.getDefaultDeviceType().getInternalId();
+        UUID defaultSpecimenType = facility.getDefaultSpecimenType().getInternalId();
+
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+
+        _service.addMultiplexResult(
+                defaultDeviceType, defaultSpecimenType, positiveCovidOnlyResult, p.getInternalId(), null);
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(0, queue.size());
+        verify(testEventReportingService).report(any());
+        verify(fhirQueueReportingService).report(any());
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void addTestResult_standardUser_successDependsOnFacilityAccess() {
+        Facility facility1 =
+                _dataFactory.createValidFacility(
+                        _organizationService.getCurrentOrganization(), "First One");
+
+        TestUserIdentities.setFacilityAuthorities(facility1);
+
+        Person p1 =
+                _personService.addPatient(
+                        (UUID) null,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "English",
+                        null,
+                        null);
+        Person p2 =
+                _personService.addPatient(
+                        facility1.getInternalId(),
+                        "BAR",
+                        "Baz",
+                        null,
+                        "",
+                        "Jr.",
+                        LocalDate.of(1900, 1, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STUDENT,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "Spanish",
+                        null,
+                        null);
+
+        _service.addPatientToQueue(
+                facility1.getInternalId(),
+                p1,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        _service.addPatientToQueue(
+                facility1.getInternalId(),
+                p2,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+
+        TestUserIdentities.setFacilityAuthorities();
+
+        UUID deviceId = _dataFactory.getGenericDevice().getInternalId();
+        UUID specimenId = _dataFactory.getGenericSpecimen().getInternalId();
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        UUID patientTwoId = p2.getInternalId();
+
+        assertThrows(
+                AccessDeniedException.class,
+                () ->
+                        _service.addMultiplexResult(
+                                deviceId, specimenId, positiveCovidOnlyResult, patientTwoId, null));
+
+        UUID patientOneId = p1.getInternalId();
+        // caller has access to the patient (whose facility is null)
+        // but cannot modify the test order which was created at a non-accessible facility
+        assertThrows(
+                AccessDeniedException.class,
+                () ->
+                        _service.addMultiplexResult(
+                                deviceId, specimenId, positiveCovidOnlyResult, patientOneId, null));
+
+        // make sure the nothing was sent to storage queue
+        verifyNoInteractions(testEventReportingService);
+
+        TestUserIdentities.setFacilityAuthorities(facility1);
+        _service.addMultiplexResult(
+                deviceId, specimenId, positiveCovidOnlyResult, p1.getInternalId(), null);
+        List<TestOrder> queue = _service.getQueue(facility1.getInternalId());
+        assertEquals(1, queue.size());
+
+        // make sure the corrected event is sent to storage queue
+        verify(testEventReportingService).report(any());
+        verify(fhirQueueReportingService).report(any());
+
+        List<MultiplexResultInput> negativeCovidResult = makeCovidOnlyResult(TestResult.NEGATIVE);
+
+        _service.addMultiplexResult(
+                deviceId, specimenId, negativeCovidResult, p2.getInternalId(), null);
+
+        queue = _service.getQueue(facility1.getInternalId());
+        assertEquals(0, queue.size());
+
+        // make sure the second event is sent to storage queue
+        verify(testEventReportingService, times(2)).report(any());
+        verify(fhirQueueReportingService, times(2)).report(any());
+    }
+
+    @Test
+    @WithSimpleReportEntryOnlyAllFacilitiesUser
+    void addTestResult_entryOnlyUserAllFacilities_ok() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p = _dataFactory.createFullPerson(org);
+        _personService.updateTestResultDeliveryPreference(
+                p.getInternalId(), TestResultDeliveryPreference.SMS);
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        _service.addMultiplexResult(
+                deviceType.getInternalId(),
+                specimenType.getInternalId(),
+                positiveCovidOnlyResult,
+                p.getInternalId(),
+                null);
+
+        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_testAlreadySubmitted_failure() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p = _dataFactory.createFullPerson(org);
+        _personService.updateTestResultDeliveryPreference(
+                p.getInternalId(), TestResultDeliveryPreference.SMS);
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        List<MultiplexResultInput> positiveCovidResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        _service.addMultiplexResult(
+                deviceType.getInternalId(),
+                specimenType.getInternalId(),
+                positiveCovidResult,
+                p.getInternalId(),
+                null);
+        UUID deviceId = deviceType.getInternalId();
+        UUID specimentId = specimenType.getInternalId();
+        UUID patientId = p.getInternalId();
+
+        assertThrows(
+                NonexistentQueueItemException.class,
+                () ->
+                        _service.addMultiplexResult(
+                                deviceId, specimentId, positiveCovidResult, patientId, null));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_correction() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p = _dataFactory.createFullPerson(org);
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                p,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        // Create test event for a later correction
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        _service.addMultiplexResult(
+                deviceType.getInternalId(),
+                specimenType.getInternalId(),
+                positiveCovidOnlyResult,
+                p.getInternalId(),
+                null);
+        List<TestEvent> testEvents =
+                _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility));
+        assertEquals(1, testEvents.size());
+
+        // Mark existing test order as "corrected", re-open as "pending" order status
+        TestEvent originalTestEvent = testEvents.get(0);
+        _service.markAsCorrection(originalTestEvent.getInternalId(), "Cold feet");
+
+        // Issue test correction
+        List<MultiplexResultInput> negativeCovidOnlyResult = makeCovidOnlyResult(TestResult.NEGATIVE);
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        negativeCovidOnlyResult,
+                        p.getInternalId(),
+                        null);
+
+        TestEvent correctionTestEvent = response.getTestOrder().getTestEvent();
+
+        assertEquals(
+                originalTestEvent.getInternalId(), correctionTestEvent.getPriorCorrectedTestEventId());
+        assertEquals(TestCorrectionStatus.CORRECTED, correctionTestEvent.getCorrectionStatus());
+        assertEquals("Cold feet", correctionTestEvent.getReasonForCorrection());
+        assertEquals(TestResult.NEGATIVE, correctionTestEvent.getCovidTestResult().get());
+        // Date of original test is overwritten by the new correction event
+        assertNotEquals(
+                LocalDate.of(1865, 12, 25),
+                LocalDate.ofInstant(
+                        correctionTestEvent.getDateTested().toInstant(), ZoneId.systemDefault()));
+        assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(correctionTestEvent).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(originalTestEvent).size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_smsDelivery() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.SMS);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+        when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(true);
+        when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(true);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        assertTrue(res.getDeliverySuccess());
+        ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
+        verify(testResultsDeliveryService).smsTestResults(patientLinkCaptor.capture());
+        assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
+                .isEqualTo(patient.getInternalId());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_smsDelivery_failure() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.SMS);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        when(testResultsDeliveryService.smsTestResults(any(PatientLink.class))).thenReturn(false);
+        when(testResultsDeliveryService.smsTestResults(any(UUID.class))).thenReturn(false);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+        assertFalse(res.getDeliverySuccess());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_emailDelivery() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
+        when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        assertTrue(res.getDeliverySuccess());
+        ArgumentCaptor<PatientLink> patientLinkCaptor = ArgumentCaptor.forClass(PatientLink.class);
+        verify(testResultsDeliveryService).emailTestResults(patientLinkCaptor.capture());
+        assertThat(patientLinkCaptor.getValue().getTestOrder().getPatient().getInternalId())
+                .isEqualTo(patient.getInternalId());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_emailDelivery_failure() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.EMAIL);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(false);
+        when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(false);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
+        assertFalse(res.getDeliverySuccess());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_emailAndSmsDelivery() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.ALL);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+        when(testResultsDeliveryService.emailTestResults(any(PatientLink.class))).thenReturn(true);
+        when(testResultsDeliveryService.emailTestResults(any(UUID.class))).thenReturn(true);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        verify(testResultsDeliveryService).emailTestResults(any(PatientLink.class));
+        verify(testResultsDeliveryService).smsTestResults(any(PatientLink.class));
+        assertTrue(res.getDeliverySuccess());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_NoTestResultDelivery() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.NONE);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        assertTrue(res.getDeliverySuccess());
+        verifyNoInteractions(testResultsDeliveryService);
+        verify(testEventReportingService).report(any());
+        verify(fhirQueueReportingService).report(any());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_savesResults() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        AddTestResultResponse res =
+                _service.addMultiplexResult(
+                        deviceType.getInternalId(),
+                        specimenType.getInternalId(),
+                        positiveCovidOnlyResult,
+                        patient.getInternalId(),
+                        null);
+
+        // THEN
+        List<Result> testOrderResults = _resultRepository.findAllByTestOrder(res.getTestOrder());
+        List<Result> testEventResults =
+                _resultRepository.findAllByTestEvent(res.getTestOrder().getTestEvent());
+        assertEquals(1, testOrderResults.size());
+        assertEquals(1, testEventResults.size());
+
+        Result testOrderResult = testOrderResults.get(0);
+        Result testEventResult = testEventResults.get(0);
+
+        // we create two different results, 1 mutable for the testOrder, 1 immutable for the testEvent
+        assertThat(testOrderResult).isNotEqualTo(testEventResult);
+
+        // verify the testOrder Result
+        assertThat(testOrderResult.getTestOrder()).isNotNull();
+        assertThat(testOrderResult.getTestEvent()).isNull();
+        assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
+        assertThat(testOrderResult.getDisease()).isEqualTo(_diseaseService.covid());
+
+        // verify the testEvent Result
+        assertThat(testEventResult.getTestOrder()).isNull();
+        assertThat(testEventResult.getTestEvent()).isNotNull();
+        assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.POSITIVE);
+        assertThat(testEventResult.getDisease()).isEqualTo(_diseaseService.covid());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void editQueueItemMultiplexResult_worksWithSingleResult() {
+        TestOrder order = addTestToQueue();
+
+        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
+
+        TestOrder updatedOrder =
+                _service.editQueueItemMultiplexResult(
+                        order.getInternalId(),
+                        _dataFactory.getGenericDevice().getInternalId(),
+                        _dataFactory.getGenericSpecimen().getInternalId(),
+                        List.of(covidResult),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertEquals(1, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void editQueueItemMultiplexResult_worksWithMultipleResults() {
+        TestOrder order = addTestToQueue();
+
+        TestOrder updatedOrder =
+                _service.editQueueItemMultiplexResult(
+                        order.getInternalId(),
+                        _dataFactory.getGenericDevice().getInternalId(),
+                        _dataFactory.getGenericSpecimen().getInternalId(),
+                        makeMultiplexTestResult(TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void editQueueItemMultiplexResult_worksWithEmptyResults() {
+        TestOrder order = addTestToQueue();
+
+        TestOrder updatedOrder =
+                _service.editQueueItemMultiplexResult(
+                        order.getInternalId(),
+                        _dataFactory.getGenericDevice().getInternalId(),
+                        _dataFactory.getGenericSpecimen().getInternalId(),
+                        List.of(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertTrue(_service.getTestOrder(updatedOrder.getInternalId()).getResults().isEmpty());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addMultiplexResult_multipleEditsBeforeSubmissionSuccessful() {
+        TestOrder order = addTestToQueue();
+
+        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", TestResult.POSITIVE);
+        MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", TestResult.NEGATIVE);
+        MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", TestResult.NEGATIVE);
+
+        _service.editQueueItemMultiplexResult(
+                order.getInternalId(),
+                _dataFactory.getGenericDevice().getInternalId(),
+                _dataFactory.getGenericSpecimen().getInternalId(),
+                List.of(covidResult, fluAResult, fluBResult),
+                convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        MultiplexResultInput updatedCovidResult =
+                new MultiplexResultInput("COVID-19", TestResult.NEGATIVE);
+        TestOrder updatedOrder =
+                _service.editQueueItemMultiplexResult(
+                        order.getInternalId(),
+                        _dataFactory.getGenericDevice().getInternalId(),
+                        _dataFactory.getGenericSpecimen().getInternalId(),
+                        List.of(updatedCovidResult, fluAResult, fluBResult),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertEquals(3, _service.getTestOrder(updatedOrder.getInternalId()).getResults().size());
+
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        updatedOrder.getDeviceType().getInternalId(),
+                        updatedOrder.getSpecimenType().getInternalId(),
+                        List.of(updatedCovidResult, fluAResult, fluBResult),
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertEquals(3, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void multiplexResultMutations_covidOnlyCorrectionSuccessful() {
+        TestOrder order = addTestToQueue();
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        order.getDeviceType().getInternalId(),
+                        order.getSpecimenType().getInternalId(),
+                        List.of(new MultiplexResultInput("COVID-19", TestResult.POSITIVE)),
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+        _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
+
+        AddTestResultResponse correctedResponse =
+                _service.addMultiplexResult(
+                        order.getDeviceType().getInternalId(),
+                        order.getSpecimenType().getInternalId(),
+                        List.of(new MultiplexResultInput("COVID-19", TestResult.NEGATIVE)),
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertEquals(1, _resultRepository.findAllByTestOrder(order).size());
+        assertEquals(
+                1,
+                _resultRepository
+                        .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
+                        .size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void multiplexResultMutations_multiplexCorrectionSuccessful() {
+
+        List<MultiplexResultInput> originalResults =
+                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.POSITIVE);
+
+        TestOrder order = addTestToQueue();
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        order.getDeviceType().getInternalId(),
+                        order.getSpecimenType().getInternalId(),
+                        originalResults,
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+        _service.markAsCorrection(originalEvent.getInternalId(), "Incorrect result");
+
+        List<MultiplexResultInput> correctedResults =
+                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE);
+
+        AddTestResultResponse correctedResponse =
+                _service.addMultiplexResult(
+                        order.getDeviceType().getInternalId(),
+                        order.getSpecimenType().getInternalId(),
+                        correctedResults,
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
+        assertEquals(
+                3,
+                _resultRepository
+                        .findAllByTestEvent(correctedResponse.getTestOrder().getTestEvent())
+                        .size());
+        assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void multiplexResultMutations_removalSuccessful() {
+        List<MultiplexResultInput> originalResults =
+                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
+
+        TestOrder order = addTestToQueue();
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        order.getDeviceType().getInternalId(),
+                        order.getSpecimenType().getInternalId(),
+                        originalResults,
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+        TestEvent removedEvent = _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
+
+        assertEquals(3, _resultRepository.findAllByTestOrder(order).size());
+        assertEquals(3, _resultRepository.findAllByTestEvent(removedEvent).size());
+        assertEquals(3, _resultRepository.findAllByTestEvent(originalEvent).size());
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void fetchTestEventsResults_standardUser_successDependsOnFacilityAccess() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createValidFacility(org);
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createTestEvent(p, facility);
+        UUID facilityId = facility.getInternalId();
+
+        assertThrows(
+                AccessDeniedException.class,
+                () ->
+                        _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+
+        TestUserIdentities.setFacilityAuthorities(facility);
+        _service.getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 10);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void fetchTestEventsAtArchivedFacility_orgAdminUser_ok() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createTestEvent(p, facility);
+
+        Page<TestEvent> testEventsByFacility =
+                _service.getFacilityTestEventsResults(
+                        facility.getInternalId(), null, null, null, null, null, 0, 10);
+        assertThat(testEventsByFacility.getTotalElements()).isEqualTo(1);
+        assertThat(testEventsByFacility.getTotalPages()).isEqualTo(1);
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void fetchTestEventsAtArchivedFacility_standardUser_failure() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createTestEvent(p, facility);
+        UUID facilityId = facility.getInternalId();
+
+        assertThrows(
+                AccessDeniedException.class,
+                () ->
+                        _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void fetchAllFacilityTestEventsResults_orgAdminUser_ok() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createValidFacility(org);
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createTestEvent(p, facility);
+
+        Page<TestEvent> testEventsByOrg =
+                _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
+        assertThat(testEventsByOrg.getTotalElements()).isEqualTo(1);
+        assertThat(testEventsByOrg.getTotalPages()).isEqualTo(1);
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void fetchAllFacilityTestEventsResults_standardUser_failure() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createValidFacility(org);
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createTestEvent(p, facility);
+
+        assertThrows(
+                AccessDeniedException.class,
+                () -> _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10));
+    }
+
+    @Test
+    @WithSimpleReportStandardUser
+    void fetchTestResults_standardUser_successDependsOnFacilityAccess() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility f1 = _dataFactory.createValidFacility(org, "First One");
+        Facility f2 = _dataFactory.createValidFacility(org, "Second One");
+        Person p1 = _dataFactory.createMinimalPerson(org, f1);
+        Person p2 = _dataFactory.createMinimalPerson(org);
+        _dataFactory.createTestEvent(p1, f1);
+        _dataFactory.createTestEvent(p2, f1);
+        _dataFactory.createTestEvent(p2, f2);
+
+        assertThrows(AccessDeniedException.class, () -> _service.getTestResults(p1));
+        // filters out all test results from inaccessible facilities, but we can still
+        // request test results for a patient whose own facility is null
+        assertEquals(0, _service.getTestResults(p2).size());
+
+        TestUserIdentities.setFacilityAuthorities(f1);
+        assertEquals(1, _service.getTestResults(p1).size());
+        // filters out all test results from inaccessible facilities
+        assertEquals(1, _service.getTestResults(p2).size());
+
+        TestUserIdentities.setFacilityAuthorities(f1, f2);
+        assertEquals(1, _service.getTestResults(p1).size());
+        assertEquals(2, _service.getTestResults(p2).size());
+    }
+
+    @Test
+    @WithSimpleReportEntryOnlyUser
+    void fetchTestResults_entryOnlyUser_error() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person p = _dataFactory.createFullPerson(org);
+        _dataFactory.createTestEvent(p, facility);
+
+        // https://github.com/CDCgov/prime-simplereport/issues/677
+        // assertSecurityError(() ->
+        // _service.getTestResults(facility.getInternalId()));
+        assertSecurityError(() -> _service.getTestResults(p));
+    }
+
+    // watch for N+1 queries
+    @Test
+    @WithSimpleReportStandardAllFacilitiesUser
+    void fetchTestEventsResults_getTestEventsResults_NPlusOne() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person p = _dataFactory.createFullPerson(org);
+
+        // add some initial data
+        _dataFactory.createTestEvent(p, facility);
+        _dataFactory.createTestEvent(p, facility);
+
+        // count queries
+        long startQueryCount = QueryCountService.get().getSelect();
+        _service.getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 50);
+        long firstPassTotal = QueryCountService.get().getSelect() - startQueryCount;
+
+        // add more data
+        _dataFactory.createTestEvent(p, facility);
+        _dataFactory.createTestEvent(p, facility);
+        _dataFactory.createTestEvent(p, facility);
+        _dataFactory.createTestEvent(p, facility);
+        _dataFactory.createTestEvent(p, facility);
+
+        // count queries again and make sure queries made didn't increase
+        startQueryCount = QueryCountService.get().getSelect();
+        _service.getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 50);
+        long secondPassTotal = QueryCountService.get().getSelect() - startQueryCount;
+        assertEquals(firstPassTotal, secondPassTotal);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void editTestResult_getQueue_NPlusOne() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        UUID facilityId = facility.getInternalId();
+
+        Person p1 =
+                _personService.addPatient(
+                        facilityId,
+                        "FOO",
+                        "Fred",
+                        null,
+                        "",
+                        "Sr.",
+                        LocalDate.of(1865, 12, 25),
+                        getAddress(),
+                        "USA",
+                        TestDataFactory.getListOfOnePhoneNumber(),
+                        PersonRole.STAFF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        "Spanish",
+                        null,
+                        null);
+
+        _service.addPatientToQueue(
+                facilityId, p1, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+
+        // get the first query count
+        long startQueryCount = QueryCountService.get().getSelect();
+        _service.getQueue(facility.getInternalId());
+        long firstRunCount = QueryCountService.get().getSelect() - startQueryCount;
+
+        for (int ii = 0; ii < 2; ii++) {
+            // add more tests to the queue. (which needs more patients)
+            Person p =
+                    _personService.addPatient(
+                            facilityId,
+                            "FOO",
+                            "Fred",
+                            null,
+                            "",
+                            "Sr.",
+                            LocalDate.of(1865, 12, 25),
+                            getAddress(),
+                            "USA",
+                            TestDataFactory.getListOfOnePhoneNumber(),
+                            PersonRole.STAFF,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            false,
+                            false,
+                            "French",
+                            null,
+                            null);
+
+            _service.addPatientToQueue(
+                    facilityId, p, "", "", Collections.emptyMap(), LocalDate.of(1865, 12, 25), false);
+        }
+
+        startQueryCount = QueryCountService.get().getSelect();
+        _service.getQueue(facility.getInternalId());
+        long secondRunCount = QueryCountService.get().getSelect() - startQueryCount;
+        assertEquals(firstRunCount, secondRunCount);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void markAsErrorTest() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person person = _dataFactory.createFullPerson(org);
+        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+        assertNotNull(deleteMarkerEvent);
+
+        assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
+        assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
+
+        assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
+
+        List<TestEvent> events_before =
+                _service
+                        .getFacilityTestEventsResults(
+                                facility.getInternalId(), null, null, null, null, null, 0, 50)
+                        .toList();
+        assertEquals(1, events_before.size());
+
+        // verify the original order was updated
+        TestEvent refreshedTestResult = _service.getTestResult(testEvent.getInternalId());
+        TestOrder onlySavedOrder = refreshedTestResult.getTestOrder();
+        TestEvent mostRecentEvent = onlySavedOrder.getTestEvent();
+        assertEquals(reasonMsg, onlySavedOrder.getReasonForCorrection());
+        assertEquals(deleteMarkerEvent.getInternalId(), mostRecentEvent.getInternalId());
+        assertEquals(TestCorrectionStatus.REMOVED, onlySavedOrder.getCorrectionStatus());
+
+        // make sure the original item is removed from the result and ONLY the
+        // "corrected" removed one is shown
+        List<TestEvent> events_after =
+                _service
+                        .getFacilityTestEventsResults(
+                                facility.getInternalId(), null, null, null, null, null, 0, 50)
+                        .toList();
+        assertEquals(1, events_after.size());
+        assertEquals(
+                deleteMarkerEvent.getInternalId().toString(),
+                events_after.get(0).getInternalId().toString());
+
+        // verify that a Result object is created for the original and new TestEvent and one for the
+        // TestOrder
+        assertEquals(1, _resultRepository.findAllByTestOrder(onlySavedOrder).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(mostRecentEvent).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(deleteMarkerEvent).size());
+
+        // make sure the corrected event is sent to storage queue, which gets picked up to be delivered
+        // to report stream
+        verify(testEventReportingService).report(deleteMarkerEvent);
+        verify(fhirQueueReportingService).report(any());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void markAsErrorTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        DeviceType device = _dataFactory.getGenericDevice();
+        SpecimenType specimen = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+        Person person = _dataFactory.createFullPerson(org);
+        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+        facility.getAddress().setState("ND");
+        _organizationService.updateFacility(
+                facility.getInternalId(),
+                facility.getFacilityName(),
+                facility.getCliaNumber(),
+                facility.getAddress(),
+                facility.getTelephone(),
+                facility.getEmail(),
+                facility.getOrderingProvider().getNameInfo(),
+                facility.getOrderingProvider().getAddress(),
+                facility.getOrderingProvider().getProviderId(),
+                facility.getOrderingProvider().getTelephone(),
+                facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
+
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        TestEvent deletedTest = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+
+        assertEquals(deletedTest.getDeviceType().getInternalId(), device.getInternalId());
+        assertEquals(deletedTest.getSpecimenType().getInternalId(), specimen.getInternalId());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void correctionsTest() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person p = _dataFactory.createFullPerson(org);
+        TestEvent e = _dataFactory.createTestEvent(p, facility);
+
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+
+        // A test correction call just returns the original TestEvent...
+        TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
+
+        // ...but re-opens the original TestOrder and updates correction status
+        TestOrder updatedOrder = originalEvent.getTestOrder();
+        assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
+        assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
+        assertEquals(e.getInternalId(), updatedOrder.getTestEvent().getInternalId());
+        assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
+
+        // Unlike marking a test as deleted, which immediately creates a second TestEvent
+        // that represents the removal, a test correction does not result in another
+        // TestEvent being generated and saved
+        long testEventCount = _testEventRepository.count();
+        assertEquals(1, testEventCount);
+
+        // Does not report to ReportStream
+        verify(testEventReportingService, times(0)).report(e);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void markAsErrorTest_backwardCompatible() {
+        // GIVEN
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person person = _dataFactory.createFullPerson(org);
+        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+        // ensure the Result will have both testEvent and testOrder populated
+        _resultRepository.deleteAll(testEvent.getOrder().getResults());
+        Set<Result> results = testEvent.getResults();
+        results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
+        _resultRepository.saveAll(results);
+
+        // assert that we have the same Result object for both testEvent and testOrder
+        List<Result> allOldResultsByTestOrder =
+                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+        List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+        assertEquals(1, allOldResultsByTestEvent.size());
+        assertEquals(1, allOldResultsByTestOrder.size());
+        Result testOrderOldResult = allOldResultsByTestOrder.get(0);
+        Result testEventOldResult = allOldResultsByTestEvent.get(0);
+        assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
+
+        // WHEN
+        TestEvent deleteMarkerEvent = _service.markAsError(testEvent.getInternalId(), reasonMsg);
+
+        // THEN
+        assertNotNull(deleteMarkerEvent);
+
+        assertEquals(TestCorrectionStatus.REMOVED, deleteMarkerEvent.getCorrectionStatus());
+        assertEquals(reasonMsg, deleteMarkerEvent.getReasonForCorrection());
+
+        assertEquals(testEvent.getTestOrder().getInternalId(), testEvent.getTestOrderId());
+
+        // assert that we have two Result objects for both testEvent and testOrder
+        List<Result> allResultsByTestOrder =
+                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+        List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+        assertEquals(1, allResultsByTestOrder.size());
+        assertEquals(1, allResultsByTestEvent.size());
+
+        Result testOrderResult = allResultsByTestOrder.get(0);
+        Result testEventResult = allResultsByTestEvent.get(0);
+        assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
+
+        assertThat(testEventResult.getTestOrder()).isNull();
+        assertThat(testEventResult.getTestEvent()).isNotNull();
+
+        assertThat(testOrderResult.getTestOrder()).isNotNull();
+        assertThat(testOrderResult.getTestEvent()).isNull();
+
+        assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+        assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void correctionsTest_backwardCompatible() {
+        // GIVEN
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person person = _dataFactory.createFullPerson(org);
+        TestEvent testEvent = _dataFactory.createTestEvent(person, facility);
+
+        // ensure the Result will have both testEvent and testOrder populated
+        _resultRepository.deleteAll(testEvent.getOrder().getResults());
+        Set<Result> results = testEvent.getResults();
+        results.forEach(result -> result.setTestOrder(testEvent.getTestOrder()));
+        _resultRepository.saveAll(results);
+
+        // assert that we have the same Result object for both testEvent and testOrder
+        List<Result> allOldResultsByTestOrder =
+                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+        List<Result> allOldResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+        assertEquals(1, allOldResultsByTestEvent.size());
+        assertEquals(1, allOldResultsByTestOrder.size());
+        Result testOrderOldResult = allOldResultsByTestOrder.get(0);
+        Result testEventOldResult = allOldResultsByTestEvent.get(0);
+        assertThat(testOrderOldResult.getInternalId()).isEqualTo(testEventOldResult.getInternalId());
+
+        // WHEN
+        TestEvent originalEvent = _service.markAsCorrection(testEvent.getInternalId(), reasonMsg);
+
+        // THEN
+        TestOrder updatedOrder = originalEvent.getTestOrder();
+        assertEquals(TestCorrectionStatus.CORRECTED, updatedOrder.getCorrectionStatus());
+        assertEquals(reasonMsg, updatedOrder.getReasonForCorrection());
+        assertEquals(testEvent.getInternalId(), updatedOrder.getTestEvent().getInternalId());
+        assertEquals(OrderStatus.PENDING, updatedOrder.getOrderStatus());
+
+        // assert that we have two Result objects for both testEvent and testOrder
+        List<Result> allResultsByTestOrder =
+                _resultRepository.findAllByTestOrder(testEvent.getTestOrder());
+        List<Result> allResultsByTestEvent = _resultRepository.findAllByTestEvent(testEvent);
+        assertEquals(1, allResultsByTestOrder.size());
+        assertEquals(1, allResultsByTestEvent.size());
+
+        Result testOrderResult = allResultsByTestOrder.get(0);
+        Result testEventResult = allResultsByTestEvent.get(0);
+        assertThat(testEventResult.getInternalId()).isNotEqualTo(testOrderResult.getInternalId());
+
+        assertThat(testEventResult.getTestOrder()).isNull();
+        assertThat(testEventResult.getTestEvent()).isNotNull();
+
+        assertThat(testOrderResult.getTestOrder()).isNotNull();
+        assertThat(testOrderResult.getTestEvent()).isNull();
+
+        assertThat(testEventResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+        assertThat(testOrderResult.getTestResult()).isEqualTo(TestResult.NEGATIVE);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void correctTest_backDatedFromCurrentDate() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person p = _dataFactory.createFullPerson(org);
+        TestEvent e = _dataFactory.createTestEvent(p, facility);
+
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+
+        assertNull(e.getTestOrder().getDateTestedBackdate());
+
+        // A test correction call just returns the original TestEvent...
+        TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
+
+        assertEquals(e.getDateTested(), originalEvent.getTestOrder().getDateTestedBackdate());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void correctTest_backdatePreserved() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+        Person p = _dataFactory.createFullPerson(org);
+
+        LocalDate localDate = LocalDate.of(2022, 1, 1);
+        Date dateTested = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        TestEvent e = _dataFactory.createTestEvent(p, facility, null, TestResult.POSITIVE, dateTested);
+
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+
+        TestEvent originalEvent = _service.markAsCorrection(e.getInternalId(), reasonMsg);
+        assertEquals(0, originalEvent.getTestOrder().getDateTestedBackdate().compareTo(dateTested));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void correctTest_usesCorrectDeviceAndSpecimenFacilityHasBeenUpdated() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        DeviceType device = _dataFactory.getGenericDevice();
+        SpecimenType specimen = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+        Person p = _dataFactory.createFullPerson(org);
+        TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
+
+        facility.getAddress().setState("ND");
+        _organizationService.updateFacility(
+                facility.getInternalId(),
+                facility.getFacilityName(),
+                facility.getCliaNumber(),
+                facility.getAddress(),
+                facility.getTelephone(),
+                facility.getEmail(),
+                facility.getOrderingProvider().getNameInfo(),
+                facility.getOrderingProvider().getAddress(),
+                facility.getOrderingProvider().getProviderId(),
+                facility.getOrderingProvider().getTelephone(),
+                facility.getDeviceTypes().stream().map(IdentifiedEntity::getInternalId).toList());
+
+        // Re-open the original test as a correction
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
+
+        // Re-submit the corrected test
+        List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        device.getInternalId(),
+                        specimen.getInternalId(),
+                        correctedTestResult,
+                        p.getInternalId(),
+                        null);
+        TestEvent correctedEvent = response.getTestOrder().getTestEvent();
+        assertEquals(correctedEvent.getDeviceType().getInternalId(), device.getInternalId());
+        assertEquals(correctedEvent.getSpecimenType().getInternalId(), specimen.getInternalId());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void removeACorrectedTest_success() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        DeviceType device = _dataFactory.getGenericDevice();
+        SpecimenType specimen = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(device, specimen);
+        Person p = _dataFactory.createFullPerson(org);
+        TestEvent originalEvent = _dataFactory.createTestEvent(p, facility);
+
+        // Re-open the original test as a correction
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        _service.markAsCorrection(originalEvent.getInternalId(), reasonMsg);
+
+        // Re-submit the corrected test
+        List<MultiplexResultInput> correctedTestResult = makeCovidOnlyResult(TestResult.UNDETERMINED);
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        device.getInternalId(),
+                        specimen.getInternalId(),
+                        correctedTestResult,
+                        p.getInternalId(),
+                        null);
+        TestEvent correctedEvent = response.getTestOrder().getTestEvent();
+
+        assertEquals(
+                2, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
+        assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
+
+        // Now mark the corrected test as an error
+        String removalMsg = "I changed my mind, remove this test " + LocalDateTime.now();
+        TestEvent deleteCorrectedEvent =
+                _service.markAsError(correctedEvent.getInternalId(), removalMsg);
+
+        // There should only be a single TestOrder, but three TestEvents - the original, the corrected,
+        // and the removed
+        // There should also be exactly 4 Result objects, 1 for the order, and 1 per each TestEvent
+        assertEquals(
+                3, _testEventRepository.findAllByPatientAndFacilities(p, List.of(facility)).size());
+        assertEquals(1, _testOrderRepository.fetchPastResults(org, facility).size());
+        assertEquals(1, _resultRepository.findAllByTestOrder(response.getTestOrder()).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(originalEvent).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(correctedEvent).size());
+        assertEquals(1, _resultRepository.findAllByTestEvent(deleteCorrectedEvent).size());
+
+        TestOrder order = deleteCorrectedEvent.getTestOrder();
+        assertEquals(TestCorrectionStatus.REMOVED, order.getCorrectionStatus());
+        assertEquals(removalMsg, order.getReasonForCorrection());
+        assertEquals(deleteCorrectedEvent.getInternalId(), order.getTestEvent().getInternalId());
+        assertEquals(OrderStatus.COMPLETED, order.getOrderStatus());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestEventsResults_pagination() {
+        List<TestEvent> testEvents = makedata();
+        List<TestEvent> results_page0 =
+                _service
+                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 0, 5)
+                        .toList();
+        List<TestEvent> results_page1 =
+                _service
+                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 1, 5)
+                        .toList();
+        List<TestEvent> results_page2 =
+                _service
+                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 2, 5)
+                        .toList();
+        List<TestEvent> results_page3 =
+                _service
+                        .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 3, 5)
+                        .toList();
+
+        Collections.reverse(testEvents);
+
+        assertTestResultsList(results_page0, testEvents.subList(0, 5));
+        assertTestResultsList(results_page1, testEvents.subList(5, 10));
+        assertTestResultsList(results_page2, testEvents.subList(10, 11));
+        assertEquals(0, results_page3.size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestEventsResults_filtering() {
+        List<TestEvent> testEvents = makedata();
+        List<TestEvent> positives =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(), null, TestResult.POSITIVE, null, null, null, 0, 10)
+                        .toList();
+        List<TestEvent> negatives =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10)
+                        .toList();
+        List<TestEvent> inconclusives =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(), null, TestResult.UNDETERMINED, null, null, null, 0, 10)
+                        .toList();
+        List<TestEvent> students =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(), null, null, PersonRole.STUDENT, null, null, 0, 10)
+                        .toList();
+        List<TestEvent> visitors =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(), null, null, PersonRole.VISITOR, null, null, 0, 10)
+                        .toList();
+        List<TestEvent> june1to3 =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(),
+                                null,
+                                null,
+                                null,
+                                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
+                                convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59)),
+                                0,
+                                10)
+                        .toList();
+        List<TestEvent> priorToJune2Noon =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(),
+                                null,
+                                null,
+                                null,
+                                null,
+                                convertDate(LocalDateTime.of(2021, 6, 2, 11, 59, 59)),
+                                0,
+                                10)
+                        .toList();
+        List<TestEvent> positivesAmos =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(),
+                                _dataFactory.getPersonByName(AMOS).getInternalId(),
+                                TestResult.POSITIVE,
+                                null,
+                                null,
+                                null,
+                                0,
+                                10)
+                        .toList();
+        List<TestEvent> negativesAmos =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(),
+                                _dataFactory.getPersonByName(AMOS).getInternalId(),
+                                TestResult.NEGATIVE,
+                                null,
+                                null,
+                                null,
+                                0,
+                                10)
+                        .toList();
+        List<TestEvent> allFilters =
+                _service
+                        .getFacilityTestEventsResults(
+                                _site.getInternalId(),
+                                _dataFactory.getPersonByName(CHARLES).getInternalId(),
+                                TestResult.POSITIVE,
+                                PersonRole.RESIDENT,
+                                convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
+                                convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59)),
+                                0,
+                                10)
+                        .toList();
+
+        Collections.reverse(testEvents);
+
+        assertTestResultsList(
+                positives,
+                testEvents.stream()
+                        .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.POSITIVE)
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                negatives,
+                testEvents.stream()
+                        .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE)
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                inconclusives,
+                testEvents.stream()
+                        .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.UNDETERMINED)
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                students,
+                testEvents.stream()
+                        .filter(t -> t.getPatient().getRole() == PersonRole.STUDENT)
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                visitors,
+                testEvents.stream()
+                        .filter(t -> t.getPatient().getRole() == PersonRole.VISITOR)
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                june1to3,
+                testEvents.stream()
+                        .filter(
+                                t ->
+                                        !t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
+                                                && !t.getDateTested()
+                                                .after(convertDate(LocalDateTime.of(2021, 6, 3, 23, 59, 59))))
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                priorToJune2Noon,
+                testEvents.stream()
+                        .filter(
+                                t -> t.getDateTested().before(convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0))))
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                positivesAmos,
+                testEvents.stream()
+                        .filter(
+                                t ->
+                                        t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
+                                                && t.getPatient().getNameInfo().equals(AMOS))
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                negativesAmos,
+                testEvents.stream()
+                        .filter(
+                                t ->
+                                        t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE
+                                                && t.getPatient().getNameInfo().equals(AMOS))
+                        .collect(Collectors.toList()));
+        assertTestResultsList(
+                allFilters,
+                testEvents.stream()
+                        .filter(
+                                t ->
+                                        t.getPatient().getNameInfo().equals(CHARLES)
+                                                && t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
+                                                && t.getPatient().getRole() == PersonRole.RESIDENT
+                                                && !t.getDateTested()
+                                                .before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
+                                                && !t.getDateTested()
+                                                .after(convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59))))
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestEventsResults_withMultiplex_returnsOnlyOneEvent() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createMultiplexTestEvent(
+                p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
+
+        var res =
+                _service
+                        .getFacilityTestEventsResults(
+                                facility.getInternalId(), null, null, null, null, null, 0, 10)
+                        .toList();
+        assertEquals(1, res.size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestEventsResults_withMultiplexAndCovid_returnsOnlyTwoEvent() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        _dataFactory.createTestEvent(p, facility);
+        _dataFactory.createMultiplexTestEvent(
+                p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, false);
+
+        var res =
+                _service
+                        .getFacilityTestEventsResults(
+                                facility.getInternalId(), null, null, null, null, null, 0, 10)
+                        .toList();
+        assertEquals(2, res.size());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestEventsResults_withResultFilter_returnsFluAndCovidNegatives() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createArchivedFacility(org, "deleted facility");
+        Person p = _dataFactory.createMinimalPerson(org, facility);
+        var notExpected_allPos =
+                _dataFactory.createMultiplexTestEvent(
+                        p, facility, TestResult.POSITIVE, TestResult.POSITIVE, TestResult.POSITIVE, false);
+        var expected_allNeg =
+                _dataFactory.createMultiplexTestEvent(
+                        p, facility, TestResult.NEGATIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
+        var expected_covidPos =
+                _dataFactory.createMultiplexTestEvent(
+                        p, facility, TestResult.POSITIVE, TestResult.NEGATIVE, TestResult.NEGATIVE, true);
+
+        var res =
+                _service.getFacilityTestEventsResults(
+                        facility.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10);
+
+        var expected = List.of(expected_allNeg.getInternalId(), expected_covidPos.getInternalId());
+        var actualInternalIds = res.stream().map(TestEvent::getInternalId).collect(Collectors.toList());
+        assertTrue(actualInternalIds.containsAll(expected));
+        assertEquals(expected.size(), actualInternalIds.size());
+        assertFalse(actualInternalIds.contains(notExpected_allPos.getInternalId()));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestResultsCount() {
+        makedata();
+        int size =
+                _service.getTestResultsCount(_site.getInternalId(), null, null, null, null, null, null);
+        assertEquals(11, size);
+    }
+
+    @Test
+    @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+    void getTestResultsCount_forOrganization() {
+        var testEvents = makeAdminData();
+        var orgId = testEvents.get(0).getOrganization().getInternalId();
+        int size = _service.getTestResultsCount(null, null, null, null, null, null, orgId);
+        assertEquals(4, size);
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTestResultsCount_forOrganization_failsForNonSiteAdmins() {
+        var otherOrgId = UUID.randomUUID();
+        assertThrows(
+                AccessDeniedException.class,
+                () -> _service.getTestResultsCount(null, null, null, null, null, null, otherOrgId));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getOrganizationLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
+        makedata();
+        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+        OrganizationLevelDashboardMetrics metrics =
+                _service.getOrganizationLevelDashboardMetrics(startDate, endDate);
+        assertEquals(3, metrics.getOrganizationPositiveTestCount());
+        assertEquals(12, metrics.getOrganizationTotalTestCount());
+        assertEquals(5, metrics.getOrganizationNegativeTestCount());
+        assertEquals(4, metrics.getFacilityMetrics().size());
+    }
+
+    @Test
+    @WithSimpleReportStandardAllFacilitiesUser
+    void getOrganizationLevelDashboardMetrics_inOrgWithStandardUser_failure() {
+        makedata();
+        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+        assertThrows(
+                AccessDeniedException.class,
+                () -> _service.getOrganizationLevelDashboardMetrics(startDate, endDate));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTopLevelDashboardMetrics_inOrgWithOrgAdmin_success() {
+        makedata();
+        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+        TopLevelDashboardMetrics metrics =
+                _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19");
+        assertEquals(3, metrics.getPositiveTestCount());
+        assertEquals(12, metrics.getTotalTestCount());
+    }
+
+    @Test
+    @WithSimpleReportStandardAllFacilitiesUser
+    void getTopLevelDashboardMetrics_inOrgWithStandardUser_failure() {
+        makedata();
+        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+        assertThrows(
+                AccessDeniedException.class,
+                () -> _service.getTopLevelDashboardMetrics(null, startDate, endDate, "COVID-19"));
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void getTopLevelDashboardMetrics_showsNonCovidResults() {
+        makedata();
+        makeSpecificDiseaseData(_diseaseService.fluA());
+        Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
+        Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
+
+        TopLevelDashboardMetrics metrics =
+                _service.getTopLevelDashboardMetrics(null, startDate, endDate, "Flu A");
+        assertEquals(1, metrics.getPositiveTestCount());
+        assertEquals(2, metrics.getTotalTestCount());
+    }
+
+    @Test
+    void markAsErrorTest_successDependsOnFacilityAccess() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _dataFactory.createValidFacility(org);
+        Person p = _dataFactory.createFullPerson(org);
+        TestEvent _e = _dataFactory.createTestEvent(p, facility);
+
+        String reasonMsg = "Testing correction marking as error " + LocalDateTime.now();
+        UUID facilityId = facility.getInternalId();
+        UUID testEventId = _e.getInternalId();
+
+        assertThrows(AccessDeniedException.class, () -> _service.markAsError(testEventId, reasonMsg));
+        assertThrows(
+                AccessDeniedException.class,
+                () ->
+                        _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+        assertThrows(AccessDeniedException.class, () -> _service.getTestResult(testEventId));
+
+        // make sure the corrected event is not sent to storage queue
+        verifyNoInteractions(testEventReportingService);
+        verifyNoInteractions(fhirQueueReportingService);
+
+        TestUserIdentities.setFacilityAuthorities(facility);
+        TestEvent correctedTestEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
+        _service.getFacilityTestEventsResults(
+                facility.getInternalId(), null, null, null, null, null, 0, 10);
+        _service.getTestResult(_e.getInternalId()).getTestOrder();
+        // make sure the corrected event is sent to storage queue
+        verify(testEventReportingService).report(correctedTestEvent);
+        verify(fhirQueueReportingService).report(any());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void removeFromQueueByFacilityId_notAuthorizedError() {
+        UUID facilityId = UUID.randomUUID();
+        assertThrows(
+                AccessDeniedException.class, () -> _service.removeFromQueueByFacilityId(facilityId));
+    }
+
+    @Test
+    @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+    void removeFromQueueByFacilityId_facilityNotFoundError() {
+        UUID facilityId = UUID.randomUUID();
+        when(this._organizationService.getFacilityById(facilityId)).thenReturn(Optional.empty());
+        assertThrows(
+                IllegalGraphqlArgumentException.class,
+                () -> _service.removeFromQueueByFacilityId(facilityId));
+    }
+
+    @Test
+    @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+    void removeFromQueueByFacilityId_success() {
+        UUID facilityId = UUID.randomUUID();
+        Facility mockFacility = mock(Facility.class);
+        List<TestOrder> mockOrders = List.of();
+        doReturn(Optional.of(mockFacility)).when(this._organizationService).getFacilityById(facilityId);
+        doReturn(mockOrders).when(_testOrderRepository).fetchQueueItemsByFacilityId(mockFacility);
+        ArgumentCaptor<List<TestOrder>> ordersCaptor = ArgumentCaptor.forClass(List.class);
+        doReturn(null).when(_testOrderRepository).saveAll(ordersCaptor.capture());
+
+        _service.removeFromQueueByFacilityId(facilityId);
+        assertEquals(mockOrders, ordersCaptor.getValue());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void addTestResult_sentToReportingService() {
+        // GIVEN
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person patient = _dataFactory.createFullPerson(org);
+
+        _service.addPatientToQueue(
+                facility.getInternalId(),
+                patient,
+                "",
+                "",
+                Collections.emptyMap(),
+                LocalDate.of(1865, 12, 25),
+                false);
+        DeviceType deviceType = _dataFactory.getGenericDevice();
+        SpecimenType specimenType = _dataFactory.getGenericSpecimen();
+        facility.setDefaultDeviceTypeSpecimenType(deviceType, specimenType);
+
+        // WHEN
+        List<MultiplexResultInput> positiveCovidOnlyResult = makeCovidOnlyResult(TestResult.POSITIVE);
+        _service.addMultiplexResult(
+                deviceType.getInternalId(),
+                specimenType.getInternalId(),
+                positiveCovidOnlyResult,
+                patient.getInternalId(),
+                null);
+
+        // THEN
+        verify(reportTestEventToRSEventListener, times(1)).handleEvent(any());
+        verify(testEventReportingService, times(1)).report(any());
+    }
+
+    @Test
+    @WithSimpleReportOrgAdminUser
+    void removeTest_sentToReportingService() {
+        // GIVEN
+        List<MultiplexResultInput> originalResults =
+                makeMultiplexTestResult(TestResult.NEGATIVE, TestResult.POSITIVE, TestResult.NEGATIVE);
+
+        TestOrder order = addTestToQueue();
+        AddTestResultResponse response =
+                _service.addMultiplexResult(
+                        order.getDeviceType().getInternalId(),
+                        order.getSpecimenType().getInternalId(),
+                        originalResults,
+                        order.getPatient().getInternalId(),
+                        convertDate(LocalDateTime.of(2022, 6, 5, 10, 10, 10, 10)));
+
+        TestEvent originalEvent = response.getTestOrder().getTestEvent();
+
+        // WHEN
+        _service.markAsError(originalEvent.getInternalId(), "Duplicate test");
+
+        // THEN
+        // Invoked once when result is added, invoked again when marked as error
+        verify(reportTestEventToRSEventListener, times(2)).handleEvent(any());
+        verify(testEventReportingService, times(2)).report(any());
+    }
+
+    private List<TestEvent> makeAdminData() {
+        var org = _organizationService.createOrganization("Da Org", "airport", "da-org-airport");
+        _organizationService.setIdentityVerified("da-org-airport", true);
+        var facility = _dataFactory.createValidFacility(org, "Da Facilitiy");
+        var person = _dataFactory.createMinimalPerson(org);
+        return List.of(
+                _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
+                _dataFactory.createTestEvent(person, facility, TestResult.POSITIVE),
+                _dataFactory.createTestEvent(person, facility, TestResult.NEGATIVE),
+                _dataFactory.createTestEvent(person, facility, TestResult.UNDETERMINED));
+    }
+
+    private List<TestEvent> makedata() {
+        Organization org = _organizationService.getCurrentOrganization();
+        _site = _dataFactory.createValidFacility(org, "The Facility");
+        Map<PersonName, TestResult> patientsToResults = new HashMap<>();
+        patientsToResults.put(AMOS, TestResult.POSITIVE);
+        patientsToResults.put(CHARLES, TestResult.POSITIVE);
+        patientsToResults.put(DEXTER, TestResult.POSITIVE);
+        patientsToResults.put(ELIZABETH, TestResult.NEGATIVE);
+        patientsToResults.put(FRANK, TestResult.NEGATIVE);
+        patientsToResults.put(GALE, TestResult.NEGATIVE);
+        patientsToResults.put(HEINRICK, TestResult.NEGATIVE);
+        patientsToResults.put(IAN, TestResult.UNDETERMINED);
+        patientsToResults.put(JANNELLE, TestResult.UNDETERMINED);
+        patientsToResults.put(KACEY, TestResult.UNDETERMINED);
+        patientsToResults.put(LEELOO, TestResult.UNDETERMINED);
+
+        Map<PersonName, Date> patientsToDates = new HashMap<>();
+        patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
+        patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
+        patientsToDates.put(DEXTER, convertDate(LocalDateTime.of(2021, 6, 2, 0, 0, 0)));
+        patientsToDates.put(ELIZABETH, convertDate(LocalDateTime.of(2021, 6, 2, 12, 0, 0)));
+        patientsToDates.put(FRANK, convertDate(LocalDateTime.of(2021, 6, 3, 0, 0, 0)));
+        patientsToDates.put(GALE, convertDate(LocalDateTime.of(2021, 6, 3, 12, 0, 0)));
+        patientsToDates.put(HEINRICK, convertDate(LocalDateTime.of(2021, 6, 4, 0, 0, 0)));
+        patientsToDates.put(IAN, convertDate(LocalDateTime.of(2021, 6, 4, 12, 0, 0)));
+        patientsToDates.put(JANNELLE, convertDate(LocalDateTime.of(2021, 6, 5, 0, 0, 0)));
+        patientsToDates.put(KACEY, convertDate(LocalDateTime.of(2021, 6, 5, 12, 0, 0)));
+        patientsToDates.put(LEELOO, convertDate(LocalDateTime.of(2021, 6, 6, 0, 0, 0)));
+
+        Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
+        patientsToRoles.put(AMOS, PersonRole.RESIDENT);
+        patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
+        patientsToRoles.put(DEXTER, PersonRole.STUDENT);
+        patientsToRoles.put(ELIZABETH, PersonRole.STUDENT);
+        patientsToRoles.put(FRANK, PersonRole.VISITOR);
+        patientsToRoles.put(GALE, PersonRole.VISITOR);
+        patientsToRoles.put(HEINRICK, PersonRole.STAFF);
+        patientsToRoles.put(IAN, PersonRole.STAFF);
+        patientsToRoles.put(JANNELLE, PersonRole.RESIDENT);
+        patientsToRoles.put(KACEY, PersonRole.RESIDENT);
+        patientsToRoles.put(LEELOO, PersonRole.STUDENT);
+
+        Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
+        patientsToSurveys.put(
+                AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+        patientsToSurveys.put(
+                CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+        patientsToSurveys.put(
+                DEXTER, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
+        patientsToSurveys.put(
+                ELIZABETH, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+        patientsToSurveys.put(
+                FRANK, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+        patientsToSurveys.put(
+                GALE, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
+        patientsToSurveys.put(
+                HEINRICK, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+        patientsToSurveys.put(
+                IAN, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+        patientsToSurveys.put(
+                JANNELLE, new AskOnEntrySurvey(null, null, Collections.emptyMap(), true, null, null));
+        patientsToSurveys.put(
+                KACEY, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+        patientsToSurveys.put(
+                LEELOO, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+
+        List<TestEvent> testEvents =
+                patientsToResults.keySet().stream()
+                        .map(
+                                n -> {
+                                    TestResult t = patientsToResults.get(n);
+                                    PersonRole r = patientsToRoles.get(n);
+                                    AskOnEntrySurvey s = patientsToSurveys.get(n);
+                                    Date d = patientsToDates.get(n);
+
+                                    Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
+                                    return _dataFactory.createTestEvent(person, _site, s, t, d);
+                                })
+                        .collect(Collectors.toList());
+        // Make one result in another facility
+        Facility _otherSite = _dataFactory.createValidFacility(org, "The Other Facility");
+        _dataFactory.createTestEvent(
+                _dataFactory.createMinimalPerson(org, _otherSite, BRAD), _otherSite, TestResult.NEGATIVE);
+        return testEvents;
+    }
+
+    private List<TestEvent> makeSpecificDiseaseData(SupportedDisease disease) {
+        Organization org = _organizationService.getCurrentOrganization();
+        _site = _dataFactory.createValidFacility(org, "The Facility for " + disease.getName());
+        Map<PersonName, TestResult> patientsToResults = new HashMap<>();
+        patientsToResults.put(AMOS, TestResult.POSITIVE);
+        patientsToResults.put(CHARLES, TestResult.NEGATIVE);
+
+        Map<PersonName, Date> patientsToDates = new HashMap<>();
+        patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
+        patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
+
+        Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
+        patientsToRoles.put(AMOS, PersonRole.RESIDENT);
+        patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
+
+        Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
+        patientsToSurveys.put(
+                AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+        patientsToSurveys.put(
+                CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+
+        return patientsToResults.keySet().stream()
+                .map(
+                        n -> {
+                            TestResult t = patientsToResults.get(n);
+                            PersonRole r = patientsToRoles.get(n);
+                            AskOnEntrySurvey s = patientsToSurveys.get(n);
+                            Date d = patientsToDates.get(n);
+
+                            Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
+                            return _dataFactory.createTestEvent(person, _site, s, t, d, disease);
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<MultiplexResultInput> makeCovidOnlyResult(TestResult covidTestResult) {
+        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
+        return List.of(covidResult);
+    }
+
+    private List<MultiplexResultInput> makeMultiplexTestResult(
+            TestResult covidTestResult, TestResult fluATestResult, TestResult fluBTestResult) {
+        MultiplexResultInput covidResult = new MultiplexResultInput("COVID-19", covidTestResult);
+        MultiplexResultInput fluAResult = new MultiplexResultInput("Flu A", fluATestResult);
+        MultiplexResultInput fluBResult = new MultiplexResultInput("Flu B", fluBTestResult);
+        return List.of(covidResult, fluAResult, fluBResult);
+    }
+
+    private static void assertTestResultsList(List<TestEvent> found, List<TestEvent> expected) {
+        // check common elements first
+        for (int i = 0; i < expected.size() && i < found.size(); i++) {
+            assertEquals(expected.get(i).getInternalId(), found.get(i).getInternalId());
+        }
+        // *then* check if there are extras
+        if (expected.size() != found.size()) {
+            fail("Expected " + expected.size() + " items but found " + found.size());
+        }
+    }
+
+    private static Date convertDate(LocalDateTime dateTime) {
+        return Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private TestOrder addTestToQueue() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Person patient = _dataFactory.createFullPerson(org);
+        return addTestToQueue(org, patient);
+    }
+
+    private TestOrder addTestToQueue(Organization org, Person patient) {
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        _personService.updateTestResultDeliveryPreference(
+                patient.getInternalId(), TestResultDeliveryPreference.SMS);
+
+        TestOrder order =
+                _service.addPatientToQueue(
+                        facility.getInternalId(),
+                        patient,
+                        "",
+                        "",
+                        Collections.emptyMap(),
+                        LocalDate.of(2022, 6, 5),
+                        false);
+
+        facility.setDefaultDeviceTypeSpecimenType(
+                _dataFactory.getGenericDevice(), _dataFactory.getGenericSpecimen());
+
+        return order;
+    }
 }

--- a/backend/src/test/resources/graphql-test/queue-dates-query.graphql
+++ b/backend/src/test/resources/graphql-test/queue-dates-query.graphql
@@ -2,6 +2,7 @@ query fetchFacilityQueue($facilityId: ID!) {
   queue(facilityId: $facilityId) {
     internalId
     pregnancy
+    syphilisHistory
     dateAdded
     symptoms
     symptomOnset

--- a/backend/src/test/resources/graphql-test/update-time-of-test-questions.graphql
+++ b/backend/src/test/resources/graphql-test/update-time-of-test-questions.graphql
@@ -3,12 +3,14 @@ mutation UpdateAOE(
   $symptoms: String
   $symptomOnset: LocalDate
   $pregnancy: String
+  $syphilisHistory: String
   $noSymptoms: Boolean
   $genderOfSexualPartners: [String]
 ) {
   updateTimeOfTestQuestions(
     patientId: $patientId
     pregnancy: $pregnancy
+    syphilisHistory: $syphilisHistory
     symptoms: $symptoms
     noSymptoms: $noSymptoms
     symptomOnset: $symptomOnset

--- a/frontend/src/app/testQueue/addToQueue/operations.graphql
+++ b/frontend/src/app/testQueue/addToQueue/operations.graphql
@@ -53,6 +53,7 @@ mutation AddPatientToQueue(
   $symptoms: String
   $symptomOnset: LocalDate
   $pregnancy: String
+  $syphilisHistory: String
   $noSymptoms: Boolean
   $testResultDelivery: TestResultDeliveryPreference
 ) {
@@ -60,6 +61,7 @@ mutation AddPatientToQueue(
     facilityId: $facilityId
     patientId: $patientId
     pregnancy: $pregnancy
+    syphilisHistory: $syphilisHistory
     noSymptoms: $noSymptoms
     symptoms: $symptoms
     symptomOnset: $symptomOnset
@@ -72,6 +74,7 @@ mutation UpdateAOE(
   $symptoms: String
   $symptomOnset: LocalDate
   $pregnancy: String
+  $syphilisHistory: String
   $noSymptoms: Boolean
   $testResultDelivery: TestResultDeliveryPreference
   $genderOfSexualPartners: [String]
@@ -79,6 +82,7 @@ mutation UpdateAOE(
   updateTimeOfTestQuestions(
     patientId: $patientId
     pregnancy: $pregnancy
+    syphilisHistory: $syphilisHistory
     symptoms: $symptoms
     noSymptoms: $noSymptoms
     symptomOnset: $symptomOnset

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -56,6 +56,7 @@ query GetFacilityQueue($facilityId: ID!) {
     queue(facilityId: $facilityId) {
         internalId
         pregnancy
+        syphilisHistory
         dateAdded
         symptoms
         symptomOnset

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -285,6 +285,7 @@ export type MutationAddPatientToQueueArgs = {
   pregnancy?: InputMaybe<Scalars["String"]["input"]>;
   symptomOnset?: InputMaybe<Scalars["LocalDate"]["input"]>;
   symptoms?: InputMaybe<Scalars["String"]["input"]>;
+  syphilisHistory?: InputMaybe<Scalars["String"]["input"]>;
   testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 };
 
@@ -532,6 +533,7 @@ export type MutationUpdateTimeOfTestQuestionsArgs = {
   pregnancy?: InputMaybe<Scalars["String"]["input"]>;
   symptomOnset?: InputMaybe<Scalars["LocalDate"]["input"]>;
   symptoms?: InputMaybe<Scalars["String"]["input"]>;
+  syphilisHistory?: InputMaybe<Scalars["String"]["input"]>;
   testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 };
 
@@ -994,6 +996,7 @@ export type TestOrder = {
   specimenType: SpecimenType;
   symptomOnset?: Maybe<Scalars["LocalDate"]["output"]>;
   symptoms?: Maybe<Scalars["String"]["output"]>;
+  syphilisHistory?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type TestResult = {
@@ -1015,6 +1018,7 @@ export type TestResult = {
   results?: Maybe<Array<Maybe<MultiplexResult>>>;
   symptomOnset?: Maybe<Scalars["LocalDate"]["output"]>;
   symptoms?: Maybe<Scalars["String"]["output"]>;
+  syphilisHistory?: Maybe<Scalars["String"]["output"]>;
 };
 
 export enum TestResultDeliveryPreference {
@@ -2164,6 +2168,7 @@ export type AddPatientToQueueMutationVariables = Exact<{
   symptoms?: InputMaybe<Scalars["String"]["input"]>;
   symptomOnset?: InputMaybe<Scalars["LocalDate"]["input"]>;
   pregnancy?: InputMaybe<Scalars["String"]["input"]>;
+  syphilisHistory?: InputMaybe<Scalars["String"]["input"]>;
   noSymptoms?: InputMaybe<Scalars["Boolean"]["input"]>;
   testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 }>;
@@ -2178,6 +2183,7 @@ export type UpdateAoeMutationVariables = Exact<{
   symptoms?: InputMaybe<Scalars["String"]["input"]>;
   symptomOnset?: InputMaybe<Scalars["LocalDate"]["input"]>;
   pregnancy?: InputMaybe<Scalars["String"]["input"]>;
+  syphilisHistory?: InputMaybe<Scalars["String"]["input"]>;
   noSymptoms?: InputMaybe<Scalars["Boolean"]["input"]>;
   testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
   genderOfSexualPartners?: InputMaybe<
@@ -2258,6 +2264,7 @@ export type GetFacilityQueueQuery = {
     __typename?: "TestOrder";
     internalId: string;
     pregnancy?: string | null;
+    syphilisHistory?: string | null;
     dateAdded: string;
     symptoms?: string | null;
     symptomOnset?: any | null;
@@ -7070,6 +7077,7 @@ export const AddPatientToQueueDocument = gql`
     $symptoms: String
     $symptomOnset: LocalDate
     $pregnancy: String
+    $syphilisHistory: String
     $noSymptoms: Boolean
     $testResultDelivery: TestResultDeliveryPreference
   ) {
@@ -7077,6 +7085,7 @@ export const AddPatientToQueueDocument = gql`
       facilityId: $facilityId
       patientId: $patientId
       pregnancy: $pregnancy
+      syphilisHistory: $syphilisHistory
       noSymptoms: $noSymptoms
       symptoms: $symptoms
       symptomOnset: $symptomOnset
@@ -7107,6 +7116,7 @@ export type AddPatientToQueueMutationFn = Apollo.MutationFunction<
  *      symptoms: // value for 'symptoms'
  *      symptomOnset: // value for 'symptomOnset'
  *      pregnancy: // value for 'pregnancy'
+ *      syphilisHistory: // value for 'syphilisHistory'
  *      noSymptoms: // value for 'noSymptoms'
  *      testResultDelivery: // value for 'testResultDelivery'
  *   },
@@ -7139,6 +7149,7 @@ export const UpdateAoeDocument = gql`
     $symptoms: String
     $symptomOnset: LocalDate
     $pregnancy: String
+    $syphilisHistory: String
     $noSymptoms: Boolean
     $testResultDelivery: TestResultDeliveryPreference
     $genderOfSexualPartners: [String]
@@ -7146,6 +7157,7 @@ export const UpdateAoeDocument = gql`
     updateTimeOfTestQuestions(
       patientId: $patientId
       pregnancy: $pregnancy
+      syphilisHistory: $syphilisHistory
       symptoms: $symptoms
       noSymptoms: $noSymptoms
       symptomOnset: $symptomOnset
@@ -7176,6 +7188,7 @@ export type UpdateAoeMutationFn = Apollo.MutationFunction<
  *      symptoms: // value for 'symptoms'
  *      symptomOnset: // value for 'symptomOnset'
  *      pregnancy: // value for 'pregnancy'
+ *      syphilisHistory: // value for 'syphilisHistory'
  *      noSymptoms: // value for 'noSymptoms'
  *      testResultDelivery: // value for 'testResultDelivery'
  *      genderOfSexualPartners: // value for 'genderOfSexualPartners'
@@ -7401,6 +7414,7 @@ export const GetFacilityQueueDocument = gql`
     queue(facilityId: $facilityId) {
       internalId
       pregnancy
+      syphilisHistory
       dateAdded
       symptoms
       symptomOnset


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Backend work for #7436 that modifies the AoE storage to accept the new syphilis history question

## Changes Proposed

- Modifies the AoE backend object to CRUD a new syphilis history field needed for the new card
- Updates the relevant GQL endpoints to query / mutate this field
- Refactors the tests with a builder pattern / with the new field for readability

## Additional Information
- I decided just to add the new field onto the existing AoE JSON like we did for the other questions, but worth considering how we refactor these endpoints in the future to be more flexible to adding new fields. Had to change the value in several places in order to get everything working, which may be an issue as we add additional sets of AoE questions for the new STI's that are coming down the pike
- I didn't add any validation for the validity of the syphilis type codes just yet because 1) we don't do that for pregnancy and 2) we're waiting for confirmation from LAC that the SNOMED's I found on Google were correct, but we might want to add a check that the values match.

Comments on either of the two above decisions welcome

## Testing

https://github.com/CDCgov/prime-simplereport/assets/29645040/c18222f0-c770-4fdf-a924-60483436ef2c

- Grab a facility ID / patient ID combination in your local dev. 
- Use the below queries to add a patient to the queue 

```gql
// Variables for mutation
{
  "patientId": YOUR-PATIENT-ID,
  "noSymptoms": true,
  "symptoms": "{\"25064002\":false,\"36955009\":false,\"43724002\":false,\"44169009\":false,\"49727002\":false,\"62315008\":false,\"64531003\":false,\"68235000\":false,\"68962001\":false,\"84229001\":false,\"103001002\":false,\"162397003\":false,\"230145002\":false,\"267036007\":false,\"422400008\":false,\"422587007\":false,\"426000000\":false}",
  "pregnancy": "60001007",
  "syphilisHistory": "14732006", // or a test string
  "testResultDelivery": null,
  "facilityId": YOUR-FACILITY-ID
}

mutation AddPatientToQueue($facilityId: ID!, $patientId: ID!, $symptoms: String, $symptomOnset: LocalDate, $pregnancy: String, $noSymptoms: Boolean, $syphilisHistory: String, $testResultDelivery: TestResultDeliveryPreference) {
  addPatientToQueue(
    facilityId: $facilityId
    patientId: $patientId
    pregnancy: $pregnancy
    syphilisHistory: $syphilisHistory
    noSymptoms: $noSymptoms
    symptoms: $symptoms
    symptomOnset: $symptomOnset
    testResultDelivery: $testResultDelivery
  )
}
```
- Use the below query to grab the queue back and notice the presence of the syphilis history code
```gql
query Queue ($facilityId: ID!) {
      queue (
        facilityId: $facilityId
      ){
        internalId
        pregnancy
        dateAdded
        syphilisHistory
      }
    }
```
<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---
