### PR TITLE
Clean up unused effective roles code

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/OrganizationRole.java
@@ -2,18 +2,10 @@ package gov.cdc.usds.simplereport.config.authorization;
 
 import java.security.Principal;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Set;
 
-/**
- * The roles that can be granted (via Okta) to a user. Since multiple roles can be granted, this
- * class also contains the logic for determining which role "matters" more for determining the
- * effective role of a user.
- *
- * <p>Specifically, the {@link EffectiveRoleComparator} can order a list of roles such that the
- * first role in the list is the "effective" role for the applicable user.
- */
+/** The roles that can be granted (via Okta) to a user. */
 public enum OrganizationRole implements Principal {
   /**
    * This is the base role that we expect every user to have. Any other role that has more specific
@@ -99,20 +91,6 @@ public enum OrganizationRole implements Principal {
   @Override
   public String getName() {
     return name();
-  }
-
-  // Allows us to sort OrganizationRole's based on the number of permissions they grant,
-  // from greatest to least; effectively sorting from the most to least permission-granting.
-  // In the event that two roles grant an equal number of permissions, the one listed later
-  // in the OrganizationRole enum will take precedence.
-  public static final class EffectiveRoleComparator implements Comparator<OrganizationRole> {
-    public int compare(OrganizationRole one, OrganizationRole other) {
-      if (other.getGrantedPermissions().size() == one.getGrantedPermissions().size()) {
-        return other.compareTo(one);
-      }
-      return Integer.compare(
-          other.getGrantedPermissions().size(), one.getGrantedPermissions().size());
-    }
   }
 
   public static final OrganizationRole getDefault() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolder.java
@@ -1,9 +1,6 @@
 package gov.cdc.usds.simplereport.config.authorization;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,47 +22,6 @@ public interface PermissionHolder {
 
   default boolean grantsArchivedFacilityAccess() {
     return getGrantedPermissions().contains(UserPermission.VIEW_ARCHIVED_FACILITIES);
-  }
-
-  // this is not used for now, but leaving it in in the event it becomes useful in the future
-  default Set<OrganizationRole> getEffectiveRoles() {
-    return getEffectiveRoles(getGrantedRoles());
-  }
-
-  /**
-   * Iterate over all granted roles from most to least permission-granting, until all granted
-   * permissions are covered by the roles added thus far, then stop and return that set of roles. In
-   * the event that two roles grant an equal number of permissions, the one listed later in the
-   * OrganizationRole enum will take precedence when calculating the effective roles from a set of
-   * roles. But all roles a user holds, whose permissions are not collectively granted by other
-   * roles listed later in the OrganizationRole enum that the user also holds, will be considered
-   * effective. e.g. [NO_ACCESS, ALL_FACILITIES, ENTRY_ONLY, USER] => [ALL_FACILITIES, USER] e.g.
-   * [NO_ACCESS, ENTRY_ONLY, USER, ADMIN] => [ADMIN]
-   */
-  static Set<OrganizationRole> getEffectiveRoles(Collection<OrganizationRole> roles) {
-    List<OrganizationRole> grantedRoles = new ArrayList<>(roles);
-    grantedRoles.sort(new OrganizationRole.EffectiveRoleComparator());
-    // set of all permissions granted by the user's granted roles
-    Set<UserPermission> grantedPerms = getPermissionsFromRoles(grantedRoles);
-
-    // minimal set of roles that effectively captures all of user's granted permissions
-    Set<OrganizationRole> effectiveRoles = EnumSet.noneOf(OrganizationRole.class);
-    // all permissions granted by the OrganizationRoles in effectiveRoles
-    Set<UserPermission> effectivePerms = EnumSet.noneOf(UserPermission.class);
-    for (OrganizationRole r : grantedRoles) {
-      if (effectivePerms.addAll(r.getGrantedPermissions())) {
-        effectiveRoles.add(r);
-      }
-      if (effectivePerms.equals(grantedPerms)) {
-        break;
-      }
-    }
-
-    if (effectiveRoles.isEmpty() && roles.contains(OrganizationRole.getDefault())) {
-      effectiveRoles.add(OrganizationRole.getDefault());
-    }
-
-    return effectiveRoles;
   }
 
   private static Set<UserPermission> getPermissionsFromRoles(Collection<OrganizationRole> roles) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolderTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolderTest.java
@@ -73,51 +73,6 @@ class PermissionHolderTest {
   }
 
   @Test
-  void getEffectiveRoles_allRoles_admin() {
-    Set<OrganizationRole> roles = EnumSet.allOf(OrganizationRole.class);
-    assertEquals(Set.of(OrganizationRole.ADMIN), makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
-  void getEffectiveRoles_noRoles_empty() {
-    Set<OrganizationRole> roles = EnumSet.noneOf(OrganizationRole.class);
-    assertEquals(Set.of(), makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
-  void getEffectiveRoles_onlyNoAccess_noAccess() {
-    Set<OrganizationRole> roles = Set.of(OrganizationRole.NO_ACCESS);
-    assertEquals(Set.of(OrganizationRole.NO_ACCESS), makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
-  void getEffectiveRoles_onlyUser_user() {
-    Set<OrganizationRole> roles = Set.of(OrganizationRole.USER);
-    assertEquals(Set.of(OrganizationRole.USER), makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
-  void getEffectiveRoles_noAccessAndEntry_entry() {
-    Set<OrganizationRole> roles = Set.of(OrganizationRole.ENTRY_ONLY, OrganizationRole.NO_ACCESS);
-    assertEquals(Set.of(OrganizationRole.ENTRY_ONLY), makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
-  void getEffectiveRoles_userAndEntry_user() {
-    Set<OrganizationRole> roles = Set.of(OrganizationRole.USER, OrganizationRole.ENTRY_ONLY);
-    assertEquals(Set.of(OrganizationRole.USER), makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
-  void getEffectiveRoles_userEntryAllFacilities_userAllFacilities() {
-    Set<OrganizationRole> roles =
-        Set.of(OrganizationRole.USER, OrganizationRole.ENTRY_ONLY, OrganizationRole.ALL_FACILITIES);
-    assertEquals(
-        Set.of(OrganizationRole.USER, OrganizationRole.ALL_FACILITIES),
-        makeHolder(roles).getEffectiveRoles());
-  }
-
-  @Test
   void grantsAllFacilityAccess_allRoles_true() {
     Set<OrganizationRole> roles = EnumSet.allOf(OrganizationRole.class);
     assertTrue(makeHolder(roles).grantsAllFacilityAccess());


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
https://github.com/CDCgov/prime-simplereport/blob/225ca05873a14b29bf4a166c805c05ea8838924f/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/PermissionHolder.java#L30

This method has been unused for 3 years. I propose we remove this because I think at this point we've lost the context of why we might want this and I personally find it confusing and keep thinking it impacts our functionality in some way.

I also don't want to have to wrangle with this logic as we're doing the Okta migration.

## Changes Proposed

Delete unused method and resulting unused test cases and comparator implementation.

## Additional Information

Before taking out of draft I want to check what logic we use in the frontend to determine what role is visible under the user's name in the Manage users screen. That's the only place I can think of that has a concept of "effective role" or needing to consolidate roles.

Edit: the role surfaced on the frontend is determined by the ordering of the Role enums here:
https://github.com/CDCgov/prime-simplereport/blob/10a8eb05cff72a2601b9a29039db413993c1947a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Role.java#L12-L16

## Testing

Make sure tests pass? This code was unused so won't impact the app functionality.