### PR TITLE
Add and initialize Okta migration feature flag

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolver.java
@@ -190,8 +190,13 @@ public class OrganizationMutationResolver {
     Organization orgToBeUpdated = organizationService.getOrganizationById(organizationId);
     List<ApiUser> usersInOrgToBeUpdated = apiUserService.getAllUsersByOrganization(orgToBeUpdated);
 
+    // Only set user to be deleted if they are an active, without check mutation will fail.
     usersInOrgToBeUpdated.forEach(
-        user -> apiUserService.setIsDeleted(user.getInternalId(), deleted));
+        user -> {
+          if (!user.isDeleted()) {
+            apiUserService.setIsDeleted(user.getInternalId(), deleted);
+          }
+        });
     Set<Facility> facilitiesToBeUpdated =
         organizationService.getFacilitiesIncludeArchived(orgToBeUpdated, !deleted);
     facilitiesToBeUpdated.forEach(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -24,6 +24,7 @@ public class FeatureFlagsConfig {
   @Setter(AccessLevel.NONE)
   private final FeatureFlagRepository _repo;
 
+  private boolean oktaMigrationEnabled;
   private boolean syphilisEnabled;
   private boolean hivBulkUploadEnabled;
   private boolean hivEnabled;
@@ -38,6 +39,7 @@ public class FeatureFlagsConfig {
 
   private void flagMapping(String flagName, Boolean flagValue) {
     switch (flagName) {
+      case "oktaMigrationEnabled" -> setOktaMigrationEnabled(flagValue);
       case "syphilisEnabled" -> setSyphilisEnabled(flagValue);
       case "hivBulkUploadEnabled" -> setHivBulkUploadEnabled(flagValue);
       case "hivEnabled" -> setHivEnabled(flagValue);

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -21,6 +21,7 @@ twilio:
   enabled: true
   from-number: "+14045312484"
 features:
+  oktaMigrationEnabled: false
   syphilisEnabled: false
   hivBulkUploadEnabled: false
   hivEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -168,6 +168,7 @@ datahub:
   csv-upload-api-client: "simple_report.csvuploader"
   csv-upload-api-fhir-client: "simple_report.fullelr"
 features:
+  oktaMigrationEnabled: true
   syphilisEnabled: true
   hivBulkUploadEnabled: true
   hivEnabled: true

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -168,7 +168,7 @@ datahub:
   csv-upload-api-client: "simple_report.csvuploader"
   csv-upload-api-fhir-client: "simple_report.fullelr"
 features:
-  oktaMigrationEnabled: true
+  oktaMigrationEnabled: false
   syphilisEnabled: true
   hivBulkUploadEnabled: true
   hivEnabled: true


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
Resolves #7596  

## Changes Proposed

- Adds Okta migration flag to our suite of feature flags and sets the default value to be false.

## Additional Information


## Testing


