### PR TITLE
Add and initialize Okta feature flag

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -24,6 +24,7 @@ public class FeatureFlagsConfig {
   @Setter(AccessLevel.NONE)
   private final FeatureFlagRepository _repo;
 
+  private boolean oktaMigrationEnabled;
   private boolean syphilisEnabled;
   private boolean hivBulkUploadEnabled;
   private boolean hivEnabled;
@@ -38,6 +39,7 @@ public class FeatureFlagsConfig {
 
   private void flagMapping(String flagName, Boolean flagValue) {
     switch (flagName) {
+      case "oktaMigrationEnabled" -> setOktaMigrationEnabled(flagValue);
       case "syphilisEnabled" -> setSyphilisEnabled(flagValue);
       case "hivBulkUploadEnabled" -> setHivBulkUploadEnabled(flagValue);
       case "hivEnabled" -> setHivEnabled(flagValue);

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -21,6 +21,7 @@ twilio:
   enabled: true
   from-number: "+14045312484"
 features:
+  oktaMigrationEnabled: false
   syphilisEnabled: false
   hivBulkUploadEnabled: false
   hivEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -168,6 +168,7 @@ datahub:
   csv-upload-api-client: "simple_report.csvuploader"
   csv-upload-api-fhir-client: "simple_report.fullelr"
 features:
+  oktaMigrationEnabled: false
   syphilisEnabled: true
   hivBulkUploadEnabled: true
   hivEnabled: true


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Resolves #7596

## Changes Proposed

Adds an Okta migration flag to our suite of feature flags and sets the default value to false across all envs.

## Additional Information

-  I went with  `oktaMigrationEnabled` for the variable name of the flag but I'm open to other suggestions if anyone has a more declarative name.

## Testing

The flag can be turned on and off  in dev4 or your local environment with following mutation:
```
mutation updateFeatureFlag($name: String!, $value: Boolean!){
 updateFeatureFlag(name:$name, value: $value){
     name
     value
 }
}
```

variables:
```
{
  "name": "oktaMigrationEnabled",
  "value": false
}
```

If testing in dev4 then check the feature flag table in metabase to verify that the endpoint is working, if in local, use your own DB.