### PR TITLE
Mike/7489 redirect alerts

### DIFF
--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -84,17 +84,17 @@ resource "azurerm_monitor_metric_alert" "uptime" {
   }
 }
 
-resource "azurerm_monitor_metric_alert" "uptime-redirects" {
+resource "azurerm_monitor_metric_alert" "uptime_redirects" {
   for_each = var.additional_uptime_test_urls
 
-  name                = "uptime-${each.key}"
+  name                = "uptime_redirects-${each.key}"
   description         = "${each.key} is not responding"
   resource_group_name = var.rg_name
   scopes              = [azurerm_application_insights_web_test.uptime[each.key].id, var.app_insights_id]
   frequency           = "PT1M"
   window_size         = "PT15M"
   severity            = var.severity
-  enabled             = contains(var.disabled_alerts, "uptime") ? false : true
+  enabled             = contains(var.disabled_alerts, "uptime_redirects") ? false : true
 
   application_insights_web_test_location_availability_criteria {
     web_test_id           = azurerm_application_insights_web_test.uptime[each.key].id

--- a/ops/services/alerts/app_service_metrics/uptime.tf
+++ b/ops/services/alerts/app_service_metrics/uptime.tf
@@ -9,18 +9,50 @@ locals {
 
   url_prefix = var.env == "prod" ? "www" : var.env
 
-  url_map = merge(
-    {
-      "${var.env}-simplereport-gov"     = "https://${local.url_prefix}.simplereport.gov/",
-      "${var.env}-simplereport-gov-api" = "https://${local.url_prefix}.simplereport.gov/api/actuator/health",
-      "${var.env}-simplereport-gov-app" = "https://${local.url_prefix}.simplereport.gov/app/health/ping"
-    },
+  base_url_map = {
+    "${var.env}-simplereport-gov"     = "https://${local.url_prefix}.simplereport.gov/",
+    "${var.env}-simplereport-gov-api" = "https://${local.url_prefix}.simplereport.gov/api/actuator/health",
+    "${var.env}-simplereport-gov-app" = "https://${local.url_prefix}.simplereport.gov/app/health/ping"
+  }
+
+  full_url_map = merge(
+    local.base_url_map,
     var.additional_uptime_test_urls
   )
+
+  base_azurerm_monitor_metric_alert_rule = {
+    name                = "uptime-${each.key}"
+    description         = "${each.key} is not responding"
+    resource_group_name = var.rg_name
+    scopes              = [azurerm_application_insights_web_test.uptime[each.key].id, var.app_insights_id]
+    frequency           = "PT1M"
+    window_size         = "PT5M"
+    severity            = var.severity
+    enabled             = contains(var.disabled_alerts, "uptime") ? false : true
+
+    application_insights_web_test_location_availability_criteria {
+      web_test_id           = azurerm_application_insights_web_test.uptime[each.key].id
+      component_id          = var.app_insights_id
+      failed_location_count = 3
+    }
+
+    dynamic "action" {
+      for_each = var.action_group_ids
+      content {
+        action_group_id    = action.value
+        webhook_properties = var.wiki_docs_json
+      }
+    }
+    lifecycle {
+      ignore_changes = [
+        tags
+      ]
+    }
+  }
 }
 
 resource "azurerm_application_insights_web_test" "uptime" {
-  for_each = local.url_map
+  for_each = local.full_url_map
 
   name                    = each.key
   description             = "Verify the URL is publicly available"
@@ -51,33 +83,18 @@ XML
 }
 
 resource "azurerm_monitor_metric_alert" "uptime" {
-  for_each = local.url_map
+  for_each = local.base_url_map
 
-  name                = "uptime-${each.key}"
-  description         = "${each.key} is not responding"
-  resource_group_name = var.rg_name
-  scopes              = [azurerm_application_insights_web_test.uptime[each.key].id, var.app_insights_id]
-  frequency           = "PT1M"
-  window_size         = "PT5M"
-  severity            = var.severity
-  enabled             = contains(var.disabled_alerts, "uptime") ? false : true
+  local.base_azurerm_monitor_metric_alert_rule
+})
 
-  application_insights_web_test_location_availability_criteria {
-    web_test_id           = azurerm_application_insights_web_test.uptime[each.key].id
-    component_id          = var.app_insights_id
-    failed_location_count = 3
-  }
+resource "azurerm_monitor_metric_alert" "uptime-redirects" {
+  for_each = var.additional_uptime_test_urls
 
-  dynamic "action" {
-    for_each = var.action_group_ids
-    content {
-      action_group_id    = action.value
-      webhook_properties = var.wiki_docs_json
+  merge(
+    local.base_azurerm_monitor_metric_alert_rule,
+    {
+        window_size         = "PT15M"
     }
-  }
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
+  )
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #7489 

## Changes Proposed

- Extends the time window from 5 to 15 minutes for the uptime alerts that test whether the redirect urls are responding. We've seen an increase in high urgency pages for these redirect urls, but the pages consistently auto-resolve within about 10 minutes.

## Additional Information

- Tried to use `locals` to create a reusable block for a base definition of the `azurerm_monitor_metric_alert` resource, but not sure if it is possible since that block itself has complex expressions like for each and dynamic action. When I tried it was invalid syntax in the configuration file.

## Testing

- Not sure if there's a good way to test this and actually trigger the alert but open to any suggestions

### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Cloud
- [x] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification