### PR TITLE
Update logic on apiUser delete in orgDelete flow

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -190,7 +190,7 @@ public class OrganizationMutationResolver {
     Organization orgToBeUpdated = organizationService.getOrganizationById(organizationId);
     List<ApiUser> usersInOrgToBeUpdated = apiUserService.getAllUsersByOrganization(orgToBeUpdated);
 
-    // Only set user to be deleted if they are an active user
+    // Only set user to be deleted if they are an active, without check mutation will fail.
     usersInOrgToBeUpdated.forEach(
         user -> {
           if (!user.isDeleted()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -190,8 +190,13 @@ public class OrganizationMutationResolver {
     Organization orgToBeUpdated = organizationService.getOrganizationById(organizationId);
     List<ApiUser> usersInOrgToBeUpdated = apiUserService.getAllUsersByOrganization(orgToBeUpdated);
 
+    // Only set user to be deleted if they are an active user
     usersInOrgToBeUpdated.forEach(
-        user -> apiUserService.setIsDeleted(user.getInternalId(), deleted));
+        user -> {
+          if (!user.isDeleted()) {
+            apiUserService.setIsDeleted(user.getInternalId(), deleted);
+          }
+        });
     Set<Facility> facilitiesToBeUpdated =
         organizationService.getFacilitiesIncludeArchived(orgToBeUpdated, !deleted);
     facilitiesToBeUpdated.forEach(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -194,7 +194,7 @@ public class OrganizationMutationResolver {
     usersInOrgToBeUpdated.forEach(
         user -> {
           if (!user.isDeleted()) {
-            apiUserService.setIsDeleted(user.getInternalId(), true);
+            apiUserService.setIsDeleted(user.getInternalId(), deleted);
           }
         });
     Set<Facility> facilitiesToBeUpdated =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -194,7 +194,7 @@ public class OrganizationMutationResolver {
     usersInOrgToBeUpdated.forEach(
         user -> {
           if (!user.isDeleted()) {
-            apiUserService.setIsDeleted(user.getInternalId(), deleted);
+            apiUserService.setIsDeleted(user.getInternalId(), true);
           }
         });
     Set<Facility> facilitiesToBeUpdated =

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -309,7 +309,6 @@ public class ApiUserService {
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUserNotSelf
   public UserInfo setIsDeleted(UUID userId, boolean deleted) {
-    // fails here
     ApiUser apiUser = getApiUser(userId, !deleted);
     apiUser.setIsDeleted(deleted);
     apiUser = _apiUserRepo.save(apiUser);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -309,6 +309,7 @@ public class ApiUserService {
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUserNotSelf
   public UserInfo setIsDeleted(UUID userId, boolean deleted) {
+    // fails here
     ApiUser apiUser = getApiUser(userId, !deleted);
     apiUser.setIsDeleted(deleted);
     apiUser = _apiUserRepo.save(apiUser);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

resolves #6165 

## Changes Proposed

Add a conditional to check if a user in an organization is already deleted, before calling `setIsDeleted` on each user in the `markOrganizationAsDeleted` mutation.

## Additional Information

For this ticket I decided to address this bug at the mutation level, instead of the the service level, as as the logic in the function contract for a single api user in [`setIsDeleted`](https://github.com/CDCgov/prime-simplereport/blob/bobby/6165/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java#L311) is sound. 

The bug stems from the fact that the `deleted` argument that is passed to `markOrganizationAsDeleted` holds the logic for if an organization is being deleted, not a user. However, the code was originally passing off this `deleted` variable to `setIsDeleted` assuming that it holds the logic for an individual user is to be deleted as well.

BUT the logic of if a user is deleted vs an org can have different values, this is what was causing the mutation to fail. By adding the check, the code now separates these two pieces of logic appropriately while also not adding any complexity to the service level functions. 

## Testing
On dev4 the organization El Test Org B has a a deleted user, E L, with the following email: elisa+eldev4testorgB1@skylight.digital.  


On Dev4 make the following api call:
```
  mutation ($orgInternalId: ID!, $deleted: Boolean!) {
    markOrganizationAsDeleted(
     organizationId: $orgInternalId,
      deleted: $deleted
    )
  }
```

with the following variables:

```
{"orgInternalId": "9b526d46-237a-410c-90c9-309126c82cf5",
"deleted": true}
```

Go to metabase and verify that the org has successfully been deleted in the organization table. 

Note that if someone else has tested this flow before you, that you might first have to reset the org to not be deleted. You can do this by making the same API call but with passing false instead of true.
## Screen Recording/Screenshots

<img width="1432" alt="Screenshot 2024-04-26 at 1 42 46 PM" src="https://github.com/CDCgov/prime-simplereport/assets/98844419/702f96b5-cc4f-4273-8d37-8af0cf34de2a">

[Screen Recording 2024-04-26 at 1.08.53 PM.zip](https://github.com/CDCgov/prime-simplereport/files/15134573/Screen.Recording.2024-04-26.at.1.08.53.PM.zip)