### PR TITLE
Add api_user_facility and api_user_role tables

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5360,10 +5360,6 @@ databaseChangeLog:
                     nullable: false
                     foreignKeyName: fk__api_user_role__role
                     references: role
-        - sql: |
-            GRANT SELECT ON ${database.defaultSchemaName}.role TO ${noPhiUsername};
-            GRANT SELECT ON ${database.defaultSchemaName}.api_user_facility TO ${noPhiUsername};
-            GRANT SELECT ON ${database.defaultSchemaName}.api_user_role TO ${noPhiUsername};
       rollback:
         - sql:
             sql: |
@@ -5371,3 +5367,17 @@ databaseChangeLog:
               DROP TABLE ${database.defaultSchemaName}.API_USER_ROLE;
               DROP TABLE ${database.defaultSchemaName}.ROLE;
               DROP TYPE ${database.defaultSchemaName}.ORGANIZATION_ROLE;
+  - changeSet:
+      id: add-user-role-and-user-facility-to-metabase
+      author: ttu8@cdc.gov
+      comment: Adds permission for the no-PHI user to select from the role, api_user_role, and api_user_facility tables
+      changes:
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.role TO ${noPhiUsername};
+            GRANT SELECT ON ${database.defaultSchemaName}.api_user_facility TO ${noPhiUsername};
+            GRANT SELECT ON ${database.defaultSchemaName}.api_user_role TO ${noPhiUsername};
+      rollback:
+        - sql: |
+            REVOKE SELECT ON TABLE ${database.defaultSchemaName}.role FROM ${noPhiUsername};
+            REVOKE SELECT ON TABLE ${database.defaultSchemaName}.api_user_facility FROM ${noPhiUsername};
+            REVOKE SELECT ON TABLE ${database.defaultSchemaName}.api_user_role FROM ${noPhiUsername};

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5276,3 +5276,98 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Syphilis';
+  - changeSet:
+      id: create-user-role-and-user-facility-tables
+      author: ttu8@cdc.gov
+      comment: creates role, api_user_role, and api_user_facility tables to begin migration of Okta role and groups
+      changes:
+        - tagDatabase:
+            tag: create-user-role-and-user-facility
+        - sql:
+            remarks: Create the OrganizationRole enumerations needed for role
+            sql: CREATE TYPE ${database.defaultSchemaName}.ORGANIZATION_ROLE as ENUM('ALL_FACILITIES', 'ENTRY_ONLY', 'USER', 'ADMIN');
+        - createTable:
+            tableName: role
+            remarks: named references to a OrganizationRole enum
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: ${database.defaultSchemaName}.ORGANIZATION_ROLE
+                  remarks: The name of the role that is an enumerated value.
+                  constraints:
+                    nullable: false
+        - createTable:
+            tableName: api_user_facility
+            remarks: creates a new table to store the relationship between api_user and facility
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: api_user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__api_user
+                    references: api_user
+              - column:
+                  name: facility_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__facility
+                    references: facility
+        - createTable:
+            tableName: api_user_role
+            remarks: creates a new table to store the relationship between api_user and role
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: api_user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__api_user
+                    references: api_user
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__organization
+                    references: organization
+              - column:
+                  name: role_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__role
+                    references: role
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.role TO ${noPhiUsername};
+            GRANT SELECT ON ${database.defaultSchemaName}.api_user_facility TO ${noPhiUsername};
+            GRANT SELECT ON ${database.defaultSchemaName}.api_user_role TO ${noPhiUsername};
+      rollback:
+        - sql:
+            sql: |
+              DROP TABLE ${database.defaultSchemaName}.API_USER_FACILITY;
+              DROP TABLE ${database.defaultSchemaName}.API_USER_ROLE;
+              DROP TABLE ${database.defaultSchemaName}.ROLE;
+              DROP TYPE ${database.defaultSchemaName}.ORGANIZATION_ROLE;


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- Resolves #7594 

## Changes Proposed
- Adds the following tables according to the["Managing User Roles Outside Okta Design Doc" - Data Schema design specifications](https://docs.google.com/document/d/1YhRh9UIWj1kWeT35tj7T5pnUjW6Rn7qyIVkiQL3cDFU/edit#heading=h.81jlslm37il6):
   - `role`
   - `api_user_role`
   - `api_user_facility`
- and adds a new enum type called `OrganizationRole`

## Additional Information
- deployed on dev2 (see metabase for new tables)

## Testing
- start up the backend on this branch and new tables should be added with the associations
- rollback the changes in the `backend` directory by running `./gradlew liquibaseRollbackCount -PliquibaseCommandValue=2`

<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->